### PR TITLE
feat(snapshot): pre-emit index.json rollup so status is O(1)

### DIFF
--- a/internal/snapshot/index.go
+++ b/internal/snapshot/index.go
@@ -1,0 +1,112 @@
+package snapshot
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"sync"
+
+	"github.com/kaeawc/krit/internal/fsutil"
+)
+
+// IndexSchemaVersion versions the index.json layout. Bumped when an
+// older reader couldn't tolerate a new field; readers that see a
+// higher version fall back to the per-manifest scan to stay correct
+// across rolling deploys.
+const IndexSchemaVersion = 1
+
+const indexFileName = "index.json"
+
+// Index is the rollup of every captured manifest, persisted as a
+// single JSON file at <root>/index.json so `snapshot status` and the
+// MCP `status` op are O(1) reads instead of O(N) directory walks.
+//
+// Missing or unreadable index files are not fatal: callers fall back
+// to LoadManifests' per-sha scan, so older repos and partially-
+// captured snapshot trees keep working.
+type Index struct {
+	SchemaVersion int        `json:"schema_version"`
+	Entries       []Manifest `json:"entries"`
+}
+
+// indexPath returns the canonical location of the rollup file.
+func indexPath(root string) string {
+	return filepath.Join(root, indexFileName)
+}
+
+// indexMu serializes index.json read-modify-writes within the same
+// process. SaveResult holds it across LoadIndex + write so a backfill
+// worker doesn't lose another worker's just-appended entry.
+var indexMu sync.Mutex
+
+// LoadIndex reads the rollup at <root>/index.json. Returns (nil, nil)
+// when the file does not exist or carries a higher schema version
+// than this binary understands — callers fall back to LoadManifests.
+func LoadIndex(root string) (*Index, error) {
+	data, err := os.ReadFile(indexPath(root))
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("snapshot: read index: %w", err)
+	}
+	var idx Index
+	if err := json.Unmarshal(data, &idx); err != nil {
+		return nil, fmt.Errorf("snapshot: parse index: %w", err)
+	}
+	if idx.SchemaVersion > IndexSchemaVersion {
+		return nil, nil
+	}
+	return &idx, nil
+}
+
+// upsertIndex loads the rollup, replaces or appends the entry for
+// m.CommitSHA, sorts by sha, and atomically rewrites the file. Held
+// under indexMu so concurrent backfill workers serialise on the
+// rollup edit without serialising the rest of capture.
+func upsertIndex(root string, m *Manifest) error {
+	if m == nil || m.CommitSHA == "" {
+		return errors.New("snapshot: upsertIndex: nil or empty-sha manifest")
+	}
+	indexMu.Lock()
+	defer indexMu.Unlock()
+
+	existing, err := LoadIndex(root)
+	if err != nil {
+		return err
+	}
+	idx := Index{SchemaVersion: IndexSchemaVersion}
+	if existing != nil {
+		idx.Entries = existing.Entries
+	}
+	replaced := false
+	for i := range idx.Entries {
+		if idx.Entries[i].CommitSHA == m.CommitSHA {
+			idx.Entries[i] = *m
+			replaced = true
+			break
+		}
+	}
+	if !replaced {
+		idx.Entries = append(idx.Entries, *m)
+	}
+	sort.Slice(idx.Entries, func(i, j int) bool {
+		return idx.Entries[i].CommitSHA < idx.Entries[j].CommitSHA
+	})
+
+	payload, err := json.MarshalIndent(idx, "", "  ")
+	if err != nil {
+		return fmt.Errorf("snapshot: marshal index: %w", err)
+	}
+	payload = append(payload, '\n')
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		return fmt.Errorf("snapshot: mkdir %s: %w", root, err)
+	}
+	if err := fsutil.WriteFileAtomic(indexPath(root), payload, 0o644); err != nil {
+		return fmt.Errorf("snapshot: write index: %w", err)
+	}
+	return nil
+}

--- a/internal/snapshot/index_test.go
+++ b/internal/snapshot/index_test.go
@@ -1,0 +1,159 @@
+package snapshot
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"sync"
+	"testing"
+)
+
+func TestSaveManifestPopulatesIndex(t *testing.T) {
+	root := t.TempDir()
+	m := &Manifest{
+		SchemaVersion: ManifestSchemaVersion,
+		CommitSHA:     "abc123def456",
+		CapturedAt:    100,
+		KritVersion:   "test",
+		Files:         3,
+		Symbols:       7,
+		Modules:       1,
+	}
+	if _, err := SaveManifest(root, m); err != nil {
+		t.Fatalf("SaveManifest: %v", err)
+	}
+	idx, err := LoadIndex(root)
+	if err != nil {
+		t.Fatalf("LoadIndex: %v", err)
+	}
+	if idx == nil || len(idx.Entries) != 1 {
+		t.Fatalf("expected 1 entry in index; got %+v", idx)
+	}
+	if idx.Entries[0].CommitSHA != m.CommitSHA {
+		t.Errorf("entry sha = %q; want %q", idx.Entries[0].CommitSHA, m.CommitSHA)
+	}
+	if idx.Entries[0].Files != 3 {
+		t.Errorf("entry counts not preserved: %+v", idx.Entries[0])
+	}
+}
+
+func TestSaveManifestUpsertReplacesByCommitSHA(t *testing.T) {
+	root := t.TempDir()
+	first := &Manifest{
+		SchemaVersion: ManifestSchemaVersion,
+		CommitSHA:     "aaaa1111",
+		Files:         1,
+	}
+	if _, err := SaveManifest(root, first); err != nil {
+		t.Fatalf("first save: %v", err)
+	}
+	updated := *first
+	updated.Files = 99
+	if _, err := SaveManifest(root, &updated); err != nil {
+		t.Fatalf("second save: %v", err)
+	}
+
+	idx, err := LoadIndex(root)
+	if err != nil {
+		t.Fatalf("LoadIndex: %v", err)
+	}
+	if len(idx.Entries) != 1 {
+		t.Fatalf("upsert should replace by sha; got %d entries", len(idx.Entries))
+	}
+	if idx.Entries[0].Files != 99 {
+		t.Errorf("expected updated count 99; got %d", idx.Entries[0].Files)
+	}
+}
+
+func TestLoadManifestsPrefersIndex(t *testing.T) {
+	root := t.TempDir()
+	for _, sha := range []string{"bb22", "aa11", "cc33"} {
+		if _, err := SaveManifest(root, &Manifest{
+			SchemaVersion: ManifestSchemaVersion,
+			CommitSHA:     sha,
+		}); err != nil {
+			t.Fatalf("SaveManifest %s: %v", sha, err)
+		}
+	}
+	got, err := LoadManifests(root)
+	if err != nil {
+		t.Fatalf("LoadManifests: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("expected 3 entries; got %d", len(got))
+	}
+	want := []string{"aa11", "bb22", "cc33"}
+	have := make([]string, len(got))
+	for i, m := range got {
+		have[i] = m.CommitSHA
+	}
+	sort.Strings(have)
+	for i := range want {
+		if have[i] != want[i] {
+			t.Errorf("index entries[%d] = %q; want %q", i, have[i], want[i])
+		}
+	}
+}
+
+func TestLoadManifestsFallsBackWhenIndexMissing(t *testing.T) {
+	root := t.TempDir()
+	// Save a manifest the legacy way, then nuke the index file so the
+	// fallback path has to fire.
+	if _, err := SaveManifest(root, &Manifest{
+		SchemaVersion: ManifestSchemaVersion,
+		CommitSHA:     "abcd1234",
+	}); err != nil {
+		t.Fatalf("SaveManifest: %v", err)
+	}
+	if err := os.Remove(filepath.Join(root, indexFileName)); err != nil {
+		t.Fatalf("nuke index: %v", err)
+	}
+	// Need a blob alongside the manifest for List() to enumerate it.
+	// Cheaper to just point List at the existing manifest dir: the
+	// fallback also needs that. Skip List dependency by writing a
+	// stub blob.
+	dir, err := shaDir(root, "abcd1234")
+	if err != nil {
+		t.Fatalf("shaDir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, blobFileName), []byte("stub"), 0o644); err != nil {
+		t.Fatalf("write blob: %v", err)
+	}
+
+	got, err := LoadManifests(root)
+	if err != nil {
+		t.Fatalf("LoadManifests: %v", err)
+	}
+	if len(got) != 1 || got[0].CommitSHA != "abcd1234" {
+		t.Fatalf("fallback path failed; got %+v", got)
+	}
+}
+
+func TestUpsertIndexConcurrentSavesAllSurvive(t *testing.T) {
+	root := t.TempDir()
+	const workers = 8
+	var wg sync.WaitGroup
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			sha := []byte("aaaa0000")
+			sha[7] = byte('0' + i)
+			_, err := SaveManifest(root, &Manifest{
+				SchemaVersion: ManifestSchemaVersion,
+				CommitSHA:     string(sha),
+			})
+			if err != nil {
+				t.Errorf("save %d: %v", i, err)
+			}
+		}(i)
+	}
+	wg.Wait()
+	idx, err := LoadIndex(root)
+	if err != nil {
+		t.Fatalf("LoadIndex: %v", err)
+	}
+	if len(idx.Entries) != workers {
+		t.Errorf("expected %d entries after concurrent upserts; got %d", workers, len(idx.Entries))
+	}
+}

--- a/internal/snapshot/manifest.go
+++ b/internal/snapshot/manifest.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 
 	"github.com/kaeawc/krit/internal/fsutil"
 )
@@ -68,6 +69,14 @@ func SaveManifest(root string, m *Manifest) (string, error) {
 	if err := fsutil.WriteFileAtomic(path, payload, 0o644); err != nil {
 		return "", fmt.Errorf("snapshot: write %s: %w", path, err)
 	}
+	// Best-effort rollup update so `snapshot status` is O(1). A failure
+	// here doesn't fail capture — LoadManifests falls back to scanning.
+	if err := upsertIndex(root, m); err != nil {
+		// Surface as a non-fatal warning via stderr would belong here,
+		// but the snapshot package is reporter-free; swallow and let
+		// the next status fall back to the scan path.
+		_ = err
+	}
 	return path, nil
 }
 
@@ -87,9 +96,19 @@ func LoadManifest(root, sha string) (*Manifest, error) {
 	return &m, nil
 }
 
-// LoadManifests returns every captured sha's manifest under root, sorted
-// by sha. Missing or malformed manifests are skipped silently.
+// LoadManifests returns every captured sha's manifest under root,
+// sorted by sha. Missing or malformed manifests are skipped silently.
+//
+// Prefers the index.json rollup (O(1) read) when present; falls back
+// to the legacy per-sha scan when the rollup is missing (older
+// captures), unreadable (corruption), or carries a newer schema.
 func LoadManifests(root string) ([]Manifest, error) {
+	if idx, err := LoadIndex(root); err == nil && idx != nil {
+		out := make([]Manifest, len(idx.Entries))
+		copy(out, idx.Entries)
+		sort.Slice(out, func(i, j int) bool { return out[i].CommitSHA < out[j].CommitSHA })
+		return out, nil
+	}
 	entries, err := List(root)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary
\`snapshot status\` was O(N) — one manifest read+parse per captured sha. Now SaveManifest atomically rewrites \`<root>/index.json\` (a sorted-by-sha rollup of every manifest) under a process-local mutex. \`LoadManifests\` prefers the rollup; falls back to the legacy directory walk when missing/corrupt/newer-schema so older repos keep working.

Closes #52.

## Test plan
- [x] New \`Index\` tests: populate, upsert-by-sha, prefer-index path, fallback path, concurrent-upsert
- [x] \`go test ./... -count=1\`
- [x] \`make integration\`