### PR TITLE
feat(daemon): enable oracle in daemon mode via resident JVM (#125 PR-B)

### DIFF
--- a/internal/scanner/index_kotlin.go
+++ b/internal/scanner/index_kotlin.go
@@ -212,17 +212,29 @@ func packageNameForFile(file *File) string {
 // take only the first non-empty, non-comment line and strip the leading
 // `package` keyword.
 func parsePackageHeaderText(raw string) string {
-	for _, line := range strings.Split(raw, "\n") {
-		line = strings.TrimSpace(line)
-		if line == "" || strings.HasPrefix(line, "//") || strings.HasPrefix(line, "/*") {
-			continue
+	// Single-pass scan: walk the line-delimited string in place so we
+	// don't allocate a slice covering every line for the typical
+	// one-or-two-line header. Mirrors firstSourceLine in rename;
+	// same shape — see #46.
+	for s := raw; ; {
+		var line string
+		i := strings.IndexByte(s, '\n')
+		if i < 0 {
+			line = strings.TrimSpace(s)
+		} else {
+			line = strings.TrimSpace(s[:i])
 		}
-		line = strings.TrimPrefix(line, "package")
-		line = strings.TrimSpace(line)
-		line = strings.TrimSuffix(line, ";")
-		return strings.TrimSpace(line)
+		if line != "" && !strings.HasPrefix(line, "//") && !strings.HasPrefix(line, "/*") {
+			line = strings.TrimPrefix(line, "package")
+			line = strings.TrimSpace(line)
+			line = strings.TrimSuffix(line, ";")
+			return strings.TrimSpace(line)
+		}
+		if i < 0 {
+			return ""
+		}
+		s = s[i+1:]
 	}
-	return ""
 }
 
 func kotlinPackageName(file *File) string {

--- a/internal/scanner/index_kotlin_test.go
+++ b/internal/scanner/index_kotlin_test.go
@@ -31,6 +31,26 @@ func TestParsePackageHeaderText(t *testing.T) {
 			raw:  "  package   com.example.foo  \n",
 			want: "com.example.foo",
 		},
+		{
+			name: "empty",
+			raw:  "",
+			want: "",
+		},
+		{
+			name: "comments only",
+			raw:  "// just a comment\n/* and another */",
+			want: "",
+		},
+		{
+			name: "leading blank lines and comments",
+			raw:  "\n\n// a comment\n\npackage com.example\n",
+			want: "com.example",
+		},
+		{
+			name: "block comment then package",
+			raw:  "/* license header */\npackage com.example.bar\n",
+			want: "com.example.bar",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary
Second of three PRs implementing #125. Wires the lazy-started oracle daemon from #127 (PR-A) through the verb path so type-aware rules in the daemon get the same precision they get in the CLI — without paying JVM startup on every \`analyze-project\` call.

## What this PR does

### Pipeline plumbing
- \`IndexInput.PrebuiltOracleDaemon\` — a \`*oracle.Daemon\` the host can pre-supply. \`runDaemonOracle\` prefers it over \`oracle.InvokeDaemon\` so the warm JVM is reused.
- \`ProjectArgs.OracleEnabled\` — per-call flag the host flips on when a daemon was successfully started.
- \`RunProject\` sets \`IndexInput.{OracleEnabled, UseDaemon, PrebuiltOracleDaemon, OracleScanPaths, NoOracleFilter}\` from the Args/Host pair when both line up. \`NoOracleFilter\` is forced on pending PR-C.
- \`IndexPhase.Run\` refactored: extracted \`buildBaseResolver\` from \`buildTypeResolver\` and call it BEFORE the oracle gate. **This is the load-bearing change** — \`runOracle\`'s gate requires a non-nil base, which previously was only built post-oracle inside \`buildTypeResolver\`. Now the cache-aware base resolver feeds \`runOracle\` directly.

### Daemon side
- \`buildProjectInput\` calls \`ensureOracleDaemon(paths)\` and threads the (possibly-nil) handle into \`Host.OracleDaemon\`. Failed start logs and degrades gracefully.
- \`Args.OracleEnabled\` set to \`(oracleDaemon != nil)\`.
- \`handleAnalyzeProject\` calls \`pingOracleDaemon\` at verb entry so a JVM that died gets replaced before \`RunProject\` hits it.

## What this PR DOES NOT do (PR-C)
Cache the oracle filter pre-scan. That filesystem walk runs on every analyze-project call today and dominates the warm cost. PR-C will fingerprint and memoize it.

## Output drift risk
When \`krit-types.jar\` is found, the daemon now produces oracle-augmented findings. This matches the CLI's default \`--type-oracle\` behavior, but is a change vs. the pre-#125 daemon (which never ran oracle). Tests in this codebase don't ship the JAR by default, so equivalence tests stay byte-equal. Real-world drift only fires for users who installed the JAR — their daemon output now matches their CLI output, which is the intent.

## Tests
- \`TestRunProject_OracleDaemonPlumbing\` — supplies a stub daemon handle, runs through the new wiring. Implicit assertion: no \`InvokeDaemon\` was called.
- \`TestRunProject_OracleDaemonNotWiredWhenDisabled\` — negative path: \`OracleEnabled=false\` ignores the daemon stub.

## Test plan
- [x] \`go build -o krit ./cmd/krit/\`
- [x] \`go vet ./...\`
- [x] \`go test ./... -count=1\`