### PR TITLE
Add ruletest package for capability-tier-aware rule tests

### DIFF
--- a/internal/rules/ruletest/ruletest.go
+++ b/internal/rules/ruletest/ruletest.go
@@ -1,0 +1,235 @@
+// Package ruletest is the canonical entry point for unit-testing rules.
+//
+// Detekt's testing API splits along the type-resolution axis: lint() for
+// rules that only need PSI and lintWithContext() for rules that need a
+// resolved BindingContext. The Krit equivalent splits along capability
+// tiers — each helper here exposes exactly one tier, and panics with a
+// clear message when the rule under test declares more than the tier
+// can provide. That makes capability declarations executable: a rule
+// that quietly grew a NeedsResolver dependency will fail loudly the
+// first time a syntax-only test runs against it.
+//
+// Tiers, narrowest first:
+//
+//   - LintSource / LintSourceJava — AST/import-only. The rule's Needs
+//     bitfield must be zero (or contain only NeedsLinePass /
+//     NeedsAggregate / NeedsConcurrent, none of which require external
+//     facts).
+//   - LintWithResolver / LintWithResolverJava — adds a source-level
+//     typeinfer.TypeResolver indexed over the file. Allowed for rules
+//     declaring NeedsResolver. NeedsOracle is rejected; use the oracle
+//     helpers instead.
+//   - LintWithFakeOracle / LintWithFakeOracleJava — adds a CompositeResolver
+//     that wraps the supplied FakeOracle in front of the source-level
+//     resolver. Allowed for rules declaring NeedsResolver and / or
+//     NeedsOracle.
+//
+// Project-scope capabilities (NeedsCrossFile, NeedsModuleIndex,
+// NeedsParsedFiles, NeedsManifest, NeedsResources, NeedsGradle) are
+// rejected by every helper — those rules need a real pipeline phase
+// beyond what a single-file unit test can provide. Tests for them
+// should use the integration harness instead.
+package ruletest
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kaeawc/krit/internal/oracle"
+	"github.com/kaeawc/krit/internal/rules"
+	api "github.com/kaeawc/krit/internal/rules/api"
+	"github.com/kaeawc/krit/internal/scanner"
+	"github.com/kaeawc/krit/internal/typeinfer"
+)
+
+// projectScopeCaps are the capability bits that require a real pipeline
+// phase. None of the helpers here can provide them.
+const projectScopeCaps = api.NeedsCrossFile | api.NeedsModuleIndex |
+	api.NeedsParsedFiles | api.NeedsManifest | api.NeedsResources | api.NeedsGradle
+
+// LintSource parses src as Kotlin and runs ruleID against it without a
+// resolver, oracle, or any cross-file context. Use for rules whose
+// Needs bitfield is zero or only contains line-pass / aggregate /
+// concurrent aspects.
+//
+// Fails the test (via t.Fatalf) if ruleID is not registered, if the
+// rule declares any capability the tier cannot satisfy, or if parsing
+// fails.
+func LintSource(t *testing.T, ruleID, src string) []scanner.Finding {
+	t.Helper()
+	rule := requireRule(t, ruleID)
+	enforceTier(t, rule, "LintSource", 0)
+	file := writeAndParseKotlin(t, src)
+	return runDispatcher(t, rule, file, nil)
+}
+
+// LintSourceJava is the Java counterpart to LintSource. Same tier
+// constraints apply.
+func LintSourceJava(t *testing.T, ruleID, src string) []scanner.Finding {
+	t.Helper()
+	rule := requireRule(t, ruleID)
+	enforceTier(t, rule, "LintSourceJava", 0)
+	file := writeAndParseJava(t, src)
+	return runDispatcher(t, rule, file, nil)
+}
+
+// LintWithResolver parses src as Kotlin and runs ruleID with a
+// source-level TypeResolver indexed over the file. Use for rules
+// declaring NeedsResolver but not NeedsOracle.
+func LintWithResolver(t *testing.T, ruleID, src string) []scanner.Finding {
+	t.Helper()
+	rule := requireRule(t, ruleID)
+	enforceTier(t, rule, "LintWithResolver", api.NeedsResolver)
+	file := writeAndParseKotlin(t, src)
+	resolver := typeinfer.NewResolver()
+	resolver.IndexFilesParallel([]*scanner.File{file}, 1)
+	return runDispatcher(t, rule, file, resolver)
+}
+
+// LintWithResolverJava is the Java counterpart to LintWithResolver.
+func LintWithResolverJava(t *testing.T, ruleID, src string) []scanner.Finding {
+	t.Helper()
+	rule := requireRule(t, ruleID)
+	enforceTier(t, rule, "LintWithResolverJava", api.NeedsResolver)
+	file := writeAndParseJava(t, src)
+	resolver := typeinfer.NewResolver()
+	resolver.IndexFilesParallel([]*scanner.File{file}, 1)
+	return runDispatcher(t, rule, file, resolver)
+}
+
+// LintWithFakeOracle parses src as Kotlin and runs ruleID with a
+// CompositeResolver that consults fake before falling back to the
+// source-level TypeResolver. Use for rules declaring NeedsOracle (and
+// optionally NeedsResolver) when a unit test wants to seed specific
+// expression types or call-target stubs without standing up the real
+// oracle daemon.
+//
+// Pass nil for fake to wire only the source-level resolver — useful
+// when the rule's tested code path doesn't actually consult the
+// oracle for the snippet under test but the rule's declared Needs
+// includes NeedsOracle.
+func LintWithFakeOracle(t *testing.T, ruleID, src string, fake *oracle.FakeOracle) []scanner.Finding {
+	t.Helper()
+	rule := requireRule(t, ruleID)
+	enforceTier(t, rule, "LintWithFakeOracle", api.NeedsResolver|api.NeedsOracle)
+	file := writeAndParseKotlin(t, src)
+	resolver := makeOracleResolver(file, fake)
+	return runDispatcher(t, rule, file, resolver)
+}
+
+// LintWithFakeOracleJava is the Java counterpart to LintWithFakeOracle.
+func LintWithFakeOracleJava(t *testing.T, ruleID, src string, fake *oracle.FakeOracle) []scanner.Finding {
+	t.Helper()
+	rule := requireRule(t, ruleID)
+	enforceTier(t, rule, "LintWithFakeOracleJava", api.NeedsResolver|api.NeedsOracle)
+	file := writeAndParseJava(t, src)
+	resolver := makeOracleResolver(file, fake)
+	return runDispatcher(t, rule, file, resolver)
+}
+
+// ErrRuleNotRegistered is returned by lookupRule when the requested
+// rule ID is not present in api.Registry. Exposed so tests for the
+// validation layer can match the error type without parsing strings.
+var ErrRuleNotRegistered = errors.New("rule not registered")
+
+func requireRule(t *testing.T, ruleID string) *api.Rule {
+	t.Helper()
+	rule, err := lookupRule(ruleID)
+	if err != nil {
+		t.Fatalf("ruletest: %v", err)
+	}
+	return rule
+}
+
+// lookupRule returns the registered rule with the given ID, or
+// ErrRuleNotRegistered when no such rule exists.
+func lookupRule(ruleID string) (*api.Rule, error) {
+	for _, r := range api.Registry {
+		if r != nil && r.ID == ruleID {
+			return r, nil
+		}
+	}
+	return nil, fmt.Errorf("%w: %q", ErrRuleNotRegistered, ruleID)
+}
+
+func enforceTier(t *testing.T, rule *api.Rule, helper string, allowed api.Capabilities) {
+	t.Helper()
+	if err := validateTier(rule, helper, allowed); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// validateTier returns nil when rule's declared Needs are compatible
+// with the helper's allowed-capability set, or a descriptive error
+// otherwise.
+//
+// allowed is the union of capability bits the tier supplies in addition
+// to the always-allowed scope-shape bits (NeedsLinePass / NeedsAggregate
+// / NeedsConcurrent), which never demand external context.
+//
+// This function is package-private but tested directly by the ruletest
+// test suite — calling t.Fatalf inside a sub-test propagates failure to
+// the parent, so the validation layer needs to be testable without
+// going through *testing.T.
+func validateTier(rule *api.Rule, helper string, allowed api.Capabilities) error {
+	if rule.Needs&projectScopeCaps != 0 {
+		return fmt.Errorf("ruletest.%s: rule %q declares project-scope capability %v; use the integration harness instead",
+			helper, rule.ID, rule.Needs&projectScopeCaps)
+	}
+	tierAllowed := allowed | api.NeedsLinePass | api.NeedsAggregate | api.NeedsConcurrent
+	if extra := rule.Needs &^ tierAllowed; extra != 0 {
+		return fmt.Errorf("ruletest.%s: rule %q declares capability %v which this tier cannot provide; use a higher-tier helper",
+			helper, rule.ID, extra)
+	}
+	return nil
+}
+
+func writeAndParseKotlin(t *testing.T, src string) *scanner.File {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "test.kt")
+	if err := os.WriteFile(path, []byte(src), 0o644); err != nil {
+		t.Fatalf("ruletest: write Kotlin temp file: %v", err)
+	}
+	file, err := scanner.ParseFile(path)
+	if err != nil {
+		t.Fatalf("ruletest: parse Kotlin: %v", err)
+	}
+	return file
+}
+
+func writeAndParseJava(t *testing.T, src string) *scanner.File {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "Test.java")
+	if err := os.WriteFile(path, []byte(src), 0o644); err != nil {
+		t.Fatalf("ruletest: write Java temp file: %v", err)
+	}
+	file, err := scanner.ParseJavaFile(path)
+	if err != nil {
+		t.Fatalf("ruletest: parse Java: %v", err)
+	}
+	return file
+}
+
+func makeOracleResolver(file *scanner.File, fake *oracle.FakeOracle) typeinfer.TypeResolver {
+	source := typeinfer.NewResolver()
+	source.IndexFilesParallel([]*scanner.File{file}, 1)
+	if fake == nil {
+		return source
+	}
+	return oracle.NewCompositeResolver(fake, source)
+}
+
+func runDispatcher(t *testing.T, rule *api.Rule, file *scanner.File, resolver typeinfer.TypeResolver) []scanner.Finding {
+	t.Helper()
+	var d *rules.Dispatcher
+	if resolver != nil {
+		d = rules.NewDispatcher([]*api.Rule{rule}, resolver)
+	} else {
+		d = rules.NewDispatcher([]*api.Rule{rule})
+	}
+	cols := d.Run(file)
+	return cols.Findings()
+}

--- a/internal/rules/ruletest/ruletest_test.go
+++ b/internal/rules/ruletest/ruletest_test.go
@@ -1,0 +1,195 @@
+package ruletest
+
+import (
+	"errors"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/kaeawc/krit/internal/oracle"
+	api "github.com/kaeawc/krit/internal/rules/api"
+	"github.com/kaeawc/krit/internal/scanner"
+)
+
+// withRegisteredRule installs a synthetic rule into api.Registry for the
+// duration of the test, restoring the prior contents on cleanup.
+func withRegisteredRule(t *testing.T, r *api.Rule) {
+	t.Helper()
+	saved := api.Registry
+	t.Cleanup(func() { api.Registry = saved })
+	api.Registry = append(append([]*api.Rule{}, saved...), r)
+}
+
+// alwaysFireCheck is a Check that emits one finding on every node it
+// receives. Combined with NodeTypes: nil + Needs = 0 it dispatches as a
+// "every node" rule via ScopePerFileAllNodes, which the harness routes
+// through the same code path real rules use.
+func alwaysFireCheck(name string) func(*api.Context) {
+	var fired atomic.Bool
+	return func(ctx *api.Context) {
+		if fired.Swap(true) {
+			return
+		}
+		ctx.Emit(scanner.Finding{
+			Rule:     name,
+			Message:  "synthetic " + name + " finding",
+			Line:     1,
+			Col:      1,
+			Severity: "warning",
+		})
+	}
+}
+
+func TestLintSource_AcceptsZeroNeedsRule(t *testing.T) {
+	withRegisteredRule(t, &api.Rule{
+		ID:          "TestRuletestLintSourceRule",
+		Description: "synthetic zero-needs rule for ruletest happy path",
+		Check:       alwaysFireCheck("TestRuletestLintSourceRule"),
+	})
+	got := LintSource(t, "TestRuletestLintSourceRule", "class A\n")
+	if len(got) == 0 {
+		t.Fatal("LintSource returned no findings; expected synthetic rule to fire")
+	}
+}
+
+func TestLintSourceJava_AcceptsZeroNeedsRule(t *testing.T) {
+	withRegisteredRule(t, &api.Rule{
+		ID:          "TestRuletestLintSourceJavaRule",
+		Description: "synthetic zero-needs rule for Java ruletest happy path",
+		Languages:   []scanner.Language{scanner.LangJava},
+		Check:       alwaysFireCheck("TestRuletestLintSourceJavaRule"),
+	})
+	got := LintSourceJava(t, "TestRuletestLintSourceJavaRule",
+		"class Test { void m() {} }\n")
+	if len(got) == 0 {
+		t.Fatal("LintSourceJava returned no findings; expected synthetic rule to fire")
+	}
+}
+
+func TestLintWithResolver_AcceptsNeedsResolver(t *testing.T) {
+	withRegisteredRule(t, &api.Rule{
+		ID:          "TestRuletestLintWithResolverRule",
+		Description: "synthetic NeedsResolver rule for ruletest happy path",
+		Needs:       api.NeedsResolver,
+		Check:       alwaysFireCheck("TestRuletestLintWithResolverRule"),
+	})
+	got := LintWithResolver(t, "TestRuletestLintWithResolverRule", "class A\n")
+	if len(got) == 0 {
+		t.Fatal("LintWithResolver returned no findings; expected synthetic rule to fire")
+	}
+}
+
+func TestLintWithFakeOracle_AcceptsNeedsOracle(t *testing.T) {
+	withRegisteredRule(t, &api.Rule{
+		ID:          "TestRuletestLintWithFakeOracleRule",
+		Description: "synthetic NeedsOracle rule for ruletest happy path",
+		Needs:       api.NeedsOracle | api.NeedsResolver,
+		Check:       alwaysFireCheck("TestRuletestLintWithFakeOracleRule"),
+	})
+	fake := oracle.NewFakeOracle()
+	got := LintWithFakeOracle(t, "TestRuletestLintWithFakeOracleRule", "class A\n", fake)
+	if len(got) == 0 {
+		t.Fatal("LintWithFakeOracle returned no findings; expected synthetic rule to fire")
+	}
+}
+
+func TestLintWithFakeOracle_NilFakeUsesSourceResolverOnly(t *testing.T) {
+	withRegisteredRule(t, &api.Rule{
+		ID:          "TestRuletestLintWithFakeOracleNilRule",
+		Description: "synthetic rule for nil-fake oracle path",
+		Needs:       api.NeedsResolver,
+		Check:       alwaysFireCheck("TestRuletestLintWithFakeOracleNilRule"),
+	})
+	got := LintWithFakeOracle(t, "TestRuletestLintWithFakeOracleNilRule", "class A\n", nil)
+	if len(got) == 0 {
+		t.Fatal("LintWithFakeOracle with nil fake returned no findings")
+	}
+}
+
+// Tier-validation tests target validateTier directly. The exported
+// helpers call t.Fatalf on a tier mismatch, but t.Fatalf inside a
+// sub-test propagates failure to the parent — so we test the pure
+// validation function instead and assume the helpers wire it correctly
+// (verified by the happy-path tests above).
+
+func TestValidateTier_LintSourceTier_RejectsNeedsResolver(t *testing.T) {
+	rule := &api.Rule{ID: "TestRuletestValidateResolver", Needs: api.NeedsResolver}
+	err := validateTier(rule, "LintSource", 0)
+	if err == nil {
+		t.Fatal("validateTier accepted NeedsResolver for the LintSource tier")
+	}
+	if !strings.Contains(err.Error(), "higher-tier helper") {
+		t.Errorf("expected tier-mismatch hint in error, got: %v", err)
+	}
+}
+
+func TestValidateTier_AnyTier_RejectsProjectScopeCapability(t *testing.T) {
+	cases := []api.Capabilities{
+		api.NeedsCrossFile,
+		api.NeedsModuleIndex,
+		api.NeedsParsedFiles,
+		api.NeedsManifest,
+		api.NeedsResources,
+		api.NeedsGradle,
+	}
+	for _, cap := range cases {
+		rule := &api.Rule{ID: "TestRuletestValidateProjectScope", Needs: cap}
+		err := validateTier(rule, "LintWithFakeOracle", api.NeedsResolver|api.NeedsOracle)
+		if err == nil {
+			t.Errorf("validateTier accepted project-scope capability %v", cap)
+			continue
+		}
+		if !strings.Contains(err.Error(), "integration harness") {
+			t.Errorf("expected integration-harness hint for %v, got: %v", cap, err)
+		}
+	}
+}
+
+func TestValidateTier_LintWithResolverTier_RejectsNeedsOracle(t *testing.T) {
+	rule := &api.Rule{ID: "TestRuletestValidateOracle", Needs: api.NeedsResolver | api.NeedsOracle}
+	err := validateTier(rule, "LintWithResolver", api.NeedsResolver)
+	if err == nil {
+		t.Fatal("validateTier accepted NeedsOracle for the LintWithResolver tier")
+	}
+}
+
+func TestValidateTier_AllowsScopeShapeBits(t *testing.T) {
+	// NeedsLinePass / NeedsAggregate / NeedsConcurrent describe the
+	// rule's dispatcher shape, not external context, so every tier
+	// must accept them.
+	for _, cap := range []api.Capabilities{api.NeedsLinePass, api.NeedsAggregate, api.NeedsConcurrent} {
+		rule := &api.Rule{ID: "TestRuletestValidateShape", Needs: cap}
+		if err := validateTier(rule, "LintSource", 0); err != nil {
+			t.Errorf("validateTier rejected scope-shape bit %v at LintSource tier: %v", cap, err)
+		}
+	}
+}
+
+func TestValidateTier_AcceptsExpectedTierCapability(t *testing.T) {
+	rule := &api.Rule{ID: "TestRuletestValidateExpected", Needs: api.NeedsResolver}
+	if err := validateTier(rule, "LintWithResolver", api.NeedsResolver); err != nil {
+		t.Errorf("validateTier rejected NeedsResolver at LintWithResolver tier: %v", err)
+	}
+}
+
+func TestLookupRule_UnknownReturnsErrRuleNotRegistered(t *testing.T) {
+	_, err := lookupRule("TestRuletestNoSuchRule_xyz")
+	if !errors.Is(err, ErrRuleNotRegistered) {
+		t.Errorf("lookupRule for unknown ID returned %v, want ErrRuleNotRegistered", err)
+	}
+}
+
+func TestLookupRule_RegisteredReturnsRule(t *testing.T) {
+	withRegisteredRule(t, &api.Rule{
+		ID:          "TestRuletestLookupHit",
+		Description: "synthetic rule for lookup test",
+		Check:       func(*api.Context) {},
+	})
+	rule, err := lookupRule("TestRuletestLookupHit")
+	if err != nil {
+		t.Fatalf("lookupRule unexpected error: %v", err)
+	}
+	if rule == nil || rule.ID != "TestRuletestLookupHit" {
+		t.Errorf("lookupRule returned %v, want rule with ID TestRuletestLookupHit", rule)
+	}
+}

--- a/internal/ruleslinter/topology.go
+++ b/internal/ruleslinter/topology.go
@@ -43,8 +43,14 @@ func AnalyzeSubpackageTopology(rulesParentDir string) ([]Violation, error) {
 		// import whatever they need; they are not domain rule packages.
 		// (v2 was renamed to api in #1210; both names are tolerated until
 		// any remaining v2 directories are removed.)
+		//
+		// ruletest is the canonical test-helper package for rule unit
+		// tests. It depends on the parent rules package (it builds a
+		// Dispatcher) and is meant to be imported from _test.go files
+		// only, so the production-side topology constraint does not
+		// apply.
 		switch e.Name() {
-		case "api", "v2", "base", "semantics":
+		case "api", "v2", "base", "semantics", "ruletest":
 			continue
 		}
 		subDir := filepath.Join(rulesParentDir, e.Name())


### PR DESCRIPTION
## Summary

Detekt's testing API splits along the type-resolution axis: `lint()` for syntax-only tests, `lintWithContext()` for type-aware tests. The Krit equivalent splits along **capability tiers** — each helper exposes exactly one tier, and rejects rules that declare more than the tier provides. That makes capability declarations executable: a rule that quietly grew a `NeedsResolver` dependency will fail loudly the first time a syntax-only test runs against it.

**Tiers** (narrowest first):

- `LintSource` / `LintSourceJava` — AST/import-only (`Needs == 0`)
- `LintWithResolver` / `LintWithResolverJava` — source-level `typeinfer.TypeResolver` (`NeedsResolver`)
- `LintWithFakeOracle` / `LintWithFakeOracleJava` — `CompositeResolver` over a caller-supplied `oracle.FakeOracle` (`NeedsResolver | NeedsOracle`)

Project-scope capabilities (`NeedsCrossFile`, `NeedsModuleIndex`, `NeedsParsedFiles`, `NeedsManifest`, `NeedsResources`, `NeedsGradle`) are rejected by every helper — those rules need a real pipeline phase.

The validation is split into pure functions (`validateTier`, `lookupRule`) so the rejection logic is unit-testable directly without going through `*testing.T` — calling `t.Fatalf` inside a sub-test propagates failure to the parent, which would otherwise force awkward sub-test-passes-when-it-fails patterns.

`ruleslinter`'s subpackage-topology check gets a new carve-out for `ruletest` (alongside `api`, `v2`, `base`, `semantics`) since `ruletest` legitimately needs to import the parent `rules` package to build a `Dispatcher`.

Existing scattered helpers (`runRuleByName`, `runRuleWithFakeOracle`, etc.) are left in place. New rule tests should reach for `ruletest`; older sites can migrate incrementally.

## Test plan

- [x] `go test ./internal/rules/ruletest/ -v` — 12 cases (5 happy paths × 4 helpers + 7 validation cases)
- [x] `go test ./internal/ruleslinter/ -v` — topology carve-out verified
- [x] `go test ./...` — all packages green
- [x] `make integration` — playground lint/fix/diff/SARIF, CLI/LSP/MCP, all unit tests
- [x] `go vet ./...` — clean