### PR TITLE
fix(scan): recover panics in cache-preload goroutine

### DIFF
--- a/internal/cli/scan/preload_cache.go
+++ b/internal/cli/scan/preload_cache.go
@@ -1,0 +1,22 @@
+package scan
+
+import "github.com/kaeawc/krit/internal/cache"
+
+// preloadAnalysisCache runs load in a background goroutine and returns a
+// buffered channel that yields its result. A panic inside load is
+// recovered and converted to a nil send so the pipeline's cacheLoad
+// receiver never deadlocks; nil is the same shape that
+// pipeline.IndexPhase already treats as "fall back to a synchronous
+// cache.Load" via the PreloadedAnalysisCache==nil branch.
+func preloadAnalysisCache(load func() *cache.Cache) <-chan *cache.Cache {
+	ch := make(chan *cache.Cache, 1)
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				ch <- nil
+			}
+		}()
+		ch <- load()
+	}()
+	return ch
+}

--- a/internal/cli/scan/preload_cache_test.go
+++ b/internal/cli/scan/preload_cache_test.go
@@ -1,0 +1,33 @@
+package scan
+
+import (
+	"testing"
+	"time"
+
+	"github.com/kaeawc/krit/internal/cache"
+)
+
+func TestPreloadAnalysisCacheReturnsLoadResult(t *testing.T) {
+	want := &cache.Cache{}
+	ch := preloadAnalysisCache(func() *cache.Cache { return want })
+	select {
+	case got := <-ch:
+		if got != want {
+			t.Fatalf("got %p; want %p", got, want)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for preload result")
+	}
+}
+
+func TestPreloadAnalysisCacheRecoversPanic(t *testing.T) {
+	ch := preloadAnalysisCache(func() *cache.Cache { panic("boom") })
+	select {
+	case got := <-ch:
+		if got != nil {
+			t.Fatalf("got %p; want nil after panic", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("preload deadlocked after panic — recover did not fire")
+	}
+}

--- a/internal/cli/scan/runner.go
+++ b/internal/cli/scan/runner.go
@@ -60,7 +60,7 @@ type runner struct {
 	// preloadedAnalysisCacheCh receives the result of a background
 	// cache.Load kicked off as soon as cacheFilePath is known, in
 	// parallel with collectFiles / projectModel / filterRules.
-	preloadedAnalysisCacheCh chan *cache.Cache
+	preloadedAnalysisCacheCh <-chan *cache.Cache
 
 	// File collection
 	files                []string
@@ -253,9 +253,9 @@ func newRunner(f *scanFlags) (*runner, int, bool) {
 		cacheFilePath:   cacheFilePath,
 	}
 	if !*f.NoCache && cacheFilePath != "" {
-		ch := make(chan *cache.Cache, 1)
-		r.preloadedAnalysisCacheCh = ch
-		go func() { ch <- cache.Load(cacheFilePath) }()
+		r.preloadedAnalysisCacheCh = preloadAnalysisCache(func() *cache.Cache {
+			return cache.Load(cacheFilePath)
+		})
 	}
 	return r, 0, true
 }


### PR DESCRIPTION
## Summary
The background \`cache.Load\` goroutine in \`newRunner\` had no \`recover()\`. If \`cache.Load\` ever panics, the goroutine dies before sending to the channel and \`r.runCacheLoad\`'s receiver deadlocks indefinitely.

Convert panics to a \`nil\` send — \`pipeline.IndexPhase\` already treats \`PreloadedAnalysisCache == nil\` as "fall back to synchronous \`cache.Load\`", so this is a clean failure mode.

Extracted as \`preloadAnalysisCache(load func)\` so the recover contract has a focused unit test (panic via injected load returns nil; happy path passes through). Defensive — not reproducing today.

Closes #64.

## Test plan
- [x] \`go test ./internal/cli/scan/... -run Preload -v\`
- [x] \`go test ./... -count=1\`
- [x] \`make integration\`