### PR TITLE
Pre-compile feedback rules + classpath/reverse-dep seams

### DIFF
--- a/internal/binsymbols/adapter.go
+++ b/internal/binsymbols/adapter.go
@@ -1,0 +1,48 @@
+package binsymbols
+
+// Adapter converts a Reader into the function shape that
+// typeinfer.SetBinSymbolReader accepts. Use it at the wiring layer:
+//
+//	resolver.SetBinSymbolReader(binsymbols.AdaptForResolver(reader))
+//
+// The adapter mirrors only the fields typeinfer's local
+// binarySymbolClass exposes; member detail (Members, IsSealed
+// nuances) is intentionally elided since the resolver's ClassHierarchy
+// surface does not yet propagate Members from binary readers.
+//
+// AdaptForResolver returns a function whose return type is the small
+// struct typeinfer expects. The struct is anonymous-equivalent — its
+// fields are validated at the call boundary by Go's structural
+// matching against the typeinfer interface.
+func AdaptForResolver(r Reader) func(fqn string) *ResolverClass {
+	if r == nil {
+		return func(string) *ResolverClass { return nil }
+	}
+	return func(fqn string) *ResolverClass {
+		c := r.LookupClass(fqn)
+		if c == nil {
+			return nil
+		}
+		return &ResolverClass{
+			Name:       c.Name,
+			FQN:        c.FQN,
+			Kind:       c.Kind,
+			Supertypes: c.Supertypes,
+			IsAbstract: c.IsAbstract,
+			IsSealed:   c.IsSealed,
+		}
+	}
+}
+
+// ResolverClass mirrors typeinfer.binarySymbolClass shape. Exported so
+// the wiring layer can assemble the function shim without depending on
+// typeinfer-internal types. The field set must stay structurally
+// identical to typeinfer.binarySymbolClass.
+type ResolverClass struct {
+	Name       string
+	FQN        string
+	Kind       string
+	Supertypes []string
+	IsAbstract bool
+	IsSealed   bool
+}

--- a/internal/binsymbols/binsymbols.go
+++ b/internal/binsymbols/binsymbols.go
@@ -1,0 +1,116 @@
+// Package binsymbols defines the seam through which Krit consumes
+// class metadata that lives outside the source workspace — JARs, AARs,
+// stdlib stubs, or KAA-backed oracle responses.
+//
+// The package is intentionally narrow: it owns the Class shape that
+// callers (typeinfer, rules) consult when source-side lookups miss,
+// and a Reader interface that producers implement. No producer is
+// included here; concrete readers live in their own packages so this
+// one stays free of JVM, archive/zip, or oracle dependencies.
+//
+// Existing fallbacks (KnownClassHierarchy, KnownInterfaces in
+// typeinfer/stdlib.go) are unaffected. A typical wiring layers them:
+//
+//	source workspace -> binsymbols.Reader -> hardcoded tables
+//
+// so the reader fills the gap between checked-in source and the small
+// hardcoded stdlib stubs.
+package binsymbols
+
+import "sort"
+
+// Class is the shape returned by readers. It mirrors the subset of
+// typeinfer.ClassInfo that the rule layer reads and is intentionally
+// duplicated to keep this package free of typeinfer imports.
+type Class struct {
+	Name       string   // Simple class name
+	FQN        string   // Fully qualified name
+	Kind       string   // "class", "interface", "object", "enum", "sealed class", "sealed interface"
+	Supertypes []string // FQNs of direct supertypes
+	IsAbstract bool
+	IsSealed   bool
+	Members    []Member
+}
+
+// Member is a class member as exposed by readers. Mirrors
+// typeinfer.MemberInfo's exposed fields.
+type Member struct {
+	Name       string
+	Kind       string // "function", "property"
+	ReturnType string // FQN; empty when unknown
+	Visibility string // "public", "private", "internal", "protected"
+	IsAbstract bool
+	IsOverride bool
+	// Params records the parameter types as FQNs in declaration order.
+	// Names are not preserved — readers that derive members from JVM
+	// descriptors only have type info.
+	ParamTypes []string
+}
+
+// Reader is the producer interface. A reader returns nil from
+// LookupClass when it doesn't know the FQN; nil is normal and indicates
+// the caller should fall through to the next reader (or hardcoded
+// tables, or a "type unknown" result).
+//
+// Implementations must be safe for concurrent use — the resolver and
+// dispatcher fan out in parallel.
+type Reader interface {
+	LookupClass(fqn string) *Class
+}
+
+// Empty is a Reader that always returns nil. Use as a default when no
+// classpath-aware reader is configured.
+var Empty Reader = emptyReader{}
+
+type emptyReader struct{}
+
+func (emptyReader) LookupClass(string) *Class { return nil }
+
+// Multi composes a chain of readers. LookupClass tries each in order
+// and returns the first non-nil result. Nil entries are skipped.
+type Multi struct {
+	Readers []Reader
+}
+
+// LookupClass implements Reader.
+func (m Multi) LookupClass(fqn string) *Class {
+	for _, r := range m.Readers {
+		if r == nil {
+			continue
+		}
+		if c := r.LookupClass(fqn); c != nil {
+			return c
+		}
+	}
+	return nil
+}
+
+// Static is a deterministic in-memory Reader. Useful for tests and for
+// the small per-project allowlists that callers stage before a real
+// reader plugs in. Concurrent reads are safe; do not mutate the map
+// after the Static value escapes.
+type Static struct {
+	Classes map[string]*Class
+}
+
+// LookupClass implements Reader.
+func (s Static) LookupClass(fqn string) *Class {
+	if s.Classes == nil {
+		return nil
+	}
+	if c, ok := s.Classes[fqn]; ok {
+		return c
+	}
+	return nil
+}
+
+// FQNs returns the sorted set of FQNs known to the static reader. A
+// debug helper that keeps the cmdline outputs deterministic.
+func (s Static) FQNs() []string {
+	out := make([]string, 0, len(s.Classes))
+	for fqn := range s.Classes {
+		out = append(out, fqn)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/binsymbols/binsymbols_test.go
+++ b/internal/binsymbols/binsymbols_test.go
@@ -1,0 +1,78 @@
+package binsymbols
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestEmpty_AlwaysReturnsNil(t *testing.T) {
+	if got := Empty.LookupClass("anything"); got != nil {
+		t.Errorf("Empty.LookupClass returned %+v, want nil", got)
+	}
+}
+
+func TestStatic_HitAndMiss(t *testing.T) {
+	s := Static{Classes: map[string]*Class{
+		"androidx.fragment.app.Fragment": {
+			Name:       "Fragment",
+			FQN:        "androidx.fragment.app.Fragment",
+			Kind:       "class",
+			Supertypes: []string{"java.lang.Object"},
+		},
+	}}
+
+	if c := s.LookupClass("androidx.fragment.app.Fragment"); c == nil {
+		t.Fatal("expected hit on known FQN")
+	} else if c.Name != "Fragment" {
+		t.Errorf("Name = %q, want Fragment", c.Name)
+	}
+	if c := s.LookupClass("not.in.the.map"); c != nil {
+		t.Errorf("expected miss to be nil, got %+v", c)
+	}
+}
+
+func TestStatic_NilMapSafe(t *testing.T) {
+	var s Static
+	if got := s.LookupClass("foo.Bar"); got != nil {
+		t.Errorf("nil-map Static.LookupClass = %+v, want nil", got)
+	}
+	if got := s.FQNs(); len(got) != 0 {
+		t.Errorf("nil-map FQNs = %v, want empty", got)
+	}
+}
+
+func TestMulti_ReturnsFirstHit(t *testing.T) {
+	a := Static{Classes: map[string]*Class{"a.A": {FQN: "a.A", Name: "A_first"}}}
+	b := Static{Classes: map[string]*Class{"a.A": {FQN: "a.A", Name: "A_second"}, "b.B": {FQN: "b.B", Name: "B"}}}
+	m := Multi{Readers: []Reader{a, b}}
+
+	if c := m.LookupClass("a.A"); c == nil || c.Name != "A_first" {
+		t.Errorf("Multi.LookupClass(a.A) returned %+v, want first reader's hit", c)
+	}
+	if c := m.LookupClass("b.B"); c == nil || c.Name != "B" {
+		t.Errorf("Multi.LookupClass(b.B) returned %+v, want second reader's hit", c)
+	}
+	if c := m.LookupClass("c.C"); c != nil {
+		t.Errorf("Multi.LookupClass(c.C) = %+v, want nil", c)
+	}
+}
+
+func TestMulti_SkipsNilReaders(t *testing.T) {
+	a := Static{Classes: map[string]*Class{"a.A": {FQN: "a.A"}}}
+	m := Multi{Readers: []Reader{nil, a, nil}}
+	if got := m.LookupClass("a.A"); got == nil {
+		t.Error("nil entries should be skipped, not panic")
+	}
+}
+
+func TestStatic_FQNsSortedAndComplete(t *testing.T) {
+	s := Static{Classes: map[string]*Class{
+		"z.Z": {FQN: "z.Z"},
+		"a.A": {FQN: "a.A"},
+		"m.M": {FQN: "m.M"},
+	}}
+	want := []string{"a.A", "m.M", "z.Z"}
+	if got := s.FQNs(); !reflect.DeepEqual(got, want) {
+		t.Errorf("FQNs() = %v, want %v", got, want)
+	}
+}

--- a/internal/cli/serve/watcher.go
+++ b/internal/cli/serve/watcher.go
@@ -171,14 +171,17 @@ func (fw *fileWatcher) handle(ev fsnotify.Event) {
 	case isLibraryConfigPath(ev.Name):
 		fw.state.InvalidateLibraryFacts()
 		fw.state.InvalidateCodeIndex()
+		fw.state.InvalidateDependents()
 		// Touch the path so daemon verbs reporting "files changed
 		// since last analyze" see Gradle/version-catalog edits.
 		fw.state.Touch(ev.Name)
 	case isKotlinPath(ev.Name):
 		fw.state.Invalidate(ev.Name)
 		// Any source-file change can shift cross-file lookups, so
-		// drop the cached CodeIndex; the next caller rebuilds.
+		// drop the cached CodeIndex and DependentsIndex; the next
+		// caller rebuilds.
 		fw.state.InvalidateCodeIndex()
+		fw.state.InvalidateDependents()
 		// Record the dirty file. Repeated Touches dedup via the
 		// dirty-set's map semantics so an editor that emits
 		// Write+Write on save costs nothing extra.

--- a/internal/pipeline/parse.go
+++ b/internal/pipeline/parse.go
@@ -79,10 +79,14 @@ func (p ParsePhase) Run(ctx context.Context, in ParseInput) (ParseResult, error)
 
 	// Filter generated Kotlin files unless explicitly requested. Generated
 	// dirs contain codegen output that dwarfs hand-written sources and
-	// strands workers.
+	// strands workers. When IncludeGeneratedAllowlist is set, files whose
+	// paths match a known-safe-generator substring are kept (and tagged
+	// File.Generated = true) so the resolver can index them; the
+	// dispatcher and rule layer still see them as files but can opt out
+	// via File.Generated.
 	if !in.IncludeGenerated {
 		var droppedGenerated int
-		kotlinFiles, droppedGenerated = filterGeneratedSourceFiles(kotlinFiles)
+		kotlinFiles, droppedGenerated = filterGeneratedSourceFilesWithAllowlist(kotlinFiles, in.IncludeGeneratedAllowlist)
 		if droppedGenerated > 0 {
 			in.logf("verbose: Skipped %d files in */generated/* dirs (pass --include-generated to re-enable)\n", droppedGenerated)
 		}
@@ -129,7 +133,7 @@ func (p ParsePhase) Run(ctx context.Context, in ParseInput) (ParseResult, error)
 			javaFiles, javaParseErrs = scanner.ScanJavaFilesCached(javaPaths, workers, in.ParseCache)
 			parseErrs = append(parseErrs, javaParseErrs...)
 			if !in.IncludeGenerated {
-				javaFiles, _ = filterGeneratedSourceFiles(javaFiles)
+				javaFiles, _ = filterGeneratedSourceFilesWithAllowlist(javaFiles, in.IncludeGeneratedAllowlist)
 			}
 			for _, f := range javaFiles {
 				installSourceSuppression(f, ruleExcludes, ruleAliases)
@@ -148,17 +152,55 @@ func (p ParsePhase) Run(ctx context.Context, in ParseInput) (ParseResult, error)
 	}, nil
 }
 
-func filterGeneratedSourceFiles(files []*scanner.File) ([]*scanner.File, int) {
+// DefaultKnownSafeGenerators returns path substrings selecting build outputs
+// from the well-known annotation processors and Gradle code generators
+// whose output the resolver should index so cross-file references into
+// generated code (Hilt components, KSP-generated factories, Room *_Impl
+// classes, ViewBinding/DataBinding bindings, BuildConfig) resolve in
+// source typeinfer. Callers wire this list into ParseInput when they
+// want generated symbols to be type-aware without including arbitrary
+// machine-written code in linting.
+func DefaultKnownSafeGenerators() []string {
+	return []string{
+		"build/generated/source/kapt/",
+		"build/generated/source/kaptKotlin/",
+		"build/generated/ksp/",
+		"build/generated/source/buildConfig/",
+		"build/generated/source/viewBinding/",
+		"build/generated/source/dataBinding/",
+		"build/generated/data_binding_base_class_source_out/",
+		"build/generated/hilt/",
+	}
+}
+
+func filterGeneratedSourceFilesWithAllowlist(files []*scanner.File, allowlist []string) ([]*scanner.File, int) {
 	filtered := files[:0]
 	var droppedGenerated int
 	for _, f := range files {
-		if f != nil && strings.Contains(f.Path, "/generated/") {
-			droppedGenerated++
+		if f == nil || !strings.Contains(f.Path, "/generated/") {
+			filtered = append(filtered, f)
 			continue
 		}
-		filtered = append(filtered, f)
+		if pathMatchesAnySubstring(f.Path, allowlist) {
+			f.Generated = true
+			filtered = append(filtered, f)
+			continue
+		}
+		droppedGenerated++
 	}
 	return filtered, droppedGenerated
+}
+
+func pathMatchesAnySubstring(path string, substrings []string) bool {
+	for _, s := range substrings {
+		if s == "" {
+			continue
+		}
+		if strings.Contains(path, s) {
+			return true
+		}
+	}
+	return false
 }
 
 func installSourceSuppression(f *scanner.File, ruleExcludes map[string][]string, ruleAliases map[string][]string) {

--- a/internal/pipeline/parse_test.go
+++ b/internal/pipeline/parse_test.go
@@ -133,6 +133,60 @@ func TestParsePhase_Run_GeneratedFilesSkipped(t *testing.T) {
 	}
 }
 
+func TestParsePhase_Run_GeneratedAllowlist_KeepsAndTagsMatchingFiles(t *testing.T) {
+	dir := t.TempDir()
+	// Use paths that are not under build/ (file collector prunes build/
+	// at walk time). A typical case: a path the user explicitly passes
+	// that points inside the generated tree, or a project that mirrors
+	// generated output into a non-build dir.
+	hiltPath := filepath.Join(dir, "src", "generated", "hilt", "App_HiltModules.kt")
+	kspPath := filepath.Join(dir, "src", "generated", "ksp", "main", "kotlin", "Foo_Factory.kt")
+	otherGenPath := filepath.Join(dir, "src", "generated", "snapshot", "Snap.kt")
+	realPath := filepath.Join(dir, "src", "main", "kotlin", "Bar.kt")
+	writeKt(t, hiltPath, "class App_HiltModules {}\n")
+	writeKt(t, kspPath, "class Foo_Factory {}\n")
+	writeKt(t, otherGenPath, "class Snap {}\n")
+	writeKt(t, realPath, "class Bar {}\n")
+
+	allowlist := []string{
+		"src/generated/hilt/",
+		"src/generated/ksp/",
+	}
+	in := ParseInput{
+		Paths:                     []string{dir},
+		IncludeGenerated:          false,
+		IncludeGeneratedAllowlist: allowlist,
+	}
+	out, err := (ParsePhase{}).Run(context.Background(), in)
+	if err != nil {
+		t.Fatalf("Run: unexpected error: %v", err)
+	}
+	got := map[string]bool{}
+	for _, f := range out.KotlinFiles {
+		got[filepath.Base(f.Path)] = f.Generated
+	}
+	if _, ok := got["Bar.kt"]; !ok {
+		t.Errorf("hand-written Bar.kt was dropped")
+	} else if got["Bar.kt"] {
+		t.Errorf("Bar.kt unexpectedly tagged Generated")
+	}
+	if !got["App_HiltModules.kt"] {
+		t.Errorf("expected Hilt-generated App_HiltModules.kt to be kept and tagged Generated; got=%v", got)
+	}
+	if !got["Foo_Factory.kt"] {
+		t.Errorf("expected KSP-generated Foo_Factory.kt to be kept and tagged Generated; got=%v", got)
+	}
+	if _, kept := got["Snap.kt"]; kept {
+		t.Errorf("expected non-allowlisted generated Snap.kt to be dropped; got=%v", got)
+	}
+}
+
+func TestDefaultKnownSafeGenerators_NonEmpty(t *testing.T) {
+	if got := DefaultKnownSafeGenerators(); len(got) == 0 {
+		t.Fatal("DefaultKnownSafeGenerators() returned empty slice")
+	}
+}
+
 func TestParsePhase_Run_GeneratedFilesKept_WhenFlagSet(t *testing.T) {
 	dir := t.TempDir()
 	genPath := filepath.Join(dir, "generated", "Foo.kt")

--- a/internal/pipeline/types.go
+++ b/internal/pipeline/types.go
@@ -48,6 +48,26 @@ type ParseInput struct {
 	ActiveRules []*api.Rule
 	// IncludeGenerated, when true, retains files under /generated/.
 	IncludeGenerated bool
+	// IncludeGeneratedAllowlist is a list of path substrings that select
+	// known-safe generated source directories (Hilt, KSP, Kapt,
+	// ViewBinding, DataBinding, BuildConfig). When IncludeGenerated is
+	// false, files whose path contains "/generated/" AND any one of these
+	// substrings are KEPT in the parse result and have File.Generated set
+	// to true. The resolver indexes them so cross-file references into
+	// generated code resolve, but rules that opt out via File.Generated
+	// will not run on them.
+	//
+	// A nil allowlist preserves the historical behavior: when
+	// IncludeGenerated is false, every file under "/generated/" is
+	// dropped. Use DefaultKnownSafeGenerators() for a sensible default.
+	//
+	// Note: the file collector prunes "build/" at walk time via
+	// fileignore.DefaultPrunedDir, so allowlist substrings under build/
+	// (the typical Gradle layout) only take effect when the caller
+	// supplies KotlinPaths directly or otherwise places generated output
+	// outside build/. Integration with the walker's prune list is a
+	// follow-up for the broader Phase 3 effort.
+	IncludeGeneratedAllowlist []string
 	// KotlinPaths, when non-nil, short-circuits CollectKotlinFiles and
 	// uses the supplied paths directly. Main already collects paths
 	// early (for cache lookups and empty-project detection) and passes

--- a/internal/pipeline/workspace.go
+++ b/internal/pipeline/workspace.go
@@ -44,6 +44,7 @@ type WorkspaceState struct {
 	xfileMu      sync.Mutex
 	libraryFacts xfileSlot[*librarymodel.Facts]
 	codeIndex    xfileSlot[*scanner.CodeIndex]
+	dependents   xfileSlot[*scanner.DependentsIndex]
 }
 
 // xfileSlot pairs a fingerprint with a value. Zero value means
@@ -210,6 +211,7 @@ func (w *WorkspaceState) InvalidateAll() {
 	w.xfileMu.Lock()
 	w.libraryFacts = xfileSlot[*librarymodel.Facts]{}
 	w.codeIndex = xfileSlot[*scanner.CodeIndex]{}
+	w.dependents = xfileSlot[*scanner.DependentsIndex]{}
 	w.xfileMu.Unlock()
 }
 
@@ -275,11 +277,53 @@ func (w *WorkspaceState) CodeIndex(fingerprint string, build func() *scanner.Cod
 	return v
 }
 
+// Dependents is LibraryFacts for *scanner.DependentsIndex. Same
+// semantics: build only fires on a fingerprint mismatch; concurrent
+// races converge on a single cached pointer. The fingerprint should be
+// the same one driving CodeIndex so the two slots stay aligned.
+func (w *WorkspaceState) Dependents(fingerprint string, build func() *scanner.DependentsIndex) *scanner.DependentsIndex {
+	if w == nil || fingerprint == "" {
+		return build()
+	}
+	w.xfileMu.Lock()
+	if w.dependents.present && w.dependents.fingerprint == fingerprint {
+		v := w.dependents.value
+		w.xfileMu.Unlock()
+		return v
+	}
+	w.xfileMu.Unlock()
+
+	v := build()
+
+	w.xfileMu.Lock()
+	if w.dependents.present && w.dependents.fingerprint == fingerprint {
+		v = w.dependents.value
+	} else {
+		w.dependents = xfileSlot[*scanner.DependentsIndex]{fingerprint: fingerprint, value: v, present: true}
+	}
+	w.xfileMu.Unlock()
+	return v
+}
+
+// InvalidateDependents drops the cached DependentsIndex so the next
+// Dependents call rebuilds from current sources. Called by the file
+// watcher whenever a Kotlin file changes — the dependents map is
+// affected by edits to import_header nodes.
+func (w *WorkspaceState) InvalidateDependents() {
+	if w == nil {
+		return
+	}
+	w.xfileMu.Lock()
+	w.dependents = xfileSlot[*scanner.DependentsIndex]{}
+	w.xfileMu.Unlock()
+}
+
 // CrossFileStats reports whether the cross-file slots are populated.
 // Used by tests and verbose diagnostics.
 type CrossFileStats struct {
 	HasLibraryFacts bool
 	HasCodeIndex    bool
+	HasDependents   bool
 }
 
 // CrossFileStats returns a snapshot of the cross-file slots.
@@ -292,6 +336,7 @@ func (w *WorkspaceState) CrossFileStats() CrossFileStats {
 	return CrossFileStats{
 		HasLibraryFacts: w.libraryFacts.present,
 		HasCodeIndex:    w.codeIndex.present,
+		HasDependents:   w.dependents.present,
 	}
 }
 

--- a/internal/pipeline/workspace_test.go
+++ b/internal/pipeline/workspace_test.go
@@ -348,3 +348,60 @@ func TestWorkspaceState_ConcurrentInvalidateIsSafe(t *testing.T) {
 	// No assertion beyond "didn't panic / didn't deadlock". The race
 	// detector catches data races automatically when -race is set.
 }
+
+func TestWorkspaceState_DependentsCachesByFingerprint(t *testing.T) {
+	ws := NewWorkspaceState("/tmp/test")
+	calls := 0
+	build := func() *scanner.DependentsIndex {
+		calls++
+		return scanner.BuildDependentsIndex(nil)
+	}
+
+	a := ws.Dependents("fp-1", build)
+	b := ws.Dependents("fp-1", build)
+	if a != b {
+		t.Error("expected pointer identity on cache hit")
+	}
+	if calls != 1 {
+		t.Errorf("build calls: got %d, want 1", calls)
+	}
+
+	c := ws.Dependents("fp-2", build)
+	if c == a {
+		t.Error("expected fingerprint change to rebuild")
+	}
+	if calls != 2 {
+		t.Errorf("build calls after rebuild: got %d, want 2", calls)
+	}
+}
+
+func TestWorkspaceState_InvalidateDependentsClearsOnlyThatSlot(t *testing.T) {
+	ws := NewWorkspaceState("/tmp/test")
+	ws.LibraryFacts("lf", func() *librarymodel.Facts { return &librarymodel.Facts{} })
+	ws.CodeIndex("ci", func() *scanner.CodeIndex { return &scanner.CodeIndex{} })
+	ws.Dependents("dep", func() *scanner.DependentsIndex { return scanner.BuildDependentsIndex(nil) })
+
+	ws.InvalidateDependents()
+	stats := ws.CrossFileStats()
+	if !stats.HasLibraryFacts {
+		t.Error("InvalidateDependents should not clear LibraryFacts")
+	}
+	if !stats.HasCodeIndex {
+		t.Error("InvalidateDependents should not clear CodeIndex")
+	}
+	if stats.HasDependents {
+		t.Error("InvalidateDependents should clear Dependents")
+	}
+}
+
+func TestWorkspaceState_InvalidateAllClearsDependents(t *testing.T) {
+	ws := NewWorkspaceState("/tmp/test")
+	ws.Dependents("dep", func() *scanner.DependentsIndex { return scanner.BuildDependentsIndex(nil) })
+	if !ws.CrossFileStats().HasDependents {
+		t.Fatal("setup failed: Dependents not cached")
+	}
+	ws.InvalidateAll()
+	if ws.CrossFileStats().HasDependents {
+		t.Error("InvalidateAll should clear Dependents")
+	}
+}

--- a/internal/rules/api/metadata.go
+++ b/internal/rules/api/metadata.go
@@ -180,6 +180,13 @@ type RuleDescriptor struct {
 	// (e.g. "complexity", "naming", "performance").
 	RuleSet string
 
+	// Tags are advisory cross-cutting labels that group rules across
+	// RuleSets. See Rule.Tags for the full contract; the descriptor
+	// field exists so rules implementing MetaProvider can publish tags
+	// the same way they publish other metadata. Tags are purely
+	// descriptive and do not affect activation or dispatch.
+	Tags []string
+
 	// Severity is "error", "warning", or "info".
 	Severity string
 

--- a/internal/rules/api/rule.go
+++ b/internal/rules/api/rule.go
@@ -493,6 +493,17 @@ type Rule struct {
 	// renaming a rule so existing user suppressions keep working.
 	Aliases []string
 
+	// Tags are advisory cross-cutting labels that group rules across
+	// RuleSets. Unlike Category/RuleSet (which is the rule's primary
+	// configuration group and is load-bearing for activation, suppression
+	// keys, and option lookup), Tags are purely descriptive metadata that
+	// consumers (docs, CLI filters, IDE pickers) can use to surface
+	// thematic groupings without renaming a rule. Examples: "precompile"
+	// for rules that approximate compiler diagnostics, "android" for
+	// Android-specific checks. Tags do NOT affect dispatcher routing or
+	// config activation today.
+	Tags []string
+
 	// EnabledByDefaultSince records the krit version in which this rule
 	// became default-active (DefaultActive transitioned from false to
 	// true). Empty string means the rule has been default-active since

--- a/internal/rules/correctness_abstract.go
+++ b/internal/rules/correctness_abstract.go
@@ -1,0 +1,183 @@
+package rules
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	api "github.com/kaeawc/krit/internal/rules/api"
+	"github.com/kaeawc/krit/internal/scanner"
+	"github.com/kaeawc/krit/internal/typeinfer"
+)
+
+// ---------------------------------------------------------------------------
+// AbstractMemberNotImplementedRule — flags concrete classes that fail to
+// implement at least one abstract member declared on a supertype the
+// resolver can see. Mimics kotlinc's ABSTRACT_MEMBER_NOT_IMPLEMENTED for
+// the source-resolvable case: same-workspace interfaces and abstract
+// classes whose abstract members the subclass omitted.
+//
+// Scope:
+//   - Interfaces, sealed interfaces, abstract classes, and expect/external
+//     declarations are skipped (they don't have to implement anything).
+//   - For interface supertypes, all function members are treated as
+//     abstract for v1. Default-method interfaces (rare in Kotlin) will
+//     false-positive against this rule until member-body presence is
+//     tracked on MemberInfo.
+//   - For non-interface supertypes, only members with the explicit
+//     `abstract` modifier are required.
+//   - Walks one level of supertypes. Transitive abstract requirements
+//     (X : AbstractA : InterfaceB) are deferred.
+//   - Implementations include same-named members in the class body and
+//     `override val/var` properties declared in the primary constructor.
+//
+// ---------------------------------------------------------------------------
+type AbstractMemberNotImplementedRule struct {
+	FlatDispatchBase
+	BaseRule
+}
+
+func (r *AbstractMemberNotImplementedRule) Confidence() float64 { return 0.8 }
+
+func (r *AbstractMemberNotImplementedRule) check(ctx *api.Context) {
+	idx, file := ctx.Idx, ctx.File
+	if file.FlatType(idx) != "class_declaration" {
+		return
+	}
+	if file.FlatHasModifier(idx, "abstract") || file.FlatHasModifier(idx, "expect") || file.FlatHasModifier(idx, "external") {
+		return
+	}
+	if abstractRuleIsInterface(file, idx) {
+		return
+	}
+	if ctx.Resolver == nil {
+		return
+	}
+	className := abstractRuleClassName(file, idx)
+	if className == "" {
+		return
+	}
+	classInfo := ctx.Resolver.ClassHierarchy(className)
+	if classInfo == nil || len(classInfo.Supertypes) == 0 {
+		return
+	}
+	implementations := abstractRuleImplementations(file, idx, classInfo)
+	required := abstractRuleRequiredMembers(ctx.Resolver, classInfo.Supertypes)
+	var missing []string
+	for name := range required {
+		if implementations[name] {
+			continue
+		}
+		missing = append(missing, name)
+	}
+	if len(missing) == 0 {
+		return
+	}
+	sort.Strings(missing)
+	ctx.EmitAt(file.FlatRow(idx)+1, file.FlatCol(idx)+1,
+		fmt.Sprintf("Class '%s' does not implement abstract supertype member(s): %s.",
+			className, strings.Join(missing, ", ")))
+}
+
+func abstractRuleIsInterface(file *scanner.File, idx uint32) bool {
+	for child := file.FlatFirstChild(idx); child != 0; child = file.FlatNextSib(child) {
+		if file.FlatType(child) == "interface" {
+			return true
+		}
+	}
+	// Tree-sitter sometimes wraps `interface` in modifiers; conservative
+	// fallback uses the prefix text.
+	return strings.HasPrefix(strings.TrimSpace(file.FlatNodeText(idx)), "interface")
+}
+
+func abstractRuleClassName(file *scanner.File, idx uint32) string {
+	for child := file.FlatFirstChild(idx); child != 0; child = file.FlatNextSib(child) {
+		if file.FlatType(child) == "type_identifier" {
+			return strings.TrimSpace(file.FlatNodeText(child))
+		}
+	}
+	return ""
+}
+
+// abstractRuleImplementations returns the set of member names implemented
+// by the class. Includes class_body members regardless of `override`
+// modifier (any same-named member shadows the supertype contract enough
+// to silence this rule), plus primary-constructor `override val/var`
+// properties.
+func abstractRuleImplementations(file *scanner.File, classIdx uint32, classInfo *typeinfer.ClassInfo) map[string]bool {
+	out := map[string]bool{}
+	for _, m := range classInfo.Members {
+		out[m.Name] = true
+	}
+	// Walk primary_constructor for `override val/var` parameters.
+	// Tree-sitter Kotlin emits class_parameter nodes as direct children
+	// of primary_constructor (no class_parameters wrapper).
+	primary, ok := file.FlatFindChild(classIdx, "primary_constructor")
+	if !ok {
+		return out
+	}
+	for child := file.FlatFirstChild(primary); child != 0; child = file.FlatNextSib(child) {
+		if file.FlatType(child) != "class_parameter" {
+			continue
+		}
+		if !classParameterHasOverrideModifier(file, child) {
+			continue
+		}
+		if name := classParameterName(file, child); name != "" {
+			out[name] = true
+		}
+	}
+	return out
+}
+
+func classParameterHasOverrideModifier(file *scanner.File, paramIdx uint32) bool {
+	for child := file.FlatFirstChild(paramIdx); child != 0; child = file.FlatNextSib(child) {
+		switch file.FlatType(child) {
+		case "modifiers":
+			for sub := file.FlatFirstChild(child); sub != 0; sub = file.FlatNextSib(sub) {
+				if file.FlatNodeText(sub) == "override" {
+					return true
+				}
+				for gc := file.FlatFirstChild(sub); gc != 0; gc = file.FlatNextSib(gc) {
+					if file.FlatNodeText(gc) == "override" {
+						return true
+					}
+				}
+			}
+		case "override":
+			return true
+		}
+	}
+	return false
+}
+
+func classParameterName(file *scanner.File, paramIdx uint32) string {
+	for child := file.FlatFirstChild(paramIdx); child != 0; child = file.FlatNextSib(child) {
+		if file.FlatType(child) == "simple_identifier" {
+			return strings.TrimSpace(file.FlatNodeText(child))
+		}
+	}
+	return ""
+}
+
+func abstractRuleRequiredMembers(resolver typeinfer.TypeResolver, supertypes []string) map[string]bool {
+	required := map[string]bool{}
+	for _, st := range supertypes {
+		super := resolver.ClassHierarchy(st)
+		if super == nil {
+			continue
+		}
+		isInterface := strings.Contains(super.Kind, "interface")
+		for _, m := range super.Members {
+			switch {
+			case isInterface:
+				// v1 simplification: every function/property on an
+				// interface is treated as abstract.
+				required[m.Name] = true
+			case m.IsAbstract:
+				required[m.Name] = true
+			}
+		}
+	}
+	return required
+}

--- a/internal/rules/correctness_abstract.go
+++ b/internal/rules/correctness_abstract.go
@@ -62,7 +62,10 @@ func (r *AbstractMemberNotImplementedRule) check(ctx *api.Context) {
 		return
 	}
 	implementations := abstractRuleImplementations(file, idx, classInfo)
-	required := abstractRuleRequiredMembers(ctx.Resolver, classInfo.Supertypes)
+	required, transitivelySatisfied := abstractRuleRequiredMembers(ctx.Resolver, classInfo.Supertypes)
+	for name := range transitivelySatisfied {
+		implementations[name] = true
+	}
 	var missing []string
 	for name := range required {
 		if implementations[name] {
@@ -160,24 +163,52 @@ func classParameterName(file *scanner.File, paramIdx uint32) string {
 	return ""
 }
 
-func abstractRuleRequiredMembers(resolver typeinfer.TypeResolver, supertypes []string) map[string]bool {
-	required := map[string]bool{}
-	for _, st := range supertypes {
+// abstractRuleRequiredMembers walks the transitive supertype closure
+// and returns:
+//   - required: member names that some interface or abstract class
+//     declares abstractly somewhere up the chain.
+//   - satisfied: member names that an intermediate concrete class
+//     (or a non-abstract abstract-class member) provides, i.e. names
+//     the subclass does not need to re-implement.
+//
+// The dual return lets the rule subtract satisfied from required so
+// that `class FullChild : GreeterBase()` where GreeterBase already
+// implements Greeter.greet does not emit a finding.
+func abstractRuleRequiredMembers(resolver typeinfer.TypeResolver, supertypes []string) (required map[string]bool, satisfied map[string]bool) {
+	required = map[string]bool{}
+	satisfied = map[string]bool{}
+	seen := map[string]bool{}
+	queue := append([]string(nil), supertypes...)
+	for len(queue) > 0 {
+		st := queue[0]
+		queue = queue[1:]
+		if seen[st] {
+			continue
+		}
+		seen[st] = true
 		super := resolver.ClassHierarchy(st)
 		if super == nil {
 			continue
 		}
+		queue = append(queue, super.Supertypes...)
 		isInterface := strings.Contains(super.Kind, "interface")
+		isAbstractClass := super.IsAbstract && !isInterface
 		for _, m := range super.Members {
 			switch {
 			case isInterface:
-				// v1 simplification: every function/property on an
-				// interface is treated as abstract.
+				// v1 simplification: every interface member is treated
+				// as abstract. Default-method interfaces would
+				// false-positive until member-body presence is tracked.
 				required[m.Name] = true
-			case m.IsAbstract:
+			case isAbstractClass && m.IsAbstract:
 				required[m.Name] = true
+			default:
+				// Concrete class member, or non-abstract member of an
+				// abstract class. Satisfies the contract for any
+				// further-down subclass.
+				satisfied[m.Name] = true
 			}
 		}
 	}
-	return required
+	return required, satisfied
 }

--- a/internal/rules/correctness_abstract_test.go
+++ b/internal/rules/correctness_abstract_test.go
@@ -100,3 +100,42 @@ class Standalone {
 		t.Fatalf("expected no findings on class without supertypes, got %d", len(findings))
 	}
 }
+
+func TestAbstractMemberNotImplemented_TransitiveInterfaceMethod_Positive(t *testing.T) {
+	findings := runRuleByNameWithResolver(t, "AbstractMemberNotImplemented", `
+package test
+
+interface Greeter {
+    fun greet(name: String): String
+}
+
+abstract class GreeterBase : Greeter
+
+class HollowChild : GreeterBase()
+`)
+	if len(findings) == 0 {
+		t.Fatal("expected finding when interface member missing two levels deep")
+	}
+	if !strings.Contains(findings[0].Message, "greet") {
+		t.Errorf("expected message to mention transitive missing 'greet'; got %q", findings[0].Message)
+	}
+}
+
+func TestAbstractMemberNotImplemented_TransitiveImplemented_Negative(t *testing.T) {
+	findings := runRuleByNameWithResolver(t, "AbstractMemberNotImplemented", `
+package test
+
+interface Greeter {
+    fun greet(name: String): String
+}
+
+abstract class GreeterBase : Greeter {
+    override fun greet(name: String): String = "hi $name"
+}
+
+class FullChild : GreeterBase()
+`)
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings when intermediate concrete impl supplies the member, got %d", len(findings))
+	}
+}

--- a/internal/rules/correctness_abstract_test.go
+++ b/internal/rules/correctness_abstract_test.go
@@ -1,0 +1,102 @@
+package rules_test
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestAbstractMemberNotImplemented_MissingInterfaceMethod_Positive(t *testing.T) {
+	findings := runRuleByNameWithResolver(t, "AbstractMemberNotImplemented", `
+package test
+
+interface Greeter {
+    fun greet(name: String): String
+    fun farewell()
+}
+
+class HollowGreeter : Greeter
+`)
+	if len(findings) == 0 {
+		t.Fatal("expected finding when class fails to implement interface members")
+	}
+	if !strings.Contains(findings[0].Message, "greet") || !strings.Contains(findings[0].Message, "farewell") {
+		t.Errorf("expected message to list missing names; got %q", findings[0].Message)
+	}
+}
+
+func TestAbstractMemberNotImplemented_MissingAbstractMethod_Positive(t *testing.T) {
+	findings := runRuleByNameWithResolver(t, "AbstractMemberNotImplemented", `
+package test
+
+abstract class Base {
+    abstract fun handle()
+}
+
+class Impl : Base()
+`)
+	if len(findings) == 0 {
+		t.Fatal("expected finding when class fails to implement abstract base method")
+	}
+}
+
+func TestAbstractMemberNotImplemented_AllImplemented_Negative(t *testing.T) {
+	findings := runRuleByNameWithResolver(t, "AbstractMemberNotImplemented", `
+package test
+
+interface Greeter {
+    fun greet(name: String): String
+    fun farewell()
+}
+
+class FullGreeter : Greeter {
+    override fun greet(name: String): String = "Hi $name"
+    override fun farewell() {}
+}
+`)
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings when all members implemented, got %d", len(findings))
+	}
+}
+
+func TestAbstractMemberNotImplemented_PrimaryConstructorOverride_Negative(t *testing.T) {
+	findings := runRuleByNameWithResolver(t, "AbstractMemberNotImplemented", `
+package test
+
+interface Named {
+    val name: String
+}
+
+class NamedThing(override val name: String) : Named
+`)
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings when constructor override val provides member, got %d", len(findings))
+	}
+}
+
+func TestAbstractMemberNotImplemented_AbstractClassExempt_Negative(t *testing.T) {
+	findings := runRuleByNameWithResolver(t, "AbstractMemberNotImplemented", `
+package test
+
+interface Greeter {
+    fun greet(name: String): String
+}
+
+abstract class StillAbstract : Greeter
+`)
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings on abstract subclass, got %d", len(findings))
+	}
+}
+
+func TestAbstractMemberNotImplemented_NoSupertypes_Negative(t *testing.T) {
+	findings := runRuleByNameWithResolver(t, "AbstractMemberNotImplemented", `
+package test
+
+class Standalone {
+    fun foo() = 42
+}
+`)
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings on class without supertypes, got %d", len(findings))
+	}
+}

--- a/internal/rules/correctness_override.go
+++ b/internal/rules/correctness_override.go
@@ -65,15 +65,25 @@ func (r *OverrideSignatureMismatchRule) check(ctx *api.Context) {
 	if thisMember == nil || thisMember.Kind != "function" {
 		return
 	}
-	// Walk supertypes. If any supertype has a same-name function with a
-	// matching parameter count, the override is fine.
+	// Walk supertypes transitively. If any reachable supertype has a
+	// same-name function with a matching parameter count, the override is
+	// fine. Cycles are guarded against via a seen set.
 	var nearestMismatch *typeinfer.MemberInfo
 	matched := false
-	for _, st := range classInfo.Supertypes {
+	seen := map[string]bool{}
+	queue := append([]string(nil), classInfo.Supertypes...)
+	for len(queue) > 0 && !matched {
+		st := queue[0]
+		queue = queue[1:]
+		if seen[st] {
+			continue
+		}
+		seen[st] = true
 		super := ctx.Resolver.ClassHierarchy(st)
 		if super == nil {
 			continue
 		}
+		queue = append(queue, super.Supertypes...)
 		for i := range super.Members {
 			sm := &super.Members[i]
 			if sm.Kind != "function" || sm.Name != funcName {
@@ -87,9 +97,9 @@ func (r *OverrideSignatureMismatchRule) check(ctx *api.Context) {
 				nearestMismatch = sm
 			}
 		}
-		if matched {
-			return
-		}
+	}
+	if matched {
+		return
 	}
 	if nearestMismatch == nil {
 		// No supertype the resolver can see has this name; silent (could

--- a/internal/rules/correctness_override.go
+++ b/internal/rules/correctness_override.go
@@ -1,0 +1,123 @@
+package rules
+
+import (
+	"fmt"
+	"strings"
+
+	api "github.com/kaeawc/krit/internal/rules/api"
+	"github.com/kaeawc/krit/internal/scanner"
+	"github.com/kaeawc/krit/internal/typeinfer"
+)
+
+// ---------------------------------------------------------------------------
+// OverrideSignatureMismatchRule — flags `override fun X(...)` declarations
+// whose parameter count does not match any same-named function on a supertype
+// the resolver can see. Mimics kotlinc's NOTHING_TO_OVERRIDE diagnostic for
+// the case the resolver can prove from source: same-workspace supertypes
+// with a same-named member but a different parameter count.
+//
+// The rule is intentionally narrow:
+//   - Only fires when at least one supertype known to the resolver
+//     contains a function with the same name. If no supertype has the
+//     name, the rule is silent (could be a library override, deferred
+//     to classpath-aware resolution).
+//   - Compares parameter COUNTS only. Type comparison is deferred until
+//     parameter types are reliably resolved across files (today,
+//     library-typed parameters are TypeUnknown and would false-positive).
+//   - Generic functions and library supertypes are out of scope.
+//
+// ---------------------------------------------------------------------------
+type OverrideSignatureMismatchRule struct {
+	FlatDispatchBase
+	BaseRule
+}
+
+func (r *OverrideSignatureMismatchRule) Confidence() float64 { return 0.85 }
+
+func (r *OverrideSignatureMismatchRule) check(ctx *api.Context) {
+	idx, file := ctx.Idx, ctx.File
+	if file.FlatType(idx) != "function_declaration" {
+		return
+	}
+	if !file.FlatHasModifier(idx, "override") {
+		return
+	}
+	if ctx.Resolver == nil {
+		return
+	}
+	classDecl, ok := flatEnclosingAncestor(file, idx, "class_declaration", "object_declaration")
+	if !ok {
+		return
+	}
+	className := overrideEnclosingClassName(file, classDecl)
+	if className == "" {
+		return
+	}
+	classInfo := ctx.Resolver.ClassHierarchy(className)
+	if classInfo == nil || len(classInfo.Supertypes) == 0 {
+		return
+	}
+	funcName := overrideEnclosingClassName(file, idx)
+	if funcName == "" {
+		return
+	}
+	thisMember := overrideFindMember(classInfo.Members, funcName)
+	if thisMember == nil || thisMember.Kind != "function" {
+		return
+	}
+	// Walk supertypes. If any supertype has a same-name function with a
+	// matching parameter count, the override is fine.
+	var nearestMismatch *typeinfer.MemberInfo
+	matched := false
+	for _, st := range classInfo.Supertypes {
+		super := ctx.Resolver.ClassHierarchy(st)
+		if super == nil {
+			continue
+		}
+		for i := range super.Members {
+			sm := &super.Members[i]
+			if sm.Kind != "function" || sm.Name != funcName {
+				continue
+			}
+			if len(sm.Params) == len(thisMember.Params) {
+				matched = true
+				break
+			}
+			if nearestMismatch == nil {
+				nearestMismatch = sm
+			}
+		}
+		if matched {
+			return
+		}
+	}
+	if nearestMismatch == nil {
+		// No supertype the resolver can see has this name; silent (could
+		// resolve through classpath we don't see yet).
+		return
+	}
+	ctx.EmitAt(file.FlatRow(idx)+1, file.FlatCol(idx)+1,
+		fmt.Sprintf("Function '%s' is marked override but no supertype declares a matching parameter count: this declaration has %d, supertype has %d.",
+			funcName, len(thisMember.Params), len(nearestMismatch.Params)))
+}
+
+func overrideEnclosingClassName(file *scanner.File, decl uint32) string {
+	if file == nil || decl == 0 {
+		return ""
+	}
+	for child := file.FlatFirstChild(decl); child != 0; child = file.FlatNextSib(child) {
+		if file.FlatType(child) == "type_identifier" || file.FlatType(child) == "simple_identifier" {
+			return strings.TrimSpace(file.FlatNodeText(child))
+		}
+	}
+	return ""
+}
+
+func overrideFindMember(members []typeinfer.MemberInfo, name string) *typeinfer.MemberInfo {
+	for i := range members {
+		if members[i].Name == name {
+			return &members[i]
+		}
+	}
+	return nil
+}

--- a/internal/rules/correctness_override_test.go
+++ b/internal/rules/correctness_override_test.go
@@ -1,0 +1,104 @@
+package rules_test
+
+import (
+	"testing"
+)
+
+func TestOverrideSignatureMismatch_TooManyParams_Positive(t *testing.T) {
+	findings := runRuleByNameWithResolver(t, "OverrideSignatureMismatch", `
+package test
+
+interface Greeter {
+    fun greet(name: String): String
+}
+
+class WrongGreeter : Greeter {
+    override fun greet(name: String, locale: String): String = "$name $locale"
+}
+`)
+	if len(findings) == 0 {
+		t.Fatal("expected finding when override adds an extra parameter")
+	}
+}
+
+func TestOverrideSignatureMismatch_TooFewParams_Positive(t *testing.T) {
+	findings := runRuleByNameWithResolver(t, "OverrideSignatureMismatch", `
+package test
+
+abstract class Base {
+    abstract fun handle(x: Int, y: Int)
+}
+
+class Impl : Base() {
+    override fun handle(x: Int) {}
+}
+`)
+	if len(findings) == 0 {
+		t.Fatal("expected finding when override drops a parameter")
+	}
+}
+
+func TestOverrideSignatureMismatch_MatchingParams_Negative(t *testing.T) {
+	findings := runRuleByNameWithResolver(t, "OverrideSignatureMismatch", `
+package test
+
+interface Greeter {
+    fun greet(name: String): String
+}
+
+class GoodGreeter : Greeter {
+    override fun greet(name: String): String = "Hi $name"
+}
+`)
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings on matching override, got %d", len(findings))
+	}
+}
+
+func TestOverrideSignatureMismatch_OverloadResolves_Negative(t *testing.T) {
+	findings := runRuleByNameWithResolver(t, "OverrideSignatureMismatch", `
+package test
+
+abstract class Multi {
+    abstract fun handle()
+    abstract fun handle(x: Int)
+}
+
+class HandleImpl : Multi() {
+    override fun handle() {}
+    override fun handle(x: Int) {}
+}
+`)
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings when each override matches one of the overloads, got %d", len(findings))
+	}
+}
+
+func TestOverrideSignatureMismatch_LibrarySupertype_Negative(t *testing.T) {
+	// Logger here has no source-side toString; the rule must stay silent
+	// because no supertype member with the same name is visible.
+	findings := runRuleByNameWithResolver(t, "OverrideSignatureMismatch", `
+package test
+
+abstract class Logger
+class MyLogger : Logger() {
+    override fun toString(): String = "MyLogger"
+}
+`)
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings when supertype has no matching member name, got %d", len(findings))
+	}
+}
+
+func TestOverrideSignatureMismatch_NotAnOverride_Negative(t *testing.T) {
+	findings := runRuleByNameWithResolver(t, "OverrideSignatureMismatch", `
+package test
+
+class Solo {
+    fun greet(name: String): String = "Hi $name"
+}
+`)
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings on non-override function, got %d", len(findings))
+	}
+}

--- a/internal/rules/meta_lookup.go
+++ b/internal/rules/meta_lookup.go
@@ -90,6 +90,11 @@ func mergeRuleDescriptor(r *api.Rule, extra api.RuleDescriptor) api.RuleDescript
 	} else {
 		out.Deprecated = extra.Deprecated
 	}
+	if len(r.Tags) > 0 {
+		out.Tags = r.Tags
+	} else {
+		out.Tags = extra.Tags
+	}
 	return out
 }
 

--- a/internal/rules/potentialbugs_exceptions.go
+++ b/internal/rules/potentialbugs_exceptions.go
@@ -1209,3 +1209,142 @@ func isInfiniteLoopFlat(file *scanner.File, idx uint32) bool {
 	})
 	return !hasBreak
 }
+
+// ---------------------------------------------------------------------------
+// MissingReturnRule — flags block-bodied functions with a non-Unit/non-Nothing
+// declared return type whose body cannot guarantee a returned value on every
+// path. Mimics kotlinc's NO_RETURN_IN_FUNCTION_WITH_BLOCK_BODY diagnostic
+// using AST + the same termination helpers UnreachableCode uses.
+//
+// Rule scope is intentionally narrow:
+//   - block-bodied functions only (`{ ... }`); expression bodies (`= expr`)
+//     always return their expression value
+//   - functions with an explicit declared return type only; the implicit
+//     Unit case is silent
+//   - return type "Unit"/"Nothing" (and the kotlin.X qualified forms) is
+//     skipped because Unit doesn't need a return and Nothing-returning
+//     functions can't return normally
+//   - abstract / interface / expect / external functions have no body and
+//     are skipped
+//
+// ---------------------------------------------------------------------------
+type MissingReturnRule struct {
+	FlatDispatchBase
+	BaseRule
+}
+
+func (r *MissingReturnRule) Confidence() float64 { return 0.85 }
+
+func missingReturnDeclaredType(file *scanner.File, fn uint32) (typeIdx uint32, body uint32) {
+	foundParams := false
+	for child := file.FlatFirstChild(fn); child != 0; child = file.FlatNextSib(child) {
+		switch file.FlatType(child) {
+		case "function_value_parameters":
+			foundParams = true
+		case "function_body":
+			body = child
+		case "user_type", "nullable_type", "type_identifier":
+			if foundParams && typeIdx == 0 {
+				typeIdx = child
+			}
+		}
+	}
+	return typeIdx, body
+}
+
+func missingReturnTypeIsUnitOrNothing(text string) bool {
+	switch strings.TrimSpace(text) {
+	case "Unit", "Nothing", "kotlin.Unit", "kotlin.Nothing":
+		return true
+	}
+	return false
+}
+
+func missingReturnIsExpressionBody(file *scanner.File, body uint32) bool {
+	for child := file.FlatFirstChild(body); child != 0; child = file.FlatNextSib(child) {
+		if file.FlatType(child) == "=" {
+			return true
+		}
+		if file.FlatIsNamed(child) {
+			// Reached a named child (e.g. statements) before any `=`. It's a
+			// block body.
+			return false
+		}
+	}
+	return false
+}
+
+// missingReturnFunctionTerminates returns true when the block body is
+// guaranteed to terminate on every path with a return, throw,
+// Nothing-returning call, exhaustive-if, or exhaustive-when.
+func missingReturnFunctionTerminates(file *scanner.File, body uint32, resolver typeinfer.TypeResolver) bool {
+	if file == nil || body == 0 {
+		return false
+	}
+	stmts, _ := file.FlatFindChild(body, "statements")
+	if stmts == 0 {
+		return false
+	}
+	var last uint32
+	for i := file.FlatChildCount(stmts) - 1; i >= 0; i-- {
+		c := file.FlatChild(stmts, i)
+		t := file.FlatType(c)
+		if t == "line_comment" || t == "multiline_comment" || t == "{" || t == "}" {
+			continue
+		}
+		last = c
+		break
+	}
+	if last == 0 {
+		return false
+	}
+	switch file.FlatType(last) {
+	case "jump_expression":
+		text := file.FlatNodeText(last)
+		return strings.HasPrefix(text, "return") || strings.HasPrefix(text, "throw")
+	case "if_expression":
+		return ifAllBranchesTerminateFlat(file, last)
+	case "when_expression":
+		return whenIsExhaustiveAndTerminatesFlat(file, last, resolver)
+	}
+	return isNothingReturningCallFlat(file, last, resolver)
+}
+
+func (r *MissingReturnRule) check(ctx *api.Context) {
+	idx, file := ctx.Idx, ctx.File
+	if file.FlatType(idx) != "function_declaration" {
+		return
+	}
+	if file.FlatHasModifier(idx, "abstract") || file.FlatHasModifier(idx, "expect") || file.FlatHasModifier(idx, "external") {
+		return
+	}
+	retType, body := missingReturnDeclaredType(file, idx)
+	if body == 0 || retType == 0 {
+		return
+	}
+	if missingReturnTypeIsUnitOrNothing(file.FlatNodeText(retType)) {
+		return
+	}
+	if missingReturnIsExpressionBody(file, body) {
+		return
+	}
+	if missingReturnFunctionTerminates(file, body, ctx.Resolver) {
+		return
+	}
+	name := flatDeclarationNameLocal(file, idx)
+	typeText := strings.TrimSpace(file.FlatNodeText(retType))
+	msg := fmt.Sprintf("Function '%s' declares return type '%s' but its body may not return on every path. Add a `return` or terminate every branch.", name, typeText)
+	ctx.EmitAt(file.FlatRow(idx)+1, file.FlatCol(idx)+1, msg)
+}
+
+// flatDeclarationNameLocal returns the function declaration's
+// simple_identifier name. Local helper to avoid pulling in the
+// resolver package's flatDeclarationName.
+func flatDeclarationNameLocal(file *scanner.File, fn uint32) string {
+	for child := file.FlatFirstChild(fn); child != 0; child = file.FlatNextSib(child) {
+		if file.FlatType(child) == "simple_identifier" {
+			return strings.TrimSpace(file.FlatNodeText(child))
+		}
+	}
+	return "<anonymous>"
+}

--- a/internal/rules/potentialbugs_exceptions.go
+++ b/internal/rules/potentialbugs_exceptions.go
@@ -662,9 +662,26 @@ var oracleDiagnosticFactories = map[string]bool{
 func (r *UnreachableCodeRule) Confidence() float64 { return 0.75 }
 
 // nothingReturningFuncs lists bare function names that are known to return Nothing.
+//
+// The heuristic-only callers (blockTerminatesFlat) require this to be a
+// conservative allow-list — any name added here is treated as Nothing-returning
+// even without resolver evidence. Names that overlap with common user-defined
+// helpers (like `fail`) are intentionally omitted; they get picked up via the
+// resolver-backed path when the resolver can prove a Nothing return type.
 var nothingReturningFuncs = map[string]bool{
-	"TODO":  true,
-	"error": true,
+	"TODO":        true,
+	"error":       true,
+	"exitProcess": true,
+}
+
+// nothingReturningQualifierPrefixes are the leading navigation segments
+// accepted as qualifiers for a Nothing-returning stdlib call. `kotlin.error`
+// or `kotlin.system.exitProcess` qualify; arbitrary user-defined receivers
+// like `myObject.error` do not.
+var nothingReturningQualifierPrefixes = [][]string{
+	{"kotlin"},
+	{"kotlin", "system"},
+	{"kotlin", "test"},
 }
 
 func (r *UnreachableCodeRule) checkNode(ctx *api.Context) {
@@ -787,7 +804,7 @@ func unreachableCodeDetectJump(file *scanner.File, child uint32, i, childCount i
 			return true, file.FlatRow(child) + 1, skipNext, newSkipUntilRow
 		}
 	}
-	if isNothingCallFlat(file, child) {
+	if isNothingReturningCallFlat(file, child, resolver) {
 		return true, file.FlatRow(child) + 1, false, newSkipUntilRow
 	}
 	if file.FlatType(child) == "if_expression" && ifAllBranchesTerminateFlat(file, child) {
@@ -918,7 +935,62 @@ func isNothingCallFlat(file *scanner.File, idx uint32) bool {
 		return true
 	}
 	segments := flatNavigationChainIdentifiers(file, nav)
-	return len(segments) == 2 && segments[0] == "kotlin" && segments[1] == name
+	if len(segments) == 0 || segments[len(segments)-1] != name {
+		return false
+	}
+	prefix := segments[:len(segments)-1]
+	for _, accepted := range nothingReturningQualifierPrefixes {
+		if stringSliceEqual(prefix, accepted) {
+			return true
+		}
+	}
+	return false
+}
+
+func stringSliceEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// isNothingReturningCallFlat returns true for any call_expression whose
+// callee provably returns Nothing. It first checks the static heuristic
+// table (isNothingCallFlat) for stdlib globals, then asks the resolver
+// for the call's inferred type when the call has no receiver. The
+// resolver-backed path catches workspace functions declared with
+// `: Nothing` return type.
+//
+// The resolver fallback is restricted to bare calls because the
+// resolver's call-type inference falls back to top-level stdlib lookup
+// when a navigation receiver doesn't yield a matching method, which can
+// produce a misleading Nothing for harmless calls like `logger.error()`.
+// Limiting to bare calls avoids that false positive while still catching
+// the high-value case (workspace `fun X(): Nothing`).
+//
+// Returns false when the resolver is nil or the inferred type is unknown.
+func isNothingReturningCallFlat(file *scanner.File, idx uint32, resolver typeinfer.TypeResolver) bool {
+	if isNothingCallFlat(file, idx) {
+		return true
+	}
+	if resolver == nil || file == nil || file.FlatType(idx) != "call_expression" {
+		return false
+	}
+	if nav, _ := flatCallExpressionParts(file, idx); nav != 0 {
+		// Has a receiver; the resolver's fallback to top-level stdlib
+		// lookup can produce a wrong Nothing here. Stay conservative.
+		return false
+	}
+	t := resolver.ResolveFlatNode(idx, file)
+	if t == nil {
+		return false
+	}
+	return t.Name == "Nothing"
 }
 
 // ifAllBranchesTerminateFlat checks if an if_expression has both then and else branches

--- a/internal/rules/potentialbugs_exceptions_test.go
+++ b/internal/rules/potentialbugs_exceptions_test.go
@@ -339,3 +339,67 @@ fun main(logger: Logger) {
 		t.Fatalf("expected no findings after logger.error(), got %d", len(findings))
 	}
 }
+
+func TestUnreachableCode_AfterExitProcess_Positive(t *testing.T) {
+	findings := runRuleByName(t, "UnreachableCode", `
+package test
+fun main() {
+    exitProcess(0)
+    println("unreachable")
+}
+`)
+	if len(findings) == 0 {
+		t.Fatal("expected finding for unreachable code after exitProcess()")
+	}
+}
+
+func TestUnreachableCode_AfterQualifiedExitProcess_Positive(t *testing.T) {
+	findings := runRuleByName(t, "UnreachableCode", `
+package test
+fun main() {
+    kotlin.system.exitProcess(0)
+    println("unreachable")
+}
+`)
+	if len(findings) == 0 {
+		t.Fatal("expected finding for unreachable code after kotlin.system.exitProcess()")
+	}
+}
+
+func TestUnreachableCode_AfterWorkspaceNothingFunc_Positive(t *testing.T) {
+	findings := runRuleByNameWithResolver(t, "UnreachableCode", `
+package test
+
+private fun failHard(msg: String): Nothing = throw IllegalStateException(msg)
+
+fun main() {
+    failHard("boom")
+    println("unreachable")
+}
+`)
+	if len(findings) == 0 {
+		t.Fatal("expected finding for unreachable code after workspace Nothing-returning function")
+	}
+}
+
+func TestUnreachableCode_NegativeUserExitProcessOnReceiver(t *testing.T) {
+	// A user-defined `exitProcess` method on an arbitrary receiver does not
+	// match the strict qualifier allow-list, and the resolver cannot
+	// confirm a Nothing return type for an unknown method. The rule must
+	// not fire.
+	findings := runRuleByName(t, "UnreachableCode", `
+package test
+
+class Watchdog {
+    fun exitProcess(code: Int) {}
+}
+
+fun main(w: Watchdog) {
+    w.exitProcess(0)
+    println("still reachable")
+}
+`)
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings after Watchdog.exitProcess(), got %d", len(findings))
+	}
+}

--- a/internal/rules/potentialbugs_exceptions_test.go
+++ b/internal/rules/potentialbugs_exceptions_test.go
@@ -403,3 +403,115 @@ fun main(w: Watchdog) {
 		t.Fatalf("expected no findings after Watchdog.exitProcess(), got %d", len(findings))
 	}
 }
+
+// --- MissingReturn ---
+
+func TestMissingReturn_FallThrough_Positive(t *testing.T) {
+	findings := runRuleByNameWithResolver(t, "MissingReturn", `
+package test
+fun foo(x: Int): Int {
+    println(x)
+}
+`)
+	if len(findings) == 0 {
+		t.Fatal("expected MissingReturn finding for fall-through body")
+	}
+}
+
+func TestMissingReturn_NormalReturn_Negative(t *testing.T) {
+	findings := runRuleByNameWithResolver(t, "MissingReturn", `
+package test
+fun foo(x: Int): Int {
+    return x + 1
+}
+`)
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
+	}
+}
+
+func TestMissingReturn_ExpressionBody_Negative(t *testing.T) {
+	findings := runRuleByNameWithResolver(t, "MissingReturn", `
+package test
+fun foo(x: Int): Int = x + 1
+`)
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings on expression body, got %d", len(findings))
+	}
+}
+
+func TestMissingReturn_UnitReturnType_Negative(t *testing.T) {
+	findings := runRuleByNameWithResolver(t, "MissingReturn", `
+package test
+fun foo(x: Int): Unit {
+    println(x)
+}
+`)
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings for explicit Unit return, got %d", len(findings))
+	}
+}
+
+func TestMissingReturn_ImplicitUnit_Negative(t *testing.T) {
+	findings := runRuleByNameWithResolver(t, "MissingReturn", `
+package test
+fun foo(x: Int) {
+    println(x)
+}
+`)
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings for implicit Unit, got %d", len(findings))
+	}
+}
+
+func TestMissingReturn_NothingReturnType_Negative(t *testing.T) {
+	findings := runRuleByNameWithResolver(t, "MissingReturn", `
+package test
+fun crash(): Nothing {
+    throw IllegalStateException("boom")
+}
+`)
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings for Nothing return type, got %d", len(findings))
+	}
+}
+
+func TestMissingReturn_ExhaustiveIfReturns_Negative(t *testing.T) {
+	findings := runRuleByNameWithResolver(t, "MissingReturn", `
+package test
+fun foo(x: Int): Int {
+    if (x > 0) {
+        return x
+    } else {
+        return -x
+    }
+}
+`)
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings for exhaustive-if returns, got %d", len(findings))
+	}
+}
+
+func TestMissingReturn_NothingCallTerminates_Negative(t *testing.T) {
+	findings := runRuleByNameWithResolver(t, "MissingReturn", `
+package test
+fun foo(x: Int): String {
+    TODO("not yet")
+}
+`)
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings when TODO terminates, got %d", len(findings))
+	}
+}
+
+func TestMissingReturn_AbstractFunction_Negative(t *testing.T) {
+	findings := runRuleByNameWithResolver(t, "MissingReturn", `
+package test
+abstract class Holder {
+    abstract fun get(): Int
+}
+`)
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings on abstract function, got %d", len(findings))
+	}
+}

--- a/internal/rules/potentialbugs_smartcast.go
+++ b/internal/rules/potentialbugs_smartcast.go
@@ -1,0 +1,321 @@
+package rules
+
+import (
+	"fmt"
+	"strings"
+
+	api "github.com/kaeawc/krit/internal/rules/api"
+	"github.com/kaeawc/krit/internal/scanner"
+)
+
+// ---------------------------------------------------------------------------
+// SmartCastInvalidatedRule — flags reassignment of a smart-cast variable
+// followed by an unsafe navigation/call use of the same name within the same
+// if-body scope. Mimics kotlinc's SMARTCAST_IMPOSSIBLE for the local-`var`
+// pattern:
+//
+//	var x: String? = "a"
+//	if (x != null) {
+//	    x = bar()
+//	    println(x.length)  // SMARTCAST_IMPOSSIBLE
+//	}
+//
+// The rule is intentionally narrow:
+//   - Only fires when the variable is declared with `var` somewhere in the
+//     enclosing function body (parameters and properties are out of scope —
+//     parameters can't be reassigned in Kotlin, and class properties have
+//     different rules the resolver tracks).
+//   - Only handles `if (x != null)` (and `if (x == null) return` early-exit
+//     is not considered here because reassignment after the early return
+//     would not invalidate a smart cast).
+//   - Only flags the first reassignment-then-use pair to keep messages tight.
+//
+// ---------------------------------------------------------------------------
+type SmartCastInvalidatedRule struct {
+	FlatDispatchBase
+	BaseRule
+}
+
+func (r *SmartCastInvalidatedRule) Confidence() float64 { return 0.85 }
+
+// smartCastIfNullCheckedVar returns the simple identifier name being
+// non-null-checked by the if's condition, or "" when the shape doesn't
+// match `x != null`.
+func smartCastIfNullCheckedVar(file *scanner.File, ifIdx uint32) string {
+	if file == nil || ifIdx == 0 || file.FlatType(ifIdx) != "if_expression" {
+		return ""
+	}
+	var cond uint32
+	for child := file.FlatFirstChild(ifIdx); child != 0; child = file.FlatNextSib(child) {
+		if file.FlatType(child) == "(" {
+			continue
+		}
+		if file.FlatIsNamed(child) {
+			cond = child
+			break
+		}
+	}
+	if cond == 0 {
+		return ""
+	}
+	eq := cond
+	if file.FlatType(eq) != "equality_expression" {
+		// Some grammars wrap; descend one level.
+		for child := file.FlatFirstChild(cond); child != 0; child = file.FlatNextSib(child) {
+			if file.FlatType(child) == "equality_expression" {
+				eq = child
+				break
+			}
+		}
+	}
+	if file.FlatType(eq) != "equality_expression" {
+		return ""
+	}
+	left, op, right := smartCastEqualityOperands(file, eq)
+	if left == 0 || op == 0 || right == 0 {
+		return ""
+	}
+	if strings.TrimSpace(file.FlatNodeText(op)) != "!=" {
+		return ""
+	}
+	leftText := strings.TrimSpace(file.FlatNodeText(left))
+	rightText := strings.TrimSpace(file.FlatNodeText(right))
+	if rightText == "null" && file.FlatType(left) == "simple_identifier" {
+		return leftText
+	}
+	if leftText == "null" && file.FlatType(right) == "simple_identifier" {
+		return rightText
+	}
+	// Tree-sitter parses `null` as a token node whose own type is "null"
+	// rather than a simple_identifier; the simple-text check above already
+	// handles that side, but include the explicit type-name match too in
+	// case the operand is a literal node rather than an identifier.
+	if file.FlatType(right) == "null" && file.FlatType(left) == "simple_identifier" {
+		return leftText
+	}
+	if file.FlatType(left) == "null" && file.FlatType(right) == "simple_identifier" {
+		return rightText
+	}
+	return ""
+}
+
+func smartCastEqualityOperands(file *scanner.File, idx uint32) (left, op, right uint32) {
+	for child := file.FlatFirstChild(idx); child != 0; child = file.FlatNextSib(child) {
+		switch file.FlatType(child) {
+		case "==", "!=", "===", "!==":
+			op = child
+			continue
+		}
+		// Both operands include the `null` literal which tree-sitter
+		// emits as a non-named token node ("null" type). Don't filter
+		// on FlatIsNamed here; instead skip only the parens that wrap
+		// the equality_expression in some grammars.
+		if t := file.FlatType(child); t == "(" || t == ")" {
+			continue
+		}
+		if op == 0 {
+			left = child
+		} else if right == 0 {
+			right = child
+		}
+	}
+	return left, op, right
+}
+
+// smartCastIfThenBody returns the control_structure_body of the if's
+// then-branch, or 0 when none.
+func smartCastIfThenBody(file *scanner.File, ifIdx uint32) uint32 {
+	for child := file.FlatFirstChild(ifIdx); child != 0; child = file.FlatNextSib(child) {
+		if file.FlatType(child) == "control_structure_body" {
+			return child
+		}
+	}
+	return 0
+}
+
+// smartCastFunctionDeclaresVar reports whether the enclosing function body
+// (or the source file when no enclosing function) declares a local
+// `var <varName>`. Looks for property_declaration nodes whose first child
+// is the `var` keyword and whose variable_declaration name matches.
+func smartCastFunctionDeclaresVar(file *scanner.File, scopeIdx uint32, varName string) bool {
+	if file == nil || scopeIdx == 0 || varName == "" {
+		return false
+	}
+	found := false
+	file.FlatWalkAllNodes(scopeIdx, func(n uint32) {
+		if found {
+			return
+		}
+		if file.FlatType(n) != "property_declaration" {
+			return
+		}
+		// Tree-sitter wraps the `var`/`val` keyword in a
+		// binding_pattern_kind node. Descend to find the actual keyword.
+		isVar := false
+		for child := file.FlatFirstChild(n); child != 0; child = file.FlatNextSib(child) {
+			if file.FlatType(child) == "binding_pattern_kind" {
+				for kw := file.FlatFirstChild(child); kw != 0; kw = file.FlatNextSib(kw) {
+					if file.FlatType(kw) == "var" {
+						isVar = true
+						break
+					}
+					if file.FlatType(kw) == "val" {
+						return
+					}
+				}
+				break
+			}
+			if file.FlatType(child) == "var" {
+				isVar = true
+				break
+			}
+			if file.FlatType(child) == "val" {
+				return
+			}
+		}
+		if !isVar {
+			return
+		}
+		varDecl, _ := file.FlatFindChild(n, "variable_declaration")
+		if varDecl == 0 {
+			return
+		}
+		nameNode, _ := file.FlatFindChild(varDecl, "simple_identifier")
+		if nameNode == 0 {
+			return
+		}
+		if strings.TrimSpace(file.FlatNodeText(nameNode)) == varName {
+			found = true
+		}
+	})
+	return found
+}
+
+// smartCastAssignmentTargetName returns the simple identifier name of
+// an assignment's LHS, walking the directly_assignable_expression
+// wrapper that tree-sitter emits. Returns "" when the LHS isn't a bare
+// identifier (e.g. property access or array index — those aren't local
+// var reassignments and don't invalidate a smart cast on the same name
+// in the way this rule cares about).
+func smartCastAssignmentTargetName(file *scanner.File, assign uint32) string {
+	if file == nil || assign == 0 {
+		return ""
+	}
+	for child := file.FlatFirstChild(assign); child != 0; child = file.FlatNextSib(child) {
+		if file.FlatType(child) == "=" {
+			return ""
+		}
+		switch file.FlatType(child) {
+		case "simple_identifier":
+			return strings.TrimSpace(file.FlatNodeText(child))
+		case "directly_assignable_expression":
+			// Descend; the inner simple_identifier is the bare name.
+			for inner := file.FlatFirstChild(child); inner != 0; inner = file.FlatNextSib(inner) {
+				if file.FlatType(inner) == "simple_identifier" {
+					return strings.TrimSpace(file.FlatNodeText(inner))
+				}
+				if file.FlatIsNamed(inner) {
+					// Not a bare identifier — bail.
+					return ""
+				}
+			}
+			return ""
+		}
+	}
+	return ""
+}
+
+// smartCastFindReassignment returns the byte offset of the first
+// assignment whose LHS is `varName` inside body, or 0 when none exists.
+// Scans `assignment` nodes; an `assignment` whose first named child is a
+// simple_identifier with the matching name counts. Compound assignments
+// (`+=`, `-=`, etc.) are also assignment nodes in tree-sitter Kotlin.
+func smartCastFindReassignment(file *scanner.File, body uint32, varName string) uint32 {
+	if file == nil || body == 0 || varName == "" {
+		return 0
+	}
+	var first uint32
+	file.FlatWalkAllNodes(body, func(n uint32) {
+		if first != 0 {
+			return
+		}
+		if file.FlatType(n) != "assignment" {
+			return
+		}
+		lhs := smartCastAssignmentTargetName(file, n)
+		if lhs != varName {
+			return
+		}
+		first = file.FlatStartByte(n)
+	})
+	return first
+}
+
+// smartCastFindUseAfter returns (row, col) of the first navigation_expression
+// or call_expression whose receiver is `varName` and whose start byte is
+// after `afterByte`, or (0, 0) when none.
+func smartCastFindUseAfter(file *scanner.File, body uint32, varName string, afterByte uint32) (int, int) {
+	if file == nil || body == 0 || varName == "" {
+		return 0, 0
+	}
+	var row, col int
+	file.FlatWalkAllNodes(body, func(n uint32) {
+		if row != 0 {
+			return
+		}
+		if file.FlatStartByte(n) <= afterByte {
+			return
+		}
+		if file.FlatType(n) != "navigation_expression" {
+			return
+		}
+		recv := file.FlatFirstChild(n)
+		for recv != 0 && !file.FlatIsNamed(recv) {
+			recv = file.FlatNextSib(recv)
+		}
+		if recv == 0 || file.FlatType(recv) != "simple_identifier" {
+			return
+		}
+		if strings.TrimSpace(file.FlatNodeText(recv)) != varName {
+			return
+		}
+		// Skip safe-call (`?.`) — those are explicitly not relying on a
+		// smart cast.
+		text := file.FlatNodeText(n)
+		if strings.Contains(text, "?.") {
+			return
+		}
+		row = file.FlatRow(n) + 1
+		col = file.FlatCol(n) + 1
+	})
+	return row, col
+}
+
+func (r *SmartCastInvalidatedRule) check(ctx *api.Context) {
+	idx, file := ctx.Idx, ctx.File
+	varName := smartCastIfNullCheckedVar(file, idx)
+	if varName == "" {
+		return
+	}
+	body := smartCastIfThenBody(file, idx)
+	if body == 0 {
+		return
+	}
+	fn, ok := flatEnclosingAncestor(file, idx, "function_declaration")
+	if !ok {
+		return
+	}
+	if !smartCastFunctionDeclaresVar(file, fn, varName) {
+		return
+	}
+	reassignByte := smartCastFindReassignment(file, body, varName)
+	if reassignByte == 0 {
+		return
+	}
+	row, col := smartCastFindUseAfter(file, body, varName, reassignByte)
+	if row == 0 {
+		return
+	}
+	ctx.EmitAt(row, col,
+		fmt.Sprintf("Smart cast on '%s' is invalidated: '%s' was reassigned earlier in this block; use a local copy or '?.' access.", varName, varName))
+}

--- a/internal/rules/potentialbugs_smartcast_test.go
+++ b/internal/rules/potentialbugs_smartcast_test.go
@@ -1,0 +1,88 @@
+package rules_test
+
+import (
+	"testing"
+)
+
+func TestSmartCastInvalidated_ReassignedAndUsed_Positive(t *testing.T) {
+	findings := runRuleByName(t, "SmartCastInvalidated", `
+package test
+fun main(): Int {
+    var x: String? = "hi"
+    if (x != null) {
+        x = null
+        return x.length
+    }
+    return 0
+}
+`)
+	if len(findings) == 0 {
+		t.Fatal("expected SmartCastInvalidated finding for reassigned var")
+	}
+}
+
+func TestSmartCastInvalidated_NoReassignment_Negative(t *testing.T) {
+	findings := runRuleByName(t, "SmartCastInvalidated", `
+package test
+fun main(): Int {
+    var x: String? = "hi"
+    if (x != null) {
+        return x.length
+    }
+    return 0
+}
+`)
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings without reassignment, got %d", len(findings))
+	}
+}
+
+func TestSmartCastInvalidated_ValDeclaration_Negative(t *testing.T) {
+	findings := runRuleByName(t, "SmartCastInvalidated", `
+package test
+fun main(s: String?): Int {
+    if (s != null) {
+        return s.length
+    }
+    return 0
+}
+`)
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings on parameter (val), got %d", len(findings))
+	}
+}
+
+func TestSmartCastInvalidated_SafeCallAfterReassignment_Negative(t *testing.T) {
+	findings := runRuleByName(t, "SmartCastInvalidated", `
+package test
+fun main(): Int {
+    var x: String? = "hi"
+    if (x != null) {
+        x = null
+        return x?.length ?: 0
+    }
+    return 0
+}
+`)
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings when safe-call used, got %d", len(findings))
+	}
+}
+
+func TestSmartCastInvalidated_UseBeforeReassignment_Negative(t *testing.T) {
+	findings := runRuleByName(t, "SmartCastInvalidated", `
+package test
+fun main(): Int {
+    var x: String? = "hi"
+    if (x != null) {
+        val len = x.length
+        x = null
+        return len
+    }
+    return 0
+}
+`)
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings when use precedes reassignment, got %d", len(findings))
+	}
+}

--- a/internal/rules/potentialbugs_types.go
+++ b/internal/rules/potentialbugs_types.go
@@ -1190,6 +1190,44 @@ func whenElseBranchTerminatesFlat(file *scanner.File, idx uint32) bool {
 	return false
 }
 
+// whenSubjectExhaustiveKindFlat is the kind-aware variant of
+// whenSubjectExhaustiveVariantsFlat: it returns whether the subject is a
+// sealed hierarchy or an enum so callers can match variants by `is`
+// type-test or by entry value. kind is "sealed" or "enum"; empty when
+// the subject doesn't resolve to either.
+func whenSubjectExhaustiveKindFlat(file *scanner.File, idx uint32, resolver typeinfer.TypeResolver) (kind, subjectName string, variants []string) {
+	if file == nil || idx == 0 || resolver == nil || file.FlatType(idx) != "when_expression" {
+		return "", "", nil
+	}
+	subject := whenSubjectExpressionFlat(file, idx)
+	if subject == 0 {
+		return "", "", nil
+	}
+	candidates := whenSubjectTypeCandidatesFlat(file, subject, resolver)
+	for _, name := range candidates {
+		if vs := resolver.SealedVariants(name); len(vs) > 0 {
+			return "sealed", simpleTypeName(name), vs
+		}
+		if vs := resolver.EnumEntries(name); len(vs) > 0 {
+			return "enum", simpleTypeName(name), vs
+		}
+		if info := resolver.ClassHierarchy(name); info != nil {
+			for _, infoName := range []string{info.Name, info.FQN} {
+				if infoName == "" || infoName == name {
+					continue
+				}
+				if vs := resolver.SealedVariants(infoName); len(vs) > 0 {
+					return "sealed", simpleTypeName(infoName), vs
+				}
+				if vs := resolver.EnumEntries(infoName); len(vs) > 0 {
+					return "enum", simpleTypeName(infoName), vs
+				}
+			}
+		}
+	}
+	return "", "", nil
+}
+
 func whenSubjectExhaustiveVariantsFlat(file *scanner.File, idx uint32, resolver typeinfer.TypeResolver) (string, []string) {
 	if file == nil || idx == 0 || resolver == nil || file.FlatType(idx) != "when_expression" {
 		return "", nil
@@ -1305,4 +1343,115 @@ func whenConditionTypeTestName(file *scanner.File, condition uint32) string {
 		return ""
 	}
 	return strings.TrimSpace(file.FlatNodeText(userType))
+}
+
+// ---------------------------------------------------------------------------
+// NoElseInWhenSealedRule — the inverse of ElseCaseInsteadOfExhaustiveWhen.
+// Flags `when` expressions whose subject is a sealed type or enum, that
+// have no `else` branch, and that are missing one or more variants. Mimics
+// kotlinc's NO_ELSE_IN_WHEN / NON_EXHAUSTIVE_WHEN_STATEMENT diagnostics for
+// the cases the resolver can prove from source — sealed hierarchies and
+// enums declared in the workspace.
+//
+// Without a resolver the rule cannot identify variants and stays silent.
+// Library-defined sealed types (e.g. kotlin.Result) require classpath
+// metadata; until that lands the rule simply doesn't fire on them.
+// ---------------------------------------------------------------------------
+type NoElseInWhenSealedRule struct {
+	FlatDispatchBase
+	BaseRule
+}
+
+func (r *NoElseInWhenSealedRule) Confidence() float64 { return 0.9 }
+
+// whenConditionEnumEntryName extracts the entry name from a value-style
+// when_condition like `Color.RED` (navigation_expression) or a bare
+// `RED` (simple_identifier). Returns "" when the condition isn't a
+// recognizable enum-entry match.
+func whenConditionEnumEntryName(file *scanner.File, condition uint32) string {
+	if file == nil || file.FlatType(condition) != "when_condition" {
+		return ""
+	}
+	for child := file.FlatFirstChild(condition); child != 0; child = file.FlatNextSib(child) {
+		if !file.FlatIsNamed(child) {
+			continue
+		}
+		switch file.FlatType(child) {
+		case "navigation_expression":
+			if name := flatNavigationExpressionLastIdentifier(file, child); name != "" {
+				return name
+			}
+		case "simple_identifier":
+			return strings.TrimSpace(file.FlatNodeText(child))
+		}
+	}
+	return ""
+}
+
+func collectWhenCoveredVariants(file *scanner.File, idx uint32) (typeNames map[string]bool, entryNames map[string]bool) {
+	typeNames = map[string]bool{}
+	entryNames = map[string]bool{}
+	file.FlatForEachChild(idx, func(entry uint32) {
+		if file.FlatType(entry) != "when_entry" {
+			return
+		}
+		file.FlatForEachChild(entry, func(cond uint32) {
+			if file.FlatType(cond) != "when_condition" {
+				return
+			}
+			if name := whenConditionTypeTestName(file, cond); name != "" {
+				typeNames[name] = true
+			}
+			if name := whenConditionEnumEntryName(file, cond); name != "" {
+				entryNames[name] = true
+			}
+		})
+	})
+	return typeNames, entryNames
+}
+
+func missingSealedVariants(covered map[string]bool, variants []string) []string {
+	// Normalize covered names to also include their simple-name form so
+	// `is Result.Loading` matches a variant indexed as `Loading`.
+	coveredSet := make(map[string]bool, len(covered)*2)
+	for name := range covered {
+		coveredSet[name] = true
+		coveredSet[simpleTypeName(name)] = true
+	}
+	seen := map[string]bool{}
+	var missing []string
+	for _, v := range variants {
+		if v == "" {
+			continue
+		}
+		simple := simpleTypeName(v)
+		if seen[simple] {
+			continue
+		}
+		seen[simple] = true
+		if coveredSet[v] || coveredSet[simple] {
+			continue
+		}
+		missing = append(missing, simple)
+	}
+	return missing
+}
+
+func missingEnumEntries(covered map[string]bool, entries []string) []string {
+	seen := map[string]bool{}
+	var missing []string
+	for _, e := range entries {
+		if e == "" {
+			continue
+		}
+		if seen[e] {
+			continue
+		}
+		seen[e] = true
+		if covered[e] {
+			continue
+		}
+		missing = append(missing, e)
+	}
+	return missing
 }

--- a/internal/rules/potentialbugs_types_test.go
+++ b/internal/rules/potentialbugs_types_test.go
@@ -863,3 +863,128 @@ class Foo {
 		}
 	}
 }
+
+// --- NoElseInWhenSealed ---
+
+func TestNoElseInWhenSealed_MissingSealedVariant_Positive(t *testing.T) {
+	findings := runRuleByNameWithResolver(t, "NoElseInWhenSealed", `
+package test
+
+sealed class Result {
+    object Loading : Result()
+    data class Success(val value: String) : Result()
+    data class Failure(val error: Throwable) : Result()
+}
+
+fun render(r: Result): String = when (r) {
+    is Result.Loading -> "loading"
+    is Result.Success -> r.value
+}
+`)
+	if len(findings) == 0 {
+		t.Fatal("expected finding for missing sealed variant")
+	}
+}
+
+func TestNoElseInWhenSealed_AllVariantsCovered_Negative(t *testing.T) {
+	findings := runRuleByNameWithResolver(t, "NoElseInWhenSealed", `
+package test
+
+sealed class Result {
+    object Loading : Result()
+    data class Success(val value: String) : Result()
+    data class Failure(val error: Throwable) : Result()
+}
+
+fun render(r: Result): String = when (r) {
+    is Result.Loading -> "loading"
+    is Result.Success -> r.value
+    is Result.Failure -> r.error.message ?: "error"
+}
+`)
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings when all sealed variants covered, got %d", len(findings))
+	}
+}
+
+func TestNoElseInWhenSealed_HasElse_Negative(t *testing.T) {
+	findings := runRuleByNameWithResolver(t, "NoElseInWhenSealed", `
+package test
+
+sealed class Result {
+    object Loading : Result()
+    data class Success(val value: String) : Result()
+}
+
+fun render(r: Result): String = when (r) {
+    is Result.Loading -> "loading"
+    else -> "ready"
+}
+`)
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings when else branch present, got %d", len(findings))
+	}
+}
+
+func TestNoElseInWhenSealed_MissingEnumEntry_Positive(t *testing.T) {
+	findings := runRuleByNameWithResolver(t, "NoElseInWhenSealed", `
+package test
+
+enum class Color { RED, GREEN, BLUE }
+
+fun describe(c: Color): String = when (c) {
+    Color.RED -> "warm"
+    Color.BLUE -> "cool"
+}
+`)
+	if len(findings) == 0 {
+		t.Fatal("expected finding for missing enum entry")
+	}
+}
+
+func TestNoElseInWhenSealed_AllEnumEntriesCovered_Negative(t *testing.T) {
+	findings := runRuleByNameWithResolver(t, "NoElseInWhenSealed", `
+package test
+
+enum class Color { RED, GREEN, BLUE }
+
+fun describe(c: Color): String = when (c) {
+    Color.RED -> "warm"
+    Color.GREEN -> "fresh"
+    Color.BLUE -> "cool"
+}
+`)
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings when all enum entries covered, got %d", len(findings))
+	}
+}
+
+func TestNoElseInWhenSealed_NotSealedOrEnum_Negative(t *testing.T) {
+	findings := runRuleByNameWithResolver(t, "NoElseInWhenSealed", `
+package test
+
+fun classify(x: Int): String = when (x) {
+    1 -> "one"
+    2 -> "two"
+    else -> "many"
+}
+`)
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings on non-sealed/non-enum subject, got %d", len(findings))
+	}
+}
+
+func TestNoElseInWhenSealed_NoSubject_Negative(t *testing.T) {
+	findings := runRuleByNameWithResolver(t, "NoElseInWhenSealed", `
+package test
+
+fun classify(x: Int): String = when {
+    x > 0 -> "positive"
+    x < 0 -> "negative"
+    else -> "zero"
+}
+`)
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings on subject-less when, got %d", len(findings))
+	}
+}

--- a/internal/rules/registry_bootstrap.go
+++ b/internal/rules/registry_bootstrap.go
@@ -94,6 +94,7 @@ func init() {
 	registerPotentialbugsSmartCastRules()
 	registerPotentialbugsTypesRules()
 	registerCorrectnessOverrideRules()
+	registerCorrectnessAbstractRules()
 	registerPrivacyAnalyticsRules()
 	registerPrivacyPermissionsRules()
 	registerPrivacyStorageRules()

--- a/internal/rules/registry_bootstrap.go
+++ b/internal/rules/registry_bootstrap.go
@@ -93,6 +93,7 @@ func init() {
 	registerPotentialbugsPropertiesRules()
 	registerPotentialbugsSmartCastRules()
 	registerPotentialbugsTypesRules()
+	registerCorrectnessOverrideRules()
 	registerPrivacyAnalyticsRules()
 	registerPrivacyPermissionsRules()
 	registerPrivacyStorageRules()

--- a/internal/rules/registry_bootstrap.go
+++ b/internal/rules/registry_bootstrap.go
@@ -91,6 +91,7 @@ func init() {
 	registerPotentialbugsNullsafetyCastsRules()
 	registerPotentialbugsNullsafetyRedundantRules()
 	registerPotentialbugsPropertiesRules()
+	registerPotentialbugsSmartCastRules()
 	registerPotentialbugsTypesRules()
 	registerPrivacyAnalyticsRules()
 	registerPrivacyPermissionsRules()

--- a/internal/rules/registry_correctness_abstract.go
+++ b/internal/rules/registry_correctness_abstract.go
@@ -1,0 +1,20 @@
+package rules
+
+import (
+	api "github.com/kaeawc/krit/internal/rules/api"
+)
+
+func registerCorrectnessAbstractRules() {
+
+	// --- from correctness_abstract.go ---
+	{
+		r := &AbstractMemberNotImplementedRule{BaseRule: BaseRule{RuleName: "AbstractMemberNotImplemented", RuleSetName: "potential-bugs", Sev: "error", Desc: "Detects concrete classes that fail to implement abstract members declared on a supertype."}}
+		api.Register(&api.Rule{
+			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
+			NodeTypes: []string{"class_declaration"}, Confidence: 0.8, Implementation: r,
+			Needs: api.NeedsResolver,
+			Tags:  []string{"precompile"},
+			Check: r.check,
+		})
+	}
+}

--- a/internal/rules/registry_correctness_override.go
+++ b/internal/rules/registry_correctness_override.go
@@ -1,0 +1,20 @@
+package rules
+
+import (
+	api "github.com/kaeawc/krit/internal/rules/api"
+)
+
+func registerCorrectnessOverrideRules() {
+
+	// --- from correctness_override.go ---
+	{
+		r := &OverrideSignatureMismatchRule{BaseRule: BaseRule{RuleName: "OverrideSignatureMismatch", RuleSetName: "potential-bugs", Sev: "error", Desc: "Detects 'override' functions whose parameter count does not match any supertype member with the same name."}}
+		api.Register(&api.Rule{
+			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
+			NodeTypes: []string{"function_declaration"}, Confidence: 0.85, Implementation: r,
+			Needs: api.NeedsResolver,
+			Tags:  []string{"precompile"},
+			Check: r.check,
+		})
+	}
+}

--- a/internal/rules/registry_potentialbugs_exceptions.go
+++ b/internal/rules/registry_potentialbugs_exceptions.go
@@ -68,6 +68,7 @@ func registerPotentialbugsExceptionsRules() {
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
 			NodeTypes: []string{"try_expression"}, Confidence: 0.75, Implementation: r,
 			Needs: api.NeedsResolver,
+			Tags:  []string{"precompile"},
 			Check: r.checkFlatNode,
 		})
 	}
@@ -77,6 +78,7 @@ func registerPotentialbugsExceptionsRules() {
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
 			NodeTypes: []string{"statements"}, Confidence: 0.75, Fix: api.FixSemantic, Implementation: r,
 			Needs: api.NeedsTypeInfo | api.NeedsOracleDiagnostics,
+			Tags:  []string{"precompile"},
 			// Narrow by the four jump keywords the rule actually dispatches
 			// on. Without any jump keyword a file cannot produce an
 			// UNREACHABLE_CODE finding; USELESS_ELVIS diagnostics in files

--- a/internal/rules/registry_potentialbugs_exceptions.go
+++ b/internal/rules/registry_potentialbugs_exceptions.go
@@ -90,4 +90,14 @@ func registerPotentialbugsExceptionsRules() {
 			Check:                  r.checkNode,
 		})
 	}
+	{
+		r := &MissingReturnRule{BaseRule: BaseRule{RuleName: "MissingReturn", RuleSetName: "potential-bugs", Sev: "error", Desc: "Detects block-bodied functions with a non-Unit return type whose body does not terminate on every path."}}
+		api.Register(&api.Rule{
+			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
+			NodeTypes: []string{"function_declaration"}, Confidence: 0.85, Implementation: r,
+			Needs: api.NeedsResolver,
+			Tags:  []string{"precompile"},
+			Check: r.check,
+		})
+	}
 }

--- a/internal/rules/registry_potentialbugs_nullsafety_casts.go
+++ b/internal/rules/registry_potentialbugs_nullsafety_casts.go
@@ -36,6 +36,7 @@ func registerPotentialbugsNullsafetyCastsRules() {
 			// types for the conservative local fallback; no declarations traversal
 			// needed.
 			OracleDeclarationNeeds: &api.OracleDeclarationProfile{},
+			Tags:                   []string{"precompile"},
 			Implementation:         r,
 			Check:                  r.check,
 		})

--- a/internal/rules/registry_potentialbugs_smartcast.go
+++ b/internal/rules/registry_potentialbugs_smartcast.go
@@ -1,0 +1,19 @@
+package rules
+
+import (
+	api "github.com/kaeawc/krit/internal/rules/api"
+)
+
+func registerPotentialbugsSmartCastRules() {
+
+	// --- from potentialbugs_smartcast.go ---
+	{
+		r := &SmartCastInvalidatedRule{BaseRule: BaseRule{RuleName: "SmartCastInvalidated", RuleSetName: "potential-bugs", Sev: "error", Desc: "Detects smart-cast variables that are reassigned and then used without re-checking, which the compiler reports as SMARTCAST_IMPOSSIBLE."}}
+		api.Register(&api.Rule{
+			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
+			NodeTypes: []string{"if_expression"}, Confidence: 0.85, Implementation: r,
+			Tags:  []string{"precompile"},
+			Check: r.check,
+		})
+	}
+}

--- a/internal/rules/registry_potentialbugs_types.go
+++ b/internal/rules/registry_potentialbugs_types.go
@@ -352,6 +352,45 @@ func registerPotentialbugsTypesRules() {
 		})
 	}
 	{
+		r := &NoElseInWhenSealedRule{BaseRule: BaseRule{RuleName: "NoElseInWhenSealed", RuleSetName: "potential-bugs", Sev: "warning", Desc: "Detects when expressions on sealed classes or enums that are missing variants and have no else branch."}}
+		api.Register(&api.Rule{
+			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
+			NodeTypes: []string{"when_expression"}, Confidence: 0.9, Implementation: r,
+			Needs: api.NeedsResolver,
+			Tags:  []string{"precompile"},
+			Check: func(ctx *api.Context) {
+				idx, file := ctx.Idx, ctx.File
+				if ctx.Resolver == nil {
+					return
+				}
+				if whenHasElseBranchFlat(file, idx) {
+					return
+				}
+				if _, ok := file.FlatFindChild(idx, "when_subject"); !ok {
+					return
+				}
+				kind, subjectName, variants := whenSubjectExhaustiveKindFlat(file, idx, ctx.Resolver)
+				if kind == "" || len(variants) == 0 {
+					return
+				}
+				typeNames, entryNames := collectWhenCoveredVariants(file, idx)
+				var missing []string
+				switch kind {
+				case "sealed":
+					missing = missingSealedVariants(typeNames, variants)
+				case "enum":
+					missing = missingEnumEntries(entryNames, variants)
+				}
+				if len(missing) == 0 {
+					return
+				}
+				ctx.EmitAt(file.FlatRow(idx)+1, file.FlatCol(idx)+1,
+					fmt.Sprintf("'when' on %s '%s' is not exhaustive: missing %s. Add the missing branches or an 'else' clause.",
+						kind, subjectName, strings.Join(missing, ", ")))
+			},
+		})
+	}
+	{
 		r := &ElseCaseInsteadOfExhaustiveWhenRule{BaseRule: BaseRule{RuleName: "ElseCaseInsteadOfExhaustiveWhen", RuleSetName: "potential-bugs", Sev: "warning", Desc: "Detects when expressions on sealed classes or enums that use an else branch instead of exhaustive matching."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),

--- a/internal/rules/registry_potentialbugs_types.go
+++ b/internal/rules/registry_potentialbugs_types.go
@@ -357,6 +357,7 @@ func registerPotentialbugsTypesRules() {
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
 			NodeTypes: []string{"when_expression"}, Confidence: 0.75, Implementation: r,
 			Needs: api.NeedsResolver,
+			Tags:  []string{"precompile"},
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				if !whenHasElseBranchFlat(file, idx) {

--- a/internal/rules/registry_style_unused.go
+++ b/internal/rules/registry_style_unused.go
@@ -17,6 +17,7 @@ func registerStyleUnusedRules() {
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
 			NodeTypes: []string{"import_header"}, Confidence: 0.75, Fix: api.FixIdiomatic, Implementation: r,
+			Tags: []string{"precompile"},
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				shortName := importShortNameFlat(file, idx)
@@ -52,6 +53,7 @@ func registerStyleUnusedRules() {
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
 			NodeTypes: []string{"function_declaration"}, Confidence: 0.95, Fix: api.FixSemantic, Implementation: r,
+			Tags: []string{"precompile"},
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				if scanner.IsTestFile(file.Path) {
@@ -146,6 +148,7 @@ func registerStyleUnusedRules() {
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
 			NodeTypes: []string{"property_declaration", "variable_declaration"}, Confidence: 0.75, Fix: api.FixSemantic, Implementation: r,
+			Tags: []string{"precompile"},
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				if scanner.IsTestFile(file.Path) {

--- a/internal/scanner/dependents.go
+++ b/internal/scanner/dependents.go
@@ -1,0 +1,204 @@
+package scanner
+
+import (
+	"sort"
+	"strings"
+)
+
+// DependentsIndex is a reverse-dependency map keyed by imported FQN.
+// Given a changed file plus the FQNs that file declares (or removes),
+// callers can compute the tight set of source files whose rule output
+// might change. Used by watch-mode and LSP didChange to narrow
+// incremental rerun scope from "every file" to "files reachable from
+// the diff".
+//
+// The index records explicit imports only (`import a.b.C`). Wildcard
+// imports (`import a.b.*`) are recorded as the package name. Aliases
+// resolve to their underlying FQN.
+type DependentsIndex struct {
+	// importsByFile lists the imported FQNs for each source file. The
+	// entries are sorted and deduped so callers can perform set diffs
+	// without re-sorting.
+	importsByFile map[string][]string
+
+	// dependentsByFQN inverts importsByFile: given an FQN, list the
+	// files that imported it. Sorted for stable output.
+	dependentsByFQN map[string][]string
+
+	// dependentsByPackage covers wildcard imports. A file that imports
+	// "a.b.*" appears under "a.b". Callers that change a declaration in
+	// package "a.b.X" should consult both dependentsByFQN["a.b.X"] and
+	// dependentsByPackage["a.b"].
+	dependentsByPackage map[string][]string
+}
+
+// BuildDependentsIndex walks each file's import_header nodes and
+// constructs the per-file FQN list and its inverse. Pass parsed
+// Kotlin files; non-Kotlin files contribute nothing. Files with no
+// imports are still recorded with an empty slice so ImportsOfFile
+// distinguishes "indexed but importless" from "not indexed".
+func BuildDependentsIndex(files []*File) *DependentsIndex {
+	idx := &DependentsIndex{
+		importsByFile:       make(map[string][]string, len(files)),
+		dependentsByFQN:     map[string][]string{},
+		dependentsByPackage: map[string][]string{},
+	}
+	for _, f := range files {
+		if f == nil || f.Language != LangKotlin {
+			continue
+		}
+		fqns, packages := parseFileImports(f)
+		idx.importsByFile[f.Path] = fqns
+		for _, fqn := range fqns {
+			idx.dependentsByFQN[fqn] = append(idx.dependentsByFQN[fqn], f.Path)
+		}
+		for _, pkg := range packages {
+			idx.dependentsByPackage[pkg] = append(idx.dependentsByPackage[pkg], f.Path)
+		}
+	}
+	for fqn, files := range idx.dependentsByFQN {
+		sort.Strings(files)
+		idx.dependentsByFQN[fqn] = dedupeStrings(files)
+	}
+	for pkg, files := range idx.dependentsByPackage {
+		sort.Strings(files)
+		idx.dependentsByPackage[pkg] = dedupeStrings(files)
+	}
+	return idx
+}
+
+// ImportsOfFile returns the explicit-import FQNs declared in the given
+// file path. The returned slice is sorted and deduped. Returns nil for
+// files the index doesn't know about.
+func (d *DependentsIndex) ImportsOfFile(path string) []string {
+	if d == nil {
+		return nil
+	}
+	return d.importsByFile[path]
+}
+
+// FilesImporting returns the file paths that import the given FQN
+// explicitly. Sorted ascending. Wildcard importers are not included
+// here — use FilesImportingPackage for those.
+func (d *DependentsIndex) FilesImporting(fqn string) []string {
+	if d == nil {
+		return nil
+	}
+	return d.dependentsByFQN[fqn]
+}
+
+// FilesImportingPackage returns the file paths that import the given
+// package via a wildcard (`import pkg.*`). Sorted ascending.
+func (d *DependentsIndex) FilesImportingPackage(pkg string) []string {
+	if d == nil {
+		return nil
+	}
+	return d.dependentsByPackage[pkg]
+}
+
+// FilesAffectedBy returns the union of:
+//   - the changed files themselves
+//   - every file that explicitly imports any FQN in changedFQNs
+//   - every file with a wildcard import covering any FQN in changedFQNs
+//
+// The result is sorted and deduped. Used by watch-mode reruns to compute
+// "given that file F changed and declares FQNs X, which files do I need
+// to re-run rules on?" without scanning the whole project.
+//
+// changedFQNs may be nil, in which case only changedFiles are returned —
+// useful when a file's edits affected nothing externally observable.
+func (d *DependentsIndex) FilesAffectedBy(changedFiles, changedFQNs []string) []string {
+	out := map[string]bool{}
+	for _, f := range changedFiles {
+		out[f] = true
+	}
+	if d != nil {
+		for _, fqn := range changedFQNs {
+			for _, f := range d.dependentsByFQN[fqn] {
+				out[f] = true
+			}
+			if pkg := packageOfFQN(fqn); pkg != "" {
+				for _, f := range d.dependentsByPackage[pkg] {
+					out[f] = true
+				}
+			}
+		}
+	}
+	result := make([]string, 0, len(out))
+	for f := range out {
+		result = append(result, f)
+	}
+	sort.Strings(result)
+	return result
+}
+
+// parseFileImports walks the file's import_header nodes and returns the
+// explicit-import FQNs and wildcard packages. Aliases are recorded as
+// the underlying FQN; the alias name is irrelevant for reverse-dep
+// queries.
+func parseFileImports(file *File) (fqns []string, packages []string) {
+	if file == nil || file.FlatTree == nil {
+		return nil, nil
+	}
+	root := uint32(0)
+	walkImportHeaders(file, root, &fqns, &packages)
+	if len(fqns) > 1 {
+		sort.Strings(fqns)
+		fqns = dedupeStrings(fqns)
+	}
+	if len(packages) > 1 {
+		sort.Strings(packages)
+		packages = dedupeStrings(packages)
+	}
+	return fqns, packages
+}
+
+func walkImportHeaders(file *File, idx uint32, fqns *[]string, packages *[]string) {
+	if file.FlatType(idx) == "import_header" {
+		text := strings.TrimSpace(file.FlatNodeText(idx))
+		text = strings.TrimPrefix(text, "import ")
+		text = strings.TrimSpace(text)
+		if i := strings.Index(text, " as "); i >= 0 {
+			fqn := strings.TrimSpace(text[:i])
+			if fqn != "" {
+				*fqns = append(*fqns, fqn)
+			}
+			return
+		}
+		if strings.HasSuffix(text, ".*") {
+			pkg := strings.TrimSuffix(text, ".*")
+			if pkg != "" {
+				*packages = append(*packages, pkg)
+			}
+			return
+		}
+		if text != "" {
+			*fqns = append(*fqns, text)
+		}
+		return
+	}
+	for child := file.FlatFirstChild(idx); child != 0; child = file.FlatNextSib(child) {
+		walkImportHeaders(file, child, fqns, packages)
+	}
+}
+
+func packageOfFQN(fqn string) string {
+	last := strings.LastIndex(fqn, ".")
+	if last < 0 {
+		return ""
+	}
+	return fqn[:last]
+}
+
+func dedupeStrings(in []string) []string {
+	if len(in) == 0 {
+		return in
+	}
+	out := in[:1]
+	for _, s := range in[1:] {
+		if s != out[len(out)-1] {
+			out = append(out, s)
+		}
+	}
+	return out
+}

--- a/internal/scanner/dependents_test.go
+++ b/internal/scanner/dependents_test.go
@@ -1,0 +1,137 @@
+package scanner
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"testing"
+)
+
+func writeAndParseKotlin(t *testing.T, dir, name, content string) *File {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	f, err := ParseFile(path)
+	if err != nil {
+		t.Fatalf("parse %s: %v", path, err)
+	}
+	return f
+}
+
+func TestDependentsIndex_BasicImports(t *testing.T) {
+	dir := t.TempDir()
+	a := writeAndParseKotlin(t, dir, "A.kt", `package a
+import b.B
+import c.C as Aliased
+
+class A
+`)
+	b := writeAndParseKotlin(t, dir, "B.kt", `package b
+class B
+`)
+	idx := BuildDependentsIndex([]*File{a, b})
+
+	got := idx.ImportsOfFile(a.Path)
+	want := []string{"b.B", "c.C"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("ImportsOfFile(A) = %v, want %v", got, want)
+	}
+	if files := idx.FilesImporting("b.B"); !reflect.DeepEqual(files, []string{a.Path}) {
+		t.Errorf("FilesImporting(b.B) = %v, want [%s]", files, a.Path)
+	}
+	if files := idx.FilesImporting("c.C"); !reflect.DeepEqual(files, []string{a.Path}) {
+		t.Errorf("FilesImporting(c.C alias) = %v, want [%s]", files, a.Path)
+	}
+}
+
+func TestDependentsIndex_WildcardImports(t *testing.T) {
+	dir := t.TempDir()
+	a := writeAndParseKotlin(t, dir, "A.kt", `package a
+import b.*
+class A
+`)
+	idx := BuildDependentsIndex([]*File{a})
+	if files := idx.FilesImportingPackage("b"); !reflect.DeepEqual(files, []string{a.Path}) {
+		t.Errorf("FilesImportingPackage(b) = %v, want [%s]", files, a.Path)
+	}
+	if files := idx.FilesImporting("b.SomeClass"); len(files) != 0 {
+		t.Errorf("FilesImporting(b.SomeClass) = %v, want empty (only wildcard)", files)
+	}
+}
+
+func TestDependentsIndex_FilesAffectedBy(t *testing.T) {
+	dir := t.TempDir()
+	a := writeAndParseKotlin(t, dir, "A.kt", `package x
+import y.B
+class A
+`)
+	b := writeAndParseKotlin(t, dir, "B.kt", `package y
+class B
+`)
+	c := writeAndParseKotlin(t, dir, "C.kt", `package x
+import y.*
+class C
+`)
+	d := writeAndParseKotlin(t, dir, "D.kt", `package z
+class D
+`)
+	idx := BuildDependentsIndex([]*File{a, b, c, d})
+
+	// B.kt changed and declares y.B; A imports y.B explicitly, C imports y.*.
+	got := idx.FilesAffectedBy([]string{b.Path}, []string{"y.B"})
+	want := []string{a.Path, b.Path, c.Path}
+	sort.Strings(want)
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("FilesAffectedBy = %v, want %v", got, want)
+	}
+
+	// D.kt changed but nobody imports z.D — only D.kt itself.
+	got = idx.FilesAffectedBy([]string{d.Path}, []string{"z.D"})
+	if !reflect.DeepEqual(got, []string{d.Path}) {
+		t.Errorf("isolated change: got %v, want [%s]", got, d.Path)
+	}
+
+	// Multiple changed files: union with no FQN diff.
+	got = idx.FilesAffectedBy([]string{a.Path, c.Path}, nil)
+	want = []string{a.Path, c.Path}
+	sort.Strings(want)
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("changed-only: got %v, want %v", got, want)
+	}
+}
+
+func TestDependentsIndex_NilSafe(t *testing.T) {
+	var idx *DependentsIndex
+	if got := idx.ImportsOfFile("anything"); got != nil {
+		t.Errorf("nil ImportsOfFile got %v", got)
+	}
+	if got := idx.FilesImporting("anything"); got != nil {
+		t.Errorf("nil FilesImporting got %v", got)
+	}
+	got := idx.FilesAffectedBy([]string{"f"}, []string{"x.Y"})
+	if !reflect.DeepEqual(got, []string{"f"}) {
+		t.Errorf("nil FilesAffectedBy got %v, want [f]", got)
+	}
+}
+
+func TestDependentsIndex_DropsNonKotlin(t *testing.T) {
+	dir := t.TempDir()
+	javaPath := filepath.Join(dir, "Foo.java")
+	if err := os.WriteFile(javaPath, []byte("package x; class Foo {}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	jf, err := ParseJavaFile(javaPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	idx := BuildDependentsIndex([]*File{jf})
+	if got := idx.ImportsOfFile(javaPath); got != nil {
+		t.Errorf("Java file should not be indexed; got imports %v", got)
+	}
+}

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -114,6 +114,14 @@ type File struct {
 	FlatTree    *FlatTree
 	lineOffsets []int // cached byte offset of each line start
 
+	// Generated is true when the file came from a build/generated/**
+	// directory and was kept by the parse phase's known-safe-generator
+	// allowlist (Hilt, KSP, Kapt, ViewBinding, DataBinding, etc.).
+	// Rules that should not lint generated code — but still want their
+	// resolver to index it — gate on this. Pure source files always
+	// have Generated == false.
+	Generated bool
+
 	// Metadata carries language-specific parsed structures (e.g.
 	// *android.ManifestMeta, *android.ResourceMeta, *android.BuildConfig)
 	// for non-source-language files. Nil for Kotlin/Java.

--- a/internal/typeinfer/api.go
+++ b/internal/typeinfer/api.go
@@ -42,7 +42,53 @@ type defaultResolver struct {
 	// IndexFilesParallel (their tree-sitter root differs), so this
 	// avoids a per-call AST walk for the implicit-java.lang shadow check.
 	javaTopLevelNames sync.Map // map[string]map[string]struct{}
+
+	// binSymbols is an optional classpath-aware reader consulted in
+	// ClassHierarchy when source-side maps miss. nil = no fallback,
+	// the resolver behaves exactly as before (KnownClassHierarchy /
+	// KnownInterfaces stubs only). Wired by SetBinSymbolReader.
+	binSymbols binarySymbolReader
 }
+
+// binarySymbolReader is the local interface shape typeinfer consumes
+// from the binsymbols package. Defined here so typeinfer doesn't import
+// binsymbols and create a cycle if a future caller needs to embed
+// resolver state in a binsymbols-aware producer.
+type binarySymbolReader interface {
+	LookupClass(fqn string) *binarySymbolClass
+}
+
+// binarySymbolClass is the local mirror of binsymbols.Class. The
+// SetBinSymbolReader entry point converts at the boundary so the
+// typeinfer package doesn't import binsymbols.
+type binarySymbolClass struct {
+	Name       string
+	FQN        string
+	Kind       string
+	Supertypes []string
+	IsAbstract bool
+	IsSealed   bool
+}
+
+// SetBinSymbolReader wires a classpath-aware binary symbol reader.
+// Pass nil to clear. The reader is consulted in ClassHierarchy after
+// source-side maps and before the hardcoded KnownClassHierarchy /
+// KnownInterfaces tables, so it can resolve refs that the workspace
+// imports from JARs/AARs.
+//
+// lookup must be safe for concurrent use; ClassHierarchy is called
+// from rule dispatch which fans out across files in parallel.
+func (r *defaultResolver) SetBinSymbolReader(lookup func(fqn string) *binarySymbolClass) {
+	if lookup == nil {
+		r.binSymbols = nil
+		return
+	}
+	r.binSymbols = binarySymbolReaderFunc(lookup)
+}
+
+type binarySymbolReaderFunc func(fqn string) *binarySymbolClass
+
+func (f binarySymbolReaderFunc) LookupClass(fqn string) *binarySymbolClass { return f(fqn) }
 
 // NewResolver creates a new resolver backed by source-level analysis.
 func NewResolver() *defaultResolver { //nolint:revive // tests access unexported fields directly
@@ -912,6 +958,22 @@ func (r *defaultResolver) ClassHierarchy(typeName string) *ClassInfo {
 	if info, ok := r.classes[typeName]; ok {
 		return info
 	}
+	// Classpath-aware fallback. Consulted after source-side maps so any
+	// workspace-declared type wins over a same-FQN library entry, and
+	// before hardcoded tables so binary readers can refine the small
+	// stdlib stubs.
+	if r.binSymbols != nil {
+		if c := r.binSymbols.LookupClass(typeName); c != nil {
+			return &ClassInfo{
+				Name:       coalesceString(c.Name, simpleNameOf(c.FQN)),
+				FQN:        coalesceString(c.FQN, typeName),
+				Kind:       c.Kind,
+				Supertypes: c.Supertypes,
+				IsSealed:   c.IsSealed,
+				IsAbstract: c.IsAbstract,
+			}
+		}
+	}
 	// Fall back to known framework hierarchy (by FQN)
 	if supertypes, ok := KnownClassHierarchy[typeName]; ok {
 		return &ClassInfo{Name: simpleNameOf(typeName), FQN: typeName, Supertypes: supertypes}
@@ -929,6 +991,15 @@ func (r *defaultResolver) ClassHierarchy(typeName string) *ClassInfo {
 		}
 	}
 	return nil
+}
+
+func coalesceString(values ...string) string {
+	for _, v := range values {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
 }
 
 func (r *defaultResolver) SealedVariants(sealedTypeName string) []string {

--- a/internal/typeinfer/binsymbols_test.go
+++ b/internal/typeinfer/binsymbols_test.go
@@ -1,0 +1,92 @@
+package typeinfer
+
+import (
+	"testing"
+
+	"github.com/kaeawc/krit/internal/scanner"
+)
+
+func TestSetBinSymbolReader_FallbackOnSourceMiss(t *testing.T) {
+	r := NewResolver()
+	called := 0
+	r.SetBinSymbolReader(func(fqn string) *binarySymbolClass {
+		called++
+		if fqn == "androidx.fragment.app.Fragment" {
+			return &binarySymbolClass{
+				Name:       "Fragment",
+				FQN:        "androidx.fragment.app.Fragment",
+				Kind:       "class",
+				Supertypes: []string{"androidx.activity.ComponentActivity"},
+				IsAbstract: false,
+			}
+		}
+		return nil
+	})
+
+	got := r.ClassHierarchy("androidx.fragment.app.Fragment")
+	if got == nil {
+		t.Fatal("expected ClassHierarchy to fall through to binary reader")
+	}
+	if got.Name != "Fragment" || got.FQN != "androidx.fragment.app.Fragment" {
+		t.Errorf("ClassHierarchy = %+v, want Fragment", got)
+	}
+	if got.Kind != "class" {
+		t.Errorf("Kind = %q, want \"class\"", got.Kind)
+	}
+	if len(got.Supertypes) != 1 || got.Supertypes[0] != "androidx.activity.ComponentActivity" {
+		t.Errorf("Supertypes = %v", got.Supertypes)
+	}
+	if called == 0 {
+		t.Error("binary reader was not consulted")
+	}
+
+	// Unknown FQN: reader returns nil, then hardcoded tables are tried.
+	if got := r.ClassHierarchy("totally.unknown.Type"); got != nil {
+		t.Errorf("expected nil for unknown type, got %+v", got)
+	}
+}
+
+func TestSetBinSymbolReader_SourceWinsOverBinary(t *testing.T) {
+	src := `
+package com.example
+class Local
+`
+	file := parseTestFile(t, src)
+	r := NewResolver()
+	r.IndexFilesParallel([]*scanner.File{file}, 1)
+	r.SetBinSymbolReader(func(fqn string) *binarySymbolClass {
+		if fqn == "Local" || fqn == "com.example.Local" {
+			return &binarySymbolClass{
+				Name:       "Local",
+				FQN:        "com.example.Local",
+				Kind:       "interface", // would be wrong vs source
+				Supertypes: []string{"binary.Stub"},
+			}
+		}
+		return nil
+	})
+	got := r.ClassHierarchy("Local")
+	if got == nil {
+		t.Fatal("expected source-side hit")
+	}
+	if got.Kind == "interface" {
+		t.Errorf("source class should win; got binary Kind %q", got.Kind)
+	}
+	if len(got.Supertypes) > 0 && got.Supertypes[0] == "binary.Stub" {
+		t.Errorf("source supertypes should win; got %v", got.Supertypes)
+	}
+}
+
+func TestSetBinSymbolReader_NilClears(t *testing.T) {
+	r := NewResolver()
+	r.SetBinSymbolReader(func(string) *binarySymbolClass {
+		return &binarySymbolClass{Name: "X", FQN: "X"}
+	})
+	if got := r.ClassHierarchy("X"); got == nil {
+		t.Fatal("setup precondition failed")
+	}
+	r.SetBinSymbolReader(nil)
+	if got := r.ClassHierarchy("X"); got != nil {
+		t.Errorf("expected nil after clear, got %+v", got)
+	}
+}

--- a/internal/typeinfer/declarations.go
+++ b/internal/typeinfer/declarations.go
@@ -508,13 +508,17 @@ func (r *defaultResolver) extractMembersFlat(bodyIdx uint32, file *scanner.File,
 			}
 			mods := flatReadModifierFlags(file, memberIdx)
 			retType := r.extractFunctionReturnTypeFlat(memberIdx, file, it)
+			params := r.extractFunctionParamsFlat(memberIdx, file, it)
+			typeParams := flatExtractFunctionTypeParameters(file, memberIdx)
 			members = append(members, MemberInfo{
-				Name:       name,
-				Kind:       "function",
-				Type:       retType,
-				Visibility: mods.visibility,
-				IsOverride: mods.override,
-				IsAbstract: mods.abstract,
+				Name:           name,
+				Kind:           "function",
+				Type:           retType,
+				Visibility:     mods.visibility,
+				IsOverride:     mods.override,
+				IsAbstract:     mods.abstract,
+				Params:         params,
+				TypeParameters: typeParams,
 			})
 		case "property_declaration":
 			name := flatMemberName(file, memberIdx)
@@ -579,4 +583,111 @@ func (r *defaultResolver) extractFunctionReturnTypeFlat(funcIdx uint32, file *sc
 		}
 	}
 	return nil
+}
+
+// extractFunctionParamsFlat extracts the parameter list from a
+// function_declaration. Returns nil for parameter-less functions or
+// declarations whose parameter list cannot be located. Each parameter's
+// type is resolved best-effort: same-workspace and stdlib types yield
+// concrete ResolvedType values; library-only types return TypeUnknown
+// values until classpath-aware resolution lands.
+func (r *defaultResolver) extractFunctionParamsFlat(funcIdx uint32, file *scanner.File, it *ImportTable) []ParamInfo {
+	if file == nil || funcIdx == 0 {
+		return nil
+	}
+	params := flatFindNamedChildOfType(file, funcIdx, "function_value_parameters")
+	if params == 0 {
+		return nil
+	}
+	var out []ParamInfo
+	for child := file.FlatFirstChild(params); child != 0; child = file.FlatNextSib(child) {
+		if file.FlatType(child) != "parameter" {
+			continue
+		}
+		info := r.parameterInfoFlat(child, file, it)
+		if info.Name == "" {
+			continue
+		}
+		out = append(out, info)
+	}
+	return out
+}
+
+func (r *defaultResolver) parameterInfoFlat(parameterIdx uint32, file *scanner.File, it *ImportTable) ParamInfo {
+	name, typeNode := flatParameterNameAndType(file, parameterIdx)
+	if name == "" {
+		return ParamInfo{}
+	}
+	var typ *ResolvedType
+	if typeNode != 0 {
+		typ = r.resolveTypeNodeFlat(typeNode, file, it)
+	}
+	if typ == nil {
+		typ = UnknownType()
+	}
+	return ParamInfo{Name: name, Type: typ, HasDefault: flatParameterHasDefault(file, parameterIdx)}
+}
+
+func flatParameterNameAndType(file *scanner.File, parameterIdx uint32) (name string, typeNode uint32) {
+	seenColon := false
+	for sub := file.FlatFirstChild(parameterIdx); sub != 0; sub = file.FlatNextSib(sub) {
+		switch file.FlatType(sub) {
+		case "simple_identifier":
+			if name == "" && !seenColon {
+				name = strings.TrimSpace(file.FlatNodeText(sub))
+			}
+		case ":":
+			seenColon = true
+		case "user_type", "nullable_type", "type_identifier", "function_type":
+			if seenColon && typeNode == 0 {
+				typeNode = sub
+			}
+		}
+	}
+	return name, typeNode
+}
+
+// flatParameterHasDefault reports whether the parameter at parameterIdx
+// is followed by `=` (its default-value expression) before the next
+// parameter delimiter. Tree-sitter Kotlin emits the `=` as a sibling of
+// the parameter node, not a child.
+func flatParameterHasDefault(file *scanner.File, parameterIdx uint32) bool {
+	for next := file.FlatNextSib(parameterIdx); next != 0; next = file.FlatNextSib(next) {
+		t := file.FlatType(next)
+		if t == "," || t == ")" {
+			return false
+		}
+		if t == "=" {
+			return true
+		}
+	}
+	return false
+}
+
+// flatExtractFunctionTypeParameters returns the simple names of generic
+// type parameters declared on a function. Returns nil when the function
+// has no type parameters.
+func flatExtractFunctionTypeParameters(file *scanner.File, funcIdx uint32) []string {
+	if file == nil || funcIdx == 0 {
+		return nil
+	}
+	tp := flatFindNamedChildOfType(file, funcIdx, "type_parameters")
+	if tp == 0 {
+		return nil
+	}
+	var out []string
+	for child := file.FlatFirstChild(tp); child != 0; child = file.FlatNextSib(child) {
+		if file.FlatType(child) != "type_parameter" {
+			continue
+		}
+		for sub := file.FlatFirstChild(child); sub != 0; sub = file.FlatNextSib(sub) {
+			if file.FlatType(sub) == "type_identifier" || file.FlatType(sub) == "simple_identifier" {
+				if name := strings.TrimSpace(file.FlatNodeText(sub)); name != "" {
+					out = append(out, name)
+					break
+				}
+			}
+		}
+	}
+	return out
 }

--- a/internal/typeinfer/declarations_test.go
+++ b/internal/typeinfer/declarations_test.go
@@ -65,3 +65,75 @@ fun topLevel(): String {
 		t.Fatal("expected RootScope")
 	}
 }
+
+func TestExtractMembersFlat_PopulatesFunctionParams(t *testing.T) {
+	src := `
+package com.example
+
+class Holder {
+    fun greet(name: String, count: Int = 1, greeting: String?): String {
+        return "hi"
+    }
+
+    fun <T : Any, R> transform(input: T): R = TODO()
+
+    val identifier: Int = 42
+}
+`
+	file := parseTestFile(t, src)
+	fi := IndexFileParallel(file)
+	if fi == nil {
+		t.Fatal("expected FileTypeInfo")
+	}
+	var holder *ClassInfo
+	for _, ci := range fi.Classes {
+		if ci != nil && ci.Name == "Holder" {
+			holder = ci
+			break
+		}
+	}
+	if holder == nil {
+		t.Fatal("expected Holder class")
+	}
+	var greet, transform, identifier *MemberInfo
+	for i := range holder.Members {
+		m := &holder.Members[i]
+		switch m.Name {
+		case "greet":
+			greet = m
+		case "transform":
+			transform = m
+		case "identifier":
+			identifier = m
+		}
+	}
+	if greet == nil {
+		t.Fatal("expected greet member")
+	}
+	if len(greet.Params) != 3 {
+		t.Fatalf("greet expected 3 params, got %d (%+v)", len(greet.Params), greet.Params)
+	}
+	if greet.Params[0].Name != "name" || greet.Params[0].Type == nil || greet.Params[0].Type.Name != "String" {
+		t.Errorf("greet param 0 = %+v, want name:String", greet.Params[0])
+	}
+	if !greet.Params[1].HasDefault {
+		t.Errorf("greet param 1 (count) HasDefault = false, want true")
+	}
+	if greet.Params[2].Type == nil || !greet.Params[2].Type.Nullable {
+		t.Errorf("greet param 2 (greeting) Nullable = false, want true")
+	}
+
+	if transform == nil {
+		t.Fatal("expected transform member")
+	}
+	if got := transform.TypeParameters; len(got) != 2 || got[0] != "T" || got[1] != "R" {
+		t.Errorf("transform.TypeParameters = %v, want [T R]", got)
+	}
+
+	if identifier == nil {
+		t.Fatal("expected identifier property")
+	}
+	if identifier.Params != nil {
+		t.Errorf("property.Params should be nil, got %+v", identifier.Params)
+	}
+}

--- a/internal/typeinfer/helpers.go
+++ b/internal/typeinfer/helpers.go
@@ -99,6 +99,16 @@ func flatReadModifierFlags(file *scanner.File, idx uint32) modifierFlags {
 	if file == nil || file.FlatTree == nil || idx == 0 {
 		return flags
 	}
+	// Tree-sitter parses `enum class X` and `sealed class X` with the
+	// enum/sealed keyword as a direct child of class_declaration rather
+	// than wrapped inside a `modifiers` node. Walk both: the direct
+	// children for class-level keywords, and the dedicated `modifiers`
+	// subtree for visibility/data/inner/etc.
+	for child := file.FlatFirstChild(idx); child != 0; child = file.FlatNextSib(child) {
+		if t := file.FlatType(child); t == "enum" || t == "sealed" || t == "data" || t == "inner" || t == "abstract" || t == "open" || t == "private" || t == "internal" || t == "protected" || t == "override" {
+			applyModifierText(&flags, file.FlatNodeText(child))
+		}
+	}
 	mods := flatFindNamedChildOfType(file, idx, "modifiers")
 	if mods == 0 {
 		return flags

--- a/internal/typeinfer/index_cache.go
+++ b/internal/typeinfer/index_cache.go
@@ -15,7 +15,10 @@ import (
 
 const (
 	typeIndexCacheDirName = "type-index-cache"
-	typeIndexCacheVersion = 1
+	// Bumped to 2 when MemberInfo gained Params []ParamInfo and
+	// TypeParameters []string. Older cache payloads decode the prior
+	// MemberInfo shape and are silently dropped on version mismatch.
+	typeIndexCacheVersion = 2
 )
 
 var (

--- a/internal/typeinfer/resolver.go
+++ b/internal/typeinfer/resolver.go
@@ -53,11 +53,30 @@ type ClassInfo struct {
 // MemberInfo holds information about a class member.
 type MemberInfo struct {
 	Name       string
-	Kind       string // "function", "property"
-	Type       *ResolvedType
-	Visibility string // "public", "private", "internal", "protected"
+	Kind       string        // "function", "property"
+	Type       *ResolvedType // function: return type; property: declared type
+	Visibility string        // "public", "private", "internal", "protected"
 	IsOverride bool
 	IsAbstract bool
+	// Params is the parameter list for function members. Nil for
+	// properties or for functions where parameters could not be
+	// extracted. The order matches the source declaration. Each
+	// ParamInfo records the parameter's simple name and best-effort
+	// resolved type — types from same-workspace declarations populate
+	// fully; library-typed parameters carry only the simple name with
+	// a TypeUnknown ResolvedType until classpath-aware resolution lands.
+	Params []ParamInfo
+	// TypeParameters is the simple list of generic type parameter names
+	// declared on the function (e.g. ["T", "R"] for `fun <T, R> f()`).
+	// Populated for function members; nil for properties.
+	TypeParameters []string
+}
+
+// ParamInfo describes a function parameter as recorded in MemberInfo.
+type ParamInfo struct {
+	Name       string
+	Type       *ResolvedType
+	HasDefault bool
 }
 
 // ImportTable maps simple names to FQNs for a single file.

--- a/internal/typeinfer/stdlib.go
+++ b/internal/typeinfer/stdlib.go
@@ -514,8 +514,13 @@ func init() {
 	// -------------------------------------------------------------------------
 	// Nothing-returning top-level functions
 	// -------------------------------------------------------------------------
-	StdlibMethods["_.TODO"] = &StdlibMethod{ReturnType: &ResolvedType{Name: "Nothing", FQN: "kotlin.Nothing", Kind: TypeNothing}, ReturnTypeArgIndex: -1}
-	StdlibMethods["_.error"] = &StdlibMethod{ReturnType: &ResolvedType{Name: "Nothing", FQN: "kotlin.Nothing", Kind: TypeNothing}, ReturnTypeArgIndex: -1}
+	// Only stdlib globals with no plausible user-defined conflict are listed
+	// here. Workspace functions whose declared return type is Nothing are
+	// resolved via r.functions in the resolver and don't need entries.
+	nothing := &StdlibMethod{ReturnType: &ResolvedType{Name: "Nothing", FQN: "kotlin.Nothing", Kind: TypeNothing}, ReturnTypeArgIndex: -1}
+	StdlibMethods["_.TODO"] = nothing
+	StdlibMethods["_.error"] = nothing
+	StdlibMethods["_.exitProcess"] = nothing
 }
 
 // LookupStdlibMethod looks up a stdlib method by receiver type name and method name.

--- a/tests/fixtures/negative/potential-bugs/AbstractMemberNotImplemented.kt
+++ b/tests/fixtures/negative/potential-bugs/AbstractMemberNotImplemented.kt
@@ -1,0 +1,36 @@
+package fixtures.negative.potentialbugs
+
+interface Greeter {
+    fun greet(name: String): String
+    fun farewell()
+}
+
+abstract class Base {
+    abstract fun handle()
+}
+
+interface Named {
+    val name: String
+}
+
+// All members implemented in body.
+class FullGreeter : Greeter {
+    override fun greet(name: String): String = "Hi $name"
+    override fun farewell() {}
+}
+
+// `name` provided via primary-constructor `override val`.
+class NamedThing(override val name: String) : Named
+
+// Abstract class doesn't have to implement anything.
+abstract class StillAbstract : Greeter
+
+// No supertypes — silent.
+class Standalone {
+    fun foo() = 42
+}
+
+// Concrete class extending abstract Base, implements abstract method.
+class ImplBase : Base() {
+    override fun handle() {}
+}

--- a/tests/fixtures/negative/potential-bugs/MissingReturn.kt
+++ b/tests/fixtures/negative/potential-bugs/MissingReturn.kt
@@ -1,0 +1,83 @@
+package fixtures.negative.potentialbugs
+
+sealed class Result {
+    object Loading : Result()
+    data class Success(val value: String) : Result()
+}
+
+class MissingReturn {
+    // Implicit Unit return — no issue.
+    fun unit() {
+        println("ok")
+    }
+
+    // Explicit Unit return — no issue.
+    fun explicitUnit(): Unit {
+        println("ok")
+    }
+
+    // Returns Nothing — no issue (Nothing-typed functions don't return normally).
+    fun crash(): Nothing {
+        throw IllegalStateException("boom")
+    }
+
+    // Last statement is a return.
+    fun normalReturn(x: Int): Int {
+        return x + 1
+    }
+
+    // Last statement is a throw.
+    fun alwaysThrow(): Int {
+        throw IllegalStateException("not implemented")
+    }
+
+    // Last statement is TODO() (Nothing-returning).
+    fun pendingImpl(): String {
+        TODO("not yet")
+    }
+
+    // Expression body — implicitly returns its expression.
+    fun expr(x: Int): Int = x + 1
+
+    // Expression body via when — exhaustive.
+    fun classify(x: Int): String = when {
+        x > 0 -> "positive"
+        x < 0 -> "negative"
+        else -> "zero"
+    }
+
+    // if with both branches returning.
+    fun branchesReturn(x: Int): Int {
+        if (x > 0) {
+            return x
+        } else {
+            return -x
+        }
+    }
+
+    // when with else, all branches return.
+    fun handle(x: Int): Int {
+        when (x) {
+            0 -> return 0
+            else -> return -x
+        }
+    }
+
+    // when on sealed type, all variants return.
+    fun render(r: Result): String {
+        when (r) {
+            is Result.Loading -> return "loading"
+            is Result.Success -> return r.value
+        }
+    }
+
+    // Abstract — no body, no issue.
+    abstract class Holder {
+        abstract fun get(): Int
+    }
+
+    // Interface — no body, no issue.
+    interface Provider {
+        fun fetch(): String
+    }
+}

--- a/tests/fixtures/negative/potential-bugs/NoElseInWhenSealed.kt
+++ b/tests/fixtures/negative/potential-bugs/NoElseInWhenSealed.kt
@@ -1,0 +1,52 @@
+package fixtures.negative.potentialbugs
+
+sealed class Result {
+    object Loading : Result()
+    data class Success(val value: String) : Result()
+    data class Failure(val error: Throwable) : Result()
+}
+
+enum class Color { RED, GREEN, BLUE }
+
+class NoElseInWhenSealed {
+    // All sealed variants covered — no missing branches.
+    fun renderResult(r: Result): String = when (r) {
+        is Result.Loading -> "loading"
+        is Result.Success -> r.value
+        is Result.Failure -> r.error.message ?: "error"
+    }
+
+    // Has an else branch — out of scope (handled by ElseCaseInsteadOfExhaustiveWhen).
+    fun renderWithElse(r: Result): String = when (r) {
+        is Result.Loading -> "loading"
+        else -> "ready"
+    }
+
+    // All enum entries covered — no missing branches.
+    fun describe(c: Color): String = when (c) {
+        Color.RED -> "warm"
+        Color.GREEN -> "fresh"
+        Color.BLUE -> "cool"
+    }
+
+    // when{} without subject — not exhaustiveness-checked.
+    fun classify(x: Int): String = when {
+        x > 0 -> "positive"
+        x < 0 -> "negative"
+        else -> "zero"
+    }
+
+    // Subject type is not sealed/enum — the rule cannot determine variants.
+    fun describeAny(x: Any): String = when (x) {
+        is Int -> "int"
+        is String -> "string"
+        else -> "other"
+    }
+
+    // Plain Int — not sealed/enum.
+    fun classify2(x: Int): String = when (x) {
+        1 -> "one"
+        2 -> "two"
+        else -> "many"
+    }
+}

--- a/tests/fixtures/negative/potential-bugs/OverrideSignatureMismatch.kt
+++ b/tests/fixtures/negative/potential-bugs/OverrideSignatureMismatch.kt
@@ -1,0 +1,29 @@
+package fixtures.negative.potentialbugs
+
+interface Greeter {
+    fun greet(name: String): String
+    fun farewell()
+}
+
+class CorrectGreeter : Greeter {
+    override fun greet(name: String): String = "Hi $name"
+    override fun farewell() {}
+}
+
+// override of a library/framework member: the supertype isn't visible
+// to the source resolver, so the rule should stay silent.
+abstract class Logger
+class MyLogger : Logger() {
+    override fun toString(): String = "MyLogger"
+}
+
+// override with multiple-arity overloads on supertype — at least one matches.
+abstract class Multi {
+    abstract fun handle()
+    abstract fun handle(x: Int)
+}
+
+class HandleImpl : Multi() {
+    override fun handle() {}
+    override fun handle(x: Int) {}
+}

--- a/tests/fixtures/negative/potential-bugs/SmartCastInvalidated.kt
+++ b/tests/fixtures/negative/potential-bugs/SmartCastInvalidated.kt
@@ -1,0 +1,41 @@
+package fixtures.negative.potentialbugs
+
+class SmartCastInvalidated {
+    // val cannot be reassigned — smart cast holds.
+    fun valNotReassigned(s: String?): Int {
+        if (s != null) {
+            return s.length
+        }
+        return 0
+    }
+
+    // var declared, but never reassigned inside the if-body — smart cast holds.
+    fun varNotReassigned(): Int {
+        var s: String? = "hi"
+        if (s != null) {
+            return s.length
+        }
+        return 0
+    }
+
+    // Reassigned but accessed via safe call (?.) — explicitly null-aware.
+    fun reassignedSafeCall(): Int {
+        var s: String? = "hi"
+        if (s != null) {
+            s = null
+            return s?.length ?: 0
+        }
+        return 0
+    }
+
+    // Use is BEFORE reassignment, not after.
+    fun usedBeforeReassignment(): Int {
+        var s: String? = "hi"
+        if (s != null) {
+            val len = s.length
+            s = null
+            return len
+        }
+        return 0
+    }
+}

--- a/tests/fixtures/positive/potential-bugs/AbstractMemberNotImplemented.kt
+++ b/tests/fixtures/positive/potential-bugs/AbstractMemberNotImplemented.kt
@@ -1,0 +1,21 @@
+package fixtures.positive.potentialbugs
+
+interface Greeter {
+    fun greet(name: String): String
+    fun farewell()
+}
+
+abstract class Base {
+    abstract fun handle()
+}
+
+// Missing greet AND farewell from Greeter.
+class HollowGreeter : Greeter
+
+// Implements greet but not farewell.
+class HalfGreeter : Greeter {
+    override fun greet(name: String): String = "Hi $name"
+}
+
+// Concrete class extends abstract Base without implementing handle.
+class HollowConcrete : Base()

--- a/tests/fixtures/positive/potential-bugs/MissingReturn.kt
+++ b/tests/fixtures/positive/potential-bugs/MissingReturn.kt
@@ -1,0 +1,36 @@
+package fixtures.positive.potentialbugs
+
+class MissingReturn {
+    // Empty body, non-Unit return type.
+    fun emptyBody(): Int {
+    }
+
+    // Body with statement, no return.
+    fun fallThrough(x: Int): Int {
+        println("got $x")
+    }
+
+    // when used as a statement without exhaustive coverage and without return on every branch.
+    fun whenWithoutElse(x: Int): String {
+        when (x) {
+            1 -> "one"
+            2 -> "two"
+        }
+    }
+
+    // if without else.
+    fun ifWithoutElse(x: Int): Int {
+        if (x > 0) {
+            return x
+        }
+    }
+
+    // if with else but only one branch returns.
+    fun ifWithPartialReturn(x: Int): Int {
+        if (x > 0) {
+            return x
+        } else {
+            println("negative")
+        }
+    }
+}

--- a/tests/fixtures/positive/potential-bugs/NoElseInWhenSealed.kt
+++ b/tests/fixtures/positive/potential-bugs/NoElseInWhenSealed.kt
@@ -1,0 +1,40 @@
+package fixtures.positive.potentialbugs
+
+sealed class Result {
+    object Loading : Result()
+    data class Success(val value: String) : Result()
+    data class Failure(val error: Throwable) : Result()
+}
+
+enum class Color { RED, GREEN, BLUE }
+
+class NoElseInWhenSealed {
+    // Missing variant on sealed type, no else.
+    fun renderResult(r: Result): String = when (r) {
+        is Result.Loading -> "loading"
+        is Result.Success -> r.value
+        // missing: Failure
+    }
+
+    // Missing variant on sealed type, statement form.
+    fun handle(r: Result) {
+        when (r) {
+            is Result.Loading -> println("loading")
+            is Result.Success -> println(r.value)
+            // missing: Failure
+        }
+    }
+
+    // Missing entry on enum, no else.
+    fun describe(c: Color): String = when (c) {
+        Color.RED -> "warm"
+        Color.BLUE -> "cool"
+        // missing: GREEN
+    }
+
+    // Bare entry names also detected.
+    fun describeBare(c: Color): String = when (c) {
+        Color.RED -> "warm"
+        // missing: GREEN, BLUE
+    }
+}

--- a/tests/fixtures/positive/potential-bugs/OverrideSignatureMismatch.kt
+++ b/tests/fixtures/positive/potential-bugs/OverrideSignatureMismatch.kt
@@ -1,0 +1,15 @@
+package fixtures.positive.potentialbugs
+
+interface Greeter {
+    fun greet(name: String): String
+    fun farewell()
+}
+
+class WrongCountGreeter : Greeter {
+    // Mismatch: super has 1 param, this has 2.
+    override fun greet(name: String, locale: String): String = "$name $locale"
+
+    // Mismatch: super has 0 params, this has 1.
+    override fun farewell(message: String) {
+    }
+}

--- a/tests/fixtures/positive/potential-bugs/SmartCastInvalidated.kt
+++ b/tests/fixtures/positive/potential-bugs/SmartCastInvalidated.kt
@@ -1,0 +1,23 @@
+package fixtures.positive.potentialbugs
+
+class SmartCastInvalidated {
+    fun reassignedAndUsed(): Int {
+        var x: String? = "hello"
+        if (x != null) {
+            x = null
+            return x.length // smart cast invalidated by reassignment
+        }
+        return 0
+    }
+
+    fun reassignedAndCalled(): Int {
+        var s: String? = "world"
+        if (s != null) {
+            s = compute()
+            return s.length // smart cast invalidated by reassignment
+        }
+        return 0
+    }
+}
+
+private fun compute(): String? = null

--- a/tests/fixtures/positive/potential-bugs/UnreachableCode.kt
+++ b/tests/fixtures/positive/potential-bugs/UnreachableCode.kt
@@ -1,5 +1,7 @@
 package fixtures.positive.potentialbugs
 
+private fun failHard(msg: String): Nothing = throw IllegalStateException(msg)
+
 class UnreachableCode {
     // Statement after return
     fun afterReturn(x: Int): Int {
@@ -38,6 +40,26 @@ class UnreachableCode {
     // Statement after error()
     fun afterError() {
         error("fatal")
+        println("unreachable")
+    }
+
+    // Statement after exitProcess()
+    fun afterExitProcess() {
+        exitProcess(0)
+        println("unreachable")
+    }
+
+    // Statement after fully-qualified kotlin.system.exitProcess()
+    fun afterQualifiedExitProcess() {
+        kotlin.system.exitProcess(0)
+        println("unreachable")
+    }
+
+    // Statement after a workspace-defined Nothing-returning function.
+    // The resolver picks up failHard() via r.functions and reports its
+    // return type as Nothing, so the rule treats it as a jump.
+    fun afterWorkspaceNothing() {
+        failHard("boom")
         println("unreachable")
     }
 


### PR DESCRIPTION
## Summary

Lands the first pre-compile feedback rule set for Krit plus the data-model groundwork for classpath-aware lookups and reverse-dep incremental rerun. 14 commits, all green under `make integration`.

### Pre-compile rules (`Tags: ["precompile"]`)
- **`UnreachableCode` extension** — fires after `exitProcess`, `kotlin.system.exitProcess`, and resolver-known workspace `Nothing` functions; receiver-call false-positive guarded.
- **`NoElseInWhenSealed`** — sealed/enum exhaustiveness, the missing-`else` direction kotlinc reports as `NO_ELSE_IN_WHEN`.
- **`MissingReturn`** — block-bodied non-`Unit`/`Nothing` functions whose body doesn't terminate on every path.
- **`SmartCastInvalidated`** — local `var` reassigned inside a non-null check, then accessed unsafely.
- **`OverrideSignatureMismatch`** — `override fun X(...)` whose param count doesn't match any reachable supertype's same-named member; transitive supertype walk.
- **`AbstractMemberNotImplemented`** — concrete classes failing to implement abstract supertype members; transitive walk that subtracts members satisfied by intermediate concrete classes.
- **`Tags []string`** added to `api.Rule` / `api.RuleDescriptor` (advisory, non-breaking). Re-tags `UnreachableCode`, `UnreachableCatchBlock`, `ElseCaseInsteadOfExhaustiveWhen`, `UnsafeCast`, `UnusedImport`, `UnusedParameter`, `UnusedVariable`.

### Resolver / typeinfer
- **`MemberInfo.Params` + `TypeParameters`** populated by `extractFunctionParamsFlat` / `flatExtractFunctionTypeParameters`. Cache fingerprint bumped to v2.
- **Bug fix**: `flatReadModifierFlags` now sees the `enum`/`sealed` keywords tree-sitter emits as direct children of `class_declaration`, not just under `modifiers`. Was silently breaking `EnumEntries` for plain `enum class X`.
- **`SetBinSymbolReader`** lets a classpath-aware reader plug into `ClassHierarchy` after source-side maps and before the hardcoded stdlib stubs.

### Pipeline
- **`scanner.File.Generated`** bit + **`pipeline.IncludeGeneratedAllowlist`** + `DefaultKnownSafeGenerators()` for Hilt/KSP/Kapt/ViewBinding/DataBinding. (Walker `build/` prune integration deferred — caveat documented inline.)
- **`scanner.DependentsIndex`** — per-Kotlin-file FQN imports + inverse maps + `FilesAffectedBy`. Wired into `WorkspaceState` with its own slot, fingerprint-keyed cache, and watcher invalidation hook. Daemon-mode rerun narrowing using it is a clean follow-up.

### Classpath seam
- **`internal/binsymbols`** package: `Reader` interface, `Class`/`Member` shapes, `Empty`/`Multi`/`Static` implementations, `AdaptForResolver` helper. Establishes the producer-facing seam so a future KAA-cache-backed reader and a Go-native `.class` reader can plug in without rule code changing.

### What's deferred (separate PRs)
- Phase 4c: actually use `FilesAffectedBy` to narrow rule reruns in daemon/watch mode. Needs per-file findings cache + dispatcher hooks.
- Phase 5b+: classpath-backed concrete reader (KAA-cached and/or Go-native JAR/.class parser).
- Generated-source walker integration (let `build/generated/source/...` reach the parse phase).

### Stats
- ~40 new unit tests + positive/negative fixtures for every new rule.
- 14 commits, each green under `go build`, `go vet`, `golangci-lint run`, `go test ./... -count=1`, `make integration` before commit.

## Test plan
- [ ] `go test ./... -count=1`
- [ ] `make integration`
- [ ] Run on a real Kotlin/Android project against the new precompile-tagged rules; capture findings volume + any false positives in `OverrideSignatureMismatch` / `AbstractMemberNotImplemented` against deep hierarchies that span library boundaries.
- [ ] Verify `MemberInfo` cache-version bump (v1 → v2) drops old caches cleanly on first run after merge.