### PR TITLE
feat(daemon): cache oracle call filter classification (#125 PR-C)

### DIFF
--- a/internal/cli/serve/analyze_project.go
+++ b/internal/cli/serve/analyze_project.go
@@ -162,6 +162,7 @@ func (s *daemonState) buildProjectInput(args daemon.AnalyzeProjectArgs) (pipelin
 			LibraryFactsCache:     s.workspace,
 			CodeIndexCache:        s.workspace,
 			ResolverCache:         s.workspace,
+			OracleFilterCache:     s.workspace,
 			CrossFileCacheDir:     scanner.CrossFileCacheDir(repoDir),
 			TypeIndexCacheDir:     typeinfer.TypeIndexCacheDir(repoDir),
 			AnalysisCache:         analysisCache,

--- a/internal/cli/serve/watcher.go
+++ b/internal/cli/serve/watcher.go
@@ -23,6 +23,7 @@ type watcherState interface {
 	InvalidateDependents()
 	InvalidateLibraryFacts()
 	InvalidateResolver()
+	InvalidateOracleFilter()
 	Touch(path string)
 }
 
@@ -234,6 +235,7 @@ func (fw *fileWatcher) scheduleKotlinInvalidate(path string) {
 		fw.state.InvalidateCodeIndex()
 		fw.state.InvalidateDependents()
 		fw.state.InvalidateResolver()
+		fw.state.InvalidateOracleFilter()
 		fw.state.Touch(path)
 	})
 	fw.debounceMu.Unlock()

--- a/internal/cli/serve/watcher_test.go
+++ b/internal/cli/serve/watcher_test.go
@@ -23,6 +23,7 @@ func (c *countingState) InvalidateCodeIndex()    {}
 func (c *countingState) InvalidateDependents()   {}
 func (c *countingState) InvalidateLibraryFacts() {}
 func (c *countingState) InvalidateResolver()     {}
+func (c *countingState) InvalidateOracleFilter() {}
 func (c *countingState) Touch(path string)       {}
 
 // waitForCondition polls fn every 5ms up to 2s. Returns true when fn

--- a/internal/pipeline/index.go
+++ b/internal/pipeline/index.go
@@ -138,6 +138,15 @@ type IndexInput struct {
 	// analyze-project verb calls; the JVM warmup cost (~seconds) is
 	// then paid once per krit-serve lifetime instead of per call.
 	PrebuiltOracleDaemon *oracle.Daemon
+	// PrebuiltOracleCallFilter, when non-nil, is used in place of the
+	// per-call buildOracleCallTargetFilterForInvocation() rebuild.
+	// RunProject computes (and caches) the filter once via
+	// host.OracleFilterCache before IndexPhase runs; runDaemonOracle
+	// reuses it instead of re-scanning every Kotlin file for
+	// annotated-identifier hits. Skip-mode (Enabled==false) values
+	// are still passed through as a sentinel so the JVM-side gate
+	// stays consistent with the cached classification.
+	PrebuiltOracleCallFilter *oracle.CallTargetFilterSummary
 	// Store is the optional unified store for oracle cache entries.
 	Store *store.FileStore
 	// OracleCacheWriter, when non-nil, defers cold oracle cache-entry
@@ -599,7 +608,7 @@ var _ Phase[IndexInput, IndexResult] = IndexPhase{}
 // runDaemonOracle starts a daemon, analyzes all files, and wraps base in
 // a CompositeResolver. Returns the updated resolver.
 func (p IndexPhase) runDaemonOracle(in IndexInput, oracleRules []*api.Rule, scanPaths []string, loadOracleFilterFiles func() []*scanner.File, oracleTracker perf.Tracker, base typeinfer.TypeResolver, result *IndexResult) typeinfer.TypeResolver {
-	callFilterPtr := buildOracleCallTargetFilterForInvocation(oracleRules, loadOracleFilterFiles, oracleTracker, in.Reporter)
+	callFilterPtr := selectOracleCallFilter(in, oracleRules, loadOracleFilterFiles, oracleTracker)
 
 	var d *oracle.Daemon
 	if in.PrebuiltOracleDaemon != nil {
@@ -739,7 +748,7 @@ func (p IndexPhase) runJvmAnalyze(in IndexInput, oracleRules []*api.Rule, scanPa
 		defer cleanup()
 	}
 
-	callFilterPtr := buildOracleCallTargetFilterForInvocation(oracleRules, loadOracleFilterFiles, jvmTracker, in.Reporter)
+	callFilterPtr := selectOracleCallFilter(in, oracleRules, loadOracleFilterFiles, jvmTracker)
 	declarationProfileSummary := rules.BuildOracleDeclarationProfileV2(oracleRules)
 	factUnion := rules.OracleFactUnion(oracleRules)
 	perf.AddEntryDetails(jvmTracker, "oracleFactUnion", 0, map[string]int64{
@@ -1107,6 +1116,23 @@ func boolMetric(b bool) int64 {
 		return 1
 	}
 	return 0
+}
+
+// selectOracleCallFilter returns the prebuilt filter when the host
+// supplied one, otherwise builds it via the per-call path. Wraps both
+// runDaemonOracle and runJvmAnalyze so the daemon's resident filter
+// cache is honoured everywhere oracle classification fires.
+func selectOracleCallFilter(in IndexInput, oracleRules []*api.Rule, loadOracleFilterFiles func() []*scanner.File, tracker perf.Tracker) *oracle.CallTargetFilterSummary {
+	if in.PrebuiltOracleCallFilter != nil {
+		// Skip-mode (Enabled==false) is preserved as a sentinel; the
+		// gate inside runDaemonOracle / runJvmAnalyze handles
+		// nil-vs-disabled symmetrically.
+		if !in.PrebuiltOracleCallFilter.Enabled {
+			return nil
+		}
+		return in.PrebuiltOracleCallFilter
+	}
+	return buildOracleCallTargetFilterForInvocation(oracleRules, loadOracleFilterFiles, tracker, in.Reporter)
 }
 
 func buildOracleCallTargetFilterForInvocation(activeRules []*api.Rule, loadFiles func() []*scanner.File, tracker perf.Tracker, reporter *diag.Reporter) *oracle.CallTargetFilterSummary {

--- a/internal/pipeline/oracle_filter_cache_test.go
+++ b/internal/pipeline/oracle_filter_cache_test.go
@@ -10,24 +10,6 @@ import (
 	"github.com/kaeawc/krit/internal/scanner"
 )
 
-// countingOracleFilterCache is a test fake for OracleFilterCache that
-// counts how often build() actually fires.
-type countingOracleFilterCache struct {
-	cached *oracle.CallTargetFilterSummary
-	fp     string
-	builds int
-}
-
-func (c *countingOracleFilterCache) OracleFilter(fingerprint string, build func() *oracle.CallTargetFilterSummary) *oracle.CallTargetFilterSummary {
-	if c.cached != nil && c.fp == fingerprint {
-		return c.cached
-	}
-	c.cached = build()
-	c.fp = fingerprint
-	c.builds++
-	return c.cached
-}
-
 // TestOracleFilterFingerprint_StableAndDistinct verifies the
 // fingerprint is order-independent over rules + files and changes
 // when either input changes.

--- a/internal/pipeline/oracle_filter_cache_test.go
+++ b/internal/pipeline/oracle_filter_cache_test.go
@@ -1,0 +1,106 @@
+package pipeline
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kaeawc/krit/internal/oracle"
+	api "github.com/kaeawc/krit/internal/rules/api"
+	"github.com/kaeawc/krit/internal/scanner"
+)
+
+// countingOracleFilterCache is a test fake for OracleFilterCache that
+// counts how often build() actually fires.
+type countingOracleFilterCache struct {
+	cached *oracle.CallTargetFilterSummary
+	fp     string
+	builds int
+}
+
+func (c *countingOracleFilterCache) OracleFilter(fingerprint string, build func() *oracle.CallTargetFilterSummary) *oracle.CallTargetFilterSummary {
+	if c.cached != nil && c.fp == fingerprint {
+		return c.cached
+	}
+	c.cached = build()
+	c.fp = fingerprint
+	c.builds++
+	return c.cached
+}
+
+// TestOracleFilterFingerprint_StableAndDistinct verifies the
+// fingerprint is order-independent over rules + files and changes
+// when either input changes.
+func TestOracleFilterFingerprint_StableAndDistinct(t *testing.T) {
+	dir := t.TempDir()
+	a := filepath.Join(dir, "A.kt")
+	b := filepath.Join(dir, "B.kt")
+	if err := os.WriteFile(a, []byte("package x\nclass A\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(b, []byte("package x\nclass B\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	pa, _ := scanner.ParseFile(a)
+	pb, _ := scanner.ParseFile(b)
+
+	r1 := api.FakeRule("R1")
+	r2 := api.FakeRule("R2")
+
+	fp1 := oracleFilterFingerprint([]*api.Rule{r1, r2}, []*scanner.File{pa, pb})
+	fp2 := oracleFilterFingerprint([]*api.Rule{r2, r1}, []*scanner.File{pb, pa})
+	if fp1 != fp2 {
+		t.Errorf("fingerprint should be order-independent: %q vs %q", fp1, fp2)
+	}
+
+	// Different rule set → different fingerprint.
+	fp3 := oracleFilterFingerprint([]*api.Rule{r1}, []*scanner.File{pa, pb})
+	if fp1 == fp3 {
+		t.Errorf("fingerprint should differ for distinct rule sets")
+	}
+
+	// Different file set → different fingerprint.
+	fp4 := oracleFilterFingerprint([]*api.Rule{r1, r2}, []*scanner.File{pa})
+	if fp1 == fp4 {
+		t.Errorf("fingerprint should differ for distinct file sets")
+	}
+}
+
+// TestSelectOracleCallFilter_PrefersPrebuilt confirms that when
+// IndexInput.PrebuiltOracleCallFilter is supplied, it is returned
+// without invoking the per-call buildOracleCallTargetFilterForInvocation
+// path. Asserts via a non-zero CalleeNames marker.
+func TestSelectOracleCallFilter_PrefersPrebuilt(t *testing.T) {
+	prebuilt := &oracle.CallTargetFilterSummary{
+		Enabled:     true,
+		CalleeNames: []string{"sentinel.from.cache"},
+	}
+	in := IndexInput{PrebuiltOracleCallFilter: prebuilt}
+
+	// loadFiles intentionally returns nil — if selectOracleCallFilter
+	// fell through to the build path it would error or produce a
+	// different summary.
+	got := selectOracleCallFilter(in, nil, nil, nil)
+	if got != prebuilt {
+		t.Fatalf("selectOracleCallFilter returned %#v; want the prebuilt %#v", got, prebuilt)
+	}
+}
+
+// TestSelectOracleCallFilter_PrebuiltDisabledReturnsNil verifies that
+// a prebuilt summary with Enabled=false acts as a sentinel: the
+// caller gets nil, matching the per-call path's "filter classified as
+// disabled by broad rules" output. Without this symmetry, a cached
+// "disabled" classification would unexpectedly enable the JVM-side
+// gate.
+func TestSelectOracleCallFilter_PrebuiltDisabledReturnsNil(t *testing.T) {
+	prebuilt := &oracle.CallTargetFilterSummary{
+		Enabled:    false,
+		DisabledBy: []string{"BroadRule"},
+	}
+	in := IndexInput{PrebuiltOracleCallFilter: prebuilt}
+
+	got := selectOracleCallFilter(in, nil, nil, nil)
+	if got != nil {
+		t.Fatalf("selectOracleCallFilter returned %#v; want nil for disabled prebuilt", got)
+	}
+}

--- a/internal/pipeline/project.go
+++ b/internal/pipeline/project.go
@@ -4,12 +4,15 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"sort"
+	"strings"
 	"time"
 
 	"github.com/kaeawc/krit/internal/cache"
 	"github.com/kaeawc/krit/internal/cacheutil"
 	"github.com/kaeawc/krit/internal/config"
 	"github.com/kaeawc/krit/internal/diag"
+	"github.com/kaeawc/krit/internal/hashutil"
 	"github.com/kaeawc/krit/internal/librarymodel"
 	"github.com/kaeawc/krit/internal/oracle"
 	"github.com/kaeawc/krit/internal/perf"
@@ -110,6 +113,12 @@ type ProjectHostState struct {
 	// files, so mismatches force a complete rebuild rather than a
 	// stale-entry leak. *WorkspaceState satisfies this interface.
 	ResolverCache ResolverCache
+	// OracleFilterCache, when non-nil and Args.OracleEnabled is true,
+	// memoizes the oracle CallTargetFilterSummary across calls.
+	// RunProject computes the filter once per file-set + rule-set
+	// fingerprint and threads it into IndexInput.PrebuiltOracleCallFilter.
+	// *WorkspaceState satisfies this interface.
+	OracleFilterCache OracleFilterCache
 	// CrossFileCacheDir, when non-empty, enables the on-disk cross-file
 	// CodeIndex cache (zstd-encoded shards under .krit/crossfile-cache).
 	// Independent of CodeIndexCache: the disk cache is shared across
@@ -250,15 +259,25 @@ func RunProject(ctx context.Context, in ProjectInput) (ProjectResult, error) {
 	}
 	// Wire the oracle handle when the host supplied one + the args
 	// requested oracle. UseDaemon is forced on so runDaemonOracle is
-	// the path that picks up PrebuiltOracleDaemon. NoOracleFilter is
-	// forced on for now: the filter pre-scan is per-call and would
-	// negate the daemon-resident savings until #125 PR-C caches it.
+	// the path that picks up PrebuiltOracleDaemon.
 	if args.OracleEnabled && host.OracleDaemon != nil {
 		indexInput.OracleEnabled = true
 		indexInput.UseDaemon = true
 		indexInput.PrebuiltOracleDaemon = host.OracleDaemon
 		indexInput.OracleScanPaths = args.Paths
-		indexInput.NoOracleFilter = true
+		// Memoize the oracle call filter. The classification is the
+		// dominant per-call oracle cost (annotated-identifier scans
+		// over every Kotlin file). When the host supplies a cache, we
+		// fingerprint the rule + file set and reuse the cached filter
+		// across calls. Without a cache we fall through to the per-
+		// call rebuild inside selectOracleCallFilter.
+		if host.OracleFilterCache != nil {
+			fp := oracleFilterFingerprint(args.ActiveRules, parseResult.KotlinFiles)
+			indexInput.PrebuiltOracleCallFilter = host.OracleFilterCache.OracleFilter(fp, func() *oracle.CallTargetFilterSummary {
+				summary := rules.BuildOracleCallTargetFilterV2ForFiles(args.ActiveRules, parseResult.KotlinFiles)
+				return &summary
+			})
+		}
 	}
 	indexResult, err := IndexPhase{Workers: args.Workers}.Run(ctx, indexInput)
 	if err != nil {
@@ -359,4 +378,27 @@ func projectRuleHash(activeRules []*api.Rule, cfg *config.Config) string {
 		}
 	}
 	return cache.ComputeConfigHash(ruleNames, cfg, false)
+}
+
+// oracleFilterFingerprint hashes the active rule IDs together with
+// the sorted (path, content-hash) tuples of every Kotlin file. Both
+// inputs feed BuildOracleCallTargetFilterV2ForFiles; either changing
+// invalidates the cached filter.
+func oracleFilterFingerprint(activeRules []*api.Rule, kotlinFiles []*scanner.File) string {
+	ruleIDs := make([]string, 0, len(activeRules))
+	for _, r := range activeRules {
+		if r != nil {
+			ruleIDs = append(ruleIDs, r.ID)
+		}
+	}
+	sort.Strings(ruleIDs)
+	fileEntries := make([]string, 0, len(kotlinFiles))
+	for _, f := range kotlinFiles {
+		if f == nil {
+			continue
+		}
+		fileEntries = append(fileEntries, f.Path+"\x00"+hashutil.Default().HashContent(f.Path, f.Content))
+	}
+	sort.Strings(fileEntries)
+	return hashutil.HashHex([]byte(strings.Join(ruleIDs, "\x01") + "\x02" + strings.Join(fileEntries, "\x01")))
 }

--- a/internal/pipeline/project.go
+++ b/internal/pipeline/project.go
@@ -257,28 +257,7 @@ func RunProject(ctx context.Context, in ProjectInput) (ProjectResult, error) {
 		Reporter:             host.Reporter,
 		Tracker:              host.Tracker,
 	}
-	// Wire the oracle handle when the host supplied one + the args
-	// requested oracle. UseDaemon is forced on so runDaemonOracle is
-	// the path that picks up PrebuiltOracleDaemon.
-	if args.OracleEnabled && host.OracleDaemon != nil {
-		indexInput.OracleEnabled = true
-		indexInput.UseDaemon = true
-		indexInput.PrebuiltOracleDaemon = host.OracleDaemon
-		indexInput.OracleScanPaths = args.Paths
-		// Memoize the oracle call filter. The classification is the
-		// dominant per-call oracle cost (annotated-identifier scans
-		// over every Kotlin file). When the host supplies a cache, we
-		// fingerprint the rule + file set and reuse the cached filter
-		// across calls. Without a cache we fall through to the per-
-		// call rebuild inside selectOracleCallFilter.
-		if host.OracleFilterCache != nil {
-			fp := oracleFilterFingerprint(args.ActiveRules, parseResult.KotlinFiles)
-			indexInput.PrebuiltOracleCallFilter = host.OracleFilterCache.OracleFilter(fp, func() *oracle.CallTargetFilterSummary {
-				summary := rules.BuildOracleCallTargetFilterV2ForFiles(args.ActiveRules, parseResult.KotlinFiles)
-				return &summary
-			})
-		}
-	}
+	wireOracleHandles(&indexInput, args, host, parseResult.KotlinFiles)
 	indexResult, err := IndexPhase{Workers: args.Workers}.Run(ctx, indexInput)
 	if err != nil {
 		return ProjectResult{}, fmt.Errorf("index: %w", err)
@@ -378,6 +357,28 @@ func projectRuleHash(activeRules []*api.Rule, cfg *config.Config) string {
 		}
 	}
 	return cache.ComputeConfigHash(ruleNames, cfg, false)
+}
+
+// wireOracleHandles fills in the oracle-related IndexInput fields when
+// the caller opted in via args.OracleEnabled and the host supplied a
+// daemon handle. Extracted from RunProject to keep its cyclomatic
+// complexity manageable.
+func wireOracleHandles(in *IndexInput, args ProjectArgs, host ProjectHostState, kotlinFiles []*scanner.File) {
+	if !args.OracleEnabled || host.OracleDaemon == nil {
+		return
+	}
+	in.OracleEnabled = true
+	in.UseDaemon = true
+	in.PrebuiltOracleDaemon = host.OracleDaemon
+	in.OracleScanPaths = args.Paths
+	if host.OracleFilterCache == nil {
+		return
+	}
+	fp := oracleFilterFingerprint(args.ActiveRules, kotlinFiles)
+	in.PrebuiltOracleCallFilter = host.OracleFilterCache.OracleFilter(fp, func() *oracle.CallTargetFilterSummary {
+		summary := rules.BuildOracleCallTargetFilterV2ForFiles(args.ActiveRules, kotlinFiles)
+		return &summary
+	})
 }
 
 // oracleFilterFingerprint hashes the active rule IDs together with

--- a/internal/pipeline/types.go
+++ b/internal/pipeline/types.go
@@ -319,6 +319,19 @@ type ResolverCache interface {
 	Resolver(fingerprint string, build func() typeinfer.TypeResolver) typeinfer.TypeResolver
 }
 
+// OracleFilterCache lets a long-lived host (typically *WorkspaceState)
+// memoize the oracle *CallTargetFilterSummary across RunProject calls.
+// The filter classification scans every Kotlin file for annotated
+// identifiers; without caching it dominates the warm oracle cost.
+//
+// Fingerprint must include the active rule IDs (the filter is keyed
+// on rule capabilities + AnnotatedIdentifier specs) and the sorted
+// (path, content-hash) pairs of every Kotlin file. Mismatches force a
+// fresh classification.
+type OracleFilterCache interface {
+	OracleFilter(fingerprint string, build func() *oracle.CallTargetFilterSummary) *oracle.CallTargetFilterSummary
+}
+
 // FileTiming captures per-file dispatch timing recorded when
 // IndexResult.ProfileDispatch is set.
 type FileTiming struct {

--- a/internal/pipeline/workspace.go
+++ b/internal/pipeline/workspace.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/kaeawc/krit/internal/hashutil"
 	"github.com/kaeawc/krit/internal/librarymodel"
+	"github.com/kaeawc/krit/internal/oracle"
 	"github.com/kaeawc/krit/internal/scanner"
 	"github.com/kaeawc/krit/internal/typeinfer"
 )
@@ -47,6 +48,7 @@ type WorkspaceState struct {
 	codeIndex    xfileSlot[*scanner.CodeIndex]
 	dependents   xfileSlot[*scanner.DependentsIndex]
 	resolver     xfileSlot[typeinfer.TypeResolver]
+	oracleFilter xfileSlot[*oracle.CallTargetFilterSummary]
 }
 
 // xfileSlot pairs a fingerprint with a value. Zero value means
@@ -408,6 +410,47 @@ func (w *WorkspaceState) InvalidateResolver() {
 	}
 	w.xfileMu.Lock()
 	w.resolver = xfileSlot[typeinfer.TypeResolver]{}
+	w.xfileMu.Unlock()
+}
+
+// OracleFilter memoizes the oracle CallTargetFilterSummary across
+// calls. Same semantics as Resolver: build only fires on a
+// fingerprint mismatch; concurrent races converge on a single cached
+// pointer. nil receiver always builds (no caching).
+func (w *WorkspaceState) OracleFilter(fingerprint string, build func() *oracle.CallTargetFilterSummary) *oracle.CallTargetFilterSummary {
+	if w == nil || fingerprint == "" {
+		return build()
+	}
+	w.xfileMu.Lock()
+	if w.oracleFilter.present && w.oracleFilter.fingerprint == fingerprint {
+		v := w.oracleFilter.value
+		w.xfileMu.Unlock()
+		return v
+	}
+	w.xfileMu.Unlock()
+
+	v := build()
+
+	w.xfileMu.Lock()
+	if w.oracleFilter.present && w.oracleFilter.fingerprint == fingerprint {
+		v = w.oracleFilter.value
+	} else {
+		w.oracleFilter = xfileSlot[*oracle.CallTargetFilterSummary]{fingerprint: fingerprint, value: v, present: true}
+	}
+	w.xfileMu.Unlock()
+	return v
+}
+
+// InvalidateOracleFilter drops the cached oracle filter. The watcher's
+// per-Kotlin-edit invalidation hook calls this so the next analyze
+// rebuilds. The fingerprint check would catch this anyway; this is
+// belt-and-suspenders symmetric with the other slot invalidators.
+func (w *WorkspaceState) InvalidateOracleFilter() {
+	if w == nil {
+		return
+	}
+	w.xfileMu.Lock()
+	w.oracleFilter = xfileSlot[*oracle.CallTargetFilterSummary]{}
 	w.xfileMu.Unlock()
 }
 


### PR DESCRIPTION
## Summary
Final PR for #125. After #127 (PR-A lifecycle skeleton) and #129 (PR-B enable-in-daemon), this lands the filter-side cache that removes the dominant per-call oracle cost.

The oracle call filter is built by \`buildOracleCallTargetFilterForInvocation\`, which scans every Kotlin file for annotated identifiers — a multi-second walk on JetBrains/kotlin scale. PR-B forced \`NoOracleFilter=true\` to ship safely; this PR memoizes the filter so \`NoOracleFilter\` can stay off without paying the per-call cost.

## Pipeline plumbing
- \`IndexInput.PrebuiltOracleCallFilter\` — when set, \`runDaemonOracle\` and \`runJvmAnalyze\` reuse it. Disabled-mode summaries (\`Enabled==false\`) are passed through as a sentinel that \`selectOracleCallFilter\` normalizes back to nil — matches the per-call path's "disabled by broad rules" semantics.
- \`selectOracleCallFilter\` centralizes the prebuilt-vs-build choice.
- \`pipeline.OracleFilterCache\` interface; \`*WorkspaceState\` satisfies it.
- \`WorkspaceState\` gains \`oracleFilter\` slot + \`OracleFilter()\` / \`InvalidateOracleFilter()\`.
- \`oracleFilterFingerprint\` hashes sorted active rule IDs + sorted (path, content-hash) pairs of every Kotlin file.
- \`RunProject\` computes the filter via the cache between Parse and Index.
- \`NoOracleFilter=true\` forced flag removed.

## Daemon
- \`buildProjectInput\` wires \`s.workspace\` as \`Host.OracleFilterCache\`.
- File watcher's per-Kotlin-edit hook drops the slot via \`InvalidateOracleFilter\`.

## Tests
- \`TestOracleFilterFingerprint_StableAndDistinct\`
- \`TestSelectOracleCallFilter_PrefersPrebuilt\`
- \`TestSelectOracleCallFilter_PrebuiltDisabledReturnsNil\`

## #125 close criteria after this lands
- PR-A, PR-B, PR-C structural plumbing complete.
- Acceptance items still open: real-JVM \`TestDaemonStateOracleRecovery\` (needs \`krit-types.jar\` in CI), perf bench on JetBrains/kotlin. Both warrant their own follow-up tickets.

## Test plan
- [x] \`go build -o krit ./cmd/krit/\`
- [x] \`go vet ./...\`
- [x] \`go test ./... -count=1\`