### PR TITLE
refactor(scan): unify cache preload as AnalysisCacheLoadFuture

### DIFF
--- a/internal/cli/scan/preload_cache.go
+++ b/internal/cli/scan/preload_cache.go
@@ -1,22 +1,90 @@
 package scan
 
-import "github.com/kaeawc/krit/internal/cache"
+import (
+	"sync"
+	"time"
 
-// preloadAnalysisCache runs load in a background goroutine and returns a
-// buffered channel that yields its result. A panic inside load is
-// recovered and converted to a nil send so the pipeline's cacheLoad
-// receiver never deadlocks; nil is the same shape that
-// pipeline.IndexPhase already treats as "fall back to a synchronous
-// cache.Load" via the PreloadedAnalysisCache==nil branch.
-func preloadAnalysisCache(load func() *cache.Cache) <-chan *cache.Cache {
-	ch := make(chan *cache.Cache, 1)
-	go func() {
-		defer func() {
-			if r := recover(); r != nil {
-				ch <- nil
+	"github.com/kaeawc/krit/internal/cache"
+)
+
+// AnalysisCacheLoadFuture memoizes a background analysis-cache load
+// kicked off as soon as cacheFilePath is known, in parallel with
+// collectFiles / projectModel / filterRules. Mirrors the shape of
+// android.ResourceScanFuture so call-sites have one familiar pattern
+// for "start work in the background, await it later" — Start once,
+// Await any number of times, Duration() reports the wall-time the
+// load actually consumed (visible to perf, unlike the pipeline's
+// cacheLoad tracker, which wraps the receive and reads ~0 ms on
+// preloaded paths).
+//
+// A panic inside load is recovered and converted to a nil result so
+// the pipeline's cacheLoad receiver (PreloadedAnalysisCache==nil
+// branch) falls back to a synchronous cache.Load — losing the
+// preload's parallelism but never deadlocking.
+type AnalysisCacheLoadFuture struct {
+	load func() *cache.Cache
+
+	once sync.Once
+	done chan struct{}
+
+	cache *cache.Cache
+	dur   time.Duration
+}
+
+// NewAnalysisCacheLoadFuture builds an unstarted future. Call Start
+// to kick off the goroutine; Await blocks until it completes.
+func NewAnalysisCacheLoadFuture(load func() *cache.Cache) *AnalysisCacheLoadFuture {
+	return &AnalysisCacheLoadFuture{
+		load: load,
+		done: make(chan struct{}),
+	}
+}
+
+// Start launches the background load. Idempotent: only the first
+// call kicks off the goroutine. Safe to call from Await for
+// fire-and-forget patterns where the caller doesn't want to track
+// Start/Await separately.
+func (f *AnalysisCacheLoadFuture) Start() {
+	if f == nil {
+		return
+	}
+	f.once.Do(func() {
+		go func() {
+			defer func() {
+				if r := recover(); r != nil {
+					// Leave f.cache == nil so Await callers fall back
+					// to synchronous load.
+				}
+				close(f.done)
+			}()
+			start := time.Now()
+			if f.load != nil {
+				f.cache = f.load()
 			}
+			f.dur = time.Since(start)
 		}()
-		ch <- load()
-	}()
-	return ch
+	})
+}
+
+// Await blocks until the load goroutine completes and returns the
+// cache (nil on panic or no-op). Auto-starts the future, so callers
+// who only ever Await never miss the kickoff.
+func (f *AnalysisCacheLoadFuture) Await() *cache.Cache {
+	if f == nil {
+		return nil
+	}
+	f.Start()
+	<-f.done
+	return f.cache
+}
+
+// Duration reports the wall-clock time the load goroutine spent.
+// Zero before Start; final value after Await returns.
+func (f *AnalysisCacheLoadFuture) Duration() time.Duration {
+	if f == nil {
+		return 0
+	}
+	f.Start()
+	<-f.done
+	return f.dur
 }

--- a/internal/cli/scan/preload_cache.go
+++ b/internal/cli/scan/preload_cache.go
@@ -50,11 +50,11 @@ func (f *AnalysisCacheLoadFuture) Start() {
 	}
 	f.once.Do(func() {
 		go func() {
+			// Recover-into-nil: leave f.cache == nil on panic so Await
+			// callers fall back to synchronous load. close(f.done)
+			// always runs so receivers never deadlock.
 			defer func() {
-				if r := recover(); r != nil {
-					// Leave f.cache == nil so Await callers fall back
-					// to synchronous load.
-				}
+				_ = recover()
 				close(f.done)
 			}()
 			start := time.Now()

--- a/internal/cli/scan/preload_cache_test.go
+++ b/internal/cli/scan/preload_cache_test.go
@@ -7,27 +7,65 @@ import (
 	"github.com/kaeawc/krit/internal/cache"
 )
 
-func TestPreloadAnalysisCacheReturnsLoadResult(t *testing.T) {
+func TestAnalysisCacheLoadFuture_ReturnsLoadResult(t *testing.T) {
 	want := &cache.Cache{}
-	ch := preloadAnalysisCache(func() *cache.Cache { return want })
-	select {
-	case got := <-ch:
-		if got != want {
-			t.Fatalf("got %p; want %p", got, want)
-		}
-	case <-time.After(time.Second):
-		t.Fatal("timed out waiting for preload result")
+	f := NewAnalysisCacheLoadFuture(func() *cache.Cache { return want })
+	f.Start()
+	got := f.Await()
+	if got != want {
+		t.Fatalf("got %p; want %p", got, want)
 	}
 }
 
-func TestPreloadAnalysisCacheRecoversPanic(t *testing.T) {
-	ch := preloadAnalysisCache(func() *cache.Cache { panic("boom") })
-	select {
-	case got := <-ch:
-		if got != nil {
-			t.Fatalf("got %p; want nil after panic", got)
+func TestAnalysisCacheLoadFuture_RecoversPanic(t *testing.T) {
+	f := NewAnalysisCacheLoadFuture(func() *cache.Cache { panic("boom") })
+	f.Start()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		if got := f.Await(); got != nil {
+			t.Errorf("got %p; want nil after panic", got)
 		}
+	}()
+	select {
+	case <-done:
 	case <-time.After(time.Second):
-		t.Fatal("preload deadlocked after panic — recover did not fire")
+		t.Fatal("Await deadlocked after panic — recover did not fire")
+	}
+}
+
+func TestAnalysisCacheLoadFuture_AwaitAutoStarts(t *testing.T) {
+	want := &cache.Cache{}
+	f := NewAnalysisCacheLoadFuture(func() *cache.Cache { return want })
+	got := f.Await()
+	if got != want {
+		t.Fatalf("got %p; want %p (Await did not auto-start)", got, want)
+	}
+}
+
+func TestAnalysisCacheLoadFuture_AwaitIsRepeatable(t *testing.T) {
+	calls := 0
+	f := NewAnalysisCacheLoadFuture(func() *cache.Cache {
+		calls++
+		return &cache.Cache{}
+	})
+	first := f.Await()
+	second := f.Await()
+	if first != second {
+		t.Errorf("repeated Await returned different caches: %p vs %p", first, second)
+	}
+	if calls != 1 {
+		t.Errorf("load fn called %d times; expected exactly once", calls)
+	}
+}
+
+func TestAnalysisCacheLoadFuture_NilSafe(t *testing.T) {
+	var f *AnalysisCacheLoadFuture
+	f.Start()
+	if got := f.Await(); got != nil {
+		t.Errorf("nil future Await = %p; want nil", got)
+	}
+	if d := f.Duration(); d != 0 {
+		t.Errorf("nil future Duration = %v; want 0", d)
 	}
 }

--- a/internal/cli/scan/runner.go
+++ b/internal/cli/scan/runner.go
@@ -58,10 +58,11 @@ type runner struct {
 	projectModelLoaded bool
 	cacheFilePath      string
 
-	// preloadedAnalysisCacheCh receives the result of a background
-	// cache.Load kicked off as soon as cacheFilePath is known, in
-	// parallel with collectFiles / projectModel / filterRules.
-	preloadedAnalysisCacheCh <-chan *cache.Cache
+	// analysisCacheLoadFuture memoizes the background cache.Load kicked
+	// off as soon as cacheFilePath is known, in parallel with
+	// collectFiles / projectModel / filterRules. nil when no preload
+	// was scheduled (--no-cache, --oracle-filter-fingerprint).
+	analysisCacheLoadFuture *AnalysisCacheLoadFuture
 
 	// File collection
 	files                []string
@@ -259,9 +260,10 @@ func newRunner(f *scanFlags) (*runner, int, bool) {
 	// short-circuit needs file collection to fire and isn't worth a
 	// pre-walk just to save the wasted load.
 	if !*f.NoCache && cacheFilePath != "" && !*f.OracleFilterFingerprint {
-		r.preloadedAnalysisCacheCh = preloadAnalysisCache(func() *cache.Cache {
+		r.analysisCacheLoadFuture = NewAnalysisCacheLoadFuture(func() *cache.Cache {
 			return cache.Load(cacheFilePath)
 		})
+		r.analysisCacheLoadFuture.Start()
 	}
 	return r, 0, true
 }
@@ -401,9 +403,14 @@ func (r *runner) runOracleIndex() (int, error) {
 	var res pipeline.IndexResult
 	var err error
 	var preloadedCache *cache.Cache
-	if r.useCache && r.preloadedAnalysisCacheCh != nil {
-		preloadedCache = <-r.preloadedAnalysisCacheCh
-		r.preloadedAnalysisCacheCh = nil
+	if r.useCache && r.analysisCacheLoadFuture != nil {
+		preloadedCache = r.analysisCacheLoadFuture.Await()
+		// Surface the actual load wall-time as a perf entry so warm
+		// runs don't read 0ms cacheLoad — the pipeline's trackSerial
+		// wraps the receive, which is near-instant on the preloaded
+		// path (see #67/#84).
+		perf.AddEntry(r.tracker, "cacheLoadAsync", r.analysisCacheLoadFuture.Duration())
+		r.analysisCacheLoadFuture = nil
 	}
 	r.tracker.TrackVoid("oracleIndex", func() {
 		in := pipeline.IndexInput{


### PR DESCRIPTION
## Summary
The preload goroutine added in #39 is now a typed \`AnalysisCacheLoadFuture\` mirroring \`android.ResourceScanFuture\`: \`Start\` / \`Await\` / \`Duration\`. Nil receiver is safe so paths that don't preload (\`--no-cache\`, \`--oracle-filter-fingerprint\`) can leave the field nil.

Adds a \`cacheLoadAsync\` perf entry sourced from the future's \`Duration()\` so the actual load wall-time becomes visible (the pipeline's existing \`cacheLoad\` wrap-the-receive tracker reads ~0ms on preloaded paths — #67).

Closes #65.

## Test plan
- [x] New future tests: returns load result, recovers panic, auto-start on Await, Await idempotent, nil-safe
- [x] \`go test ./... -count=1\` and \`make integration\` clean