### PR TITLE
feat(snapshot): read gate thresholds from krit.yml

### DIFF
--- a/docs/snapshots.md
+++ b/docs/snapshots.md
@@ -131,6 +131,27 @@ prefixing with a module path (`:feature:checkout/fan_in`,
 split is on the last `/`, so module IDs containing `/` survive intact.
 Multiple flags on the same metric stack independently.
 
+Thresholds can also live in `krit.yml` so every CI run picks them up
+without flag noise:
+
+```yaml
+snapshot:
+  gate:
+    repo:
+      - metric: loc
+        max_increase_pct: 5
+      - metric: cyclomatic
+        max_increase_pct: 10
+    module:
+      ":app":
+        - metric: fan_in
+          max_absolute: 30
+```
+
+CLI flags merge on top of the config: a flag that sets a constraint
+config didn't (or overrides one config did) wins, while constraints
+defined only in config still apply.
+
 ### CI usage
 
 The gate compares two captured snapshots, so a CI run that wants to

--- a/internal/cli/snapshot/snapshot.go
+++ b/internal/cli/snapshot/snapshot.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/kaeawc/krit/internal/cli/clishared"
+	"github.com/kaeawc/krit/internal/config"
 	snap "github.com/kaeawc/krit/internal/snapshot"
 )
 
@@ -406,19 +407,24 @@ func runGate(args []string) int {
 		return 1
 	}
 
-	thresholds, err := parseGateThresholds(maxAbs, maxDelta, maxPct)
+	cliThresholds, err := parseGateThresholds(maxAbs, maxDelta, maxPct)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
-		return 1
-	}
-	if len(thresholds) == 0 {
-		fmt.Fprintln(os.Stderr, "error: at least one --max-abs / --max-delta / --max-pct required")
 		return 1
 	}
 
 	repoRoot, code := resolveRepoRoot(*repoFlag)
 	if code != 0 {
 		return code
+	}
+
+	// Layer in krit.yml's snapshot.gate section, with CLI flags taking
+	// precedence over config on the same (module, metric, constraint).
+	configThresholds := loadGateThresholdsFromKritYml(repoRoot)
+	thresholds := mergeGateThresholds(configThresholds, cliThresholds)
+	if len(thresholds) == 0 {
+		fmt.Fprintln(os.Stderr, "error: at least one --max-abs / --max-delta / --max-pct required (or a snapshot.gate section in krit.yml)")
+		return 1
 	}
 
 	root := snap.SnapshotsDir(repoRoot)
@@ -726,4 +732,173 @@ func printPruneText(res *snap.PruneResult, dryRun bool) {
 			shortSHA(e.CommitSHA), e.Reach, marker, e.Reason)
 	}
 	fmt.Printf("snapshot prune: %d %s, %d kept\n", res.Pruned, verb, len(res.Entries)-res.Pruned)
+}
+
+// loadGateThresholdsFromKritYml reads snapshot.gate.{repo,module} from
+// the krit.yml at repoRoot and returns the resulting thresholds. A
+// missing config or missing section yields no thresholds and no
+// error: callers fall through to CLI flags only.
+func loadGateThresholdsFromKritYml(repoRoot string) []snap.GateThreshold {
+	cfgPath := clishared.FindConfigInDir(repoRoot)
+	if cfgPath == "" {
+		return nil
+	}
+	cfg, err := config.LoadConfig(cfgPath)
+	if err != nil || cfg == nil {
+		return nil
+	}
+	return parseGateConfigSection(cfg.Data())
+}
+
+// parseGateConfigSection walks the snapshot.gate.{repo,module} schema
+// out of a krit.yml's raw map. Pulled out for unit-test isolation.
+//
+//	snapshot:
+//	  gate:
+//	    repo:
+//	      - metric: loc
+//	        max_increase_pct: 5
+//	    module:
+//	      ":app":
+//	        - metric: fan_in
+//	          max_absolute: 30
+func parseGateConfigSection(data map[string]interface{}) []snap.GateThreshold {
+	gate := nestedMap(data, "snapshot", "gate")
+	if gate == nil {
+		return nil
+	}
+	var out []snap.GateThreshold
+	if repoEntries, ok := gate["repo"].([]interface{}); ok {
+		for _, e := range repoEntries {
+			if t, ok := decodeThresholdEntry("", e); ok {
+				out = append(out, t)
+			}
+		}
+	}
+	if moduleMap, ok := gate["module"].(map[string]interface{}); ok {
+		for module, raw := range moduleMap {
+			entries, ok := raw.([]interface{})
+			if !ok {
+				continue
+			}
+			for _, e := range entries {
+				if t, ok := decodeThresholdEntry(module, e); ok {
+					out = append(out, t)
+				}
+			}
+		}
+	}
+	return out
+}
+
+// nestedMap returns the map at data[path[0]][path[1]]... or nil if
+// any segment is missing or non-map.
+func nestedMap(data map[string]interface{}, path ...string) map[string]interface{} {
+	cur := data
+	for _, key := range path {
+		raw, ok := cur[key]
+		if !ok {
+			return nil
+		}
+		next, ok := raw.(map[string]interface{})
+		if !ok {
+			return nil
+		}
+		cur = next
+	}
+	return cur
+}
+
+// decodeThresholdEntry reads one {metric, max_*} entry. Returns
+// ok=false when the metric is missing or no constraint is set —
+// callers skip silently to keep config malformed-but-non-fatal.
+func decodeThresholdEntry(module string, raw interface{}) (snap.GateThreshold, bool) {
+	m, ok := raw.(map[string]interface{})
+	if !ok {
+		return snap.GateThreshold{}, false
+	}
+	metric, _ := m["metric"].(string)
+	metric = strings.TrimSpace(metric)
+	if metric == "" {
+		return snap.GateThreshold{}, false
+	}
+	t := snap.GateThreshold{Module: module, Metric: metric}
+	hit := false
+	if v, ok := configFloat(m["max_absolute"]); ok {
+		t.MaxAbsolute = &v
+		hit = true
+	}
+	if v, ok := configFloat(m["max_increase"]); ok {
+		t.MaxIncrease = &v
+		hit = true
+	}
+	if v, ok := configFloat(m["max_increase_pct"]); ok {
+		t.MaxIncreasePct = &v
+		hit = true
+	}
+	if !hit {
+		return snap.GateThreshold{}, false
+	}
+	return t, true
+}
+
+// configFloat coerces a YAML scalar into float64. Tolerates int and
+// float YAML node types (yaml.v3 picks one based on syntax) and
+// number-bearing strings (so users who quote values still work).
+func configFloat(v interface{}) (float64, bool) {
+	switch x := v.(type) {
+	case nil:
+		return 0, false
+	case float64:
+		return x, true
+	case int:
+		return float64(x), true
+	case int64:
+		return float64(x), true
+	case string:
+		f, err := strconv.ParseFloat(strings.TrimSpace(x), 64)
+		if err != nil {
+			return 0, false
+		}
+		return f, true
+	}
+	return 0, false
+}
+
+// mergeGateThresholds applies CLI thresholds on top of config
+// thresholds. CLI takes precedence per (module, metric, constraint),
+// so a user passing --max-pct loc=10 on top of a krit.yml that says
+// 5 wins. Constraints not set on the CLI side fall through to config.
+func mergeGateThresholds(config, cli []snap.GateThreshold) []snap.GateThreshold {
+	type key struct{ module, metric string }
+	byKey := make(map[key]*snap.GateThreshold)
+	add := func(src snap.GateThreshold, override bool) {
+		k := key{module: src.Module, metric: src.Metric}
+		dst := byKey[k]
+		if dst == nil {
+			cp := src
+			byKey[k] = &cp
+			return
+		}
+		if src.MaxAbsolute != nil && (override || dst.MaxAbsolute == nil) {
+			dst.MaxAbsolute = src.MaxAbsolute
+		}
+		if src.MaxIncrease != nil && (override || dst.MaxIncrease == nil) {
+			dst.MaxIncrease = src.MaxIncrease
+		}
+		if src.MaxIncreasePct != nil && (override || dst.MaxIncreasePct == nil) {
+			dst.MaxIncreasePct = src.MaxIncreasePct
+		}
+	}
+	for _, t := range config {
+		add(t, false)
+	}
+	for _, t := range cli {
+		add(t, true)
+	}
+	out := make([]snap.GateThreshold, 0, len(byKey))
+	for _, t := range byKey {
+		out = append(out, *t)
+	}
+	return out
 }

--- a/internal/cli/snapshot/snapshot_test.go
+++ b/internal/cli/snapshot/snapshot_test.go
@@ -5,6 +5,8 @@ import (
 	"io/fs"
 	"strings"
 	"testing"
+
+	snap "github.com/kaeawc/krit/internal/snapshot"
 )
 
 func TestFormatInfoError_FriendlyOnMissing(t *testing.T) {
@@ -83,5 +85,164 @@ func TestParseGateThresholds_RepoAndModuleScope(t *testing.T) {
 	}
 	if !sawApp || !sawRepo {
 		t.Errorf("expected both repo and module thresholds: app=%v repo=%v", sawApp, sawRepo)
+	}
+}
+
+func TestParseGateConfigSection_RepoEntries(t *testing.T) {
+	data := map[string]interface{}{
+		"snapshot": map[string]interface{}{
+			"gate": map[string]interface{}{
+				"repo": []interface{}{
+					map[string]interface{}{"metric": "loc", "max_increase_pct": 5},
+					map[string]interface{}{"metric": "cyclomatic", "max_absolute": 100},
+				},
+			},
+		},
+	}
+	got := parseGateConfigSection(data)
+	if len(got) != 2 {
+		t.Fatalf("want 2 thresholds; got %+v", got)
+	}
+	for _, th := range got {
+		if th.Module != "" {
+			t.Errorf("repo entries should have empty Module; got %q", th.Module)
+		}
+		switch th.Metric {
+		case "loc":
+			if th.MaxIncreasePct == nil || *th.MaxIncreasePct != 5 {
+				t.Errorf("loc.MaxIncreasePct = %v; want 5", th.MaxIncreasePct)
+			}
+		case "cyclomatic":
+			if th.MaxAbsolute == nil || *th.MaxAbsolute != 100 {
+				t.Errorf("cyclomatic.MaxAbsolute = %v; want 100", th.MaxAbsolute)
+			}
+		default:
+			t.Errorf("unexpected metric %q", th.Metric)
+		}
+	}
+}
+
+func TestParseGateConfigSection_ModuleEntries(t *testing.T) {
+	data := map[string]interface{}{
+		"snapshot": map[string]interface{}{
+			"gate": map[string]interface{}{
+				"module": map[string]interface{}{
+					":app": []interface{}{
+						map[string]interface{}{"metric": "fan_in", "max_absolute": 30},
+					},
+				},
+			},
+		},
+	}
+	got := parseGateConfigSection(data)
+	if len(got) != 1 {
+		t.Fatalf("want 1 threshold; got %+v", got)
+	}
+	if got[0].Module != ":app" || got[0].Metric != "fan_in" {
+		t.Errorf("wrong (module, metric): %+v", got[0])
+	}
+	if got[0].MaxAbsolute == nil || *got[0].MaxAbsolute != 30 {
+		t.Errorf("MaxAbsolute = %v; want 30", got[0].MaxAbsolute)
+	}
+}
+
+func TestParseGateConfigSection_RejectsEmptyMetricAndMissingConstraints(t *testing.T) {
+	data := map[string]interface{}{
+		"snapshot": map[string]interface{}{
+			"gate": map[string]interface{}{
+				"repo": []interface{}{
+					map[string]interface{}{"metric": "", "max_absolute": 10},
+					map[string]interface{}{"metric": "loc"}, // no constraint
+					map[string]interface{}{"metric": "cyclomatic", "max_increase_pct": 5},
+				},
+			},
+		},
+	}
+	got := parseGateConfigSection(data)
+	if len(got) != 1 || got[0].Metric != "cyclomatic" {
+		t.Fatalf("only cyclomatic should survive: %+v", got)
+	}
+}
+
+func TestParseGateConfigSection_TolerantOfNumericTypes(t *testing.T) {
+	data := map[string]interface{}{
+		"snapshot": map[string]interface{}{
+			"gate": map[string]interface{}{
+				"repo": []interface{}{
+					map[string]interface{}{"metric": "a", "max_absolute": int(10)},
+					map[string]interface{}{"metric": "b", "max_increase_pct": float64(5.5)},
+					map[string]interface{}{"metric": "c", "max_increase": "20"},
+				},
+			},
+		},
+	}
+	got := parseGateConfigSection(data)
+	if len(got) != 3 {
+		t.Fatalf("want 3 thresholds; got %+v", got)
+	}
+	have := map[string]float64{}
+	for _, th := range got {
+		switch {
+		case th.MaxAbsolute != nil:
+			have[th.Metric+":abs"] = *th.MaxAbsolute
+		case th.MaxIncreasePct != nil:
+			have[th.Metric+":pct"] = *th.MaxIncreasePct
+		case th.MaxIncrease != nil:
+			have[th.Metric+":delta"] = *th.MaxIncrease
+		}
+	}
+	if have["a:abs"] != 10 || have["b:pct"] != 5.5 || have["c:delta"] != 20 {
+		t.Errorf("type coercion failed: %+v", have)
+	}
+}
+
+func TestMergeGateThresholds_CLIWinsOnSameKey(t *testing.T) {
+	cfgPct := 5.0
+	cliPct := 10.0
+	configThresholds := []snap.GateThreshold{
+		{Metric: "loc", MaxIncreasePct: &cfgPct},
+	}
+	cliThresholds := []snap.GateThreshold{
+		{Metric: "loc", MaxIncreasePct: &cliPct},
+	}
+	got := mergeGateThresholds(configThresholds, cliThresholds)
+	if len(got) != 1 {
+		t.Fatalf("want 1 merged threshold; got %+v", got)
+	}
+	if got[0].MaxIncreasePct == nil || *got[0].MaxIncreasePct != 10 {
+		t.Errorf("CLI should win; got %v", got[0].MaxIncreasePct)
+	}
+}
+
+func TestMergeGateThresholds_MergesDisjointConstraints(t *testing.T) {
+	pct := 5.0
+	abs := 100.0
+	configThresholds := []snap.GateThreshold{
+		{Metric: "loc", MaxIncreasePct: &pct},
+	}
+	cliThresholds := []snap.GateThreshold{
+		{Metric: "loc", MaxAbsolute: &abs},
+	}
+	got := mergeGateThresholds(configThresholds, cliThresholds)
+	if len(got) != 1 {
+		t.Fatalf("want 1 merged threshold; got %+v", got)
+	}
+	if got[0].MaxIncreasePct == nil || *got[0].MaxIncreasePct != 5 {
+		t.Errorf("config-only constraint dropped: %+v", got[0])
+	}
+	if got[0].MaxAbsolute == nil || *got[0].MaxAbsolute != 100 {
+		t.Errorf("CLI-only constraint dropped: %+v", got[0])
+	}
+}
+
+func TestMergeGateThresholds_KeepsDistinctKeysSeparate(t *testing.T) {
+	a := 5.0
+	b := 10.0
+	got := mergeGateThresholds(
+		[]snap.GateThreshold{{Metric: "loc", MaxIncreasePct: &a}},
+		[]snap.GateThreshold{{Module: ":app", Metric: "fan_in", MaxAbsolute: &b}},
+	)
+	if len(got) != 2 {
+		t.Fatalf("repo + module keys should not collapse; got %+v", got)
 	}
 }


### PR DESCRIPTION
## Summary
\`krit snapshot gate\` learns to read its thresholds from \`snapshot.gate.{repo,module}\` in krit.yml. CLI flags continue to work and override config on overlapping (module, metric, constraint) triples. Yaml type coercion is tolerant of int / float / quoted-string number forms.

Closes #74.

## Test plan
- [x] New \`TestParseGateConfigSection_*\` (repo entries, module entries, empty-metric/missing-constraint rejection, numeric-type tolerance)
- [x] New \`TestMergeGateThresholds_*\` (CLI wins on overlap, disjoint constraints merge, distinct keys stay separate)
- [x] \`go test ./... -count=1\` and \`make integration\` clean
- [x] \`golangci-lint run ./internal/cli/snapshot/...\` clean