### PR TITLE
Add inline-snippet rule-test helpers

### DIFF
--- a/internal/rules/assert_inline_example_test.go
+++ b/internal/rules/assert_inline_example_test.go
@@ -1,0 +1,24 @@
+package rules_test
+
+import "testing"
+
+// Demonstration tests for the inline-snippet rule-test pattern. These
+// double as a smoke test that assertFlags / assertClean route a real
+// rule end-to-end through the dispatcher and produce the expected
+// pass/fail result. New regression tests should follow this shape.
+
+func TestInlineSnippet_EmptyFunctionBlockFlagsBlankBody(t *testing.T) {
+	assertFlags(t, "EmptyFunctionBlock", `package test
+
+fun blank() {}
+`)
+}
+
+func TestInlineSnippet_EmptyFunctionBlockSkipsNonEmptyBody(t *testing.T) {
+	assertClean(t, "EmptyFunctionBlock", `package test
+
+fun nonBlank() {
+    println("hi")
+}
+`)
+}

--- a/internal/rules/assert_inline_helpers_test.go
+++ b/internal/rules/assert_inline_helpers_test.go
@@ -1,0 +1,130 @@
+package rules_test
+
+import (
+	"testing"
+
+	api "github.com/kaeawc/krit/internal/rules/api"
+	"github.com/kaeawc/krit/internal/scanner"
+)
+
+// These tests exercise the inline-snippet test helpers via
+// api.FakeRule, so a regression in the helper wiring (parse →
+// dispatch → return findings) is caught independently of any real
+// rule's behavior.
+
+const inlineHelperKotlin = `package test
+
+fun greet() {
+    println("hi")
+}
+`
+
+func TestInlineHelpers_FindingsForReturnsFakeRuleEmissions(t *testing.T) {
+	file := inlineKotlin(t, inlineHelperKotlin)
+
+	emits := api.FakeRule("InlineHelpersFakeEmits",
+		api.WithNodeTypes("call_expression"),
+		api.WithCheck(func(ctx *api.Context) {
+			ctx.EmitAt(1, 1, "fake finding")
+		}),
+	)
+
+	findings := findingsFor(t, emits, file)
+	if len(findings) == 0 {
+		t.Fatalf("expected findings from emitting fake rule, got none")
+	}
+	for _, f := range findings {
+		if f.Rule != "InlineHelpersFakeEmits" {
+			t.Errorf("unexpected rule on finding: %s", f.Rule)
+		}
+	}
+}
+
+func TestInlineHelpers_FindingsForReturnsEmptyForSilentRule(t *testing.T) {
+	file := inlineKotlin(t, inlineHelperKotlin)
+
+	silent := api.FakeRule("InlineHelpersFakeSilent",
+		api.WithNodeTypes("call_expression"),
+		api.WithCheck(func(ctx *api.Context) {}),
+	)
+
+	findings := findingsFor(t, silent, file)
+	if len(findings) != 0 {
+		t.Fatalf("expected zero findings from silent fake rule, got %d", len(findings))
+	}
+}
+
+func TestInlineHelpers_AssertFlagsOnPassesWhenRuleEmits(t *testing.T) {
+	file := inlineKotlin(t, inlineHelperKotlin)
+
+	emits := api.FakeRule("InlineHelpersAssertFlagsPos",
+		api.WithNodeTypes("call_expression"),
+		api.WithCheck(func(ctx *api.Context) {
+			ctx.EmitAt(1, 1, "fake finding")
+		}),
+	)
+
+	got := assertFlagsOn(t, emits, file)
+	if len(got) == 0 {
+		t.Fatalf("assertFlagsOn returned empty findings slice when expecting >=1")
+	}
+}
+
+func TestInlineHelpers_AssertCleanOnPassesWhenRuleSilent(t *testing.T) {
+	file := inlineKotlin(t, inlineHelperKotlin)
+
+	silent := api.FakeRule("InlineHelpersAssertCleanPos",
+		api.WithNodeTypes("call_expression"),
+		api.WithCheck(func(ctx *api.Context) {}),
+	)
+
+	// If this calls t.Fatalf, the test fails — which is the assertion
+	// we want.
+	assertCleanOn(t, silent, file)
+}
+
+func TestInlineHelpers_FlagsAssertionFailsForEmptyFindings(t *testing.T) {
+	rule := api.FakeRule("InlineHelpersFlagsPredicate")
+	file := inlineKotlin(t, inlineHelperKotlin)
+
+	ok, msg := flagsAssertion(rule, file, nil)
+	if ok {
+		t.Fatalf("flagsAssertion should fail for empty findings")
+	}
+	if msg == "" {
+		t.Errorf("expected non-empty failure message")
+	}
+	if ok2, _ := flagsAssertion(rule, file, []scanner.Finding{{Line: 1}}); !ok2 {
+		t.Errorf("flagsAssertion should pass with at least one finding")
+	}
+}
+
+func TestInlineHelpers_CleanAssertionFailsForNonEmptyFindings(t *testing.T) {
+	rule := api.FakeRule("InlineHelpersCleanPredicate")
+	file := inlineKotlin(t, inlineHelperKotlin)
+
+	ok, msg := cleanAssertion(rule, file, []scanner.Finding{{Line: 3, Message: "boom"}})
+	if ok {
+		t.Fatalf("cleanAssertion should fail for non-empty findings")
+	}
+	if msg == "" {
+		t.Errorf("expected non-empty failure message")
+	}
+	if ok2, _ := cleanAssertion(rule, file, nil); !ok2 {
+		t.Errorf("cleanAssertion should pass with no findings")
+	}
+}
+
+func TestInlineHelpers_FindRuleByIDFindsRegisteredRule(t *testing.T) {
+	if len(api.Registry) == 0 {
+		t.Skip("registry empty in this build configuration")
+	}
+	first := api.Registry[0]
+	if first == nil || first.ID == "" {
+		t.Fatalf("first registry entry is missing an ID: %+v", first)
+	}
+	got := findRuleByID(t, first.ID)
+	if got != first {
+		t.Errorf("findRuleByID returned %p, want %p", got, first)
+	}
+}

--- a/internal/rules/assert_inline_test.go
+++ b/internal/rules/assert_inline_test.go
@@ -1,0 +1,132 @@
+package rules_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kaeawc/krit/internal/rules"
+	api "github.com/kaeawc/krit/internal/rules/api"
+	"github.com/kaeawc/krit/internal/scanner"
+	"github.com/kaeawc/krit/internal/typeinfer"
+)
+
+// Inline-snippet rule-test helpers. Pattern (borrowed from ktfmt's
+// assertFormatted): one bug, one inline source snippet, one assertion.
+// Use these for surgical regression tests of false positives or false
+// negatives where a fixture would fragment the bug story across
+// multiple files.
+//
+//   func TestRule_doesNotFlagX(t *testing.T) {
+//       assertClean(t, "RuleName", `
+//   package test
+//   fun f() = ...
+//   `)
+//   }
+//
+// For broader behavioral coverage, prefer per-rule fixtures under
+// tests/fixtures/. This file is for the cases where co-locating the
+// snippet with the test is clearer than indirecting through a
+// fixture file.
+
+// inlineKotlin writes src to t.TempDir()/test.kt and parses it.
+// (A Java variant can be added when the first Java caller appears.)
+func inlineKotlin(t *testing.T, src string) *scanner.File {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "test.kt")
+	if err := os.WriteFile(path, []byte(src), 0644); err != nil {
+		t.Fatalf("write inline source: %v", err)
+	}
+	f, err := scanner.ParseFile(path)
+	if err != nil {
+		t.Fatalf("parse inline source: %v", err)
+	}
+	return f
+}
+
+// findRuleByID looks rule up in api.Registry. Failure is fatal.
+func findRuleByID(t *testing.T, ruleID string) *api.Rule {
+	t.Helper()
+	for _, r := range api.Registry {
+		if r != nil && r.ID == ruleID {
+			return r
+		}
+	}
+	t.Fatalf("rule %q not found in api.Registry", ruleID)
+	return nil
+}
+
+// findingsFor runs rule against file in a single-rule dispatcher.
+// The dispatcher only invokes the given rule, so cross-rule churn
+// can't pollute the result.
+func findingsFor(t *testing.T, rule *api.Rule, file *scanner.File) []scanner.Finding {
+	t.Helper()
+	d := rules.NewDispatcher([]*api.Rule{rule})
+	if rule.Needs.Has(api.NeedsResolver) {
+		resolver := typeinfer.NewResolver()
+		resolver.IndexFilesParallel([]*scanner.File{file}, 1)
+		d = rules.NewDispatcher([]*api.Rule{rule}, resolver)
+	}
+	cols := d.Run(file)
+	return cols.Findings()
+}
+
+// flagsAssertion evaluates the assertFlagsOn predicate without
+// touching testing.T. ok is true when the assertion would pass; msg
+// is the failure message that would be reported when ok is false.
+// Exposed as a separate function so unit tests can verify the
+// predicate without driving a real test into a failure state.
+func flagsAssertion(rule *api.Rule, file *scanner.File, findings []scanner.Finding) (ok bool, msg string) {
+	if len(findings) > 0 {
+		return true, ""
+	}
+	return false, fmt.Sprintf("%s: expected at least one finding on %s, got none", rule.ID, file.Path)
+}
+
+// cleanAssertion is the assertCleanOn predicate. See flagsAssertion.
+func cleanAssertion(rule *api.Rule, file *scanner.File, findings []scanner.Finding) (ok bool, msg string) {
+	if len(findings) == 0 {
+		return true, ""
+	}
+	msgs := make([]string, 0, len(findings))
+	for _, f := range findings {
+		msgs = append(msgs, fmt.Sprintf("L%d: %s", f.Line, f.Message))
+	}
+	return false, fmt.Sprintf("%s: expected no findings on %s, got %d:\n  %s", rule.ID, file.Path, len(findings), strings.Join(msgs, "\n  "))
+}
+
+// assertFlagsOn fails the test if rule produces zero findings on
+// file. Returns the findings for further inspection.
+func assertFlagsOn(t *testing.T, rule *api.Rule, file *scanner.File) []scanner.Finding {
+	t.Helper()
+	findings := findingsFor(t, rule, file)
+	if ok, msg := flagsAssertion(rule, file, findings); !ok {
+		t.Fatal(msg)
+	}
+	return findings
+}
+
+// assertCleanOn fails the test if rule produces any findings on file.
+func assertCleanOn(t *testing.T, rule *api.Rule, file *scanner.File) {
+	t.Helper()
+	findings := findingsFor(t, rule, file)
+	if ok, msg := cleanAssertion(rule, file, findings); !ok {
+		t.Fatal(msg)
+	}
+}
+
+// assertFlags asserts that ruleID produces at least one finding when
+// run over the inline Kotlin snippet src. Returns the findings.
+func assertFlags(t *testing.T, ruleID, src string) []scanner.Finding {
+	t.Helper()
+	return assertFlagsOn(t, findRuleByID(t, ruleID), inlineKotlin(t, src))
+}
+
+// assertClean asserts that ruleID produces zero findings when run
+// over the inline Kotlin snippet src.
+func assertClean(t *testing.T, ruleID, src string) {
+	t.Helper()
+	assertCleanOn(t, findRuleByID(t, ruleID), inlineKotlin(t, src))
+}


### PR DESCRIPTION
## Summary

Adds \`assertFlags\` / \`assertClean\` for surgical regression tests where co-locating a Kotlin snippet with the test is clearer than indirecting through a fixture file. Borrows ktfmt's \`assertFormatted("""...""")\` shape: one bug, one snippet, one assertion.

\`\`\`go
func TestSomeRule_doesNotFlagX(t *testing.T) {
    assertClean(t, "SomeRule", \`package test
fun f() = ...
\`)
}
\`\`\`

## Why

Existing tests use the \`runRuleByName\` helper (2k+ call sites) but each caller hand-rolls its own assertion + failure message. \`assertFlags\` / \`assertClean\` give consistent failure messages for the two most common shapes (false positive / false negative) and keep the regression test compact. Fixture-driven tests are unaffected — this is purely additive.

## What's in the PR

- \`assert_inline_test.go\` — \`assertFlags\`, \`assertClean\`, plus the \`assertFlagsOn\` / \`assertCleanOn\` core that takes a \`*api.Rule\` directly. The \`flagsAssertion\` / \`cleanAssertion\` predicates are split out so they can be unit-tested without driving \`testing.T\` into a failure state.
- \`assert_inline_helpers_test.go\` — fakes-based unit tests (\`api.FakeRule\`) covering helper wiring, predicate pass/fail behavior, and \`findRuleByID\`.
- \`assert_inline_example_test.go\` — two demonstration tests routing \`EmptyFunctionBlock\` end-to-end through the helpers, also serving as a smoke test that the API works for a real registered rule.

Java variants are deferred until the first caller needs them.

## Test plan

- [x] \`go test ./internal/rules/ -run "TestInlineHelpers|TestInlineSnippet"\` passes (9 tests)
- [x] \`go vet ./...\`, \`golangci-lint run ./...\` clean for new files
- [x] \`make integration\`, \`make regression\`, \`make lint-rules\` all pass