### PR TITLE
perf(scan): skip cache preload on --oracle-filter-fingerprint

### DIFF
--- a/internal/cli/scan/runner.go
+++ b/internal/cli/scan/runner.go
@@ -253,7 +253,12 @@ func newRunner(f *scanFlags) (*runner, int, bool) {
 		libraryFacts:    librarymodel.DefaultFacts(),
 		cacheFilePath:   cacheFilePath,
 	}
-	if !*f.NoCache && cacheFilePath != "" {
+	// Skip the preload on early-exit paths that never reach
+	// runOracleIndex. --oracle-filter-fingerprint is the only one
+	// detectable here without doing the file walk first; the empty-repo
+	// short-circuit needs file collection to fire and isn't worth a
+	// pre-walk just to save the wasted load.
+	if !*f.NoCache && cacheFilePath != "" && !*f.OracleFilterFingerprint {
 		r.preloadedAnalysisCacheCh = preloadAnalysisCache(func() *cache.Cache {
 			return cache.Load(cacheFilePath)
 		})


### PR DESCRIPTION
## Summary
The background \`cache.Load\` goroutine in \`newRunner\` is wasted on \`--oracle-filter-fingerprint\` runs (the diagnostic exits before \`runOracleIndex\`). One-line guard skips the kickoff.

The other early-exit (empty repo) is not addressed: detecting it would require running the file walk before the kickoff, which is exactly the parallelism the preload exists to use. Issue #66 explicitly accepts this tradeoff.

Closes #66.

## Test plan
- [x] \`go test ./internal/cli/scan/... -count=1\`
- [x] \`make integration\`