### PR TITLE
feat(daemon): expose ResolverHit + OracleFilterHit in verb stats

### DIFF
--- a/internal/cli/serve/analyze_project.go
+++ b/internal/cli/serve/analyze_project.go
@@ -78,6 +78,8 @@ func handleAnalyzeProject(ctx context.Context, state *daemonState, raw json.RawM
 			WallSeconds:     time.Since(start).Seconds(),
 			CodeIndexHit:    xfile.HasCodeIndex,
 			LibraryFactsHit: xfile.HasLibraryFacts,
+			ResolverHit:     xfile.HasResolver,
+			OracleFilterHit: xfile.HasOracleFilter,
 			DirtyFiles:      len(dirty),
 			Cold:            cold,
 			ParseHits:       out.ParseHits,

--- a/internal/daemon/protocol.go
+++ b/internal/daemon/protocol.go
@@ -181,6 +181,16 @@ type AnalyzeProjectStats struct {
 	WallSeconds     float64 `json:"wall_seconds"`
 	CodeIndexHit    bool    `json:"code_index_hit"`
 	LibraryFactsHit bool    `json:"library_facts_hit"`
+	// ResolverHit reports whether the resident type-resolver slot was
+	// consulted and served (cached pointer reused). Mirrors
+	// CodeIndexHit semantics — true means the slot was populated when
+	// the verb ran; the run may have rebuilt mid-verb on fingerprint
+	// mismatch.
+	ResolverHit bool `json:"resolver_hit"`
+	// OracleFilterHit reports whether the resident oracle call-filter
+	// slot was populated at verb entry. Useful for confirming that
+	// PR-C's filter cache is warm after the first oracle-enabled call.
+	OracleFilterHit bool `json:"oracle_filter_hit"`
 	// DirtyFiles is the count of files Touched in WorkspaceState
 	// since the last analyze-project call (drained at the start of
 	// this call). Useful for clients that want to show "N files

--- a/internal/pipeline/cross_file_stats_test.go
+++ b/internal/pipeline/cross_file_stats_test.go
@@ -1,0 +1,74 @@
+package pipeline
+
+import (
+	"testing"
+
+	"github.com/kaeawc/krit/internal/librarymodel"
+	"github.com/kaeawc/krit/internal/oracle"
+	"github.com/kaeawc/krit/internal/scanner"
+	"github.com/kaeawc/krit/internal/typeinfer"
+)
+
+// TestCrossFileStats_ReportsAllSlots confirms CrossFileStats exposes
+// every resident slot the daemon's analyze-project response surfaces.
+// Drives the per-slot bools by populating each cache method and
+// reading the snapshot back.
+func TestCrossFileStats_ReportsAllSlots(t *testing.T) {
+	ws := NewWorkspaceState(t.TempDir())
+
+	// Cold: every slot should be empty.
+	stats := ws.CrossFileStats()
+	if stats.HasLibraryFacts || stats.HasCodeIndex || stats.HasDependents ||
+		stats.HasResolver || stats.HasOracleFilter {
+		t.Fatalf("cold stats not all-false: %+v", stats)
+	}
+
+	// Populate each slot via its cache method.
+	ws.LibraryFacts("lf-fp", func() *librarymodel.Facts {
+		return &librarymodel.Facts{}
+	})
+	ws.CodeIndex("ci-fp", func() *scanner.CodeIndex {
+		return &scanner.CodeIndex{}
+	})
+	ws.Dependents("dep-fp", func() *scanner.DependentsIndex {
+		return &scanner.DependentsIndex{}
+	})
+	ws.Resolver("res-fp", func() typeinfer.TypeResolver {
+		return typeinfer.NewResolver()
+	})
+	ws.OracleFilter("of-fp", func() *oracle.CallTargetFilterSummary {
+		return &oracle.CallTargetFilterSummary{Enabled: true}
+	})
+
+	stats = ws.CrossFileStats()
+	if !stats.HasLibraryFacts {
+		t.Errorf("HasLibraryFacts = false; expected true after LibraryFacts call")
+	}
+	if !stats.HasCodeIndex {
+		t.Errorf("HasCodeIndex = false; expected true after CodeIndex call")
+	}
+	if !stats.HasDependents {
+		t.Errorf("HasDependents = false; expected true after Dependents call")
+	}
+	if !stats.HasResolver {
+		t.Errorf("HasResolver = false; expected true after Resolver call")
+	}
+	if !stats.HasOracleFilter {
+		t.Errorf("HasOracleFilter = false; expected true after OracleFilter call")
+	}
+
+	// Invalidate the new slots and re-check.
+	ws.InvalidateResolver()
+	ws.InvalidateOracleFilter()
+	stats = ws.CrossFileStats()
+	if stats.HasResolver {
+		t.Errorf("HasResolver still true after InvalidateResolver")
+	}
+	if stats.HasOracleFilter {
+		t.Errorf("HasOracleFilter still true after InvalidateOracleFilter")
+	}
+	// Pre-existing slots should be untouched.
+	if !stats.HasLibraryFacts || !stats.HasCodeIndex {
+		t.Errorf("pre-existing slots dropped on Resolver/OracleFilter invalidate: %+v", stats)
+	}
+}

--- a/internal/pipeline/workspace.go
+++ b/internal/pipeline/workspace.go
@@ -328,6 +328,8 @@ type CrossFileStats struct {
 	HasLibraryFacts bool
 	HasCodeIndex    bool
 	HasDependents   bool
+	HasResolver     bool
+	HasOracleFilter bool
 }
 
 // CrossFileStats returns a snapshot of the cross-file slots.
@@ -341,6 +343,8 @@ func (w *WorkspaceState) CrossFileStats() CrossFileStats {
 		HasLibraryFacts: w.libraryFacts.present,
 		HasCodeIndex:    w.codeIndex.present,
 		HasDependents:   w.dependents.present,
+		HasResolver:     w.resolver.present,
+		HasOracleFilter: w.oracleFilter.present,
 	}
 }
 


### PR DESCRIPTION
## Summary
Round-out PR after the #48 daemon-resident state work landed. The \`analyze-project\` response already reports \`CodeIndexHit\` and \`LibraryFactsHit\`; this adds the two slots that weren't surfaced: \`ResolverHit\` (#123) and \`OracleFilterHit\` (#130).

Operators and tests currently can't see whether the resident resolver / oracle-filter caches are warm. \`CodeIndexHit\` served that purpose for #120 from day one — bringing the other two slots up to the same observability level closes that gap.

## Changes
- \`WorkspaceState.CrossFileStats\`: \`HasResolver\` + \`HasOracleFilter\` fields populated from the existing \`xfileSlot[].present\`.
- \`daemon.AnalyzeProjectStats\`: \`ResolverHit\` + \`OracleFilterHit\` JSON fields. Wire-format additive (new fields default to false on the client side).
- \`handleAnalyzeProject\` populates the new stats from the workspace snapshot.

## Test
- \`TestCrossFileStats_ReportsAllSlots\` drives every cache method, asserts the snapshot reflects each populate + invalidate cycle.

## Test plan
- [x] \`go build -o krit ./cmd/krit/\`
- [x] \`go vet ./...\`
- [x] \`go test ./... -count=1\`