### PR TITLE
feat(rename): add --allow-multiple-declarations to bypass ambiguity guard

### DIFF
--- a/internal/cli/rename/rename.go
+++ b/internal/cli/rename/rename.go
@@ -12,11 +12,12 @@ import (
 )
 
 type renameCommand struct {
-	FromFQN string
-	ToFQN   string
-	Paths   []string
-	Jobs    int
-	Apply   bool
+	FromFQN                   string
+	ToFQN                     string
+	Paths                     []string
+	Jobs                      int
+	Apply                     bool
+	AllowMultipleDeclarations bool
 }
 
 func Run(args []string) int {
@@ -25,6 +26,7 @@ func Run(args []string) int {
 	fs.SetOutput(os.Stderr)
 	fs.IntVar(&cmd.Jobs, "j", runtime.NumCPU(), "Number of parallel jobs")
 	fs.BoolVar(&cmd.Apply, "apply", false, "Apply the rename to the working tree (default: dry-run)")
+	fs.BoolVar(&cmd.AllowMultipleDeclarations, "allow-multiple-declarations", false, "Bypass the multi-decl ambiguity guard (e.g. for legitimate Kotlin overload sets sharing an FQN)")
 	fs.Usage = func() {
 		fmt.Fprintln(os.Stderr, "Usage: krit rename [flags] <from-fqn> <to-fqn> [paths...]")
 		fs.PrintDefaults()
@@ -66,7 +68,9 @@ func runRenameCommand(cmd renameCommand) int {
 		return 2
 	}
 
-	if err := krename.ValidatePlan(plan); err != nil {
+	if err := krename.ValidatePlan(plan, krename.ValidateOptions{
+		AllowMultipleDeclarations: cmd.AllowMultipleDeclarations,
+	}); err != nil {
 		fmt.Fprintf(os.Stderr, "error: rename: %v\n", err)
 		return 2
 	}

--- a/internal/rename/apply_test.go
+++ b/internal/rename/apply_test.go
@@ -409,6 +409,47 @@ func TestValidatePlan_RejectsAmbiguousDeclarations(t *testing.T) {
 	}
 }
 
+func TestValidatePlan_AllowMultipleDeclarationsBypassesGuard(t *testing.T) {
+	target, _ := ParseTarget("com.example.OldName", "com.example.NewName")
+	plan := Plan{
+		Target: target,
+		Declarations: []scanner.Symbol{
+			{Name: "OldName", FQN: "com.example.OldName", File: "a.kt"},
+			{Name: "OldName", FQN: "com.example.OldName", File: "b.kt"},
+		},
+	}
+	if err := ValidatePlan(plan, ValidateOptions{AllowMultipleDeclarations: true}); err != nil {
+		t.Fatalf("ValidatePlan should accept multi-decl when AllowMultipleDeclarations is true: %v", err)
+	}
+}
+
+func TestApply_RewritesAllDeclarationsWhenAllowedMultiple(t *testing.T) {
+	dir := t.TempDir()
+	a := filepath.Join(dir, "A.kt")
+	b := filepath.Join(dir, "B.kt")
+	writeFile(t, a, "package com.example\n\nfun OldName(x: String) = x\n")
+	writeFile(t, b, "package com.example\n\nfun OldName(x: Int) = x\n")
+
+	plan := buildKotlinPlan(t, []string{a, b}, "com.example.OldName", "com.example.NewName")
+	if got := len(plan.Declarations); got < 2 {
+		t.Fatalf("expected ≥2 declarations to exercise the guard; got %d", got)
+	}
+	if err := ValidatePlan(plan, ValidateOptions{AllowMultipleDeclarations: true}); err != nil {
+		t.Fatalf("ValidatePlan with override: %v", err)
+	}
+	if _, err := Apply(plan); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	for _, p := range []string{a, b} {
+		if _, err := os.Stat(p); err != nil {
+			continue
+		}
+		if content := readFile(t, p); strings.Contains(content, "OldName") {
+			t.Errorf("residual OldName in %s after multi-decl rename:\n%s", p, content)
+		}
+	}
+}
+
 func TestValidatePlan_RejectsOccupiedDestination(t *testing.T) {
 	target, _ := ParseTarget("com.example.OldName", "com.example.NewName")
 	plan := Plan{

--- a/internal/rename/plan.go
+++ b/internal/rename/plan.go
@@ -8,12 +8,26 @@ import (
 	"github.com/kaeawc/krit/internal/scanner"
 )
 
+// ValidateOptions tunes ValidatePlan's safety guards. The zero value
+// is the safe default (the multi-decl ambiguity guard is enforced).
+type ValidateOptions struct {
+	// AllowMultipleDeclarations skips the multi-decl guard so renames
+	// across legitimate overload sets — e.g. extension functions that
+	// share an FQN, or a class plus a companion-object member sharing
+	// a name — go through. Apply still rewrites every matching site.
+	AllowMultipleDeclarations bool
+}
+
 // ValidatePlan reports conflicts that would make the rename ambiguous or
 // destructive: more than one declaration matching FromFQN, or an existing
-// declaration already at ToFQN.
-func ValidatePlan(plan Plan) error {
-	if len(plan.Declarations) > 1 {
-		return fmt.Errorf("rename: %s resolves to %d declarations; refusing to proceed", plan.Target.FromFQN, len(plan.Declarations))
+// declaration already at ToFQN. Pass options to relax specific guards.
+func ValidatePlan(plan Plan, opts ...ValidateOptions) error {
+	var o ValidateOptions
+	if len(opts) > 0 {
+		o = opts[0]
+	}
+	if len(plan.Declarations) > 1 && !o.AllowMultipleDeclarations {
+		return fmt.Errorf("rename: %s resolves to %d declarations; refusing to proceed (pass --allow-multiple-declarations to bypass)", plan.Target.FromFQN, len(plan.Declarations))
 	}
 	if plan.Target.FromFQN == plan.Target.ToFQN {
 		return fmt.Errorf("rename: from and to are identical")


### PR DESCRIPTION
## Summary
\`krit rename\` refused to proceed whenever \`FromFQN\` resolved to multiple declarations. That's a sound default, but legitimate overload sets (Kotlin extension functions sharing an FQN, class+companion overload, etc.) had no escape hatch.

\`ValidatePlan\` now takes an optional \`ValidateOptions{AllowMultipleDeclarations: true}\`; the CLI exposes \`--allow-multiple-declarations\`. Default behaviour unchanged.

Closes #42.

## Test plan
- [x] New \`TestValidatePlan_AllowMultipleDeclarationsBypassesGuard\`
- [x] New \`TestApply_RewritesAllDeclarationsWhenAllowedMultiple\` round-trip with two overload decls
- [x] \`go test ./... -count=1\` and \`make integration\` clean