### PR TITLE
Add rule aliases for @Suppress / krit:ignore

### DIFF
--- a/internal/pipeline/parse.go
+++ b/internal/pipeline/parse.go
@@ -102,8 +102,9 @@ func (p ParsePhase) Run(ctx context.Context, in ParseInput) (ParseResult, error)
 	// LSP/MCP callers that construct files directly still get nil
 	// fields here and fall through to the dispatcher's lazy build.
 	ruleExcludes := rules.GetAllRuleExcludes()
+	ruleAliases := rules.AllSuppressionAliases()
 	for _, f := range kotlinFiles {
-		installSourceSuppression(f, ruleExcludes)
+		installSourceSuppression(f, ruleExcludes, ruleAliases)
 	}
 
 	caps := unionNeeds(in.ActiveRules)
@@ -131,7 +132,7 @@ func (p ParsePhase) Run(ctx context.Context, in ParseInput) (ParseResult, error)
 				javaFiles, _ = filterGeneratedSourceFiles(javaFiles)
 			}
 			for _, f := range javaFiles {
-				installSourceSuppression(f, ruleExcludes)
+				installSourceSuppression(f, ruleExcludes, ruleAliases)
 			}
 		}
 	}
@@ -160,11 +161,11 @@ func filterGeneratedSourceFiles(files []*scanner.File) ([]*scanner.File, int) {
 	return filtered, droppedGenerated
 }
 
-func installSourceSuppression(f *scanner.File, ruleExcludes map[string][]string) {
+func installSourceSuppression(f *scanner.File, ruleExcludes map[string][]string, ruleAliases map[string][]string) {
 	if f == nil || f.FlatTree == nil {
 		return
 	}
-	f.Suppression = scanner.BuildSuppressionFilter(f, nil, ruleExcludes, "")
+	f.Suppression = scanner.BuildSuppressionFilter(f, nil, ruleExcludes, "").WithRuleAliases(ruleAliases)
 	f.SuppressionIdx = f.Suppression.Annotations()
 }
 

--- a/internal/rules/aliases.go
+++ b/internal/rules/aliases.go
@@ -1,0 +1,33 @@
+package rules
+
+import (
+	api "github.com/kaeawc/krit/internal/rules/api"
+)
+
+// AllSuppressionAliases returns a snapshot of every rule's suppression
+// aliases, keyed by canonical rule ID. The pipeline Parse phase passes
+// this into scanner.SuppressionFilter.WithRuleAliases so an
+// @Suppress("LegacyName") (or `// krit:ignore[LegacyName]`) silences
+// findings emitted under the canonical ID.
+//
+// Returns a nil map when no registered rule declares any aliases. The
+// scanner side treats nil and empty equivalently, so a nil result is a
+// safe drop-in.
+func AllSuppressionAliases() map[string][]string {
+	var out map[string][]string
+	for _, r := range api.Registry {
+		if r == nil || len(r.Aliases) == 0 {
+			continue
+		}
+		if out == nil {
+			out = make(map[string][]string)
+		}
+		// Defensive copy: rules treat Aliases as immutable, but the
+		// scanner caches the slice by reference and we don't want a
+		// later registry mutation to bleed in.
+		clone := make([]string, len(r.Aliases))
+		copy(clone, r.Aliases)
+		out[r.ID] = clone
+	}
+	return out
+}

--- a/internal/rules/aliases_test.go
+++ b/internal/rules/aliases_test.go
@@ -1,0 +1,97 @@
+package rules
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+
+	api "github.com/kaeawc/krit/internal/rules/api"
+)
+
+func TestAllSuppressionAliases_IncludesRegisteredRule(t *testing.T) {
+	saved := api.Registry
+	t.Cleanup(func() { api.Registry = saved })
+
+	api.Registry = append(append([]*api.Rule{}, saved...), &api.Rule{
+		ID:          "TestAliasRule",
+		Description: "synthetic rule for AllSuppressionAliases unit test",
+		Aliases:     []string{"OldName", "AncientName"},
+		Check:       func(*api.Context) {},
+	})
+
+	got := AllSuppressionAliases()
+	aliases, ok := got["TestAliasRule"]
+	if !ok {
+		t.Fatalf("AllSuppressionAliases missing entry for TestAliasRule; got keys: %v", keys(got))
+	}
+	want := []string{"OldName", "AncientName"}
+	if !reflect.DeepEqual(aliases, want) {
+		t.Errorf("aliases for TestAliasRule = %v, want %v", aliases, want)
+	}
+}
+
+func TestAllSuppressionAliases_DefensivelyCopiesSlice(t *testing.T) {
+	saved := api.Registry
+	t.Cleanup(func() { api.Registry = saved })
+
+	original := []string{"Old"}
+	api.Registry = append(append([]*api.Rule{}, saved...), &api.Rule{
+		ID:          "TestAliasCopyRule",
+		Description: "synthetic rule for slice-copy unit test",
+		Aliases:     original,
+		Check:       func(*api.Context) {},
+	})
+
+	got := AllSuppressionAliases()["TestAliasCopyRule"]
+	got[0] = "Mutated"
+	if original[0] != "Old" {
+		t.Errorf("AllSuppressionAliases must defensively copy; original aliases mutated to %q", original[0])
+	}
+}
+
+func TestAllSuppressionAliases_ReturnsNilWhenNoRulesDeclareAliases(t *testing.T) {
+	saved := api.Registry
+	t.Cleanup(func() { api.Registry = saved })
+
+	// Strip aliases from every registered rule for the duration of this
+	// test so we can verify the empty-result path.
+	stripped := make([]*api.Rule, 0, len(saved))
+	for _, r := range saved {
+		if r == nil {
+			continue
+		}
+		clone := *r
+		clone.Aliases = nil
+		stripped = append(stripped, &clone)
+	}
+	api.Registry = stripped
+
+	if got := AllSuppressionAliases(); got != nil {
+		t.Errorf("AllSuppressionAliases with no aliases declared = %v, want nil", got)
+	}
+}
+
+func TestMetaForRuleIncludesAliasesFromRuleField(t *testing.T) {
+	r := &api.Rule{
+		ID:          "TestAliasMergeFromField",
+		Description: "synthetic rule for alias merge",
+		Aliases:     []string{"OldName"},
+		Check:       func(*api.Context) {},
+	}
+	meta, ok := MetaForRule(r)
+	if !ok {
+		t.Fatal("MetaForRule returned !ok for non-nil rule")
+	}
+	if len(meta.Aliases) != 1 || meta.Aliases[0] != "OldName" {
+		t.Errorf("descriptor aliases = %v, want [OldName]", meta.Aliases)
+	}
+}
+
+func keys(m map[string][]string) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/rules/api/metadata.go
+++ b/internal/rules/api/metadata.go
@@ -160,6 +160,12 @@ type RuleDescriptor struct {
 	// ID is the stable rule identifier (matches the rule's Name()).
 	ID string
 
+	// Aliases are legacy or alternate IDs honored by suppression. See
+	// Rule.Aliases for the full contract; the descriptor field exists so
+	// rules implementing MetaProvider can publish aliases the same way
+	// they publish other metadata.
+	Aliases []string
+
 	// RuleSet is the configuration group this rule belongs to
 	// (e.g. "complexity", "naming", "performance").
 	RuleSet string

--- a/internal/rules/api/rule.go
+++ b/internal/rules/api/rule.go
@@ -378,6 +378,13 @@ type Rule struct {
 	Description string
 	Sev         Severity
 
+	// Aliases are legacy or alternate IDs for this rule. They do NOT
+	// appear in the registry as separate rules; they only affect
+	// suppression: @Suppress("<alias>") (and inline `// krit:ignore[<alias>]`)
+	// silences findings emitted under the canonical ID. Use when
+	// renaming a rule so existing user suppressions keep working.
+	Aliases []string
+
 	// Dispatch routing.
 	//
 	// Scope, when set, declares the rule's primary dispatcher bucket

--- a/internal/rules/dispatcher.go
+++ b/internal/rules/dispatcher.go
@@ -385,7 +385,7 @@ func (d *Dispatcher) RunColumnsWithStats(file *scanner.File) (scanner.FindingCol
 	start := time.Now()
 	filter := file.Suppression
 	if filter == nil {
-		filter = scanner.BuildSuppressionFilter(file, nil, allRuleExcludes(), "")
+		filter = scanner.BuildSuppressionFilter(file, nil, allRuleExcludes(), "").WithRuleAliases(AllSuppressionAliases())
 		file.Suppression = filter
 		file.SuppressionIdx = filter.Annotations()
 	}
@@ -822,7 +822,7 @@ func (d *Dispatcher) RunResourceSource(file *scanner.File, idx *android.Resource
 
 	filter := file.Suppression
 	if filter == nil {
-		filter = scanner.BuildSuppressionFilter(file, nil, allRuleExcludes(), "")
+		filter = scanner.BuildSuppressionFilter(file, nil, allRuleExcludes(), "").WithRuleAliases(AllSuppressionAliases())
 		file.Suppression = filter
 		file.SuppressionIdx = filter.Annotations()
 	}

--- a/internal/rules/meta_lookup.go
+++ b/internal/rules/meta_lookup.go
@@ -75,6 +75,11 @@ func mergeRuleDescriptor(r *api.Rule, extra api.RuleDescriptor) api.RuleDescript
 	if out.FixLevel == "" && r.Fix != api.FixNone {
 		out.FixLevel = r.Fix.String()
 	}
+	if len(r.Aliases) > 0 {
+		out.Aliases = r.Aliases
+	} else {
+		out.Aliases = extra.Aliases
+	}
 	return out
 }
 

--- a/internal/scanner/suppress.go
+++ b/internal/scanner/suppress.go
@@ -27,6 +27,30 @@ type SuppressionFilter struct {
 	inline        map[int]map[string]bool // line (1-based) → suppressed rule IDs; "" key means all
 	baseline      *Baseline
 	basePath      string
+	// ruleAliases maps a canonical rule ID to its legacy/alternate IDs.
+	// Populated lazily by callers via WithRuleAliases. When set, an
+	// @Suppress / inline-ignore listing any alias silences findings
+	// emitted under the canonical ID. nil disables alias matching.
+	ruleAliases map[string][]string
+}
+
+// WithRuleAliases attaches an alias index to the filter and returns it
+// for chaining. Map key is a canonical rule ID; value is the list of
+// alternate IDs (legacy names, renames) that should also suppress the
+// canonical rule when written in @Suppress / krit:ignore.
+//
+// Safe on a nil receiver (returns nil). Callers without alias data
+// simply omit the call — alias matching is purely additive.
+func (f *SuppressionFilter) WithRuleAliases(aliases map[string][]string) *SuppressionFilter {
+	if f == nil {
+		return nil
+	}
+	if len(aliases) == 0 {
+		f.ruleAliases = nil
+		return f
+	}
+	f.ruleAliases = aliases
+	return f
 }
 
 // BuildSuppressionFilter collects every per-file suppression source for
@@ -82,6 +106,7 @@ func (f *SuppressionFilter) IsSuppressed(ruleID, ruleSet string, line int) bool 
 	if f.excludedRules[ruleID] {
 		return true
 	}
+	aliases := f.ruleAliases[ruleID]
 	if suppressed := f.inline[line]; suppressed != nil {
 		if suppressed[""] || suppressed[ruleID] {
 			return true
@@ -89,13 +114,21 @@ func (f *SuppressionFilter) IsSuppressed(ruleID, ruleSet string, line int) bool 
 		if ruleSet != "" && (suppressed[ruleSet+"."+ruleID] || suppressed[ruleSet+":"+ruleID]) {
 			return true
 		}
+		for _, alias := range aliases {
+			if suppressed[alias] {
+				return true
+			}
+			if ruleSet != "" && (suppressed[ruleSet+"."+alias] || suppressed[ruleSet+":"+alias]) {
+				return true
+			}
+		}
 	}
 	if f.annotations != nil && f.file != nil {
 		byteOffset := 0
 		if line > 0 {
 			byteOffset = f.file.LineOffset(line - 1)
 		}
-		if f.annotations.IsSuppressed(byteOffset, ruleID, ruleSet) {
+		if f.annotations.isSuppressedWithAliases(byteOffset, ruleID, ruleSet, aliases) {
 			return true
 		}
 	}
@@ -273,6 +306,10 @@ func BuildSuppressionIndexFlat(tree *FlatTree, content []byte) *SuppressionIndex
 
 // IsSuppressed checks if a finding at the given byte offset is suppressed for the given rule.
 func (idx *SuppressionIndex) IsSuppressed(byteOffset int, ruleName string, ruleSetName string) bool {
+	return idx.isSuppressedWithAliases(byteOffset, ruleName, ruleSetName, nil)
+}
+
+func (idx *SuppressionIndex) isSuppressedWithAliases(byteOffset int, ruleName, ruleSetName string, aliases []string) bool {
 	if len(idx.suppressions) == 0 {
 		return false
 	}
@@ -291,6 +328,11 @@ func (idx *SuppressionIndex) IsSuppressed(byteOffset int, ruleName string, ruleS
 		if byteOffset >= s.StartByte && byteOffset <= s.EndByte {
 			if suppressionMatches(s.Rules, ruleName, ruleSetName) {
 				return true
+			}
+			for _, alias := range aliases {
+				if suppressionMatches(s.Rules, alias, ruleSetName) {
+					return true
+				}
 			}
 		}
 	}

--- a/internal/scanner/suppress_filter_test.go
+++ b/internal/scanner/suppress_filter_test.go
@@ -98,6 +98,92 @@ func TestSuppressionFilter_ExcludeGlob(t *testing.T) {
 	}
 }
 
+func TestSuppressionFilter_AliasAnnotation(t *testing.T) {
+	src := "@Suppress(\"LegacyName\")\nclass X {\n    val y = 42\n}\n"
+	f := parsedFileForFilter(t, "X.kt", src)
+	sf := BuildSuppressionFilter(f, nil, nil, "").WithRuleAliases(map[string][]string{
+		"NewName": {"LegacyName"},
+	})
+
+	if !sf.IsSuppressed("NewName", "style", 3) {
+		t.Error("@Suppress(LegacyName) should suppress canonical NewName when alias is registered")
+	}
+	if sf.IsSuppressed("Unrelated", "style", 3) {
+		t.Error("alias must not bleed to unrelated rules")
+	}
+}
+
+func TestSuppressionFilter_AliasInline(t *testing.T) {
+	src := "class A\nval x = 1 // krit:ignore[LegacyName]\nval y = 2\n"
+	f := parsedFileForFilter(t, "A.kt", src)
+	sf := BuildSuppressionFilter(f, nil, nil, "").WithRuleAliases(map[string][]string{
+		"NewName": {"LegacyName"},
+	})
+
+	if !sf.IsSuppressed("NewName", "style", 2) {
+		t.Error("inline ignore listing alias should suppress canonical rule")
+	}
+	if sf.IsSuppressed("NewName", "style", 3) {
+		t.Error("inline alias suppression should not bleed to other lines")
+	}
+}
+
+func TestSuppressionFilter_AliasWithRulesetPrefix(t *testing.T) {
+	src := "@Suppress(\"style.LegacyName\")\nclass X {\n    val y = 42\n}\n"
+	f := parsedFileForFilter(t, "X.kt", src)
+	sf := BuildSuppressionFilter(f, nil, nil, "").WithRuleAliases(map[string][]string{
+		"NewName": {"LegacyName"},
+	})
+
+	if !sf.IsSuppressed("NewName", "style", 3) {
+		t.Error("ruleset-qualified alias (style.LegacyName) should suppress canonical NewName")
+	}
+}
+
+func TestSuppressionFilter_AliasInlineWithRulesetPrefix(t *testing.T) {
+	src := "val x = 1 // krit:ignore[style.LegacyName]\n"
+	f := parsedFileForFilter(t, "x.kt", src)
+	sf := BuildSuppressionFilter(f, nil, nil, "").WithRuleAliases(map[string][]string{
+		"NewName": {"LegacyName"},
+	})
+
+	if !sf.IsSuppressed("NewName", "style", 1) {
+		t.Error("inline ruleset-qualified alias should suppress canonical rule")
+	}
+}
+
+func TestSuppressionFilter_AliasMissing(t *testing.T) {
+	src := "@Suppress(\"LegacyName\")\nclass X {\n    val y = 42\n}\n"
+	f := parsedFileForFilter(t, "X.kt", src)
+	sf := BuildSuppressionFilter(f, nil, nil, "")
+
+	if sf.IsSuppressed("NewName", "style", 3) {
+		t.Error("without WithRuleAliases the legacy name must not silence canonical rule")
+	}
+	if !sf.IsSuppressed("LegacyName", "style", 3) {
+		t.Error("the literal suppressed name still works as before")
+	}
+}
+
+func TestSuppressionFilter_WithRuleAliasesEmpty(t *testing.T) {
+	src := "@Suppress(\"NewName\")\nclass X {\n}\n"
+	f := parsedFileForFilter(t, "X.kt", src)
+	sf := BuildSuppressionFilter(f, nil, nil, "").
+		WithRuleAliases(map[string][]string{"NewName": {"Old"}}).
+		WithRuleAliases(nil)
+
+	if !sf.IsSuppressed("NewName", "", 3) {
+		t.Error("clearing aliases must not break canonical-name suppression")
+	}
+}
+
+func TestSuppressionFilter_WithRuleAliasesNilReceiver(t *testing.T) {
+	var sf *SuppressionFilter
+	if got := sf.WithRuleAliases(map[string][]string{"X": {"Y"}}); got != nil {
+		t.Error("WithRuleAliases on nil receiver must return nil")
+	}
+}
+
 func TestSuppressionFilter_NilSafe(t *testing.T) {
 	var sf *SuppressionFilter
 	if sf.IsSuppressed("X", "", 1) {


### PR DESCRIPTION
## Summary

Adds an `Aliases []string` field to `api.Rule` (and the mirror on `RuleDescriptor`) that lets a rule declare legacy or alternate IDs honored by suppression. When a rule is renamed, existing user `@Suppress("OldName")` or `// krit:ignore[OldName]` keeps working — declare `Aliases: []string{"OldName"}` on the canonical registration.

- `rules.AllSuppressionAliases()` snapshots the registry into a canonical-to-aliases map.
- The pipeline parse phase and dispatcher fallback chain it into `BuildSuppressionFilter` via a new fluent `WithRuleAliases` setter.
- Match logic delegates through the existing annotation and inline-ignore paths so ruleset-prefixed forms (`style.OldName`) and the kotlin-compiler alias map continue to work.
- No rule declares aliases yet — this is infrastructure. A follow-up can fold the dual-registered `DynamicVersion`/`GradleDynamicVersion` pair into one rule with an alias, retiring `aliasDefaultInactive`'s manual list.

## Test plan

- [x] `go test ./...` — all packages green
- [x] `go test ./internal/scanner/ -run TestSuppressionFilter_Alias` — 7 new filter cases (annotation, inline, ruleset-prefixed annotation, ruleset-prefixed inline, missing aliases, empty alias map, nil receiver)
- [x] `go test ./internal/rules/ -run "TestAllSuppressionAliases|TestMetaForRuleIncludesAliases" -race -count=3` — registry-snapshot tests are race-clean
- [x] `make integration` — playground lint, fix, diff, SARIF, CLI/LSP/MCP, all unit tests
- [x] `go vet ./...`, `golangci-lint run ./internal/scanner/ ./internal/rules/ ./internal/rules/api/ ./internal/pipeline/` — only pre-existing unused-function warnings, none from this change