### PR TITLE
feat(snapshot): gitignore .krit/snapshots/ on install-hook

### DIFF
--- a/docs/snapshots.md
+++ b/docs/snapshots.md
@@ -33,6 +33,10 @@ krit snapshot install-hook --uninstall  # removes it
 krit snapshot install-hook --print      # print the script (for core.hooksPath setups)
 ```
 
+`install-hook` also appends `.krit/snapshots/` to the repo's root
+`.gitignore` (idempotent, best-effort) so captured blobs and manifests
+don't get committed by accident.
+
 The hook runs `krit snapshot capture HEAD` detached, so a slow capture
 never blocks `git commit`. Capture latency on a warm parse cache is a
 few hundred milliseconds on small-to-medium repos; the first capture of

--- a/internal/snapshot/gitignore.go
+++ b/internal/snapshot/gitignore.go
@@ -1,0 +1,68 @@
+package snapshot
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/kaeawc/krit/internal/fsutil"
+)
+
+// SnapshotsGitignorePattern is the entry EnsureGitignoreEntry adds to the
+// repo's root .gitignore so users don't accidentally commit captured
+// snapshot blobs and manifests.
+const SnapshotsGitignorePattern = ".krit/snapshots/"
+
+// EnsureGitignoreEntry appends pattern to the repo root .gitignore if it
+// is not already present (as an exact line match, ignoring surrounding
+// whitespace). It is best-effort: if the .gitignore can't be read or
+// written, the error is returned but callers may choose to ignore it.
+//
+// Returns added=true when the pattern was newly written, and false if it
+// was already present (or if pattern was empty).
+func EnsureGitignoreEntry(repoRoot, pattern string) (added bool, err error) {
+	if repoRoot == "" {
+		return false, errors.New("snapshot: EnsureGitignoreEntry requires repoRoot")
+	}
+	if pattern == "" {
+		return false, nil
+	}
+	path := filepath.Join(repoRoot, ".gitignore")
+	existing, err := os.ReadFile(path)
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return false, fmt.Errorf("snapshot: read %s: %w", path, err)
+	}
+	if hasGitignoreLine(existing, pattern) {
+		return false, nil
+	}
+	out := append([]byte(nil), existing...)
+	if len(out) > 0 && out[len(out)-1] != '\n' {
+		out = append(out, '\n')
+	}
+	out = append(out, pattern...)
+	out = append(out, '\n')
+	if err := fsutil.WriteFileAtomic(path, out, 0o644); err != nil {
+		return false, fmt.Errorf("snapshot: write %s: %w", path, err)
+	}
+	return true, nil
+}
+
+// hasGitignoreLine reports whether content contains pattern as a non-comment
+// line (trimmed). A negated entry (`!pattern`) does not count as present, since
+// it un-ignores the path. Patterns that differ only in trailing slash are
+// treated as equivalent so ".krit/snapshots" and ".krit/snapshots/" both match.
+func hasGitignoreLine(content []byte, pattern string) bool {
+	want := strings.TrimSuffix(pattern, "/")
+	for _, line := range strings.Split(string(content), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") || strings.HasPrefix(trimmed, "!") {
+			continue
+		}
+		if strings.TrimSuffix(trimmed, "/") == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/snapshot/gitignore_test.go
+++ b/internal/snapshot/gitignore_test.go
@@ -1,0 +1,110 @@
+package snapshot
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestEnsureGitignoreEntryCreatesFile(t *testing.T) {
+	repo := t.TempDir()
+	added, err := EnsureGitignoreEntry(repo, SnapshotsGitignorePattern)
+	if err != nil {
+		t.Fatalf("EnsureGitignoreEntry: %v", err)
+	}
+	if !added {
+		t.Fatal("expected added=true on missing .gitignore")
+	}
+	data, err := os.ReadFile(filepath.Join(repo, ".gitignore"))
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if !strings.Contains(string(data), SnapshotsGitignorePattern) {
+		t.Fatalf("missing pattern: %q", data)
+	}
+}
+
+func TestEnsureGitignoreEntryIdempotent(t *testing.T) {
+	repo := t.TempDir()
+	path := filepath.Join(repo, ".gitignore")
+	if err := os.WriteFile(path, []byte("build/\n.krit/snapshots/\n"), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	added, err := EnsureGitignoreEntry(repo, SnapshotsGitignorePattern)
+	if err != nil {
+		t.Fatalf("EnsureGitignoreEntry: %v", err)
+	}
+	if added {
+		t.Fatal("expected added=false when pattern already present")
+	}
+	data, _ := os.ReadFile(path)
+	if strings.Count(string(data), SnapshotsGitignorePattern) != 1 {
+		t.Fatalf("pattern duplicated: %q", data)
+	}
+}
+
+func TestEnsureGitignoreEntryEquivalentTrailingSlash(t *testing.T) {
+	repo := t.TempDir()
+	path := filepath.Join(repo, ".gitignore")
+	// Pre-existing entry without trailing slash should still count.
+	if err := os.WriteFile(path, []byte(".krit/snapshots\n"), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	added, err := EnsureGitignoreEntry(repo, SnapshotsGitignorePattern)
+	if err != nil {
+		t.Fatalf("EnsureGitignoreEntry: %v", err)
+	}
+	if added {
+		t.Fatal("expected slash-equivalent pattern to be detected")
+	}
+}
+
+func TestEnsureGitignoreEntryAppendsWithNewline(t *testing.T) {
+	repo := t.TempDir()
+	path := filepath.Join(repo, ".gitignore")
+	// Existing file without trailing newline.
+	if err := os.WriteFile(path, []byte("build/"), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if _, err := EnsureGitignoreEntry(repo, SnapshotsGitignorePattern); err != nil {
+		t.Fatalf("EnsureGitignoreEntry: %v", err)
+	}
+	data, _ := os.ReadFile(path)
+	got := string(data)
+	if !strings.Contains(got, "build/\n.krit/snapshots/\n") {
+		t.Fatalf("expected newline-separated entries, got %q", got)
+	}
+}
+
+func TestEnsureGitignoreIgnoresCommentLines(t *testing.T) {
+	repo := t.TempDir()
+	path := filepath.Join(repo, ".gitignore")
+	if err := os.WriteFile(path, []byte("# .krit/snapshots/\n"), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	added, err := EnsureGitignoreEntry(repo, SnapshotsGitignorePattern)
+	if err != nil {
+		t.Fatalf("EnsureGitignoreEntry: %v", err)
+	}
+	if !added {
+		t.Fatal("commented-out pattern should not count as present")
+	}
+}
+
+func TestInstallHookAppendsGitignoreEntry(t *testing.T) {
+	repo := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(repo, ".git", "hooks"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if _, err := InstallHook(repo, false); err != nil {
+		t.Fatalf("InstallHook: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(repo, ".gitignore"))
+	if err != nil {
+		t.Fatalf("expected .gitignore to be created: %v", err)
+	}
+	if !strings.Contains(string(data), SnapshotsGitignorePattern) {
+		t.Fatalf("missing pattern in .gitignore: %q", data)
+	}
+}

--- a/internal/snapshot/hook.go
+++ b/internal/snapshot/hook.go
@@ -47,6 +47,9 @@ func InstallHook(repoRoot string, force bool) (string, error) {
 	if err := fsutil.WriteFileAtomic(path, []byte(taggedHook()), 0o755); err != nil {
 		return "", fmt.Errorf("snapshot: write %s: %w", path, err)
 	}
+	// Best-effort: keep generated snapshot artifacts out of git. Failures
+	// here (read-only fs, permission errors) shouldn't block hook install.
+	_, _ = EnsureGitignoreEntry(repoRoot, SnapshotsGitignorePattern)
 	return path, nil
 }
 


### PR DESCRIPTION
## Summary
- `krit snapshot install-hook` now appends `.krit/snapshots/` to the repo's root `.gitignore` (idempotent, best-effort) so captured blobs and manifests don't get committed.
- New `EnsureGitignoreEntry` helper in `internal/snapshot` with trailing-slash equivalence and negation-aware line detection.
- Doc note in `docs/snapshots.md`.

Closes #78.

## Test plan
- [x] `go test ./internal/snapshot/... -count=1`
- [x] `go vet ./...`
- [x] `make integration`