### PR TITLE
feat(snapshot): support module-scope thresholds in gate

### DIFF
--- a/docs/snapshots.md
+++ b/docs/snapshots.md
@@ -121,12 +121,15 @@ krit snapshot gate origin/main HEAD \
     --max-delta files=20
 ```
 
-- `--max-abs metric=v` — cap on the to-side absolute reading
-- `--max-delta metric=v` — cap on the absolute increase
-- `--max-pct metric=v` — cap on the percent increase from the from-side
+- `--max-abs [module/]metric=v` — cap on the to-side absolute reading
+- `--max-delta [module/]metric=v` — cap on the absolute increase
+- `--max-pct [module/]metric=v` — cap on the percent increase from the from-side
 
-Multiple flags on the same metric stack independently. Repo-scope only
-in v1.
+Bare metric names (`loc`, `cyclomatic`) target the repo-scope reading;
+prefixing with a module path (`:feature:checkout/fan_in`,
+`:app/cyclomatic`) targets that module's reading from the diff. The
+split is on the last `/`, so module IDs containing `/` survive intact.
+Multiple flags on the same metric stack independently.
 
 ### CI usage
 

--- a/internal/cli/snapshot/snapshot.go
+++ b/internal/cli/snapshot/snapshot.go
@@ -391,9 +391,9 @@ func runGate(args []string) int {
 	repoFlag := fs.String("repo", "", "repository root (default: cwd)")
 	formatFlag := fs.String("format", "text", "output format: text|json")
 	var maxAbs, maxDelta, maxPct clishared.MultiString
-	fs.Var(&maxAbs, "max-abs", "metric=value (absolute cap on the to-side reading); repeatable")
-	fs.Var(&maxDelta, "max-delta", "metric=value (cap on absolute increase); repeatable")
-	fs.Var(&maxPct, "max-pct", "metric=value (cap on percent increase from from-side); repeatable")
+	fs.Var(&maxAbs, "max-abs", "[module/]metric=value (absolute cap on to-side); repeatable")
+	fs.Var(&maxDelta, "max-delta", "[module/]metric=value (cap on absolute increase); repeatable")
+	fs.Var(&maxPct, "max-pct", "[module/]metric=value (cap on percent increase from from-side); repeatable")
 	positional, rest := clishared.SplitPositional(args, 2)
 	if err := fs.Parse(rest); err != nil {
 		return 1
@@ -450,16 +450,19 @@ func runGate(args []string) int {
 }
 
 func parseGateThresholds(maxAbs, maxDelta, maxPct []string) ([]snap.GateThreshold, error) {
-	byMetric := make(map[string]*snap.GateThreshold)
+	type key struct{ module, metric string }
+	byKey := make(map[key]*snap.GateThreshold)
 	add := func(raw, kind string) error {
-		metric, value, err := parseMetricKV(raw)
+		spec, value, err := parseMetricKV(raw)
 		if err != nil {
 			return err
 		}
-		t := byMetric[metric]
+		module, metric := splitModuleMetric(spec)
+		k := key{module: module, metric: metric}
+		t := byKey[k]
 		if t == nil {
-			t = &snap.GateThreshold{Metric: metric}
-			byMetric[metric] = t
+			t = &snap.GateThreshold{Module: module, Metric: metric}
+			byKey[k] = t
 		}
 		v := value
 		switch kind {
@@ -487,11 +490,25 @@ func parseGateThresholds(maxAbs, maxDelta, maxPct []string) ([]snap.GateThreshol
 			return nil, err
 		}
 	}
-	out := make([]snap.GateThreshold, 0, len(byMetric))
-	for _, t := range byMetric {
+	out := make([]snap.GateThreshold, 0, len(byKey))
+	for _, t := range byKey {
 		out = append(out, *t)
 	}
 	return out, nil
+}
+
+// splitModuleMetric splits a threshold spec into (module, metric).
+// Bare metric names ("loc") return ("", "loc"); a module-prefixed
+// form (":app/cyclomatic", "app/loc") returns the leading segment as
+// module and the trailing segment as metric. The split is on the
+// LAST '/' so module paths that themselves contain '/' (rare but
+// legal in nested Gradle module IDs) survive intact.
+func splitModuleMetric(spec string) (string, string) {
+	idx := strings.LastIndexByte(spec, '/')
+	if idx < 0 {
+		return "", spec
+	}
+	return spec[:idx], spec[idx+1:]
 }
 
 func parseMetricKV(raw string) (string, float64, error) {
@@ -515,8 +532,12 @@ func printGateText(res *snap.GateResult) {
 	}
 	fmt.Printf("gate: %d violation(s)\n", len(res.Violations))
 	for _, v := range res.Violations {
-		fmt.Printf("  %-16s %s: limit=%g got=%g (from=%g to=%g)\n",
-			v.Metric, v.Constraint, v.Limit, v.Got, v.From, v.To)
+		label := v.Metric
+		if v.Module != "" {
+			label = v.Module + "/" + v.Metric
+		}
+		fmt.Printf("  %-32s %s: limit=%g got=%g (from=%g to=%g)\n",
+			label, v.Constraint, v.Limit, v.Got, v.From, v.To)
 	}
 }
 

--- a/internal/cli/snapshot/snapshot_test.go
+++ b/internal/cli/snapshot/snapshot_test.go
@@ -30,3 +30,58 @@ func TestFormatInfoError_PassthroughOnOtherError(t *testing.T) {
 		t.Errorf("non-ENOENT error should not get the friendly hint: %q", got)
 	}
 }
+
+func TestSplitModuleMetric(t *testing.T) {
+	cases := []struct {
+		spec    string
+		module  string
+		metric  string
+	}{
+		{"loc", "", "loc"},
+		{"cyclomatic", "", "cyclomatic"},
+		{":app/loc", ":app", "loc"},
+		{":feature:checkout/fan_in", ":feature:checkout", "fan_in"},
+		{"a/b/loc", "a/b", "loc"},
+	}
+	for _, tc := range cases {
+		gotMod, gotMetric := splitModuleMetric(tc.spec)
+		if gotMod != tc.module || gotMetric != tc.metric {
+			t.Errorf("splitModuleMetric(%q) = (%q, %q); want (%q, %q)",
+				tc.spec, gotMod, gotMetric, tc.module, tc.metric)
+		}
+	}
+}
+
+func TestParseGateThresholds_RepoAndModuleScope(t *testing.T) {
+	out, err := parseGateThresholds(
+		[]string{":app/fan_in=30"},
+		[]string{},
+		[]string{"loc=5"},
+	)
+	if err != nil {
+		t.Fatalf("parseGateThresholds: %v", err)
+	}
+	if len(out) != 2 {
+		t.Fatalf("expected 2 thresholds, got %+v", out)
+	}
+	var sawApp, sawRepo bool
+	for _, th := range out {
+		switch {
+		case th.Module == ":app" && th.Metric == "fan_in":
+			sawApp = true
+			if th.MaxAbsolute == nil || *th.MaxAbsolute != 30 {
+				t.Errorf("module-scope MaxAbsolute = %v; want 30", th.MaxAbsolute)
+			}
+		case th.Module == "" && th.Metric == "loc":
+			sawRepo = true
+			if th.MaxIncreasePct == nil || *th.MaxIncreasePct != 5 {
+				t.Errorf("repo-scope MaxIncreasePct = %v; want 5", th.MaxIncreasePct)
+			}
+		default:
+			t.Errorf("unexpected threshold: %+v", th)
+		}
+	}
+	if !sawApp || !sawRepo {
+		t.Errorf("expected both repo and module thresholds: app=%v repo=%v", sawApp, sawRepo)
+	}
+}

--- a/internal/cli/snapshot/snapshot_test.go
+++ b/internal/cli/snapshot/snapshot_test.go
@@ -33,9 +33,9 @@ func TestFormatInfoError_PassthroughOnOtherError(t *testing.T) {
 
 func TestSplitModuleMetric(t *testing.T) {
 	cases := []struct {
-		spec    string
-		module  string
-		metric  string
+		spec   string
+		module string
+		metric string
 	}{
 		{"loc", "", "loc"},
 		{"cyclomatic", "", "cyclomatic"},

--- a/internal/snapshot/gate.go
+++ b/internal/snapshot/gate.go
@@ -15,9 +15,12 @@ const (
 	ConstraintMaxIncreasePct GateConstraint = "max_increase_pct"
 )
 
-// GateThreshold expresses one constraint on a repo-scope metric. At
-// least one of MaxAbsolute / MaxIncrease / MaxIncreasePct must be set.
+// GateThreshold expresses one constraint on a metric. Empty Module
+// targets the repo-scope reading; a non-empty Module targets that
+// module's reading from DiffResult.ModuleMetrics. At least one of
+// MaxAbsolute / MaxIncrease / MaxIncreasePct must be set.
 type GateThreshold struct {
+	Module         string
 	Metric         string
 	MaxAbsolute    *float64
 	MaxIncrease    *float64
@@ -25,6 +28,9 @@ type GateThreshold struct {
 }
 
 type GateViolation struct {
+	// Module is empty for repo-scope thresholds; otherwise the module
+	// path the violation applies to (e.g. ":feature:checkout").
+	Module     string         `json:"module,omitempty"`
 	Metric     string         `json:"metric"`
 	Constraint GateConstraint `json:"constraint"`
 	Limit      float64        `json:"limit"`
@@ -56,19 +62,19 @@ func Gate(opts GateOptions) (*GateResult, error) {
 	}
 	out := &GateResult{From: d.From.CommitSHA, To: d.To.CommitSHA}
 	for _, t := range opts.Thresholds {
-		m, ok := d.RepoMetrics[t.Metric]
+		m, ok := lookupMetric(d, t.Module, t.Metric)
 		if !ok {
 			continue
 		}
 		if t.MaxAbsolute != nil && m.To > *t.MaxAbsolute {
 			out.Violations = append(out.Violations, GateViolation{
-				Metric: t.Metric, Constraint: ConstraintMaxAbsolute,
+				Module: t.Module, Metric: t.Metric, Constraint: ConstraintMaxAbsolute,
 				Limit: *t.MaxAbsolute, Got: m.To, From: m.From, To: m.To,
 			})
 		}
 		if t.MaxIncrease != nil && m.Delta > *t.MaxIncrease {
 			out.Violations = append(out.Violations, GateViolation{
-				Metric: t.Metric, Constraint: ConstraintMaxIncrease,
+				Module: t.Module, Metric: t.Metric, Constraint: ConstraintMaxIncrease,
 				Limit: *t.MaxIncrease, Got: m.Delta, From: m.From, To: m.To,
 			})
 		}
@@ -76,19 +82,40 @@ func Gate(opts GateOptions) (*GateResult, error) {
 			pct := percentChange(m.From, m.Delta)
 			if pct > *t.MaxIncreasePct {
 				out.Violations = append(out.Violations, GateViolation{
-					Metric: t.Metric, Constraint: ConstraintMaxIncreasePct,
+					Module: t.Module, Metric: t.Metric, Constraint: ConstraintMaxIncreasePct,
 					Limit: *t.MaxIncreasePct, Got: pct, From: m.From, To: m.To,
 				})
 			}
 		}
 	}
 	sort.Slice(out.Violations, func(i, j int) bool {
+		if out.Violations[i].Module != out.Violations[j].Module {
+			return out.Violations[i].Module < out.Violations[j].Module
+		}
 		if out.Violations[i].Metric != out.Violations[j].Metric {
 			return out.Violations[i].Metric < out.Violations[j].Metric
 		}
 		return out.Violations[i].Constraint < out.Violations[j].Constraint
 	})
 	return out, nil
+}
+
+// lookupMetric resolves a (module, metric) pair against a DiffResult.
+// Empty module reads RepoMetrics; a non-empty module reads
+// ModuleMetrics. Missing module/metric pairs return false so callers
+// can silently skip thresholds against snapshots that don't carry the
+// requested target (mirrors the pre-existing repo-scope behaviour).
+func lookupMetric(d *DiffResult, module, metric string) (MetricDelta, bool) {
+	if module == "" {
+		m, ok := d.RepoMetrics[metric]
+		return m, ok
+	}
+	mm, ok := d.ModuleMetrics[module]
+	if !ok {
+		return MetricDelta{}, false
+	}
+	m, ok := mm[metric]
+	return m, ok
 }
 
 // percentChange handles the from=0 case explicitly: any positive delta

--- a/internal/snapshot/gate_test.go
+++ b/internal/snapshot/gate_test.go
@@ -89,6 +89,96 @@ func TestGateRequiresThresholds(t *testing.T) {
 	}
 }
 
+func TestGate_ModuleScopeFlagsBreach(t *testing.T) {
+	root := writeGateModuleFixtures(t, 30, 40, 0, 1)
+	deltaCap := 5.0
+	res, err := Gate(GateOptions{
+		Root: root, FromSHA: gateFromSHA, ToSHA: gateToSHA,
+		Thresholds: []GateThreshold{
+			// Repo-scope LOC moved 30 -> 40 (delta=10) — fails.
+			{Metric: "loc", MaxIncrease: &deltaCap},
+			// Module :app fan_in moved 0 -> 1 (delta=1) — passes.
+			{Module: ":app", Metric: "fan_in", MaxIncrease: &deltaCap},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Gate: %v", err)
+	}
+	if len(res.Violations) != 1 {
+		t.Fatalf("expected exactly the repo-scope LOC violation, got %+v", res.Violations)
+	}
+	if res.Violations[0].Module != "" || res.Violations[0].Metric != "loc" {
+		t.Errorf("wrong violation: %+v", res.Violations[0])
+	}
+}
+
+func TestGate_ModuleScopeAbsoluteCap(t *testing.T) {
+	root := writeGateModuleFixtures(t, 30, 30, 5, 12)
+	cap := 10.0
+	res, err := Gate(GateOptions{
+		Root: root, FromSHA: gateFromSHA, ToSHA: gateToSHA,
+		Thresholds: []GateThreshold{
+			{Module: ":app", Metric: "fan_in", MaxAbsolute: &cap},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Gate: %v", err)
+	}
+	if len(res.Violations) != 1 {
+		t.Fatalf("expected one module-scope violation, got %+v", res.Violations)
+	}
+	v := res.Violations[0]
+	if v.Module != ":app" || v.Metric != "fan_in" || v.Constraint != ConstraintMaxAbsolute {
+		t.Errorf("wrong violation shape: %+v", v)
+	}
+	if v.From != 5 || v.To != 12 {
+		t.Errorf("violation should carry module-scope readings; got %+v", v)
+	}
+}
+
+func TestGate_UnknownModuleSkipsThreshold(t *testing.T) {
+	root := writeGateModuleFixtures(t, 30, 40, 0, 1)
+	deltaCap := 0.0
+	res, err := Gate(GateOptions{
+		Root: root, FromSHA: gateFromSHA, ToSHA: gateToSHA,
+		Thresholds: []GateThreshold{
+			{Module: ":does-not-exist", Metric: "fan_in", MaxIncrease: &deltaCap},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Gate: %v", err)
+	}
+	if len(res.Violations) != 0 {
+		t.Fatalf("missing module should silently skip; got %+v", res.Violations)
+	}
+}
+
+func writeGateModuleFixtures(t *testing.T, fromLOC, toLOC, fromFanIn, toFanIn int) string {
+	t.Helper()
+	dir := t.TempDir()
+	root := filepath.Join(dir, ".krit", "snapshots")
+
+	for _, pair := range []struct {
+		sha   string
+		loc   int
+		fanIn int
+	}{{gateFromSHA, fromLOC, fromFanIn}, {gateToSHA, toLOC, toFanIn}} {
+		if _, err := Save(root, &Blob{SchemaVersion: SchemaVersion, CommitSHA: pair.sha, CapturedAt: 1}); err != nil {
+			t.Fatalf("Save: %v", err)
+		}
+		m := &Metrics{
+			SchemaVersion: MetricsSchemaVersion,
+			CommitSHA:     pair.sha,
+			Files:         []FileMetrics{{Path: "app/a.kt", Module: ":app", LOC: pair.loc}},
+			Modules:       []ModuleMetrics{{Path: ":app", LOC: pair.loc, FanIn: pair.fanIn}},
+		}
+		if _, err := SaveMetrics(root, m); err != nil {
+			t.Fatalf("SaveMetrics: %v", err)
+		}
+	}
+	return root
+}
+
 const (
 	gateFromSHA = "11111111111111111111111111111111aaaaaaaa"
 	gateToSHA   = "22222222222222222222222222222222bbbbbbbb"


### PR DESCRIPTION
## Summary
Threshold flags on \`krit snapshot gate\` now accept a \`module/metric\` form (\`:feature:checkout/fan_in=30\`). Bare metric names stay repo-scope. Splits on the last \`/\` so nested Gradle module IDs survive intact.

\`GateThreshold\` and \`GateViolation\` gain a \`Module\` field; lookup routes to \`DiffResult.ModuleMetrics[module]\` when non-empty. Missing modules silently skip the threshold (mirrors the pre-existing repo-scope missing-metric behaviour).

Closes #73 (and unblocks #74's krit.yml binding).

## Test plan
- [x] New module-scope tests in \`gate_test.go\` (breach, abs cap, unknown-module-skip)
- [x] New parser tests in \`snapshot_test.go\` (\`splitModuleMetric\`, mixed repo+module thresholds)
- [x] \`go test ./... -count=1\` and \`make integration\` clean