### PR TITLE
fix: route remaining 3 import/package strips through sourceheader

### DIFF
--- a/internal/rules/package_naming_convention_drift.go
+++ b/internal/rules/package_naming_convention_drift.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/kaeawc/krit/internal/scanner"
+	"github.com/kaeawc/krit/internal/sourceheader"
 )
 
 const packageNamingConventionDriftSourceRoot = "/src/main/kotlin/"
@@ -26,12 +27,7 @@ func packageHeaderNameFlat(file *scanner.File, idx uint32) string {
 	if idNode, ok := file.FlatFindChild(idx, "identifier"); ok {
 		return strings.TrimSpace(file.FlatNodeText(idNode))
 	}
-
-	text := strings.TrimSpace(strings.TrimPrefix(file.FlatNodeText(idx), "package "))
-	if idx := strings.IndexByte(text, '\n'); idx >= 0 {
-		text = strings.TrimSpace(text[:idx])
-	}
-	return text
+	return sourceheader.FirstHeaderLine(file.FlatNodeText(idx), "package")
 }
 
 func packageNamingConventionExpectedPrefix(filePath string) string {

--- a/internal/rules/release_engineering_helpers.go
+++ b/internal/rules/release_engineering_helpers.go
@@ -12,6 +12,8 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+
+	"github.com/kaeawc/krit/internal/sourceheader"
 )
 
 // commentedOutCallRe matches a single line that looks like a Kotlin call
@@ -246,11 +248,14 @@ func isGeneratedSourcePath(path string) bool {
 //
 // Returns ("", "", false) when text is not an import line.
 func parseSourceImport(text string) (qualifiedName string, localName string, wildcard bool) {
-	text = strings.TrimSpace(text)
-	if !strings.HasPrefix(text, "import") {
+	// FirstSourceLine skips tree-sitter trailing trivia (block comment
+	// trailers, blank-line tails) so the import-keyword gate isn't fooled
+	// by a leading line/block comment.
+	line := sourceheader.FirstSourceLine(text)
+	if !strings.HasPrefix(line, "import") {
 		return "", "", false
 	}
-	body := strings.TrimSpace(strings.TrimPrefix(text, "import"))
+	body := strings.TrimSpace(strings.TrimPrefix(line, "import"))
 	body = strings.TrimSpace(strings.TrimSuffix(body, ";"))
 	body = strings.TrimPrefix(body, "static ")
 	body = strings.TrimSpace(body)

--- a/internal/rules/release_engineering_helpers_test.go
+++ b/internal/rules/release_engineering_helpers_test.go
@@ -309,6 +309,14 @@ func TestParseSourceImport(t *testing.T) {
 		{"java static", "import static com.example.Foo.bar", "com.example.Foo.bar", "bar", false},
 		{"not import", "package com.example", "", "", false},
 		{"empty body", "import   ", "", "", false},
+		// Regression for #114: tree-sitter trailing trivia (a leading
+		// block comment attached to the import_header node) must not
+		// fool the import-keyword gate. Pre-fix returned ("", "", false).
+		{"leading block comment trivia", "/* doc */\nimport com.example.Foo", "com.example.Foo", "Foo", false},
+		// Pre-fix this passed because TrimSpace + TrimPrefix("import")
+		// happened to handle the leading newline; included to lock the
+		// behavior in.
+		{"leading newline", "\nimport com.example.Foo", "com.example.Foo", "Foo", false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/rules/style_forbidden.go
+++ b/internal/rules/style_forbidden.go
@@ -8,6 +8,7 @@ import (
 	api "github.com/kaeawc/krit/internal/rules/api"
 	"github.com/kaeawc/krit/internal/rules/semantics"
 	"github.com/kaeawc/krit/internal/scanner"
+	"github.com/kaeawc/krit/internal/sourceheader"
 )
 
 // WildcardImportRule detects import x.y.* statements.
@@ -43,10 +44,11 @@ func importStatementPath(file *scanner.File, idx uint32) string {
 	if file == nil || idx == 0 {
 		return ""
 	}
-	text := strings.TrimSpace(file.FlatNodeText(idx))
-	text = strings.TrimSpace(strings.TrimPrefix(text, "import"))
+	// FirstHeaderLine handles tree-sitter trailing trivia (comments,
+	// trailing semicolon). Java imports may carry a leading `static`
+	// modifier; strip it after the keyword/trivia pass.
+	text := sourceheader.FirstHeaderLine(file.FlatNodeText(idx), "import")
 	text = strings.TrimSpace(strings.TrimPrefix(text, "static"))
-	text = strings.TrimSuffix(text, ";")
 	return strings.TrimSpace(text)
 }
 


### PR DESCRIPTION
## Summary
Closes the trivia-bug fix campaign in #114.

Remaining sites that needed extra handling beyond a drop-in:

- \`internal/rules/style_forbidden.go\` (\`importStatementPath\`) — FirstHeaderLine handles the keyword + trivia + \`;\`, then strip Java's optional \`static\` modifier.
- \`internal/rules/release_engineering_helpers.go\` (\`parseSourceImport\`) — FirstSourceLine first so the \`HasPrefix(\"import\")\` gate isn't fooled by a leading block-comment trailer; then the existing import/\`;\`/\`static\` handling runs against the cleaned line.
- \`internal/rules/package_naming_convention_drift.go\` (\`packageHeaderNameFlat\`) — identifier-child fast path stays; fallback delegates to FirstHeaderLine.

## Verified regression
\`TestParseSourceImport\` gains \"leading block comment trivia\" + \"leading newline\". The block-comment case fails on the pre-migration code:

\`\`\`
parseSourceImport(\"/* doc */\\nimport com.example.Foo\") =
  (\"\", \"\", false)               // before — HasPrefix gate sees the comment
  (\"com.example.Foo\", \"Foo\", false)  // after
\`\`\`

Closes #114.

## Test plan
- [x] \`go build -o krit ./cmd/krit/\`
- [x] \`go vet ./...\`
- [x] \`go test ./... -count=1\`