### PR TITLE
perf(daemon): wire type-index-cache through IndexPhase

### DIFF
--- a/internal/cli/serve/analyze_project.go
+++ b/internal/cli/serve/analyze_project.go
@@ -13,6 +13,7 @@ import (
 	"github.com/kaeawc/krit/internal/daemon"
 	"github.com/kaeawc/krit/internal/pipeline"
 	"github.com/kaeawc/krit/internal/rules"
+	"github.com/kaeawc/krit/internal/typeinfer"
 )
 
 // errDaemonNotWarm is returned to RequireWarm clients on a cold
@@ -137,6 +138,7 @@ func (s *daemonState) buildProjectInput(args daemon.AnalyzeProjectArgs) (pipelin
 		Host: pipeline.ProjectHostState{
 			ParseCache:        parseCache,
 			LibraryFactsCache: s.workspace,
+			TypeIndexCacheDir: typeinfer.TypeIndexCacheDir(repoDir),
 		},
 	}, nil
 }

--- a/internal/pipeline/index.go
+++ b/internal/pipeline/index.go
@@ -69,6 +69,12 @@ type IndexInput struct {
 	// is derived from the discovered Gradle paths; the host's watcher
 	// drops the slot when Gradle / version-catalog files change.
 	LibraryFactsCache LibraryFactsCache
+	// TypeIndexCacheDir, when non-empty, enables the per-file
+	// FileTypeInfo cache (typeinfer.IndexFilesParallelCachedWithTracker).
+	// Unchanged files are read from disk instead of re-extracted, which
+	// is the dominant cost (~336 ms / 19k files in the planning-doc
+	// measurement) on warm + 1-edit runs. Empty disables the cache.
+	TypeIndexCacheDir string
 	// Reporter routes verbose progress and warning lines from IndexPhase.
 	// Nil means silent.
 	Reporter *diag.Reporter
@@ -289,6 +295,26 @@ func (p IndexPhase) buildTypeResolver(ctx context.Context, in IndexInput, resolv
 	workers := p.Workers
 	if workers <= 0 {
 		workers = runtime.NumCPU()
+	}
+	if in.TypeIndexCacheDir != "" {
+		if cached, ok := interface{}(r).(interface {
+			IndexFilesParallelCachedWithTracker([]*scanner.File, int, string, perf.Tracker) (int, int)
+		}); ok {
+			var hits, misses int
+			if in.Tracker != nil {
+				child := in.Tracker.Serial("typeIndex")
+				hits, misses = cached.IndexFilesParallelCachedWithTracker(in.KotlinFiles, workers, in.TypeIndexCacheDir, child)
+				perf.AddEntryDetails(child, "cacheSummary", 0, map[string]int64{
+					"hits":   int64(hits),
+					"misses": int64(misses),
+				}, nil)
+				child.End()
+			} else {
+				hits, misses = cached.IndexFilesParallelCachedWithTracker(in.KotlinFiles, workers, in.TypeIndexCacheDir, nil)
+			}
+			in.logf("verbose: Indexed %d Kotlin files for type resolution (typeIndex cache: %d hits, %d misses)", len(in.KotlinFiles), hits, misses)
+			return r, nil
+		}
 	}
 	if indexer, ok := interface{}(r).(interface {
 		IndexFilesParallel([]*scanner.File, int)

--- a/internal/pipeline/project.go
+++ b/internal/pipeline/project.go
@@ -93,6 +93,12 @@ type ProjectHostState struct {
 	// watcher fires WorkspaceState.InvalidateLibraryFacts on Gradle /
 	// version-catalog edits). *WorkspaceState satisfies this interface.
 	LibraryFactsCache LibraryFactsCache
+	// TypeIndexCacheDir, when non-empty, enables the per-file
+	// FileTypeInfo on-disk cache so warm runs skip per-file
+	// extraction for unchanged files. Empty disables the cache (the
+	// CLI runner sets this from typeinfer.TypeIndexCacheDir(repoDir)
+	// when --no-cache is not passed; the daemon does the same).
+	TypeIndexCacheDir string
 	// Oracle, when non-nil, is the resident type-oracle handle.
 	Oracle *oracle.Oracle
 	// OracleDaemon, when non-nil, is the long-lived krit-types JVM
@@ -206,6 +212,7 @@ func RunProject(ctx context.Context, in ProjectInput) (ProjectResult, error) {
 		PrebuiltResolver:     host.PrebuiltResolver,
 		PrebuiltLibraryFacts: host.PrebuiltLibraryFacts,
 		LibraryFactsCache:    host.LibraryFactsCache,
+		TypeIndexCacheDir:    host.TypeIndexCacheDir,
 		Reporter:             host.Reporter,
 		Tracker:              host.Tracker,
 	}

--- a/internal/pipeline/type_index_cache_test.go
+++ b/internal/pipeline/type_index_cache_test.go
@@ -1,0 +1,74 @@
+package pipeline
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kaeawc/krit/internal/cacheutil"
+	api "github.com/kaeawc/krit/internal/rules/api"
+	"github.com/kaeawc/krit/internal/scanner"
+)
+
+// TestIndexPhase_TypeIndexCacheDir_HitsOnSecondRun runs IndexPhase twice
+// with TypeIndexCacheDir set; the second run should hit the on-disk
+// FileTypeInfo cache and report misses=0. Acceptance criterion for #56:
+// warm runs skip per-file extraction for unchanged files.
+func TestIndexPhase_TypeIndexCacheDir_HitsOnSecondRun(t *testing.T) {
+	dir := t.TempDir()
+	cacheDir := t.TempDir()
+	src := filepath.Join(dir, "Sample.kt")
+	if err := os.WriteFile(src, []byte("package test\n\nclass Sample\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	parsed, err := scanner.ParseFile(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// IndexPhase only runs IndexFilesParallel when at least one rule
+	// declares NeedsResolver. Construct a synthetic one.
+	rule := api.FakeRule("R", api.WithNeeds(api.NeedsResolver))
+
+	in := IndexInput{
+		ParseResult: ParseResult{
+			Paths:        []string{dir},
+			KotlinFiles:  []*scanner.File{parsed},
+			ActiveRules:  []*api.Rule{rule},
+		},
+		TypeIndexCacheDir: cacheDir,
+	}
+
+	if _, err := (IndexPhase{SkipModules: true, SkipAndroid: true}).Run(context.Background(), in); err != nil {
+		t.Fatalf("first Run: %v", err)
+	}
+
+	// First run populates the cache. Verify by scanning cacheDir.
+	entries, _ := os.ReadDir(cacheDir)
+	if len(entries) == 0 {
+		t.Fatal("first Run did not populate type-index cache directory")
+	}
+
+	// Snapshot cache stats, then run again. The second run should
+	// register hits without rebuilding.
+	hitsBefore, _, _ := readTypeIndexStats()
+
+	if _, err := (IndexPhase{SkipModules: true, SkipAndroid: true}).Run(context.Background(), in); err != nil {
+		t.Fatalf("second Run: %v", err)
+	}
+
+	hitsAfter, _, _ := readTypeIndexStats()
+	if hitsAfter <= hitsBefore {
+		t.Errorf("second Run did not hit type-index cache: hits before=%d after=%d", hitsBefore, hitsAfter)
+	}
+}
+
+func readTypeIndexStats() (hits, misses, bytes int64) {
+	for _, e := range cacheutil.AllStats() {
+		if e.Name == "type-index-cache" {
+			return e.Stats.Hits, e.Stats.Misses, e.Stats.Bytes
+		}
+	}
+	return 0, 0, 0
+}


### PR DESCRIPTION
## Summary
Stacked on #116. Closes the type-index half of #56.

The CLI runner already calls \`IndexFilesParallelCachedWithTracker\` via \`runner.runCachedTypeIndex\`. The daemon's \`IndexPhase\` only had the non-cached \`IndexFilesParallel\` path, so every \`analyze-project\` call paid ~336 ms / 19k Kotlin files for per-file extraction even though the on-disk cache exists, is registered, and works.

## Wire-through
- \`ProjectHostState.TypeIndexCacheDir\` (host-side path)
- \`IndexInput.TypeIndexCacheDir\` (plumbed by \`RunProject\`)
- \`IndexPhase.buildTypeResolver\`: prefer the cached path when set, fall back to \`IndexFilesParallel\`.
- \`daemonState.buildProjectInput\` sets it from \`typeinfer.TypeIndexCacheDir(repoDir)\`.
- Perf tracker emits hits/misses summary under the \`typeIndex\` child node.

## Test
\`TestIndexPhase_TypeIndexCacheDir_HitsOnSecondRun\` runs \`IndexPhase\` twice with \`TypeIndexCacheDir\` set, confirms the second run registers cache hits via \`cacheutil.AllStats\`. Verified to fail-build on the pre-wiring code (\`TypeIndexCacheDir\` field absent from \`IndexInput\`).

## Out of scope (#56 follow-up)
Oracle-cache wire-up. The oracle write path (\`WriteFreshEntriesWithTrackerScopedV2\`) is currently bound to the cold bootstrap; promoting it to the warm path needs care around the serial-write contract and will land in a separate PR.

## Test plan
- [x] \`go build -o krit ./cmd/krit/\`
- [x] \`go vet ./...\`
- [x] \`go test ./... -count=1\`