### PR TITLE
feat(daemon): make CodeIndex daemon-resident via WorkspaceState

### DIFF
--- a/internal/cli/serve/analyze_project.go
+++ b/internal/cli/serve/analyze_project.go
@@ -13,6 +13,7 @@ import (
 	"github.com/kaeawc/krit/internal/daemon"
 	"github.com/kaeawc/krit/internal/pipeline"
 	"github.com/kaeawc/krit/internal/rules"
+	"github.com/kaeawc/krit/internal/scanner"
 )
 
 // errDaemonNotWarm is returned to RequireWarm clients on a cold
@@ -137,6 +138,8 @@ func (s *daemonState) buildProjectInput(args daemon.AnalyzeProjectArgs) (pipelin
 		Host: pipeline.ProjectHostState{
 			ParseCache:        parseCache,
 			LibraryFactsCache: s.workspace,
+			CodeIndexCache:    s.workspace,
+			CrossFileCacheDir: scanner.CrossFileCacheDir(repoDir),
 		},
 	}, nil
 }

--- a/internal/pipeline/code_index_cache_test.go
+++ b/internal/pipeline/code_index_cache_test.go
@@ -1,0 +1,108 @@
+package pipeline
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	api "github.com/kaeawc/krit/internal/rules/api"
+	"github.com/kaeawc/krit/internal/scanner"
+)
+
+// countingCodeIndexCache is a test fake implementing CodeIndexCache
+// that counts how often build() actually fires versus how often the
+// cached pointer is returned.
+type countingCodeIndexCache struct {
+	cached *scanner.CodeIndex
+	fp     string
+	builds int
+}
+
+func (c *countingCodeIndexCache) CodeIndex(fingerprint string, build func() *scanner.CodeIndex) *scanner.CodeIndex {
+	if c.cached != nil && c.fp == fingerprint {
+		return c.cached
+	}
+	c.cached = build()
+	c.fp = fingerprint
+	c.builds++
+	return c.cached
+}
+
+// TestCrossFilePhase_CodeIndexCache_BuildsOnceAcrossRuns confirms the
+// in-memory CodeIndexCache slot serves the second CrossFilePhase.Run
+// when the file set is unchanged. Acceptance for #48: warm runs reuse
+// the constructed cross-file index instead of rebuilding.
+func TestCrossFilePhase_CodeIndexCache_BuildsOnceAcrossRuns(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "Sample.kt")
+	if err := os.WriteFile(src, []byte("package test\n\nclass Sample\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	parsed, err := scanner.ParseFile(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// CrossFilePhase only builds CodeIndex when at least one rule
+	// declares NeedsCrossFile. Construct a synthetic one.
+	rule := api.FakeRule("XF", api.WithNeeds(api.NeedsCrossFile))
+
+	cache := &countingCodeIndexCache{}
+	in := DispatchResult{
+		IndexResult: IndexResult{
+			ParseResult: ParseResult{
+				Paths:       []string{dir},
+				KotlinFiles: []*scanner.File{parsed},
+				ActiveRules: []*api.Rule{rule},
+			},
+			CodeIndexCache: cache,
+		},
+	}
+
+	r1, err := CrossFilePhase{}.Run(context.Background(), in)
+	if err != nil {
+		t.Fatalf("first Run: %v", err)
+	}
+	if r1.CodeIndex == nil {
+		t.Fatal("first Run produced nil CodeIndex")
+	}
+	if cache.builds != 1 {
+		t.Fatalf("after first Run, builds = %d, want 1", cache.builds)
+	}
+
+	r2, err := CrossFilePhase{}.Run(context.Background(), in)
+	if err != nil {
+		t.Fatalf("second Run: %v", err)
+	}
+	if cache.builds != 1 {
+		t.Fatalf("after second Run, builds = %d, want 1 (cache miss)", cache.builds)
+	}
+	if r1.CodeIndex != r2.CodeIndex {
+		t.Errorf("CodeIndex pointer changed across runs; cache is not reusing the cached value")
+	}
+}
+
+func TestCodeIndexFingerprint_StableAndDistinct(t *testing.T) {
+	dir := t.TempDir()
+	a := filepath.Join(dir, "A.kt")
+	b := filepath.Join(dir, "B.kt")
+	if err := os.WriteFile(a, []byte("package x\nclass A\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(b, []byte("package x\nclass B\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	pa, _ := scanner.ParseFile(a)
+	pb, _ := scanner.ParseFile(b)
+
+	fp1 := codeIndexFingerprint([]*scanner.File{pa, pb}, nil)
+	fp2 := codeIndexFingerprint([]*scanner.File{pb, pa}, nil)
+	if fp1 != fp2 {
+		t.Errorf("fingerprint should be order-independent: %q vs %q", fp1, fp2)
+	}
+	fp3 := codeIndexFingerprint([]*scanner.File{pa}, nil)
+	if fp1 == fp3 {
+		t.Errorf("fingerprint should differ for distinct file sets: %q", fp1)
+	}
+}

--- a/internal/pipeline/crossfile.go
+++ b/internal/pipeline/crossfile.go
@@ -3,9 +3,12 @@ package pipeline
 import (
 	"context"
 	"runtime"
+	"sort"
+	"strings"
 	"sync"
 	"time"
 
+	"github.com/kaeawc/krit/internal/hashutil"
 	"github.com/kaeawc/krit/internal/javafacts"
 	"github.com/kaeawc/krit/internal/librarymodel"
 	"github.com/kaeawc/krit/internal/module"
@@ -53,6 +56,15 @@ func (CrossFilePhase) classifyCrossFileNeeds(activeRules []*api.Rule) (hasIndexB
 
 // buildOrReuseCodeIndex returns the pre-built CodeIndex when available;
 // otherwise it builds a new one when hasIndexBacked is true.
+//
+// Build precedence:
+//   - in.CodeIndex non-nil: caller already built it; use as-is.
+//   - !hasIndexBacked: rules don't need cross-file data; nil.
+//   - in.CodeIndexCache non-nil: in-memory slot keyed by content
+//     fingerprint. Cache miss falls through to the disk-backed cache
+//     when CrossFileCacheDir is set, else uncached BuildIndex.
+//   - in.CrossFileCacheDir non-empty: BuildIndexCached (disk-backed).
+//   - default: scanner.BuildIndex (uncached).
 func (p CrossFilePhase) buildOrReuseCodeIndex(in DispatchResult, hasIndexBacked bool) *scanner.CodeIndex {
 	if in.CodeIndex != nil || !hasIndexBacked {
 		return in.CodeIndex
@@ -64,7 +76,40 @@ func (p CrossFilePhase) buildOrReuseCodeIndex(in DispatchResult, hasIndexBacked 
 			workers = 1
 		}
 	}
-	return scanner.BuildIndex(in.KotlinFiles, workers, in.JavaFiles...)
+	build := func() *scanner.CodeIndex {
+		if in.CrossFileCacheDir != "" {
+			idx, _ := scanner.BuildIndexCached(in.CrossFileCacheDir, in.KotlinFiles, workers, nil, in.JavaFiles...)
+			return idx
+		}
+		return scanner.BuildIndex(in.KotlinFiles, workers, in.JavaFiles...)
+	}
+	if in.CodeIndexCache != nil {
+		return in.CodeIndexCache.CodeIndex(codeIndexFingerprint(in.KotlinFiles, in.JavaFiles), build)
+	}
+	return build()
+}
+
+// codeIndexFingerprint returns a stable cache key derived from the
+// sorted (path, content-hash) pairs of every Kotlin and Java file
+// contributing to the CodeIndex. Mismatches force a rebuild via
+// CodeIndexCache.CodeIndex; the watcher's InvalidateCodeIndex is the
+// daemon's belt-and-suspenders for cross-process drift.
+func codeIndexFingerprint(kotlin, java []*scanner.File) string {
+	entries := make([]string, 0, len(kotlin)+len(java))
+	addEntry := func(file *scanner.File) {
+		if file == nil {
+			return
+		}
+		entries = append(entries, file.Path+"\x00"+hashutil.Default().HashContent(file.Path, file.Content))
+	}
+	for _, f := range kotlin {
+		addEntry(f)
+	}
+	for _, f := range java {
+		addEntry(f)
+	}
+	sort.Strings(entries)
+	return hashutil.HashHex([]byte(strings.Join(entries, "\x01")))
 }
 
 // runCrossRuleSet executes serial and concurrent cross-file rules against

--- a/internal/pipeline/index.go
+++ b/internal/pipeline/index.go
@@ -69,6 +69,10 @@ type IndexInput struct {
 	// is derived from the discovered Gradle paths; the host's watcher
 	// drops the slot when Gradle / version-catalog files change.
 	LibraryFactsCache LibraryFactsCache
+	// CodeIndexCache, when non-nil, memoizes *scanner.CodeIndex across
+	// calls. Forwarded to IndexResult so CrossFilePhase consults it
+	// before calling scanner.BuildIndex.
+	CodeIndexCache CodeIndexCache
 	// Reporter routes verbose progress and warning lines from IndexPhase.
 	// Nil means silent.
 	Reporter *diag.Reporter
@@ -376,7 +380,13 @@ func (p IndexPhase) Run(ctx context.Context, in IndexInput) (IndexResult, error)
 		return IndexResult{}, err
 	}
 
-	result := IndexResult{ParseResult: in.ParseResult, LibraryFacts: in.PrebuiltLibraryFacts, CrossFindingsCacheDir: in.CrossFindingsCacheDir}
+	result := IndexResult{
+		ParseResult:           in.ParseResult,
+		LibraryFacts:          in.PrebuiltLibraryFacts,
+		CrossFindingsCacheDir: in.CrossFindingsCacheDir,
+		CrossFileCacheDir:     in.CrossFileCacheDir,
+		CodeIndexCache:        in.CodeIndexCache,
+	}
 
 	caps := unionNeeds(in.ActiveRules)
 

--- a/internal/pipeline/project.go
+++ b/internal/pipeline/project.go
@@ -93,6 +93,17 @@ type ProjectHostState struct {
 	// watcher fires WorkspaceState.InvalidateLibraryFacts on Gradle /
 	// version-catalog edits). *WorkspaceState satisfies this interface.
 	LibraryFactsCache LibraryFactsCache
+	// CodeIndexCache, when non-nil, memoizes *scanner.CodeIndex across
+	// calls. CrossFilePhase consults the slot before falling through to
+	// the disk-backed cross-file cache (CrossFileCacheDir) and finally
+	// to scanner.BuildIndex. *WorkspaceState satisfies this interface.
+	CodeIndexCache CodeIndexCache
+	// CrossFileCacheDir, when non-empty, enables the on-disk cross-file
+	// CodeIndex cache (zstd-encoded shards under .krit/crossfile-cache).
+	// Independent of CodeIndexCache: the disk cache is shared across
+	// daemon restarts, while the in-memory cache survives within a
+	// single daemon's lifetime.
+	CrossFileCacheDir string
 	// Oracle, when non-nil, is the resident type-oracle handle.
 	Oracle *oracle.Oracle
 	// OracleDaemon, when non-nil, is the long-lived krit-types JVM
@@ -206,6 +217,8 @@ func RunProject(ctx context.Context, in ProjectInput) (ProjectResult, error) {
 		PrebuiltResolver:     host.PrebuiltResolver,
 		PrebuiltLibraryFacts: host.PrebuiltLibraryFacts,
 		LibraryFactsCache:    host.LibraryFactsCache,
+		CodeIndexCache:       host.CodeIndexCache,
+		CrossFileCacheDir:    host.CrossFileCacheDir,
 		Reporter:             host.Reporter,
 		Tracker:              host.Tracker,
 	}

--- a/internal/pipeline/types.go
+++ b/internal/pipeline/types.go
@@ -285,6 +285,25 @@ type IndexResult struct {
 	// normally and writes the result back; hit appends cached findings
 	// to the run's collector and skips rule execution.
 	CrossFindingsCacheDir string
+	// CrossFileCacheDir, when non-empty, enables the on-disk cross-file
+	// CodeIndex cache used by CrossFilePhase.buildOrReuseCodeIndex when
+	// in.CodeIndex is nil. Empty forces an uncached BuildIndex on every
+	// rebuild. Mirrors the IndexInput field of the same name.
+	CrossFileCacheDir string
+	// CodeIndexCache, when non-nil, layers an in-memory CodeIndex slot
+	// on top of the on-disk cache so a daemon avoids the disk-decode
+	// pass on warm calls. Nil means no in-memory cache. *WorkspaceState
+	// satisfies this interface.
+	CodeIndexCache CodeIndexCache
+}
+
+// CodeIndexCache lets a long-lived host (typically *WorkspaceState)
+// memoize *scanner.CodeIndex across RunProject calls. The host is
+// responsible for invalidating its slot when the underlying file set
+// changes; the watcher's InvalidateCodeIndex call covers the daemon.
+// Fingerprint mismatches force a rebuild via build.
+type CodeIndexCache interface {
+	CodeIndex(fingerprint string, build func() *scanner.CodeIndex) *scanner.CodeIndex
 }
 
 // FileTiming captures per-file dispatch timing recorded when


### PR DESCRIPTION
## Summary
Second daemon-resident state piece for #48 (after #116 LibraryFacts). Promotes \`*scanner.CodeIndex\` off the per-call hot path so the daemon stops re-running cross-file symbol/reference indexing on every \`analyze-project\` call.

\`scanner.CodeIndex\` is consumed by every NeedsCrossFile rule. Today \`CrossFilePhase.buildOrReuseCodeIndex\` falls through to \`scanner.BuildIndex\` (uncached) on every call. On JetBrains/kotlin (~63k files), this is the dominant warm-call cost after the parse cache is hit.

## Three-layer cache
\`buildOrReuseCodeIndex\` now layers three caches:

1. \`in.CodeIndex\` — caller already built it (CLI runner via \`runCodeIndexBuild\`).
2. \`in.CodeIndexCache\` — in-memory slot, daemon lifetime. \`*WorkspaceState\` satisfies via its existing \`codeIndex xfileSlot\`.
3. \`in.CrossFileCacheDir\` — on-disk shards under \`.krit/crossfile-cache\`, cross-restart.
4. Fallback: uncached \`BuildIndex\`.

## Fingerprint
\`codeIndexFingerprint\` hashes the sorted \`(path, content-hash)\` tuples of every Kotlin + Java file. Mismatches force a rebuild via the cache callback; the daemon's file watcher additionally invalidates via \`InvalidateCodeIndex\` on \`.kt\` / \`.kts\` edits.

## Tests
- \`TestCrossFilePhase_CodeIndexCache_BuildsOnceAcrossRuns\` — counting fake confirms \`build()\` fires once across two \`CrossFilePhase.Run\` calls; pointer is reused.
- \`TestCodeIndexFingerprint_StableAndDistinct\` — order-independent, distinguishes path sets.
- Verified to fail-build on pre-wire code.

## Out of scope (#48 follow-up — each warrants its own PR)
- **Resolver promotion**: \`typeinfer.defaultResolver\` merges into maps that aren't path-keyed (\`classes\`, \`classFQN\`, \`sealedVariants\`, \`extensions\`). Reusing across calls leaks stale entries from removed/renamed files. Substantial typeinfer refactor needed for per-file contribution tracking.
- **Oracle / OracleDaemon**: daemon doesn't enable oracle today (\`OracleEnabled=false\`); promoting requires both enabling AND JVM subprocess lifecycle management (per-entry ping + auto-rebuild on crash). Compounded change.
- **AnalysisCache**: daemon doesn't load the analysis cache today; promoting is two changes (enable + resident) and risks daemon output drift.

## Test plan
- [x] \`go build -o krit ./cmd/krit/\`
- [x] \`go vet ./...\`
- [x] \`go test ./... -count=1\`