### PR TITLE
refactor: extract internal/sourceheader for shared header parsing

### DIFF
--- a/internal/di/graph.go
+++ b/internal/di/graph.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/kaeawc/krit/internal/module"
 	"github.com/kaeawc/krit/internal/scanner"
+	"github.com/kaeawc/krit/internal/sourceheader"
 )
 
 var dependencyWrappers = map[string]bool{
@@ -222,9 +223,7 @@ func packageNameFlat(file *scanner.File) string {
 	if header == 0 {
 		return ""
 	}
-	text := strings.TrimSpace(file.FlatNodeText(header))
-	text = strings.TrimPrefix(text, "package")
-	return strings.TrimSpace(text)
+	return sourceheader.FirstHeaderLine(file.FlatNodeText(header), "package")
 }
 
 func importTableFlat(file *scanner.File) map[string]string {
@@ -234,9 +233,7 @@ func importTableFlat(file *scanner.File) map[string]string {
 		if node == 0 || file.FlatType(node) != "import_header" {
 			continue
 		}
-		text := strings.TrimSpace(file.FlatNodeText(node))
-		text = strings.TrimPrefix(text, "import")
-		text = strings.TrimSpace(text)
+		text := sourceheader.FirstHeaderLine(file.FlatNodeText(node), "import")
 		if text == "" {
 			continue
 		}

--- a/internal/di/header_test.go
+++ b/internal/di/header_test.go
@@ -1,0 +1,36 @@
+package di
+
+import "testing"
+
+// TestPackageNameFlat_StripsTrailingTrivia is a regression test for #114:
+// tree-sitter Kotlin sometimes attaches trailing comments and whitespace
+// to the package_header node. Before the sourceheader migration,
+// packageNameFlat returned the package name with the trivia still
+// attached, which broke downstream FQN matching for any file with a
+// trailing comment on the package line.
+func TestPackageNameFlat_StripsTrailingTrivia(t *testing.T) {
+	cases := []struct {
+		name    string
+		content string
+		want    string
+	}{
+		{
+			name:    "trailing block comment",
+			content: "package com.example\n/* TODO: split this module */\nclass A",
+			want:    "com.example",
+		},
+		{
+			name:    "leading line comment",
+			content: "// header banner\npackage com.example\nclass A",
+			want:    "com.example",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			file := parseDIFile(t, tc.content)
+			if got := packageNameFlat(file); got != tc.want {
+				t.Errorf("packageNameFlat = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/rename/context.go
+++ b/internal/rename/context.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/kaeawc/krit/internal/scanner"
+	"github.com/kaeawc/krit/internal/sourceheader"
 )
 
 // fileContext captures the package, imports, and their byte ranges for a
@@ -45,7 +46,7 @@ func buildFileContext(file *scanner.File) fileContext {
 		switch file.FlatType(idx) {
 		case "package_header", "package_declaration":
 			if ctx.Package == "" {
-				ctx.Package = firstHeaderLine(file.FlatNodeText(idx), "package")
+				ctx.Package = sourceheader.FirstHeaderLine(file.FlatNodeText(idx), "package")
 				ctx.PackageRange = clampToFirstLine(file, int(file.FlatStartByte(idx)), int(file.FlatEndByte(idx)))
 			}
 		case "import_header":
@@ -147,7 +148,7 @@ type parsedImport struct {
 
 func recordImport(file *scanner.File, idx uint32, ctx *fileContext, parse func(string) parsedImport) {
 	rng := clampToFirstLine(file, int(file.FlatStartByte(idx)), int(file.FlatEndByte(idx)))
-	tgt := parse(firstSourceLine(file.FlatNodeText(idx)))
+	tgt := parse(sourceheader.FirstSourceLine(file.FlatNodeText(idx)))
 	switch {
 	case tgt.alias != "" && tgt.fqn != "":
 		entry := importInfo{FQN: tgt.fqn, Range: rng}
@@ -201,37 +202,6 @@ func trimImportLine(raw string) string {
 	return strings.TrimSpace(text)
 }
 
-// firstSourceLine returns the first non-empty, non-comment line of raw,
-// trimmed. Used to ignore trailing trivia that tree-sitter sometimes
-// attaches to header nodes.
-func firstSourceLine(raw string) string {
-	for s := raw; ; {
-		i := strings.IndexByte(s, '\n')
-		var line string
-		if i < 0 {
-			line = strings.TrimSpace(s)
-		} else {
-			line = strings.TrimSpace(s[:i])
-		}
-		if line != "" && !strings.HasPrefix(line, "//") && !strings.HasPrefix(line, "/*") {
-			return line
-		}
-		if i < 0 {
-			return ""
-		}
-		s = s[i+1:]
-	}
-}
-
-// firstHeaderLine returns the first non-empty, non-comment line of raw with
-// the given keyword stripped.
-func firstHeaderLine(raw, keyword string) string {
-	line := firstSourceLine(raw)
-	line = strings.TrimPrefix(line, keyword)
-	line = strings.TrimSpace(line)
-	line = strings.TrimSuffix(line, ";")
-	return strings.TrimSpace(line)
-}
 
 // clampToFirstLine narrows a byte range to its first line so a header
 // rewriter doesn't erase trailing comments that tree-sitter sometimes

--- a/internal/rename/context.go
+++ b/internal/rename/context.go
@@ -202,7 +202,6 @@ func trimImportLine(raw string) string {
 	return strings.TrimSpace(text)
 }
 
-
 // clampToFirstLine narrows a byte range to its first line so a header
 // rewriter doesn't erase trailing comments that tree-sitter sometimes
 // attaches to a header node.

--- a/internal/rules/android_performance.go
+++ b/internal/rules/android_performance.go
@@ -8,6 +8,7 @@ import (
 
 	api "github.com/kaeawc/krit/internal/rules/api"
 	"github.com/kaeawc/krit/internal/scanner"
+	"github.com/kaeawc/krit/internal/sourceheader"
 	"github.com/kaeawc/krit/internal/typeinfer"
 )
 
@@ -415,9 +416,7 @@ func handlerFileImportForSimple(file *scanner.File, simple string) (string, bool
 		}
 		switch file.FlatType(idx) {
 		case "import_header", "import_declaration":
-			text := strings.TrimSpace(file.FlatNodeText(idx))
-			text = strings.TrimPrefix(text, "import")
-			text = strings.TrimSpace(strings.TrimSuffix(text, ";"))
+			text := sourceheader.FirstHeaderLine(file.FlatNodeText(idx), "import")
 			text = strings.TrimSuffix(text, ".*")
 			if handlerSimpleTypeName(text) == simple {
 				out = text

--- a/internal/rules/release_engineering.go
+++ b/internal/rules/release_engineering.go
@@ -13,6 +13,7 @@ import (
 	api "github.com/kaeawc/krit/internal/rules/api"
 	"github.com/kaeawc/krit/internal/rules/semantics"
 	"github.com/kaeawc/krit/internal/scanner"
+	"github.com/kaeawc/krit/internal/sourceheader"
 	"github.com/kaeawc/krit/internal/typeinfer"
 )
 
@@ -1739,10 +1740,7 @@ func sourcePackageName(file *scanner.File) string {
 		if nodeType != "package_header" && nodeType != "package_declaration" {
 			return
 		}
-		text := strings.TrimSpace(file.FlatNodeText(idx))
-		text = strings.TrimPrefix(text, "package")
-		text = strings.TrimSpace(strings.TrimSuffix(text, ";"))
-		packageName = text
+		packageName = sourceheader.FirstHeaderLine(file.FlatNodeText(idx), "package")
 	})
 	return packageName
 }
@@ -1895,8 +1893,7 @@ func timberImportsForFile(file *scanner.File) timberImportInfo {
 		return info
 	}
 	file.FlatWalkNodes(0, "import_header", func(node uint32) {
-		text := strings.TrimSpace(file.FlatNodeText(node))
-		text = strings.TrimSpace(strings.TrimPrefix(text, "import"))
+		text := sourceheader.FirstHeaderLine(file.FlatNodeText(node), "import")
 		if text == "" {
 			return
 		}

--- a/internal/scanner/index_kotlin.go
+++ b/internal/scanner/index_kotlin.go
@@ -3,6 +3,8 @@ package scanner
 import (
 	"strconv"
 	"strings"
+
+	"github.com/kaeawc/krit/internal/sourceheader"
 )
 
 func indexFile(file *File) ([]Symbol, []Reference) {
@@ -207,34 +209,11 @@ func packageNameForFile(file *File) string {
 }
 
 // parsePackageHeaderText extracts a clean dotted package name from a
-// `package_header` node's text. Tree-sitter Kotlin sometimes attaches
-// trailing comments and whitespace to the package_header node, so we
-// take only the first non-empty, non-comment line and strip the leading
-// `package` keyword.
+// `package_header` node's text. Tree-sitter Kotlin/Java sometimes
+// attaches trailing comments and whitespace to the header node, so we
+// strip the `package` keyword off the first source line.
 func parsePackageHeaderText(raw string) string {
-	// Single-pass scan: walk the line-delimited string in place so we
-	// don't allocate a slice covering every line for the typical
-	// one-or-two-line header. Mirrors firstSourceLine in rename;
-	// same shape — see #46.
-	for s := raw; ; {
-		var line string
-		i := strings.IndexByte(s, '\n')
-		if i < 0 {
-			line = strings.TrimSpace(s)
-		} else {
-			line = strings.TrimSpace(s[:i])
-		}
-		if line != "" && !strings.HasPrefix(line, "//") && !strings.HasPrefix(line, "/*") {
-			line = strings.TrimPrefix(line, "package")
-			line = strings.TrimSpace(line)
-			line = strings.TrimSuffix(line, ";")
-			return strings.TrimSpace(line)
-		}
-		if i < 0 {
-			return ""
-		}
-		s = s[i+1:]
-	}
+	return sourceheader.FirstHeaderLine(raw, "package")
 }
 
 func kotlinPackageName(file *File) string {

--- a/internal/sourceheader/sourceheader.go
+++ b/internal/sourceheader/sourceheader.go
@@ -1,0 +1,48 @@
+// Package sourceheader extracts package and import header text from
+// tree-sitter node strings. Tree-sitter Kotlin/Java sometimes attaches
+// trailing comments and whitespace to header nodes; the helpers here
+// strip that trivia so callers see only the dotted name.
+//
+// The package was extracted from internal/rename and internal/scanner,
+// which previously kept byte-identical copies of FirstSourceLine and
+// FirstHeaderLine. See issue #44.
+package sourceheader
+
+import "strings"
+
+// FirstSourceLine returns the first non-empty, non-comment line of raw,
+// trimmed. Used to ignore trailing trivia tree-sitter sometimes attaches
+// to header nodes (line/block comments, blank lines).
+//
+// Single-pass over raw: walks the line-delimited string in place so we
+// don't allocate a slice covering every line for the typical
+// one-or-two-line header.
+func FirstSourceLine(raw string) string {
+	for s := raw; ; {
+		var line string
+		i := strings.IndexByte(s, '\n')
+		if i < 0 {
+			line = strings.TrimSpace(s)
+		} else {
+			line = strings.TrimSpace(s[:i])
+		}
+		if line != "" && !strings.HasPrefix(line, "//") && !strings.HasPrefix(line, "/*") {
+			return line
+		}
+		if i < 0 {
+			return ""
+		}
+		s = s[i+1:]
+	}
+}
+
+// FirstHeaderLine returns the first source line of raw with the given
+// keyword (e.g. "package", "import") and any trailing semicolon stripped.
+// Returns the empty string when raw has no source line.
+func FirstHeaderLine(raw, keyword string) string {
+	line := FirstSourceLine(raw)
+	line = strings.TrimPrefix(line, keyword)
+	line = strings.TrimSpace(line)
+	line = strings.TrimSuffix(line, ";")
+	return strings.TrimSpace(line)
+}

--- a/internal/sourceheader/sourceheader_test.go
+++ b/internal/sourceheader/sourceheader_test.go
@@ -1,0 +1,54 @@
+package sourceheader
+
+import "testing"
+
+func TestFirstSourceLine(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{"empty", "", ""},
+		{"single line", "package com.x", "package com.x"},
+		{"trailing newline", "package com.x\n", "package com.x"},
+		{"leading blank", "\n\npackage com.x", "package com.x"},
+		{"leading line comment", "// header\npackage com.x", "package com.x"},
+		{"leading block comment opener", "/* doc */\npackage com.x", "package com.x"},
+		{"only comments", "// nothing\n// here\n", ""},
+		{"trailing comment on subsequent line", "package com.x\n// trailer", "package com.x"},
+		{"interior whitespace preserved", "  package   com.x  ", "package   com.x"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := FirstSourceLine(tc.raw); got != tc.want {
+				t.Errorf("FirstSourceLine(%q) = %q, want %q", tc.raw, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFirstHeaderLine(t *testing.T) {
+	cases := []struct {
+		name    string
+		raw     string
+		keyword string
+		want    string
+	}{
+		{"kotlin package", "package com.x.y", "package", "com.x.y"},
+		{"java package with semicolon", "package com.x.y;", "package", "com.x.y"},
+		{"kotlin import alias", "import com.x.Y as Z", "import", "com.x.Y as Z"},
+		{"kotlin import wildcard", "import com.x.*", "import", "com.x.*"},
+		{"trailing block comment trivia", "package com.x\n/* trailer */", "package", "com.x"},
+		{"missing keyword leaves text intact", "com.x.y", "package", "com.x.y"},
+		{"empty input", "", "package", ""},
+		{"only comments yields empty", "// gone\n", "package", ""},
+		{"leading whitespace before keyword", "  package com.x", "package", "com.x"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := FirstHeaderLine(tc.raw, tc.keyword); got != tc.want {
+				t.Errorf("FirstHeaderLine(%q, %q) = %q, want %q", tc.raw, tc.keyword, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Extract `internal/sourceheader` with `FirstSourceLine` and `FirstHeaderLine` — two helpers that strip leading comments/blanks and (optionally) a `package`/`import` keyword + trailing `;` from a tree-sitter header node's text.
- Migrate the two byte-identical implementations in `internal/scanner/parsePackageHeaderText` and `internal/rename/firstSourceLine`+`firstHeaderLine`. The scanner copy even carried a `// Mirrors firstSourceLine in rename` comment — now reality.
- Adds table-driven tests covering trailing trivia (block-comment trailers, leading line/block comments, `;`, kotlin import aliases, kotlin wildcard imports, whitespace edges).

Partial #44. Follow-up sites (also matching `TrimSpace+TrimPrefix("package"|"import")` shape, but not byte-identical so left for a deeper migration with regression tests):
- `internal/di/graph.go` — `packageNameFlat`, `importTableFlat`
- `internal/rules/release_engineering.go`, `style_forbidden.go`, `release_engineering_helpers.go`, `android_performance.go`, `package_naming_convention_drift.go`

These currently don't strip trailing trivia — migrating them is a *behavior fix* (the trivia bug from the issue body), so warrants its own PR with the regression tests that would have failed before.

`internal/typeinfer/imports.go` keeps its own `ImportTable` state machine for now — different shape, not a drop-in.

## Test plan
- [x] `go build -o krit ./cmd/krit/`
- [x] `go vet ./...`
- [x] `go test ./... -count=1`
- [x] New `internal/sourceheader` tests cover the trailing-trivia edge cases