### PR TITLE
Add krit-mcp to Homebrew cask, fix docs deploy

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,7 +25,7 @@ jobs:
 
       - run: pip install mkdocs mkdocs-material
 
-      - run: python scripts/github/deploy_pages.py build
+      - run: mkdocs build
 
       - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -77,6 +77,7 @@ homebrew_casks:
     binaries:
       - krit
       - krit-lsp
+      - krit-mcp
 scoops:
   - repository:
       owner: kaeawc

--- a/homebrew/README.md
+++ b/homebrew/README.md
@@ -32,22 +32,12 @@ shasum -a 256 krit_0.1.0_darwin_arm64.tar.gz
 
 ## GoReleaser Integration
 
-GoReleaser can auto-update this formula on each release. Add to `.goreleaser.yaml`:
-```yaml
-brews:
-  - repository:
-      owner: kaeawc
-      name: homebrew-tap
-    folder: Formula
-    homepage: "https://github.com/kaeawc/krit"
-    description: "Go-first static analysis for Kotlin, Java, and Android"
-    license: "MIT"
-    install: |
-      bin.install "krit"
-      bin.install "krit-lsp"
-      bin.install "krit-mcp"
-    test: |
-      system "#{bin}/krit", "--version"
-```
+GoReleaser auto-publishes the formula to `kaeawc/homebrew-tap` on every
+tagged release — see the `brews:` block in `.goreleaser.yml` at the repo
+root. The manual formula in this directory is only a fallback template for
+the first release or for emergency manual publishes; under normal operation
+GoReleaser overwrites `Formula/krit.rb` in the tap repo with the correct
+URLs and SHAs.
 
-With this configuration, GoReleaser will automatically push updated formulas to the tap repository on every release.
+The release workflow needs a `HOMEBREW_TAP_TOKEN` secret with write access
+to `kaeawc/homebrew-tap`.

--- a/homebrew/krit.rb
+++ b/homebrew/krit.rb
@@ -31,6 +31,6 @@ class Krit < Formula
   end
 
   test do
-    system "#{bin}/krit", "--version"
+    system bin/"krit", "--version"
   end
 end


### PR DESCRIPTION
## Summary
- Adds `krit-mcp` to `homebrew_casks.binaries` so `brew install` actually installs the MCP server alongside `krit` and `krit-lsp`.
- Replaces the missing `python scripts/github/deploy_pages.py build` step in the docs workflow with a direct `mkdocs build` (the script does not exist in-tree, so every Pages deploy was failing).
- Audit nit in the manual `homebrew/krit.rb` template (`bin/"krit"` form).
- Updates `homebrew/README.md` to describe the GoReleaser-driven cask flow and the `HOMEBREW_TAP_TOKEN` requirement.

The lint failures on main (gofmt, gosec G107, four unused funcs) were already addressed on `origin/main` between the time I started and the rebase, so no rule-package changes ride along here.

## Test plan
- [x] `golangci-lint run ./...` → 0 issues
- [x] `go vet ./...` → clean
- [x] `goreleaser check` → config validates with no warnings
- [ ] Confirm next tag publishes `krit-mcp` into the cask in `kaeawc/homebrew-tap`