### PR TITLE
Add Maturity tier so experimental rules can ship dark

### DIFF
--- a/internal/cli/scan/flags.go
+++ b/internal/cli/scan/flags.go
@@ -31,6 +31,7 @@ type scanFlags struct {
 	FixLevel                 *string
 	DryRun                   *bool
 	AllRules                 *bool
+	Experimental             *bool
 	Baseline                 *string
 	CreateBaseline           *string
 	BasePath                 *string
@@ -128,6 +129,7 @@ func registerScanFlags(fs *flag.FlagSet) *scanFlags {
 	f.FixLevel = fs.String("fix-level", "idiomatic", "Maximum fix level: cosmetic, idiomatic, semantic")
 	f.DryRun = fs.Bool("dry-run", false, "Show what --fix would change without modifying files")
 	f.AllRules = fs.Bool("all-rules", false, "Enable all rules including opt-in")
+	f.Experimental = fs.Bool("experimental", false, "Enable rules whose Maturity is experimental (does not enable deprecated rules)")
 	f.Baseline = fs.String("baseline", "", "Baseline file to suppress known issues (XML or JSON)")
 	f.CreateBaseline = fs.String("create-baseline", "", "Create a baseline file from current findings")
 	f.BasePath = fs.String("base-path", "", "Base path for relative file paths in baselines and reports (default: first scan path)")

--- a/internal/cli/scan/runner.go
+++ b/internal/cli/scan/runner.go
@@ -319,7 +319,8 @@ func (r *runner) filterRules() (handled bool, code int) {
 	r.tracker.TrackVoid("filterRules", func() {
 		disabledSet := parseRuleNameSet(*r.f.DisableRules)
 		enabledSet := parseRuleNameSet(*r.f.EnableRules)
-		r.activeRules = rules.ActiveRulesV2(disabledSet, enabledSet, *r.f.AllRules)
+		experimental := *r.f.Experimental || r.cfg.GetTopLevelBool("experimental", false)
+		r.activeRules = rules.ActiveRulesV2(disabledSet, enabledSet, *r.f.AllRules, experimental)
 		if rulesNeedProjectModel(r.activeRules) {
 			r.ensureProjectModel()
 		}

--- a/internal/cli/scorecard/scorecard.go
+++ b/internal/cli/scorecard/scorecard.go
@@ -85,7 +85,7 @@ func Build(paths []string, configPath string) ([]Row, error) {
 		cfg = config.NewConfig()
 	}
 	rules.ApplyConfig(cfg)
-	active := rules.ActiveRulesV2(nil, nil, false)
+	active := rules.ActiveRulesV2(nil, nil, false, false)
 	findings := runRules(files, active)
 
 	pmi := module.BuildPerModuleIndex(graph, files, runtime.NumCPU())

--- a/internal/rules/api/fake.go
+++ b/internal/rules/api/fake.go
@@ -73,6 +73,11 @@ func WithLibraryFacts() FakeOption {
 	return func(r *Rule) { r.NeedsLibraryFacts = true }
 }
 
+// WithMaturity sets the rule's lifecycle stage.
+func WithMaturity(m Maturity) FakeOption {
+	return func(r *Rule) { r.Maturity = m }
+}
+
 // FakeContext creates a minimal context for testing with the given file.
 // A FindingCollector is pre-allocated; use ContextFindings(ctx) to read results.
 func FakeContext(file *scanner.File) *Context {

--- a/internal/rules/api/rule.go
+++ b/internal/rules/api/rule.go
@@ -297,6 +297,46 @@ const (
 	SeverityInfo    Severity = "info"
 )
 
+// Maturity describes a rule's lifecycle stage. The default zero value is
+// MaturityStable so existing rule registrations remain unchanged.
+//
+// Experimental rules ship dark: they are filtered out of the default-active
+// set and only run when the user opts in via --experimental, the
+// `experimental: true` top-level config key, --all-rules, or by naming the
+// rule explicitly with --enable-rules.
+//
+// Deprecated rules are also default-inactive and never re-enabled by the
+// experimental flag — the only way to run them is to name them explicitly
+// with --enable-rules. This gives rule authors a one-release deprecation
+// window without surprising default users.
+type Maturity uint8
+
+const (
+	// MaturityStable is the zero value: the rule is part of the supported
+	// built-in rule set and runs by default unless DefaultActive=false.
+	MaturityStable Maturity = iota
+	// MaturityExperimental marks a rule that has not yet soaked under
+	// real-world usage. It is default-inactive and only runs when the
+	// user explicitly enables experimental rules.
+	MaturityExperimental
+	// MaturityDeprecated marks a rule that is on its way out. It is
+	// default-inactive and is NOT re-enabled by --experimental; users who
+	// still want it must pass --enable-rules <ID> or set it in config.
+	MaturityDeprecated
+)
+
+// String returns a human-readable label for the Maturity value.
+func (m Maturity) String() string {
+	switch m {
+	case MaturityExperimental:
+		return "experimental"
+	case MaturityDeprecated:
+		return "deprecated"
+	default:
+		return "stable"
+	}
+}
+
 // OracleFilter declares when a rule needs oracle type information.
 type OracleFilter struct {
 	Identifiers []string
@@ -425,6 +465,11 @@ type Rule struct {
 	// The dispatcher uses RuleLanguages() to skip rules whose language
 	// list does not include the current file's Language.
 	Languages []scanner.Language
+
+	// Maturity is the rule's lifecycle stage. The zero value is
+	// MaturityStable. Experimental and deprecated rules are
+	// default-inactive; see the Maturity type docs for the full contract.
+	Maturity Maturity
 
 	// Fix metadata
 	Fix FixLevel // FixNone → not fixable

--- a/internal/rules/api/rule_test.go
+++ b/internal/rules/api/rule_test.go
@@ -64,6 +64,37 @@ func TestRule_Name(t *testing.T) {
 	}
 }
 
+func TestMaturity_String(t *testing.T) {
+	tests := []struct {
+		m    Maturity
+		want string
+	}{
+		{MaturityStable, "stable"},
+		{MaturityExperimental, "experimental"},
+		{MaturityDeprecated, "deprecated"},
+		{Maturity(255), "stable"}, // unknown values fall back to stable
+	}
+	for _, tt := range tests {
+		if got := tt.m.String(); got != tt.want {
+			t.Errorf("Maturity(%d).String() = %q, want %q", tt.m, got, tt.want)
+		}
+	}
+}
+
+func TestRule_MaturityZeroValueIsStable(t *testing.T) {
+	r := &Rule{ID: "x"}
+	if r.Maturity != MaturityStable {
+		t.Errorf("zero-value Rule.Maturity = %v, want MaturityStable", r.Maturity)
+	}
+}
+
+func TestFakeRule_WithMaturity(t *testing.T) {
+	r := FakeRule("exp", WithMaturity(MaturityExperimental))
+	if r.Maturity != MaturityExperimental {
+		t.Errorf("Maturity = %v, want MaturityExperimental", r.Maturity)
+	}
+}
+
 func TestFixLevel_String(t *testing.T) {
 	tests := []struct {
 		level FixLevel

--- a/internal/rules/defaults.go
+++ b/internal/rules/defaults.go
@@ -22,6 +22,17 @@ import (
 // ApplyConfig mutates this map at runtime to reflect YAML overrides.
 var DefaultInactive = map[string]bool{}
 
+// experimentalRules lists rules whose Maturity is MaturityExperimental.
+// Populated by ensureDefaultInactive alongside DefaultInactive so that
+// ActiveRulesV2 can re-enable them when --experimental is set without
+// flipping deprecated rules at the same time.
+var experimentalRules = map[string]bool{}
+
+// deprecatedRules lists rules whose Maturity is MaturityDeprecated. These
+// are default-inactive and stay off even when --experimental is set; users
+// must name them explicitly via --enable-rules to run them.
+var deprecatedRules = map[string]bool{}
+
 var defaultInactiveOnce sync.Once
 
 // ensureDefaultInactive populates DefaultInactive from every registered
@@ -40,6 +51,14 @@ func ensureDefaultInactive() {
 		seen := make(map[string]struct{}, len(api.Registry))
 		for _, r := range api.Registry {
 			seen[r.ID] = struct{}{}
+			switch r.Maturity {
+			case api.MaturityExperimental:
+				experimentalRules[r.ID] = true
+				DefaultInactive[r.ID] = true
+			case api.MaturityDeprecated:
+				deprecatedRules[r.ID] = true
+				DefaultInactive[r.ID] = true
+			}
 			desc, ok := MetaForRule(r)
 			if !ok {
 				continue
@@ -108,16 +127,70 @@ func IsDefaultActive(name string) bool {
 	return !DefaultInactive[name]
 }
 
-// ActiveRulesV2 filters api.Registry using config-driven activation. Returns
-// rules that are enabled, not disabled, and either in enabledSet,
-// allRules=true, or IsDefaultActive.
-func ActiveRulesV2(disabledSet, enabledSet map[string]bool, allRules bool) []*api.Rule {
+// IsExperimental reports whether a rule's Maturity is MaturityExperimental.
+// Returns false for stable, deprecated, or unknown rule IDs.
+func IsExperimental(name string) bool {
+	ensureDefaultInactive()
+	return experimentalRules[name]
+}
+
+// IsDeprecated reports whether a rule's Maturity is MaturityDeprecated.
+// Returns false for stable, experimental, or unknown rule IDs.
+func IsDeprecated(name string) bool {
+	ensureDefaultInactive()
+	return deprecatedRules[name]
+}
+
+// ActiveRulesV2 filters api.Registry using config-driven activation.
+//
+// A rule is included when it is not in disabledSet AND either:
+//   - it is named in enabledSet (explicit user opt-in always wins);
+//   - allRules=true (--all-rules);
+//   - experimental=true and the rule's Maturity is MaturityExperimental; OR
+//   - it is default-active (IsDefaultActive).
+//
+// Deprecated rules are never included via allRules or experimental — the
+// only path that re-enables a deprecated rule is naming it explicitly in
+// enabledSet. This keeps deprecated rules from coming back to life when
+// users flip broad opt-in flags.
+func ActiveRulesV2(disabledSet, enabledSet map[string]bool, allRules, experimental bool) []*api.Rule {
+	ensureDefaultInactive()
+	return selectActiveRules(api.Registry, disabledSet, enabledSet, allRules, experimental, experimentalRules, deprecatedRules, DefaultInactive)
+}
+
+// selectActiveRules is the registry-agnostic core of ActiveRulesV2,
+// extracted so tests can supply a fake registry and fake maturity sets
+// without mutating the global api.Registry.
+//
+// defaultInactive carries the same semantics as the package-level
+// DefaultInactive map: presence means the rule is opt-in.
+func selectActiveRules(
+	reg []*api.Rule,
+	disabledSet, enabledSet map[string]bool,
+	allRules, experimental bool,
+	experimentalSet, deprecatedSet, defaultInactive map[string]bool,
+) []*api.Rule {
 	var out []*api.Rule
-	for _, r := range api.Registry {
+	for _, r := range reg {
 		if disabledSet[r.ID] {
 			continue
 		}
-		if enabledSet[r.ID] || allRules || IsDefaultActive(r.ID) {
+		if enabledSet[r.ID] {
+			out = append(out, r)
+			continue
+		}
+		if deprecatedSet[r.ID] {
+			continue
+		}
+		if allRules {
+			out = append(out, r)
+			continue
+		}
+		if experimental && experimentalSet[r.ID] {
+			out = append(out, r)
+			continue
+		}
+		if !defaultInactive[r.ID] {
 			out = append(out, r)
 		}
 	}

--- a/internal/rules/defaults_test.go
+++ b/internal/rules/defaults_test.go
@@ -1,0 +1,145 @@
+package rules
+
+import (
+	"testing"
+
+	api "github.com/kaeawc/krit/internal/rules/api"
+)
+
+// fakeRule returns a minimal *api.Rule fixture with just enough fields for
+// selectActiveRules to inspect. It avoids registering with the global
+// api.Registry so tests stay hermetic.
+func fakeRule(id string, m api.Maturity) *api.Rule {
+	return &api.Rule{
+		ID:          id,
+		Description: "fake",
+		Maturity:    m,
+		Check:       func(*api.Context) {},
+	}
+}
+
+func ruleIDs(rs []*api.Rule) []string {
+	out := make([]string, len(rs))
+	for i, r := range rs {
+		out[i] = r.ID
+	}
+	return out
+}
+
+func containsID(ss []string, s string) bool {
+	for _, v := range ss {
+		if v == s {
+			return true
+		}
+	}
+	return false
+}
+
+// TestSelectActiveRules_StableDefault: a stable rule that is not in
+// defaultInactive runs by default.
+func TestSelectActiveRules_StableDefault(t *testing.T) {
+	reg := []*api.Rule{fakeRule("Stable", api.MaturityStable)}
+	got := selectActiveRules(reg, nil, nil, false, false, nil, nil, nil)
+	if !containsID(ruleIDs(got), "Stable") {
+		t.Fatalf("stable rule should be active by default; got %v", ruleIDs(got))
+	}
+}
+
+// TestSelectActiveRules_ExperimentalOffByDefault: an experimental rule is
+// excluded unless experimental=true (or it is named explicitly).
+func TestSelectActiveRules_ExperimentalOffByDefault(t *testing.T) {
+	reg := []*api.Rule{fakeRule("Exp", api.MaturityExperimental)}
+	exp := map[string]bool{"Exp": true}
+	inactive := map[string]bool{"Exp": true}
+
+	got := selectActiveRules(reg, nil, nil, false, false, exp, nil, inactive)
+	if containsID(ruleIDs(got), "Exp") {
+		t.Fatalf("experimental rule should be off by default; got %v", ruleIDs(got))
+	}
+
+	got = selectActiveRules(reg, nil, nil, false, true, exp, nil, inactive)
+	if !containsID(ruleIDs(got), "Exp") {
+		t.Fatalf("--experimental should re-enable experimental rules; got %v", ruleIDs(got))
+	}
+}
+
+// TestSelectActiveRules_DeprecatedNeverImplicitlyOn: a deprecated rule must
+// not be re-enabled by --experimental or --all-rules. Only an explicit
+// enabledSet entry runs it.
+func TestSelectActiveRules_DeprecatedNeverImplicitlyOn(t *testing.T) {
+	reg := []*api.Rule{fakeRule("Old", api.MaturityDeprecated)}
+	dep := map[string]bool{"Old": true}
+	inactive := map[string]bool{"Old": true}
+
+	cases := []struct {
+		name             string
+		allRules, expFlg bool
+	}{
+		{"plain", false, false},
+		{"experimental", false, true},
+		{"all-rules", true, false},
+		{"all + experimental", true, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := selectActiveRules(reg, nil, nil, c.allRules, c.expFlg, nil, dep, inactive)
+			if containsID(ruleIDs(got), "Old") {
+				t.Errorf("deprecated rule must not be implicitly enabled by %s; got %v", c.name, ruleIDs(got))
+			}
+		})
+	}
+
+	en := map[string]bool{"Old": true}
+	got := selectActiveRules(reg, nil, en, false, false, nil, dep, inactive)
+	if !containsID(ruleIDs(got), "Old") {
+		t.Fatalf("explicit enable should run a deprecated rule; got %v", ruleIDs(got))
+	}
+}
+
+// TestSelectActiveRules_DisabledAlwaysWins: disabledSet wins over every
+// other opt-in path including explicit enable.
+func TestSelectActiveRules_DisabledAlwaysWins(t *testing.T) {
+	reg := []*api.Rule{fakeRule("X", api.MaturityStable)}
+	dis := map[string]bool{"X": true}
+	en := map[string]bool{"X": true}
+
+	got := selectActiveRules(reg, dis, en, true, true, nil, nil, nil)
+	if containsID(ruleIDs(got), "X") {
+		t.Fatalf("disabledSet must override every other path; got %v", ruleIDs(got))
+	}
+}
+
+// TestSelectActiveRules_AllRulesIncludesExperimental: --all-rules opts in
+// experimental rules but still excludes deprecated ones.
+func TestSelectActiveRules_AllRulesIncludesExperimental(t *testing.T) {
+	reg := []*api.Rule{
+		fakeRule("Stable", api.MaturityStable),
+		fakeRule("Exp", api.MaturityExperimental),
+		fakeRule("Old", api.MaturityDeprecated),
+	}
+	exp := map[string]bool{"Exp": true}
+	dep := map[string]bool{"Old": true}
+	inactive := map[string]bool{"Exp": true, "Old": true}
+
+	got := ruleIDs(selectActiveRules(reg, nil, nil, true, false, exp, dep, inactive))
+	if !containsID(got, "Stable") || !containsID(got, "Exp") {
+		t.Errorf("--all-rules should include stable and experimental; got %v", got)
+	}
+	if containsID(got, "Old") {
+		t.Errorf("--all-rules must not include deprecated rules; got %v", got)
+	}
+}
+
+// TestSelectActiveRules_OptInDefaultInactiveStillRunsViaEnableSet: a stable
+// rule that is default-inactive (DefaultActive=false in its descriptor)
+// must still run when explicitly enabled.
+func TestSelectActiveRules_OptInStillRunsViaEnableSet(t *testing.T) {
+	reg := []*api.Rule{fakeRule("OptIn", api.MaturityStable)}
+	inactive := map[string]bool{"OptIn": true}
+	en := map[string]bool{"OptIn": true}
+
+	got := selectActiveRules(reg, nil, en, false, false, nil, nil, inactive)
+	if !containsID(ruleIDs(got), "OptIn") {
+		t.Fatalf("explicit enable should run an opt-in rule; got %v", ruleIDs(got))
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `api.Maturity` (Stable/Experimental/Deprecated) and a `Rule.Maturity` field, mirroring ktlint's `Rule.Experimental` pattern so new rules can soak as opt-in before becoming default-active.
- Experimental rules are default-inactive; the new `--experimental` CLI flag (or `experimental: true` top-level config key) re-enables them as a set.
- Deprecated rules are default-inactive and intentionally **not** re-enabled by `--experimental` or `--all-rules` — users must name them explicitly via `--enable-rules` through the deprecation window.
- `ActiveRulesV2` gains an `experimental bool` parameter; `selectActiveRules` is the registry-agnostic core so unit tests can supply fake rule sets without touching global `api.Registry`.

Existing rules default to `MaturityStable` (zero value), so no registered rule changes activation behavior in this PR.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./... -count=1`
- [x] `make integration` (11/11 green)
- [x] New tests: `TestMaturity_String`, `TestRule_MaturityZeroValueIsStable`, `TestFakeRule_WithMaturity`, and 6 `TestSelectActiveRules_*` cases covering stable default, experimental gating, deprecated lockdown, disabled-wins, --all-rules behavior, and explicit enable.