### PR TITLE
Fix pre-existing CI lint failures

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -48,6 +48,7 @@ linters:
     gosec:
       excludes:
         - G104  # best-effort cleanup is intentional
+        - G107  # caller-supplied URLs are by-design (lint-catalog, httpx)
         - G115  # integer-overflow conversions are bounded by upstream invariants
         - G204  # Krit shells out to git/gradle/javac/etc. by design
         - G301  # directory permissions intentional for project dirs

--- a/cmd/lint-catalog/main.go
+++ b/cmd/lint-catalog/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -43,8 +44,8 @@ type CheckInfo struct {
 // Catalog is the top-level structure written to catalog.json.
 type Catalog struct {
 	Source    string      `json:"source"`
-	FetchedAt string     `json:"fetchedAt"`
-	Checks   []CheckInfo `json:"checks"`
+	FetchedAt string      `json:"fetchedAt"`
+	Checks    []CheckInfo `json:"checks"`
 }
 
 func main() {
@@ -124,7 +125,7 @@ func run() error {
 	catalog := Catalog{
 		Source:    sourceURL,
 		FetchedAt: time.Now().UTC().Format(time.RFC3339),
-		Checks:   checks,
+		Checks:    checks,
 	}
 
 	catalogJSON, err := json.MarshalIndent(catalog, "", "  ")
@@ -142,7 +143,11 @@ func run() error {
 }
 
 func httpGet(url string) (string, error) {
-	resp, err := http.Get(url)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, url, nil)
+	if err != nil {
+		return "", err
+	}
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return "", err
 	}

--- a/internal/rules/compose.go
+++ b/internal/rules/compose.go
@@ -736,10 +736,6 @@ func composeFileHasRuntimeComposableEvidence(file *scanner.File) bool {
 		bytes.Contains(file.Content, []byte("@androidx.compose.runtime.Composable"))
 }
 
-func composeFunctionHasPreviewAnnotation(file *scanner.File, fn uint32) bool {
-	return composeFunctionHasPreviewAnnotationWithConfig(file, fn, defaultCustomPreviewConfig())
-}
-
 func composeFunctionHasPreviewAnnotationWithConfig(file *scanner.File, fn uint32, cfg customPreviewConfig) bool {
 	if flatHasCustomPreviewAnnotation(file, fn, cfg) {
 		return true

--- a/internal/rules/custom_preview.go
+++ b/internal/rules/custom_preview.go
@@ -11,10 +11,6 @@ type customPreviewConfig struct {
 	Prefixes []string
 }
 
-func defaultCustomPreviewConfig() customPreviewConfig {
-	return customPreviewConfig{Wildcard: true}
-}
-
 func customPreviewConfigFromFields(wildcard bool, prefixes []string) customPreviewConfig {
 	return customPreviewConfig{Wildcard: wildcard, Prefixes: prefixes}
 }

--- a/internal/rules/style_forbidden.go
+++ b/internal/rules/style_forbidden.go
@@ -679,13 +679,9 @@ func callExpressionHasDurationUnitArg(file *scanner.File, callIdx uint32) bool {
 	return false
 }
 
-// isInsidePreviewOrSampleFunction returns true if the node is inside a
-// function whose name or annotation marks it as a preview / sample / fake
-// / mock / stub — UI tooling scaffolding rather than production code.
-func isInsidePreviewOrSampleFunctionFlat(file *scanner.File, idx uint32) bool {
-	return isInsidePreviewOrSampleFunctionFlatWithConfig(file, idx, defaultCustomPreviewConfig())
-}
-
+// isInsidePreviewOrSampleFunctionFlatWithConfig returns true if the node is
+// inside a function whose name or annotation marks it as a preview / sample
+// / fake / mock / stub — UI tooling scaffolding rather than production code.
 func isInsidePreviewOrSampleFunctionFlatWithConfig(file *scanner.File, idx uint32, cfg customPreviewConfig) bool {
 	for p, ok := file.FlatParent(idx); ok; p, ok = file.FlatParent(p) {
 		nodeType := file.FlatType(p)
@@ -715,10 +711,6 @@ func isInsidePreviewOrSampleFunctionFlatWithConfig(file *scanner.File, idx uint3
 		return false
 	}
 	return false
-}
-
-func previewOrSampleFunctionLikeText(text string) bool {
-	return previewOrSampleFunctionLikeTextWithConfig(text, defaultCustomPreviewConfig())
 }
 
 func previewOrSampleFunctionLikeTextWithConfig(text string, cfg customPreviewConfig) bool {


### PR DESCRIPTION
## Summary

\`golangci-lint\` on \`main\` has been failing for six issues unrelated to recent feature work. They block branch protection on every new PR. This unblocks them.

| Linter | File | Fix |
|---|---|---|
| gofmt | \`cmd/lint-catalog/main.go:46\` | Realign struct tags |
| noctx (was G107 in prior CI run) | \`cmd/lint-catalog/main.go:145\` | \`http.Get\` → \`NewRequestWithContext\` + \`DefaultClient.Do\` |
| gosec | \`.golangci.yml\` | Add \`G107\` to excludes (matches the standalone \`gosec\` invocation in \`.github/workflows/ci.yml\`) |
| unused × 4 | \`internal/rules/{compose,custom_preview,style_forbidden}.go\` | Drop default-args wrappers with no callers; the \`*WithConfig\` variants are widely used |

## Why

Without this, every new PR gets a red \`golangci-lint\` check from issues it didn't introduce, and \`gh pr merge --squash\` is rejected with \"the base branch policy prohibits the merge.\"

## Test plan

- [x] \`golangci-lint run ./...\` → \`0 issues\`
- [x] \`go vet ./...\`, \`go test ./... -count=1\` clean
- [x] \`make integration\` (11/11 pass)
- [x] \`make regression\` pass
- [x] \`go build ./cmd/lint-catalog/\` clean (the http.Get refactor compiles)