### PR TITLE
feat(daemon): make LibraryFacts daemon-resident via WorkspaceState

### DIFF
--- a/internal/cli/serve/analyze_project.go
+++ b/internal/cli/serve/analyze_project.go
@@ -129,12 +129,15 @@ func (s *daemonState) buildProjectInput(args daemon.AnalyzeProjectArgs) (pipelin
 			IncludeGenerated: args.IncludeGenerated,
 			Version:          kritVersion(),
 		},
-		// Resolver, Oracle, AnalysisCache, PrebuiltLibraryFacts will be
-		// wired into Host as the daemon promotes them to resident state
-		// in follow-up commits (see #48). RunProject treats nil as
-		// "construct per-call as the CLI runner does today", so the
-		// verb is already correct — just slower than its eventual ceiling.
-		Host: pipeline.ProjectHostState{ParseCache: parseCache},
+		// Resolver, Oracle, AnalysisCache will be wired into Host as the
+		// daemon promotes them to resident state in follow-up commits
+		// (see #48). RunProject treats nil as "construct per-call as the
+		// CLI runner does today", so the verb is already correct — just
+		// slower than its eventual ceiling.
+		Host: pipeline.ProjectHostState{
+			ParseCache:        parseCache,
+			LibraryFactsCache: s.workspace,
+		},
 	}, nil
 }
 

--- a/internal/pipeline/index.go
+++ b/internal/pipeline/index.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"strings"
 
 	"time"
@@ -61,7 +62,13 @@ type IndexInput struct {
 	PrebuiltResolver typeinfer.TypeResolver
 	// PrebuiltLibraryFacts, when non-nil, is passed through to downstream
 	// rule contexts instead of being rebuilt from detected Gradle files.
+	// Highest precedence — wins over LibraryFactsCache.
 	PrebuiltLibraryFacts *librarymodel.Facts
+	// LibraryFactsCache, when non-nil and PrebuiltLibraryFacts is nil,
+	// memoizes the constructed Facts across calls. The fingerprint key
+	// is derived from the discovered Gradle paths; the host's watcher
+	// drops the slot when Gradle / version-catalog files change.
+	LibraryFactsCache LibraryFactsCache
 	// Reporter routes verbose progress and warning lines from IndexPhase.
 	// Nil means silent.
 	Reporter *diag.Reporter
@@ -315,6 +322,16 @@ func (p IndexPhase) discoverModuleGraph(in IndexInput) *module.Graph {
 	return graph
 }
 
+// libraryFactsFingerprint is a stable cache key for a Gradle path set.
+// Watcher-driven InvalidateLibraryFacts is the source of truth for
+// staleness; this just needs to differ between distinct path sets so
+// concurrent projects don't collide on the same daemon's cache slot.
+func libraryFactsFingerprint(gradlePaths []string) string {
+	sorted := append([]string(nil), gradlePaths...)
+	sort.Strings(sorted)
+	return strings.Join(sorted, "\x00")
+}
+
 // detectAndroidProject detects the Android project and populates
 // LibraryFacts from its Gradle paths when not already set.
 func (p IndexPhase) detectAndroidProject(in IndexInput, result *IndexResult) {
@@ -323,8 +340,15 @@ func (p IndexPhase) detectAndroidProject(in IndexInput, result *IndexResult) {
 	}
 	result.AndroidProject = android.DetectProject(in.Paths)
 	if result.LibraryFacts == nil && result.AndroidProject != nil {
-		profile := librarymodel.ProfileFromGradlePaths(result.AndroidProject.GradlePaths)
-		result.LibraryFacts = librarymodel.FactsForProfile(profile)
+		gradle := result.AndroidProject.GradlePaths
+		build := func() *librarymodel.Facts {
+			return librarymodel.FactsForProfile(librarymodel.ProfileFromGradlePaths(gradle))
+		}
+		if in.LibraryFactsCache != nil && len(gradle) > 0 {
+			result.LibraryFacts = in.LibraryFactsCache.LibraryFacts(libraryFactsFingerprint(gradle), build)
+		} else {
+			result.LibraryFacts = build()
+		}
 	}
 }
 

--- a/internal/pipeline/library_facts_cache_test.go
+++ b/internal/pipeline/library_facts_cache_test.go
@@ -1,0 +1,77 @@
+package pipeline
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kaeawc/krit/internal/librarymodel"
+)
+
+// countingLibraryFactsCache is a test fake implementing LibraryFactsCache
+// that counts how often build() actually fires versus how often the cached
+// pointer is returned.
+type countingLibraryFactsCache struct {
+	cached *librarymodel.Facts
+	fp     string
+	builds int
+}
+
+func (c *countingLibraryFactsCache) LibraryFacts(fingerprint string, build func() *librarymodel.Facts) *librarymodel.Facts {
+	if c.cached != nil && c.fp == fingerprint {
+		return c.cached
+	}
+	c.cached = build()
+	c.fp = fingerprint
+	c.builds++
+	return c.cached
+}
+
+func TestIndexPhase_LibraryFactsCache_BuildsOnceAcrossRuns(t *testing.T) {
+	dir := t.TempDir()
+	gradlePath := filepath.Join(dir, "build.gradle.kts")
+	if err := os.WriteFile(gradlePath, []byte("plugins { id(\"com.android.application\") }\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cache := &countingLibraryFactsCache{}
+	in := IndexInput{
+		ParseResult:       ParseResult{Paths: []string{dir}},
+		LibraryFactsCache: cache,
+	}
+
+	r1, err := IndexPhase{SkipModules: true, SkipResolverIndex: true}.Run(context.Background(), in)
+	if err != nil {
+		t.Fatalf("first Run: %v", err)
+	}
+	if r1.LibraryFacts == nil {
+		t.Fatal("first Run produced nil LibraryFacts")
+	}
+	if cache.builds != 1 {
+		t.Fatalf("after first Run, builds = %d, want 1", cache.builds)
+	}
+
+	r2, err := IndexPhase{SkipModules: true, SkipResolverIndex: true}.Run(context.Background(), in)
+	if err != nil {
+		t.Fatalf("second Run: %v", err)
+	}
+	if cache.builds != 1 {
+		t.Fatalf("after second Run, builds = %d, want 1 (cache miss)", cache.builds)
+	}
+	if r1.LibraryFacts != r2.LibraryFacts {
+		t.Errorf("LibraryFacts pointer changed across runs; cache is not reusing the cached value")
+	}
+}
+
+func TestLibraryFactsFingerprint_StableAndDistinct(t *testing.T) {
+	a := libraryFactsFingerprint([]string{"/x/build.gradle", "/y/build.gradle"})
+	b := libraryFactsFingerprint([]string{"/y/build.gradle", "/x/build.gradle"})
+	if a != b {
+		t.Errorf("fingerprint should be order-independent: %q vs %q", a, b)
+	}
+	c := libraryFactsFingerprint([]string{"/x/build.gradle"})
+	if a == c {
+		t.Errorf("fingerprint should differ for distinct path sets: %q", a)
+	}
+}

--- a/internal/pipeline/project.go
+++ b/internal/pipeline/project.go
@@ -19,6 +19,14 @@ import (
 	"github.com/kaeawc/krit/internal/typeinfer"
 )
 
+// LibraryFactsCache lets a long-lived host (typically *WorkspaceState)
+// memoize *librarymodel.Facts across RunProject calls so the daemon
+// doesn't repay Gradle/version-catalog discovery on every analyze.
+// build is invoked on a fingerprint mismatch.
+type LibraryFactsCache interface {
+	LibraryFacts(fingerprint string, build func() *librarymodel.Facts) *librarymodel.Facts
+}
+
 // ProjectArgs is the per-call subset of ProjectInput: caller-provided
 // knobs that mirror a small, stable subset of CLI flags. These change
 // per request and are never stashed by the daemon.
@@ -77,7 +85,14 @@ type ProjectHostState struct {
 	PrebuiltResolver typeinfer.TypeResolver
 	// PrebuiltLibraryFacts, when non-nil, is forwarded to rule
 	// contexts instead of being rebuilt from detected Gradle files.
+	// Highest precedence — wins over LibraryFactsCache.
 	PrebuiltLibraryFacts *librarymodel.Facts
+	// LibraryFactsCache, when non-nil, is consulted in IndexPhase to
+	// reuse a daemon-resident *librarymodel.Facts across calls. Cache
+	// invalidation is the host's responsibility (the daemon's file
+	// watcher fires WorkspaceState.InvalidateLibraryFacts on Gradle /
+	// version-catalog edits). *WorkspaceState satisfies this interface.
+	LibraryFactsCache LibraryFactsCache
 	// Oracle, when non-nil, is the resident type-oracle handle.
 	Oracle *oracle.Oracle
 	// OracleDaemon, when non-nil, is the long-lived krit-types JVM
@@ -190,6 +205,7 @@ func RunProject(ctx context.Context, in ProjectInput) (ProjectResult, error) {
 		ParseResult:          parseResult,
 		PrebuiltResolver:     host.PrebuiltResolver,
 		PrebuiltLibraryFacts: host.PrebuiltLibraryFacts,
+		LibraryFactsCache:    host.LibraryFactsCache,
 		Reporter:             host.Reporter,
 		Tracker:              host.Tracker,
 	}


### PR DESCRIPTION
## Summary
First focused step of #48 — promote \`*librarymodel.Facts\` off the per-call hot path so the daemon stops re-running Gradle/version-catalog discovery on every \`analyze-project\` call.

The plumbing was already in place:
- \`WorkspaceState\` has a fingerprint-keyed \`LibraryFacts(fp, build)\` slot.
- File watcher already calls \`InvalidateLibraryFacts\` on Gradle / version-catalog edits.

What this PR adds:
- \`pipeline.LibraryFactsCache\` interface (one method) — \`*WorkspaceState\` already satisfies it.
- \`ProjectHostState.LibraryFactsCache\` and \`IndexInput.LibraryFactsCache\` plumbing.
- \`IndexPhase.detectAndroidProject\` consults the cache before \`librarymodel.FactsForProfile\`. \`PrebuiltLibraryFacts\` still wins (highest precedence).
- \`libraryFactsFingerprint\` — stable, order-independent join of discovered Gradle paths. Watcher invalidation is the source of truth for staleness.
- \`daemonState.buildProjectInput\` wires \`s.workspace\` as the cache.

## Out of scope (#48 follow-up)
- \`PrebuiltResolver\` (\`typeinfer.TypeResolver\`) — needs incremental invalidation; today \`IndexFilesParallel\` re-indexes everything per call, so a resident resolver would accumulate stale entries across edits. Bigger change.
- \`Oracle\` / \`OracleDaemon\` — subprocess lifecycle management (per-entry ping + auto-rebuild on JVM crash).
- \`AnalysisCache\` — write-path serialization concerns.

Each of those gets its own PR.

## Tests
- \`TestIndexPhase_LibraryFactsCache_BuildsOnceAcrossRuns\` — counting fake confirms \`build()\` fires once across two \`IndexPhase.Run\` calls and pointer is reused.
- \`TestLibraryFactsFingerprint_StableAndDistinct\` — fingerprint is order-independent and distinguishes path sets.
- Existing \`TestAnalyzeProject_OutputMatchesDirectRunProject\` byte-equal contract still passes.

## Test plan
- [x] \`go build -o krit ./cmd/krit/\`
- [x] \`go vet ./...\`
- [x] \`go test ./... -count=1\`