### PR TITLE
perf(daemon): cache config + repoDir on daemonState with watcher invalidation

### DIFF
--- a/internal/cli/serve/analyze_project.go
+++ b/internal/cli/serve/analyze_project.go
@@ -11,7 +11,6 @@ import (
 	"github.com/kaeawc/krit/internal/cli/clishared"
 	"github.com/kaeawc/krit/internal/config"
 	"github.com/kaeawc/krit/internal/daemon"
-	"github.com/kaeawc/krit/internal/oracle"
 	"github.com/kaeawc/krit/internal/pipeline"
 	"github.com/kaeawc/krit/internal/rules"
 )
@@ -83,7 +82,7 @@ func handleAnalyzeProject(ctx context.Context, state *daemonState, raw json.RawM
 // where CLI-flag-style knobs (rule lists, format) are wired into the
 // pipeline's typed value inputs.
 func (s *daemonState) buildProjectInput(args daemon.AnalyzeProjectArgs) (pipeline.ProjectInput, error) {
-	cfg, err := loadDaemonConfig(s.root)
+	cfg, err := s.ensureConfig()
 	if err != nil {
 		return pipeline.ProjectInput{}, fmt.Errorf("load config: %w", err)
 	}
@@ -99,7 +98,10 @@ func (s *daemonState) buildProjectInput(args daemon.AnalyzeProjectArgs) (pipelin
 		paths = []string{s.root}
 	}
 
-	repoDir := oracle.FindRepoDir(paths)
+	// Cached at construction — oracle.FindRepoDir is a filesystem walk
+	// for VCS markers and the answer can't change for the duration of
+	// a daemon process. See #49.
+	repoDir := s.repoDir
 	if repoDir == "" {
 		repoDir = s.root
 	}

--- a/internal/cli/serve/daemon_config_cache_test.go
+++ b/internal/cli/serve/daemon_config_cache_test.go
@@ -1,0 +1,86 @@
+package serve
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDaemonState_ConfigCachedAcrossCalls(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "krit.yml"), []byte("# empty\n"), 0o644); err != nil {
+		t.Fatalf("seed config: %v", err)
+	}
+	state := newDaemonState(root)
+
+	first, err := state.ensureConfig()
+	if err != nil {
+		t.Fatalf("ensureConfig (first): %v", err)
+	}
+	second, err := state.ensureConfig()
+	if err != nil {
+		t.Fatalf("ensureConfig (second): %v", err)
+	}
+	if first != second {
+		t.Errorf("expected ensureConfig to return the cached pointer; got %p / %p", first, second)
+	}
+}
+
+func TestDaemonState_ConfigInvalidatedRebuilds(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "krit.yml"), []byte("# v1\n"), 0o644); err != nil {
+		t.Fatalf("seed config: %v", err)
+	}
+	state := newDaemonState(root)
+
+	first, err := state.ensureConfig()
+	if err != nil {
+		t.Fatalf("ensureConfig (first): %v", err)
+	}
+	state.InvalidateConfig()
+	if err := os.WriteFile(filepath.Join(root, "krit.yml"), []byte("# v2\n"), 0o644); err != nil {
+		t.Fatalf("rewrite config: %v", err)
+	}
+	second, err := state.ensureConfig()
+	if err != nil {
+		t.Fatalf("ensureConfig (second): %v", err)
+	}
+	if first == second {
+		t.Errorf("expected post-invalidation ensureConfig to rebuild; got the same pointer back")
+	}
+}
+
+func TestDaemonState_RepoDirStableAcrossLookups(t *testing.T) {
+	root := t.TempDir()
+	state := newDaemonState(root)
+	first := state.repoDir
+	for i := 0; i < 10; i++ {
+		if state.repoDir != first {
+			t.Fatalf("repoDir flipped at iter %d: %q vs %q", i, state.repoDir, first)
+		}
+	}
+	if first == "" {
+		t.Errorf("repoDir should fall back to root; got empty")
+	}
+}
+
+func TestIsKritConfigPath(t *testing.T) {
+	cases := []struct {
+		path string
+		want bool
+	}{
+		{"krit.yml", true},
+		{".krit.yml", true},
+		{"a/b/krit.yml", true},
+		{"a/.krit.yml", true},
+		{"krit.yaml", false},
+		{"krit.yml.bak", false},
+		{"build.gradle.kts", false},
+		{"Foo.kt", false},
+	}
+	for _, tc := range cases {
+		if got := isKritConfigPath(tc.path); got != tc.want {
+			t.Errorf("isKritConfigPath(%q) = %v; want %v", tc.path, got, tc.want)
+		}
+	}
+}

--- a/internal/cli/serve/serve.go
+++ b/internal/cli/serve/serve.go
@@ -21,8 +21,10 @@ import (
 
 	"github.com/kaeawc/krit/internal/arch"
 	"github.com/kaeawc/krit/internal/cli/clishared"
+	"github.com/kaeawc/krit/internal/config"
 	"github.com/kaeawc/krit/internal/daemon"
 	"github.com/kaeawc/krit/internal/module"
+	"github.com/kaeawc/krit/internal/oracle"
 	"github.com/kaeawc/krit/internal/pipeline"
 	"github.com/kaeawc/krit/internal/scanner"
 )
@@ -126,7 +128,7 @@ func Run(args []string) int {
 	}
 
 	if !*noWatcherFlag {
-		if w, err := startFileWatcher(ctx, root, state.workspace, srv.Reporter); err != nil {
+		if w, err := startFileWatcher(ctx, root, state.workspace, srv.Reporter, withConfigChangeCallback(state.InvalidateConfig)); err != nil {
 			fmt.Fprintf(os.Stderr, "krit serve: filesystem watcher disabled: %v\n", err)
 		} else {
 			defer w.Stop()
@@ -158,9 +160,24 @@ type daemonState struct {
 	root         string
 	warmDuration time.Duration
 
+	// repoDir is the resolved repository root for repo-local krit
+	// state. Filled once at construction (oracle.FindRepoDir is a
+	// filesystem walk; the value can't change for the duration of a
+	// daemon process). Falls back to root when no VCS marker is
+	// found.
+	repoDir string
+
 	mu    sync.RWMutex
 	graph *module.Graph
 	files int
+
+	// configMu guards cachedConfig + configDirty. Use ensureConfig().
+	configMu     sync.Mutex
+	cachedConfig *config.Config
+	// configDirty is set by InvalidateConfig (called from the file
+	// watcher on krit.yml / .krit.yml edits). The next ensureConfig
+	// reloads from disk and clears the flag.
+	configDirty atomic.Bool
 
 	// workspace memoizes parsed buffers across analyze-buffer calls so
 	// the daemon stays cheap across short-lived client requests.
@@ -195,10 +212,44 @@ type daemonState struct {
 }
 
 func newDaemonState(root string) *daemonState {
+	repoDir := oracle.FindRepoDir([]string{root})
+	if repoDir == "" {
+		repoDir = root
+	}
 	return &daemonState{
 		root:      root,
+		repoDir:   repoDir,
 		workspace: pipeline.NewWorkspaceState(root),
 	}
+}
+
+// ensureConfig returns the daemon's cached *config.Config, loading
+// from disk on the first call and on any call after InvalidateConfig
+// has been signalled. Concurrent callers serialise on configMu but
+// only the loader pays the I/O.
+func (s *daemonState) ensureConfig() (*config.Config, error) {
+	if cfg := s.cachedConfig; cfg != nil && !s.configDirty.Load() {
+		return cfg, nil
+	}
+	s.configMu.Lock()
+	defer s.configMu.Unlock()
+	if s.cachedConfig != nil && !s.configDirty.Load() {
+		return s.cachedConfig, nil
+	}
+	cfg, err := loadDaemonConfig(s.root)
+	if err != nil {
+		return nil, err
+	}
+	s.cachedConfig = cfg
+	s.configDirty.Store(false)
+	return cfg, nil
+}
+
+// InvalidateConfig flags the cached config stale; the next
+// ensureConfig call reloads krit.yml from disk. Called by the file
+// watcher on krit.yml / .krit.yml edits.
+func (s *daemonState) InvalidateConfig() {
+	s.configDirty.Store(true)
 }
 
 // singleFileAnalyzer returns the lazily-built shared analyzer.

--- a/internal/cli/serve/watcher.go
+++ b/internal/cli/serve/watcher.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/fsnotify/fsnotify"
 
+	"github.com/kaeawc/krit/internal/config"
 	"github.com/kaeawc/krit/internal/diag"
 	"github.com/kaeawc/krit/internal/pipeline"
 )
@@ -28,6 +29,11 @@ type fileWatcher struct {
 	root     string
 	state    *pipeline.WorkspaceState
 	reporter *diag.Reporter
+	// onConfigChange fires when the watcher observes an edit to a
+	// krit.yml / .krit.yml file. Daemon callers wire this to
+	// daemonState.InvalidateConfig so the next analyze-project verb
+	// reloads. Nil is allowed (no daemon, no callback).
+	onConfigChange func()
 
 	closeOnce sync.Once
 	done      chan struct{}
@@ -46,7 +52,7 @@ type fileWatcher struct {
 // must call Stop to release the underlying fsnotify resources.
 // Returns nil + error when the watcher couldn't be created (e.g. on
 // platforms without inotify/kqueue or when the root doesn't exist).
-func startFileWatcher(ctx context.Context, root string, state *pipeline.WorkspaceState, reporter *diag.Reporter) (*fileWatcher, error) {
+func startFileWatcher(ctx context.Context, root string, state *pipeline.WorkspaceState, reporter *diag.Reporter, opts ...watcherOption) (*fileWatcher, error) {
 	w, err := fsnotify.NewWatcher()
 	if err != nil {
 		return nil, err
@@ -58,6 +64,9 @@ func startFileWatcher(ctx context.Context, root string, state *pipeline.Workspac
 		reporter: reporter,
 		done:     make(chan struct{}),
 		ready:    make(chan struct{}),
+	}
+	for _, opt := range opts {
+		opt(fw)
 	}
 	// Add the root synchronously so files written directly under it
 	// are caught from t=0. The recursive descent runs in a goroutine —
@@ -87,6 +96,17 @@ func (fw *fileWatcher) populate() {
 // walk has finished. Tests that exercise pre-existing subtrees can
 // wait on it; production callers don't need to.
 func (fw *fileWatcher) Ready() <-chan struct{} { return fw.ready }
+
+// watcherOption tunes startFileWatcher. Variadic so callers without a
+// daemonState (e.g. unit tests of the watcher itself) don't need to
+// pass a no-op callback.
+type watcherOption func(*fileWatcher)
+
+// withConfigChangeCallback wires fw.onConfigChange. Used by serve.Run
+// to flag the daemon's cached config stale on krit.yml edits.
+func withConfigChangeCallback(fn func()) watcherOption {
+	return func(fw *fileWatcher) { fw.onConfigChange = fn }
+}
 
 // Stop releases the watcher. Safe to call multiple times.
 func (fw *fileWatcher) Stop() {
@@ -140,6 +160,14 @@ func (fw *fileWatcher) handle(ev fsnotify.Event) {
 	// isKotlinPath because of its extension, but it drives library
 	// facts, not the per-file parse cache.
 	switch {
+	case isKritConfigPath(ev.Name):
+		// krit.yml / .krit.yml drives rule selection. The cached
+		// config on the daemon is now stale; the next analyze-project
+		// call rebuilds.
+		if fw.onConfigChange != nil {
+			fw.onConfigChange()
+		}
+		fw.state.Touch(ev.Name)
 	case isLibraryConfigPath(ev.Name):
 		fw.state.InvalidateLibraryFacts()
 		fw.state.InvalidateCodeIndex()
@@ -206,6 +234,19 @@ func (fw *fileWatcher) warn(format string, args ...any) {
 // .kts. Mirrors the precommit/cli filter.
 func isKotlinPath(p string) bool {
 	return strings.HasSuffix(p, ".kt") || strings.HasSuffix(p, ".kts")
+}
+
+// isKritConfigPath reports whether the path is the krit.yml /
+// .krit.yml the daemon honours for rule selection. Editing one
+// invalidates the daemon's cached *config.Config.
+func isKritConfigPath(p string) bool {
+	base := filepath.Base(p)
+	for _, name := range config.Filenames {
+		if base == name {
+			return true
+		}
+	}
+	return false
 }
 
 // isLibraryConfigPath reports whether the path is a Gradle build


### PR DESCRIPTION
## Summary
\`loadDaemonConfig\` and \`oracle.FindRepoDir\` ran on every analyze-project verb call — pure waste, since neither result can change without an external signal we already have.

- \`daemonState.repoDir\` resolved once at construction.
- \`daemonState.ensureConfig()\` lazy-loads + caches krit.yml; \`InvalidateConfig()\` flags it stale.
- File watcher detects krit.yml / .krit.yml edits via new \`isKritConfigPath\` and fires the registered callback.

Closes #49.

## Test plan
- [x] New \`TestDaemonState_ConfigCachedAcrossCalls\`
- [x] New \`TestDaemonState_ConfigInvalidatedRebuilds\`
- [x] New \`TestDaemonState_RepoDirStableAcrossLookups\`
- [x] New \`TestIsKritConfigPath\`
- [x] \`go test ./... -count=1\` and \`make integration\` clean