### PR TITLE
perf(serve): async recursive watcher populate at daemon startup

### DIFF
--- a/internal/cli/serve/watcher.go
+++ b/internal/cli/serve/watcher.go
@@ -31,6 +31,15 @@ type fileWatcher struct {
 
 	closeOnce sync.Once
 	done      chan struct{}
+	// ready closes once the initial recursive walk has finished. The
+	// walk runs asynchronously after startFileWatcher returns so the
+	// daemon's startup latency is bounded by NewWatcher() + a single
+	// root Add() rather than by a full project tree walk. Callers who
+	// need a fully primed watcher (tests on sub-dirs, e.g.) can wait
+	// on Ready() — production callers don't need to: events arriving
+	// before the walk completes for a still-unwatched subtree are
+	// covered by the watcher's documented best-effort contract.
+	ready chan struct{}
 }
 
 // startFileWatcher returns a started watcher rooted at root. Callers
@@ -48,14 +57,36 @@ func startFileWatcher(ctx context.Context, root string, state *pipeline.Workspac
 		state:    state,
 		reporter: reporter,
 		done:     make(chan struct{}),
+		ready:    make(chan struct{}),
 	}
-	if err := fw.addRecursive(root); err != nil {
+	// Add the root synchronously so files written directly under it
+	// are caught from t=0. The recursive descent runs in a goroutine —
+	// on a 60k-file repo a sync walk costs multiple seconds, which is
+	// the daemon's first-call latency budget.
+	if err := w.Add(root); err != nil {
 		_ = w.Close()
 		return nil, err
 	}
+	go fw.populate()
 	go fw.run(ctx)
 	return fw, nil
 }
+
+// populate walks the project tree and registers each directory with
+// the underlying watcher. Closes fw.ready when done. Errors are
+// logged via the reporter — a partial registration just means the
+// usual best-effort fallback (next request rehashes contents).
+func (fw *fileWatcher) populate() {
+	defer close(fw.ready)
+	if err := fw.addRecursiveSkip(fw.root, true); err != nil {
+		fw.warn("watch populate: %v\n", err)
+	}
+}
+
+// Ready returns a channel that closes once the initial recursive
+// walk has finished. Tests that exercise pre-existing subtrees can
+// wait on it; production callers don't need to.
+func (fw *fileWatcher) Ready() <-chan struct{} { return fw.ready }
 
 // Stop releases the watcher. Safe to call multiple times.
 func (fw *fileWatcher) Stop() {
@@ -132,6 +163,13 @@ func (fw *fileWatcher) handle(ev fsnotify.Event) {
 // analyses files under them, so receiving events for them just
 // burns descriptors and CPU.
 func (fw *fileWatcher) addRecursive(dir string) error {
+	return fw.addRecursiveSkip(dir, false)
+}
+
+// addRecursiveSkip is addRecursive with a hook to skip the root Add —
+// startFileWatcher adds the root synchronously and only the async
+// descendant walk should skip re-adding it.
+func (fw *fileWatcher) addRecursiveSkip(dir string, skipRoot bool) error {
 	return filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			// Skip unreadable entries — the daemon shouldn't crash
@@ -146,6 +184,9 @@ func (fw *fileWatcher) addRecursive(dir string) error {
 		base := filepath.Base(path)
 		if isPrunedDir(base) && path != dir {
 			return filepath.SkipDir
+		}
+		if skipRoot && path == dir {
+			return nil
 		}
 		if err := fw.w.Add(path); err != nil {
 			fw.warn("watch %s: %v\n", path, err)

--- a/internal/cli/serve/watcher_startup_test.go
+++ b/internal/cli/serve/watcher_startup_test.go
@@ -1,0 +1,52 @@
+package serve
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/kaeawc/krit/internal/pipeline"
+)
+
+// TestFileWatcher_StartupIsFastWithDeepTree asserts startFileWatcher
+// returns quickly even when the project tree has many directories.
+// The recursive add now runs in a background goroutine, so startup
+// should be bounded by NewWatcher() + a single root Add().
+func TestFileWatcher_StartupIsFastWithDeepTree(t *testing.T) {
+	root := t.TempDir()
+	// 200 nested+sibling directories. On a busy CI runner a sync
+	// recursive Add of this is still fast, but the test exists to
+	// keep the contract honest as the tree grows.
+	for i := 0; i < 200; i++ {
+		dir := filepath.Join(root, fmt.Sprintf("d%03d", i))
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+	ws := pipeline.NewWorkspaceState(root)
+
+	start := time.Now()
+	w, err := startFileWatcher(context.Background(), root, ws, nil)
+	if err != nil {
+		t.Fatalf("startFileWatcher: %v", err)
+	}
+	defer w.Stop()
+	startup := time.Since(start)
+
+	// 100ms is generous on any developer/CI machine; if startup ever
+	// regresses to a sync walk it'll blow well past this.
+	if startup > 100*time.Millisecond {
+		t.Errorf("startFileWatcher took %v; expected <100ms with async populate", startup)
+	}
+
+	// Ready should fire within a reasonable window once the walk
+	// completes — bounded loosely so a slow CI runner doesn't flake.
+	select {
+	case <-w.Ready():
+	case <-time.After(2 * time.Second):
+		t.Fatal("watcher Ready() did not fire within 2s")
+	}
+}


### PR DESCRIPTION
## Summary
\`startFileWatcher\` previously walked the whole project tree synchronously, adding multiple seconds of first-call latency to \`krit serve\` on large repos (JetBrains/kotlin etc.). Now:

- Root added synchronously — events on top-level files caught from t=0.
- Descendant walk runs in a goroutine.
- New \`Ready()\` channel for callers that need to wait on full population.

Adds a startup-latency regression test against a 200-dir tree.

Closes #61.

## Test plan
- [x] \`go test ./internal/cli/serve/... -count=1\`
- [x] \`go test ./... -count=1\`
- [x] \`make integration\`