### PR TITLE
fix(rename): reject when destination FQN is already declared

### DIFF
--- a/internal/rename/apply_test.go
+++ b/internal/rename/apply_test.go
@@ -409,6 +409,59 @@ func TestValidatePlan_RejectsAmbiguousDeclarations(t *testing.T) {
 	}
 }
 
+func TestValidatePlan_RejectsOccupiedDestination(t *testing.T) {
+	target, _ := ParseTarget("com.example.OldName", "com.example.NewName")
+	plan := Plan{
+		Target: target,
+		Declarations: []scanner.Symbol{
+			{Name: "OldName", FQN: "com.example.OldName", File: "a.kt", Line: 3},
+		},
+		Conflicts: []scanner.Symbol{
+			{Name: "NewName", FQN: "com.example.NewName", File: "b.kt", Line: 7},
+		},
+	}
+	err := ValidatePlan(plan)
+	if err == nil {
+		t.Fatalf("expected ValidatePlan to reject rename into occupied FQN")
+	}
+	if !strings.Contains(err.Error(), "b.kt:7") || !strings.Contains(err.Error(), "com.example.NewName") {
+		t.Errorf("error %q should mention conflicting site b.kt:7 and dest FQN", err.Error())
+	}
+}
+
+func TestBuildPlan_PopulatesConflictsWhenDestinationOccupied(t *testing.T) {
+	dir := t.TempDir()
+	a := filepath.Join(dir, "A.kt")
+	b := filepath.Join(dir, "B.kt")
+	writeFile(t, a, "package com.example\n\nclass OldName\n")
+	writeFile(t, b, "package com.example\n\nclass NewName\n")
+
+	plan := buildKotlinPlan(t, []string{a, b}, "com.example.OldName", "com.example.NewName")
+	if len(plan.Conflicts) != 1 {
+		t.Fatalf("expected 1 conflict at destination FQN; got %d (%+v)", len(plan.Conflicts), plan.Conflicts)
+	}
+	if plan.Conflicts[0].FQN != "com.example.NewName" {
+		t.Errorf("conflict FQN = %q; want com.example.NewName", plan.Conflicts[0].FQN)
+	}
+	if err := ValidatePlan(plan); err == nil {
+		t.Fatalf("ValidatePlan should reject when destination is already declared")
+	}
+}
+
+func TestBuildPlan_NoConflictsWhenDestinationFree(t *testing.T) {
+	dir := t.TempDir()
+	a := filepath.Join(dir, "A.kt")
+	writeFile(t, a, "package com.example\n\nclass OldName\n")
+
+	plan := buildKotlinPlan(t, []string{a}, "com.example.OldName", "com.example.NewName")
+	if len(plan.Conflicts) != 0 {
+		t.Fatalf("expected no conflicts; got %d (%+v)", len(plan.Conflicts), plan.Conflicts)
+	}
+	if err := ValidatePlan(plan); err != nil {
+		t.Fatalf("ValidatePlan should accept rename to free FQN: %v", err)
+	}
+}
+
 func buildKotlinPlan(t *testing.T, paths []string, fromFQN, toFQN string) Plan {
 	t.Helper()
 	files, errs := scanner.ScanFiles(paths, 1)

--- a/internal/rename/plan.go
+++ b/internal/rename/plan.go
@@ -139,33 +139,8 @@ func BuildPlanWithFiles(idx *scanner.CodeIndex, target Target, extraFiles []*sca
 	}
 
 	files := make(map[string]bool)
-
-	for _, sym := range idx.Symbols {
-		if sym.Name == target.ToName && sym.FQN == target.ToFQN {
-			plan.Conflicts = append(plan.Conflicts, sym)
-		}
-		if sym.Name != target.FromName {
-			continue
-		}
-		if sym.FQN != "" && sym.FQN != target.FromFQN {
-			continue
-		}
-		plan.Declarations = append(plan.Declarations, sym)
-		files[sym.File] = true
-	}
-
-	if idx.MayHaveReference(target.FromName) {
-		for _, ref := range idx.References {
-			if ref.Name != target.FromName || ref.InComment {
-				continue
-			}
-			if !plan.referenceMatchesTarget(ref) {
-				continue
-			}
-			plan.References = append(plan.References, ref)
-			files[ref.File] = true
-		}
-	}
+	plan.collectSymbols(idx, target, files)
+	plan.collectReferences(idx, target, files)
 
 	sort.Slice(plan.Conflicts, func(i, j int) bool {
 		if plan.Conflicts[i].File != plan.Conflicts[j].File {
@@ -213,6 +188,38 @@ func (p Plan) Summary() Summary {
 func (p Plan) CandidateCount() int {
 	summary := p.Summary()
 	return summary.Declarations + summary.References
+}
+
+func (p *Plan) collectSymbols(idx *scanner.CodeIndex, target Target, files map[string]bool) {
+	for _, sym := range idx.Symbols {
+		if sym.Name == target.ToName && sym.FQN == target.ToFQN {
+			p.Conflicts = append(p.Conflicts, sym)
+		}
+		if sym.Name != target.FromName {
+			continue
+		}
+		if sym.FQN != "" && sym.FQN != target.FromFQN {
+			continue
+		}
+		p.Declarations = append(p.Declarations, sym)
+		files[sym.File] = true
+	}
+}
+
+func (p *Plan) collectReferences(idx *scanner.CodeIndex, target Target, files map[string]bool) {
+	if !idx.MayHaveReference(target.FromName) {
+		return
+	}
+	for _, ref := range idx.References {
+		if ref.Name != target.FromName || ref.InComment {
+			continue
+		}
+		if !p.referenceMatchesTarget(ref) {
+			continue
+		}
+		p.References = append(p.References, ref)
+		files[ref.File] = true
+	}
 }
 
 // indexFile records the parsed file and its derived context. Idempotent

--- a/internal/rename/plan.go
+++ b/internal/rename/plan.go
@@ -18,6 +18,10 @@ func ValidatePlan(plan Plan) error {
 	if plan.Target.FromFQN == plan.Target.ToFQN {
 		return fmt.Errorf("rename: from and to are identical")
 	}
+	if len(plan.Conflicts) > 0 {
+		c := plan.Conflicts[0]
+		return fmt.Errorf("rename: destination %s already declared at %s:%d; refusing to proceed", plan.Target.ToFQN, c.File, c.Line)
+	}
 	return nil
 }
 
@@ -69,6 +73,10 @@ type Plan struct {
 	Declarations []scanner.Symbol
 	References   []scanner.Reference
 	Files        []string
+	// Conflicts are declarations already present at Target.ToFQN — a
+	// rename into an occupied FQN would land two declarations at the
+	// same name. ValidatePlan refuses to proceed when this is non-empty.
+	Conflicts []scanner.Symbol
 
 	contexts    map[string]fileContext
 	filesByPath map[string]*scanner.File
@@ -133,6 +141,9 @@ func BuildPlanWithFiles(idx *scanner.CodeIndex, target Target, extraFiles []*sca
 	files := make(map[string]bool)
 
 	for _, sym := range idx.Symbols {
+		if sym.Name == target.ToName && sym.FQN == target.ToFQN {
+			plan.Conflicts = append(plan.Conflicts, sym)
+		}
 		if sym.Name != target.FromName {
 			continue
 		}
@@ -156,6 +167,12 @@ func BuildPlanWithFiles(idx *scanner.CodeIndex, target Target, extraFiles []*sca
 		}
 	}
 
+	sort.Slice(plan.Conflicts, func(i, j int) bool {
+		if plan.Conflicts[i].File != plan.Conflicts[j].File {
+			return plan.Conflicts[i].File < plan.Conflicts[j].File
+		}
+		return plan.Conflicts[i].Line < plan.Conflicts[j].Line
+	})
 	sort.Slice(plan.Declarations, func(i, j int) bool {
 		if plan.Declarations[i].File != plan.Declarations[j].File {
 			return plan.Declarations[i].File < plan.Declarations[j].File


### PR DESCRIPTION
## Summary
\`ValidatePlan\` accepted renames into already-occupied FQNs, which would land two declarations at the same name. \`BuildPlan\` now scans the index for any existing declaration at \`Target.ToFQN\` and stores them on \`Plan.Conflicts\`; \`ValidatePlan\` refuses with a message pointing at the first conflicting site.

Closes #43.

## Test plan
- [x] New: \`TestBuildPlan_PopulatesConflictsWhenDestinationOccupied\`
- [x] New: \`TestBuildPlan_NoConflictsWhenDestinationFree\`
- [x] New: \`TestValidatePlan_RejectsOccupiedDestination\`
- [x] \`go test ./... -count=1\` and \`make integration\` clean