### PR TITLE
Re-enable SBOM generation via anchore/sbom-action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,12 @@ jobs:
           passphrase: ${{ secrets.GPG_PASSPHRASE }}
           fingerprint: ${{ secrets.GPG_FINGERPRINT }}
 
+      # Install syft so goreleaser's sboms: block can run. None of the
+      # GitHub-hosted runners ship syft preinstalled. anchore/sbom-action
+      # downloads the right binary for the current OS/arch.
+      - name: Install syft
+        uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+
       # `goreleaser release` doesn't accept --id filters (build-only flag),
       # so we filter the config down to this matrix entry's ids before
       # invoking it. See scripts/release/filter-goreleaser-config.py.

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -156,11 +156,11 @@ signs:
       - "--detach-sign"
       - "${artifact}"
 
-# SBOMs are disabled for the initial rc; goreleaser's `sboms:` invokes
-# `syft` which isn't preinstalled on runners. To re-enable: install via
-# `anchore/sbom-action` (or similar) in the workflow and uncomment.
-# sboms:
-#   - artifacts: archive
+# goreleaser invokes `syft` to catalog each archive into an SBOM.
+# The release workflow installs syft via anchore/sbom-action before
+# invoking goreleaser on each runner.
+sboms:
+  - artifacts: archive
 
 changelog:
   sort: asc


### PR DESCRIPTION
## Summary

The initial release disabled goreleaser's `sboms:` block because `syft` isn't preinstalled on any GitHub-hosted runner — rc1 retries failed with `exec: "syft": executable file not found`.

This adds `anchore/sbom-action/download-syft` (pinned at `v0.24.0`) on each matrix runner before goreleaser runs, then re-enables `sboms: - artifacts: archive` in `.goreleaser.yml`. Each platform's matrix runner produces an SBOM next to its archive; the funnel job's existing `*.sbom` glob already picks them up and includes them in the GitHub release.

## Test plan

- [ ] `goreleaser check` (passes locally)
- [ ] Push a `v*-rc` tag and verify `*.sbom` files appear as release assets alongside each archive