### PR TITLE
perf(daemon): wire type-index-cache through IndexPhase (recovers #117)

### DIFF
--- a/internal/cli/serve/analyze_project.go
+++ b/internal/cli/serve/analyze_project.go
@@ -14,6 +14,7 @@ import (
 	"github.com/kaeawc/krit/internal/pipeline"
 	"github.com/kaeawc/krit/internal/rules"
 	"github.com/kaeawc/krit/internal/scanner"
+	"github.com/kaeawc/krit/internal/typeinfer"
 )
 
 // errDaemonNotWarm is returned to RequireWarm clients on a cold
@@ -146,6 +147,7 @@ func (s *daemonState) buildProjectInput(args daemon.AnalyzeProjectArgs) (pipelin
 			CodeIndexCache:        s.workspace,
 			ResolverCache:         s.workspace,
 			CrossFileCacheDir:     scanner.CrossFileCacheDir(repoDir),
+			TypeIndexCacheDir:     typeinfer.TypeIndexCacheDir(repoDir),
 			AnalysisCache:         analysisCache,
 			AnalysisCacheFilePath: analysisCachePath,
 		},

--- a/internal/pipeline/index.go
+++ b/internal/pipeline/index.go
@@ -79,6 +79,12 @@ type IndexInput struct {
 	// entire perFileExtraction + merge + resolveSupertypes skip on
 	// warm-no-change runs.
 	ResolverCache ResolverCache
+	// TypeIndexCacheDir, when non-empty, enables the per-file
+	// FileTypeInfo cache (typeinfer.IndexFilesParallelCachedWithTracker).
+	// Unchanged files are read from disk instead of re-extracted, which
+	// is the dominant cost (~336 ms / 19k files in the planning-doc
+	// measurement) on warm + 1-edit runs. Empty disables the cache.
+	TypeIndexCacheDir string
 	// Reporter routes verbose progress and warning lines from IndexPhase.
 	// Nil means silent.
 	Reporter *diag.Reporter
@@ -301,6 +307,26 @@ func (p IndexPhase) buildTypeResolver(ctx context.Context, in IndexInput, resolv
 	}
 	build := func() typeinfer.TypeResolver {
 		r := typeinfer.NewResolver()
+		if in.TypeIndexCacheDir != "" {
+			if cached, ok := interface{}(r).(interface {
+				IndexFilesParallelCachedWithTracker([]*scanner.File, int, string, perf.Tracker) (int, int)
+			}); ok {
+				var hits, misses int
+				if in.Tracker != nil {
+					child := in.Tracker.Serial("typeIndex")
+					hits, misses = cached.IndexFilesParallelCachedWithTracker(in.KotlinFiles, workers, in.TypeIndexCacheDir, child)
+					perf.AddEntryDetails(child, "cacheSummary", 0, map[string]int64{
+						"hits":   int64(hits),
+						"misses": int64(misses),
+					}, nil)
+					child.End()
+				} else {
+					hits, misses = cached.IndexFilesParallelCachedWithTracker(in.KotlinFiles, workers, in.TypeIndexCacheDir, nil)
+				}
+				in.logf("verbose: Indexed %d Kotlin files for type resolution (typeIndex cache: %d hits, %d misses)", len(in.KotlinFiles), hits, misses)
+				return r
+			}
+		}
 		if indexer, ok := interface{}(r).(interface {
 			IndexFilesParallel([]*scanner.File, int)
 		}); ok {

--- a/internal/pipeline/project.go
+++ b/internal/pipeline/project.go
@@ -111,6 +111,12 @@ type ProjectHostState struct {
 	// daemon restarts, while the in-memory cache survives within a
 	// single daemon's lifetime.
 	CrossFileCacheDir string
+	// TypeIndexCacheDir, when non-empty, enables the per-file
+	// FileTypeInfo on-disk cache so warm runs skip per-file
+	// extraction for unchanged files. Empty disables the cache (the
+	// CLI runner sets this from typeinfer.TypeIndexCacheDir(repoDir)
+	// when --no-cache is not passed; the daemon does the same).
+	TypeIndexCacheDir string
 	// Oracle, when non-nil, is the resident type-oracle handle.
 	Oracle *oracle.Oracle
 	// OracleDaemon, when non-nil, is the long-lived krit-types JVM
@@ -233,6 +239,7 @@ func RunProject(ctx context.Context, in ProjectInput) (ProjectResult, error) {
 		CodeIndexCache:       host.CodeIndexCache,
 		ResolverCache:        host.ResolverCache,
 		CrossFileCacheDir:    host.CrossFileCacheDir,
+		TypeIndexCacheDir:    host.TypeIndexCacheDir,
 		Reporter:             host.Reporter,
 		Tracker:              host.Tracker,
 	}

--- a/internal/pipeline/type_index_cache_test.go
+++ b/internal/pipeline/type_index_cache_test.go
@@ -1,0 +1,74 @@
+package pipeline
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kaeawc/krit/internal/cacheutil"
+	api "github.com/kaeawc/krit/internal/rules/api"
+	"github.com/kaeawc/krit/internal/scanner"
+)
+
+// TestIndexPhase_TypeIndexCacheDir_HitsOnSecondRun runs IndexPhase twice
+// with TypeIndexCacheDir set; the second run should hit the on-disk
+// FileTypeInfo cache and report misses=0. Acceptance criterion for #56:
+// warm runs skip per-file extraction for unchanged files.
+func TestIndexPhase_TypeIndexCacheDir_HitsOnSecondRun(t *testing.T) {
+	dir := t.TempDir()
+	cacheDir := t.TempDir()
+	src := filepath.Join(dir, "Sample.kt")
+	if err := os.WriteFile(src, []byte("package test\n\nclass Sample\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	parsed, err := scanner.ParseFile(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// IndexPhase only runs IndexFilesParallel when at least one rule
+	// declares NeedsResolver. Construct a synthetic one.
+	rule := api.FakeRule("R", api.WithNeeds(api.NeedsResolver))
+
+	in := IndexInput{
+		ParseResult: ParseResult{
+			Paths:        []string{dir},
+			KotlinFiles:  []*scanner.File{parsed},
+			ActiveRules:  []*api.Rule{rule},
+		},
+		TypeIndexCacheDir: cacheDir,
+	}
+
+	if _, err := (IndexPhase{SkipModules: true, SkipAndroid: true}).Run(context.Background(), in); err != nil {
+		t.Fatalf("first Run: %v", err)
+	}
+
+	// First run populates the cache. Verify by scanning cacheDir.
+	entries, _ := os.ReadDir(cacheDir)
+	if len(entries) == 0 {
+		t.Fatal("first Run did not populate type-index cache directory")
+	}
+
+	// Snapshot cache stats, then run again. The second run should
+	// register hits without rebuilding.
+	hitsBefore, _, _ := readTypeIndexStats()
+
+	if _, err := (IndexPhase{SkipModules: true, SkipAndroid: true}).Run(context.Background(), in); err != nil {
+		t.Fatalf("second Run: %v", err)
+	}
+
+	hitsAfter, _, _ := readTypeIndexStats()
+	if hitsAfter <= hitsBefore {
+		t.Errorf("second Run did not hit type-index cache: hits before=%d after=%d", hitsBefore, hitsAfter)
+	}
+}
+
+func readTypeIndexStats() (hits, misses, bytes int64) {
+	for _, e := range cacheutil.AllStats() {
+		if e.Name == "type-index-cache" {
+			return e.Stats.Hits, e.Stats.Misses, e.Stats.Bytes
+		}
+	}
+	return 0, 0, 0
+}

--- a/internal/pipeline/type_index_cache_test.go
+++ b/internal/pipeline/type_index_cache_test.go
@@ -33,9 +33,9 @@ func TestIndexPhase_TypeIndexCacheDir_HitsOnSecondRun(t *testing.T) {
 
 	in := IndexInput{
 		ParseResult: ParseResult{
-			Paths:        []string{dir},
-			KotlinFiles:  []*scanner.File{parsed},
-			ActiveRules:  []*api.Rule{rule},
+			Paths:       []string{dir},
+			KotlinFiles: []*scanner.File{parsed},
+			ActiveRules: []*api.Rule{rule},
 		},
 		TypeIndexCacheDir: cacheDir,
 	}


### PR DESCRIPTION
## Summary
Recovery PR. PR #117 was stacked on #116 and merged into the stack branch, but the stacked-PR retarget to main never fired — so its content got lost when #116 squashed into main. Cherry-picks the original commit (\`5a68830\`) onto a fresh branch targeting main.

Original PR description:

The CLI runner already calls \`IndexFilesParallelCachedWithTracker\` via \`runner.runCachedTypeIndex\`. The daemon's \`IndexPhase\` only had the non-cached \`IndexFilesParallel\` path, so every \`analyze-project\` call paid ~336 ms / 19k Kotlin files for per-file extraction even though the on-disk cache exists, is registered, and works.

Wire-through:
- \`ProjectHostState.TypeIndexCacheDir\`
- \`IndexInput.TypeIndexCacheDir\` (plumbed by \`RunProject\`)
- \`IndexPhase.buildTypeResolver\` prefers the cached path when set; falls back to \`IndexFilesParallel\`.
- \`daemonState.buildProjectInput\` sets it from \`typeinfer.TypeIndexCacheDir(repoDir)\`.

Test: \`TestIndexPhase_TypeIndexCacheDir_HitsOnSecondRun\` runs \`IndexPhase\` twice with \`TypeIndexCacheDir\` set; second run hits the cache.

## Test plan
- [x] \`go build -o krit ./cmd/krit/\`
- [x] \`go vet ./...\`
- [x] \`go test ./... -count=1\`