### PR TITLE
Re-enable linux/arm64 cross-compilation with explicit sysroot

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,10 +33,14 @@ jobs:
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with: { go-version-file: go.mod }
 
-      # No cross-toolchain install needed for the initial rc: linux is
-      # amd64-only (native gcc), darwin builds both archs via Apple
-      # clang's -arch flag, windows is amd64 native. arm64-linux and
-      # musl are disabled — see comments in .goreleaser.yml.
+      # Linux runner builds amd64 natively and arm64 via the
+      # gcc-aarch64-linux-gnu cross-toolchain. .goreleaser.yml's arm64
+      # override points CGO_CFLAGS / CGO_LDFLAGS at the arm64 sysroot
+      # so cgo finds the right headers. libc6-dev-arm64-cross is
+      # pulled in as a dependency of gcc-aarch64-linux-gnu.
+      - if: matrix.goos == 'linux'
+        name: Install Linux cross toolchains
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends gcc-aarch64-linux-gnu
 
       # Import the release signing subkey for goreleaser's signs: block.
       - name: Import GPG signing key

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -30,11 +30,20 @@ builds:
     ldflags:
       - -s -w -X main.version={{.Version}}
     goos: [linux]
-    goarch: [amd64]
-    # arm64-linux is disabled — aarch64-linux-gnu-gcc + cgo on
-    # ubuntu-24.04 picks up the host's /usr/include instead of the
-    # arm64 sysroot and fails on bits/libc-header-start.h. Tracked as
-    # a follow-up; needs sysroot configuration or zig-cc.
+    goarch: [amd64, arm64]
+    overrides:
+      - goos: linux
+        goarch: arm64
+        # ubuntu-24.04 ships gcc-aarch64-linux-gnu (apt-installed by
+        # release.yml). Without an explicit sysroot, cgo's
+        # _cgo_export.c falls through to /usr/include (host glibc),
+        # which fails on bits/libc-header-start.h. The sysroot points
+        # the cross-compiler at the arm64 dev headers instead.
+        env:
+          - CGO_ENABLED=1
+          - CC=aarch64-linux-gnu-gcc
+          - CGO_CFLAGS=--sysroot=/usr/aarch64-linux-gnu
+          - CGO_LDFLAGS=--sysroot=/usr/aarch64-linux-gnu
   - id: krit-lsp-linux
     main: ./cmd/krit-lsp
     binary: krit-lsp
@@ -42,11 +51,20 @@ builds:
     ldflags:
       - -s -w -X main.version={{.Version}}
     goos: [linux]
-    goarch: [amd64]
-    # arm64-linux is disabled — aarch64-linux-gnu-gcc + cgo on
-    # ubuntu-24.04 picks up the host's /usr/include instead of the
-    # arm64 sysroot and fails on bits/libc-header-start.h. Tracked as
-    # a follow-up; needs sysroot configuration or zig-cc.
+    goarch: [amd64, arm64]
+    overrides:
+      - goos: linux
+        goarch: arm64
+        # ubuntu-24.04 ships gcc-aarch64-linux-gnu (apt-installed by
+        # release.yml). Without an explicit sysroot, cgo's
+        # _cgo_export.c falls through to /usr/include (host glibc),
+        # which fails on bits/libc-header-start.h. The sysroot points
+        # the cross-compiler at the arm64 dev headers instead.
+        env:
+          - CGO_ENABLED=1
+          - CC=aarch64-linux-gnu-gcc
+          - CGO_CFLAGS=--sysroot=/usr/aarch64-linux-gnu
+          - CGO_LDFLAGS=--sysroot=/usr/aarch64-linux-gnu
   - id: krit-mcp-linux
     main: ./cmd/krit-mcp
     binary: krit-mcp
@@ -54,11 +72,20 @@ builds:
     ldflags:
       - -s -w -X main.version={{.Version}}
     goos: [linux]
-    goarch: [amd64]
-    # arm64-linux is disabled — aarch64-linux-gnu-gcc + cgo on
-    # ubuntu-24.04 picks up the host's /usr/include instead of the
-    # arm64 sysroot and fails on bits/libc-header-start.h. Tracked as
-    # a follow-up; needs sysroot configuration or zig-cc.
+    goarch: [amd64, arm64]
+    overrides:
+      - goos: linux
+        goarch: arm64
+        # ubuntu-24.04 ships gcc-aarch64-linux-gnu (apt-installed by
+        # release.yml). Without an explicit sysroot, cgo's
+        # _cgo_export.c falls through to /usr/include (host glibc),
+        # which fails on bits/libc-header-start.h. The sysroot points
+        # the cross-compiler at the arm64 dev headers instead.
+        env:
+          - CGO_ENABLED=1
+          - CC=aarch64-linux-gnu-gcc
+          - CGO_CFLAGS=--sysroot=/usr/aarch64-linux-gnu
+          - CGO_LDFLAGS=--sysroot=/usr/aarch64-linux-gnu
 
   # --- Linux / musl ----------------------------------------------------------
   # Disabled for now: ubuntu-24.04's musl-tools wrapper falls back to

--- a/install.sh
+++ b/install.sh
@@ -88,10 +88,10 @@ if [ "$goos" = linux ] && ldd /bin/ls 2>&1 | grep -qi musl; then
 fi
 
 # Currently published archives:
-#   linux/amd64, darwin/amd64, darwin/arm64, windows/amd64
+#   linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, windows/amd64
 # Anything else is a follow-up; bail with a build-from-source pointer.
 case "${goos}/${goarch}" in
-  linux/amd64|darwin/amd64|darwin/arm64|windows/amd64) ;;
+  linux/amd64|linux/arm64|darwin/amd64|darwin/arm64|windows/amd64) ;;
   *)
     err "${goos}/${goarch} archives are not currently published; build from source with 'go install github.com/kaeawc/krit/cmd/krit@latest'"
     ;;

--- a/scripts/release/update-brew-tap.sh
+++ b/scripts/release/update-brew-tap.sh
@@ -33,6 +33,7 @@ sha_for() {
 # uses a relative dist/ path). Only the archives we currently publish.
 DARWIN_ARM64=$(sha_for "krit_${VERSION}_darwin_arm64.tar.gz")
 DARWIN_AMD64=$(sha_for "krit_${VERSION}_darwin_amd64.tar.gz")
+LINUX_ARM64=$(sha_for "krit_${VERSION}_linux_arm64.tar.gz")
 LINUX_AMD64=$(sha_for "krit_${VERSION}_linux_amd64.tar.gz")
 
 URL_BASE="https://github.com/${REPO}/releases/download/${TAG}"
@@ -63,12 +64,14 @@ cask "krit" do
   end
 
   on_linux do
+    on_arm do
+      url "${URL_BASE}/krit_#{version}_linux_arm64.tar.gz"
+      sha256 "${LINUX_ARM64}"
+    end
     on_intel do
       url "${URL_BASE}/krit_#{version}_linux_amd64.tar.gz"
       sha256 "${LINUX_AMD64}"
     end
-    # Linux arm64 archive is a follow-up; the cross-toolchain on
-    # ubuntu-24.04 needs sysroot fixes to build cgo cleanly.
   end
 
   name "krit"


### PR DESCRIPTION
## Summary

The initial release disabled `linux/arm64` because `aarch64-linux-gnu-gcc` + cgo on `ubuntu-24.04` picks up the host's `/usr/include` (amd64 glibc) and fails on `bits/libc-header-start.h`.

This sets explicit sysroot env vars in the goreleaser arm64 override:

```
CGO_ENABLED=1
CC=aarch64-linux-gnu-gcc
CGO_CFLAGS=--sysroot=/usr/aarch64-linux-gnu
CGO_LDFLAGS=--sysroot=/usr/aarch64-linux-gnu
```

`gcc-aarch64-linux-gnu` (apt-installed by the workflow) ships the arm64 dev headers under `/usr/aarch64-linux-gnu/include/`. The sysroot points cgo at those instead of the host's amd64 headers.

`install.sh` and the brew cask now include `linux/arm64` in their published-archive list.

## Test plan

- [ ] `goreleaser check` (passes locally)
- [ ] Push a `v*-rc` tag and verify `krit_<ver>_linux_arm64.tar.gz` is among the release assets and runs on an aarch64 Linux host
- [ ] `brew install --cask kaeawc/tap/krit` on Linux/arm64 picks up the new archive (ARM Linux installs are limited but the cask should at least render)