### PR TITLE
fix: route 5 more package/import header strips through sourceheader

### DIFF
--- a/internal/di/graph.go
+++ b/internal/di/graph.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/kaeawc/krit/internal/module"
 	"github.com/kaeawc/krit/internal/scanner"
+	"github.com/kaeawc/krit/internal/sourceheader"
 )
 
 var dependencyWrappers = map[string]bool{
@@ -222,9 +223,7 @@ func packageNameFlat(file *scanner.File) string {
 	if header == 0 {
 		return ""
 	}
-	text := strings.TrimSpace(file.FlatNodeText(header))
-	text = strings.TrimPrefix(text, "package")
-	return strings.TrimSpace(text)
+	return sourceheader.FirstHeaderLine(file.FlatNodeText(header), "package")
 }
 
 func importTableFlat(file *scanner.File) map[string]string {
@@ -234,9 +233,7 @@ func importTableFlat(file *scanner.File) map[string]string {
 		if node == 0 || file.FlatType(node) != "import_header" {
 			continue
 		}
-		text := strings.TrimSpace(file.FlatNodeText(node))
-		text = strings.TrimPrefix(text, "import")
-		text = strings.TrimSpace(text)
+		text := sourceheader.FirstHeaderLine(file.FlatNodeText(node), "import")
 		if text == "" {
 			continue
 		}

--- a/internal/di/header_test.go
+++ b/internal/di/header_test.go
@@ -1,0 +1,36 @@
+package di
+
+import "testing"
+
+// TestPackageNameFlat_StripsTrailingTrivia is a regression test for #114:
+// tree-sitter Kotlin sometimes attaches trailing comments and whitespace
+// to the package_header node. Before the sourceheader migration,
+// packageNameFlat returned the package name with the trivia still
+// attached, which broke downstream FQN matching for any file with a
+// trailing comment on the package line.
+func TestPackageNameFlat_StripsTrailingTrivia(t *testing.T) {
+	cases := []struct {
+		name    string
+		content string
+		want    string
+	}{
+		{
+			name:    "trailing block comment",
+			content: "package com.example\n/* TODO: split this module */\nclass A",
+			want:    "com.example",
+		},
+		{
+			name:    "leading line comment",
+			content: "// header banner\npackage com.example\nclass A",
+			want:    "com.example",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			file := parseDIFile(t, tc.content)
+			if got := packageNameFlat(file); got != tc.want {
+				t.Errorf("packageNameFlat = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/rules/android_performance.go
+++ b/internal/rules/android_performance.go
@@ -8,6 +8,7 @@ import (
 
 	api "github.com/kaeawc/krit/internal/rules/api"
 	"github.com/kaeawc/krit/internal/scanner"
+	"github.com/kaeawc/krit/internal/sourceheader"
 	"github.com/kaeawc/krit/internal/typeinfer"
 )
 
@@ -415,9 +416,7 @@ func handlerFileImportForSimple(file *scanner.File, simple string) (string, bool
 		}
 		switch file.FlatType(idx) {
 		case "import_header", "import_declaration":
-			text := strings.TrimSpace(file.FlatNodeText(idx))
-			text = strings.TrimPrefix(text, "import")
-			text = strings.TrimSpace(strings.TrimSuffix(text, ";"))
+			text := sourceheader.FirstHeaderLine(file.FlatNodeText(idx), "import")
 			text = strings.TrimSuffix(text, ".*")
 			if handlerSimpleTypeName(text) == simple {
 				out = text

--- a/internal/rules/release_engineering.go
+++ b/internal/rules/release_engineering.go
@@ -13,6 +13,7 @@ import (
 	api "github.com/kaeawc/krit/internal/rules/api"
 	"github.com/kaeawc/krit/internal/rules/semantics"
 	"github.com/kaeawc/krit/internal/scanner"
+	"github.com/kaeawc/krit/internal/sourceheader"
 	"github.com/kaeawc/krit/internal/typeinfer"
 )
 
@@ -1739,10 +1740,7 @@ func sourcePackageName(file *scanner.File) string {
 		if nodeType != "package_header" && nodeType != "package_declaration" {
 			return
 		}
-		text := strings.TrimSpace(file.FlatNodeText(idx))
-		text = strings.TrimPrefix(text, "package")
-		text = strings.TrimSpace(strings.TrimSuffix(text, ";"))
-		packageName = text
+		packageName = sourceheader.FirstHeaderLine(file.FlatNodeText(idx), "package")
 	})
 	return packageName
 }
@@ -1895,8 +1893,7 @@ func timberImportsForFile(file *scanner.File) timberImportInfo {
 		return info
 	}
 	file.FlatWalkNodes(0, "import_header", func(node uint32) {
-		text := strings.TrimSpace(file.FlatNodeText(node))
-		text = strings.TrimSpace(strings.TrimPrefix(text, "import"))
+		text := sourceheader.FirstHeaderLine(file.FlatNodeText(node), "import")
 		if text == "" {
 			return
 		}


### PR DESCRIPTION
## Summary
Stacked on #113. Migrates 5 hand-rolled \`TrimSpace+TrimPrefix(\"package\"|\"import\")\` sites to \`sourceheader.FirstHeaderLine\`, fixing the trailing-trivia bug from #44 at:
- \`internal/di/graph.go\` — \`packageNameFlat\`, \`importTableFlat\`
- \`internal/rules/release_engineering.go\` — package + import strips
- \`internal/rules/android_performance.go\` — import strip

## Why this is a fix, not a refactor
Tree-sitter attaches trailing block-comment trivia to \`package_header\` / \`import_header\` nodes. The pre-migration code returned the dotted name with trivia still appended, e.g.:

\`\`\`
packageNameFlat = "com.example\\n/* TODO: split this module */"   // before
packageNameFlat = "com.example"                                 // after
\`\`\`

\`internal/di/header_test.go\` is a regression test verified to **fail on the old code, pass on the new** (covers trailing block comment + leading line comment).

## Out of scope (#114 follow-up)
\`style_forbidden.go\` (Java \`static\` prefix), \`release_engineering_helpers.go\` (\`HasPrefix\` gate), \`package_naming_convention_drift.go\` (identifier child first) — each needs extra handling beyond a drop-in.

Closes #114 partially.

## Test plan
- [x] \`go build -o krit ./cmd/krit/\`
- [x] \`go vet ./...\`
- [x] \`go test ./... -count=1\`
- [x] New \`TestPackageNameFlat_StripsTrailingTrivia\` passes; verified to fail on the pre-migration impl