### PR TITLE
feat(snapshot): nest Manifest counts under a Counts struct

### DIFF
--- a/internal/snapshot/manifest.go
+++ b/internal/snapshot/manifest.go
@@ -11,11 +11,26 @@ import (
 	"github.com/kaeawc/krit/internal/fsutil"
 )
 
-// ManifestSchemaVersion versions the JSON manifest layout. Bumped only
-// when a field is added that older readers cannot tolerate.
-const ManifestSchemaVersion = 1
+// ManifestSchemaVersion versions the JSON manifest layout.
+//
+//	v1 — flat Files / Symbols / Modules count fields at the top level.
+//	v2 — counts moved into a nested Counts struct so future additions
+//	     (LinesOfCode, FailedFiles, FindingsTotal) don't widen the
+//	     top-level shape. v1 readers still see the flat fields: writers
+//	     populate both, and the v1->v2 migrator copies them in on read
+//	     so older payloads compare correctly.
+const ManifestSchemaVersion = 2
 
 const manifestFileName = "manifest.json"
+
+// ManifestCounts is the per-snapshot count rollup nested under
+// Manifest at v2. New count fields land here without touching the
+// top-level shape.
+type ManifestCounts struct {
+	Files   int `json:"files"`
+	Symbols int `json:"symbols"`
+	Modules int `json:"modules"`
+}
 
 // Manifest is the JSON sidecar describing a captured snapshot. Greppable
 // without krit; lets callers answer "what shas have we captured, at
@@ -25,6 +40,11 @@ const manifestFileName = "manifest.json"
 // RuleSetHash is reserved for the findings-rollup phase: when non-empty
 // it identifies the rule registry + config used to compute findings,
 // so cross-version diffs can refuse to compare incomparable counts.
+//
+// The flat Files / Symbols / Modules fields and the nested Counts
+// struct carry the same numbers — writers populate both so v1 readers
+// (and grep/jq pipelines) keep working through the transition. New
+// code should prefer Counts.
 type Manifest struct {
 	SchemaVersion int      `json:"schema_version"`
 	CommitSHA     string   `json:"commit_sha"`
@@ -33,10 +53,14 @@ type Manifest struct {
 	KritVersion   string   `json:"krit_version"`
 	BlobSchema    int      `json:"blob_schema"`
 	MetricsSchema int      `json:"metrics_schema"`
-	Files         int      `json:"files"`
-	Symbols       int      `json:"symbols"`
-	Modules       int      `json:"modules"`
-	RuleSetHash   string   `json:"rule_set_hash,omitempty"`
+	// Files / Symbols / Modules are kept at the top level for v1
+	// reader compatibility. Prefer Counts in new code; the two move
+	// in lockstep.
+	Files       int            `json:"files"`
+	Symbols     int            `json:"symbols"`
+	Modules     int            `json:"modules"`
+	Counts      ManifestCounts `json:"counts"`
+	RuleSetHash string         `json:"rule_set_hash,omitempty"`
 }
 
 func manifestPath(root, sha string) (string, error) {
@@ -168,6 +192,11 @@ func buildManifest(res *Result, repoRoot, kritVersion string) *Manifest {
 		return nil
 	}
 	parents, _ := ResolveParentSHAs(repoRoot, res.Blob.CommitSHA)
+	counts := ManifestCounts{
+		Files:   len(res.Blob.Files),
+		Symbols: len(res.Blob.Symbols),
+		Modules: len(res.Blob.Modules),
+	}
 	m := &Manifest{
 		SchemaVersion: ManifestSchemaVersion,
 		CommitSHA:     res.Blob.CommitSHA,
@@ -175,9 +204,11 @@ func buildManifest(res *Result, repoRoot, kritVersion string) *Manifest {
 		CapturedAt:    res.Blob.CapturedAt,
 		KritVersion:   kritVersion,
 		BlobSchema:    res.Blob.SchemaVersion,
-		Files:         len(res.Blob.Files),
-		Symbols:       len(res.Blob.Symbols),
-		Modules:       len(res.Blob.Modules),
+		// Flat fields kept for v1 reader compatibility; mirror Counts.
+		Files:   counts.Files,
+		Symbols: counts.Symbols,
+		Modules: counts.Modules,
+		Counts:  counts,
 	}
 	if res.Metrics != nil {
 		m.MetricsSchema = res.Metrics.SchemaVersion

--- a/internal/snapshot/migrate.go
+++ b/internal/snapshot/migrate.go
@@ -27,7 +27,30 @@ var blobMigrators = map[int]func(*Blob) (*Blob, error){}
 var metricsMigrators = map[int]func(*Metrics) (*Metrics, error){}
 
 // manifestMigrators is the per-step migration table for *Manifest.
-var manifestMigrators = map[int]func(*Manifest) (*Manifest, error){}
+var manifestMigrators = map[int]func(*Manifest) (*Manifest, error){
+	1: migrateManifestV1ToV2,
+}
+
+// migrateManifestV1ToV2 lifts the flat Files / Symbols / Modules
+// count fields into the new Counts struct introduced at v2. Writers
+// populate both fields in lockstep, so old readers continue to see
+// the flat layout — the migrator only matters when a newer binary
+// loads a payload captured at v1.
+//
+// The error return is part of the migrator-table contract; this
+// particular migrator can't fail, but future migrators may.
+//
+//nolint:unparam // matches the manifestMigrators map signature.
+func migrateManifestV1ToV2(m *Manifest) (*Manifest, error) {
+	cp := *m
+	cp.SchemaVersion = 2
+	cp.Counts = ManifestCounts{
+		Files:   m.Files,
+		Symbols: m.Symbols,
+		Modules: m.Modules,
+	}
+	return &cp, nil
+}
 
 // MigrateBlob walks blob's schema up to the current SchemaVersion.
 // Returns blob unchanged when already current; refuses to operate on

--- a/internal/snapshot/migrate_test.go
+++ b/internal/snapshot/migrate_test.go
@@ -164,3 +164,52 @@ func TestMigratorChainExecutesInOrder(t *testing.T) {
 		t.Errorf("expected ordered v(N-2) -> v(N-1) -> v(N) chain; got calls=%v", calls)
 	}
 }
+
+func TestMigrateManifestV1ToV2_LiftsFlatCountsIntoStruct(t *testing.T) {
+	in := &Manifest{
+		SchemaVersion: 1,
+		CommitSHA:     "abc",
+		Files:         12,
+		Symbols:       34,
+		Modules:       2,
+	}
+	got, err := MigrateManifest(in)
+	if err != nil {
+		t.Fatalf("MigrateManifest: %v", err)
+	}
+	if got.SchemaVersion != ManifestSchemaVersion {
+		t.Errorf("SchemaVersion = %d; want %d", got.SchemaVersion, ManifestSchemaVersion)
+	}
+	if got.Counts.Files != 12 || got.Counts.Symbols != 34 || got.Counts.Modules != 2 {
+		t.Errorf("Counts not lifted: %+v", got.Counts)
+	}
+	// Flat fields should still be intact for v1 readers iterating
+	// the same manifest.
+	if got.Files != 12 || got.Symbols != 34 || got.Modules != 2 {
+		t.Errorf("flat counts dropped during migration: %+v", got)
+	}
+}
+
+func TestMigrateManifestV1ToV2_RoundTripsViaSaveLoad(t *testing.T) {
+	root := t.TempDir()
+	v1 := &Manifest{
+		SchemaVersion: 1,
+		CommitSHA:     "abcd1234",
+		Files:         5,
+		Symbols:       7,
+		Modules:       1,
+	}
+	if _, err := SaveManifest(root, v1); err != nil {
+		t.Fatalf("SaveManifest: %v", err)
+	}
+	got, err := LoadManifest(root, "abcd1234")
+	if err != nil {
+		t.Fatalf("LoadManifest: %v", err)
+	}
+	if got.SchemaVersion != ManifestSchemaVersion {
+		t.Errorf("re-loaded schema = %d; want %d", got.SchemaVersion, ManifestSchemaVersion)
+	}
+	if got.Counts.Files != 5 || got.Counts.Symbols != 7 || got.Counts.Modules != 1 {
+		t.Errorf("Counts not populated on load: %+v", got.Counts)
+	}
+}


### PR DESCRIPTION
## Summary
Bumps \`ManifestSchemaVersion\` to 2 and introduces a nested \`Counts\` struct so future count fields don't widen the top-level shape. Writers populate both flat (\`Files\`/\`Symbols\`/\`Modules\`) and nested (\`Counts\`) in lockstep — v1 readers stay correct, new code prefers \`Counts\`.

The v1->v2 migrator (registered in the framework from #76) lifts flat counts into Counts on read so older payloads round-trip transparently.

Closes #54.

## Test plan
- [x] \`TestMigrateManifestV1ToV2_LiftsFlatCountsIntoStruct\`
- [x] \`TestMigrateManifestV1ToV2_RoundTripsViaSaveLoad\`
- [x] Existing manifest tests still pass
- [x] \`go test ./... -count=1\` and \`make integration\` clean
- [x] \`golangci-lint run ./internal/snapshot/...\` clean