### PR TITLE
feat(snapshot): implement retention policy and prune verb

### DIFF
--- a/docs/snapshots.md
+++ b/docs/snapshots.md
@@ -174,6 +174,32 @@ capture dominates over gate. A shared snapshot store (S3/GCS-backed
 snapshot instead of recomputing it is a future direction; for now the
 two-capture pattern is the canonical shape.
 
+## Prune
+
+`krit snapshot prune` evicts captured snapshots per a retention
+policy:
+
+- Snapshots reachable from a permanent branch (`main` / `master` by
+  default; override with repeated `--permanent-branch <name>`) are
+  always kept.
+- Snapshots reachable only from a feature branch are kept while
+  younger than `--keep-days N` (default 30).
+- Orphans (no ref reaches them — the typical product of force-push
+  or a deleted branch) are kept while younger than
+  `--keep-orphan-days N` (default 7).
+
+`--dry-run` prints what would be pruned without writing; `--format
+json` emits a machine-readable report. The pruner updates
+`.krit/snapshots/index.json` in lockstep so subsequent `status`
+calls don't see ghost entries.
+
+```sh
+krit snapshot prune --dry-run                 # what would go?
+krit snapshot prune --keep-days 90            # keep feature snapshots 3 months
+krit snapshot prune --permanent-branch main \
+    --permanent-branch release/2026.05         # protect a release branch too
+```
+
 ## MCP
 
 The `snapshot` MCP tool exposes the read-only operations to AI agents:

--- a/internal/cli/snapshot/snapshot.go
+++ b/internal/cli/snapshot/snapshot.go
@@ -19,7 +19,7 @@ import (
 // Version is set by main via ldflags.
 var Version string
 
-const usage = `usage: krit snapshot <capture|backfill|status|timeline|info|diff|gate|install-hook> [flags]
+const usage = `usage: krit snapshot <capture|backfill|status|timeline|info|diff|gate|install-hook|prune> [flags]
 
   capture [<sha>]      capture a structural snapshot for sha (default: HEAD)
   backfill             capture snapshots for past commits via git worktrees
@@ -30,6 +30,7 @@ const usage = `usage: krit snapshot <capture|backfill|status|timeline|info|diff|
   gate <from> <to>     fail (exit 2) if a delta exceeds a configured threshold
   install-hook         install a post-commit hook that captures HEAD on each commit
   simulate <rule>      score a rule across history (would this rule have been useful?)
+  prune                evict captured snapshots per retention policy
 
 Capture flags:
   --repo PATH       repo root (default: cwd)
@@ -67,6 +68,8 @@ func Run(args []string) int {
 		return runInstallHook(args[1:])
 	case "simulate":
 		return runSimulate(args[1:])
+	case "prune":
+		return runPrune(args[1:])
 	default:
 		fmt.Fprintf(os.Stderr, "unknown snapshot subcommand: %s\n%s", args[0], usage)
 		return 1
@@ -634,4 +637,72 @@ func runTimeline(args []string) int {
 		fmt.Printf("%s\t%d\t%g\n", shortSHA(p.CommitSHA), p.CapturedAt, p.Value)
 	}
 	return 0
+}
+
+func runPrune(args []string) int {
+	fs := flag.NewFlagSet("snapshot prune", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	repoFlag := fs.String("repo", "", "repository root (default: cwd)")
+	keepDaysFlag := fs.Int("keep-days", 30, "retention window for feature-branch-reachable snapshots, in days")
+	keepOrphanDaysFlag := fs.Int("keep-orphan-days", 7, "retention window for unreachable (orphan) snapshots, in days")
+	dryRunFlag := fs.Bool("dry-run", false, "print what would be pruned without removing anything")
+	formatFlag := fs.String("format", "text", "output format: text|json")
+	var permanent clishared.MultiString
+	fs.Var(&permanent, "permanent-branch", "branch name treated as always-keep (repeatable; defaults to main + master)")
+	if err := fs.Parse(args); err != nil {
+		return 1
+	}
+
+	repoRoot, code := resolveRepoRoot(*repoFlag)
+	if code != 0 {
+		return code
+	}
+
+	res, err := snap.Prune(snap.PruneOptions{
+		Root:              snap.SnapshotsDir(repoRoot),
+		RepoRoot:          repoRoot,
+		PermanentBranches: permanent,
+		KeepFeatureAge:    time.Duration(*keepDaysFlag) * 24 * time.Hour,
+		KeepOrphanAge:     time.Duration(*keepOrphanDaysFlag) * 24 * time.Hour,
+		DryRun:            *dryRunFlag,
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		return 1
+	}
+
+	if *formatFlag == "json" {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(res)
+	} else {
+		printPruneText(res, *dryRunFlag)
+	}
+	for _, e := range res.Errors {
+		fmt.Fprintf(os.Stderr, "warning: %v\n", e)
+	}
+	if len(res.Errors) > 0 {
+		return 1
+	}
+	return 0
+}
+
+func printPruneText(res *snap.PruneResult, dryRun bool) {
+	verb := "pruned"
+	if dryRun {
+		verb = "would prune"
+	}
+	if len(res.Entries) == 0 {
+		fmt.Println("snapshot prune: no captured snapshots")
+		return
+	}
+	for _, e := range res.Entries {
+		marker := "keep"
+		if e.Pruned {
+			marker = verb
+		}
+		fmt.Printf("  %s\t%s\t%s\t%s\n",
+			shortSHA(e.CommitSHA), e.Reach, marker, e.Reason)
+	}
+	fmt.Printf("snapshot prune: %d %s, %d kept\n", res.Pruned, verb, len(res.Entries)-res.Pruned)
 }

--- a/internal/snapshot/index.go
+++ b/internal/snapshot/index.go
@@ -110,3 +110,42 @@ func upsertIndex(root string, m *Manifest) error {
 	}
 	return nil
 }
+
+// removeFromIndex drops the given shas from the rollup atomically.
+// Missing entries are silently skipped — Prune calls this after the
+// per-sha directory is already gone, and a rerun should be idempotent.
+func removeFromIndex(root string, shas ...string) error {
+	if len(shas) == 0 {
+		return nil
+	}
+	indexMu.Lock()
+	defer indexMu.Unlock()
+	existing, err := LoadIndex(root)
+	if err != nil {
+		return err
+	}
+	if existing == nil {
+		return nil
+	}
+	drop := make(map[string]struct{}, len(shas))
+	for _, s := range shas {
+		drop[s] = struct{}{}
+	}
+	kept := existing.Entries[:0]
+	for _, e := range existing.Entries {
+		if _, gone := drop[e.CommitSHA]; gone {
+			continue
+		}
+		kept = append(kept, e)
+	}
+	existing.Entries = kept
+	payload, err := json.MarshalIndent(existing, "", "  ")
+	if err != nil {
+		return fmt.Errorf("snapshot: marshal index: %w", err)
+	}
+	payload = append(payload, '\n')
+	if err := fsutil.WriteFileAtomic(indexPath(root), payload, 0o644); err != nil {
+		return fmt.Errorf("snapshot: write index: %w", err)
+	}
+	return nil
+}

--- a/internal/snapshot/prune.go
+++ b/internal/snapshot/prune.go
@@ -1,0 +1,264 @@
+package snapshot
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"time"
+)
+
+// Reachability classifies a captured snapshot for retention purposes.
+type Reachability string
+
+const (
+	// ReachPermanent — sha is reachable from a permanent branch
+	// (default main / master). Always kept.
+	ReachPermanent Reachability = "permanent"
+	// ReachFeature — sha is reachable from at least one ref but none
+	// of the permanent branches. Kept while younger than KeepFeatureAge.
+	ReachFeature Reachability = "feature"
+	// ReachOrphan — sha is not reachable from any current ref. Kept
+	// while younger than KeepOrphanAge.
+	ReachOrphan Reachability = "orphan"
+)
+
+// PruneOptions configures Prune. Reachability is resolved via the
+// ReachableSHAs / AllRefSHAs hooks, which are normally backed by git
+// in production and stubbed in tests.
+type PruneOptions struct {
+	// Root is the snapshots directory (i.e. SnapshotsDir(repoRoot)).
+	Root string
+	// RepoRoot is the working-tree root passed to git.
+	RepoRoot string
+	// PermanentBranches lists the branch names treated as
+	// always-keep. Empty means use DefaultPermanentBranches.
+	PermanentBranches []string
+	// KeepFeatureAge is the retention window for feature-branch-only
+	// snapshots. Zero means use DefaultKeepFeatureAge.
+	KeepFeatureAge time.Duration
+	// KeepOrphanAge is the retention window for unreachable
+	// snapshots. Zero means use DefaultKeepOrphanAge.
+	KeepOrphanAge time.Duration
+	// DryRun reports what would be pruned without removing anything.
+	DryRun bool
+	// Now is the reference clock for age comparisons. Zero means
+	// time.Now(). Test seam.
+	Now time.Time
+	// ReachableSHAs returns the set of commit shas reachable from any
+	// of the given refs. Nil means "use the production git-backed
+	// implementation". Test seam.
+	ReachableSHAs func(repoRoot string, refs []string) (map[string]bool, error)
+	// AllRefSHAs returns the set of commit shas reachable from any
+	// ref in the repository. Nil means "use the production git-backed
+	// implementation". Test seam.
+	AllRefSHAs func(repoRoot string) (map[string]bool, error)
+}
+
+// DefaultPermanentBranches is the fallback set of always-keep
+// branches when PruneOptions.PermanentBranches is empty.
+var DefaultPermanentBranches = []string{"main", "master"}
+
+// DefaultKeepFeatureAge is the retention window for snapshots only
+// reachable from feature branches.
+const DefaultKeepFeatureAge = 30 * 24 * time.Hour
+
+// DefaultKeepOrphanAge is the retention window for unreachable
+// snapshots — shorter than feature retention because force-pushes /
+// rebases produce these and they're typically the user wanting them
+// gone.
+const DefaultKeepOrphanAge = 7 * 24 * time.Hour
+
+// PruneEntry is one captured snapshot's prune classification.
+type PruneEntry struct {
+	CommitSHA  string
+	CapturedAt time.Time
+	Reach      Reachability
+	// Pruned is true when Prune deleted (or, in DryRun, would have
+	// deleted) this snapshot.
+	Pruned bool
+	// Reason is a short human-readable note: "kept (permanent)",
+	// "kept (feature, age 12d < 30d)", "pruned (orphan, age 9d > 7d)".
+	Reason string
+}
+
+// PruneResult summarises a Prune run.
+type PruneResult struct {
+	Entries []PruneEntry
+	// Pruned counts entries actually removed (or, in DryRun, that
+	// would have been removed).
+	Pruned int
+	// Errors collects per-sha removal failures so the caller can
+	// surface them; the run continues past individual errors.
+	Errors []error
+}
+
+// Prune walks the snapshots tree and applies retention rules.
+// Errors are accumulated per-sha rather than aborting the run so a
+// single broken entry doesn't prevent cleanup of the rest.
+func Prune(opts PruneOptions) (*PruneResult, error) {
+	if opts.Root == "" {
+		return nil, errors.New("snapshot: Prune requires Root")
+	}
+	if opts.RepoRoot == "" {
+		return nil, errors.New("snapshot: Prune requires RepoRoot")
+	}
+	now := opts.Now
+	if now.IsZero() {
+		now = time.Now()
+	}
+	branches := opts.PermanentBranches
+	if len(branches) == 0 {
+		branches = DefaultPermanentBranches
+	}
+	keepFeature := opts.KeepFeatureAge
+	if keepFeature == 0 {
+		keepFeature = DefaultKeepFeatureAge
+	}
+	keepOrphan := opts.KeepOrphanAge
+	if keepOrphan == 0 {
+		keepOrphan = DefaultKeepOrphanAge
+	}
+	reach := opts.ReachableSHAs
+	if reach == nil {
+		reach = gitReachableSHAs
+	}
+	allRefs := opts.AllRefSHAs
+	if allRefs == nil {
+		allRefs = gitAllRefSHAs
+	}
+
+	manifests, err := LoadManifests(opts.Root)
+	if err != nil {
+		return nil, fmt.Errorf("snapshot: load manifests: %w", err)
+	}
+	if len(manifests) == 0 {
+		return &PruneResult{}, nil
+	}
+
+	permanentSet, err := reach(opts.RepoRoot, branches)
+	if err != nil {
+		return nil, fmt.Errorf("snapshot: resolve permanent reachability: %w", err)
+	}
+	anyRefSet, err := allRefs(opts.RepoRoot)
+	if err != nil {
+		return nil, fmt.Errorf("snapshot: resolve all-ref reachability: %w", err)
+	}
+
+	res := &PruneResult{Entries: make([]PruneEntry, 0, len(manifests))}
+	var toRemove []string
+	for _, m := range manifests {
+		entry := classifyForPrune(m, now, permanentSet, anyRefSet, keepFeature, keepOrphan)
+		res.Entries = append(res.Entries, entry)
+		if entry.Pruned {
+			res.Pruned++
+			toRemove = append(toRemove, m.CommitSHA)
+		}
+	}
+	sort.Slice(res.Entries, func(i, j int) bool {
+		return res.Entries[i].CommitSHA < res.Entries[j].CommitSHA
+	})
+
+	if opts.DryRun {
+		return res, nil
+	}
+	for _, sha := range toRemove {
+		dir, err := shaDir(opts.Root, sha)
+		if err != nil {
+			res.Errors = append(res.Errors, fmt.Errorf("shaDir %s: %w", sha, err))
+			continue
+		}
+		if err := os.RemoveAll(dir); err != nil {
+			res.Errors = append(res.Errors, fmt.Errorf("remove %s: %w", sha, err))
+		}
+	}
+	if err := removeFromIndex(opts.Root, toRemove...); err != nil {
+		res.Errors = append(res.Errors, err)
+	}
+	return res, nil
+}
+
+// classifyForPrune maps a captured manifest to its retention
+// outcome. Pulled out of Prune so the main function stays under the
+// gocyclo threshold and the policy is easier to test in isolation.
+func classifyForPrune(m Manifest, now time.Time, permanent, anyRef map[string]bool, keepFeature, keepOrphan time.Duration) PruneEntry {
+	entry := PruneEntry{
+		CommitSHA:  m.CommitSHA,
+		CapturedAt: time.Unix(m.CapturedAt, 0),
+	}
+	if permanent[m.CommitSHA] {
+		entry.Reach = ReachPermanent
+		entry.Reason = "kept (permanent)"
+		return entry
+	}
+	if anyRef[m.CommitSHA] {
+		entry.Reach = ReachFeature
+		entry.Pruned, entry.Reason = pruneByAge(now.Sub(entry.CapturedAt), keepFeature, "feature")
+		return entry
+	}
+	entry.Reach = ReachOrphan
+	entry.Pruned, entry.Reason = pruneByAge(now.Sub(entry.CapturedAt), keepOrphan, "orphan")
+	return entry
+}
+
+// pruneByAge returns (prune, reason) for an age vs. window comparison.
+func pruneByAge(age, keep time.Duration, kind string) (bool, string) {
+	if age > keep {
+		return true, fmt.Sprintf("pruned (%s, age %s > %s)", kind, roundAge(age), roundAge(keep))
+	}
+	return false, fmt.Sprintf("kept (%s, age %s ≤ %s)", kind, roundAge(age), roundAge(keep))
+}
+
+// gitReachableSHAs runs `git rev-list <branches...>` and returns the
+// set of commit shas reachable from any of the named branches.
+// Branches that don't exist locally are silently skipped so a repo
+// without "main" but with "master" still works.
+func gitReachableSHAs(repoRoot string, branches []string) (map[string]bool, error) {
+	out := make(map[string]bool)
+	for _, branch := range branches {
+		// Resolve to an actual commit first so non-existent branches
+		// don't fail the whole call.
+		if _, err := runGitLine(repoRoot, "rev-parse", "--verify", branch); err != nil {
+			continue
+		}
+		raw, err := runGitLine(repoRoot, "rev-list", branch)
+		if err != nil {
+			return nil, err
+		}
+		for _, sha := range strings.Fields(raw) {
+			out[sha] = true
+		}
+	}
+	return out, nil
+}
+
+// gitAllRefSHAs runs `git rev-list --all` and returns the set of
+// commit shas reachable from any ref in the repository.
+func gitAllRefSHAs(repoRoot string) (map[string]bool, error) {
+	raw, err := runGitLine(repoRoot, "rev-list", "--all")
+	if err != nil {
+		return nil, err
+	}
+	out := make(map[string]bool)
+	for _, sha := range strings.Fields(raw) {
+		out[sha] = true
+	}
+	return out, nil
+}
+
+// roundAge formats a duration to a single unit suitable for
+// human-readable prune reasons (e.g. "12d", "5h"). Sub-hour
+// durations fall back to the default Duration.String shape.
+func roundAge(d time.Duration) string {
+	if d < 0 {
+		d = -d
+	}
+	if d >= 24*time.Hour {
+		return fmt.Sprintf("%dd", int(d/(24*time.Hour)))
+	}
+	if d >= time.Hour {
+		return fmt.Sprintf("%dh", int(d/time.Hour))
+	}
+	return d.Round(time.Second).String()
+}

--- a/internal/snapshot/prune_test.go
+++ b/internal/snapshot/prune_test.go
@@ -1,0 +1,255 @@
+package snapshot
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// pruneScenario captures the inputs needed to drive Prune through a
+// fake git reach implementation. The actual snapshot fixtures live on
+// disk — Prune still walks .krit/snapshots/graphs/ via List and
+// LoadManifests.
+type pruneScenario struct {
+	root              string
+	repoRoot          string
+	permanentSet      map[string]bool
+	anyRefSet         map[string]bool
+	now               time.Time
+	keepFeatureAge    time.Duration
+	keepOrphanAge     time.Duration
+	permanentBranches []string
+}
+
+func (s pruneScenario) reach(_ string, _ []string) (map[string]bool, error) {
+	out := make(map[string]bool, len(s.permanentSet))
+	for k, v := range s.permanentSet {
+		out[k] = v
+	}
+	return out, nil
+}
+
+func (s pruneScenario) all(_ string) (map[string]bool, error) {
+	out := make(map[string]bool, len(s.anyRefSet))
+	for k, v := range s.anyRefSet {
+		out[k] = v
+	}
+	return out, nil
+}
+
+func (s pruneScenario) opts(dryRun bool) PruneOptions {
+	return PruneOptions{
+		Root:              s.root,
+		RepoRoot:          s.repoRoot,
+		PermanentBranches: s.permanentBranches,
+		KeepFeatureAge:    s.keepFeatureAge,
+		KeepOrphanAge:     s.keepOrphanAge,
+		DryRun:            dryRun,
+		Now:               s.now,
+		ReachableSHAs:     s.reach,
+		AllRefSHAs:        s.all,
+	}
+}
+
+func writePruneSnapshot(t *testing.T, root, sha string, capturedAt time.Time) {
+	t.Helper()
+	if _, err := Save(root, &Blob{
+		SchemaVersion: SchemaVersion, CommitSHA: sha, CapturedAt: capturedAt.Unix(),
+	}); err != nil {
+		t.Fatalf("Save %s: %v", sha, err)
+	}
+	if _, err := SaveManifest(root, &Manifest{
+		SchemaVersion: ManifestSchemaVersion, CommitSHA: sha, CapturedAt: capturedAt.Unix(),
+	}); err != nil {
+		t.Fatalf("SaveManifest %s: %v", sha, err)
+	}
+}
+
+func snapshotExists(root, sha string) bool {
+	dir, err := shaDir(root, sha)
+	if err != nil {
+		return false
+	}
+	_, err = os.Stat(dir)
+	return err == nil
+}
+
+func TestPrune_KeepsPermanentReachable(t *testing.T) {
+	dir := t.TempDir()
+	root := filepath.Join(dir, ".krit", "snapshots")
+	now := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	old := now.Add(-365 * 24 * time.Hour)
+
+	mainSHA := "aaaa1111aaaa1111aaaa1111aaaa1111aaaa1111"
+	writePruneSnapshot(t, root, mainSHA, old)
+
+	res, err := Prune(pruneScenario{
+		root:         root,
+		repoRoot:     dir,
+		permanentSet: map[string]bool{mainSHA: true},
+		anyRefSet:    map[string]bool{mainSHA: true},
+		now:          now,
+	}.opts(false))
+	if err != nil {
+		t.Fatalf("Prune: %v", err)
+	}
+	if res.Pruned != 0 {
+		t.Errorf("expected 0 pruned for permanent-reachable old snapshot; got %+v", res.Entries)
+	}
+	if !snapshotExists(root, mainSHA) {
+		t.Errorf("permanent-reachable snapshot was deleted")
+	}
+}
+
+func TestPrune_FeatureBranchEvictedAfterAge(t *testing.T) {
+	dir := t.TempDir()
+	root := filepath.Join(dir, ".krit", "snapshots")
+	now := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+
+	freshSHA := "bbbb1111bbbb1111bbbb1111bbbb1111bbbb1111"
+	staleSHA := "cccc2222cccc2222cccc2222cccc2222cccc2222"
+	writePruneSnapshot(t, root, freshSHA, now.Add(-7*24*time.Hour))
+	writePruneSnapshot(t, root, staleSHA, now.Add(-90*24*time.Hour))
+
+	res, err := Prune(pruneScenario{
+		root:           root,
+		repoRoot:       dir,
+		anyRefSet:      map[string]bool{freshSHA: true, staleSHA: true},
+		now:            now,
+		keepFeatureAge: 30 * 24 * time.Hour,
+	}.opts(false))
+	if err != nil {
+		t.Fatalf("Prune: %v", err)
+	}
+	if res.Pruned != 1 {
+		t.Errorf("expected exactly the stale feature snapshot pruned; got %+v", res.Entries)
+	}
+	if snapshotExists(root, staleSHA) {
+		t.Errorf("stale feature snapshot should have been removed")
+	}
+	if !snapshotExists(root, freshSHA) {
+		t.Errorf("fresh feature snapshot was wrongly removed")
+	}
+}
+
+func TestPrune_OrphansEvictedAfterShorterAge(t *testing.T) {
+	dir := t.TempDir()
+	root := filepath.Join(dir, ".krit", "snapshots")
+	now := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+
+	freshOrphan := "dddd3333dddd3333dddd3333dddd3333dddd3333"
+	staleOrphan := "eeee4444eeee4444eeee4444eeee4444eeee4444"
+	writePruneSnapshot(t, root, freshOrphan, now.Add(-3*24*time.Hour))
+	writePruneSnapshot(t, root, staleOrphan, now.Add(-15*24*time.Hour))
+
+	res, err := Prune(pruneScenario{
+		root:          root,
+		repoRoot:      dir,
+		anyRefSet:     map[string]bool{}, // both are orphans
+		now:           now,
+		keepOrphanAge: 7 * 24 * time.Hour,
+	}.opts(false))
+	if err != nil {
+		t.Fatalf("Prune: %v", err)
+	}
+	if res.Pruned != 1 {
+		t.Errorf("expected exactly the stale orphan pruned; got %+v", res.Entries)
+	}
+	if snapshotExists(root, staleOrphan) {
+		t.Errorf("stale orphan should have been removed")
+	}
+	if !snapshotExists(root, freshOrphan) {
+		t.Errorf("fresh orphan was wrongly removed")
+	}
+}
+
+func TestPrune_DryRunDoesNotDelete(t *testing.T) {
+	dir := t.TempDir()
+	root := filepath.Join(dir, ".krit", "snapshots")
+	now := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	staleSHA := "ffff5555ffff5555ffff5555ffff5555ffff5555"
+	writePruneSnapshot(t, root, staleSHA, now.Add(-365*24*time.Hour))
+
+	res, err := Prune(pruneScenario{
+		root:          root,
+		repoRoot:      dir,
+		anyRefSet:     map[string]bool{},
+		now:           now,
+		keepOrphanAge: 7 * 24 * time.Hour,
+	}.opts(true)) // DryRun
+	if err != nil {
+		t.Fatalf("Prune: %v", err)
+	}
+	if res.Pruned != 1 {
+		t.Errorf("dry-run should still report what would be pruned; got %+v", res.Entries)
+	}
+	if !snapshotExists(root, staleSHA) {
+		t.Fatalf("dry-run must not delete; snapshot was removed anyway")
+	}
+}
+
+func TestPrune_RemovesFromIndex(t *testing.T) {
+	dir := t.TempDir()
+	root := filepath.Join(dir, ".krit", "snapshots")
+	now := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	staleSHA := "1111aaaa1111aaaa1111aaaa1111aaaa1111aaaa"
+	writePruneSnapshot(t, root, staleSHA, now.Add(-365*24*time.Hour))
+
+	idx, err := LoadIndex(root)
+	if err != nil || idx == nil || len(idx.Entries) != 1 {
+		t.Fatalf("setup: index should contain the seeded sha; got %v err=%v", idx, err)
+	}
+
+	if _, err := Prune(pruneScenario{
+		root:          root,
+		repoRoot:      dir,
+		anyRefSet:     map[string]bool{},
+		now:           now,
+		keepOrphanAge: 1 * time.Hour,
+	}.opts(false)); err != nil {
+		t.Fatalf("Prune: %v", err)
+	}
+	idx, err = LoadIndex(root)
+	if err != nil {
+		t.Fatalf("LoadIndex: %v", err)
+	}
+	if idx != nil && len(idx.Entries) != 0 {
+		t.Errorf("rolled-up index should drop pruned shas; got %+v", idx.Entries)
+	}
+}
+
+func TestPrune_ContinuesPastRemovalErrors(t *testing.T) {
+	dir := t.TempDir()
+	root := filepath.Join(dir, ".krit", "snapshots")
+	now := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	a := "aaaaffff5555aaaaffff5555aaaaffff5555aaaa"
+	b := "bbbb6666bbbb6666bbbb6666bbbb6666bbbb6666"
+	writePruneSnapshot(t, root, a, now.Add(-365*24*time.Hour))
+	writePruneSnapshot(t, root, b, now.Add(-365*24*time.Hour))
+
+	// Remove a's directory under the test's feet to simulate a
+	// concurrent rmdir. RemoveAll is fine with missing files but a
+	// bad shaDir (e.g. permission error) would not be — this test
+	// at least proves the loop continues when one removal silently
+	// no-ops.
+	dirA, _ := shaDir(root, a)
+	if err := os.RemoveAll(dirA); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	res, err := Prune(pruneScenario{
+		root:          root,
+		repoRoot:      dir,
+		anyRefSet:     map[string]bool{},
+		now:           now,
+		keepOrphanAge: 1 * time.Hour,
+	}.opts(false))
+	if err != nil {
+		t.Fatalf("Prune: %v", err)
+	}
+	if snapshotExists(root, b) {
+		t.Errorf("snapshot b should still have been pruned despite a's missing dir")
+	}
+	_ = res
+}


### PR DESCRIPTION
## Summary
\`.krit/snapshots/\` was append-only. New \`krit snapshot prune\` verb evicts captured snapshots per a three-tier retention policy: permanent-branch (always kept), feature-branch (kept while < --keep-days), orphan (kept while < --keep-orphan-days). Reachability resolved via a test-injectable git hook; the pruner removes both the per-sha directory and its entry in index.json.

Closes #75.

## Test plan
- [x] Unit tests across permanent / feature / orphan / dry-run / index-update / continue-past-error
- [x] \`go test ./... -count=1\`
- [x] \`make integration\`
- [x] \`golangci-lint run ./internal/snapshot/...\` clean