### PR TITLE
Fix pre-existing golangci-lint failures

### DIFF
--- a/cmd/lint-catalog/main.go
+++ b/cmd/lint-catalog/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -43,8 +44,8 @@ type CheckInfo struct {
 // Catalog is the top-level structure written to catalog.json.
 type Catalog struct {
 	Source    string      `json:"source"`
-	FetchedAt string     `json:"fetchedAt"`
-	Checks   []CheckInfo `json:"checks"`
+	FetchedAt string      `json:"fetchedAt"`
+	Checks    []CheckInfo `json:"checks"`
 }
 
 func main() {
@@ -124,7 +125,7 @@ func run() error {
 	catalog := Catalog{
 		Source:    sourceURL,
 		FetchedAt: time.Now().UTC().Format(time.RFC3339),
-		Checks:   checks,
+		Checks:    checks,
 	}
 
 	catalogJSON, err := json.MarshalIndent(catalog, "", "  ")
@@ -142,7 +143,13 @@ func run() error {
 }
 
 func httpGet(url string) (string, error) {
-	resp, err := http.Get(url)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil) // #nosec G107 -- catalog fetcher: URL is supplied by the operator, not external input
+	if err != nil {
+		return "", err
+	}
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return "", err
 	}

--- a/internal/rules/compose.go
+++ b/internal/rules/compose.go
@@ -736,10 +736,6 @@ func composeFileHasRuntimeComposableEvidence(file *scanner.File) bool {
 		bytes.Contains(file.Content, []byte("@androidx.compose.runtime.Composable"))
 }
 
-func composeFunctionHasPreviewAnnotation(file *scanner.File, fn uint32) bool {
-	return composeFunctionHasPreviewAnnotationWithConfig(file, fn, defaultCustomPreviewConfig())
-}
-
 func composeFunctionHasPreviewAnnotationWithConfig(file *scanner.File, fn uint32, cfg customPreviewConfig) bool {
 	if flatHasCustomPreviewAnnotation(file, fn, cfg) {
 		return true

--- a/internal/rules/custom_preview.go
+++ b/internal/rules/custom_preview.go
@@ -11,10 +11,6 @@ type customPreviewConfig struct {
 	Prefixes []string
 }
 
-func defaultCustomPreviewConfig() customPreviewConfig {
-	return customPreviewConfig{Wildcard: true}
-}
-
 func customPreviewConfigFromFields(wildcard bool, prefixes []string) customPreviewConfig {
 	return customPreviewConfig{Wildcard: wildcard, Prefixes: prefixes}
 }

--- a/internal/rules/style_forbidden.go
+++ b/internal/rules/style_forbidden.go
@@ -679,13 +679,9 @@ func callExpressionHasDurationUnitArg(file *scanner.File, callIdx uint32) bool {
 	return false
 }
 
-// isInsidePreviewOrSampleFunction returns true if the node is inside a
-// function whose name or annotation marks it as a preview / sample / fake
-// / mock / stub — UI tooling scaffolding rather than production code.
-func isInsidePreviewOrSampleFunctionFlat(file *scanner.File, idx uint32) bool {
-	return isInsidePreviewOrSampleFunctionFlatWithConfig(file, idx, defaultCustomPreviewConfig())
-}
-
+// isInsidePreviewOrSampleFunctionFlatWithConfig returns true if the node is
+// inside a function whose name or annotation marks it as a preview / sample /
+// fake / mock / stub — UI tooling scaffolding rather than production code.
 func isInsidePreviewOrSampleFunctionFlatWithConfig(file *scanner.File, idx uint32, cfg customPreviewConfig) bool {
 	for p, ok := file.FlatParent(idx); ok; p, ok = file.FlatParent(p) {
 		nodeType := file.FlatType(p)
@@ -715,10 +711,6 @@ func isInsidePreviewOrSampleFunctionFlatWithConfig(file *scanner.File, idx uint3
 		return false
 	}
 	return false
-}
-
-func previewOrSampleFunctionLikeText(text string) bool {
-	return previewOrSampleFunctionLikeTextWithConfig(text, defaultCustomPreviewConfig())
 }
 
 func previewOrSampleFunctionLikeTextWithConfig(text string, cfg customPreviewConfig) bool {


### PR DESCRIPTION
## Summary
- gofmt the Catalog struct in `cmd/lint-catalog/main.go` and switch `httpGet` to `http.NewRequestWithContext` with a 30s timeout (silences `noctx`); URL is operator-supplied so the request keeps a `#nosec G107` annotation.
- Delete four unused default-config wrappers in `internal/rules/compose.go`, `style_forbidden.go`, and `custom_preview.go`. Every caller already threads the `WithConfig` variant via `customPreviewConfigFromFields`.

These six findings have been red on main since the initial commit, blocking auto-merge for every downstream PR. After this change `golangci-lint run ./...` reports `0 issues` and `go test ./... -count=1` passes.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...` → 0 issues
- [x] `go test ./... -count=1`