### PR TITLE
perf: cut warm+1-edit scan time ~10s -> ~3.5s on Kotlin compiler

### DIFF
--- a/internal/cacheutil/lru.go
+++ b/internal/cacheutil/lru.go
@@ -30,10 +30,12 @@ import (
 )
 
 // DefaultParseCacheCapBytes is the default cap for the parse cache.
-// Picked from measured usage across large Android and Kotlin repos. 200 MB
-// covers typical Android/KMP repos with headroom while keeping very large
-// repositories bounded.
-const DefaultParseCacheCapBytes int64 = 200 * 1024 * 1024
+// Sized for very large monorepos (e.g. the Kotlin compiler at ~19k source
+// files needs ~430 MB to avoid LRU thrashing on warm runs). Smaller caps
+// caused multi-second background flushes on every warm scan as entries
+// were evicted and re-encoded; 1 GB has comfortable headroom for the
+// largest repos we benchmark against.
+const DefaultParseCacheCapBytes int64 = 1024 * 1024 * 1024
 
 const (
 	lruSidecarVersion    uint32 = 1

--- a/internal/cli/scan/flags.go
+++ b/internal/cli/scan/flags.go
@@ -137,7 +137,7 @@ func registerScanFlags(fs *flag.FlagSet) *scanFlags {
 	f.Version = fs.Bool("version", false, "Print version")
 	f.NoCache = fs.Bool("no-cache", false, "Disable incremental analysis cache")
 	f.NoParseCache = fs.Bool("no-parse-cache", false, "Disable the on-disk tree-sitter parse cache (forces re-parse of every file)")
-	f.ParseCacheCapMB = fs.Int("parse-cache-cap-mb", 0, "Size cap in MB for .krit/parse-cache/ (0 = use config or default 200; negative = unlimited)")
+	f.ParseCacheCapMB = fs.Int("parse-cache-cap-mb", 0, "Size cap in MB for .krit/parse-cache/ (0 = use config or default 1024; negative = unlimited)")
 	f.NoResourceCache = fs.Bool("no-resource-cache", false, "Disable the on-disk Android values-XML ResourceIndex cache (forces re-parse of every values XML file)")
 	f.ClearCache = fs.Bool("clear-cache", false, "Delete all on-disk caches (incremental, parse) and exit")
 	f.NoMatrixCache = fs.Bool("no-matrix-cache", false, "Disable the experiment-matrix baseline cache (no read, no write)")

--- a/internal/cli/scan/runner.go
+++ b/internal/cli/scan/runner.go
@@ -57,6 +57,11 @@ type runner struct {
 	projectModelLoaded bool
 	cacheFilePath      string
 
+	// preloadedAnalysisCacheCh receives the result of a background
+	// cache.Load kicked off as soon as cacheFilePath is known, in
+	// parallel with collectFiles / projectModel / filterRules.
+	preloadedAnalysisCacheCh chan *cache.Cache
+
 	// File collection
 	files                []string
 	allJavaPaths         []string
@@ -233,7 +238,7 @@ func newRunner(f *scanFlags) (*runner, int, bool) {
 		return nil, 2, false
 	}
 
-	return &runner{
+	r := &runner{
 		f:               f,
 		cfg:             cfg,
 		paths:           paths,
@@ -246,7 +251,13 @@ func newRunner(f *scanFlags) (*runner, int, bool) {
 		trackedFiles:    trackedfiles.NewGitIndex(),
 		libraryFacts:    librarymodel.DefaultFacts(),
 		cacheFilePath:   cacheFilePath,
-	}, 0, true
+	}
+	if !*f.NoCache && cacheFilePath != "" {
+		ch := make(chan *cache.Cache, 1)
+		r.preloadedAnalysisCacheCh = ch
+		go func() { ch <- cache.Load(cacheFilePath) }()
+	}
+	return r, 0, true
 }
 
 // collectFiles walks the scan paths once for both Kotlin and Java files,
@@ -383,6 +394,11 @@ func (r *runner) runOracleIndex() (int, error) {
 	}
 	var res pipeline.IndexResult
 	var err error
+	var preloadedCache *cache.Cache
+	if r.useCache && r.preloadedAnalysisCacheCh != nil {
+		preloadedCache = <-r.preloadedAnalysisCacheCh
+		r.preloadedAnalysisCacheCh = nil
+	}
 	r.tracker.TrackVoid("oracleIndex", func() {
 		in := pipeline.IndexInput{
 			ParseResult:       pipeline.ParseResult{ActiveRules: r.activeRules},
@@ -408,6 +424,7 @@ func (r *runner) runOracleIndex() (int, error) {
 			CacheFilePaths:           r.cacheFilePaths,
 			CacheConfig:              r.cfg,
 			CacheEditorConfigEnabled: *r.f.EditorConfig,
+			PreloadedAnalysisCache:   preloadedCache,
 		}
 		res, err = (pipeline.IndexPhase{
 			SkipModules:       true,

--- a/internal/pipeline/android.go
+++ b/internal/pipeline/android.go
@@ -672,16 +672,44 @@ func tryResourceSourceBundleDelta(in AndroidInput, mergedSourceIdx *android.Reso
 }
 
 func sourcePathsForManifest(in AndroidInput) []string {
-	if len(in.SourcePaths) > 0 {
-		return in.SourcePaths
-	}
-	paths := make([]string, 0, len(in.SourceFiles))
+	// Build the set of paths we have hashable evidence for: a SourceFile or
+	// a precomputed SourceHash. Anything else can't take part in the manifest
+	// (its hash can't be recomputed at load time), so excluding it keeps the
+	// save-side and load-side path lists in lockstep.
+	have := make(map[string]struct{}, len(in.SourceFiles)+len(in.SourceHashes))
 	for _, file := range in.SourceFiles {
-		if file != nil {
-			paths = append(paths, file.Path)
+		if file != nil && file.Path != "" {
+			have[file.Path] = struct{}{}
 		}
 	}
-	return paths
+	for path, hash := range in.SourceHashes {
+		if path != "" && hash != "" {
+			have[path] = struct{}{}
+		}
+	}
+	src := in.SourcePaths
+	if len(src) == 0 {
+		src = make([]string, 0, len(have))
+		for path := range have {
+			src = append(src, path)
+		}
+	}
+	seen := make(map[string]struct{}, len(src))
+	out := make([]string, 0, len(src))
+	for _, p := range src {
+		if p == "" {
+			continue
+		}
+		if _, ok := have[p]; !ok {
+			continue
+		}
+		if _, dup := seen[p]; dup {
+			continue
+		}
+		seen[p] = struct{}{}
+		out = append(out, p)
+	}
+	return out
 }
 
 func resourceSourceHashes(in AndroidInput) (map[string]string, bool) {

--- a/internal/pipeline/index.go
+++ b/internal/pipeline/index.go
@@ -148,6 +148,13 @@ type IndexInput struct {
 	// ComputeConfigHash.
 	CacheEditorConfigEnabled bool
 
+	// PreloadedAnalysisCache, when non-nil, is used in place of cache.Load
+	// during the cacheLoad phase. The CLI runner kicks off the load in a
+	// background goroutine while collectFiles / projectModel / filterRules
+	// run, then passes the result here so cacheLoad becomes a near-zero
+	// receive instead of a serialized disk read.
+	PreloadedAnalysisCache *cache.Cache
+
 	// --- Oracle/cache bypass knobs. The CLI runs IndexPhase twice: once
 	// before ParsePhase for oracle + cache (pre-parse block) and once
 	// after ParsePhase for CodeIndex / module graph / Android. The second
@@ -407,7 +414,11 @@ func (p IndexPhase) runCacheLoad(in IndexInput, result *IndexResult) {
 	var analysisCache *cache.Cache
 	_ = in.trackSerial("cacheLoad", func() error {
 		loadStart = time.Now()
-		analysisCache = cache.Load(in.CacheFilePath)
+		if in.PreloadedAnalysisCache != nil {
+			analysisCache = in.PreloadedAnalysisCache
+		} else {
+			analysisCache = cache.Load(in.CacheFilePath)
+		}
 		return nil
 	})
 

--- a/internal/rules/semantic_rule_helpers.go
+++ b/internal/rules/semantic_rule_helpers.go
@@ -1,6 +1,7 @@
 package rules
 
 import (
+	"bytes"
 	"strings"
 
 	"github.com/kaeawc/krit/internal/filefacts"
@@ -262,26 +263,70 @@ func classHasNestedViewHolderFlat(file *scanner.File, class uint32) bool {
 	return found
 }
 
+// recyclerAdapterSupertypeNames are the supertype names the RecyclerAdapter
+// rules treat as Adapter-implementing. Shared between the local AST check and
+// the resolver-fallback hierarchy walk to keep both paths in sync.
+var recyclerAdapterSupertypeNames = []string{
+	"androidx.recyclerview.widget.RecyclerView.Adapter",
+	"android.support.v7.widget.RecyclerView.Adapter",
+	"android.widget.BaseAdapter",
+	"RecyclerView.Adapter",
+	"BaseAdapter",
+	"Adapter",
+}
+
 func isRecyclerAdapterClassFlat(ctx *api.Context, class uint32) bool {
 	file := ctx.File
-	if ctx.Resolver != nil {
-		name := extractIdentifierFlat(file, class)
-		if info := ctx.Resolver.ClassHierarchy(name); info != nil {
-			for _, st := range info.Supertypes {
-				if semanticTypeNameMatches(st,
-					"androidx.recyclerview.widget.RecyclerView.Adapter",
-					"android.support.v7.widget.RecyclerView.Adapter",
-					"android.widget.BaseAdapter",
-					"RecyclerView.Adapter",
-					"BaseAdapter",
-					"Adapter",
-				) {
-					return true
-				}
-			}
+	if classExtendsAnyFlat(file, class, recyclerAdapterSupertypeNames...) {
+		return true
+	}
+	if ctx.Resolver == nil || !classHasAdapterLikeSupertypeFlat(file, class) {
+		return false
+	}
+	info := ctx.Resolver.ClassHierarchy(extractIdentifierFlat(file, class))
+	if info == nil {
+		return false
+	}
+	for _, st := range info.Supertypes {
+		if semanticTypeNameMatches(st, recyclerAdapterSupertypeNames...) {
+			return true
 		}
 	}
-	return classExtendsAnyFlat(file, class, "RecyclerView.Adapter", "BaseAdapter", "Adapter")
+	return false
+}
+
+// classHasAdapterLikeSupertypeFlat returns true when the class has at least
+// one direct supertype whose type identifier ends in "Adapter" or contains
+// "RecyclerView" — a cheap signal that consulting the type oracle might
+// produce a real Adapter match. The walk is restricted to type-identifier
+// shapes so generic args, lambda bodies, and value arguments don't trigger.
+func classHasAdapterLikeSupertypeFlat(file *scanner.File, class uint32) bool {
+	if file == nil || class == 0 {
+		return false
+	}
+	adapter := []byte("Adapter")
+	recyclerView := []byte("RecyclerView")
+	found := false
+	for child := file.FlatFirstChild(class); child != 0 && !found; child = file.FlatNextSib(child) {
+		switch file.FlatType(child) {
+		case "delegation_specifier", "superclass", "super_interfaces":
+		default:
+			continue
+		}
+		file.FlatWalkAllNodes(child, func(n uint32) {
+			if found {
+				return
+			}
+			switch file.FlatType(n) {
+			case "type_identifier", "scoped_type_identifier", "scoped_identifier", "generic_type":
+				text := file.FlatNodeBytes(n)
+				if bytes.HasSuffix(text, adapter) || bytes.Contains(text, recyclerView) {
+					found = true
+				}
+			}
+		})
+	}
+	return found
 }
 
 func logCallIsAndroidLog(ctx *api.Context, call uint32) bool {


### PR DESCRIPTION
## Summary

Five fixes to the warm-run path, benchmarked against `github.com/JetBrains/kotlin` (19k source files, 66,946 findings):

- **Parse-cache default 200 MB → 1 GB.** Kotlin compiler needs ~430 MB; the prior cap forced multi-second LRU eviction + zstd re-encoding every warm run.
- **Fix `sourcePathsForManifest`.** Returned 18,801 paths (duplicates + paths without SourceFiles) but `resourceSourceHashes` returned only 18,699 entries (map keys collapse), so `len(hashes) != len(paths)` always failed and the resourceSource bundle manifest was *never* written. With the manifest now persisted, the existing `tryResourceSourceBundleDelta` fast-path fires (`bundles: 1`), dropping `resourceSourceRuleChecks` from ~900 ms to ~100 ms.
- **`RecyclerAdapterWithoutDiffUtil` resolver gating.** The rule called `ctx.Resolver.ClassHierarchy(name)` on every `class_declaration`, which lazy-deserialized the 41 MB `types.json` on first hit. Cheap local AST check now runs first; resolver only consulted when a direct supertype text-shape plausibly resolves to an Adapter. Type-identifier-only walk via `FlatNodeBytes` avoids string allocs and matches in lambda bodies / generic args.
- **Background cache preload.** `cache.Load` (~260 ms) now runs in a goroutine kicked off in `newRunner` and overlaps with `collectFiles` + `projectModel` + `filterRules`. The `cacheLoad` phase becomes a near-zero channel receive.
- **Shared `recyclerAdapterSupertypeNames` constant** so the local AST path and resolver-fallback hierarchy walk can't drift.

### Numbers (kotlin compiler, warm + 1 .kt edit, no flags)

| State | Wall |
|---|---:|
| Before | 10.78 s |
| 1 GB cache only | 6.70 s |
| + resourceSource delta path fires | ~5.0 s |
| + RecyclerAdapter gate | ~4.4 s |
| + cache preload | **~3.5 s** |

## Test plan

- [x] `go build ./cmd/krit/` clean
- [x] `go vet ./...` clean
- [x] `go test ./... -count=1` — all packages green
- [x] Findings count stable at 66,946 across runs on `~/github/kotlin`
- [x] `cacheBudget.capBytes` reports 1 GB on default invocation
- [x] `resourceSourceCache.metrics.bundles == 1` on warm+1-edit (was 0)