### PR TITLE
feat(daemon): make TypeResolver daemon-resident via WorkspaceState

### DIFF
--- a/internal/cli/serve/analyze_project.go
+++ b/internal/cli/serve/analyze_project.go
@@ -139,6 +139,7 @@ func (s *daemonState) buildProjectInput(args daemon.AnalyzeProjectArgs) (pipelin
 			ParseCache:        parseCache,
 			LibraryFactsCache: s.workspace,
 			CodeIndexCache:    s.workspace,
+			ResolverCache:     s.workspace,
 			CrossFileCacheDir: scanner.CrossFileCacheDir(repoDir),
 		},
 	}, nil

--- a/internal/cli/serve/watcher.go
+++ b/internal/cli/serve/watcher.go
@@ -22,6 +22,7 @@ type watcherState interface {
 	InvalidateCodeIndex()
 	InvalidateDependents()
 	InvalidateLibraryFacts()
+	InvalidateResolver()
 	Touch(path string)
 }
 
@@ -232,6 +233,7 @@ func (fw *fileWatcher) scheduleKotlinInvalidate(path string) {
 		fw.state.Invalidate(path)
 		fw.state.InvalidateCodeIndex()
 		fw.state.InvalidateDependents()
+		fw.state.InvalidateResolver()
 		fw.state.Touch(path)
 	})
 	fw.debounceMu.Unlock()

--- a/internal/cli/serve/watcher_test.go
+++ b/internal/cli/serve/watcher_test.go
@@ -22,6 +22,7 @@ func (c *countingState) Invalidate(path string)  { c.invalidateCalls.Add(1) }
 func (c *countingState) InvalidateCodeIndex()    {}
 func (c *countingState) InvalidateDependents()   {}
 func (c *countingState) InvalidateLibraryFacts() {}
+func (c *countingState) InvalidateResolver()     {}
 func (c *countingState) Touch(path string)       {}
 
 // waitForCondition polls fn every 5ms up to 2s. Returns true when fn

--- a/internal/pipeline/index.go
+++ b/internal/pipeline/index.go
@@ -14,6 +14,7 @@ import (
 	"github.com/kaeawc/krit/internal/cache"
 	"github.com/kaeawc/krit/internal/config"
 	"github.com/kaeawc/krit/internal/diag"
+	"github.com/kaeawc/krit/internal/hashutil"
 	"github.com/kaeawc/krit/internal/librarymodel"
 	"github.com/kaeawc/krit/internal/module"
 	"github.com/kaeawc/krit/internal/oracle"
@@ -73,6 +74,11 @@ type IndexInput struct {
 	// calls. Forwarded to IndexResult so CrossFilePhase consults it
 	// before calling scanner.BuildIndex.
 	CodeIndexCache CodeIndexCache
+	// ResolverCache, when non-nil and PrebuiltResolver is nil,
+	// memoizes the constructed TypeResolver across calls. Buys an
+	// entire perFileExtraction + merge + resolveSupertypes skip on
+	// warm-no-change runs.
+	ResolverCache ResolverCache
 	// Reporter routes verbose progress and warning lines from IndexPhase.
 	// Nil means silent.
 	Reporter *diag.Reporter
@@ -286,7 +292,6 @@ func (p IndexPhase) buildTypeResolver(ctx context.Context, in IndexInput, resolv
 	if p.SkipResolverIndex || !caps.Has(api.NeedsResolver) {
 		return nil, nil
 	}
-	r := typeinfer.NewResolver()
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
@@ -294,16 +299,39 @@ func (p IndexPhase) buildTypeResolver(ctx context.Context, in IndexInput, resolv
 	if workers <= 0 {
 		workers = runtime.NumCPU()
 	}
-	if indexer, ok := interface{}(r).(interface {
-		IndexFilesParallel([]*scanner.File, int)
-	}); ok {
-		_ = in.trackSerial("typeIndex", func() error {
-			indexer.IndexFilesParallel(in.KotlinFiles, workers)
-			return nil
-		})
-		in.logf("verbose: Indexed %d Kotlin files for type resolution", len(in.KotlinFiles))
+	build := func() typeinfer.TypeResolver {
+		r := typeinfer.NewResolver()
+		if indexer, ok := interface{}(r).(interface {
+			IndexFilesParallel([]*scanner.File, int)
+		}); ok {
+			_ = in.trackSerial("typeIndex", func() error {
+				indexer.IndexFilesParallel(in.KotlinFiles, workers)
+				return nil
+			})
+			in.logf("verbose: Indexed %d Kotlin files for type resolution", len(in.KotlinFiles))
+		}
+		return r
 	}
-	return r, nil
+	if in.ResolverCache != nil {
+		return in.ResolverCache.Resolver(resolverFingerprint(in.KotlinFiles), build), nil
+	}
+	return build(), nil
+}
+
+// resolverFingerprint hashes the sorted (path, content-hash) pairs of
+// every Kotlin file contributing to typeinfer.TypeResolver state.
+// Mismatch forces a complete rebuild via ResolverCache.Resolver — no
+// stale entries from removed/renamed files survive across calls.
+func resolverFingerprint(files []*scanner.File) string {
+	entries := make([]string, 0, len(files))
+	for _, f := range files {
+		if f == nil {
+			continue
+		}
+		entries = append(entries, f.Path+"\x00"+hashutil.Default().HashContent(f.Path, f.Content))
+	}
+	sort.Strings(entries)
+	return hashutil.HashHex([]byte(strings.Join(entries, "\x01")))
 }
 
 // discoverModuleGraph performs a best-effort module discovery when

--- a/internal/pipeline/project.go
+++ b/internal/pipeline/project.go
@@ -98,6 +98,13 @@ type ProjectHostState struct {
 	// the disk-backed cross-file cache (CrossFileCacheDir) and finally
 	// to scanner.BuildIndex. *WorkspaceState satisfies this interface.
 	CodeIndexCache CodeIndexCache
+	// ResolverCache, when non-nil, memoizes the typeinfer.TypeResolver
+	// across calls. IndexPhase consults the slot before falling through
+	// to a fresh resolver + IndexFilesParallel*. The slot is keyed by
+	// the sorted (path, content-hash) pairs of all indexed Kotlin
+	// files, so mismatches force a complete rebuild rather than a
+	// stale-entry leak. *WorkspaceState satisfies this interface.
+	ResolverCache ResolverCache
 	// CrossFileCacheDir, when non-empty, enables the on-disk cross-file
 	// CodeIndex cache (zstd-encoded shards under .krit/crossfile-cache).
 	// Independent of CodeIndexCache: the disk cache is shared across
@@ -218,6 +225,7 @@ func RunProject(ctx context.Context, in ProjectInput) (ProjectResult, error) {
 		PrebuiltLibraryFacts: host.PrebuiltLibraryFacts,
 		LibraryFactsCache:    host.LibraryFactsCache,
 		CodeIndexCache:       host.CodeIndexCache,
+		ResolverCache:        host.ResolverCache,
 		CrossFileCacheDir:    host.CrossFileCacheDir,
 		Reporter:             host.Reporter,
 		Tracker:              host.Tracker,

--- a/internal/pipeline/resolver_cache_test.go
+++ b/internal/pipeline/resolver_cache_test.go
@@ -1,0 +1,158 @@
+package pipeline
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	api "github.com/kaeawc/krit/internal/rules/api"
+	"github.com/kaeawc/krit/internal/scanner"
+	"github.com/kaeawc/krit/internal/typeinfer"
+)
+
+// countingResolverCache is a test fake implementing ResolverCache that
+// counts how often build() actually fires versus how often the cached
+// pointer is returned.
+type countingResolverCache struct {
+	cached typeinfer.TypeResolver
+	fp     string
+	builds int
+}
+
+func (c *countingResolverCache) Resolver(fingerprint string, build func() typeinfer.TypeResolver) typeinfer.TypeResolver {
+	if c.cached != nil && c.fp == fingerprint {
+		return c.cached
+	}
+	c.cached = build()
+	c.fp = fingerprint
+	c.builds++
+	return c.cached
+}
+
+// TestIndexPhase_ResolverCache_BuildsOnceAcrossRuns confirms the
+// in-memory ResolverCache slot serves the second IndexPhase.Run when
+// the file set is unchanged. Acceptance for #48: warm-no-change runs
+// skip the entire perFileExtraction + merge + resolveSupertypes pass.
+func TestIndexPhase_ResolverCache_BuildsOnceAcrossRuns(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "Sample.kt")
+	if err := os.WriteFile(src, []byte("package test\n\nclass Sample\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	parsed, err := scanner.ParseFile(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rule := api.FakeRule("R", api.WithNeeds(api.NeedsResolver))
+
+	cache := &countingResolverCache{}
+	in := IndexInput{
+		ParseResult: ParseResult{
+			Paths:       []string{dir},
+			KotlinFiles: []*scanner.File{parsed},
+			ActiveRules: []*api.Rule{rule},
+		},
+		ResolverCache: cache,
+	}
+
+	r1, err := IndexPhase{SkipModules: true, SkipAndroid: true}.Run(context.Background(), in)
+	if err != nil {
+		t.Fatalf("first Run: %v", err)
+	}
+	if r1.Resolver == nil {
+		t.Fatal("first Run produced nil Resolver")
+	}
+	if cache.builds != 1 {
+		t.Fatalf("after first Run, builds = %d, want 1", cache.builds)
+	}
+
+	r2, err := IndexPhase{SkipModules: true, SkipAndroid: true}.Run(context.Background(), in)
+	if err != nil {
+		t.Fatalf("second Run: %v", err)
+	}
+	if cache.builds != 1 {
+		t.Fatalf("after second Run, builds = %d, want 1 (cache miss)", cache.builds)
+	}
+	if r1.Resolver != r2.Resolver {
+		t.Errorf("Resolver pointer changed across runs; cache is not reusing the cached value")
+	}
+}
+
+// TestIndexPhase_ResolverCache_RebuildsOnContentChange confirms a
+// content edit to one indexed file produces a fingerprint mismatch
+// and forces a fresh resolver. This is the safety contract that
+// prevents stale class/extension data from leaking across edits.
+func TestIndexPhase_ResolverCache_RebuildsOnContentChange(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "Sample.kt")
+	if err := os.WriteFile(src, []byte("package test\nclass A\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	parsed1, err := scanner.ParseFile(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rule := api.FakeRule("R", api.WithNeeds(api.NeedsResolver))
+	cache := &countingResolverCache{}
+
+	mkInput := func(file *scanner.File) IndexInput {
+		return IndexInput{
+			ParseResult: ParseResult{
+				Paths:       []string{dir},
+				KotlinFiles: []*scanner.File{file},
+				ActiveRules: []*api.Rule{rule},
+			},
+			ResolverCache: cache,
+		}
+	}
+
+	if _, err := (IndexPhase{SkipModules: true, SkipAndroid: true}).Run(context.Background(), mkInput(parsed1)); err != nil {
+		t.Fatal(err)
+	}
+	if cache.builds != 1 {
+		t.Fatalf("after first Run, builds = %d, want 1", cache.builds)
+	}
+
+	// Rewrite content (different bytes → different content hash).
+	if err := os.WriteFile(src, []byte("package test\nclass B\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	parsed2, err := scanner.ParseFile(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := (IndexPhase{SkipModules: true, SkipAndroid: true}).Run(context.Background(), mkInput(parsed2)); err != nil {
+		t.Fatal(err)
+	}
+	if cache.builds != 2 {
+		t.Fatalf("after content change, builds = %d, want 2 (rebuild on fingerprint mismatch)", cache.builds)
+	}
+}
+
+func TestResolverFingerprint_StableAndDistinct(t *testing.T) {
+	dir := t.TempDir()
+	a := filepath.Join(dir, "A.kt")
+	b := filepath.Join(dir, "B.kt")
+	if err := os.WriteFile(a, []byte("package x\nclass A\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(b, []byte("package x\nclass B\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	pa, _ := scanner.ParseFile(a)
+	pb, _ := scanner.ParseFile(b)
+
+	fp1 := resolverFingerprint([]*scanner.File{pa, pb})
+	fp2 := resolverFingerprint([]*scanner.File{pb, pa})
+	if fp1 != fp2 {
+		t.Errorf("fingerprint should be order-independent: %q vs %q", fp1, fp2)
+	}
+	fp3 := resolverFingerprint([]*scanner.File{pa})
+	if fp1 == fp3 {
+		t.Errorf("fingerprint should differ for distinct file sets: %q", fp1)
+	}
+}

--- a/internal/pipeline/types.go
+++ b/internal/pipeline/types.go
@@ -306,6 +306,19 @@ type CodeIndexCache interface {
 	CodeIndex(fingerprint string, build func() *scanner.CodeIndex) *scanner.CodeIndex
 }
 
+// ResolverCache lets a long-lived host (typically *WorkspaceState)
+// memoize a typeinfer.TypeResolver across RunProject calls. Same
+// shape and contract as CodeIndexCache: build fires on a fingerprint
+// mismatch; the watcher's InvalidateResolver call covers the daemon.
+//
+// Fingerprint must capture every input that affects resolver state:
+// today the sorted (path, content-hash) pairs of every Kotlin file
+// indexed. Mismatches force a fresh resolver — no stale entries from
+// removed/renamed files leak across the boundary.
+type ResolverCache interface {
+	Resolver(fingerprint string, build func() typeinfer.TypeResolver) typeinfer.TypeResolver
+}
+
 // FileTiming captures per-file dispatch timing recorded when
 // IndexResult.ProfileDispatch is set.
 type FileTiming struct {

--- a/internal/pipeline/workspace.go
+++ b/internal/pipeline/workspace.go
@@ -10,6 +10,7 @@ import (
 	"github.com/kaeawc/krit/internal/hashutil"
 	"github.com/kaeawc/krit/internal/librarymodel"
 	"github.com/kaeawc/krit/internal/scanner"
+	"github.com/kaeawc/krit/internal/typeinfer"
 )
 
 // WorkspaceState is the long-lived in-memory parse cache shared by
@@ -45,6 +46,7 @@ type WorkspaceState struct {
 	libraryFacts xfileSlot[*librarymodel.Facts]
 	codeIndex    xfileSlot[*scanner.CodeIndex]
 	dependents   xfileSlot[*scanner.DependentsIndex]
+	resolver     xfileSlot[typeinfer.TypeResolver]
 }
 
 // xfileSlot pairs a fingerprint with a value. Zero value means
@@ -362,6 +364,50 @@ func (w *WorkspaceState) InvalidateCodeIndex() {
 	}
 	w.xfileMu.Lock()
 	w.codeIndex = xfileSlot[*scanner.CodeIndex]{}
+	w.xfileMu.Unlock()
+}
+
+// Resolver memoizes a typeinfer.TypeResolver across calls. Same
+// semantics as CodeIndex: build only fires on a fingerprint mismatch;
+// concurrent races converge on a single cached pointer. The
+// fingerprint must capture every input that affects resolver state
+// (Kotlin file paths + content hashes today). A nil receiver always
+// builds (no caching).
+func (w *WorkspaceState) Resolver(fingerprint string, build func() typeinfer.TypeResolver) typeinfer.TypeResolver {
+	if w == nil || fingerprint == "" {
+		return build()
+	}
+	w.xfileMu.Lock()
+	if w.resolver.present && w.resolver.fingerprint == fingerprint {
+		v := w.resolver.value
+		w.xfileMu.Unlock()
+		return v
+	}
+	w.xfileMu.Unlock()
+
+	v := build()
+
+	w.xfileMu.Lock()
+	if w.resolver.present && w.resolver.fingerprint == fingerprint {
+		v = w.resolver.value
+	} else {
+		w.resolver = xfileSlot[typeinfer.TypeResolver]{fingerprint: fingerprint, value: v, present: true}
+	}
+	w.xfileMu.Unlock()
+	return v
+}
+
+// InvalidateResolver drops the cached resolver. Called when any
+// Kotlin source file changes — typeinfer's ImportTable / class /
+// extension state aggregates across files, so any edit invalidates
+// the whole slot. Belt-and-suspenders alongside the fingerprint
+// check.
+func (w *WorkspaceState) InvalidateResolver() {
+	if w == nil {
+		return
+	}
+	w.xfileMu.Lock()
+	w.resolver = xfileSlot[typeinfer.TypeResolver]{}
 	w.xfileMu.Unlock()
 }
 


### PR DESCRIPTION
## Summary
Third daemon-resident state piece for #48. Stacked on #120 (CodeIndex). After this lands the only remaining #48 items are Oracle (subprocess lifecycle) and AnalysisCache (semantic enable change) — both warrant their own design discussion.

\`typeinfer.TypeResolver\` carries the project's class hierarchy, import tables, scopes, type aliases, sealed variants, enum entries, and extensions. Today the daemon constructs a fresh resolver on every \`analyze-project\` call and re-runs perFileExtraction + merge + resolveSupertypes. After #117 the per-file extraction is disk-cached; this PR eliminates the merge + supertype work on warm-no-change runs.

## Design — fingerprint-keyed slot, not incremental merge

The prior PR's body called this out as risky because \`defaultResolver\` merges into maps that aren't path-keyed (\`classes\`, \`classFQN\`, \`sealedVariants\`, \`extensions\`) — reusing **incrementally** leaks stale entries from removed/renamed files.

The fingerprint-keyed slot avoids this by **not reusing incrementally**: it returns the exact same resolver pointer when the file set is byte-identical, rebuilds from scratch otherwise. Either we hit (state IS correct) or we miss (start fresh, no staleness).

\`resolverFingerprint\` = hash of sorted \`(path, content-hash)\` tuples of every Kotlin file. Any added/removed/renamed/edited file produces a mismatch.

## Belt-and-suspenders watcher integration
\`WorkspaceState.InvalidateResolver\` added; \`fileWatcher.scheduleKotlinInvalidate\` drops the slot on every \`.kt\` / \`.kts\` edit. The fingerprint check would catch this anyway, but invalidating eagerly avoids holding stale state in memory between edits.

## Tests
- \`TestIndexPhase_ResolverCache_BuildsOnceAcrossRuns\` — counting fake confirms \`build()\` fires once across two \`IndexPhase.Run\` calls; pointer is reused.
- \`TestIndexPhase_ResolverCache_RebuildsOnContentChange\` — content edit forces \`builds=2\` via fingerprint mismatch. **This is the safety contract.**
- \`TestResolverFingerprint_StableAndDistinct\` — order-independent, distinguishes file sets.

## Out of scope (#48 follow-up)
- **Oracle / OracleDaemon** — subprocess lifecycle + \"enable in daemon\" coupled with \"make resident\". Two compounded changes.
- **AnalysisCache** — daemon doesn't load it today; promoting is enable+resident with output-drift risk.

## Test plan
- [x] \`go build -o krit ./cmd/krit/\`
- [x] \`go vet ./...\`
- [x] \`go test ./... -count=1\`