### PR TITLE
feat(daemon): 50ms per-path debounce for Kotlin file-watcher events

### DIFF
--- a/internal/cli/serve/watcher.go
+++ b/internal/cli/serve/watcher.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/fsnotify/fsnotify"
 
@@ -13,6 +14,18 @@ import (
 	"github.com/kaeawc/krit/internal/diag"
 	"github.com/kaeawc/krit/internal/pipeline"
 )
+
+// watcherState is the subset of pipeline.WorkspaceState the file watcher
+// calls. The interface lets tests substitute a counting fake.
+type watcherState interface {
+	Invalidate(path string)
+	InvalidateCodeIndex()
+	InvalidateDependents()
+	InvalidateLibraryFacts()
+	Touch(path string)
+}
+
+const defaultDebounceWindow = 50 * time.Millisecond
 
 // fileWatcher pushes filesystem-change events into a daemon's
 // WorkspaceState invalidation API. It watches the project root
@@ -27,7 +40,7 @@ import (
 type fileWatcher struct {
 	w        *fsnotify.Watcher
 	root     string
-	state    *pipeline.WorkspaceState
+	state    watcherState
 	reporter *diag.Reporter
 	// onConfigChange fires when the watcher observes an edit to a
 	// krit.yml / .krit.yml file. Daemon callers wire this to
@@ -46,6 +59,14 @@ type fileWatcher struct {
 	// before the walk completes for a still-unwatched subtree are
 	// covered by the watcher's documented best-effort contract.
 	ready chan struct{}
+
+	// debounce coalesces rapid Write+Write+Chmod sequences that editors
+	// emit on a single logical save. Each path gets its own sliding timer;
+	// events within debounceWindow of each other are collapsed into one
+	// Invalidate+Touch call.
+	debounceMu     sync.Mutex
+	debounce       map[string]*time.Timer
+	debounceWindow time.Duration
 }
 
 // startFileWatcher returns a started watcher rooted at root. Callers
@@ -53,17 +74,23 @@ type fileWatcher struct {
 // Returns nil + error when the watcher couldn't be created (e.g. on
 // platforms without inotify/kqueue or when the root doesn't exist).
 func startFileWatcher(ctx context.Context, root string, state *pipeline.WorkspaceState, reporter *diag.Reporter, opts ...watcherOption) (*fileWatcher, error) {
+	return startFileWatcherWithState(ctx, root, state, reporter, opts...)
+}
+
+func startFileWatcherWithState(ctx context.Context, root string, state watcherState, reporter *diag.Reporter, opts ...watcherOption) (*fileWatcher, error) {
 	w, err := fsnotify.NewWatcher()
 	if err != nil {
 		return nil, err
 	}
 	fw := &fileWatcher{
-		w:        w,
-		root:     root,
-		state:    state,
-		reporter: reporter,
-		done:     make(chan struct{}),
-		ready:    make(chan struct{}),
+		w:              w,
+		root:           root,
+		state:          state,
+		reporter:       reporter,
+		done:           make(chan struct{}),
+		ready:          make(chan struct{}),
+		debounce:       make(map[string]*time.Timer),
+		debounceWindow: defaultDebounceWindow,
 	}
 	for _, opt := range opts {
 		opt(fw)
@@ -106,6 +133,12 @@ type watcherOption func(*fileWatcher)
 // to flag the daemon's cached config stale on krit.yml edits.
 func withConfigChangeCallback(fn func()) watcherOption {
 	return func(fw *fileWatcher) { fw.onConfigChange = fn }
+}
+
+// withDebounceWindow overrides the Kotlin-file debounce window. Used by
+// tests that need a shorter window to avoid slow test runs.
+func withDebounceWindow(d time.Duration) watcherOption {
+	return func(fw *fileWatcher) { fw.debounceWindow = d }
 }
 
 // Stop releases the watcher. Safe to call multiple times.
@@ -176,17 +209,32 @@ func (fw *fileWatcher) handle(ev fsnotify.Event) {
 		// since last analyze" see Gradle/version-catalog edits.
 		fw.state.Touch(ev.Name)
 	case isKotlinPath(ev.Name):
-		fw.state.Invalidate(ev.Name)
-		// Any source-file change can shift cross-file lookups, so
-		// drop the cached CodeIndex and DependentsIndex; the next
-		// caller rebuilds.
+		// Editors emit Write+Write+Chmod on a single logical save.
+		// Coalesce within debounceWindow so only one Invalidate+Touch
+		// fires per burst — the dirty-set's map semantics already dedup
+		// Touch, but Invalidate and CodeIndex drops are not free.
+		fw.scheduleKotlinInvalidate(ev.Name)
+	}
+}
+
+// scheduleKotlinInvalidate coalesces rapid fsnotify events for path into a
+// single Invalidate+Touch call fired after fw.debounceWindow of silence.
+// Each new event within the window restarts the timer (sliding debounce).
+func (fw *fileWatcher) scheduleKotlinInvalidate(path string) {
+	fw.debounceMu.Lock()
+	if t, ok := fw.debounce[path]; ok {
+		t.Stop()
+	}
+	fw.debounce[path] = time.AfterFunc(fw.debounceWindow, func() {
+		fw.debounceMu.Lock()
+		delete(fw.debounce, path)
+		fw.debounceMu.Unlock()
+		fw.state.Invalidate(path)
 		fw.state.InvalidateCodeIndex()
 		fw.state.InvalidateDependents()
-		// Record the dirty file. Repeated Touches dedup via the
-		// dirty-set's map semantics so an editor that emits
-		// Write+Write on save costs nothing extra.
-		fw.state.Touch(ev.Name)
-	}
+		fw.state.Touch(path)
+	})
+	fw.debounceMu.Unlock()
 }
 
 // addRecursive walks dir and adds every directory to the watcher.

--- a/internal/cli/serve/watcher_test.go
+++ b/internal/cli/serve/watcher_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -11,6 +12,17 @@ import (
 	"github.com/kaeawc/krit/internal/pipeline"
 	"github.com/kaeawc/krit/internal/scanner"
 )
+
+// countingState is a watcherState fake that counts Invalidate calls.
+type countingState struct {
+	invalidateCalls atomic.Int64
+}
+
+func (c *countingState) Invalidate(path string)  { c.invalidateCalls.Add(1) }
+func (c *countingState) InvalidateCodeIndex()    {}
+func (c *countingState) InvalidateDependents()   {}
+func (c *countingState) InvalidateLibraryFacts() {}
+func (c *countingState) Touch(path string)       {}
 
 // waitForCondition polls fn every 5ms up to 2s. Returns true when fn
 // turns true; false on timeout. Used to bridge the async fsnotify
@@ -295,12 +307,10 @@ func TestFileWatcher_TouchPropagatesOnKotlinWrite(t *testing.T) {
 	if len(dirty) == 0 {
 		t.Fatal("expected dirty-set to contain the written path within 2s")
 	}
-	if got := time.Since(start); got > 200*time.Millisecond {
-		// Soft warning: the SLO is a plan-level target; tests on a
-		// loaded CI runner may exceed it. We log rather than fail to
-		// avoid flakes; the daemon's end-to-end test in step 8
-		// asserts the SLO directly.
-		t.Logf("watcher latency = %v (target ≤ 200ms)", got)
+	if got := time.Since(start); got > 250*time.Millisecond {
+		// Soft warning: 50ms debounce + 200ms OS/queue latency budget.
+		// Log rather than fail to avoid CI flakes on loaded runners.
+		t.Logf("watcher latency = %v (target ≤ 250ms incl. 50ms debounce)", got)
 	}
 	// Path should match the touched file (after WorkspaceState's
 	// normalisation, which evaluates symlinks consistent with what
@@ -346,6 +356,48 @@ func TestFileWatcher_TouchPropagatesOnGradleWrite(t *testing.T) {
 	}
 	if len(dirty) == 0 {
 		t.Fatal("expected dirty-set to contain build.gradle.kts within 2s")
+	}
+}
+
+// TestFileWatcher_DebounceEditorSavePattern verifies that three rapid events
+// for the same Kotlin file coalesce into a single Invalidate call.
+func TestFileWatcher_DebounceEditorSavePattern(t *testing.T) {
+	root := t.TempDir()
+	ktPath := filepath.Join(root, "Foo.kt")
+	if err := os.WriteFile(ktPath, []byte("fun a() {}\n"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	state := &countingState{}
+	const window = 20 * time.Millisecond
+	w, err := startFileWatcherWithState(context.Background(), root, state, nil,
+		withDebounceWindow(window))
+	if err != nil {
+		t.Fatalf("startFileWatcher: %v", err)
+	}
+	defer w.Stop()
+	<-w.Ready()
+
+	// Simulate three Write+Write+Chmod events within 5ms — a typical
+	// editor save burst.
+	for range 3 {
+		if err := os.WriteFile(ktPath, []byte("fun a() { 1 }\n"), 0o644); err != nil {
+			t.Fatalf("rewrite: %v", err)
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+
+	// Wait for the debounce window to fire (window + generous margin).
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if state.invalidateCalls.Load() > 0 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	if got := state.invalidateCalls.Load(); got != 1 {
+		t.Errorf("Invalidate called %d times, want 1 (debounce should coalesce burst)", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Adds a sliding per-path 50ms debounce in `fileWatcher` for Kotlin file events
- Editors emit `Write+Write+Chmod` sequences on a single save; previously each event triggered `Invalidate+InvalidateCodeIndex+InvalidateDependents+Touch` independently. Now only one call fires per burst.
- The dirty-set map already deduped `Touch`; this change also dedupes the more expensive `Invalidate` and CodeIndex/DependentsIndex drops.
- Extracts a `watcherState` interface (5 methods) so tests can substitute a counting fake without relying on `WorkspaceState` side-effects.
- Adds `withDebounceWindow` option for tests (20ms in `TestFileWatcher_DebounceEditorSavePattern`).
- Adds `startFileWatcherWithState` taking the interface; production `startFileWatcher` delegates to it.

## Test plan

- [x] `TestFileWatcher_DebounceEditorSavePattern` — 3 writes within 6ms coalesce to 1 `Invalidate` call
- [x] All existing watcher tests still pass (2s deadline >> 50ms debounce delay)
- [x] `go test ./internal/cli/serve/ -count=1 -race` — all pass
- [x] `golangci-lint run` — 0 issues

Closes #62