### PR TITLE
fix(perf): cacheLoad and cacheBudget no longer mislead

### DIFF
--- a/internal/cli/scan/perf_snapshot.go
+++ b/internal/cli/scan/perf_snapshot.go
@@ -18,9 +18,10 @@ type perfSnapshot struct {
 // OutputPhase needs it. Returns a zero-value snapshot when perfEnabled
 // is false; otherwise pulls timings from the tracker (when the tracker
 // itself is enabled) and snapshots all named caches plus the parse-cache
-// budget. Pulled out of scan.Run so the conditional structure has one
-// named owner instead of two adjacent if blocks.
-func capturePerfSnapshot(perfEnabled bool, tracker perf.Tracker) perfSnapshot {
+// budget. capBytes is the effective parse-cache cap (after --parse-cache-cap-mb
+// and krit.yml have been applied) — passing a stale default would make
+// pctOfCap misreport against the wrong ceiling.
+func capturePerfSnapshot(perfEnabled bool, tracker perf.Tracker, capBytes int64) perfSnapshot {
 	var snap perfSnapshot
 	if !perfEnabled {
 		return snap
@@ -29,7 +30,7 @@ func capturePerfSnapshot(perfEnabled bool, tracker perf.Tracker) perfSnapshot {
 		snap.Timings = tracker.GetTimings()
 	}
 	snap.Caches = cacheutil.AllStats()
-	b := cacheutil.Budget(cacheutil.DefaultParseCacheCapBytes)
+	b := cacheutil.Budget(capBytes)
 	snap.Budget = &b
 	return snap
 }

--- a/internal/cli/scan/perf_snapshot_test.go
+++ b/internal/cli/scan/perf_snapshot_test.go
@@ -3,11 +3,12 @@ package scan
 import (
 	"testing"
 
+	"github.com/kaeawc/krit/internal/cacheutil"
 	"github.com/kaeawc/krit/internal/perf"
 )
 
 func TestCapturePerfSnapshotDisabled(t *testing.T) {
-	snap := capturePerfSnapshot(false, perf.New(true))
+	snap := capturePerfSnapshot(false, perf.New(true), cacheutil.DefaultParseCacheCapBytes)
 	if snap.Timings != nil {
 		t.Errorf("Timings = %v; want nil", snap.Timings)
 	}
@@ -22,7 +23,7 @@ func TestCapturePerfSnapshotDisabled(t *testing.T) {
 func TestCapturePerfSnapshotEnabledWithDisabledTracker(t *testing.T) {
 	// --perf on but tracker.New(false) is the noopTracker (IsEnabled=false).
 	// Caches+Budget should populate; Timings should stay nil.
-	snap := capturePerfSnapshot(true, perf.New(false))
+	snap := capturePerfSnapshot(true, perf.New(false), cacheutil.DefaultParseCacheCapBytes)
 	if snap.Timings != nil {
 		t.Errorf("Timings = %v; want nil for disabled tracker", snap.Timings)
 	}
@@ -40,7 +41,7 @@ func TestCapturePerfSnapshotEnabledWithDisabledTracker(t *testing.T) {
 func TestCapturePerfSnapshotEnabledWithEnabledTracker(t *testing.T) {
 	tr := perf.New(true)
 	tr.TrackVoid("smoke", func() {})
-	snap := capturePerfSnapshot(true, tr)
+	snap := capturePerfSnapshot(true, tr, cacheutil.DefaultParseCacheCapBytes)
 	// Timings should now be a non-nil slice (may be empty, but the slice
 	// itself comes from tracker.GetTimings() which returns []perf.TimingEntry).
 	// The contract is just "Timings != nil when tracker.IsEnabled()".
@@ -52,10 +53,21 @@ func TestCapturePerfSnapshotEnabledWithEnabledTracker(t *testing.T) {
 	}
 }
 
+func TestCapturePerfSnapshotPropagatesCap(t *testing.T) {
+	const customCap int64 = 512 * 1024 * 1024
+	snap := capturePerfSnapshot(true, nil, customCap)
+	if snap.Budget == nil {
+		t.Fatal("Budget = nil; want non-nil")
+	}
+	if snap.Budget.CapBytes != customCap {
+		t.Errorf("Budget.CapBytes = %d; want %d (effective cap should propagate, not the package default)", snap.Budget.CapBytes, customCap)
+	}
+}
+
 func TestCapturePerfSnapshotNilTracker(t *testing.T) {
 	// Defensive: nil tracker must not panic. perfEnabled=true triggers the
 	// caches/budget capture but skips the GetTimings call.
-	snap := capturePerfSnapshot(true, nil)
+	snap := capturePerfSnapshot(true, nil, cacheutil.DefaultParseCacheCapBytes)
 	if snap.Timings != nil {
 		t.Errorf("Timings = %v; want nil for nil tracker", snap.Timings)
 	}

--- a/internal/cli/scan/runner.go
+++ b/internal/cli/scan/runner.go
@@ -1296,7 +1296,7 @@ func (r *runner) recordTotalTimingAndStopProfiles() {
 // outputPhase wires the Findings columns through OutputPhase, after first
 // short-circuiting --sample-rule and --rule-audit.
 func (r *runner) outputPhase() int {
-	perfSnap := capturePerfSnapshot(*r.f.Perf, r.tracker)
+	perfSnap := capturePerfSnapshot(*r.f.Perf, r.tracker, resolveParseCacheCap(*r.f.ParseCacheCapMB, r.cfg))
 
 	if handled, code := runSampleRuleShortCircuit(r.allColumns, sampleRuleOpts{
 		Rule:         *r.f.SampleRule,

--- a/internal/pipeline/index.go
+++ b/internal/pipeline/index.go
@@ -412,15 +412,20 @@ func (p IndexPhase) runCacheLoad(in IndexInput, result *IndexResult) {
 
 	var loadStart time.Time
 	var analysisCache *cache.Cache
-	_ = in.trackSerial("cacheLoad", func() error {
+	if in.PreloadedAnalysisCache != nil {
+		// The async preload happens in newRunner before the pipeline
+		// starts; wrapping the assignment in trackSerial would record
+		// a misleading ~0 ms cacheLoad entry. The goroutine's wall
+		// time is owned by the runner.
 		loadStart = time.Now()
-		if in.PreloadedAnalysisCache != nil {
-			analysisCache = in.PreloadedAnalysisCache
-		} else {
+		analysisCache = in.PreloadedAnalysisCache
+	} else {
+		_ = in.trackSerial("cacheLoad", func() error {
+			loadStart = time.Now()
 			analysisCache = cache.Load(in.CacheFilePath)
-		}
-		return nil
-	})
+			return nil
+		})
+	}
 
 	// Attach the unified store when available so incremental cache
 	// entries are persisted per-file in the store instead of the JSON file.


### PR DESCRIPTION
## Summary
Two unrelated perf-output glitches surfaced after #39:

- **cacheLoad ≈ 0 ms on warm runs.** When `PreloadedAnalysisCache` is non-nil, the load already happened in `newRunner`'s goroutine; wrapping the pointer assignment in `trackSerial(\"cacheLoad\", ...)` recorded a misleading 0 ms entry. Skip the tracker on the preloaded path.
- **cacheBudget.capBytes ignored \`--parse-cache-cap-mb\`.** \`capturePerfSnapshot\` always passed \`cacheutil.DefaultParseCacheCapBytes\`, so \`pctOfCap\` was computed against the wrong ceiling. Thread the effective cap through from the runner.

Adds a regression test that the cap propagates.

Closes #67.

## Test plan
- [x] \`go test ./... -count=1\`
- [x] \`make integration\`