### PR TITLE
Add pkg/extension public surface for out-of-tree rules

### DIFF
--- a/docs/external-rules.md
+++ b/docs/external-rules.md
@@ -1,0 +1,75 @@
+# External Rules
+
+Krit's built-in registry follows the
+[rule scope guardrail](rule-scope.md). For rules that don't qualify —
+house style, project-specific conventions, opinionated checks — Krit
+exposes a public registration package so a downstream project can add
+rules without forking the analyzer.
+
+## In-process registration (today)
+
+A consumer that builds Krit from source (or vendors it as a library)
+imports [`pkg/extension`](../pkg/extension/extension.go) and calls
+`Register` from an `init()` block:
+
+```go
+package myteamrules
+
+import (
+    "github.com/kaeawc/krit/pkg/extension"
+)
+
+func init() {
+    extension.Register(&extension.Rule{
+        ID:          "MyTeamRule",
+        Category:    "myteam",
+        Description: "Forbid direct calls to InternalThing",
+        Sev:         extension.SeverityWarning,
+        NodeTypes:   []string{"call_expression"},
+        Maturity:    extension.MaturityExperimental,
+        Check: func(ctx *extension.Context) {
+            // ...
+        },
+    })
+}
+```
+
+Importing the package anywhere in the build (`import _ "myorg/myteamrules"`
+in `cmd/krit/main.go`, for example) is enough — Go's `init()` runs the
+registration, and the dispatcher picks the rule up alongside the
+built-ins.
+
+External rules participate in every analyzer feature on equal footing:
+
+- `Maturity` gating (default-inactive Experimental, opt-in via
+  `--experimental` or `experimental: true` in `krit.yml`).
+- `RunAfter` ordering, so an external rule can depend on a built-in
+  by ID.
+- All scope buckets: per-file node, line pass, cross-file, manifest,
+  resource, gradle, aggregate.
+- Suppression via `@Suppress("MyTeamRule")` and `// krit:ignore[...]`.
+
+The `--list-rules` output, JSON/SARIF emitters, baseline files, and
+LSP/MCP servers see externals identically to built-ins.
+
+## Open design questions for true out-of-tree loading
+
+In-process registration requires recompiling Krit's binary. ktlint
+takes a different path — JARs discovered via `ServiceLoader`,
+loaded with `ktlint -R`. For Krit, every option has trade-offs:
+
+- **Go plugins** (`-buildmode=plugin`): supported on Linux/macOS but
+  notoriously brittle (toolchain pinning, race-detector incompatibility,
+  no reload on macOS). Not a good fit.
+- **Sidecar process**: spawn a rule provider over a stable IPC contract
+  (similar to `tools/krit-types/`). Most flexible, biggest implementation
+  cost (RPC schema, lifecycle, performance).
+- **WASM rule sandbox**: portable, sandboxed, slower than native. Open
+  question whether the API surface (`scanner.File`, `FlatTree`, oracle
+  facts) maps cleanly to a WASM contract.
+- **Embedded scripting** (Starlark, Lua): cheaper to integrate; only
+  expresses lexical/AST checks. Insufficient for type-aware rules.
+
+Until one of these lands, embedding via `pkg/extension` is the
+supported path. Open a discussion on the repo if your project has a
+strong opinion on which loader to invest in next.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -58,4 +58,5 @@ nav:
   - Configuration: configuration.md
   - Rules: rules.md
   - Rule Scope: rule-scope.md
+  - External Rules: external-rules.md
   - Integrations: integrations.md

--- a/pkg/extension/extension.go
+++ b/pkg/extension/extension.go
@@ -1,0 +1,119 @@
+// Package extension is the stable, public surface that downstream
+// projects use to register additional rules with Krit's analyzer.
+//
+// Krit's rule contract lives in internal/rules/api so the built-in
+// rule set can iterate it freely without committing to a public
+// import path. This package re-exports the subset that out-of-tree
+// rule authors need, so a project that vendors or builds against
+// Krit can register a rule without importing internal/.
+//
+// Today, registration is in-process only: a downstream project
+// imports this package, calls Register inside an init() block (or at
+// startup before the dispatcher is built), and the rule joins
+// api.Registry alongside the built-ins. True dynamic loading
+// (Go plugins, WASM rule sandboxes, sidecar protocols) is an open
+// design question — see docs/external-rules.md.
+//
+// Example:
+//
+//	package myrules
+//
+//	import (
+//	    "github.com/kaeawc/krit/pkg/extension"
+//	)
+//
+//	func init() {
+//	    extension.Register(&extension.Rule{
+//	        ID:          "MyTeamRule",
+//	        Category:    "myteam",
+//	        Description: "Checks an internal convention.",
+//	        Sev:         extension.SeverityWarning,
+//	        NodeTypes:   []string{"call_expression"},
+//	        Maturity:    extension.MaturityExperimental,
+//	        Check: func(ctx *extension.Context) {
+//	            // ...
+//	        },
+//	    })
+//	}
+//
+// External rules participate in every analyzer feature on equal
+// footing with built-ins: maturity gating, RunAfter ordering,
+// cross-file phases, suppression, and finding output.
+package extension
+
+import (
+	api "github.com/kaeawc/krit/internal/rules/api"
+)
+
+// Rule is the descriptor an external author registers. See
+// internal/rules/api.Rule for the full field documentation.
+type Rule = api.Rule
+
+// Context is the per-invocation context passed to a rule's Check.
+type Context = api.Context
+
+// Severity, FixLevel, Maturity, and Capabilities mirror the api
+// types so external code does not import internal/.
+type (
+	Severity     = api.Severity
+	FixLevel     = api.FixLevel
+	Maturity     = api.Maturity
+	Capabilities = api.Capabilities
+	Scope        = api.Scope
+)
+
+// Severity constants.
+const (
+	SeverityError   = api.SeverityError
+	SeverityWarning = api.SeverityWarning
+	SeverityInfo    = api.SeverityInfo
+)
+
+// FixLevel constants.
+const (
+	FixNone      = api.FixNone
+	FixCosmetic  = api.FixCosmetic
+	FixIdiomatic = api.FixIdiomatic
+	FixSemantic  = api.FixSemantic
+)
+
+// Maturity constants.
+const (
+	MaturityStable       = api.MaturityStable
+	MaturityExperimental = api.MaturityExperimental
+	MaturityDeprecated   = api.MaturityDeprecated
+)
+
+// Capability bits commonly set by external rules. The full list lives
+// on api.Capabilities; the names below cover the typical cases.
+const (
+	NeedsResolver    = api.NeedsResolver
+	NeedsLinePass    = api.NeedsLinePass
+	NeedsCrossFile   = api.NeedsCrossFile
+	NeedsParsedFiles = api.NeedsParsedFiles
+	NeedsConcurrent  = api.NeedsConcurrent
+)
+
+// Register adds a rule to Krit's registry. Panics with the same
+// preconditions as api.Register: ID and Description are required, and
+// Check (or Aggregate when NeedsAggregate is set) must be non-nil.
+//
+// Call this from init() in the downstream package, or from main()
+// before constructing the dispatcher. The order of registration
+// follows package init order; use Rule.RunAfter to declare any
+// dependency on a built-in rule by ID.
+func Register(r *Rule) {
+	api.Register(r)
+}
+
+// RegisterAll registers every rule in rs. nil entries are ignored.
+// Convenience for constructing a slice of rules in one place and
+// registering them in a single call.
+func RegisterAll(rs []*Rule) {
+	for _, r := range rs {
+		if r == nil {
+			continue
+		}
+		api.Register(r)
+	}
+}

--- a/pkg/extension/extension_test.go
+++ b/pkg/extension/extension_test.go
@@ -1,0 +1,83 @@
+package extension
+
+import (
+	"testing"
+
+	api "github.com/kaeawc/krit/internal/rules/api"
+)
+
+// TestRegister_AddsToRegistry confirms the public Register entrypoint
+// joins api.Registry on equal footing with built-in rules.
+func TestRegister_AddsToRegistry(t *testing.T) {
+	before := len(api.Registry)
+	defer restoreRegistry(before)
+
+	r := &Rule{
+		ID:          "ExtensionTestRule",
+		Category:    "test",
+		Description: "test rule registered via the public extension package",
+		Sev:         SeverityWarning,
+		Maturity:    MaturityExperimental,
+		Check:       func(*Context) {},
+	}
+	Register(r)
+
+	if len(api.Registry) != before+1 {
+		t.Fatalf("registry length = %d, want %d", len(api.Registry), before+1)
+	}
+	got := api.Registry[len(api.Registry)-1]
+	if got.ID != "ExtensionTestRule" {
+		t.Errorf("registered rule ID = %q, want ExtensionTestRule", got.ID)
+	}
+	if got.Maturity != MaturityExperimental {
+		t.Errorf("registered rule Maturity = %v, want experimental", got.Maturity)
+	}
+}
+
+// TestRegisterAll_SkipsNil confirms RegisterAll accepts a slice with
+// nil entries without panicking and registers only the real ones.
+func TestRegisterAll_SkipsNil(t *testing.T) {
+	before := len(api.Registry)
+	defer restoreRegistry(before)
+
+	RegisterAll([]*Rule{
+		nil,
+		{
+			ID:          "ExtensionBatchRuleA",
+			Description: "batch a",
+			Check:       func(*Context) {},
+		},
+		nil,
+		{
+			ID:          "ExtensionBatchRuleB",
+			Description: "batch b",
+			Check:       func(*Context) {},
+		},
+	})
+
+	if len(api.Registry) != before+2 {
+		t.Fatalf("registry length = %d, want %d", len(api.Registry), before+2)
+	}
+}
+
+// TestSeverityAndFixLevelAliases confirms the type aliases pass
+// through to api so external users can compare values directly.
+func TestSeverityAndFixLevelAliases(t *testing.T) {
+	if SeverityError != api.SeverityError {
+		t.Error("SeverityError alias drift")
+	}
+	if FixIdiomatic != api.FixIdiomatic {
+		t.Error("FixIdiomatic alias drift")
+	}
+	if MaturityDeprecated != api.MaturityDeprecated {
+		t.Error("MaturityDeprecated alias drift")
+	}
+}
+
+// restoreRegistry trims api.Registry back to the supplied length so
+// tests do not pollute later runs that count rules.
+func restoreRegistry(n int) {
+	if len(api.Registry) > n {
+		api.Registry = api.Registry[:n]
+	}
+}


### PR DESCRIPTION
## Summary
Krit's rule contract lives in `internal/rules/api`, so today downstream projects who want to add a rule have to fork or copy code — Go forbids importing `internal/`. This PR adds `pkg/extension` as a stable public surface that re-exports the subset out-of-tree authors need:

- Type aliases for `Rule`, `Context`, `Severity`, `FixLevel`, `Maturity`, `Capabilities`, `Scope`.
- Constants for common `Severity` / `FixLevel` / `Maturity` values and the capability bits external rules typically set.
- `Register` / `RegisterAll` wrappers around `api.Register` so a consumer can register a rule from `init()` and have it picked up by the dispatcher alongside built-ins.

External rules participate in every analyzer feature on equal footing: maturity gating, `RunAfter` ordering, every scope bucket, suppression, `--list-rules`, JSON/SARIF, baselines, LSP/MCP.

[`docs/external-rules.md`](docs/external-rules.md) walks through the embedder pattern with a worked example and lays out the open design questions for true out-of-tree loading (Go plugins, sidecar process, WASM, scripting). `mkdocs.yml` adds it to the nav.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `golangci-lint run ./...` (0 issues)
- [x] `go test ./... -count=1`
- [x] `make integration` (11/11 green)
- [x] Three unit tests in [pkg/extension/extension_test.go](pkg/extension/extension_test.go): Register adds to registry, RegisterAll skips nil, alias-drift guard between extension and api constants.