### PR TITLE
feat(scanner): include Java files in CodeIndex.Files

### DIFF
--- a/internal/cli/rename/rename.go
+++ b/internal/cli/rename/rename.go
@@ -139,7 +139,7 @@ func buildRenamePlan(paths []string, workers int, target krename.Target) (krenam
 	}
 
 	idx := scanner.BuildIndex(parsedFiles, workers, parsedJavaFiles...)
-	return krename.BuildPlanWithFiles(idx, target, parsedJavaFiles), nil
+	return krename.BuildPlan(idx, target), nil
 }
 
 func joinErrors(errs []error) error {

--- a/internal/rename/plan.go
+++ b/internal/rename/plan.go
@@ -125,9 +125,7 @@ func ParseTarget(fromFQN, toFQN string) (Target, error) {
 	}, nil
 }
 
-// BuildPlan computes a rename plan from the index. Use BuildPlanWithFiles
-// when extra Java files need to participate (CodeIndex.Files only carries
-// Kotlin files).
+// BuildPlan computes a rename plan from the index.
 func BuildPlan(idx *scanner.CodeIndex, target Target) Plan {
 	return BuildPlanWithFiles(idx, target, nil)
 }

--- a/internal/scanner/index.go
+++ b/internal/scanner/index.go
@@ -110,12 +110,14 @@ func BuildIndexCached(cacheDir string, files []*File, workers int, tracker perf.
 	// Warm path: full payload hit via unpackFull (includes lookup maps).
 	if cachedIdx, ok := LoadCrossFileCacheIndex(cacheDir, fingerprint); ok {
 		cachedIdx.Files = append(cachedIdx.Files, files...)
+		cachedIdx.Files = append(cachedIdx.Files, javaFiles...)
 		cachedIdx.Fingerprint = fingerprint
 		return cachedIdx, true
 	}
 
 	if idx, ok := buildIndexFromPriorOverlay(cacheDir, entries, files, javaFiles, xmlFiles, workers, tracker); ok {
 		idx.Files = append(idx.Files, files...)
+		idx.Files = append(idx.Files, javaFiles...)
 		idx.Fingerprint = fingerprint
 		return idx, false
 	}
@@ -127,6 +129,7 @@ func BuildIndexCached(cacheDir string, files []*File, workers int, tracker perf.
 	symbols, refs, prebuiltBloom := collectIndexDataSharded(cacheDir, files, javaFiles, xmlFiles, workers, tracker)
 	idx := BuildIndexFromDataWithBloom(symbols, refs, prebuiltBloom, tracker)
 	idx.Files = append(idx.Files, files...)
+	idx.Files = append(idx.Files, javaFiles...)
 	idx.Fingerprint = fingerprint
 
 	meta := CrossFileCacheMeta{
@@ -145,6 +148,7 @@ func BuildIndexWithTracker(files []*File, workers int, tracker perf.Tracker, jav
 	symbols, refs := collectIndexDataWithTracker(files, workers, tracker, javaFiles...)
 	idx := BuildIndexFromDataWithTracker(symbols, refs, tracker)
 	idx.Files = append(idx.Files, files...)
+	idx.Files = append(idx.Files, javaFiles...)
 	return idx
 }
 

--- a/internal/scanner/index.go
+++ b/internal/scanner/index.go
@@ -78,8 +78,7 @@ type CodeIndex struct {
 	refBloom *bloom.BloomFilter
 }
 
-// BuildIndex constructs a cross-file index from parsed Kotlin files,
-// optionally including Java files for reference-only indexing.
+// BuildIndex constructs a cross-file index from parsed Kotlin and Java files.
 func BuildIndex(files []*File, workers int, javaFiles ...*File) *CodeIndex {
 	return BuildIndexWithTracker(files, workers, nil, javaFiles...)
 }
@@ -109,15 +108,13 @@ func BuildIndexCached(cacheDir string, files []*File, workers int, tracker perf.
 
 	// Warm path: full payload hit via unpackFull (includes lookup maps).
 	if cachedIdx, ok := LoadCrossFileCacheIndex(cacheDir, fingerprint); ok {
-		cachedIdx.Files = append(cachedIdx.Files, files...)
-		cachedIdx.Files = append(cachedIdx.Files, javaFiles...)
+		cachedIdx.Files = appendSourceFiles(cachedIdx.Files, files, javaFiles)
 		cachedIdx.Fingerprint = fingerprint
 		return cachedIdx, true
 	}
 
 	if idx, ok := buildIndexFromPriorOverlay(cacheDir, entries, files, javaFiles, xmlFiles, workers, tracker); ok {
-		idx.Files = append(idx.Files, files...)
-		idx.Files = append(idx.Files, javaFiles...)
+		idx.Files = appendSourceFiles(idx.Files, files, javaFiles)
 		idx.Fingerprint = fingerprint
 		return idx, false
 	}
@@ -128,8 +125,7 @@ func BuildIndexCached(cacheDir string, files []*File, workers int, tracker perf.
 	// build skip the per-reference AddString loop.
 	symbols, refs, prebuiltBloom := collectIndexDataSharded(cacheDir, files, javaFiles, xmlFiles, workers, tracker)
 	idx := BuildIndexFromDataWithBloom(symbols, refs, prebuiltBloom, tracker)
-	idx.Files = append(idx.Files, files...)
-	idx.Files = append(idx.Files, javaFiles...)
+	idx.Files = appendSourceFiles(idx.Files, files, javaFiles)
 	idx.Fingerprint = fingerprint
 
 	meta := CrossFileCacheMeta{
@@ -147,9 +143,22 @@ func BuildIndexCached(cacheDir string, files []*File, workers int, tracker perf.
 func BuildIndexWithTracker(files []*File, workers int, tracker perf.Tracker, javaFiles ...*File) *CodeIndex {
 	symbols, refs := collectIndexDataWithTracker(files, workers, tracker, javaFiles...)
 	idx := BuildIndexFromDataWithTracker(symbols, refs, tracker)
-	idx.Files = append(idx.Files, files...)
-	idx.Files = append(idx.Files, javaFiles...)
+	idx.Files = appendSourceFiles(idx.Files, files, javaFiles)
 	return idx
+}
+
+// appendSourceFiles appends kotlin then java files to dst, pre-sizing to avoid
+// two allocations when both slices are non-empty.
+func appendSourceFiles(dst, kotlinFiles, javaFiles []*File) []*File {
+	need := len(dst) + len(kotlinFiles) + len(javaFiles)
+	if cap(dst) < need {
+		grown := make([]*File, len(dst), need)
+		copy(grown, dst)
+		dst = grown
+	}
+	dst = append(dst, kotlinFiles...)
+	dst = append(dst, javaFiles...)
+	return dst
 }
 
 // BuildIndexFromData constructs a CodeIndex from pre-collected symbols and

--- a/internal/scanner/index_test.go
+++ b/internal/scanner/index_test.go
@@ -458,24 +458,20 @@ func TestBuildIndex_JavaFilesAppearInIndexFiles(t *testing.T) {
 
 	idx := BuildIndex([]*File{kt}, 1, javaFile)
 
-	var paths []string
-	for _, f := range idx.Files {
-		paths = append(paths, f.Path)
-	}
 	hasKotlin, hasJava := false, false
-	for _, p := range paths {
-		if p == kotlinPath {
+	for _, f := range idx.Files {
+		switch f.Path {
+		case kotlinPath:
 			hasKotlin = true
-		}
-		if p == javaPath {
+		case javaPath:
 			hasJava = true
 		}
 	}
 	if !hasKotlin {
-		t.Errorf("CodeIndex.Files missing Kotlin file; got %v", paths)
+		t.Errorf("CodeIndex.Files missing Kotlin file %s", kotlinPath)
 	}
 	if !hasJava {
-		t.Errorf("CodeIndex.Files missing Java file; got %v", paths)
+		t.Errorf("CodeIndex.Files missing Java file %s", javaPath)
 	}
 }
 

--- a/internal/scanner/index_test.go
+++ b/internal/scanner/index_test.go
@@ -440,6 +440,45 @@ fun use(helper: JavaHelper) = helper.label()
 	}
 }
 
+func TestBuildIndex_JavaFilesAppearInIndexFiles(t *testing.T) {
+	dir := t.TempDir()
+	javaPath := filepath.Join(dir, "JavaHelper.java")
+	if err := os.WriteFile(javaPath, []byte("package com.example;\npublic class JavaHelper {}\n"), 0o644); err != nil {
+		t.Fatalf("write java: %v", err)
+	}
+	kotlinPath := writeTempKt(t, dir, "UseJava.kt", "package com.example\n")
+	kt, err := ParseFile(kotlinPath)
+	if err != nil {
+		t.Fatalf("ParseFile: %v", err)
+	}
+	javaFile, err := ParseJavaFile(javaPath)
+	if err != nil {
+		t.Fatalf("ParseJavaFile: %v", err)
+	}
+
+	idx := BuildIndex([]*File{kt}, 1, javaFile)
+
+	var paths []string
+	for _, f := range idx.Files {
+		paths = append(paths, f.Path)
+	}
+	hasKotlin, hasJava := false, false
+	for _, p := range paths {
+		if p == kotlinPath {
+			hasKotlin = true
+		}
+		if p == javaPath {
+			hasJava = true
+		}
+	}
+	if !hasKotlin {
+		t.Errorf("CodeIndex.Files missing Kotlin file; got %v", paths)
+	}
+	if !hasJava {
+		t.Errorf("CodeIndex.Files missing Java file; got %v", paths)
+	}
+}
+
 func TestCollectJavaReferencesFlat_AddsScopedNames(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "UseJava.java")


### PR DESCRIPTION
## Summary

- Appends `javaFiles` to `idx.Files` in all four index build paths (`BuildIndexWithTracker`, and the three branches of `BuildIndexCached`)
- Extracts `appendSourceFiles` helper to avoid 4 × duplicate append pairs and pre-size the slice in one shot
- Removes the `BuildPlanWithFiles(idx, target, parsedJavaFiles)` workaround in `internal/cli/rename/rename.go` — Java files are now in `idx.Files` so `BuildPlan` finds them via the normal path
- `indexFileByPath` in the LSP go-to-test action now finds Java files too

## Audit
All `idx.Files` consumers in `internal/rules/` use `bytes.Contains` guards with Kotlin-specific markers before any AST work — Java files iterate and skip immediately. No Kotlin-only assumptions broken.

## Test plan

- [x] `TestBuildIndex_JavaFilesAppearInIndexFiles` — new test verifying both Kotlin and Java paths appear in `idx.Files`
- [x] `go test ./... -count=1` — all pass
- [x] `golangci-lint run` — 0 issues

Closes #45