### PR TITLE
perf(scanner): single-pass parsePackageHeaderText

### DIFF
--- a/internal/scanner/index_kotlin.go
+++ b/internal/scanner/index_kotlin.go
@@ -212,17 +212,29 @@ func packageNameForFile(file *File) string {
 // take only the first non-empty, non-comment line and strip the leading
 // `package` keyword.
 func parsePackageHeaderText(raw string) string {
-	for _, line := range strings.Split(raw, "\n") {
-		line = strings.TrimSpace(line)
-		if line == "" || strings.HasPrefix(line, "//") || strings.HasPrefix(line, "/*") {
-			continue
+	// Single-pass scan: walk the line-delimited string in place so we
+	// don't allocate a slice covering every line for the typical
+	// one-or-two-line header. Mirrors firstSourceLine in rename;
+	// same shape — see #46.
+	for s := raw; ; {
+		var line string
+		i := strings.IndexByte(s, '\n')
+		if i < 0 {
+			line = strings.TrimSpace(s)
+		} else {
+			line = strings.TrimSpace(s[:i])
 		}
-		line = strings.TrimPrefix(line, "package")
-		line = strings.TrimSpace(line)
-		line = strings.TrimSuffix(line, ";")
-		return strings.TrimSpace(line)
+		if line != "" && !strings.HasPrefix(line, "//") && !strings.HasPrefix(line, "/*") {
+			line = strings.TrimPrefix(line, "package")
+			line = strings.TrimSpace(line)
+			line = strings.TrimSuffix(line, ";")
+			return strings.TrimSpace(line)
+		}
+		if i < 0 {
+			return ""
+		}
+		s = s[i+1:]
 	}
-	return ""
 }
 
 func kotlinPackageName(file *File) string {

--- a/internal/scanner/index_kotlin_test.go
+++ b/internal/scanner/index_kotlin_test.go
@@ -31,6 +31,26 @@ func TestParsePackageHeaderText(t *testing.T) {
 			raw:  "  package   com.example.foo  \n",
 			want: "com.example.foo",
 		},
+		{
+			name: "empty",
+			raw:  "",
+			want: "",
+		},
+		{
+			name: "comments only",
+			raw:  "// just a comment\n/* and another */",
+			want: "",
+		},
+		{
+			name: "leading blank lines and comments",
+			raw:  "\n\n// a comment\n\npackage com.example\n",
+			want: "com.example",
+		},
+		{
+			name: "block comment then package",
+			raw:  "/* license header */\npackage com.example.bar\n",
+			want: "com.example.bar",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary
\`parsePackageHeaderText\` did \`strings.Split(raw, \"\\n\")\` per package header, allocating a slice covering every line. Switch to the in-place \`strings.IndexByte('\\n')\` loop \`firstSourceLine\` already uses; allocation per header drops from O(lines) to O(1).

Closes #46.

## Test plan
- [x] Existing \`TestParsePackageHeaderText\` cases all pass
- [x] New cases cover: empty input, comments only, leading blank lines + comments, block comment then package
- [x] \`go test ./... -count=1\` and \`make integration\` clean
- [x] \`golangci-lint run ./internal/scanner/...\` clean