### PR TITLE
perf(oracle): preload lazy types.json off the rule path

### DIFF
--- a/internal/oracle/lazy.go
+++ b/internal/oracle/lazy.go
@@ -29,13 +29,33 @@ func (l *LazyLookup) get() *Oracle {
 	if l == nil || l.path == "" {
 		return nil
 	}
-	l.once.Do(func() {
-		l.loaded, l.err = Load(l.path)
-		if l.err != nil && l.onError != nil {
-			l.onError(l.err)
-		}
-	})
+	l.once.Do(l.load)
 	return l.loaded
+}
+
+// load is the once-guarded body invoked by both get() and Preload.
+// Pulled out as a method so Preload can hand it to once.Do without
+// allocating a fresh closure per call.
+func (l *LazyLookup) load() {
+	l.loaded, l.err = Load(l.path)
+	if l.err != nil && l.onError != nil {
+		l.onError(l.err)
+	}
+}
+
+// Preload kicks off the JSON deserialization in a background goroutine
+// so the first lookup observes a warm sync.Once instead of paying the
+// load latency itself. On large repos (Kotlin compiler: ~41 MB
+// types.json) the deferred load was ~500 ms, surfacing in per-rule
+// timings as whichever rule happened to fire first — Preload moves
+// that wall time off the rule path. Idempotent: multiple Preload
+// calls (or Preload followed by a real lookup) coalesce on the same
+// sync.Once.
+func (l *LazyLookup) Preload() {
+	if l == nil || l.path == "" {
+		return
+	}
+	go l.once.Do(l.load)
 }
 
 // Loaded reports whether the JSON has been deserialized successfully.

--- a/internal/oracle/lazy_test.go
+++ b/internal/oracle/lazy_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 func writeLazyOracleJSON(t *testing.T, dir string) string {
@@ -75,4 +76,44 @@ func TestLazyLookupReportsLoadErrorOnce(t *testing.T) {
 	if lazy.Err() == nil {
 		t.Fatal("expected retained load error")
 	}
+}
+
+func TestLazyLookupPreload_LoadsAhead(t *testing.T) {
+	path := writeLazyOracleJSON(t, t.TempDir())
+	lazy := NewLazyLookup(path, nil)
+	lazy.Preload()
+
+	// Spin briefly waiting for the goroutine to land. Generous bound
+	// because cold-cache test runners can drift.
+	deadline := time.Now().Add(time.Second)
+	for !lazy.Loaded() && time.Now().Before(deadline) {
+		time.Sleep(2 * time.Millisecond)
+	}
+	if !lazy.Loaded() {
+		t.Fatalf("Preload did not populate within 1s")
+	}
+}
+
+func TestLazyLookupPreload_IdempotentWithLookup(t *testing.T) {
+	path := writeLazyOracleJSON(t, t.TempDir())
+	lazy := NewLazyLookup(path, nil)
+	for i := 0; i < 5; i++ {
+		lazy.Preload()
+	}
+	info := lazy.LookupClass("Foo")
+	if info == nil {
+		t.Fatalf("LookupClass after Preload returned nil")
+	}
+	if info.FQN != "com.example.Foo" {
+		t.Fatalf("FQN = %q; want com.example.Foo", info.FQN)
+	}
+}
+
+func TestLazyLookupPreload_NilSafe(t *testing.T) {
+	var l *LazyLookup
+	l.Preload() // must not panic
+	if got := (&LazyLookup{}).Loaded(); got {
+		t.Fatalf("empty path should not load; Loaded() = %v", got)
+	}
+	(&LazyLookup{}).Preload() // path == "" — must not panic or load
 }

--- a/internal/pipeline/index.go
+++ b/internal/pipeline/index.go
@@ -673,6 +673,10 @@ func (p IndexPhase) loadOracleFromPath(in IndexInput, oraclePath string, oracleT
 	lazy := oracle.NewLazyLookup(oraclePath, func(err error) {
 		in.warnf("warning: type oracle: %v\n", err)
 	})
+	// Move the JSON deserialization off the rule path; on large
+	// projects this is ~500 ms otherwise charged to whichever rule
+	// fires first. See #57.
+	lazy.Preload()
 	return oracle.NewCompositeResolver(lazy, base)
 }
 


### PR DESCRIPTION
## Summary
\`LazyLookup\` deferred deserializing the (often >40 MB) types.json until the first \`ctx.Resolver.*\` call, charging ~500-700 ms to whichever rule fired first. Adds \`LazyLookup.Preload()\` (goroutine-driven, sync.Once-coalesced) and calls it from \`IndexPhase.loadOracleFromPath\`. First lookup now observes a warm Once.

Closes #57.

## Test plan
- [x] \`TestLazyLookupPreload_LoadsAhead\` (Loaded() flips before any lookup)
- [x] \`TestLazyLookupPreload_IdempotentWithLookup\` (multiple Preload + a real lookup coalesce)
- [x] \`TestLazyLookupPreload_NilSafe\` (nil receiver / empty path are no-ops)
- [x] \`go test ./... -count=1\` and \`make integration\` clean
- [x] \`golangci-lint run ./internal/oracle/... ./internal/pipeline/...\` clean