### PR TITLE
Add Rule.RunAfter so dependent rules run in stable order

### DIFF
--- a/internal/rules/api/rule.go
+++ b/internal/rules/api/rule.go
@@ -471,6 +471,21 @@ type Rule struct {
 	// default-inactive; see the Maturity type docs for the full contract.
 	Maturity Maturity
 
+	// RunAfter declares rule IDs that must run before this rule within
+	// the dispatcher. The dispatcher topologically sorts active rules by
+	// these constraints once at construction; rules that name a non-active
+	// dependency are unconstrained (the missing dependency is silently
+	// ignored). Cycles among active rules are a programmer error and
+	// cause NewDispatcher to panic with the offending rule IDs.
+	//
+	// Use cases:
+	//   - A fixable rule whose autofix output another rule reads.
+	//   - Two rules emitting findings on the same node where downstream
+	//     tooling expects a stable ordering.
+	//
+	// Most rules do not need RunAfter and should leave it nil.
+	RunAfter []string
+
 	// Fix metadata
 	Fix FixLevel // FixNone → not fixable
 

--- a/internal/rules/dispatcher.go
+++ b/internal/rules/dispatcher.go
@@ -125,6 +125,11 @@ func NewDispatcher(rules []*api.Rule, resolver ...typeinfer.TypeResolver) *Dispa
 		d.typeResolver = resolver[0]
 	}
 
+	// Apply RunAfter ordering so any rule that declares a dependency
+	// runs after the rule(s) it depends on across every per-file scope
+	// bucket. Rules without RunAfter keep their original relative order.
+	rules = SortByRunAfter(rules)
+
 	// Classify each rule by its Scope (set explicitly on the rule, or
 	// derived from Needs + NodeTypes via RuleScope).
 	for _, r := range rules {

--- a/internal/rules/runafter.go
+++ b/internal/rules/runafter.go
@@ -1,0 +1,118 @@
+package rules
+
+import (
+	"sort"
+	"strings"
+
+	api "github.com/kaeawc/krit/internal/rules/api"
+)
+
+// SortByRunAfter returns rules reordered so each rule's RunAfter
+// dependencies precede it. The sort is stable: rules that are unrelated
+// to any dependency keep their original relative order. Nil entries are
+// dropped (the dispatcher already filters them).
+//
+// Dependencies that are not present in rules are silently ignored — a
+// rule can declare RunAfter on a constraint that only applies in some
+// rule sets without becoming a hard requirement.
+//
+// A cycle among active rules is a programmer error. SortByRunAfter
+// panics with the cycle's rule IDs so the offending registration shows
+// up in tests rather than as a silent runtime drift.
+func SortByRunAfter(rules []*api.Rule) []*api.Rule {
+	n := 0
+	for _, r := range rules {
+		if r != nil {
+			n++
+		}
+	}
+	if n == 0 {
+		return nil
+	}
+
+	byID := make(map[string]*api.Rule, n)
+	pos := make(map[string]int, n)
+	order := make([]*api.Rule, 0, n)
+	for i, r := range rules {
+		if r == nil {
+			continue
+		}
+		if _, dup := byID[r.ID]; dup {
+			// Duplicate IDs in the registry are a separate bug; preserve
+			// the first occurrence and drop the rest so the topo sort
+			// has a deterministic input.
+			continue
+		}
+		byID[r.ID] = r
+		pos[r.ID] = i
+		order = append(order, r)
+	}
+
+	indeg := make(map[string]int, len(order))
+	dependents := make(map[string][]string, len(order))
+	for _, r := range order {
+		for _, dep := range r.RunAfter {
+			if _, ok := byID[dep]; !ok {
+				continue
+			}
+			if dep == r.ID {
+				continue // self-edges are a no-op
+			}
+			indeg[r.ID]++
+			dependents[dep] = append(dependents[dep], r.ID)
+		}
+	}
+
+	// Kahn's algorithm with a stable tiebreaker: ready entries are
+	// processed in original-input order so unrelated rules keep their
+	// registry sequence.
+	ready := make([]string, 0, len(order))
+	for _, r := range order {
+		if indeg[r.ID] == 0 {
+			ready = append(ready, r.ID)
+		}
+	}
+
+	out := make([]*api.Rule, 0, len(order))
+	processed := make(map[string]bool, len(order))
+	for len(ready) > 0 {
+		id := ready[0]
+		ready = ready[1:]
+		if processed[id] {
+			continue
+		}
+		processed[id] = true
+		out = append(out, byID[id])
+
+		deps := dependents[id]
+		sort.SliceStable(deps, func(i, j int) bool {
+			return pos[deps[i]] < pos[deps[j]]
+		})
+		newReady := make([]string, 0, len(deps))
+		for _, dep := range deps {
+			indeg[dep]--
+			if indeg[dep] == 0 {
+				newReady = append(newReady, dep)
+			}
+		}
+		// Insert new-ready entries at the head in original-input order
+		// so they queue before any already-pending entries with later
+		// positions. This matches the stable ordering guarantee.
+		ready = append(newReady, ready...)
+		sort.SliceStable(ready, func(i, j int) bool {
+			return pos[ready[i]] < pos[ready[j]]
+		})
+	}
+
+	if len(out) != len(order) {
+		var cycle []string
+		for _, r := range order {
+			if !processed[r.ID] {
+				cycle = append(cycle, r.ID)
+			}
+		}
+		sort.Strings(cycle)
+		panic("rules: RunAfter cycle detected among: " + strings.Join(cycle, ", "))
+	}
+	return out
+}

--- a/internal/rules/runafter_test.go
+++ b/internal/rules/runafter_test.go
@@ -1,0 +1,142 @@
+package rules
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	api "github.com/kaeawc/krit/internal/rules/api"
+)
+
+func runAfterRule(id string, after ...string) *api.Rule {
+	return &api.Rule{
+		ID:          id,
+		Description: "fake",
+		RunAfter:    after,
+		Check:       func(*api.Context) {},
+	}
+}
+
+func runAfterIDs(rs []*api.Rule) []string {
+	out := make([]string, len(rs))
+	for i, r := range rs {
+		out[i] = r.ID
+	}
+	return out
+}
+
+func TestSortByRunAfter_NoConstraintsKeepsOrder(t *testing.T) {
+	in := []*api.Rule{runAfterRule("A"), runAfterRule("B"), runAfterRule("C")}
+	got := runAfterIDs(SortByRunAfter(in))
+	want := []string{"A", "B", "C"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("order = %v, want %v", got, want)
+	}
+}
+
+func TestSortByRunAfter_DepRunsFirst(t *testing.T) {
+	// B depends on A; both in registration order [B, A] → A must come first.
+	in := []*api.Rule{runAfterRule("B", "A"), runAfterRule("A")}
+	got := runAfterIDs(SortByRunAfter(in))
+	want := []string{"A", "B"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("order = %v, want %v", got, want)
+	}
+}
+
+func TestSortByRunAfter_StableForUnrelated(t *testing.T) {
+	// X has no relationship with the A→B chain; it must keep its
+	// original position relative to other unrelated rules.
+	in := []*api.Rule{
+		runAfterRule("X"),
+		runAfterRule("B", "A"),
+		runAfterRule("Y"),
+		runAfterRule("A"),
+	}
+	got := runAfterIDs(SortByRunAfter(in))
+	// A must precede B; X and Y keep registry order; A is allowed to
+	// move earlier than its registration position to satisfy B's
+	// constraint, but X (which has no dependency) must still appear
+	// before Y because that was the registry order.
+	if posOf(got, "A") >= posOf(got, "B") {
+		t.Errorf("A must run before B; got %v", got)
+	}
+	if posOf(got, "X") >= posOf(got, "Y") {
+		t.Errorf("X must keep its order before Y; got %v", got)
+	}
+}
+
+func TestSortByRunAfter_MissingDepIsIgnored(t *testing.T) {
+	// B depends on a rule that is not in the active set; the
+	// constraint becomes a no-op and original order is preserved.
+	in := []*api.Rule{runAfterRule("B", "GhostRule"), runAfterRule("A")}
+	got := runAfterIDs(SortByRunAfter(in))
+	want := []string{"B", "A"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("order = %v, want %v (missing deps must be ignored)", got, want)
+	}
+}
+
+func TestSortByRunAfter_SelfEdgeIsIgnored(t *testing.T) {
+	// A self-edge would otherwise make in-degree non-zero forever.
+	in := []*api.Rule{runAfterRule("A", "A"), runAfterRule("B")}
+	got := runAfterIDs(SortByRunAfter(in))
+	want := []string{"A", "B"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("order = %v, want %v", got, want)
+	}
+}
+
+func TestSortByRunAfter_DropsNilEntries(t *testing.T) {
+	in := []*api.Rule{nil, runAfterRule("A"), nil, runAfterRule("B", "A")}
+	got := runAfterIDs(SortByRunAfter(in))
+	want := []string{"A", "B"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("order = %v, want %v", got, want)
+	}
+}
+
+func TestSortByRunAfter_CyclePanics(t *testing.T) {
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("expected panic on cycle")
+		}
+		msg, ok := r.(string)
+		if !ok || !strings.Contains(msg, "RunAfter cycle") {
+			t.Fatalf("expected RunAfter cycle message, got %v", r)
+		}
+		if !strings.Contains(msg, "A") || !strings.Contains(msg, "B") {
+			t.Fatalf("cycle message should name both rules, got %q", msg)
+		}
+	}()
+	in := []*api.Rule{
+		runAfterRule("A", "B"),
+		runAfterRule("B", "A"),
+	}
+	SortByRunAfter(in)
+}
+
+func TestSortByRunAfter_TransitiveChain(t *testing.T) {
+	// C depends on B; B depends on A. Output must be A, B, C even when
+	// inputs are reversed.
+	in := []*api.Rule{
+		runAfterRule("C", "B"),
+		runAfterRule("B", "A"),
+		runAfterRule("A"),
+	}
+	got := runAfterIDs(SortByRunAfter(in))
+	want := []string{"A", "B", "C"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("order = %v, want %v", got, want)
+	}
+}
+
+func posOf(ss []string, s string) int {
+	for i, v := range ss {
+		if v == s {
+			return i
+		}
+	}
+	return -1
+}


### PR DESCRIPTION
## Summary
ktlint exposes `runAfter` so e.g. `max-line-length` runs after `trailing-comma` rewrites. Krit fires rules in registration order with no way to declare a dependency, which makes overlapping fixes and downstream tooling fragile when two rules touch the same node.

- New `Rule.RunAfter []string` on `api.Rule`. Most rules leave it nil.
- `SortByRunAfter(rules)` — Kahn's algorithm with a stable tiebreaker so unrelated rules keep their registry order. Missing deps are silently ignored, self-edges are ignored, cycles among active rules panic with the offending rule IDs.
- `NewDispatcher` applies the sort once before classification so every per-file scope bucket sees the ordered rule set.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `golangci-lint run ./...` (0 issues)
- [x] `go test ./... -count=1` (full suite green)
- [x] `make integration` (11/11 green)
- [x] 8 new unit tests in [internal/rules/runafter_test.go](internal/rules/runafter_test.go): no-constraint passthrough, basic dep ordering, stability for unrelated rules, missing-dep no-op, self-edge no-op, nil filtering, cycle panic message, transitive chain.