### PR TITLE
fix(typeinfer): route ImportTable header parsing through sourceheader

### DIFF
--- a/internal/typeinfer/imports.go
+++ b/internal/typeinfer/imports.go
@@ -80,6 +80,6 @@ func extractImportsFlat(nodeIdx uint32, file *scanner.File, it *ImportTable) {
 	})
 }
 
-func extractPackageFlat(rootIdx uint32, file *scanner.File) string {
-	return scanFileHeadersFlat(rootIdx, file).pkg
+func extractPackageFlat(file *scanner.File) string {
+	return scanFileHeadersFlat(0, file).pkg
 }

--- a/internal/typeinfer/imports.go
+++ b/internal/typeinfer/imports.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/kaeawc/krit/internal/scanner"
+	"github.com/kaeawc/krit/internal/sourceheader"
 )
 
 type fileHeaders struct {
@@ -24,9 +25,7 @@ func scanFileHeadersFlat(rootIdx uint32, file *scanner.File) fileHeaders {
 	visitChild := func(child uint32) {
 		switch file.FlatType(child) {
 		case "package_header":
-			text := strings.TrimSpace(file.FlatNodeText(child))
-			text = strings.TrimPrefix(text, "package ")
-			headers.pkg = strings.TrimSpace(text)
+			headers.pkg = sourceheader.FirstHeaderLine(file.FlatNodeText(child), "package")
 		case "import_header", "import_list":
 			extractImportsFlat(child, file, headers.it)
 		}
@@ -53,9 +52,7 @@ func extractImportsFlat(nodeIdx uint32, file *scanner.File, it *ImportTable) {
 		return
 	}
 	if file.FlatType(nodeIdx) == "import_header" {
-		text := strings.TrimSpace(file.FlatNodeText(nodeIdx))
-		text = strings.TrimPrefix(text, "import ")
-		text = strings.TrimSpace(text)
+		text := sourceheader.FirstHeaderLine(file.FlatNodeText(nodeIdx), "import")
 
 		if idx := strings.Index(text, " as "); idx >= 0 {
 			fqn := strings.TrimSpace(text[:idx])

--- a/internal/typeinfer/imports_test.go
+++ b/internal/typeinfer/imports_test.go
@@ -118,7 +118,7 @@ class Foo
 `
 	file := parseTestFile(t, src)
 
-	got := extractPackageFlat(0, file)
+	got := extractPackageFlat(file)
 	if got != "com.example.app" {
 		t.Errorf("expected 'com.example.app', got %q", got)
 	}
@@ -129,7 +129,7 @@ func TestExtractPackage_NoPackage(t *testing.T) {
 `
 	file := parseTestFile(t, src)
 
-	got := extractPackageFlat(0, file)
+	got := extractPackageFlat(file)
 	if got != "" {
 		t.Errorf("expected empty string for no package, got %q", got)
 	}
@@ -147,7 +147,7 @@ class Foo
 `
 	file := parseTestFile(t, src)
 
-	got := extractPackageFlat(0, file)
+	got := extractPackageFlat(file)
 	if got != "com.example.app" {
 		t.Errorf("expected 'com.example.app' (trivia stripped), got %q", got)
 	}
@@ -208,7 +208,7 @@ class Foo
 `
 	file := parseTestFile(t, src)
 
-	got := extractPackageFlat(0, file)
+	got := extractPackageFlat(file)
 	if got != "org.example" {
 		t.Errorf("expected 'org.example', got %q", got)
 	}

--- a/internal/typeinfer/imports_test.go
+++ b/internal/typeinfer/imports_test.go
@@ -135,6 +135,44 @@ func TestExtractPackage_NoPackage(t *testing.T) {
 	}
 }
 
+// Regression for #44 / #114: tree-sitter Kotlin sometimes attaches a
+// trailing block comment to the package_header node. The pre-migration
+// code did `TrimPrefix(text, "package ")` and stopped — leaving the
+// trivia attached to the returned package name.
+func TestExtractPackage_StripsTrailingBlockCommentTrivia(t *testing.T) {
+	src := `package com.example.app
+/* TODO: split this module */
+
+class Foo
+`
+	file := parseTestFile(t, src)
+
+	got := extractPackageFlat(0, file)
+	if got != "com.example.app" {
+		t.Errorf("expected 'com.example.app' (trivia stripped), got %q", got)
+	}
+}
+
+// Regression for the same bug surfaced via buildImportTableFlat.
+func TestImportTable_StripsTrailingBlockCommentTrivia(t *testing.T) {
+	src := `package test
+
+import com.example.Foo
+/* trailing trivia attached to last import */
+
+class Bar { fun f() = Foo() }
+`
+	file := parseTestFile(t, src)
+	it := buildImportTableFlat(file)
+	got, ok := it.Explicit["Foo"]
+	if !ok {
+		t.Fatalf("Foo missing from Explicit imports: %+v", it.Explicit)
+	}
+	if got != "com.example.Foo" {
+		t.Errorf("Explicit[Foo] = %q, want com.example.Foo (trivia stripped)", got)
+	}
+}
+
 // --- Kotlin auto-imports of java.lang.* ---
 
 func TestImportTable_Resolve_KotlinAutoImports(t *testing.T) {


### PR DESCRIPTION
## Summary
Closes the final tractable piece of #44 — typeinfer's \`scanFileHeadersFlat\` / \`extractImportsFlat\` were the last sites holding hand-rolled \`TrimPrefix(\"package \")\` / \`TrimPrefix(\"import \")\` strips. They had **two real bugs** the regression tests demonstrate:

1. **Trivia leaked into the package name and the import-table map keys.** The pre-migration code returned things like:

\`\`\`
extractPackageFlat = \"com.example.app\\n/* TODO: split this module */\"
it.Explicit map keyed by \"Foo\\n/* trailing trivia */\"
\`\`\`

This means any file with a trailing block comment after its imports was silently breaking type resolution — the resolver looked up \`\"Foo\"\` but the map held \`\"Foo\\n/* … */\"\` as the key.

2. **Required a literal trailing space** after the keyword. \`TrimPrefix(text, \"package \")\` silently fails to strip if tree-sitter ever omits the space.

Both fixed by switching to \`sourceheader.FirstHeaderLine\`.

## Verified regression
\`TestExtractPackage_StripsTrailingBlockCommentTrivia\` and \`TestImportTable_StripsTrailingBlockCommentTrivia\` both **fail on pre-migration** code with the exact leakage shown above; pass after.

\`ImportTable\` struct shape itself is unchanged — this is purely the parsing seam.

Closes #44.

## Test plan
- [x] \`go build -o krit ./cmd/krit/\`
- [x] \`go vet ./...\`
- [x] \`go test ./... -count=1\`