### PR TITLE
feat(daemon): plumb real ParseCache hit/miss stats through ProjectResult

### DIFF
--- a/internal/cli/serve/analyze_project.go
+++ b/internal/cli/serve/analyze_project.go
@@ -72,6 +72,8 @@ func handleAnalyzeProject(ctx context.Context, state *daemonState, raw json.RawM
 			LibraryFactsHit: xfile.HasLibraryFacts,
 			DirtyFiles:      len(dirty),
 			Cold:            cold,
+			ParseHits:       out.ParseHits,
+			ParseMisses:     out.ParseMisses,
 		},
 	}, nil
 }

--- a/internal/cli/serve/analyze_project_parse_stats_test.go
+++ b/internal/cli/serve/analyze_project_parse_stats_test.go
@@ -1,0 +1,53 @@
+package serve
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/kaeawc/krit/internal/daemon"
+)
+
+// kotlinFixture returns a Kotlin source string ≥ 1KB so the parse
+// cache (which skips small files via parseCacheMinFileSize) actually
+// participates.
+func kotlinFixture(name string) string {
+	body := strings.Repeat("    val padding = \"x\"\n", 60)
+	return "package demo\n\nclass " + name + " {\n" + body + "}\n"
+}
+
+// TestAnalyzeProject_ParseCacheStatsReportPerCallDelta asserts the
+// parse-cache hit/miss counts on AnalyzeProjectStats reflect the
+// per-call work, not cumulative-since-daemon-startup. First call
+// over a 3-file fixture should populate misses; the second call
+// over the same content should be all hits.
+func TestAnalyzeProject_ParseCacheStatsReportPerCallDelta(t *testing.T) {
+	socket, state := startServerForTest(t)
+	writeKotlinFile(t, state.root, "A.kt", kotlinFixture("A"))
+	writeKotlinFile(t, state.root, "B.kt", kotlinFixture("B"))
+	writeKotlinFile(t, state.root, "C.kt", kotlinFixture("C"))
+
+	var first daemon.AnalyzeProjectResult
+	if err := daemon.Call(socket, daemon.VerbAnalyzeProject,
+		daemon.AnalyzeProjectArgs{}, &first); err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+	if first.Stats.ParseMisses == 0 {
+		t.Errorf("first call should record parse misses; got Stats=%+v", first.Stats)
+	}
+
+	var second daemon.AnalyzeProjectResult
+	if err := daemon.Call(socket, daemon.VerbAnalyzeProject,
+		daemon.AnalyzeProjectArgs{}, &second); err != nil {
+		t.Fatalf("second call: %v", err)
+	}
+	// The second call's delta should not include the first call's
+	// misses (proves ParseHits/ParseMisses are per-call deltas, not
+	// cumulative). On a warm cache we expect hits to dominate.
+	if second.Stats.ParseMisses >= first.Stats.ParseMisses {
+		t.Errorf("second call's ParseMisses (%d) should be lower than the first's (%d) once the cache is warm — looks like cumulative, not delta",
+			second.Stats.ParseMisses, first.Stats.ParseMisses)
+	}
+	if second.Stats.ParseHits == 0 {
+		t.Errorf("second call should record parse hits against the warm cache; got Stats=%+v", second.Stats)
+	}
+}

--- a/internal/daemon/protocol.go
+++ b/internal/daemon/protocol.go
@@ -175,14 +175,6 @@ type AnalyzeProjectResult struct {
 // for clients that want to log warm-vs-cold cadence, or for tests
 // asserting that the dirty-set behaves as expected after a single-
 // file change.
-//
-// Parse-cache hit/miss accounting is intentionally absent: the
-// daemon-resident *scanner.ParseCache used by RunProject does not
-// yet expose per-call hit/miss deltas through the daemon's
-// observable surface. WorkspaceState's hit/miss counters track a
-// different cache (used by analyze-buffer) and would mislead
-// callers if reported here. Plumbing real per-call cache stats
-// from RunProject's ProjectResult is tracked as a follow-up.
 type AnalyzeProjectStats struct {
 	FilesScanned    int     `json:"files_scanned"`
 	FindingsCount   int     `json:"findings_count"`
@@ -197,4 +189,9 @@ type AnalyzeProjectStats struct {
 	// Cold is true on the first analyze-project call after daemon
 	// startup; subsequent calls report false.
 	Cold bool `json:"cold"`
+	// ParseHits and ParseMisses are the per-call delta against the
+	// resident parse cache (combined Kotlin + Java). Both stay 0 when
+	// no parse cache is attached.
+	ParseHits   int64 `json:"parse_hits"`
+	ParseMisses int64 `json:"parse_misses"`
 }

--- a/internal/pipeline/project.go
+++ b/internal/pipeline/project.go
@@ -113,6 +113,11 @@ type ProjectResult struct {
 	Stats rules.RunStats
 	// Caches is the unified cache stats array for the run.
 	Caches []cacheutil.NamedCacheStats
+	// ParseHits and ParseMisses report the per-call delta against
+	// ProjectInput.ParseCache (when one is attached). Both stay 0 when
+	// the input ran without a parse cache.
+	ParseHits   int64
+	ParseMisses int64
 }
 
 // RunProject runs the core scan pipeline against the given input and
@@ -148,6 +153,11 @@ func RunProject(ctx context.Context, in ProjectInput) (ProjectResult, error) {
 	if format == "" {
 		format = "json"
 	}
+
+	// Snapshot the parse-cache counters at the start of the run so the
+	// post-run delta is the per-call hit/miss accounting we report back
+	// to daemon clients. nil ParseCache returns the zero value.
+	hits0, misses0 := parseCacheCounters(in.ParseCache)
 
 	// Phase 1: parse.
 	parseResult, err := ParsePhase{Workers: in.Workers}.Run(ctx, ParseInput{
@@ -222,6 +232,7 @@ func RunProject(ctx context.Context, in ProjectInput) (ProjectResult, error) {
 		return ProjectResult{}, fmt.Errorf("output: %w", err)
 	}
 
+	hits1, misses1 := parseCacheCounters(in.ParseCache)
 	return ProjectResult{
 		JSON:          buf.Bytes(),
 		FinalFindings: outResult.FinalFindings,
@@ -229,5 +240,18 @@ func RunProject(ctx context.Context, in ProjectInput) (ProjectResult, error) {
 		FindingsCount: outResult.FinalFindings.Len(),
 		ParseErrors:   parseResult.ParseErrors,
 		Stats:         dispatchResult.Stats,
+		ParseHits:     hits1 - hits0,
+		ParseMisses:   misses1 - misses0,
 	}, nil
+}
+
+// parseCacheCounters extracts the cumulative Hits/Misses pair from a
+// *scanner.ParseCache. nil pc returns (0, 0). RunProject snaps these
+// before and after the run so the delta is the per-call accounting.
+func parseCacheCounters(pc *scanner.ParseCache) (int64, int64) {
+	if pc == nil {
+		return 0, 0
+	}
+	s := pc.Stats()
+	return s.Hits, s.Misses
 }


### PR DESCRIPTION
## Summary
\`AnalyzeProjectStats\` regains \`ParseHits\` / \`ParseMisses\`, but populated from the resident \`scanner.ParseCache\` (the one RunProject uses) rather than the WorkspaceState counters that lied. Implementation: \`pipeline.RunProject\` snaps \`ParseCache.Stats()\` before and after the run and stores the per-call delta on \`ProjectResult.ParseHits\` / \`ParseMisses\`; the daemon forwards them to the wire response.

Closes #51.

## Test plan
- [x] New \`TestAnalyzeProject_ParseCacheStatsReportPerCallDelta\` (two-call assertion that delta != cumulative)
- [x] \`go test ./... -count=1\`
- [x] \`make integration\`