### PR TITLE
Re-enable linux/musl builds via zig cc

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
         include:
           - os: ubuntu-latest
             goos: linux
-            ids: krit-linux,krit-lsp-linux,krit-mcp-linux
+            ids: krit-linux,krit-lsp-linux,krit-mcp-linux,krit-linux-musl,krit-lsp-linux-musl,krit-mcp-linux-musl
           - os: macos-latest
             goos: darwin
             ids: krit-darwin,krit-lsp-darwin,krit-mcp-darwin
@@ -33,18 +33,11 @@ jobs:
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with: { go-version-file: go.mod }
 
-      # Linux runner builds amd64 natively and arm64 via the
-      # gcc-aarch64-linux-gnu cross-toolchain. .goreleaser.yml's arm64
-      # override points CGO_CFLAGS / CGO_LDFLAGS at the arm64 sysroot
-      # so cgo finds the right headers. libc6-dev-arm64-cross is
-      # pulled in as a dependency of gcc-aarch64-linux-gnu.
-      # Linux cross-compilation uses zig cc for both arm64 and musl
-      # targets. Ubuntu's gcc-aarch64-linux-gnu + libc6-dev-arm64-cross
-      # combo has flaky sysroot/lib paths (linker can't find
-      # /usr/aarch64-linux-gnu/lib/libc.so.6 because the cross packages
-      # use a multiarch layout the --sysroot flag doesn't follow). zig
-      # bundles glibc + musl + sysroots in one binary and is the
-      # standard escape hatch. We install it once and write per-target
+      # Linux cross-compilation uses zig cc for both arm64-glibc and
+      # amd64-musl targets. Ubuntu's gcc-aarch64-linux-gnu and
+      # musl-tools have well-known sysroot/library issues with cgo;
+      # zig bundles glibc + musl + sysroots in one binary and is the
+      # standard escape hatch. Install once and write per-target
       # wrapper scripts on PATH so .goreleaser.yml can reference plain
       # CC values.
       - if: matrix.goos == 'linux'
@@ -55,7 +48,7 @@ jobs:
           curl -fsSL "https://ziglang.org/download/${ZIG_VERSION}/zig-linux-x86_64-${ZIG_VERSION}.tar.xz" \
             | sudo tar -xJ -C /opt
           sudo ln -sf "/opt/zig-linux-x86_64-${ZIG_VERSION}/zig" /usr/local/bin/zig
-          for target in glibc-arm64:aarch64-linux-gnu; do
+          for target in glibc-arm64:aarch64-linux-gnu musl-amd64:x86_64-linux-musl; do
             name="${target%:*}"
             zig_target="${target##*:}"
             sudo tee "/usr/local/bin/zigcc-${name}" > /dev/null <<EOF
@@ -66,6 +59,7 @@ jobs:
           done
           zig version
           zigcc-glibc-arm64 --version | head -1
+          zigcc-musl-amd64 --version | head -1
 
       # Import the release signing subkey for goreleaser's signs: block.
       - name: Import GPG signing key

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -73,12 +73,38 @@ builds:
         env: [CGO_ENABLED=1, CC=zigcc-glibc-arm64]
 
   # --- Linux / musl ----------------------------------------------------------
-  # Disabled for now: ubuntu-24.04's musl-tools wrapper falls back to
-  # glibc headers when cgo invokes it through go build, producing
-  # `fatal error: bits/libc-header-start.h` from /usr/include/stdlib.h.
-  # Fix is to install a proper musl-cross toolchain (musl-cross-make,
-  # `apk add` style) on the runner and pass through CC properly. Tracked
-  # as a follow-up.
+  # ubuntu-24.04's musl-tools wrapper falls back to glibc headers when
+  # invoked through cgo. Use zig as the CC instead — it bundles musl
+  # libc + a working sysroot. The release.yml workflow installs zig and
+  # creates a /usr/local/bin/zigcc-musl-amd64 wrapper that fixes the
+  # target. Fully static-linked.
+  - id: krit-linux-musl
+    main: ./cmd/krit
+    binary: krit
+    env: [CGO_ENABLED=1, CC=zigcc-musl-amd64]
+    ldflags:
+      - -s -w -X main.version={{.Version}}
+      - -linkmode=external -extldflags=-static
+    goos: [linux]
+    goarch: [amd64]
+  - id: krit-lsp-linux-musl
+    main: ./cmd/krit-lsp
+    binary: krit-lsp
+    env: [CGO_ENABLED=1, CC=zigcc-musl-amd64]
+    ldflags:
+      - -s -w -X main.version={{.Version}}
+      - -linkmode=external -extldflags=-static
+    goos: [linux]
+    goarch: [amd64]
+  - id: krit-mcp-linux-musl
+    main: ./cmd/krit-mcp
+    binary: krit-mcp
+    env: [CGO_ENABLED=1, CC=zigcc-musl-amd64]
+    ldflags:
+      - -s -w -X main.version={{.Version}}
+      - -linkmode=external -extldflags=-static
+    goos: [linux]
+    goarch: [amd64]
 
   # --- Darwin ----------------------------------------------------------------
   # Built on a macos-latest runner (Apple Silicon / arm64). Cross-compiles
@@ -151,6 +177,13 @@ archives:
     format_overrides:
       - goos: windows
         formats: [zip]
+  - id: linux-musl
+    ids:
+      - krit-linux-musl
+      - krit-lsp-linux-musl
+      - krit-mcp-linux-musl
+    name_template: "{{ .ProjectName }}_{{ .Version }}_linux_musl_{{ .Arch }}"
+
 checksum:
   name_template: 'checksums.txt'
 

--- a/install.sh
+++ b/install.sh
@@ -79,16 +79,22 @@ case "$arch" in
   *) err "unsupported architecture: $arch (amd64 and arm64 are supported)" ;;
 esac
 
-# musl-libc Linux distros (Alpine, etc.) aren't currently shipped as
-# separate archives — the published linux archives are glibc-linked.
-# `ldd /bin/ls` is the canonical detector if we re-enable musl builds.
+# Detect musl libc on Linux (Alpine, Void, etc.) so we fetch the
+# static-linked musl archive instead of the glibc one. arm64-musl
+# isn't shipped yet — fall back to glibc with a warning since it's
+# unlikely to run.
 libc=glibc
 if [ "$goos" = linux ] && ldd /bin/ls 2>&1 | grep -qi musl; then
-  log "musl libc detected; krit currently only ships glibc archives. The downloaded binary may not run on this system. Build from source via 'go install github.com/kaeawc/krit/cmd/krit@latest' or wait for musl support to land."
+  if [ "$goarch" = amd64 ]; then
+    libc=musl
+  else
+    log "musl libc detected on $goarch but only linux/musl/amd64 builds are published; falling back to glibc archive (may not run)"
+  fi
 fi
 
 # Currently published archives:
-#   linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, windows/amd64
+#   linux/amd64, linux/arm64, linux/musl/amd64,
+#   darwin/amd64, darwin/arm64, windows/amd64
 # Anything else is a follow-up; bail with a build-from-source pointer.
 case "${goos}/${goarch}" in
   linux/amd64|linux/arm64|darwin/amd64|darwin/arm64|windows/amd64) ;;
@@ -115,6 +121,8 @@ ver="${KRIT_VERSION#v}"
 
 if [ "$goos" = windows ]; then
   archive="krit_${ver}_${goos}_${goarch}.zip"
+elif [ "$goos" = linux ] && [ "$libc" = musl ]; then
+  archive="krit_${ver}_linux_musl_${goarch}.tar.gz"
 else
   archive="krit_${ver}_${goos}_${goarch}.tar.gz"
 fi


### PR DESCRIPTION
## Summary

The initial release disabled `linux/musl` because ubuntu-24.04's `musl-tools` wrapper falls back to glibc headers when invoked through cgo, hitting `fatal error: bits/libc-header-start.h` on `_cgo_export.c`.

This replaces `musl-tools` with **zig cc**, which bundles musl libc + a working sysroot in a single binary and is the standard escape hatch for static-musl Go builds. The release workflow downloads zig 0.13.0 and writes a wrapper:

```
$ cat /usr/local/bin/zigcc-musl-amd64
#!/usr/bin/env bash
exec zig cc -target x86_64-linux-musl "$@"
```

so `.goreleaser.yml` can reference `CC=zigcc-musl-amd64` as a plain command (cgo's CC parsing doesn't handle multi-word commands well; a wrapper is the simplest fix). The three musl build entries are fully static (`-linkmode=external -extldflags=-static`) and produce `krit_<ver>_linux_musl_amd64.tar.gz`.

`install.sh` re-grows musl detection via `ldd /bin/ls` and selects the musl archive on `linux/amd64`-musl distros (Alpine, Void, etc.).

`arm64-musl` is still a follow-up — needs a `zigcc-musl-arm64` wrapper and a matching build entry. Both are copy-paste of the amd64 work.

## Test plan

- [ ] `goreleaser check` (passes locally)
- [ ] Push a `v*-rc` tag and verify `krit_<ver>_linux_musl_amd64.tar.gz` is among the release assets
- [ ] On Alpine 3.x: `curl … | sh` selects the musl archive and the binary runs