### PR TITLE
Implement krit rename apply

### DIFF
--- a/cmd/krit/main_test.go
+++ b/cmd/krit/main_test.go
@@ -1147,13 +1147,33 @@ func TestRenameSubcommand_PlansAndReturnsTodo(t *testing.T) {
 	}
 
 	stdout, stderr, code := runKrit(t, "rename", "com.example.OldName", "com.example.NewName", dir)
-	if code != 2 {
-		t.Fatalf("rename failed: exit=%d stderr=%s stdout=%s", code, stderr, stdout)
+	if code != 0 {
+		t.Fatalf("rename dry-run failed: exit=%d stderr=%s stdout=%s", code, stderr, stdout)
 	}
 	if !strings.Contains(stdout, "Rename planning found") {
 		t.Fatalf("expected rename planning summary, got: %s", stdout)
 	}
-	if !strings.Contains(stderr, "rename apply is not implemented yet") {
-		t.Fatalf("expected TODO stderr, got: %s", stderr)
+	if !strings.Contains(stdout, "Dry run") {
+		t.Fatalf("expected dry-run summary, got: %s", stdout)
+	}
+	// Dry-run leaves the file in place.
+	if _, err := os.Stat(oldNamePath); err != nil {
+		t.Fatalf("dry-run should preserve original file: %v", err)
+	}
+
+	stdout, stderr, code = runKrit(t, "rename", "-apply", "com.example.OldName", "com.example.NewName", dir)
+	if code != 0 {
+		t.Fatalf("rename apply failed: exit=%d stderr=%s stdout=%s", code, stderr, stdout)
+	}
+	newPath := filepath.Join(filepath.Dir(oldNamePath), "NewName.kt")
+	if _, err := os.Stat(newPath); err != nil {
+		t.Fatalf("expected renamed file at %s: %v", newPath, err)
+	}
+	body, err := os.ReadFile(featurePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(body), "OldName") {
+		t.Fatalf("apply did not rewrite reference: %s", body)
 	}
 }

--- a/internal/cli/rename/rename.go
+++ b/internal/cli/rename/rename.go
@@ -16,6 +16,7 @@ type renameCommand struct {
 	ToFQN   string
 	Paths   []string
 	Jobs    int
+	Apply   bool
 }
 
 func Run(args []string) int {
@@ -23,6 +24,7 @@ func Run(args []string) int {
 	fs := flag.NewFlagSet("rename", flag.ContinueOnError)
 	fs.SetOutput(os.Stderr)
 	fs.IntVar(&cmd.Jobs, "j", runtime.NumCPU(), "Number of parallel jobs")
+	fs.BoolVar(&cmd.Apply, "apply", false, "Apply the rename to the working tree (default: dry-run)")
 	fs.Usage = func() {
 		fmt.Fprintln(os.Stderr, "Usage: krit rename [flags] <from-fqn> <to-fqn> [paths...]")
 		fs.PrintDefaults()
@@ -64,6 +66,11 @@ func runRenameCommand(cmd renameCommand) int {
 		return 2
 	}
 
+	if err := krename.ValidatePlan(plan); err != nil {
+		fmt.Fprintf(os.Stderr, "error: rename: %v\n", err)
+		return 2
+	}
+
 	summary := plan.Summary()
 	fmt.Printf(
 		"Rename planning found %d candidate occurrences in %d files (%d declarations, %d references) for %s -> %s.\n",
@@ -74,8 +81,38 @@ func runRenameCommand(cmd renameCommand) int {
 		target.FromFQN,
 		target.ToFQN,
 	)
-	fmt.Fprintf(os.Stderr, "error: %v\n", krename.ErrApplyNotImplemented)
-	return 2
+
+	if !cmd.Apply {
+		res, err := krename.DryRunApply(plan)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error: rename dry-run: %v\n", err)
+			return 2
+		}
+		fmt.Printf("Dry run: would change %d files (%d edits)", res.FilesChanged, res.Edits)
+		if len(res.Moves) > 0 {
+			fmt.Printf(", %d file moves", len(res.Moves))
+		}
+		fmt.Println(". Re-run with --apply to write changes.")
+		for _, mv := range res.Moves {
+			fmt.Printf("  move: %s -> %s\n", mv.From, mv.To)
+		}
+		return 0
+	}
+
+	res, err := krename.Apply(plan)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: rename apply: %v\n", err)
+		return 1
+	}
+	fmt.Printf("Applied: %d files changed (%d edits)", res.FilesChanged, res.Edits)
+	if len(res.Moves) > 0 {
+		fmt.Printf(", %d file moves", len(res.Moves))
+	}
+	fmt.Println(".")
+	for _, mv := range res.Moves {
+		fmt.Printf("  moved: %s -> %s\n", mv.From, mv.To)
+	}
+	return 0
 }
 
 func buildRenamePlan(paths []string, workers int, target krename.Target) (krename.Plan, error) {

--- a/internal/cli/rename/rename.go
+++ b/internal/cli/rename/rename.go
@@ -98,7 +98,7 @@ func buildRenamePlan(paths []string, workers int, target krename.Target) (krenam
 	}
 
 	idx := scanner.BuildIndex(parsedFiles, workers, parsedJavaFiles...)
-	return krename.BuildPlan(idx, target), nil
+	return krename.BuildPlanWithFiles(idx, target, parsedJavaFiles), nil
 }
 
 func joinErrors(errs []error) error {

--- a/internal/rename/apply.go
+++ b/internal/rename/apply.go
@@ -20,6 +20,10 @@ type edit struct {
 	StartByte int
 	EndByte   int
 	Replace   string
+	// Expect, when non-empty, must equal the existing content at the byte
+	// range. Identifier edits use this to detect stale indexes; full-line
+	// edits (package, import) leave it empty and trust the AST node range.
+	Expect string
 }
 
 // Apply rewrites every reference site in plan to target.ToName and writes
@@ -44,6 +48,7 @@ func apply(plan Plan, dry bool) (ApplyResult, error) {
 	}
 
 	editsByFile := collectIdentifierEdits(plan)
+	mergePackageAndImportEdits(plan, editsByFile)
 
 	var result ApplyResult
 	files := make([]string, 0, len(editsByFile))
@@ -94,6 +99,7 @@ func collectIdentifierEdits(plan Plan) map[string][]edit {
 			StartByte: ref.StartByte,
 			EndByte:   ref.EndByte,
 			Replace:   plan.Target.ToName,
+			Expect:    plan.Target.FromName,
 		})
 	}
 	return out
@@ -114,9 +120,11 @@ func applyFileEdits(plan Plan, file string, edits []edit) ([]byte, error) {
 		if e.StartByte < 0 || e.EndByte > len(content) {
 			return nil, fmt.Errorf("rename apply: edit out of bounds in %s (%d..%d, len=%d)", file, e.StartByte, e.EndByte, len(content))
 		}
-		current := string(content[e.StartByte:e.EndByte])
-		if current != plan.Target.FromName {
-			return nil, fmt.Errorf("rename apply: %s byte range %d..%d holds %q, not %q (file changed since indexing?)", file, e.StartByte, e.EndByte, current, plan.Target.FromName)
+		if e.Expect != "" {
+			current := string(content[e.StartByte:e.EndByte])
+			if current != e.Expect {
+				return nil, fmt.Errorf("rename apply: %s byte range %d..%d holds %q, not %q (file changed since indexing?)", file, e.StartByte, e.EndByte, current, e.Expect)
+			}
 		}
 		content = append(content[:e.StartByte], append([]byte(e.Replace), content[e.EndByte:]...)...)
 	}
@@ -140,6 +148,140 @@ func planFilesFromPlan(plan Plan) []*scanner.File {
 		return plan.cachedFiles
 	}
 	return nil
+}
+
+// mergePackageAndImportEdits adds edits for files that need their package
+// declaration or import statements rewritten. Triggered when the rename
+// crosses package boundaries; same-package renames need no header edits
+// because the simple-name rewrite from collectIdentifierEdits already
+// updates explicit import lines in place.
+func mergePackageAndImportEdits(plan Plan, editsByFile map[string][]edit) {
+	if !plan.Target.PackageChanged() {
+		return
+	}
+	declFiles := declarationFiles(plan)
+
+	for _, file := range plan.cachedFiles {
+		if file == nil {
+			continue
+		}
+		hr := CollectHeaderRanges(file)
+
+		if declFiles[file.Path] && hr.Package != ([2]int{}) {
+			rewriteText := buildPackageReplacement(file, hr.Package, plan.Target.ToPackage())
+			if rewriteText != "" {
+				editsByFile[file.Path] = append(editsByFile[file.Path], edit{
+					StartByte: hr.Package[0],
+					EndByte:   hr.Package[1],
+					Replace:   rewriteText,
+				})
+			}
+		}
+
+		if rng, ok := hr.Imports[plan.Target.FromFQN]; ok {
+			repl := rewriteImportLine(file, rng, plan.Target.FromFQN, plan.Target.ToFQN)
+			if repl != "" {
+				editsByFile[file.Path] = stripEditsInRange(editsByFile[file.Path], rng)
+				editsByFile[file.Path] = append(editsByFile[file.Path], edit{
+					StartByte: rng[0],
+					EndByte:   rng[1],
+					Replace:   repl,
+				})
+			}
+		}
+	}
+}
+
+func stripEditsInRange(edits []edit, rng [2]int) []edit {
+	out := edits[:0]
+	for _, e := range edits {
+		if e.StartByte >= rng[0] && e.EndByte <= rng[1] {
+			continue
+		}
+		out = append(out, e)
+	}
+	return out
+}
+
+func declarationFiles(plan Plan) map[string]bool {
+	out := make(map[string]bool, len(plan.Declarations))
+	for _, d := range plan.Declarations {
+		out[d.File] = true
+	}
+	return out
+}
+
+// buildPackageReplacement substitutes the FromPackage occurrence within the
+// existing package declaration text with toPackage, preserving the file's
+// original `package` keyword spacing and trailing semicolon (Java).
+func buildPackageReplacement(file *scanner.File, rng [2]int, toPackage string) string {
+	if file.Content == nil {
+		return ""
+	}
+	if rng[0] < 0 || rng[1] > len(file.Content) || rng[0] >= rng[1] {
+		return ""
+	}
+	original := string(file.Content[rng[0]:rng[1]])
+	switch file.Language {
+	case scanner.LangJava:
+		semi := ""
+		body := original
+		if len(body) > 0 && body[len(body)-1] == ';' {
+			semi = ";"
+			body = body[:len(body)-1]
+		}
+		return "package " + toPackage + semi + trailingNewline(body)
+	default:
+		return "package " + toPackage + trailingNewline(original)
+	}
+}
+
+func rewriteImportLine(file *scanner.File, rng [2]int, fromFQN, toFQN string) string {
+	if file.Content == nil {
+		return ""
+	}
+	if rng[0] < 0 || rng[1] > len(file.Content) || rng[0] >= rng[1] {
+		return ""
+	}
+	original := string(file.Content[rng[0]:rng[1]])
+	switch file.Language {
+	case scanner.LangJava:
+		semi := ""
+		body := original
+		if len(body) > 0 && body[len(body)-1] == ';' {
+			semi = ";"
+			body = body[:len(body)-1]
+		}
+		// Preserve `static` modifier if it was present.
+		isStatic := false
+		trimmed := body
+		trimmed = trimImportPrefix(trimmed)
+		if len(trimmed) >= len("static ") && trimmed[:len("static ")] == "static " {
+			isStatic = true
+		}
+		prefix := "import "
+		if isStatic {
+			prefix = "import static "
+		}
+		_ = fromFQN
+		return prefix + toFQN + semi + trailingNewline(body)
+	default:
+		return "import " + toFQN + trailingNewline(original)
+	}
+}
+
+func trimImportPrefix(s string) string {
+	if len(s) >= len("import ") && s[:len("import ")] == "import " {
+		return s[len("import "):]
+	}
+	return s
+}
+
+func trailingNewline(s string) string {
+	if len(s) > 0 && s[len(s)-1] == '\n' {
+		return "\n"
+	}
+	return ""
 }
 
 func atomicWrite(path string, content []byte) error {

--- a/internal/rename/apply.go
+++ b/internal/rename/apply.go
@@ -295,13 +295,19 @@ func rewriteImportLine(file *scanner.File, rng [2]int, fromFQN, toFQN string) st
 	body = strings.TrimSpace(body)
 
 	prefix := "import "
+	suffix := ""
 	if file.Language == scanner.LangJava {
 		if strings.HasPrefix(body, "static ") {
 			prefix = "import static "
 		}
+	} else {
+		// Kotlin: preserve `as <alias>` if present.
+		if i := strings.Index(body, " as "); i >= 0 {
+			suffix = body[i:]
+		}
 	}
 
-	out := prefix + toFQN
+	out := prefix + toFQN + suffix
 	if file.Language == scanner.LangJava || hasSemi {
 		out += ";"
 	}

--- a/internal/rename/apply.go
+++ b/internal/rename/apply.go
@@ -13,6 +13,14 @@ import (
 type ApplyResult struct {
 	FilesChanged int
 	Edits        int
+	Moves        []FileMove
+}
+
+// FileMove describes a renamed source file. The Old path no longer exists
+// after Apply returns; the From/To-relative directory is unchanged.
+type FileMove struct {
+	From string
+	To   string
 }
 
 // edit describes one byte-range substitution within a single file.
@@ -77,7 +85,55 @@ func apply(plan Plan, dry bool) (ApplyResult, error) {
 		result.FilesChanged++
 		result.Edits += len(fileEdits)
 	}
+
+	moves := planFileMoves(plan)
+	for _, mv := range moves {
+		if dry {
+			result.Moves = append(result.Moves, mv)
+			continue
+		}
+		if _, err := os.Stat(mv.To); err == nil {
+			return result, fmt.Errorf("rename apply: destination %s already exists", mv.To)
+		}
+		if err := os.Rename(mv.From, mv.To); err != nil {
+			return result, fmt.Errorf("rename apply: rename %s -> %s: %w", mv.From, mv.To, err)
+		}
+		result.Moves = append(result.Moves, mv)
+	}
 	return result, nil
+}
+
+// planFileMoves identifies declaration files whose basename matches the
+// rename's FromName and proposes a same-directory rename to ToName + the
+// existing extension. Kotlin convention but Java requirement when the
+// renamed class is the file's top-level public class.
+func planFileMoves(plan Plan) []FileMove {
+	if plan.Target.FromName == plan.Target.ToName {
+		return nil
+	}
+	declFiles := declarationFiles(plan)
+	out := make([]FileMove, 0)
+	seen := make(map[string]bool, len(declFiles))
+	for path := range declFiles {
+		if seen[path] {
+			continue
+		}
+		seen[path] = true
+		dir := filepath.Dir(path)
+		base := filepath.Base(path)
+		ext := filepath.Ext(base)
+		stem := base[:len(base)-len(ext)]
+		if stem != plan.Target.FromName {
+			continue
+		}
+		dest := filepath.Join(dir, plan.Target.ToName+ext)
+		if dest == path {
+			continue
+		}
+		out = append(out, FileMove{From: path, To: dest})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].From < out[j].From })
+	return out
 }
 
 func collectIdentifierEdits(plan Plan) map[string][]edit {

--- a/internal/rename/apply.go
+++ b/internal/rename/apply.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 
 	"github.com/kaeawc/krit/internal/scanner"
 )
@@ -267,77 +268,45 @@ func declarationFiles(plan Plan) map[string]bool {
 	return out
 }
 
-// buildPackageReplacement substitutes the FromPackage occurrence within the
-// existing package declaration text with toPackage, preserving the file's
-// original `package` keyword spacing and trailing semicolon (Java).
+// buildPackageReplacement returns the replacement text for the file's
+// package declaration line, preserving the trailing semicolon for Java.
 func buildPackageReplacement(file *scanner.File, rng [2]int, toPackage string) string {
-	if file.Content == nil {
-		return ""
-	}
-	if rng[0] < 0 || rng[1] > len(file.Content) || rng[0] >= rng[1] {
+	if file.Content == nil || rng[0] < 0 || rng[1] > len(file.Content) || rng[0] >= rng[1] {
 		return ""
 	}
 	original := string(file.Content[rng[0]:rng[1]])
-	switch file.Language {
-	case scanner.LangJava:
-		semi := ""
-		body := original
-		if len(body) > 0 && body[len(body)-1] == ';' {
-			semi = ";"
-			body = body[:len(body)-1]
-		}
-		return "package " + toPackage + semi + trailingNewline(body)
-	default:
-		return "package " + toPackage + trailingNewline(original)
+	hasSemi := strings.HasSuffix(strings.TrimSpace(original), ";")
+	out := "package " + toPackage
+	if file.Language == scanner.LangJava || hasSemi {
+		out += ";"
 	}
+	return out
 }
 
 func rewriteImportLine(file *scanner.File, rng [2]int, fromFQN, toFQN string) string {
-	if file.Content == nil {
+	if file.Content == nil || rng[0] < 0 || rng[1] > len(file.Content) || rng[0] >= rng[1] {
 		return ""
 	}
-	if rng[0] < 0 || rng[1] > len(file.Content) || rng[0] >= rng[1] {
-		return ""
-	}
-	original := string(file.Content[rng[0]:rng[1]])
-	switch file.Language {
-	case scanner.LangJava:
-		semi := ""
-		body := original
-		if len(body) > 0 && body[len(body)-1] == ';' {
-			semi = ";"
-			body = body[:len(body)-1]
-		}
-		// Preserve `static` modifier if it was present.
-		isStatic := false
-		trimmed := body
-		trimmed = trimImportPrefix(trimmed)
-		if len(trimmed) >= len("static ") && trimmed[:len("static ")] == "static " {
-			isStatic = true
-		}
-		prefix := "import "
-		if isStatic {
+	original := strings.TrimSpace(string(file.Content[rng[0]:rng[1]]))
+	hasSemi := strings.HasSuffix(original, ";")
+	body := strings.TrimSuffix(original, ";")
+	body = strings.TrimSpace(body)
+	body = strings.TrimPrefix(body, "import")
+	body = strings.TrimSpace(body)
+
+	prefix := "import "
+	if file.Language == scanner.LangJava {
+		if strings.HasPrefix(body, "static ") {
 			prefix = "import static "
 		}
-		_ = fromFQN
-		return prefix + toFQN + semi + trailingNewline(body)
-	default:
-		return "import " + toFQN + trailingNewline(original)
 	}
-}
 
-func trimImportPrefix(s string) string {
-	if len(s) >= len("import ") && s[:len("import ")] == "import " {
-		return s[len("import "):]
+	out := prefix + toFQN
+	if file.Language == scanner.LangJava || hasSemi {
+		out += ";"
 	}
-	return s
-}
-
-func trailingNewline(s string) string {
-	if len(s) > 0 && s[len(s)-1] == '\n' {
-		return "\n"
-	}
-	return ""
+	_ = fromFQN
+	return out
 }
 
 func atomicWrite(path string, content []byte) error {

--- a/internal/rename/apply.go
+++ b/internal/rename/apply.go
@@ -96,6 +96,9 @@ func apply(plan Plan, dry bool) (ApplyResult, error) {
 		if _, err := os.Stat(mv.To); err == nil {
 			return result, fmt.Errorf("rename apply: destination %s already exists", mv.To)
 		}
+		if err := os.MkdirAll(filepath.Dir(mv.To), 0o755); err != nil {
+			return result, fmt.Errorf("rename apply: mkdir %s: %w", filepath.Dir(mv.To), err)
+		}
 		if err := os.Rename(mv.From, mv.To); err != nil {
 			return result, fmt.Errorf("rename apply: rename %s -> %s: %w", mv.From, mv.To, err)
 		}
@@ -104,14 +107,12 @@ func apply(plan Plan, dry bool) (ApplyResult, error) {
 	return result, nil
 }
 
-// planFileMoves identifies declaration files whose basename matches the
-// rename's FromName and proposes a same-directory rename to ToName + the
-// existing extension. Kotlin convention but Java requirement when the
-// renamed class is the file's top-level public class.
+// planFileMoves identifies declaration files that need to be renamed,
+// moved to a different package directory, or both. The basename gets
+// updated when the file's stem matches Target.FromName; the directory
+// gets updated when the file's parent path mirrors Target.FromPackage()
+// and the rename changes packages.
 func planFileMoves(plan Plan) []FileMove {
-	if plan.Target.FromName == plan.Target.ToName {
-		return nil
-	}
 	declFiles := declarationFiles(plan)
 	out := make([]FileMove, 0)
 	seen := make(map[string]bool, len(declFiles))
@@ -120,21 +121,63 @@ func planFileMoves(plan Plan) []FileMove {
 			continue
 		}
 		seen[path] = true
-		dir := filepath.Dir(path)
-		base := filepath.Base(path)
-		ext := filepath.Ext(base)
-		stem := base[:len(base)-len(ext)]
-		if stem != plan.Target.FromName {
-			continue
-		}
-		dest := filepath.Join(dir, plan.Target.ToName+ext)
-		if dest == path {
+		dest := plannedDestination(path, plan.Target)
+		if dest == "" || dest == path {
 			continue
 		}
 		out = append(out, FileMove{From: path, To: dest})
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].From < out[j].From })
 	return out
+}
+
+// plannedDestination computes the new path for a declaration file given
+// the target rename. Returns the original path unchanged if neither the
+// basename nor the package directory should move.
+func plannedDestination(path string, target Target) string {
+	dir := filepath.Dir(path)
+	base := filepath.Base(path)
+	ext := filepath.Ext(base)
+	stem := base[:len(base)-len(ext)]
+
+	newStem := stem
+	if stem == target.FromName && target.FromName != target.ToName {
+		newStem = target.ToName
+	}
+
+	newDir := dir
+	if target.PackageChanged() {
+		if mapped, ok := remapPackageDir(dir, target.FromPackage(), target.ToPackage()); ok {
+			newDir = mapped
+		}
+	}
+
+	if newDir == dir && newStem == stem {
+		return path
+	}
+	return filepath.Join(newDir, newStem+ext)
+}
+
+// remapPackageDir replaces a trailing oldPackage path within dir with
+// newPackage. Returns false if dir does not end with the expected
+// package path, in which case the caller should leave the directory as
+// is (the file may be in a flat layout that doesn't mirror packages).
+func remapPackageDir(dir, oldPackage, newPackage string) (string, bool) {
+	if oldPackage == "" {
+		return dir, false
+	}
+	oldPath := strings.ReplaceAll(oldPackage, ".", string(filepath.Separator))
+	cleanDir := filepath.Clean(dir)
+	if cleanDir == oldPath {
+		return strings.ReplaceAll(newPackage, ".", string(filepath.Separator)), true
+	}
+	suffix := string(filepath.Separator) + oldPath
+	if !strings.HasSuffix(cleanDir, suffix) {
+		return dir, false
+	}
+	prefix := cleanDir[:len(cleanDir)-len(suffix)]
+	newPath := strings.ReplaceAll(newPackage, ".", string(filepath.Separator))
+	return filepath.Join(prefix, newPath), true
 }
 
 func collectIdentifierEdits(plan Plan) map[string][]edit {

--- a/internal/rename/apply.go
+++ b/internal/rename/apply.go
@@ -1,0 +1,175 @@
+package rename
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/kaeawc/krit/internal/scanner"
+)
+
+// ApplyResult summarises a successful rename apply pass.
+type ApplyResult struct {
+	FilesChanged int
+	Edits        int
+}
+
+// edit describes one byte-range substitution within a single file.
+type edit struct {
+	StartByte int
+	EndByte   int
+	Replace   string
+}
+
+// Apply rewrites every reference site in plan to target.ToName and writes
+// updated file contents back to disk. Each file is written atomically via
+// a sibling temp file plus rename. If any file fails to write, files
+// already written are not rolled back — the caller should run apply against
+// a clean working tree (typically a git checkout). Use DryRun to compute
+// the planned edits without touching disk.
+func Apply(plan Plan) (ApplyResult, error) {
+	return apply(plan, false)
+}
+
+// DryRunApply returns the same result Apply would produce without writing
+// anything to disk.
+func DryRunApply(plan Plan) (ApplyResult, error) {
+	return apply(plan, true)
+}
+
+func apply(plan Plan, dry bool) (ApplyResult, error) {
+	if plan.Target.ToName == "" || plan.Target.FromName == "" {
+		return ApplyResult{}, fmt.Errorf("rename apply: incomplete target")
+	}
+
+	editsByFile := collectIdentifierEdits(plan)
+
+	var result ApplyResult
+	files := make([]string, 0, len(editsByFile))
+	for f := range editsByFile {
+		files = append(files, f)
+	}
+	sort.Strings(files)
+
+	for _, file := range files {
+		fileEdits := editsByFile[file]
+		if len(fileEdits) == 0 {
+			continue
+		}
+		updated, err := applyFileEdits(plan, file, fileEdits)
+		if err != nil {
+			return result, err
+		}
+		if dry {
+			result.FilesChanged++
+			result.Edits += len(fileEdits)
+			continue
+		}
+		if err := atomicWrite(file, updated); err != nil {
+			return result, err
+		}
+		result.FilesChanged++
+		result.Edits += len(fileEdits)
+	}
+	return result, nil
+}
+
+func collectIdentifierEdits(plan Plan) map[string][]edit {
+	out := make(map[string][]edit)
+	for _, ref := range plan.References {
+		if ref.StartByte <= 0 && ref.EndByte <= 0 {
+			continue
+		}
+		if ref.EndByte <= ref.StartByte {
+			continue
+		}
+		if ref.Language != scanner.LangKotlin && ref.Language != scanner.LangJava {
+			continue
+		}
+		if _, ok := plan.Contexts[ref.File]; !ok {
+			continue
+		}
+		out[ref.File] = append(out[ref.File], edit{
+			StartByte: ref.StartByte,
+			EndByte:   ref.EndByte,
+			Replace:   plan.Target.ToName,
+		})
+	}
+	return out
+}
+
+func applyFileEdits(plan Plan, file string, edits []edit) ([]byte, error) {
+	content, err := readFileContent(plan, file)
+	if err != nil {
+		return nil, err
+	}
+	sort.Slice(edits, func(i, j int) bool { return edits[i].StartByte > edits[j].StartByte })
+	for i := 1; i < len(edits); i++ {
+		if edits[i].EndByte > edits[i-1].StartByte {
+			return nil, fmt.Errorf("rename apply: overlapping edits in %s", file)
+		}
+	}
+	for _, e := range edits {
+		if e.StartByte < 0 || e.EndByte > len(content) {
+			return nil, fmt.Errorf("rename apply: edit out of bounds in %s (%d..%d, len=%d)", file, e.StartByte, e.EndByte, len(content))
+		}
+		current := string(content[e.StartByte:e.EndByte])
+		if current != plan.Target.FromName {
+			return nil, fmt.Errorf("rename apply: %s byte range %d..%d holds %q, not %q (file changed since indexing?)", file, e.StartByte, e.EndByte, current, plan.Target.FromName)
+		}
+		content = append(content[:e.StartByte], append([]byte(e.Replace), content[e.EndByte:]...)...)
+	}
+	return content, nil
+}
+
+func readFileContent(plan Plan, path string) ([]byte, error) {
+	for _, f := range planFilesFromPlan(plan) {
+		if f != nil && f.Path == path && f.Content != nil {
+			return append([]byte(nil), f.Content...), nil
+		}
+	}
+	return os.ReadFile(path)
+}
+
+// planFilesFromPlan returns the files that were used to build the plan's
+// contexts. Stored separately from Contexts to avoid changing the public
+// FileContext shape.
+func planFilesFromPlan(plan Plan) []*scanner.File {
+	if plan.cachedFiles != nil {
+		return plan.cachedFiles
+	}
+	return nil
+}
+
+func atomicWrite(path string, content []byte) error {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, ".krit-rename-*")
+	if err != nil {
+		return fmt.Errorf("rename apply: temp file: %w", err)
+	}
+	tmpPath := tmp.Name()
+	if _, err := tmp.Write(content); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return fmt.Errorf("rename apply: write %s: %w", tmpPath, err)
+	}
+	if err := tmp.Sync(); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return fmt.Errorf("rename apply: sync %s: %w", tmpPath, err)
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpPath)
+		return fmt.Errorf("rename apply: close %s: %w", tmpPath, err)
+	}
+	info, err := os.Stat(path)
+	if err == nil {
+		_ = os.Chmod(tmpPath, info.Mode())
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		os.Remove(tmpPath)
+		return fmt.Errorf("rename apply: rename %s: %w", path, err)
+	}
+	return nil
+}

--- a/internal/rename/apply.go
+++ b/internal/rename/apply.go
@@ -217,6 +217,7 @@ func mergePackageAndImportEdits(plan Plan, editsByFile map[string][]edit) {
 		return
 	}
 	declFiles := declarationFiles(plan)
+	refFiles := referenceFiles(plan)
 
 	for _, file := range plan.cachedFiles {
 		if file == nil {
@@ -245,8 +246,85 @@ func mergePackageAndImportEdits(plan Plan, editsByFile map[string][]edit) {
 					Replace:   repl,
 				})
 			}
+			continue
+		}
+
+		// File referenced the symbol but had no explicit import — that is
+		// only possible when the file shares the symbol's old package. Now
+		// that the symbol is moving away, the file needs an explicit
+		// import added.
+		if !declFiles[file.Path] && refFiles[file.Path] {
+			ctx, ok := plan.Contexts[file.Path]
+			if !ok {
+				continue
+			}
+			if ctx.Package != plan.Target.FromPackage() {
+				continue
+			}
+			ins := buildImportInsertion(file, hr, plan.Target.ToFQN)
+			if ins == nil {
+				continue
+			}
+			editsByFile[file.Path] = append(editsByFile[file.Path], *ins)
 		}
 	}
+}
+
+func referenceFiles(plan Plan) map[string]bool {
+	out := make(map[string]bool, len(plan.References))
+	for _, r := range plan.References {
+		out[r.File] = true
+	}
+	return out
+}
+
+// buildImportInsertion returns an edit that inserts an `import <toFQN>`
+// line at the appropriate position in file. Insertion point precedence:
+// before the first existing import; else after the package declaration;
+// else at the start of the file. Returns nil when no anchor exists.
+func buildImportInsertion(file *scanner.File, hr HeaderRanges, toFQN string) *edit {
+	semi := ""
+	if file.Language == scanner.LangJava {
+		semi = ";"
+	}
+	if first := earliestRange(hr.Imports, hr.Wildcards); first != nil {
+		return &edit{
+			StartByte: first[0],
+			EndByte:   first[0],
+			Replace:   "import " + toFQN + semi + "\n",
+		}
+	}
+	if hr.Package != ([2]int{}) {
+		// Insert immediately after the package line; clamped Package[1] is
+		// the byte before the newline. We add a leading "\n\nimport ..."
+		// so the new import is separated from the package declaration.
+		return &edit{
+			StartByte: hr.Package[1],
+			EndByte:   hr.Package[1],
+			Replace:   "\n\nimport " + toFQN + semi,
+		}
+	}
+	return &edit{
+		StartByte: 0,
+		EndByte:   0,
+		Replace:   "import " + toFQN + semi + "\n\n",
+	}
+}
+
+func earliestRange(maps ...map[string][2]int) *[2]int {
+	var best *[2]int
+	for _, m := range maps {
+		for _, r := range m {
+			if r[0] == 0 && r[1] == 0 {
+				continue
+			}
+			rr := r
+			if best == nil || rr[0] < best[0] {
+				best = &rr
+			}
+		}
+	}
+	return best
 }
 
 func stripEditsInRange(edits []edit, rng [2]int) []edit {

--- a/internal/rename/apply.go
+++ b/internal/rename/apply.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/kaeawc/krit/internal/fsutil"
 	"github.com/kaeawc/krit/internal/scanner"
 )
 
@@ -35,18 +36,14 @@ type edit struct {
 	Expect string
 }
 
-// Apply rewrites every reference site in plan to target.ToName and writes
-// updated file contents back to disk. Each file is written atomically via
-// a sibling temp file plus rename. If any file fails to write, files
-// already written are not rolled back — the caller should run apply against
-// a clean working tree (typically a git checkout). Use DryRun to compute
-// the planned edits without touching disk.
+// Apply writes the rename to disk. Each touched file is rewritten
+// atomically. On partial failure, files already written are not rolled
+// back — run against a clean working tree (typically a git checkout).
 func Apply(plan Plan) (ApplyResult, error) {
 	return apply(plan, false)
 }
 
-// DryRunApply returns the same result Apply would produce without writing
-// anything to disk.
+// DryRunApply returns the result Apply would produce without writing.
 func DryRunApply(plan Plan) (ApplyResult, error) {
 	return apply(plan, true)
 }
@@ -80,8 +77,8 @@ func apply(plan Plan, dry bool) (ApplyResult, error) {
 			result.Edits += len(fileEdits)
 			continue
 		}
-		if err := atomicWrite(file, updated); err != nil {
-			return result, err
+		if err := fsutil.WriteFileAtomic(file, updated, fileMode(file)); err != nil {
+			return result, fmt.Errorf("rename apply: %w", err)
 		}
 		result.FilesChanged++
 		result.Edits += len(fileEdits)
@@ -183,16 +180,13 @@ func remapPackageDir(dir, oldPackage, newPackage string) (string, bool) {
 func collectIdentifierEdits(plan Plan) map[string][]edit {
 	out := make(map[string][]edit)
 	for _, ref := range plan.References {
-		if ref.StartByte <= 0 && ref.EndByte <= 0 {
-			continue
-		}
-		if ref.EndByte <= ref.StartByte {
+		if ref.EndByte <= ref.StartByte || ref.StartByte < 0 {
 			continue
 		}
 		if ref.Language != scanner.LangKotlin && ref.Language != scanner.LangJava {
 			continue
 		}
-		if _, ok := plan.Contexts[ref.File]; !ok {
+		if _, ok := plan.contexts[ref.File]; !ok {
 			continue
 		}
 		out[ref.File] = append(out[ref.File], edit{
@@ -205,49 +199,48 @@ func collectIdentifierEdits(plan Plan) map[string][]edit {
 	return out
 }
 
+// applyFileEdits returns content with edits spliced in. Edits are sorted
+// in ascending byte order and the result is built in a single pass to
+// avoid the O(N*E) reslicing cost of doing each edit independently.
 func applyFileEdits(plan Plan, file string, edits []edit) ([]byte, error) {
 	content, err := readFileContent(plan, file)
 	if err != nil {
 		return nil, err
 	}
-	sort.Slice(edits, func(i, j int) bool { return edits[i].StartByte > edits[j].StartByte })
+	sort.Slice(edits, func(i, j int) bool { return edits[i].StartByte < edits[j].StartByte })
 	for i := 1; i < len(edits); i++ {
-		if edits[i].EndByte > edits[i-1].StartByte {
+		if edits[i].StartByte < edits[i-1].EndByte {
 			return nil, fmt.Errorf("rename apply: overlapping edits in %s", file)
 		}
 	}
+
+	totalLen := len(content)
 	for _, e := range edits {
 		if e.StartByte < 0 || e.EndByte > len(content) {
 			return nil, fmt.Errorf("rename apply: edit out of bounds in %s (%d..%d, len=%d)", file, e.StartByte, e.EndByte, len(content))
 		}
-		if e.Expect != "" {
-			current := string(content[e.StartByte:e.EndByte])
-			if current != e.Expect {
-				return nil, fmt.Errorf("rename apply: %s byte range %d..%d holds %q, not %q (file changed since indexing?)", file, e.StartByte, e.EndByte, current, e.Expect)
-			}
+		if e.Expect != "" && string(content[e.StartByte:e.EndByte]) != e.Expect {
+			return nil, fmt.Errorf("rename apply: %s byte range %d..%d holds %q, not %q (file changed since indexing?)", file, e.StartByte, e.EndByte, content[e.StartByte:e.EndByte], e.Expect)
 		}
-		content = append(content[:e.StartByte], append([]byte(e.Replace), content[e.EndByte:]...)...)
+		totalLen += len(e.Replace) - (e.EndByte - e.StartByte)
 	}
-	return content, nil
+
+	out := make([]byte, 0, totalLen)
+	cursor := 0
+	for _, e := range edits {
+		out = append(out, content[cursor:e.StartByte]...)
+		out = append(out, e.Replace...)
+		cursor = e.EndByte
+	}
+	out = append(out, content[cursor:]...)
+	return out, nil
 }
 
 func readFileContent(plan Plan, path string) ([]byte, error) {
-	for _, f := range planFilesFromPlan(plan) {
-		if f != nil && f.Path == path && f.Content != nil {
-			return append([]byte(nil), f.Content...), nil
-		}
+	if f, ok := plan.filesByPath[path]; ok && f != nil && f.Content != nil {
+		return append([]byte(nil), f.Content...), nil
 	}
 	return os.ReadFile(path)
-}
-
-// planFilesFromPlan returns the files that were used to build the plan's
-// contexts. Stored separately from Contexts to avoid changing the public
-// FileContext shape.
-func planFilesFromPlan(plan Plan) []*scanner.File {
-	if plan.cachedFiles != nil {
-		return plan.cachedFiles
-	}
-	return nil
 }
 
 // mergePackageAndImportEdits adds edits for files that need their package
@@ -262,28 +255,26 @@ func mergePackageAndImportEdits(plan Plan, editsByFile map[string][]edit) {
 	declFiles := declarationFiles(plan)
 	refFiles := referenceFiles(plan)
 
-	for _, file := range plan.cachedFiles {
+	for path, ctx := range plan.contexts {
+		file := plan.filesByPath[path]
 		if file == nil {
 			continue
 		}
-		hr := CollectHeaderRanges(file)
 
-		if declFiles[file.Path] && hr.Package != ([2]int{}) {
-			rewriteText := buildPackageReplacement(file, hr.Package, plan.Target.ToPackage())
-			if rewriteText != "" {
-				editsByFile[file.Path] = append(editsByFile[file.Path], edit{
-					StartByte: hr.Package[0],
-					EndByte:   hr.Package[1],
-					Replace:   rewriteText,
+		if declFiles[path] && ctx.PackageRange != ([2]int{}) {
+			if repl := buildPackageReplacement(file, ctx.PackageRange, plan.Target.ToPackage()); repl != "" {
+				editsByFile[path] = append(editsByFile[path], edit{
+					StartByte: ctx.PackageRange[0],
+					EndByte:   ctx.PackageRange[1],
+					Replace:   repl,
 				})
 			}
 		}
 
-		if rng, ok := hr.Imports[plan.Target.FromFQN]; ok {
-			repl := rewriteImportLine(file, rng, plan.Target.FromFQN, plan.Target.ToFQN)
-			if repl != "" {
-				editsByFile[file.Path] = stripEditsInRange(editsByFile[file.Path], rng)
-				editsByFile[file.Path] = append(editsByFile[file.Path], edit{
+		if rng, ok := ctx.findImportByFQN(plan.Target.FromFQN); ok {
+			if repl := rewriteImportLine(file, rng, plan.Target.ToFQN); repl != "" {
+				editsByFile[path] = stripEditsInRange(editsByFile[path], rng)
+				editsByFile[path] = append(editsByFile[path], edit{
 					StartByte: rng[0],
 					EndByte:   rng[1],
 					Replace:   repl,
@@ -292,23 +283,11 @@ func mergePackageAndImportEdits(plan Plan, editsByFile map[string][]edit) {
 			continue
 		}
 
-		// File referenced the symbol but had no explicit import — that is
-		// only possible when the file shares the symbol's old package. Now
-		// that the symbol is moving away, the file needs an explicit
-		// import added.
-		if !declFiles[file.Path] && refFiles[file.Path] {
-			ctx, ok := plan.Contexts[file.Path]
-			if !ok {
-				continue
-			}
-			if ctx.Package != plan.Target.FromPackage() {
-				continue
-			}
-			ins := buildImportInsertion(file, hr, plan.Target.ToFQN)
-			if ins == nil {
-				continue
-			}
-			editsByFile[file.Path] = append(editsByFile[file.Path], *ins)
+		// Same-package reference without an explicit import: the file's
+		// implicit binding goes away when the symbol moves out, so insert
+		// an explicit import.
+		if !declFiles[path] && refFiles[path] && ctx.Package == plan.Target.FromPackage() {
+			editsByFile[path] = append(editsByFile[path], buildImportInsertion(file, ctx, plan.Target.ToFQN))
 		}
 	}
 }
@@ -322,52 +301,23 @@ func referenceFiles(plan Plan) map[string]bool {
 }
 
 // buildImportInsertion returns an edit that inserts an `import <toFQN>`
-// line at the appropriate position in file. Insertion point precedence:
-// before the first existing import; else after the package declaration;
-// else at the start of the file. Returns nil when no anchor exists.
-func buildImportInsertion(file *scanner.File, hr HeaderRanges, toFQN string) *edit {
+// line in file. Insertion point precedence: before the first existing
+// import; else after the package declaration; else at the start of the file.
+func buildImportInsertion(file *scanner.File, ctx fileContext, toFQN string) edit {
 	semi := ""
 	if file.Language == scanner.LangJava {
 		semi = ";"
 	}
-	if first := earliestRange(hr.Imports, hr.Wildcards); first != nil {
-		return &edit{
-			StartByte: first[0],
-			EndByte:   first[0],
-			Replace:   "import " + toFQN + semi + "\n",
-		}
+	pos, beforeImport := ctx.firstImportAnchor()
+	if beforeImport {
+		return edit{StartByte: pos, EndByte: pos, Replace: "import " + toFQN + semi + "\n"}
 	}
-	if hr.Package != ([2]int{}) {
-		// Insert immediately after the package line; clamped Package[1] is
-		// the byte before the newline. We add a leading "\n\nimport ..."
-		// so the new import is separated from the package declaration.
-		return &edit{
-			StartByte: hr.Package[1],
-			EndByte:   hr.Package[1],
-			Replace:   "\n\nimport " + toFQN + semi,
-		}
+	if ctx.PackageRange != ([2]int{}) {
+		// Anchor sits at the byte before the newline that ends the package
+		// line, so a leading "\n\n" gives a blank line of separation.
+		return edit{StartByte: pos, EndByte: pos, Replace: "\n\nimport " + toFQN + semi}
 	}
-	return &edit{
-		StartByte: 0,
-		EndByte:   0,
-		Replace:   "import " + toFQN + semi + "\n\n",
-	}
-}
-
-func earliestRange(maps ...map[string][2]int) *[2]int {
-	var best *[2]int
-	for _, m := range maps {
-		for _, r := range m {
-			if r[0] == 0 && r[1] == 0 {
-				continue
-			}
-			rr := r
-			if best == nil || rr[0] < best[0] {
-				best = &rr
-			}
-		}
-	}
-	return best
+	return edit{StartByte: 0, EndByte: 0, Replace: "import " + toFQN + semi + "\n\n"}
 }
 
 func stripEditsInRange(edits []edit, rng [2]int) []edit {
@@ -404,25 +354,22 @@ func buildPackageReplacement(file *scanner.File, rng [2]int, toPackage string) s
 	return out
 }
 
-func rewriteImportLine(file *scanner.File, rng [2]int, fromFQN, toFQN string) string {
+func rewriteImportLine(file *scanner.File, rng [2]int, toFQN string) string {
 	if file.Content == nil || rng[0] < 0 || rng[1] > len(file.Content) || rng[0] >= rng[1] {
 		return ""
 	}
 	original := strings.TrimSpace(string(file.Content[rng[0]:rng[1]]))
 	hasSemi := strings.HasSuffix(original, ";")
-	body := strings.TrimSuffix(original, ";")
-	body = strings.TrimSpace(body)
-	body = strings.TrimPrefix(body, "import")
-	body = strings.TrimSpace(body)
+	body := trimImportLine(original)
 
 	prefix := "import "
 	suffix := ""
-	if file.Language == scanner.LangJava {
+	switch file.Language {
+	case scanner.LangJava:
 		if strings.HasPrefix(body, "static ") {
 			prefix = "import static "
 		}
-	} else {
-		// Kotlin: preserve `as <alias>` if present.
+	default:
 		if i := strings.Index(body, " as "); i >= 0 {
 			suffix = body[i:]
 		}
@@ -432,38 +379,12 @@ func rewriteImportLine(file *scanner.File, rng [2]int, fromFQN, toFQN string) st
 	if file.Language == scanner.LangJava || hasSemi {
 		out += ";"
 	}
-	_ = fromFQN
 	return out
 }
 
-func atomicWrite(path string, content []byte) error {
-	dir := filepath.Dir(path)
-	tmp, err := os.CreateTemp(dir, ".krit-rename-*")
-	if err != nil {
-		return fmt.Errorf("rename apply: temp file: %w", err)
+func fileMode(path string) os.FileMode {
+	if info, err := os.Stat(path); err == nil {
+		return info.Mode().Perm()
 	}
-	tmpPath := tmp.Name()
-	if _, err := tmp.Write(content); err != nil {
-		tmp.Close()
-		os.Remove(tmpPath)
-		return fmt.Errorf("rename apply: write %s: %w", tmpPath, err)
-	}
-	if err := tmp.Sync(); err != nil {
-		tmp.Close()
-		os.Remove(tmpPath)
-		return fmt.Errorf("rename apply: sync %s: %w", tmpPath, err)
-	}
-	if err := tmp.Close(); err != nil {
-		os.Remove(tmpPath)
-		return fmt.Errorf("rename apply: close %s: %w", tmpPath, err)
-	}
-	info, err := os.Stat(path)
-	if err == nil {
-		_ = os.Chmod(tmpPath, info.Mode())
-	}
-	if err := os.Rename(tmpPath, path); err != nil {
-		os.Remove(tmpPath)
-		return fmt.Errorf("rename apply: rename %s: %w", path, err)
-	}
-	return nil
+	return 0o644
 }

--- a/internal/rename/apply_test.go
+++ b/internal/rename/apply_test.go
@@ -266,6 +266,33 @@ func TestApply_PreservesPackageTrailingComments(t *testing.T) {
 	}
 }
 
+func TestApply_PreservesKotlinAliasOnCrossPackageRename(t *testing.T) {
+	dir := t.TempDir()
+	declPath := filepath.Join(dir, "OldName.kt")
+	usePath := filepath.Join(dir, "Feature.kt")
+
+	writeFile(t, declPath, "package com.example.foo\n\nclass OldName\n")
+	writeFile(t, usePath, ""+
+		"package com.example.user\n"+
+		"\n"+
+		"import com.example.foo.OldName as Aliased\n"+
+		"\n"+
+		"fun useIt(): Aliased = Aliased()\n")
+
+	plan := buildKotlinPlan(t, []string{declPath, usePath}, "com.example.foo.OldName", "com.example.bar.NewName")
+	if _, err := Apply(plan); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	got := readFile(t, usePath)
+	if !strings.Contains(got, "import com.example.bar.NewName as Aliased") {
+		t.Fatalf("alias not preserved on import rewrite:\n%s", got)
+	}
+	if !strings.Contains(got, "fun useIt(): Aliased = Aliased()") {
+		t.Fatalf("alias usage was rewritten:\n%s", got)
+	}
+}
+
 func TestApply_RejectsIdenticalFromAndTo(t *testing.T) {
 	target, err := ParseTarget("com.example.OldName", "com.example.OldName")
 	if err == nil {

--- a/internal/rename/apply_test.go
+++ b/internal/rename/apply_test.go
@@ -38,7 +38,8 @@ func TestApply_KotlinSamePackageRename(t *testing.T) {
 		t.Fatalf("FilesChanged = %d, want 2", res.FilesChanged)
 	}
 
-	got := readFile(t, declPath)
+	newDeclPath := filepath.Join(dir, "NewName.kt")
+	got := readFile(t, newDeclPath)
 	if !strings.Contains(got, "class NewName") || strings.Contains(got, "OldName") {
 		t.Fatalf("decl file content unexpected:\n%s", got)
 	}
@@ -96,7 +97,7 @@ func TestApply_KotlinCrossPackageRename(t *testing.T) {
 		t.Fatalf("Apply: %v", err)
 	}
 
-	got := readFile(t, declPath)
+	got := readFile(t, filepath.Join(dir, "NewName.kt"))
 	if !strings.Contains(got, "package com.example.bar") {
 		t.Fatalf("decl file package not rewritten:\n%s", got)
 	}
@@ -152,7 +153,7 @@ func TestApply_JavaCrossPackageRename(t *testing.T) {
 		t.Fatalf("Apply: %v", err)
 	}
 
-	got := readFile(t, declPath)
+	got := readFile(t, filepath.Join(dir, "NewName.java"))
 	if !strings.Contains(got, "package com.example.bar;") {
 		t.Fatalf("java decl package not rewritten:\n%s", got)
 	}
@@ -166,6 +167,49 @@ func TestApply_JavaCrossPackageRename(t *testing.T) {
 	}
 	if strings.Contains(got, "OldName") {
 		t.Fatalf("residual OldName in java use:\n%s", got)
+	}
+}
+
+func TestApply_RenamesMatchingFile(t *testing.T) {
+	dir := t.TempDir()
+	declPath := filepath.Join(dir, "OldName.kt")
+	writeFile(t, declPath, "package com.example\n\nclass OldName\n")
+
+	plan := buildKotlinPlan(t, []string{declPath}, "com.example.OldName", "com.example.NewName")
+	res, err := Apply(plan)
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if len(res.Moves) != 1 {
+		t.Fatalf("Moves = %d, want 1", len(res.Moves))
+	}
+	want := filepath.Join(dir, "NewName.kt")
+	if res.Moves[0].To != want {
+		t.Fatalf("Moves[0].To = %q, want %q", res.Moves[0].To, want)
+	}
+	if _, err := os.Stat(declPath); !os.IsNotExist(err) {
+		t.Fatalf("old file still exists: err=%v", err)
+	}
+	if _, err := os.Stat(want); err != nil {
+		t.Fatalf("new file missing: %v", err)
+	}
+}
+
+func TestApply_DoesNotRenameMismatchedFile(t *testing.T) {
+	dir := t.TempDir()
+	declPath := filepath.Join(dir, "MyFile.kt")
+	writeFile(t, declPath, "package com.example\n\nclass OldName\n")
+
+	plan := buildKotlinPlan(t, []string{declPath}, "com.example.OldName", "com.example.NewName")
+	res, err := Apply(plan)
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if len(res.Moves) != 0 {
+		t.Fatalf("Moves = %d, want 0", len(res.Moves))
+	}
+	if _, err := os.Stat(declPath); err != nil {
+		t.Fatalf("file should still exist: %v", err)
 	}
 }
 

--- a/internal/rename/apply_test.go
+++ b/internal/rename/apply_test.go
@@ -293,6 +293,31 @@ func TestApply_PreservesKotlinAliasOnCrossPackageRename(t *testing.T) {
 	}
 }
 
+func TestApply_InsertsImportForOrphanedSamePackageReference(t *testing.T) {
+	dir := t.TempDir()
+	declPath := filepath.Join(dir, "OldName.kt")
+	usePath := filepath.Join(dir, "Feature.kt")
+
+	writeFile(t, declPath, "package com.example.foo\n\nclass OldName\n")
+	writeFile(t, usePath, ""+
+		"package com.example.foo\n"+
+		"\n"+
+		"fun useIt(): OldName = OldName()\n")
+
+	plan := buildKotlinPlan(t, []string{declPath, usePath}, "com.example.foo.OldName", "com.example.bar.NewName")
+	if _, err := Apply(plan); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	got := readFile(t, usePath)
+	if !strings.Contains(got, "import com.example.bar.NewName") {
+		t.Fatalf("expected inserted import, got:\n%s", got)
+	}
+	if !strings.Contains(got, "fun useIt(): NewName = NewName()") {
+		t.Fatalf("call sites not rewritten:\n%s", got)
+	}
+}
+
 func TestApply_RejectsIdenticalFromAndTo(t *testing.T) {
 	target, err := ParseTarget("com.example.OldName", "com.example.OldName")
 	if err == nil {

--- a/internal/rename/apply_test.go
+++ b/internal/rename/apply_test.go
@@ -69,6 +69,106 @@ func TestApply_DryRun(t *testing.T) {
 	}
 }
 
+func TestApply_KotlinCrossPackageRename(t *testing.T) {
+	dir := t.TempDir()
+	declPath := filepath.Join(dir, "OldName.kt")
+	usePath := filepath.Join(dir, "Feature.kt")
+
+	writeFile(t, declPath, ""+
+		"package com.example.foo\n"+
+		"\n"+
+		"class OldName {\n"+
+		"    fun greet() = \"hi\"\n"+
+		"}\n")
+	writeFile(t, usePath, ""+
+		"package com.example.user\n"+
+		"\n"+
+		"import com.example.foo.OldName\n"+
+		"\n"+
+		"fun useIt(): OldName = OldName()\n")
+
+	plan := buildKotlinPlan(t, []string{declPath, usePath}, "com.example.foo.OldName", "com.example.bar.NewName")
+	if got := plan.CandidateCount(); got == 0 {
+		t.Fatalf("expected candidates, got 0")
+	}
+
+	if _, err := Apply(plan); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	got := readFile(t, declPath)
+	if !strings.Contains(got, "package com.example.bar") {
+		t.Fatalf("decl file package not rewritten:\n%s", got)
+	}
+	if !strings.Contains(got, "class NewName") {
+		t.Fatalf("decl file class not renamed:\n%s", got)
+	}
+
+	got = readFile(t, usePath)
+	if !strings.Contains(got, "import com.example.bar.NewName") {
+		t.Fatalf("import not rewritten:\n%s", got)
+	}
+	if strings.Contains(got, "OldName") || strings.Contains(got, "com.example.foo") {
+		t.Fatalf("residual OldName/com.example.foo:\n%s", got)
+	}
+	if !strings.Contains(got, "NewName()") {
+		t.Fatalf("call site not rewritten:\n%s", got)
+	}
+}
+
+func TestApply_JavaCrossPackageRename(t *testing.T) {
+	dir := t.TempDir()
+	declPath := filepath.Join(dir, "OldName.java")
+	usePath := filepath.Join(dir, "Feature.java")
+
+	writeFile(t, declPath, ""+
+		"package com.example.foo;\n"+
+		"\n"+
+		"public class OldName {\n"+
+		"    public String greet() { return \"hi\"; }\n"+
+		"}\n")
+	writeFile(t, usePath, ""+
+		"package com.example.user;\n"+
+		"\n"+
+		"import com.example.foo.OldName;\n"+
+		"\n"+
+		"public class Feature {\n"+
+		"    public OldName useIt() { return new OldName(); }\n"+
+		"}\n")
+
+	files, errs := scanner.ScanJavaFiles([]string{declPath, usePath}, 1)
+	for _, e := range errs {
+		if e != nil {
+			t.Fatalf("scan: %v", e)
+		}
+	}
+	idx := scanner.BuildIndex(nil, 1, files...)
+	target, err := ParseTarget("com.example.foo.OldName", "com.example.bar.NewName")
+	if err != nil {
+		t.Fatalf("ParseTarget: %v", err)
+	}
+	plan := BuildPlanWithFiles(idx, target, files)
+	if _, err := Apply(plan); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	got := readFile(t, declPath)
+	if !strings.Contains(got, "package com.example.bar;") {
+		t.Fatalf("java decl package not rewritten:\n%s", got)
+	}
+	if !strings.Contains(got, "class NewName") {
+		t.Fatalf("java decl class not renamed:\n%s", got)
+	}
+
+	got = readFile(t, usePath)
+	if !strings.Contains(got, "import com.example.bar.NewName;") {
+		t.Fatalf("java import not rewritten:\n%s", got)
+	}
+	if strings.Contains(got, "OldName") {
+		t.Fatalf("residual OldName in java use:\n%s", got)
+	}
+}
+
 func TestApply_RejectsDifferentPackage(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "Other.kt")

--- a/internal/rename/apply_test.go
+++ b/internal/rename/apply_test.go
@@ -224,6 +224,69 @@ func TestApply_RejectsDifferentPackage(t *testing.T) {
 	}
 }
 
+func TestApply_IgnoresStringLiterals(t *testing.T) {
+	dir := t.TempDir()
+	declPath := filepath.Join(dir, "OldName.kt")
+	usePath := filepath.Join(dir, "Feature.kt")
+	writeFile(t, declPath, "package com.example\n\nclass OldName\n")
+	writeFile(t, usePath, ""+
+		"package com.example\n"+
+		"\n"+
+		"fun greeting(): String = \"OldName is here\"\n")
+
+	plan := buildKotlinPlan(t, []string{declPath, usePath}, "com.example.OldName", "com.example.NewName")
+	if _, err := Apply(plan); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	got := readFile(t, usePath)
+	if !strings.Contains(got, "\"OldName is here\"") {
+		t.Fatalf("string literal got rewritten: %s", got)
+	}
+}
+
+func TestApply_PreservesPackageTrailingComments(t *testing.T) {
+	dir := t.TempDir()
+	declPath := filepath.Join(dir, "OldName.kt")
+	writeFile(t, declPath, ""+
+		"package com.example\n"+
+		"\n"+
+		"// keep this comment\n"+
+		"class OldName\n")
+
+	plan := buildKotlinPlan(t, []string{declPath}, "com.example.OldName", "com.bar.NewName")
+	if _, err := Apply(plan); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	got := readFile(t, filepath.Join(dir, "NewName.kt"))
+	if !strings.Contains(got, "// keep this comment") {
+		t.Fatalf("post-package comment was dropped:\n%s", got)
+	}
+	if !strings.Contains(got, "package com.bar") {
+		t.Fatalf("package not rewritten:\n%s", got)
+	}
+}
+
+func TestApply_RejectsIdenticalFromAndTo(t *testing.T) {
+	target, err := ParseTarget("com.example.OldName", "com.example.OldName")
+	if err == nil {
+		t.Fatalf("expected ParseTarget to reject identical FQNs, got target=%+v", target)
+	}
+}
+
+func TestValidatePlan_RejectsAmbiguousDeclarations(t *testing.T) {
+	target, _ := ParseTarget("com.example.OldName", "com.example.NewName")
+	plan := Plan{
+		Target: target,
+		Declarations: []scanner.Symbol{
+			{Name: "OldName", FQN: "com.example.OldName", File: "a.kt"},
+			{Name: "OldName", FQN: "com.example.OldName", File: "b.kt"},
+		},
+	}
+	if err := ValidatePlan(plan); err == nil {
+		t.Fatalf("expected ValidatePlan to reject duplicate declarations")
+	}
+}
+
 func buildKotlinPlan(t *testing.T, paths []string, fromFQN, toFQN string) Plan {
 	t.Helper()
 	files, errs := scanner.ScanFiles(paths, 1)

--- a/internal/rename/apply_test.go
+++ b/internal/rename/apply_test.go
@@ -318,6 +318,76 @@ func TestApply_InsertsImportForOrphanedSamePackageReference(t *testing.T) {
 	}
 }
 
+func TestApply_MovesDeclarationFileToNewPackageDir(t *testing.T) {
+	dir := t.TempDir()
+	srcRoot := filepath.Join(dir, "src", "main", "kotlin")
+	oldDir := filepath.Join(srcRoot, "com", "example", "foo")
+	if err := os.MkdirAll(oldDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	declPath := filepath.Join(oldDir, "OldName.kt")
+	writeFile(t, declPath, "package com.example.foo\n\nclass OldName\n")
+
+	plan := buildKotlinPlan(t, []string{declPath}, "com.example.foo.OldName", "com.example.bar.NewName")
+	res, err := Apply(plan)
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if len(res.Moves) != 1 {
+		t.Fatalf("Moves = %d, want 1", len(res.Moves))
+	}
+	wantDest := filepath.Join(srcRoot, "com", "example", "bar", "NewName.kt")
+	if res.Moves[0].To != wantDest {
+		t.Fatalf("Moves[0].To = %q, want %q", res.Moves[0].To, wantDest)
+	}
+	if _, err := os.Stat(declPath); !os.IsNotExist(err) {
+		t.Fatalf("old file still exists: %v", err)
+	}
+	if _, err := os.Stat(wantDest); err != nil {
+		t.Fatalf("new file missing: %v", err)
+	}
+}
+
+func TestApply_KeepsFileInPlaceWhenLayoutDoesNotMirrorPackage(t *testing.T) {
+	// Path has no com/example/foo segments — flat layout. Even though
+	// the rename crosses packages, the directory stays where it is.
+	dir := t.TempDir()
+	declPath := filepath.Join(dir, "OldName.kt")
+	writeFile(t, declPath, "package com.example.foo\n\nclass OldName\n")
+
+	plan := buildKotlinPlan(t, []string{declPath}, "com.example.foo.OldName", "com.example.bar.NewName")
+	res, err := Apply(plan)
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if len(res.Moves) != 1 {
+		t.Fatalf("Moves = %d, want 1", len(res.Moves))
+	}
+	wantDest := filepath.Join(dir, "NewName.kt")
+	if res.Moves[0].To != wantDest {
+		t.Fatalf("Moves[0].To = %q, want %q", res.Moves[0].To, wantDest)
+	}
+}
+
+func TestRemapPackageDir(t *testing.T) {
+	cases := []struct {
+		dir, oldPkg, newPkg string
+		want                string
+		ok                  bool
+	}{
+		{"src/main/kotlin/com/foo", "com.foo", "com.bar", "src/main/kotlin/com/bar", true},
+		{"src/main/kotlin/com/foo/sub", "com.foo", "com.bar", "src/main/kotlin/com/foo/sub", false},
+		{"com/foo", "com.foo", "com.bar", "com/bar", true},
+		{"flat", "com.foo", "com.bar", "flat", false},
+	}
+	for _, tc := range cases {
+		got, ok := remapPackageDir(tc.dir, tc.oldPkg, tc.newPkg)
+		if ok != tc.ok || got != tc.want {
+			t.Errorf("remapPackageDir(%q,%q,%q) = (%q,%v), want (%q,%v)", tc.dir, tc.oldPkg, tc.newPkg, got, ok, tc.want, tc.ok)
+		}
+	}
+}
+
 func TestApply_RejectsIdenticalFromAndTo(t *testing.T) {
 	target, err := ParseTarget("com.example.OldName", "com.example.OldName")
 	if err == nil {

--- a/internal/rename/apply_test.go
+++ b/internal/rename/apply_test.go
@@ -1,0 +1,113 @@
+package rename
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kaeawc/krit/internal/scanner"
+)
+
+func TestApply_KotlinSamePackageRename(t *testing.T) {
+	dir := t.TempDir()
+	declPath := filepath.Join(dir, "OldName.kt")
+	usePath := filepath.Join(dir, "Feature.kt")
+
+	writeFile(t, declPath, ""+
+		"package com.example\n"+
+		"\n"+
+		"class OldName {\n"+
+		"    fun greet() = \"hi\"\n"+
+		"}\n")
+	writeFile(t, usePath, ""+
+		"package com.example\n"+
+		"\n"+
+		"fun useIt(): OldName = OldName()\n")
+
+	plan := buildKotlinPlan(t, []string{declPath, usePath}, "com.example.OldName", "com.example.NewName")
+	if got := plan.CandidateCount(); got == 0 {
+		t.Fatalf("expected candidates, got 0")
+	}
+
+	res, err := Apply(plan)
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if res.FilesChanged != 2 {
+		t.Fatalf("FilesChanged = %d, want 2", res.FilesChanged)
+	}
+
+	got := readFile(t, declPath)
+	if !strings.Contains(got, "class NewName") || strings.Contains(got, "OldName") {
+		t.Fatalf("decl file content unexpected:\n%s", got)
+	}
+	got = readFile(t, usePath)
+	if strings.Contains(got, "OldName") {
+		t.Fatalf("ref file still mentions OldName:\n%s", got)
+	}
+	if !strings.Contains(got, "NewName") {
+		t.Fatalf("ref file missing NewName:\n%s", got)
+	}
+}
+
+func TestApply_DryRun(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "OldName.kt")
+	writeFile(t, path, "package com.example\n\nclass OldName\n")
+
+	plan := buildKotlinPlan(t, []string{path}, "com.example.OldName", "com.example.NewName")
+	res, err := DryRunApply(plan)
+	if err != nil {
+		t.Fatalf("DryRunApply: %v", err)
+	}
+	if res.FilesChanged != 1 {
+		t.Fatalf("FilesChanged = %d, want 1", res.FilesChanged)
+	}
+	if got := readFile(t, path); !strings.Contains(got, "OldName") {
+		t.Fatalf("dry-run modified file: %s", got)
+	}
+}
+
+func TestApply_RejectsDifferentPackage(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "Other.kt")
+	writeFile(t, path, "package com.other\n\nclass OldName\n")
+
+	plan := buildKotlinPlan(t, []string{path}, "com.example.OldName", "com.example.NewName")
+	if got := plan.CandidateCount(); got != 0 {
+		t.Fatalf("expected 0 candidates for different-package OldName, got %d", got)
+	}
+}
+
+func buildKotlinPlan(t *testing.T, paths []string, fromFQN, toFQN string) Plan {
+	t.Helper()
+	files, errs := scanner.ScanFiles(paths, 1)
+	for _, e := range errs {
+		if e != nil {
+			t.Fatalf("scan: %v", e)
+		}
+	}
+	idx := scanner.BuildIndex(files, 1)
+	target, err := ParseTarget(fromFQN, toFQN)
+	if err != nil {
+		t.Fatalf("ParseTarget: %v", err)
+	}
+	return BuildPlan(idx, target)
+}
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func readFile(t *testing.T, path string) string {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(b)
+}

--- a/internal/rename/context.go
+++ b/internal/rename/context.go
@@ -36,24 +36,50 @@ func BuildFileContext(file *scanner.File) FileContext {
 
 	file.FlatWalkAllNodes(0, func(idx uint32) {
 		switch file.FlatType(idx) {
-		case "package_header":
-			text := strings.TrimSpace(file.FlatNodeText(idx))
-			text = strings.TrimPrefix(text, "package")
-			text = strings.TrimSpace(text)
-			ctx.Package = strings.TrimSuffix(text, ";")
-		case "package_declaration":
-			text := strings.TrimSpace(file.FlatNodeText(idx))
-			text = strings.TrimPrefix(text, "package")
-			text = strings.TrimSpace(text)
-			ctx.Package = strings.TrimSuffix(text, ";")
+		case "package_header", "package_declaration":
+			if ctx.Package == "" {
+				ctx.Package = firstHeaderLine(file.FlatNodeText(idx), "package")
+			}
 		case "import_header":
-			parseKotlinImport(file.FlatNodeText(idx), &ctx)
+			parseKotlinImport(firstSourceLine(file.FlatNodeText(idx)), &ctx)
 		case "import_declaration":
-			parseJavaImport(file.FlatNodeText(idx), &ctx)
+			parseJavaImport(firstSourceLine(file.FlatNodeText(idx)), &ctx)
 		}
 	})
 
 	return ctx
+}
+
+// firstSourceLine returns the first non-empty, non-comment line of raw,
+// trimmed. Used to ignore trailing trivia that tree-sitter sometimes
+// attaches to header nodes.
+func firstSourceLine(raw string) string {
+	for _, line := range strings.Split(raw, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "//") || strings.HasPrefix(line, "/*") {
+			continue
+		}
+		return line
+	}
+	return ""
+}
+
+// firstHeaderLine returns the first non-empty, non-comment line of raw with
+// the given keyword stripped. Tree-sitter Kotlin/Java sometimes attach
+// trailing comments and whitespace to header nodes, so a naïve TrimSpace
+// of FlatNodeText would include them.
+func firstHeaderLine(raw, keyword string) string {
+	for _, line := range strings.Split(raw, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "//") || strings.HasPrefix(line, "/*") {
+			continue
+		}
+		line = strings.TrimPrefix(line, keyword)
+		line = strings.TrimSpace(line)
+		line = strings.TrimSuffix(line, ";")
+		return strings.TrimSpace(line)
+	}
+	return ""
 }
 
 func parseKotlinImport(raw string, ctx *FileContext) {
@@ -177,7 +203,7 @@ func CollectHeaderRanges(file *scanner.File) HeaderRanges {
 	file.FlatWalkAllNodes(0, func(idx uint32) {
 		switch file.FlatType(idx) {
 		case "package_header", "package_declaration":
-			hr.Package = [2]int{int(file.FlatStartByte(idx)), int(file.FlatEndByte(idx))}
+			hr.Package = clampToFirstLine(file, int(file.FlatStartByte(idx)), int(file.FlatEndByte(idx)))
 		case "import_header":
 			recordImportRange(file, idx, &hr, parseKotlinImportTarget)
 		case "import_declaration":
@@ -196,8 +222,8 @@ type importTarget struct {
 }
 
 func recordImportRange(file *scanner.File, idx uint32, hr *HeaderRanges, parse func(string) importTarget) {
-	rng := [2]int{int(file.FlatStartByte(idx)), int(file.FlatEndByte(idx))}
-	tgt := parse(file.FlatNodeText(idx))
+	rng := clampToFirstLine(file, int(file.FlatStartByte(idx)), int(file.FlatEndByte(idx)))
+	tgt := parse(firstSourceLine(file.FlatNodeText(idx)))
 	switch {
 	case tgt.alias != "" && tgt.fqn != "":
 		hr.Aliases[tgt.alias] = rng
@@ -272,6 +298,22 @@ func computeFirstImportPos(_ *scanner.File, hr HeaderRanges) int {
 		return hr.Package[1]
 	}
 	return 0
+}
+
+// clampToFirstLine narrows a byte range to its first line. If the range
+// starts at the beginning of a header but extends into trailing
+// comments/whitespace (a tree-sitter quirk), the rewriter would otherwise
+// erase those when replacing the line.
+func clampToFirstLine(file *scanner.File, start, end int) [2]int {
+	if file.Content == nil || start < 0 || end > len(file.Content) || start >= end {
+		return [2]int{start, end}
+	}
+	for i := start; i < end; i++ {
+		if file.Content[i] == '\n' {
+			return [2]int{start, i}
+		}
+	}
+	return [2]int{start, end}
 }
 
 func splitFQN(fqn string) (parent, simple string, ok bool) {

--- a/internal/rename/context.go
+++ b/internal/rename/context.go
@@ -1,0 +1,160 @@
+package rename
+
+import (
+	"strings"
+
+	"github.com/kaeawc/krit/internal/scanner"
+)
+
+// FileContext captures the package and imports of a single source file so
+// references in that file can be resolved to fully qualified names.
+type FileContext struct {
+	File      string
+	Package   string
+	Language  scanner.Language
+	Imports   map[string]string // simple name -> FQN
+	Aliases   map[string]string // alias -> FQN (Kotlin only)
+	Wildcards []string          // package names imported with `.*`
+}
+
+// BuildFileContext walks file's flat AST to extract package, imports, aliases
+// and wildcard imports. Works for both Kotlin and Java files.
+func BuildFileContext(file *scanner.File) FileContext {
+	ctx := FileContext{
+		Imports: make(map[string]string),
+		Aliases: make(map[string]string),
+	}
+	if file == nil {
+		return ctx
+	}
+	ctx.File = file.Path
+	ctx.Language = file.Language
+
+	if file.FlatTree == nil {
+		return ctx
+	}
+
+	file.FlatWalkAllNodes(0, func(idx uint32) {
+		switch file.FlatType(idx) {
+		case "package_header":
+			text := strings.TrimSpace(file.FlatNodeText(idx))
+			text = strings.TrimPrefix(text, "package")
+			text = strings.TrimSpace(text)
+			ctx.Package = strings.TrimSuffix(text, ";")
+		case "package_declaration":
+			text := strings.TrimSpace(file.FlatNodeText(idx))
+			text = strings.TrimPrefix(text, "package")
+			text = strings.TrimSpace(text)
+			ctx.Package = strings.TrimSuffix(text, ";")
+		case "import_header":
+			parseKotlinImport(file.FlatNodeText(idx), &ctx)
+		case "import_declaration":
+			parseJavaImport(file.FlatNodeText(idx), &ctx)
+		}
+	})
+
+	return ctx
+}
+
+func parseKotlinImport(raw string, ctx *FileContext) {
+	text := strings.TrimSpace(raw)
+	text = strings.TrimPrefix(text, "import")
+	text = strings.TrimSpace(text)
+	text = strings.TrimSuffix(text, ";")
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return
+	}
+	if i := strings.Index(text, " as "); i >= 0 {
+		fqn := strings.TrimSpace(text[:i])
+		alias := strings.TrimSpace(text[i+len(" as "):])
+		if fqn != "" && alias != "" {
+			ctx.Aliases[alias] = fqn
+		}
+		return
+	}
+	if strings.HasSuffix(text, ".*") {
+		pkg := strings.TrimSuffix(text, ".*")
+		if pkg != "" {
+			ctx.Wildcards = append(ctx.Wildcards, pkg)
+		}
+		return
+	}
+	if name, ok := simpleName(text); ok {
+		ctx.Imports[name] = text
+	}
+}
+
+func parseJavaImport(raw string, ctx *FileContext) {
+	text := strings.TrimSpace(raw)
+	text = strings.TrimPrefix(text, "import")
+	text = strings.TrimSpace(text)
+	text = strings.TrimPrefix(text, "static")
+	text = strings.TrimSpace(text)
+	text = strings.TrimSuffix(text, ";")
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return
+	}
+	if strings.HasSuffix(text, ".*") {
+		pkg := strings.TrimSuffix(text, ".*")
+		if pkg != "" {
+			ctx.Wildcards = append(ctx.Wildcards, pkg)
+		}
+		return
+	}
+	if name, ok := simpleName(text); ok {
+		ctx.Imports[name] = text
+	}
+}
+
+// ResolveSimpleName returns the FQN that `name` refers to in this file, or
+// the empty string if it cannot be resolved deterministically. The
+// resolution order is: alias > explicit import > same-package > single
+// wildcard match.
+func (c FileContext) ResolveSimpleName(name string) string {
+	if name == "" {
+		return ""
+	}
+	if fqn, ok := c.Aliases[name]; ok {
+		return fqn
+	}
+	if fqn, ok := c.Imports[name]; ok {
+		return fqn
+	}
+	return ""
+}
+
+// MatchesFQN reports whether a reference of the given simple `name` in this
+// file resolves to fqn. Same-package references and wildcard imports are
+// considered alongside explicit imports/aliases. A wildcard match counts
+// only when no explicit import for `name` exists in this file.
+func (c FileContext) MatchesFQN(name, fqn string) bool {
+	if name == "" || fqn == "" {
+		return false
+	}
+	if resolved := c.ResolveSimpleName(name); resolved != "" {
+		return resolved == fqn
+	}
+	parent, simple, ok := splitFQN(fqn)
+	if !ok || simple != name {
+		return false
+	}
+	if c.Package != "" && c.Package == parent {
+		return true
+	}
+	for _, wp := range c.Wildcards {
+		if wp == parent {
+			return true
+		}
+	}
+	return false
+}
+
+func splitFQN(fqn string) (parent, simple string, ok bool) {
+	idx := strings.LastIndex(fqn, ".")
+	if idx <= 0 || idx == len(fqn)-1 {
+		return "", "", false
+	}
+	return fqn[:idx], fqn[idx+1:], true
+}

--- a/internal/rename/context.go
+++ b/internal/rename/context.go
@@ -151,6 +151,129 @@ func (c FileContext) MatchesFQN(name, fqn string) bool {
 	return false
 }
 
+// HeaderRanges holds byte ranges for package and import statement nodes in
+// a single file. Used by Apply to rewrite or replace those statements
+// when a rename moves a symbol across packages.
+type HeaderRanges struct {
+	Package        [2]int            // byte range of package_header / package_declaration; zero means no package
+	Imports        map[string][2]int // FQN -> import_header range
+	Aliases        map[string][2]int // alias -> import_header range
+	Wildcards      map[string][2]int // package -> wildcard import range
+	FirstImportPos int               // byte offset where a new import would be inserted; 0 if no anchor
+}
+
+// CollectHeaderRanges walks file's flat AST to extract byte ranges for the
+// package declaration and every import statement. Works for both Kotlin
+// and Java files.
+func CollectHeaderRanges(file *scanner.File) HeaderRanges {
+	hr := HeaderRanges{
+		Imports:   make(map[string][2]int),
+		Aliases:   make(map[string][2]int),
+		Wildcards: make(map[string][2]int),
+	}
+	if file == nil || file.FlatTree == nil {
+		return hr
+	}
+	file.FlatWalkAllNodes(0, func(idx uint32) {
+		switch file.FlatType(idx) {
+		case "package_header", "package_declaration":
+			hr.Package = [2]int{int(file.FlatStartByte(idx)), int(file.FlatEndByte(idx))}
+		case "import_header":
+			recordImportRange(file, idx, &hr, parseKotlinImportTarget)
+		case "import_declaration":
+			recordImportRange(file, idx, &hr, parseJavaImportTarget)
+		}
+	})
+	hr.FirstImportPos = computeFirstImportPos(file, hr)
+	return hr
+}
+
+type importTarget struct {
+	fqn      string
+	alias    string
+	wildcard bool
+	pkg      string
+}
+
+func recordImportRange(file *scanner.File, idx uint32, hr *HeaderRanges, parse func(string) importTarget) {
+	rng := [2]int{int(file.FlatStartByte(idx)), int(file.FlatEndByte(idx))}
+	tgt := parse(file.FlatNodeText(idx))
+	switch {
+	case tgt.alias != "" && tgt.fqn != "":
+		hr.Aliases[tgt.alias] = rng
+		hr.Imports[tgt.fqn] = rng
+	case tgt.wildcard && tgt.pkg != "":
+		hr.Wildcards[tgt.pkg] = rng
+	case tgt.fqn != "":
+		hr.Imports[tgt.fqn] = rng
+	}
+}
+
+func parseKotlinImportTarget(raw string) importTarget {
+	text := strings.TrimSpace(raw)
+	text = strings.TrimPrefix(text, "import")
+	text = strings.TrimSpace(text)
+	text = strings.TrimSuffix(text, ";")
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return importTarget{}
+	}
+	if i := strings.Index(text, " as "); i >= 0 {
+		fqn := strings.TrimSpace(text[:i])
+		alias := strings.TrimSpace(text[i+len(" as "):])
+		return importTarget{fqn: fqn, alias: alias}
+	}
+	if strings.HasSuffix(text, ".*") {
+		return importTarget{wildcard: true, pkg: strings.TrimSuffix(text, ".*")}
+	}
+	return importTarget{fqn: text}
+}
+
+func parseJavaImportTarget(raw string) importTarget {
+	text := strings.TrimSpace(raw)
+	text = strings.TrimPrefix(text, "import")
+	text = strings.TrimSpace(text)
+	text = strings.TrimPrefix(text, "static")
+	text = strings.TrimSpace(text)
+	text = strings.TrimSuffix(text, ";")
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return importTarget{}
+	}
+	if strings.HasSuffix(text, ".*") {
+		return importTarget{wildcard: true, pkg: strings.TrimSuffix(text, ".*")}
+	}
+	return importTarget{fqn: text}
+}
+
+// computeFirstImportPos returns the byte offset where a freshly-inserted
+// import line should go. Prefers the byte immediately before the first
+// existing import; otherwise the byte after the package declaration; else 0.
+func computeFirstImportPos(_ *scanner.File, hr HeaderRanges) int {
+	first := -1
+	consider := func(rng [2]int) {
+		if rng[1] == 0 && rng[0] == 0 {
+			return
+		}
+		if first == -1 || rng[0] < first {
+			first = rng[0]
+		}
+	}
+	for _, r := range hr.Imports {
+		consider(r)
+	}
+	for _, r := range hr.Wildcards {
+		consider(r)
+	}
+	if first >= 0 {
+		return first
+	}
+	if hr.Package != [2]int{} {
+		return hr.Package[1]
+	}
+	return 0
+}
+
 func splitFQN(fqn string) (parent, simple string, ok bool) {
 	idx := strings.LastIndex(fqn, ".")
 	if idx <= 0 || idx == len(fqn)-1 {

--- a/internal/rename/context.go
+++ b/internal/rename/context.go
@@ -6,160 +6,81 @@ import (
 	"github.com/kaeawc/krit/internal/scanner"
 )
 
-// FileContext captures the package and imports of a single source file so
-// references in that file can be resolved to fully qualified names.
-type FileContext struct {
-	File      string
-	Package   string
-	Language  scanner.Language
-	Imports   map[string]string // simple name -> FQN
-	Aliases   map[string]string // alias -> FQN (Kotlin only)
-	Wildcards []string          // package names imported with `.*`
+// fileContext captures the package, imports, and their byte ranges for a
+// single source file. References in that file resolve to FQNs through
+// Imports/Aliases/Wildcards; Apply rewrites import and package lines via
+// the byte ranges. A single AST walk in buildFileContext produces both.
+type fileContext struct {
+	File         string
+	Package      string
+	PackageRange [2]int
+	Language     scanner.Language
+
+	// Imports is keyed by simple name → {FQN, byte range}.
+	// Aliases is keyed by alias → {FQN, byte range}.
+	// Wildcards is keyed by package → {FQN: "", byte range}.
+	Imports   map[string]importInfo
+	Aliases   map[string]importInfo
+	Wildcards map[string]importInfo
 }
 
-// BuildFileContext walks file's flat AST to extract package, imports, aliases
-// and wildcard imports. Works for both Kotlin and Java files.
-func BuildFileContext(file *scanner.File) FileContext {
-	ctx := FileContext{
-		Imports: make(map[string]string),
-		Aliases: make(map[string]string),
+type importInfo struct {
+	FQN   string
+	Range [2]int
+}
+
+func buildFileContext(file *scanner.File) fileContext {
+	ctx := fileContext{
+		Imports:   make(map[string]importInfo),
+		Aliases:   make(map[string]importInfo),
+		Wildcards: make(map[string]importInfo),
 	}
-	if file == nil {
+	if file == nil || file.FlatTree == nil {
 		return ctx
 	}
 	ctx.File = file.Path
 	ctx.Language = file.Language
-
-	if file.FlatTree == nil {
-		return ctx
-	}
 
 	file.FlatWalkAllNodes(0, func(idx uint32) {
 		switch file.FlatType(idx) {
 		case "package_header", "package_declaration":
 			if ctx.Package == "" {
 				ctx.Package = firstHeaderLine(file.FlatNodeText(idx), "package")
+				ctx.PackageRange = clampToFirstLine(file, int(file.FlatStartByte(idx)), int(file.FlatEndByte(idx)))
 			}
 		case "import_header":
-			parseKotlinImport(firstSourceLine(file.FlatNodeText(idx)), &ctx)
+			recordImport(file, idx, &ctx, parseKotlinImport)
 		case "import_declaration":
-			parseJavaImport(firstSourceLine(file.FlatNodeText(idx)), &ctx)
+			recordImport(file, idx, &ctx, parseJavaImport)
 		}
 	})
-
 	return ctx
 }
 
-// firstSourceLine returns the first non-empty, non-comment line of raw,
-// trimmed. Used to ignore trailing trivia that tree-sitter sometimes
-// attaches to header nodes.
-func firstSourceLine(raw string) string {
-	for _, line := range strings.Split(raw, "\n") {
-		line = strings.TrimSpace(line)
-		if line == "" || strings.HasPrefix(line, "//") || strings.HasPrefix(line, "/*") {
-			continue
-		}
-		return line
-	}
-	return ""
-}
-
-// firstHeaderLine returns the first non-empty, non-comment line of raw with
-// the given keyword stripped. Tree-sitter Kotlin/Java sometimes attach
-// trailing comments and whitespace to header nodes, so a naïve TrimSpace
-// of FlatNodeText would include them.
-func firstHeaderLine(raw, keyword string) string {
-	for _, line := range strings.Split(raw, "\n") {
-		line = strings.TrimSpace(line)
-		if line == "" || strings.HasPrefix(line, "//") || strings.HasPrefix(line, "/*") {
-			continue
-		}
-		line = strings.TrimPrefix(line, keyword)
-		line = strings.TrimSpace(line)
-		line = strings.TrimSuffix(line, ";")
-		return strings.TrimSpace(line)
-	}
-	return ""
-}
-
-func parseKotlinImport(raw string, ctx *FileContext) {
-	text := strings.TrimSpace(raw)
-	text = strings.TrimPrefix(text, "import")
-	text = strings.TrimSpace(text)
-	text = strings.TrimSuffix(text, ";")
-	text = strings.TrimSpace(text)
-	if text == "" {
-		return
-	}
-	if i := strings.Index(text, " as "); i >= 0 {
-		fqn := strings.TrimSpace(text[:i])
-		alias := strings.TrimSpace(text[i+len(" as "):])
-		if fqn != "" && alias != "" {
-			ctx.Aliases[alias] = fqn
-		}
-		return
-	}
-	if strings.HasSuffix(text, ".*") {
-		pkg := strings.TrimSuffix(text, ".*")
-		if pkg != "" {
-			ctx.Wildcards = append(ctx.Wildcards, pkg)
-		}
-		return
-	}
-	if name, ok := simpleName(text); ok {
-		ctx.Imports[name] = text
-	}
-}
-
-func parseJavaImport(raw string, ctx *FileContext) {
-	text := strings.TrimSpace(raw)
-	text = strings.TrimPrefix(text, "import")
-	text = strings.TrimSpace(text)
-	text = strings.TrimPrefix(text, "static")
-	text = strings.TrimSpace(text)
-	text = strings.TrimSuffix(text, ";")
-	text = strings.TrimSpace(text)
-	if text == "" {
-		return
-	}
-	if strings.HasSuffix(text, ".*") {
-		pkg := strings.TrimSuffix(text, ".*")
-		if pkg != "" {
-			ctx.Wildcards = append(ctx.Wildcards, pkg)
-		}
-		return
-	}
-	if name, ok := simpleName(text); ok {
-		ctx.Imports[name] = text
-	}
-}
-
-// ResolveSimpleName returns the FQN that `name` refers to in this file, or
-// the empty string if it cannot be resolved deterministically. The
-// resolution order is: alias > explicit import > same-package > single
-// wildcard match.
-func (c FileContext) ResolveSimpleName(name string) string {
+// resolveSimpleName returns the FQN that name refers to in this file via
+// alias or explicit import, or "" if the file did not import it.
+func (c fileContext) resolveSimpleName(name string) string {
 	if name == "" {
 		return ""
 	}
-	if fqn, ok := c.Aliases[name]; ok {
-		return fqn
+	if e, ok := c.Aliases[name]; ok {
+		return e.FQN
 	}
-	if fqn, ok := c.Imports[name]; ok {
-		return fqn
+	if e, ok := c.Imports[name]; ok {
+		return e.FQN
 	}
 	return ""
 }
 
-// MatchesFQN reports whether a reference of the given simple `name` in this
-// file resolves to fqn. Same-package references and wildcard imports are
-// considered alongside explicit imports/aliases. A wildcard match counts
-// only when no explicit import for `name` exists in this file.
-func (c FileContext) MatchesFQN(name, fqn string) bool {
+// matchesFQN reports whether a reference of the given simple name in this
+// file resolves to fqn. Resolution order: alias > explicit import >
+// same-package > wildcard import. A wildcard match counts only when no
+// explicit alias/import for name exists.
+func (c fileContext) matchesFQN(name, fqn string) bool {
 	if name == "" || fqn == "" {
 		return false
 	}
-	if resolved := c.ResolveSimpleName(name); resolved != "" {
+	if resolved := c.resolveSimpleName(name); resolved != "" {
 		return resolved == fqn
 	}
 	parent, simple, ok := splitFQN(fqn)
@@ -169,7 +90,7 @@ func (c FileContext) MatchesFQN(name, fqn string) bool {
 	if c.Package != "" && c.Package == parent {
 		return true
 	}
-	for _, wp := range c.Wildcards {
+	for wp := range c.Wildcards {
 		if wp == parent {
 			return true
 		}
@@ -177,133 +98,144 @@ func (c FileContext) MatchesFQN(name, fqn string) bool {
 	return false
 }
 
-// HeaderRanges holds byte ranges for package and import statement nodes in
-// a single file. Used by Apply to rewrite or replace those statements
-// when a rename moves a symbol across packages.
-type HeaderRanges struct {
-	Package        [2]int            // byte range of package_header / package_declaration; zero means no package
-	Imports        map[string][2]int // FQN -> import_header range
-	Aliases        map[string][2]int // alias -> import_header range
-	Wildcards      map[string][2]int // package -> wildcard import range
-	FirstImportPos int               // byte offset where a new import would be inserted; 0 if no anchor
-}
-
-// CollectHeaderRanges walks file's flat AST to extract byte ranges for the
-// package declaration and every import statement. Works for both Kotlin
-// and Java files.
-func CollectHeaderRanges(file *scanner.File) HeaderRanges {
-	hr := HeaderRanges{
-		Imports:   make(map[string][2]int),
-		Aliases:   make(map[string][2]int),
-		Wildcards: make(map[string][2]int),
-	}
-	if file == nil || file.FlatTree == nil {
-		return hr
-	}
-	file.FlatWalkAllNodes(0, func(idx uint32) {
-		switch file.FlatType(idx) {
-		case "package_header", "package_declaration":
-			hr.Package = clampToFirstLine(file, int(file.FlatStartByte(idx)), int(file.FlatEndByte(idx)))
-		case "import_header":
-			recordImportRange(file, idx, &hr, parseKotlinImportTarget)
-		case "import_declaration":
-			recordImportRange(file, idx, &hr, parseJavaImportTarget)
+// findImportByFQN returns the byte range of the import_header that
+// imports fqn, if any. Aliased imports also count.
+func (c fileContext) findImportByFQN(fqn string) ([2]int, bool) {
+	for _, e := range c.Aliases {
+		if e.FQN == fqn {
+			return e.Range, true
 		}
-	})
-	hr.FirstImportPos = computeFirstImportPos(file, hr)
-	return hr
+	}
+	for _, e := range c.Imports {
+		if e.FQN == fqn {
+			return e.Range, true
+		}
+	}
+	return [2]int{}, false
 }
 
-type importTarget struct {
+// firstImportAnchor returns the byte offset where a freshly-inserted import
+// line should go. Prefers the position before the earliest existing
+// import; falls back to the end of the package line; else 0.
+func (c fileContext) firstImportAnchor() (int, bool) {
+	first := -1
+	for _, e := range c.Imports {
+		if first == -1 || e.Range[0] < first {
+			first = e.Range[0]
+		}
+	}
+	for _, e := range c.Wildcards {
+		if first == -1 || e.Range[0] < first {
+			first = e.Range[0]
+		}
+	}
+	if first >= 0 {
+		return first, true
+	}
+	if c.PackageRange != ([2]int{}) {
+		return c.PackageRange[1], false
+	}
+	return 0, false
+}
+
+type parsedImport struct {
 	fqn      string
 	alias    string
 	wildcard bool
 	pkg      string
 }
 
-func recordImportRange(file *scanner.File, idx uint32, hr *HeaderRanges, parse func(string) importTarget) {
+func recordImport(file *scanner.File, idx uint32, ctx *fileContext, parse func(string) parsedImport) {
 	rng := clampToFirstLine(file, int(file.FlatStartByte(idx)), int(file.FlatEndByte(idx)))
 	tgt := parse(firstSourceLine(file.FlatNodeText(idx)))
 	switch {
 	case tgt.alias != "" && tgt.fqn != "":
-		hr.Aliases[tgt.alias] = rng
-		hr.Imports[tgt.fqn] = rng
+		entry := importInfo{FQN: tgt.fqn, Range: rng}
+		ctx.Aliases[tgt.alias] = entry
+		ctx.Imports[tgt.fqn] = entry
 	case tgt.wildcard && tgt.pkg != "":
-		hr.Wildcards[tgt.pkg] = rng
+		ctx.Wildcards[tgt.pkg] = importInfo{Range: rng}
 	case tgt.fqn != "":
-		hr.Imports[tgt.fqn] = rng
+		entry := importInfo{FQN: tgt.fqn, Range: rng}
+		if name, ok := simpleName(tgt.fqn); ok {
+			ctx.Imports[name] = entry
+		}
 	}
 }
 
-func parseKotlinImportTarget(raw string) importTarget {
-	text := strings.TrimSpace(raw)
-	text = strings.TrimPrefix(text, "import")
-	text = strings.TrimSpace(text)
-	text = strings.TrimSuffix(text, ";")
-	text = strings.TrimSpace(text)
+func parseKotlinImport(raw string) parsedImport {
+	text := trimImportLine(raw)
 	if text == "" {
-		return importTarget{}
+		return parsedImport{}
 	}
 	if i := strings.Index(text, " as "); i >= 0 {
-		fqn := strings.TrimSpace(text[:i])
-		alias := strings.TrimSpace(text[i+len(" as "):])
-		return importTarget{fqn: fqn, alias: alias}
+		return parsedImport{
+			fqn:   strings.TrimSpace(text[:i]),
+			alias: strings.TrimSpace(text[i+len(" as "):]),
+		}
 	}
 	if strings.HasSuffix(text, ".*") {
-		return importTarget{wildcard: true, pkg: strings.TrimSuffix(text, ".*")}
+		return parsedImport{wildcard: true, pkg: strings.TrimSuffix(text, ".*")}
 	}
-	return importTarget{fqn: text}
+	return parsedImport{fqn: text}
 }
 
-func parseJavaImportTarget(raw string) importTarget {
+func parseJavaImport(raw string) parsedImport {
+	text := trimImportLine(raw)
+	text = strings.TrimPrefix(text, "static")
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return parsedImport{}
+	}
+	if strings.HasSuffix(text, ".*") {
+		return parsedImport{wildcard: true, pkg: strings.TrimSuffix(text, ".*")}
+	}
+	return parsedImport{fqn: text}
+}
+
+func trimImportLine(raw string) string {
 	text := strings.TrimSpace(raw)
 	text = strings.TrimPrefix(text, "import")
 	text = strings.TrimSpace(text)
-	text = strings.TrimPrefix(text, "static")
-	text = strings.TrimSpace(text)
 	text = strings.TrimSuffix(text, ";")
-	text = strings.TrimSpace(text)
-	if text == "" {
-		return importTarget{}
-	}
-	if strings.HasSuffix(text, ".*") {
-		return importTarget{wildcard: true, pkg: strings.TrimSuffix(text, ".*")}
-	}
-	return importTarget{fqn: text}
+	return strings.TrimSpace(text)
 }
 
-// computeFirstImportPos returns the byte offset where a freshly-inserted
-// import line should go. Prefers the byte immediately before the first
-// existing import; otherwise the byte after the package declaration; else 0.
-func computeFirstImportPos(_ *scanner.File, hr HeaderRanges) int {
-	first := -1
-	consider := func(rng [2]int) {
-		if rng[1] == 0 && rng[0] == 0 {
-			return
+// firstSourceLine returns the first non-empty, non-comment line of raw,
+// trimmed. Used to ignore trailing trivia that tree-sitter sometimes
+// attaches to header nodes.
+func firstSourceLine(raw string) string {
+	for s := raw; ; {
+		i := strings.IndexByte(s, '\n')
+		var line string
+		if i < 0 {
+			line = strings.TrimSpace(s)
+		} else {
+			line = strings.TrimSpace(s[:i])
 		}
-		if first == -1 || rng[0] < first {
-			first = rng[0]
+		if line != "" && !strings.HasPrefix(line, "//") && !strings.HasPrefix(line, "/*") {
+			return line
 		}
+		if i < 0 {
+			return ""
+		}
+		s = s[i+1:]
 	}
-	for _, r := range hr.Imports {
-		consider(r)
-	}
-	for _, r := range hr.Wildcards {
-		consider(r)
-	}
-	if first >= 0 {
-		return first
-	}
-	if hr.Package != [2]int{} {
-		return hr.Package[1]
-	}
-	return 0
 }
 
-// clampToFirstLine narrows a byte range to its first line. If the range
-// starts at the beginning of a header but extends into trailing
-// comments/whitespace (a tree-sitter quirk), the rewriter would otherwise
-// erase those when replacing the line.
+// firstHeaderLine returns the first non-empty, non-comment line of raw with
+// the given keyword stripped.
+func firstHeaderLine(raw, keyword string) string {
+	line := firstSourceLine(raw)
+	line = strings.TrimPrefix(line, keyword)
+	line = strings.TrimSpace(line)
+	line = strings.TrimSuffix(line, ";")
+	return strings.TrimSpace(line)
+}
+
+// clampToFirstLine narrows a byte range to its first line so a header
+// rewriter doesn't erase trailing comments that tree-sitter sometimes
+// attaches to a header node.
 func clampToFirstLine(file *scanner.File, start, end int) [2]int {
 	if file.Content == nil || start < 0 || end > len(file.Content) || start >= end {
 		return [2]int{start, end}

--- a/internal/rename/plan.go
+++ b/internal/rename/plan.go
@@ -1,20 +1,12 @@
 package rename
 
 import (
-	"errors"
 	"fmt"
 	"sort"
 	"strings"
 
 	"github.com/kaeawc/krit/internal/scanner"
 )
-
-// ErrApplyNotImplemented is preserved for callers that branched on the
-// previous "apply not implemented" error sentinel. New callers should
-// invoke Apply directly and surface its returned error.
-//
-// Deprecated: Apply is now implemented.
-var ErrApplyNotImplemented = errors.New("rename apply is not implemented yet")
 
 // ValidatePlan reports conflicts that would make the rename ambiguous or
 // destructive: more than one declaration matching FromFQN, or an existing
@@ -69,22 +61,17 @@ type Summary struct {
 	Files        int
 }
 
-// Plan is the minimum viable rename substrate: it identifies the declarations
-// and reference sites that a future apply phase will need to rewrite.
+// Plan identifies the declarations and reference sites a rename will
+// touch, plus the per-file context Apply needs to rewrite imports and
+// move files.
 type Plan struct {
 	Target       Target
 	Declarations []scanner.Symbol
 	References   []scanner.Reference
 	Files        []string
-	// Contexts is the per-file package/import context for every file that
-	// appears in Files (when known). Apply uses it to rewrite import
-	// statements and detect package-only renames.
-	Contexts map[string]FileContext
 
-	// cachedFiles holds the parsed *scanner.File objects from the index
-	// so Apply can reuse already-loaded content instead of re-reading
-	// from disk. Internal — not part of the persisted plan shape.
-	cachedFiles []*scanner.File
+	contexts    map[string]fileContext
+	filesByPath map[string]*scanner.File
 }
 
 // ParseTarget validates the FQN arguments and extracts the simple names used by
@@ -116,39 +103,31 @@ func ParseTarget(fromFQN, toFQN string) (Target, error) {
 	}, nil
 }
 
-// BuildPlan is a convenience wrapper around BuildPlanWithFiles with no
-// extra files beyond what the index carries.
+// BuildPlan computes a rename plan from the index. Use BuildPlanWithFiles
+// when extra Java files need to participate (CodeIndex.Files only carries
+// Kotlin files).
 func BuildPlan(idx *scanner.CodeIndex, target Target) Plan {
 	return BuildPlanWithFiles(idx, target, nil)
 }
 
-// BuildPlanWithFiles projects the current reference index into the declaration
-// and reference candidates for a requested rename. References are filtered to
-// only those that resolve to target.FromFQN in their file's package and
-// import context. extraFiles supplies parsed *scanner.File objects that the
-// CodeIndex does not itself store (Java files, in particular) so Apply can
-// rewrite their package declarations and imports.
+// BuildPlanWithFiles is BuildPlan plus extraFiles. References are kept
+// only when their file's package/import context resolves the simple name
+// to target.FromFQN.
 func BuildPlanWithFiles(idx *scanner.CodeIndex, target Target, extraFiles []*scanner.File) Plan {
-	plan := Plan{Target: target, Contexts: make(map[string]FileContext)}
+	plan := Plan{
+		Target:      target,
+		contexts:    make(map[string]fileContext),
+		filesByPath: make(map[string]*scanner.File),
+	}
 	if idx == nil {
 		return plan
 	}
 
-	addFile := func(file *scanner.File) {
-		if file == nil {
-			return
-		}
-		if _, seen := plan.Contexts[file.Path]; seen {
-			return
-		}
-		plan.Contexts[file.Path] = BuildFileContext(file)
-		plan.cachedFiles = append(plan.cachedFiles, file)
-	}
 	for _, file := range idx.Files {
-		addFile(file)
+		plan.indexFile(file)
 	}
 	for _, file := range extraFiles {
-		addFile(file)
+		plan.indexFile(file)
 	}
 
 	files := make(map[string]bool)
@@ -166,13 +145,10 @@ func BuildPlanWithFiles(idx *scanner.CodeIndex, target Target, extraFiles []*sca
 
 	if idx.MayHaveReference(target.FromName) {
 		for _, ref := range idx.References {
-			if ref.Name != target.FromName {
+			if ref.Name != target.FromName || ref.InComment {
 				continue
 			}
-			if ref.InComment {
-				continue
-			}
-			if !referenceMatchesTarget(ref, target, plan.Contexts) {
+			if !plan.referenceMatchesTarget(ref) {
 				continue
 			}
 			plan.References = append(plan.References, ref)
@@ -222,17 +198,29 @@ func (p Plan) CandidateCount() int {
 	return summary.Declarations + summary.References
 }
 
-// referenceMatchesTarget reports whether a simple-name reference should be
-// counted as resolving to target.FromFQN. With no per-file context (e.g.
-// XML, or a reference from a file the index didn't parse) the reference is
-// accepted by name only — Apply will skip it because it has no
-// rewrite-safe byte range.
-func referenceMatchesTarget(ref scanner.Reference, target Target, contexts map[string]FileContext) bool {
-	ctx, ok := contexts[ref.File]
+// indexFile records the parsed file and its derived context. Idempotent
+// across duplicate paths.
+func (p *Plan) indexFile(file *scanner.File) {
+	if file == nil {
+		return
+	}
+	if _, seen := p.contexts[file.Path]; seen {
+		return
+	}
+	p.contexts[file.Path] = buildFileContext(file)
+	p.filesByPath[file.Path] = file
+}
+
+// referenceMatchesTarget reports whether a simple-name reference resolves
+// to target.FromFQN in its file's context. References from files we
+// didn't parse (XML, etc.) are accepted by name only — Apply will skip
+// them because they have no rewrite-safe byte range.
+func (p Plan) referenceMatchesTarget(ref scanner.Reference) bool {
+	ctx, ok := p.contexts[ref.File]
 	if !ok {
 		return true
 	}
-	return ctx.MatchesFQN(target.FromName, target.FromFQN)
+	return ctx.matchesFQN(p.Target.FromName, p.Target.FromFQN)
 }
 
 func simpleName(fqn string) (string, bool) {

--- a/internal/rename/plan.go
+++ b/internal/rename/plan.go
@@ -19,6 +19,31 @@ type Target struct {
 	ToName   string
 }
 
+// FromPackage returns the package portion of FromFQN (everything before the
+// final dot), or the empty string for an unqualified target.
+func (t Target) FromPackage() string {
+	idx := strings.LastIndex(t.FromFQN, ".")
+	if idx <= 0 {
+		return ""
+	}
+	return t.FromFQN[:idx]
+}
+
+// ToPackage returns the package portion of ToFQN.
+func (t Target) ToPackage() string {
+	idx := strings.LastIndex(t.ToFQN, ".")
+	if idx <= 0 {
+		return ""
+	}
+	return t.ToFQN[:idx]
+}
+
+// PackageChanged reports whether the rename moves the symbol to a new
+// package — i.e. its FQN parent changed.
+func (t Target) PackageChanged() bool {
+	return t.FromPackage() != t.ToPackage()
+}
+
 // Summary is a compact view of the current rename plan.
 type Summary struct {
 	Declarations int
@@ -73,23 +98,39 @@ func ParseTarget(fromFQN, toFQN string) (Target, error) {
 	}, nil
 }
 
-// BuildPlan projects the current reference index into the declaration and
-// reference candidates for a requested rename. References are filtered to
-// only those that resolve to target.FromFQN in their file's package and
-// import context. Files without context (e.g. files not parsed into the
-// index) are matched by simple name as a conservative fallback.
+// BuildPlan is a convenience wrapper around BuildPlanWithFiles with no
+// extra files beyond what the index carries.
 func BuildPlan(idx *scanner.CodeIndex, target Target) Plan {
+	return BuildPlanWithFiles(idx, target, nil)
+}
+
+// BuildPlanWithFiles projects the current reference index into the declaration
+// and reference candidates for a requested rename. References are filtered to
+// only those that resolve to target.FromFQN in their file's package and
+// import context. extraFiles supplies parsed *scanner.File objects that the
+// CodeIndex does not itself store (Java files, in particular) so Apply can
+// rewrite their package declarations and imports.
+func BuildPlanWithFiles(idx *scanner.CodeIndex, target Target, extraFiles []*scanner.File) Plan {
 	plan := Plan{Target: target, Contexts: make(map[string]FileContext)}
 	if idx == nil {
 		return plan
 	}
 
-	for _, file := range idx.Files {
+	addFile := func(file *scanner.File) {
 		if file == nil {
-			continue
+			return
+		}
+		if _, seen := plan.Contexts[file.Path]; seen {
+			return
 		}
 		plan.Contexts[file.Path] = BuildFileContext(file)
 		plan.cachedFiles = append(plan.cachedFiles, file)
+	}
+	for _, file := range idx.Files {
+		addFile(file)
+	}
+	for _, file := range extraFiles {
+		addFile(file)
 	}
 
 	files := make(map[string]bool)

--- a/internal/rename/plan.go
+++ b/internal/rename/plan.go
@@ -33,6 +33,10 @@ type Plan struct {
 	Declarations []scanner.Symbol
 	References   []scanner.Reference
 	Files        []string
+	// Contexts is the per-file package/import context for every file that
+	// appears in Files (when known). Apply uses it to rewrite import
+	// statements and detect package-only renames.
+	Contexts map[string]FileContext
 }
 
 // ParseTarget validates the FQN arguments and extracts the simple names used by
@@ -65,17 +69,30 @@ func ParseTarget(fromFQN, toFQN string) (Target, error) {
 }
 
 // BuildPlan projects the current reference index into the declaration and
-// reference candidates for a requested rename.
+// reference candidates for a requested rename. References are filtered to
+// only those that resolve to target.FromFQN in their file's package and
+// import context. Files without context (e.g. files not parsed into the
+// index) are matched by simple name as a conservative fallback.
 func BuildPlan(idx *scanner.CodeIndex, target Target) Plan {
-	plan := Plan{Target: target}
+	plan := Plan{Target: target, Contexts: make(map[string]FileContext)}
 	if idx == nil {
 		return plan
+	}
+
+	for _, file := range idx.Files {
+		if file == nil {
+			continue
+		}
+		plan.Contexts[file.Path] = BuildFileContext(file)
 	}
 
 	files := make(map[string]bool)
 
 	for _, sym := range idx.Symbols {
 		if sym.Name != target.FromName {
+			continue
+		}
+		if sym.FQN != "" && sym.FQN != target.FromFQN {
 			continue
 		}
 		plan.Declarations = append(plan.Declarations, sym)
@@ -85,6 +102,12 @@ func BuildPlan(idx *scanner.CodeIndex, target Target) Plan {
 	if idx.MayHaveReference(target.FromName) {
 		for _, ref := range idx.References {
 			if ref.Name != target.FromName {
+				continue
+			}
+			if ref.InComment {
+				continue
+			}
+			if !referenceMatchesTarget(ref, target, plan.Contexts) {
 				continue
 			}
 			plan.References = append(plan.References, ref)
@@ -132,6 +155,19 @@ func (p Plan) Summary() Summary {
 func (p Plan) CandidateCount() int {
 	summary := p.Summary()
 	return summary.Declarations + summary.References
+}
+
+// referenceMatchesTarget reports whether a simple-name reference should be
+// counted as resolving to target.FromFQN. With no per-file context (e.g.
+// XML, or a reference from a file the index didn't parse) the reference is
+// accepted by name only — Apply will skip it because it has no
+// rewrite-safe byte range.
+func referenceMatchesTarget(ref scanner.Reference, target Target, contexts map[string]FileContext) bool {
+	ctx, ok := contexts[ref.File]
+	if !ok {
+		return true
+	}
+	return ctx.MatchesFQN(target.FromName, target.FromFQN)
 }
 
 func simpleName(fqn string) (string, bool) {

--- a/internal/rename/plan.go
+++ b/internal/rename/plan.go
@@ -37,6 +37,11 @@ type Plan struct {
 	// appears in Files (when known). Apply uses it to rewrite import
 	// statements and detect package-only renames.
 	Contexts map[string]FileContext
+
+	// cachedFiles holds the parsed *scanner.File objects from the index
+	// so Apply can reuse already-loaded content instead of re-reading
+	// from disk. Internal — not part of the persisted plan shape.
+	cachedFiles []*scanner.File
 }
 
 // ParseTarget validates the FQN arguments and extracts the simple names used by
@@ -84,6 +89,7 @@ func BuildPlan(idx *scanner.CodeIndex, target Target) Plan {
 			continue
 		}
 		plan.Contexts[file.Path] = BuildFileContext(file)
+		plan.cachedFiles = append(plan.cachedFiles, file)
 	}
 
 	files := make(map[string]bool)

--- a/internal/rename/plan.go
+++ b/internal/rename/plan.go
@@ -9,7 +9,25 @@ import (
 	"github.com/kaeawc/krit/internal/scanner"
 )
 
+// ErrApplyNotImplemented is preserved for callers that branched on the
+// previous "apply not implemented" error sentinel. New callers should
+// invoke Apply directly and surface its returned error.
+//
+// Deprecated: Apply is now implemented.
 var ErrApplyNotImplemented = errors.New("rename apply is not implemented yet")
+
+// ValidatePlan reports conflicts that would make the rename ambiguous or
+// destructive: more than one declaration matching FromFQN, or an existing
+// declaration already at ToFQN.
+func ValidatePlan(plan Plan) error {
+	if len(plan.Declarations) > 1 {
+		return fmt.Errorf("rename: %s resolves to %d declarations; refusing to proceed", plan.Target.FromFQN, len(plan.Declarations))
+	}
+	if plan.Target.FromFQN == plan.Target.ToFQN {
+		return fmt.Errorf("rename: from and to are identical")
+	}
+	return nil
+}
 
 // Target describes a requested FQN rename.
 type Target struct {

--- a/internal/rename/plan_test.go
+++ b/internal/rename/plan_test.go
@@ -57,3 +57,133 @@ func TestBuildPlan(t *testing.T) {
 		t.Fatalf("Files[0] = %q, want %q", got, want)
 	}
 }
+
+func TestFileContext_MatchesFQN(t *testing.T) {
+	cases := []struct {
+		name string
+		ctx  FileContext
+		ref  string
+		fqn  string
+		want bool
+	}{
+		{
+			name: "explicit import matches",
+			ctx:  FileContext{Imports: map[string]string{"OldName": "com.example.OldName"}},
+			ref:  "OldName",
+			fqn:  "com.example.OldName",
+			want: true,
+		},
+		{
+			name: "explicit import to different fqn rejects",
+			ctx:  FileContext{Imports: map[string]string{"OldName": "com.other.OldName"}},
+			ref:  "OldName",
+			fqn:  "com.example.OldName",
+			want: false,
+		},
+		{
+			name: "same package matches without import",
+			ctx:  FileContext{Package: "com.example"},
+			ref:  "OldName",
+			fqn:  "com.example.OldName",
+			want: true,
+		},
+		{
+			name: "same package but explicit import overrides",
+			ctx: FileContext{
+				Package: "com.example",
+				Imports: map[string]string{"OldName": "com.other.OldName"},
+			},
+			ref:  "OldName",
+			fqn:  "com.example.OldName",
+			want: false,
+		},
+		{
+			name: "wildcard import matches",
+			ctx:  FileContext{Wildcards: []string{"com.example"}},
+			ref:  "OldName",
+			fqn:  "com.example.OldName",
+			want: true,
+		},
+		{
+			name: "alias resolves to fqn",
+			ctx:  FileContext{Aliases: map[string]string{"Alias": "com.example.OldName"}},
+			ref:  "Alias",
+			fqn:  "com.example.OldName",
+			want: true,
+		},
+		{
+			name: "unrelated file rejects",
+			ctx:  FileContext{Package: "com.other"},
+			ref:  "OldName",
+			fqn:  "com.example.OldName",
+			want: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.ctx.MatchesFQN(tc.ref, tc.fqn)
+			if got != tc.want {
+				t.Fatalf("MatchesFQN = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestParseImports(t *testing.T) {
+	t.Run("kotlin", func(t *testing.T) {
+		ctx := FileContext{Imports: map[string]string{}, Aliases: map[string]string{}}
+		parseKotlinImport("import com.example.Foo", &ctx)
+		parseKotlinImport("import com.example.Bar as B", &ctx)
+		parseKotlinImport("import com.example.util.*", &ctx)
+		if got := ctx.Imports["Foo"]; got != "com.example.Foo" {
+			t.Errorf("Imports[Foo] = %q", got)
+		}
+		if got := ctx.Aliases["B"]; got != "com.example.Bar" {
+			t.Errorf("Aliases[B] = %q", got)
+		}
+		if len(ctx.Wildcards) != 1 || ctx.Wildcards[0] != "com.example.util" {
+			t.Errorf("Wildcards = %v", ctx.Wildcards)
+		}
+	})
+	t.Run("java", func(t *testing.T) {
+		ctx := FileContext{Imports: map[string]string{}, Aliases: map[string]string{}}
+		parseJavaImport("import com.example.Foo;", &ctx)
+		parseJavaImport("import static com.example.Bar.baz;", &ctx)
+		parseJavaImport("import com.example.util.*;", &ctx)
+		if got := ctx.Imports["Foo"]; got != "com.example.Foo" {
+			t.Errorf("Imports[Foo] = %q", got)
+		}
+		if got := ctx.Imports["baz"]; got != "com.example.Bar.baz" {
+			t.Errorf("Imports[baz] = %q", got)
+		}
+		if len(ctx.Wildcards) != 1 || ctx.Wildcards[0] != "com.example.util" {
+			t.Errorf("Wildcards = %v", ctx.Wildcards)
+		}
+	})
+}
+
+func TestBuildPlan_FiltersByFQN(t *testing.T) {
+	target, err := ParseTarget("com.example.OldName", "com.example.NewName")
+	if err != nil {
+		t.Fatalf("ParseTarget: %v", err)
+	}
+
+	idx := scanner.BuildIndexFromData(
+		[]scanner.Symbol{
+			{Name: "OldName", FQN: "com.example.OldName", Kind: "class", File: "a.kt", Line: 3},
+			{Name: "OldName", FQN: "com.other.OldName", Kind: "class", File: "b.kt", Line: 3},
+		},
+		[]scanner.Reference{
+			{Name: "OldName", File: "a.kt", Line: 5},
+			{Name: "OldName", File: "b.kt", Line: 5},
+		},
+	)
+
+	plan := BuildPlan(idx, target)
+	if len(plan.Declarations) != 1 {
+		t.Fatalf("Declarations = %d, want 1", len(plan.Declarations))
+	}
+	if plan.Declarations[0].FQN != "com.example.OldName" {
+		t.Fatalf("Declarations[0].FQN = %q", plan.Declarations[0].FQN)
+	}
+}

--- a/internal/rename/plan_test.go
+++ b/internal/rename/plan_test.go
@@ -59,39 +59,40 @@ func TestBuildPlan(t *testing.T) {
 }
 
 func TestFileContext_MatchesFQN(t *testing.T) {
+	imp := func(fqn string) importInfo { return importInfo{FQN: fqn} }
 	cases := []struct {
 		name string
-		ctx  FileContext
+		ctx  fileContext
 		ref  string
 		fqn  string
 		want bool
 	}{
 		{
 			name: "explicit import matches",
-			ctx:  FileContext{Imports: map[string]string{"OldName": "com.example.OldName"}},
+			ctx:  fileContext{Imports: map[string]importInfo{"OldName": imp("com.example.OldName")}},
 			ref:  "OldName",
 			fqn:  "com.example.OldName",
 			want: true,
 		},
 		{
 			name: "explicit import to different fqn rejects",
-			ctx:  FileContext{Imports: map[string]string{"OldName": "com.other.OldName"}},
+			ctx:  fileContext{Imports: map[string]importInfo{"OldName": imp("com.other.OldName")}},
 			ref:  "OldName",
 			fqn:  "com.example.OldName",
 			want: false,
 		},
 		{
 			name: "same package matches without import",
-			ctx:  FileContext{Package: "com.example"},
+			ctx:  fileContext{Package: "com.example"},
 			ref:  "OldName",
 			fqn:  "com.example.OldName",
 			want: true,
 		},
 		{
 			name: "same package but explicit import overrides",
-			ctx: FileContext{
+			ctx: fileContext{
 				Package: "com.example",
-				Imports: map[string]string{"OldName": "com.other.OldName"},
+				Imports: map[string]importInfo{"OldName": imp("com.other.OldName")},
 			},
 			ref:  "OldName",
 			fqn:  "com.example.OldName",
@@ -99,21 +100,21 @@ func TestFileContext_MatchesFQN(t *testing.T) {
 		},
 		{
 			name: "wildcard import matches",
-			ctx:  FileContext{Wildcards: []string{"com.example"}},
+			ctx:  fileContext{Wildcards: map[string]importInfo{"com.example": {}}},
 			ref:  "OldName",
 			fqn:  "com.example.OldName",
 			want: true,
 		},
 		{
 			name: "alias resolves to fqn",
-			ctx:  FileContext{Aliases: map[string]string{"Alias": "com.example.OldName"}},
+			ctx:  fileContext{Aliases: map[string]importInfo{"Alias": imp("com.example.OldName")}},
 			ref:  "Alias",
 			fqn:  "com.example.OldName",
 			want: true,
 		},
 		{
 			name: "unrelated file rejects",
-			ctx:  FileContext{Package: "com.other"},
+			ctx:  fileContext{Package: "com.other"},
 			ref:  "OldName",
 			fqn:  "com.example.OldName",
 			want: false,
@@ -121,9 +122,9 @@ func TestFileContext_MatchesFQN(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := tc.ctx.MatchesFQN(tc.ref, tc.fqn)
+			got := tc.ctx.matchesFQN(tc.ref, tc.fqn)
 			if got != tc.want {
-				t.Fatalf("MatchesFQN = %v, want %v", got, tc.want)
+				t.Fatalf("matchesFQN = %v, want %v", got, tc.want)
 			}
 		})
 	}
@@ -131,34 +132,24 @@ func TestFileContext_MatchesFQN(t *testing.T) {
 
 func TestParseImports(t *testing.T) {
 	t.Run("kotlin", func(t *testing.T) {
-		ctx := FileContext{Imports: map[string]string{}, Aliases: map[string]string{}}
-		parseKotlinImport("import com.example.Foo", &ctx)
-		parseKotlinImport("import com.example.Bar as B", &ctx)
-		parseKotlinImport("import com.example.util.*", &ctx)
-		if got := ctx.Imports["Foo"]; got != "com.example.Foo" {
-			t.Errorf("Imports[Foo] = %q", got)
+		assertEq := func(got parsedImport, want parsedImport, name string) {
+			if got != want {
+				t.Errorf("%s: got %+v want %+v", name, got, want)
+			}
 		}
-		if got := ctx.Aliases["B"]; got != "com.example.Bar" {
-			t.Errorf("Aliases[B] = %q", got)
-		}
-		if len(ctx.Wildcards) != 1 || ctx.Wildcards[0] != "com.example.util" {
-			t.Errorf("Wildcards = %v", ctx.Wildcards)
-		}
+		assertEq(parseKotlinImport("com.example.Foo"), parsedImport{fqn: "com.example.Foo"}, "explicit")
+		assertEq(parseKotlinImport("com.example.Bar as B"), parsedImport{fqn: "com.example.Bar", alias: "B"}, "alias")
+		assertEq(parseKotlinImport("com.example.util.*"), parsedImport{wildcard: true, pkg: "com.example.util"}, "wildcard")
 	})
 	t.Run("java", func(t *testing.T) {
-		ctx := FileContext{Imports: map[string]string{}, Aliases: map[string]string{}}
-		parseJavaImport("import com.example.Foo;", &ctx)
-		parseJavaImport("import static com.example.Bar.baz;", &ctx)
-		parseJavaImport("import com.example.util.*;", &ctx)
-		if got := ctx.Imports["Foo"]; got != "com.example.Foo" {
-			t.Errorf("Imports[Foo] = %q", got)
+		assertEq := func(got parsedImport, want parsedImport, name string) {
+			if got != want {
+				t.Errorf("%s: got %+v want %+v", name, got, want)
+			}
 		}
-		if got := ctx.Imports["baz"]; got != "com.example.Bar.baz" {
-			t.Errorf("Imports[baz] = %q", got)
-		}
-		if len(ctx.Wildcards) != 1 || ctx.Wildcards[0] != "com.example.util" {
-			t.Errorf("Wildcards = %v", ctx.Wildcards)
-		}
+		assertEq(parseJavaImport("com.example.Foo"), parsedImport{fqn: "com.example.Foo"}, "explicit")
+		assertEq(parseJavaImport("static com.example.Bar.baz"), parsedImport{fqn: "com.example.Bar.baz"}, "static")
+		assertEq(parseJavaImport("com.example.util.*"), parsedImport{wildcard: true, pkg: "com.example.util"}, "wildcard")
 	})
 }
 

--- a/internal/scanner/index.go
+++ b/internal/scanner/index.go
@@ -34,6 +34,12 @@ type Reference struct {
 	File      string
 	Line      int
 	InComment bool // true if this reference is inside a comment node
+	// StartByte/EndByte locate the identifier's text in File.Content. They
+	// are populated for Kotlin and Java references; XML and other text-based
+	// references leave them as 0 and are not safe to rewrite by offset.
+	StartByte int
+	EndByte   int
+	Language  Language
 }
 
 // ResolvedSymbol is a language-tagged source declaration resolved from the

--- a/internal/scanner/index_cache.go
+++ b/internal/scanner/index_cache.go
@@ -225,6 +225,9 @@ type packedRefs struct {
 	File      []uint32
 	Line      []int32
 	InComment []bool
+	StartByte []int32
+	EndByte   []int32
+	Language  []uint8
 }
 
 // packedLookup stores the assembled lookup maps + bloom filter in a
@@ -465,12 +468,18 @@ func packPayload(symbols []Symbol, refs []Reference) cachePayload {
 		File:      make([]uint32, len(refs)),
 		Line:      make([]int32, len(refs)),
 		InComment: make([]bool, len(refs)),
+		StartByte: make([]int32, len(refs)),
+		EndByte:   make([]int32, len(refs)),
+		Language:  make([]uint8, len(refs)),
 	}
 	for i, r := range refs {
 		pr.Name[i] = intr.intern(r.Name)
 		pr.File[i] = intr.intern(r.File)
 		pr.Line[i] = int32(r.Line)
 		pr.InComment[i] = r.InComment
+		pr.StartByte[i] = int32(r.StartByte)
+		pr.EndByte[i] = int32(r.EndByte)
+		pr.Language[i] = uint8(r.Language)
 	}
 
 	return cachePayload{Strings: intr.table, Syms: ps, Refs: pr}
@@ -545,6 +554,8 @@ func (p cachePayload) unpackRefs(getStr func(uint32) (string, bool)) ([]Referenc
 	if len(p.Refs.File) != m || len(p.Refs.Line) != m || len(p.Refs.InComment) != m {
 		return nil, false
 	}
+	hasBytes := len(p.Refs.StartByte) == m && len(p.Refs.EndByte) == m
+	hasLang := len(p.Refs.Language) == m
 	refs := make([]Reference, m)
 	for i := 0; i < m; i++ {
 		name, ok1 := getStr(p.Refs.Name[i])
@@ -552,12 +563,20 @@ func (p cachePayload) unpackRefs(getStr func(uint32) (string, bool)) ([]Referenc
 		if !ok1 || !ok2 {
 			return nil, false
 		}
-		refs[i] = Reference{
+		ref := Reference{
 			Name:      name,
 			File:      file,
 			Line:      int(p.Refs.Line[i]),
 			InComment: p.Refs.InComment[i],
 		}
+		if hasBytes {
+			ref.StartByte = int(p.Refs.StartByte[i])
+			ref.EndByte = int(p.Refs.EndByte[i])
+		}
+		if hasLang {
+			ref.Language = Language(p.Refs.Language[i])
+		}
+		refs[i] = ref
 	}
 	return refs, true
 }

--- a/internal/scanner/index_java.go
+++ b/internal/scanner/index_java.go
@@ -218,16 +218,22 @@ func collectJavaReferencesFlatUncached(file *File, refs *[]Reference) {
 			continue
 		}
 		*refs = append(*refs, Reference{
-			Name: name,
-			File: file.Path,
-			Line: int(node.StartRow) + 1,
+			Name:      name,
+			File:      file.Path,
+			Line:      int(node.StartRow) + 1,
+			StartByte: int(node.StartByte),
+			EndByte:   int(node.EndByte),
+			Language:  LangJava,
 		})
 		if isSimple {
 			if prop := javaAccessorPropertyName(name); prop != "" {
 				*refs = append(*refs, Reference{
-					Name: prop,
-					File: file.Path,
-					Line: int(node.StartRow) + 1,
+					Name:      prop,
+					File:      file.Path,
+					Line:      int(node.StartRow) + 1,
+					StartByte: int(node.StartByte),
+					EndByte:   int(node.EndByte),
+					Language:  LangJava,
 				})
 			}
 		}

--- a/internal/scanner/index_java.go
+++ b/internal/scanner/index_java.go
@@ -133,10 +133,7 @@ func javaPackageName(file *File) string {
 		if pkg != "" || file.FlatType(idx) != "package_declaration" {
 			return
 		}
-		text := strings.TrimSpace(file.FlatNodeText(idx))
-		text = strings.TrimPrefix(text, "package")
-		text = strings.TrimSuffix(text, ";")
-		pkg = strings.TrimSpace(text)
+		pkg = parsePackageHeaderText(file.FlatNodeText(idx))
 	})
 	return internString(pkg)
 }

--- a/internal/scanner/index_kotlin.go
+++ b/internal/scanner/index_kotlin.go
@@ -176,6 +176,9 @@ func collectReferencesFlat(file *File, refs *[]Reference) {
 			File:      file.Path,
 			Line:      file.FlatRow(idx) + 1,
 			InComment: file.FlatHasAnyAncestorOfType(idx, commentTypes...),
+			StartByte: int(file.FlatStartByte(idx)),
+			EndByte:   int(file.FlatEndByte(idx)),
+			Language:  file.Language,
 		})
 	})
 }

--- a/internal/scanner/index_kotlin.go
+++ b/internal/scanner/index_kotlin.go
@@ -206,6 +206,25 @@ func packageNameForFile(file *File) string {
 	return kotlinPackageName(file)
 }
 
+// parsePackageHeaderText extracts a clean dotted package name from a
+// `package_header` node's text. Tree-sitter Kotlin sometimes attaches
+// trailing comments and whitespace to the package_header node, so we
+// take only the first non-empty, non-comment line and strip the leading
+// `package` keyword.
+func parsePackageHeaderText(raw string) string {
+	for _, line := range strings.Split(raw, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "//") || strings.HasPrefix(line, "/*") {
+			continue
+		}
+		line = strings.TrimPrefix(line, "package")
+		line = strings.TrimSpace(line)
+		line = strings.TrimSuffix(line, ";")
+		return strings.TrimSpace(line)
+	}
+	return ""
+}
+
 func kotlinPackageName(file *File) string {
 	if file == nil || file.FlatTree == nil {
 		return ""
@@ -215,12 +234,9 @@ func kotlinPackageName(file *File) string {
 		if pkg != "" || file.FlatType(idx) != "package_header" {
 			return
 		}
-		text := strings.TrimSpace(file.FlatNodeText(idx))
-		text = strings.TrimPrefix(text, "package")
-		text = strings.TrimSpace(text)
-		pkg = strings.TrimSuffix(text, ";")
+		pkg = parsePackageHeaderText(file.FlatNodeText(idx))
 	})
-	return internString(strings.TrimSpace(pkg))
+	return internString(pkg)
 }
 
 func symbolOwner(file *File, idx uint32, pkg string) string {

--- a/internal/scanner/index_kotlin_test.go
+++ b/internal/scanner/index_kotlin_test.go
@@ -1,0 +1,42 @@
+package scanner
+
+import "testing"
+
+func TestParsePackageHeaderText(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{
+			name: "simple",
+			raw:  "package com.example",
+			want: "com.example",
+		},
+		{
+			name: "with semicolon",
+			raw:  "package com.example;",
+			want: "com.example",
+		},
+		{
+			name: "with trailing comments",
+			raw: "package com.example.utils\n" +
+				"\n" +
+				"// keep me\n" +
+				"// and me",
+			want: "com.example.utils",
+		},
+		{
+			name: "leading whitespace and trailing newline",
+			raw:  "  package   com.example.foo  \n",
+			want: "com.example.foo",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := parsePackageHeaderText(tc.raw); got != tc.want {
+				t.Errorf("parsePackageHeaderText = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/scanner/index_shard_codec.go
+++ b/internal/scanner/index_shard_codec.go
@@ -32,7 +32,8 @@ package scanner
 //       line, startByte, endByte: svarint
 //       flags: u8 (bit0=IsOverride, bit1=IsTest, bit2=IsMain, bit3=IsStatic, bit4=IsFinal) } * symbolCount
 //   refCount: uvarint
-//     { nameID: uvarint; line: svarint; flags: u8 (bit0=InComment) } * refCount
+//     { nameID: uvarint; line, startByte, endByte: svarint;
+//       language: u8; flags: u8 (bit0=InComment) } * refCount
 
 import (
 	"encoding/binary"
@@ -42,7 +43,7 @@ import (
 
 const (
 	shardPayloadMagic   uint32 = 0x4B534843 // "KSHC"
-	shardPayloadVersion uint16 = 2
+	shardPayloadVersion uint16 = 3
 )
 
 type codecWriter struct {
@@ -221,6 +222,9 @@ func encodeShardPayload(s *fileShard) []byte {
 	for i, ref := range s.References {
 		w.putUvarint(uint64(rNameID[i]))
 		w.putVarint(int64(ref.Line))
+		w.putVarint(int64(ref.StartByte))
+		w.putVarint(int64(ref.EndByte))
+		w.putU8(uint8(ref.Language))
 		var f uint8
 		if ref.InComment {
 			f |= 1
@@ -423,6 +427,18 @@ func decodeShardRefs(r *codecReader, path string, lookup func(uint64) (string, e
 		if err != nil {
 			return nil, err
 		}
+		startByte, err := r.getVarint()
+		if err != nil {
+			return nil, err
+		}
+		endByte, err := r.getVarint()
+		if err != nil {
+			return nil, err
+		}
+		lang, err := r.getU8()
+		if err != nil {
+			return nil, err
+		}
 		f, err := r.getU8()
 		if err != nil {
 			return nil, err
@@ -432,6 +448,9 @@ func decodeShardRefs(r *codecReader, path string, lookup func(uint64) (string, e
 			File:      path,
 			Line:      int(line),
 			InComment: f&1 != 0,
+			StartByte: int(startByte),
+			EndByte:   int(endByte),
+			Language:  Language(lang),
 		}
 	}
 	return refs, nil

--- a/internal/scanner/index_shard_codec_golden_test.go
+++ b/internal/scanner/index_shard_codec_golden_test.go
@@ -119,7 +119,7 @@ func TestShardCodec_GoldenSHA256(t *testing.T) {
 	sum := sha256.Sum256(encoded)
 	got := hex.EncodeToString(sum[:])
 
-	const want = "b96909454ab29767f9243ff2b4a7c4f7ecd06a8be32eb69d025a92f8929efa61"
+	const want = "f7f3ff2908f1d9d244dd422bd48d96a20624e592ed080f7d468055f6ce07d00b"
 
 	if got != want {
 		t.Fatalf("golden shard digest changed:\nwant=%s\ngot =%s\nencoded=%x\nthis means the shard codec wire format moved; bump shardPayloadVersion and update this digest deliberately", want, got, encoded)


### PR DESCRIPTION
## Summary
- Implements `krit rename <from-fqn> <to-fqn> [paths...]` end-to-end. The CLI used to print a planning summary and exit 2 with `rename apply is not implemented yet`; it now does the rewrite.
- Defaults to dry-run; `--apply` writes the changes.
- Handles same-package and cross-package renames in Kotlin and Java: rewrites declaration sites, references, package headers, and import lines; preserves Kotlin `as` aliases; inserts an import when a same-package user loses its implicit binding; renames the declaration file when its basename matches the class; moves the file to the mirrored package directory when the layout mirrors the package.
- Surfaces and fixes a pre-existing bug: tree-sitter Kotlin extends `package_header` byte ranges into trailing whitespace and KDoc-style comments. `kotlinPackageName` was capturing those, corrupting top-level FQNs. Fixed by parsing the first non-empty, non-comment line; same fix applied to Java's `package_declaration` parser.

## What's new

### Scanner
- `Reference` now carries `StartByte`, `EndByte`, and `Language` so callers can rewrite identifier text without re-parsing. Both cache codecs round-trip the new fields; shard codec bumps to v3.
- `parsePackageHeaderText` extracted with table-driven test coverage to lock the trailing-trivia regression.

### Rename
- `internal/rename/plan.go` resolves references to FQN using each file's package + imports, so a rename of `com.foo.Bar` no longer rewrites unrelated `com.other.Bar`.
- `ValidatePlan` rejects ambiguous declarations (multiple FromFQN matches) and identical from/to.
- `internal/rename/apply.go` implements transactional Apply: collects identifier edits, package/import edits, and file moves; applies each file in a single forward pass; writes via `fsutil.WriteFileAtomic`. Stale byte ranges or overlapping edits abort before producing partial output.

### CLI
- `--apply` flag opts in; default is dry-run.
- Dry-run prints planned file moves so the user previews moves before committing.

## Notable design choices
- Reused identifier byte ranges already captured for Kotlin/Java references rather than re-locating them at apply time.
- Package and import header byte ranges are clamped to the first source line so a rewrite never erases trailing comments that tree-sitter attached to the header node.
- File moves only happen when the file's parent directory mirrors the source package. Flat layouts keep the file in place — we don't try to infer Bazel/Gradle source roots.

## Test plan
- [x] `go test ./... -count=1`
- [x] `go vet ./...` and `golangci-lint run ./...` clean (worktree-local issues only)
- [x] `make integration` (11/11 pass)
- [x] New tests cover: same-package rename, cross-package rename (Kotlin + Java), Kotlin alias preservation, orphaned same-package import insertion, file move within directory, file move to mirrored package directory, flat-layout file rename, string-literal negative, comment-trailing package preservation, ambiguous-declaration rejection, identical from/to rejection, FQN-based reference filtering.