### PR TITLE
fix(snapshot): clearer error when info <sha> is not captured

### DIFF
--- a/internal/cli/snapshot/snapshot.go
+++ b/internal/cli/snapshot/snapshot.go
@@ -3,8 +3,10 @@ package snapshot
 
 import (
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
+	"io/fs"
 	"os"
 	"strconv"
 	"strings"
@@ -184,6 +186,16 @@ func runStatus(args []string) int {
 	return 0
 }
 
+// formatInfoError shapes a LoadManifest failure for `snapshot info <arg>`.
+// Missing-snapshot errors get a friendly hint; other failures fall through
+// as the underlying message.
+func formatInfoError(arg string, err error) string {
+	if errors.Is(err, fs.ErrNotExist) {
+		return fmt.Sprintf("error: %q is not a captured snapshot. Try `krit snapshot status` to list captured shas.", arg)
+	}
+	return fmt.Sprintf("error: %v", err)
+}
+
 func runInfo(args []string) int {
 	fs := flag.NewFlagSet("snapshot info", flag.ContinueOnError)
 	fs.SetOutput(os.Stderr)
@@ -211,7 +223,7 @@ func runInfo(args []string) int {
 	}
 	m, err := snap.LoadManifest(root, sha)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		fmt.Fprintln(os.Stderr, formatInfoError(positional[0], err))
 		return 1
 	}
 	enc := json.NewEncoder(os.Stdout)

--- a/internal/cli/snapshot/snapshot_test.go
+++ b/internal/cli/snapshot/snapshot_test.go
@@ -1,0 +1,32 @@
+package snapshot
+
+import (
+	"errors"
+	"io/fs"
+	"strings"
+	"testing"
+)
+
+func TestFormatInfoError_FriendlyOnMissing(t *testing.T) {
+	got := formatInfoError("abc1234", fs.ErrNotExist)
+	if !strings.Contains(got, "abc1234") {
+		t.Errorf("missing arg in message: %q", got)
+	}
+	if !strings.Contains(got, "is not a captured snapshot") {
+		t.Errorf("missing friendly hint: %q", got)
+	}
+	if !strings.Contains(got, "krit snapshot status") {
+		t.Errorf("missing status hint: %q", got)
+	}
+}
+
+func TestFormatInfoError_PassthroughOnOtherError(t *testing.T) {
+	custom := errors.New("boom")
+	got := formatInfoError("abc1234", custom)
+	if !strings.Contains(got, "boom") {
+		t.Errorf("expected non-ENOENT error to pass through: %q", got)
+	}
+	if strings.Contains(got, "is not a captured snapshot") {
+		t.Errorf("non-ENOENT error should not get the friendly hint: %q", got)
+	}
+}


### PR DESCRIPTION
## Summary
\`krit snapshot info <sha>\` against an uncaptured sha used to print the raw \`ENOENT\` path. Now it prints a short hint that the sha isn't captured and points to \`krit snapshot status\`. Other failures (parse, permission) still pass through.

Closes #59.

## Test plan
- [x] New \`TestFormatInfoError_FriendlyOnMissing\` / \`PassthroughOnOtherError\`
- [x] \`go test ./... -count=1\`
- [x] \`make integration\`