### PR TITLE
feat(daemon): make AnalysisCache write-back daemon-resident

### DIFF
--- a/internal/cli/serve/analyze_project.go
+++ b/internal/cli/serve/analyze_project.go
@@ -117,6 +117,12 @@ func (s *daemonState) buildProjectInput(args daemon.AnalyzeProjectArgs) (pipelin
 		parseCache = nil
 	}
 
+	// AnalysisCache is daemon-resident: lazy-loaded on first request,
+	// keyed by the resolved cache file path so distinct scan-path sets
+	// don't share an entry. DispatchPhase will merge new findings into
+	// it and persist to disk on each call.
+	analysisCache, analysisCachePath := s.analysisCacheFor(paths)
+
 	return pipeline.ProjectInput{
 		Args: pipeline.ProjectArgs{
 			Config:           cfg,
@@ -130,17 +136,18 @@ func (s *daemonState) buildProjectInput(args daemon.AnalyzeProjectArgs) (pipelin
 			IncludeGenerated: args.IncludeGenerated,
 			Version:          kritVersion(),
 		},
-		// Resolver, Oracle, AnalysisCache will be wired into Host as the
-		// daemon promotes them to resident state in follow-up commits
+		// Oracle daemon-resident wiring will land in a follow-up commit
 		// (see #48). RunProject treats nil as "construct per-call as the
 		// CLI runner does today", so the verb is already correct — just
 		// slower than its eventual ceiling.
 		Host: pipeline.ProjectHostState{
-			ParseCache:        parseCache,
-			LibraryFactsCache: s.workspace,
-			CodeIndexCache:    s.workspace,
-			ResolverCache:     s.workspace,
-			CrossFileCacheDir: scanner.CrossFileCacheDir(repoDir),
+			ParseCache:            parseCache,
+			LibraryFactsCache:     s.workspace,
+			CodeIndexCache:        s.workspace,
+			ResolverCache:         s.workspace,
+			CrossFileCacheDir:     scanner.CrossFileCacheDir(repoDir),
+			AnalysisCache:         analysisCache,
+			AnalysisCacheFilePath: analysisCachePath,
 		},
 	}, nil
 }

--- a/internal/cli/serve/serve.go
+++ b/internal/cli/serve/serve.go
@@ -203,7 +203,7 @@ type daemonState struct {
 	// dispatch merges per-file findings into the cache and saves it on
 	// each analyze-project call. The CLI's existing on-disk format is
 	// preserved so subsequent CLI runs read the daemon-populated cache.
-	analysisCacheMu   sync.Mutex
+	analysisCacheMu    sync.Mutex
 	analysisCacheByKey map[string]*analysisCacheEntry
 
 	// analyzeMu serializes whole-project analysis. The pipeline mutates

--- a/internal/cli/serve/serve.go
+++ b/internal/cli/serve/serve.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/kaeawc/krit/internal/arch"
+	"github.com/kaeawc/krit/internal/cache"
 	"github.com/kaeawc/krit/internal/cli/clishared"
 	"github.com/kaeawc/krit/internal/config"
 	"github.com/kaeawc/krit/internal/daemon"
@@ -197,6 +198,14 @@ type daemonState struct {
 	parseCache     *scanner.ParseCache
 	parseCacheErr  error
 
+	// analysisCacheMu guards lazy construction of the resident
+	// *cache.Cache + its file path, scoped per scan-path set. Pipeline
+	// dispatch merges per-file findings into the cache and saves it on
+	// each analyze-project call. The CLI's existing on-disk format is
+	// preserved so subsequent CLI runs read the daemon-populated cache.
+	analysisCacheMu   sync.Mutex
+	analysisCacheByKey map[string]*analysisCacheEntry
+
 	// analyzeMu serializes whole-project analysis. The pipeline mutates
 	// resolver / oracle state and the analysis-cache write-back path
 	// is not safe under concurrent runs; queueing is acceptable
@@ -217,10 +226,40 @@ func newDaemonState(root string) *daemonState {
 		repoDir = root
 	}
 	return &daemonState{
-		root:      root,
-		repoDir:   repoDir,
-		workspace: pipeline.NewWorkspaceState(root),
+		root:               root,
+		repoDir:            repoDir,
+		workspace:          pipeline.NewWorkspaceState(root),
+		analysisCacheByKey: make(map[string]*analysisCacheEntry),
 	}
+}
+
+// analysisCacheEntry holds a lazily-loaded *cache.Cache and the file
+// path it persists to. Keyed by the cache file path inside daemonState
+// so distinct scan-path sets don't share an entry.
+type analysisCacheEntry struct {
+	cache *cache.Cache
+	path  string
+}
+
+// analysisCacheFor returns the resident *cache.Cache and its file path
+// for the given scan paths, lazily loading from disk on first request.
+// Returns (nil, "") when the cache directory cannot be derived (no
+// repo root found). Subsequent calls with the same scan-path set
+// return the same pointer so DispatchPhase write-back is amortized
+// across daemon calls.
+func (s *daemonState) analysisCacheFor(scanPaths []string) (*cache.Cache, string) {
+	cacheDir, filePath := cache.ResolveCacheDir("", scanPaths)
+	if cacheDir == "" || filePath == "" {
+		return nil, ""
+	}
+	s.analysisCacheMu.Lock()
+	defer s.analysisCacheMu.Unlock()
+	if entry, ok := s.analysisCacheByKey[filePath]; ok {
+		return entry.cache, entry.path
+	}
+	loaded := cache.Load(filePath)
+	s.analysisCacheByKey[filePath] = &analysisCacheEntry{cache: loaded, path: filePath}
+	return loaded, filePath
 }
 
 // ensureConfig returns the daemon's cached *config.Config, loading

--- a/internal/pipeline/analysis_cache_test.go
+++ b/internal/pipeline/analysis_cache_test.go
@@ -1,0 +1,80 @@
+package pipeline
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kaeawc/krit/internal/cache"
+	"github.com/kaeawc/krit/internal/config"
+	api "github.com/kaeawc/krit/internal/rules/api"
+)
+
+// TestRunProject_AnalysisCacheWriteBack confirms that when Host carries
+// an AnalysisCache + AnalysisCacheFilePath, RunProject populates the
+// cache with per-file findings and persists it to disk. Lookup-side
+// (file-skip on hit) is intentionally out of scope for this PR; the
+// write-only contract verified here is enough for subsequent CLI runs
+// to benefit from the daemon-populated cache.
+func TestRunProject_AnalysisCacheWriteBack(t *testing.T) {
+	dir := t.TempDir()
+	cacheDir := filepath.Join(dir, ".krit", "cache")
+	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cachePath := filepath.Join(cacheDir, "krit.cache")
+	src := filepath.Join(dir, "Sample.kt")
+	if err := os.WriteFile(src, []byte("package test\n\nclass Sample\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	rule := api.FakeRule("ProjectSmokeClassDecl",
+		api.WithNodeTypes("class_declaration"),
+		api.WithSeverity(api.SeverityWarning),
+		api.WithCheck(func(ctx *api.Context) {
+			ctx.EmitAt(int(ctx.Node.StartRow)+1, 1, "class declared")
+		}),
+	)
+
+	loaded := cache.Load(cachePath)
+	if loaded == nil {
+		t.Fatal("cache.Load returned nil")
+	}
+
+	res, err := RunProject(context.Background(), ProjectInput{
+		Args: ProjectArgs{
+			Config:      config.NewConfig(),
+			Paths:       []string{dir},
+			ActiveRules: []*api.Rule{rule},
+			Format:      "json",
+			Version:     "test",
+		},
+		Host: ProjectHostState{
+			AnalysisCache:         loaded,
+			AnalysisCacheFilePath: cachePath,
+		},
+	})
+	if err != nil {
+		t.Fatalf("RunProject: %v", err)
+	}
+	if res.FindingsCount != 1 {
+		t.Errorf("FindingsCount = %d, want 1", res.FindingsCount)
+	}
+
+	// Reload from disk and confirm the cache file persisted with a
+	// non-empty entry for the dispatched file.
+	reloaded := cache.Load(cachePath)
+	if reloaded == nil {
+		t.Fatal("reload: cache.Load returned nil")
+	}
+	if len(reloaded.Files) == 0 {
+		t.Fatalf("expected cache to be populated after dispatch; got %d entries", len(reloaded.Files))
+	}
+	if reloaded.RuleHash == "" {
+		t.Errorf("expected RuleHash to be set after dispatch")
+	}
+	if reloaded.Version != "test" {
+		t.Errorf("Version = %q, want \"test\"", reloaded.Version)
+	}
+}

--- a/internal/pipeline/project.go
+++ b/internal/pipeline/project.go
@@ -117,8 +117,14 @@ type ProjectHostState struct {
 	// daemon handle (used only when Oracle is also set).
 	OracleDaemon *oracle.Daemon
 	// AnalysisCache, when non-nil, drives the incremental findings
-	// cache. Nil disables the cache entirely.
+	// cache. DispatchPhase merges new per-file findings into it and
+	// saves the result to AnalysisCacheFilePath after dispatch. Nil
+	// disables cache write-back entirely.
 	AnalysisCache *cache.Cache
+	// AnalysisCacheFilePath is where AnalysisCache is persisted on
+	// dispatch write-back. Required when AnalysisCache is non-nil. The
+	// daemon derives this from cache.FilePath(cacheDir, scanPaths).
+	AnalysisCacheFilePath string
 }
 
 // ProjectInput is the value type that drives RunProject. The split
@@ -247,6 +253,20 @@ func RunProject(ctx context.Context, in ProjectInput) (ProjectResult, error) {
 		indexResult.Daemon = host.OracleDaemon
 	}
 	indexResult.Cache = host.AnalysisCache
+	if host.AnalysisCache != nil {
+		// Wire the dispatch-side write-back fields so writeCacheBack
+		// can update the cache and persist it on each call. Lookup-side
+		// (file-skip on hit) requires CacheResult population in
+		// IndexPhase.runCacheLoad and stays out of scope for this
+		// promotion — populating the cache without skipping is safe
+		// (no output drift) and benefits subsequent CLI runs.
+		indexResult.CacheFilePath = host.AnalysisCacheFilePath
+		indexResult.CacheScanPaths = args.Paths
+		indexResult.Version = args.Version
+		if indexResult.RuleHash == "" {
+			indexResult.RuleHash = projectRuleHash(args.ActiveRules, args.Config)
+		}
+	}
 
 	// Phase 3: dispatch (per-file rules).
 	dispatchResult, err := DispatchPhase{}.Run(ctx, indexResult)
@@ -301,4 +321,18 @@ func parseCacheCounters(pc *scanner.ParseCache) (int64, int64) {
 	}
 	s := pc.Stats()
 	return s.Hits, s.Misses
+}
+
+// projectRuleHash mirrors IndexPhase.computeRuleHash for the daemon's
+// AnalysisCache write-back path. RuleHash is set on the saved cache so
+// subsequent CLI lookups reject the cache when the rule set / config
+// has drifted.
+func projectRuleHash(activeRules []*api.Rule, cfg *config.Config) string {
+	ruleNames := make([]string, 0, len(activeRules))
+	for _, r := range activeRules {
+		if r != nil {
+			ruleNames = append(ruleNames, r.ID)
+		}
+	}
+	return cache.ComputeConfigHash(ruleNames, cfg, false)
 }


### PR DESCRIPTION
## Summary
Fourth daemon-resident state piece for #48 (after #116, #120, #123). The daemon today doesn't load \`*cache.Cache\` at all, so its \`analyze-project\` calls don't populate the incremental findings cache that the CLI relies on for warm-run skipping. This PR makes the cache resident on the daemon side and turns on dispatch write-back.

## What this PR does (write-only)
- \`daemonState.analysisCacheFor(scanPaths)\`: lazy \`cache.Load\` keyed by cache file path so distinct scan-path sets don't share an entry.
- \`ProjectHostState\` gains \`AnalysisCache\` (now used) + \`AnalysisCacheFilePath\`.
- \`RunProject\` populates \`IndexResult.{CacheFilePath, CacheScanPaths, Version, RuleHash}\` when \`host.AnalysisCache\` is set, so \`DispatchPhase.writeCacheBack\` persists the cache after dispatch.
- \`projectRuleHash\` mirrors \`IndexPhase.computeRuleHash\` so the saved cache's \`RuleHash\` stays consistent with the CLI's read path.

## What this PR DOESN'T do (deliberate, follow-up)
- **Lookup-side file-skip.** Populating \`CacheResult.CachedPaths\` so \`DispatchPhase\` can skip per-file rule execution requires running \`cache.CheckFiles\` in \`IndexPhase.runCacheLoad\`. That's gated by \`CacheEnabled\`, which the daemon doesn't set, and enabling it risks daemon-vs-CLI output drift (e.g. baseline / diff filters interacting with cached entries). Left out so **this PR ships with NO output-behavior change** — every dispatched file still runs every rule on every call.

Net effect: the daemon now warms the on-disk cache that subsequent CLI runs read. A follow-up PR can wire the daemon's own lookup path once the \`CacheEnabled\` plumbing has its own byte-equal contract test.

## Test
- \`TestRunProject_AnalysisCacheWriteBack\` — runs a synthetic project, asserts the cache file persists post-dispatch with non-empty \`Files\` map, \`RuleHash\` set, \`Version\` set. Verified to fail-build on pre-wire code.

## Test plan
- [x] \`go build -o krit ./cmd/krit/\`
- [x] \`go vet ./...\`
- [x] \`go test ./... -count=1\`