### PR TITLE
Add lifecycle metadata: EnabledByDefaultSince and Deprecated

### DIFF
--- a/internal/rules/api/metadata.go
+++ b/internal/rules/api/metadata.go
@@ -166,6 +166,16 @@ type RuleDescriptor struct {
 	// they publish other metadata.
 	Aliases []string
 
+	// EnabledByDefaultSince mirrors Rule.EnabledByDefaultSince — the
+	// krit version in which this rule became default-active. Empty
+	// string means inception or unrecorded.
+	EnabledByDefaultSince string
+
+	// Deprecated mirrors Rule.Deprecated. Non-nil means the rule is
+	// scheduled for removal; consumers should surface migration
+	// guidance via ReplacedBy / Reason.
+	Deprecated *Deprecation
+
 	// RuleSet is the configuration group this rule belongs to
 	// (e.g. "complexity", "naming", "performance").
 	RuleSet string
@@ -208,6 +218,26 @@ type RuleDescriptor struct {
 	// implementation (e.g. the real ConfigAdapter) and no-op on the fake
 	// sources used by unit tests.
 	CustomApply func(target interface{}, cfg ConfigSource)
+}
+
+// Deprecation marks a rule as scheduled for removal and points users
+// at a migration target.
+//
+// Treat the struct as immutable after construction so descriptors stay
+// safe to copy and share.
+type Deprecation struct {
+	// Since is the krit version in which this rule was deprecated.
+	// Empty string means the deprecation predates version tracking.
+	Since string
+
+	// ReplacedBy is the canonical ID of the rule users should migrate
+	// to. Empty string means the rule was retired without a direct
+	// replacement (the user should remove their suppression entirely).
+	ReplacedBy string
+
+	// Reason is a one-line explanation surfaced to users alongside the
+	// deprecation. Keep terse — not a full migration guide.
+	Reason string
 }
 
 // LanguageSupportStatus is the stable support classification for a rule or

--- a/internal/rules/api/rule.go
+++ b/internal/rules/api/rule.go
@@ -385,6 +385,20 @@ type Rule struct {
 	// renaming a rule so existing user suppressions keep working.
 	Aliases []string
 
+	// EnabledByDefaultSince records the krit version in which this rule
+	// became default-active (DefaultActive transitioned from false to
+	// true). Empty string means the rule has been default-active since
+	// inception, or the version was not recorded. Used by docs and
+	// release-note generation; the runtime does not key behavior on it.
+	EnabledByDefaultSince string
+
+	// Deprecated, when non-nil, marks the rule as scheduled for removal.
+	// Consumers (docs, output formatters, CI gates) read this to surface
+	// migration guidance. The dispatcher does NOT skip deprecated rules
+	// — they continue to fire so existing baselines stay valid until the
+	// user migrates.
+	Deprecated *Deprecation
+
 	// Dispatch routing.
 	//
 	// Scope, when set, declares the rule's primary dispatcher bucket

--- a/internal/rules/lifecycle.go
+++ b/internal/rules/lifecycle.go
@@ -1,0 +1,48 @@
+package rules
+
+import (
+	api "github.com/kaeawc/krit/internal/rules/api"
+)
+
+// DeprecationFor returns the deprecation metadata for a rule, or
+// (nil, false) if the rule is not deprecated or is unknown.
+//
+// Consumers (output formatters, CI gates, the docs generator) call this
+// to surface ReplacedBy / Reason guidance when a deprecated rule is
+// active.
+func DeprecationFor(ruleID string) (*api.Deprecation, bool) {
+	if ruleID == "" {
+		return nil, false
+	}
+	for _, r := range api.Registry {
+		if r == nil || r.ID != ruleID {
+			continue
+		}
+		if r.Deprecated == nil {
+			return nil, false
+		}
+		return r.Deprecated, true
+	}
+	return nil, false
+}
+
+// AllDeprecations returns a snapshot of every registered rule's
+// Deprecation metadata, keyed by rule ID. Rules without a Deprecation
+// are omitted; the result is nil when no rule is deprecated.
+//
+// The returned map and its values are not shared with the registry —
+// the deprecation pointer is copied so callers can read it without
+// holding a reference to a registered rule.
+func AllDeprecations() map[string]api.Deprecation {
+	var out map[string]api.Deprecation
+	for _, r := range api.Registry {
+		if r == nil || r.Deprecated == nil {
+			continue
+		}
+		if out == nil {
+			out = make(map[string]api.Deprecation)
+		}
+		out[r.ID] = *r.Deprecated
+	}
+	return out
+}

--- a/internal/rules/lifecycle_test.go
+++ b/internal/rules/lifecycle_test.go
@@ -1,0 +1,150 @@
+package rules
+
+import (
+	"testing"
+
+	api "github.com/kaeawc/krit/internal/rules/api"
+)
+
+func TestDeprecationFor_RegisteredRule(t *testing.T) {
+	saved := api.Registry
+	t.Cleanup(func() { api.Registry = saved })
+
+	api.Registry = append(append([]*api.Rule{}, saved...), &api.Rule{
+		ID:          "TestDeprecatedRule",
+		Description: "synthetic deprecated rule",
+		Deprecated: &api.Deprecation{
+			Since:      "0.7.0",
+			ReplacedBy: "TestReplacement",
+			Reason:     "rolled into TestReplacement",
+		},
+		Check: func(*api.Context) {},
+	})
+
+	got, ok := DeprecationFor("TestDeprecatedRule")
+	if !ok {
+		t.Fatal("DeprecationFor missing entry for TestDeprecatedRule")
+	}
+	if got.Since != "0.7.0" || got.ReplacedBy != "TestReplacement" || got.Reason != "rolled into TestReplacement" {
+		t.Errorf("DeprecationFor returned %+v, want Since=0.7.0 ReplacedBy=TestReplacement Reason=...", got)
+	}
+}
+
+func TestDeprecationFor_NonDeprecatedReturnsFalse(t *testing.T) {
+	saved := api.Registry
+	t.Cleanup(func() { api.Registry = saved })
+
+	api.Registry = append(append([]*api.Rule{}, saved...), &api.Rule{
+		ID:          "TestActiveRule",
+		Description: "synthetic active rule",
+		Check:       func(*api.Context) {},
+	})
+
+	if _, ok := DeprecationFor("TestActiveRule"); ok {
+		t.Error("DeprecationFor should return false for a rule with Deprecated == nil")
+	}
+}
+
+func TestDeprecationFor_UnknownRuleReturnsFalse(t *testing.T) {
+	if _, ok := DeprecationFor("NoSuchRule_xyz"); ok {
+		t.Error("DeprecationFor should return false for an unknown rule ID")
+	}
+	if _, ok := DeprecationFor(""); ok {
+		t.Error("DeprecationFor(\"\") should return false")
+	}
+}
+
+func TestAllDeprecations_IncludesEveryDeprecated(t *testing.T) {
+	saved := api.Registry
+	t.Cleanup(func() { api.Registry = saved })
+
+	api.Registry = append(append([]*api.Rule{}, saved...),
+		&api.Rule{
+			ID:          "TestDeprecatedA",
+			Description: "synthetic deprecated rule A",
+			Deprecated:  &api.Deprecation{Since: "0.5.0", ReplacedBy: "ReplacementA"},
+			Check:       func(*api.Context) {},
+		},
+		&api.Rule{
+			ID:          "TestDeprecatedB",
+			Description: "synthetic deprecated rule B",
+			Deprecated:  &api.Deprecation{Since: "0.6.0"},
+			Check:       func(*api.Context) {},
+		},
+		&api.Rule{
+			ID:          "TestActiveRule2",
+			Description: "synthetic active rule",
+			Check:       func(*api.Context) {},
+		},
+	)
+
+	got := AllDeprecations()
+	if _, ok := got["TestDeprecatedA"]; !ok {
+		t.Error("AllDeprecations missing TestDeprecatedA")
+	}
+	if _, ok := got["TestDeprecatedB"]; !ok {
+		t.Error("AllDeprecations missing TestDeprecatedB")
+	}
+	if _, ok := got["TestActiveRule2"]; ok {
+		t.Error("AllDeprecations should not include rules with Deprecated == nil")
+	}
+}
+
+func TestAllDeprecations_ReturnsNilWhenNoneDeprecated(t *testing.T) {
+	saved := api.Registry
+	t.Cleanup(func() { api.Registry = saved })
+
+	stripped := make([]*api.Rule, 0, len(saved))
+	for _, r := range saved {
+		if r == nil {
+			continue
+		}
+		clone := *r
+		clone.Deprecated = nil
+		stripped = append(stripped, &clone)
+	}
+	api.Registry = stripped
+
+	if got := AllDeprecations(); got != nil {
+		t.Errorf("AllDeprecations with no deprecations = %v, want nil", got)
+	}
+}
+
+func TestAllDeprecations_DefensiveCopy(t *testing.T) {
+	saved := api.Registry
+	t.Cleanup(func() { api.Registry = saved })
+
+	original := &api.Deprecation{Since: "0.5.0", ReplacedBy: "Replacement"}
+	api.Registry = append(append([]*api.Rule{}, saved...), &api.Rule{
+		ID:          "TestDeprecatedCopy",
+		Description: "synthetic rule for defensive-copy test",
+		Deprecated:  original,
+		Check:       func(*api.Context) {},
+	})
+
+	got := AllDeprecations()["TestDeprecatedCopy"]
+	got.ReplacedBy = "Mutated"
+	if original.ReplacedBy != "Replacement" {
+		t.Errorf("AllDeprecations must defensively copy; original ReplacedBy mutated to %q", original.ReplacedBy)
+	}
+}
+
+func TestMetaForRuleIncludesLifecycleFromRuleField(t *testing.T) {
+	r := &api.Rule{
+		ID:                    "TestLifecycleMergeFromField",
+		Description:           "synthetic rule for lifecycle merge",
+		EnabledByDefaultSince: "0.4.0",
+		Deprecated:            &api.Deprecation{Since: "0.7.0", ReplacedBy: "TestNewRule"},
+		Check:                 func(*api.Context) {},
+	}
+	meta, ok := MetaForRule(r)
+	if !ok {
+		t.Fatal("MetaForRule returned !ok for non-nil rule")
+	}
+	if meta.EnabledByDefaultSince != "0.4.0" {
+		t.Errorf("descriptor EnabledByDefaultSince = %q, want 0.4.0", meta.EnabledByDefaultSince)
+	}
+	if meta.Deprecated == nil || meta.Deprecated.Since != "0.7.0" || meta.Deprecated.ReplacedBy != "TestNewRule" {
+		t.Errorf("descriptor Deprecated = %+v, want {Since:0.7.0 ReplacedBy:TestNewRule}", meta.Deprecated)
+	}
+}

--- a/internal/rules/meta_lookup.go
+++ b/internal/rules/meta_lookup.go
@@ -80,6 +80,16 @@ func mergeRuleDescriptor(r *api.Rule, extra api.RuleDescriptor) api.RuleDescript
 	} else {
 		out.Aliases = extra.Aliases
 	}
+	if r.EnabledByDefaultSince != "" {
+		out.EnabledByDefaultSince = r.EnabledByDefaultSince
+	} else {
+		out.EnabledByDefaultSince = extra.EnabledByDefaultSince
+	}
+	if r.Deprecated != nil {
+		out.Deprecated = r.Deprecated
+	} else {
+		out.Deprecated = extra.Deprecated
+	}
 	return out
 }
 


### PR DESCRIPTION
## Summary

Lets a rule record the krit version it became default-active (`EnabledByDefaultSince`) and mark itself deprecated (`Deprecated *Deprecation`) with a `ReplacedBy` migration target. Pairs with the alias support added in #4 — together they give clean rename + deprecation paths.

- New fields on `api.Rule` and `RuleDescriptor` (mirrored on each, with the descriptor preferring the inline field per the existing migration pattern in `mergeRuleDescriptor`).
- New `api.Deprecation` struct with `Since`, `ReplacedBy`, `Reason`.
- New helpers `rules.DeprecationFor(ruleID)` and `rules.AllDeprecations()` that consumers (docs generator, output formatters, CI gates) can use to surface migration guidance.
- The dispatcher deliberately does NOT skip deprecated rules — they keep firing so existing baselines stay valid until users migrate.

Surfacing the deprecation warning in CLI / SARIF / LSP output is intentionally deferred to a follow-up PR; this change is purely the data model and lookup helpers.

## Test plan

- [x] `go test ./...` — all packages green
- [x] `go test ./internal/rules/ -run "TestDeprecation|TestAllDeprecations|TestMetaForRuleIncludesLifecycle" -race -count=2` — all helper tests race-clean
- [x] `make integration` — playground lint/fix/diff/SARIF, CLI/LSP/MCP, all unit tests
- [x] `go vet ./...` — clean