### PR TITLE
refactor(serve): extract startServerWith for daemon test setup

### DIFF
--- a/internal/cli/serve/analyze_project_bench_test.go
+++ b/internal/cli/serve/analyze_project_bench_test.go
@@ -19,8 +19,6 @@
 package serve
 
 import (
-	"context"
-	"fmt"
 	"os"
 	"runtime"
 	"testing"
@@ -141,31 +139,10 @@ func BenchmarkAnalyzeProjectLeak(b *testing.B) {
 	}
 }
 
-// startServerForCorpus is the corpus-rooted analogue of
-// startServerForTest. Differences: --root points at the corpus
-// (not t.TempDir()), the socket lives in /tmp, no test-only
-// shortcuts. Cleanup is registered on b so the daemon and socket
-// are torn down between iterations of cold-bench loops.
+// startServerForCorpus is the corpus-rooted wrapper over
+// startServerWith. readyTimeout=0 so the bench tight-spins on
+// daemon.Available — startup cost isn't part of the measurement.
 func startServerForCorpus(b *testing.B, root string) (string, *daemonState) {
 	b.Helper()
-	socketDir, err := os.MkdirTemp("/tmp", "krit-corpus-")
-	if err != nil {
-		b.Fatalf("MkdirTemp: %v", err)
-	}
-	b.Cleanup(func() { _ = os.RemoveAll(socketDir) })
-	socket := fmt.Sprintf("%s/d.sock", socketDir)
-
-	state := newDaemonState(root)
-	srv := daemon.NewServer(socket)
-	registerVerbs(srv, state)
-	if err := srv.Start(context.Background()); err != nil {
-		b.Fatalf("start: %v", err)
-	}
-	b.Cleanup(srv.Stop)
-
-	for !daemon.Available(socket) {
-		// Spin briefly; benchmarks tolerate this since they're not
-		// measuring startup cost.
-	}
-	return socket, state
+	return startServerWith(b, root, 0)
 }

--- a/internal/cli/serve/serve_test.go
+++ b/internal/cli/serve/serve_test.go
@@ -1,49 +1,19 @@
 package serve
 
 import (
-	"context"
 	"encoding/json"
-	"os"
-	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/kaeawc/krit/internal/daemon"
 )
 
-// startServerForTest spins up a serve.Server with the standard verbs
-// registered. warm() is intentionally skipped: analyze-buffer doesn't
-// need the module graph, and warm() would try to scan t.TempDir() as
-// a project.
-//
-// macOS limits Unix-socket paths to 104 bytes; with long test names
-// even t.TempDir() overruns. Place the socket under a short MkdirTemp
-// rooted at /tmp so the path stays well under the cap.
+// startServerForTest spins up a serve.Server rooted at t.TempDir() and
+// waits up to one second for the socket to become available. Thin
+// wrapper over startServerWith.
 func startServerForTest(t *testing.T) (string, *daemonState) {
 	t.Helper()
-	socketDir, err := os.MkdirTemp("/tmp", "krit-srv-")
-	if err != nil {
-		t.Fatalf("MkdirTemp: %v", err)
-	}
-	t.Cleanup(func() { _ = os.RemoveAll(socketDir) })
-	socket := filepath.Join(socketDir, "d.sock")
-
-	state := newDaemonState(t.TempDir())
-	srv := daemon.NewServer(socket)
-	registerVerbs(srv, state)
-
-	if err := srv.Start(context.Background()); err != nil {
-		t.Fatalf("start: %v", err)
-	}
-	t.Cleanup(srv.Stop)
-	deadline := time.Now().Add(time.Second)
-	for time.Now().Before(deadline) {
-		if daemon.Available(socket) {
-			break
-		}
-		time.Sleep(5 * time.Millisecond)
-	}
-	return socket, state
+	return startServerWith(t, t.TempDir(), time.Second)
 }
 
 func TestAnalyzeBuffer_RoundTrip(t *testing.T) {

--- a/internal/cli/serve/server_testhelper_test.go
+++ b/internal/cli/serve/server_testhelper_test.go
@@ -1,0 +1,58 @@
+package serve
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/kaeawc/krit/internal/daemon"
+)
+
+// startServerWith spins up a serve.Server rooted at root with the
+// standard verbs registered, returns the socket path and the daemon
+// state, and registers teardown on tb. warm() is intentionally not
+// invoked — analyze-buffer and the corpus benches drive their own
+// warm/cold cadence.
+//
+// macOS limits Unix-socket paths to 104 bytes; with long test names
+// even t.TempDir() overruns. Place the socket under a short MkdirTemp
+// rooted at /tmp so the path stays well under the cap.
+//
+// readyTimeout caps the daemon.Available polling. Use 0 for a tight
+// spin (benchmarks tolerate startup latency); pass a deadline for
+// unit tests where a stuck server should fail fast.
+func startServerWith(tb testing.TB, root string, readyTimeout time.Duration) (string, *daemonState) {
+	tb.Helper()
+	socketDir, err := os.MkdirTemp("/tmp", "krit-srv-")
+	if err != nil {
+		tb.Fatalf("MkdirTemp: %v", err)
+	}
+	tb.Cleanup(func() { _ = os.RemoveAll(socketDir) })
+	socket := filepath.Join(socketDir, "d.sock")
+
+	state := newDaemonState(root)
+	srv := daemon.NewServer(socket)
+	registerVerbs(srv, state)
+	if err := srv.Start(context.Background()); err != nil {
+		tb.Fatalf("start: %v", err)
+	}
+	tb.Cleanup(srv.Stop)
+
+	if readyTimeout > 0 {
+		deadline := time.Now().Add(readyTimeout)
+		for time.Now().Before(deadline) {
+			if daemon.Available(socket) {
+				break
+			}
+			time.Sleep(5 * time.Millisecond)
+		}
+	} else {
+		for !daemon.Available(socket) {
+			// Spin briefly; benchmarks tolerate this since they're not
+			// measuring startup cost.
+		}
+	}
+	return socket, state
+}


### PR DESCRIPTION
## Summary
- New \`startServerWith(tb, root, readyTimeout)\` in \`server_testhelper_test.go\` owns the socket-dir + registerVerbs + readiness-poll setup.
- \`startServerForTest(t)\` and \`startServerForCorpus(b, root)\` collapse to thin wrappers.
- \`readyTimeout=0\` preserves the bench's tight-spin (startup cost is not measured).

Closes #69.

## Test plan
- [x] \`go test ./internal/cli/serve/... -count=1\`
- [x] \`go vet -tags=kotlin_corpus ./internal/cli/serve/...\`
- [x] \`make integration\`