### PR TITLE
fix(pipeline): InvalidateAll covers resident resolver + oracle filter

### DIFF
--- a/internal/cli/serve/serve.go
+++ b/internal/cli/serve/serve.go
@@ -274,11 +274,11 @@ type oracleDaemonEntry struct {
 // verb proceeds without type resolution. Subsequent calls with the
 // same scan-path key reuse the cached *oracle.Daemon.
 //
-// This is the lifecycle skeleton from issue #125 PR-A. Today no
-// daemon code path actually consumes the returned handle: the
-// analyze-project verb still calls RunProject without OracleEnabled.
-// PR-B will thread the handle through to ProjectHostState once the
-// CLI-flag plumbing for OracleEnabled lands.
+// Wired into the analyze-project verb path: buildProjectInput threads
+// the returned handle into ProjectHostState.OracleDaemon and flips
+// ProjectArgs.OracleEnabled when the daemon is non-nil, so type-aware
+// rules in the daemon get oracle precision without paying JVM startup
+// on every call.
 func (s *daemonState) ensureOracleDaemon(scanPaths []string) (*oracle.Daemon, error) {
 	jarPath := oracle.FindJar(scanPaths)
 	if jarPath == "" {

--- a/internal/pipeline/workspace.go
+++ b/internal/pipeline/workspace.go
@@ -216,6 +216,8 @@ func (w *WorkspaceState) InvalidateAll() {
 	w.libraryFacts = xfileSlot[*librarymodel.Facts]{}
 	w.codeIndex = xfileSlot[*scanner.CodeIndex]{}
 	w.dependents = xfileSlot[*scanner.DependentsIndex]{}
+	w.resolver = xfileSlot[typeinfer.TypeResolver]{}
+	w.oracleFilter = xfileSlot[*oracle.CallTargetFilterSummary]{}
 	w.xfileMu.Unlock()
 }
 

--- a/internal/pipeline/workspace_test.go
+++ b/internal/pipeline/workspace_test.go
@@ -6,7 +6,9 @@ import (
 	"testing"
 
 	"github.com/kaeawc/krit/internal/librarymodel"
+	"github.com/kaeawc/krit/internal/oracle"
 	"github.com/kaeawc/krit/internal/scanner"
+	"github.com/kaeawc/krit/internal/typeinfer"
 )
 
 const sampleKotlin = `package demo
@@ -318,10 +320,14 @@ func TestWorkspaceState_InvalidateAllClearsCrossFile(t *testing.T) {
 	ws := NewWorkspaceState("/tmp/test")
 	ws.LibraryFacts("lf", func() *librarymodel.Facts { return &librarymodel.Facts{} })
 	ws.CodeIndex("ci", func() *scanner.CodeIndex { return &scanner.CodeIndex{} })
+	ws.Dependents("dep", func() *scanner.DependentsIndex { return &scanner.DependentsIndex{} })
+	ws.Resolver("res", func() typeinfer.TypeResolver { return typeinfer.NewResolver() })
+	ws.OracleFilter("of", func() *oracle.CallTargetFilterSummary { return &oracle.CallTargetFilterSummary{Enabled: true} })
 	ws.InvalidateAll()
 	stats := ws.CrossFileStats()
-	if stats.HasLibraryFacts || stats.HasCodeIndex {
-		t.Errorf("InvalidateAll should clear cross-file slots, got %+v", stats)
+	if stats.HasLibraryFacts || stats.HasCodeIndex || stats.HasDependents ||
+		stats.HasResolver || stats.HasOracleFilter {
+		t.Errorf("InvalidateAll should clear every cross-file slot, got %+v", stats)
 	}
 }
 


### PR DESCRIPTION
## Summary
Two small follow-ups after the #48 work shipped:

1. **\`WorkspaceState.InvalidateAll\` missed the resolver + oracleFilter slots** added in #123 and #130. The slots survived the call, leaking across what was supposed to be a full reset. Fixed by extending the reset block + the corresponding regression case in \`TestWorkspaceState_InvalidateAllClearsCrossFile\`.

2. **Stale doc comment on \`ensureOracleDaemon\`** said \"no daemon code path actually consumes the returned handle\". That was true for PR-A (#127) but stale after PR-B (#129): \`buildProjectInput\` now wires the handle into \`ProjectHostState.OracleDaemon\` and flips \`ProjectArgs.OracleEnabled\`.

No new behavior; just plugging a slot leak and refreshing one comment.

## Test plan
- [x] \`go build -o krit ./cmd/krit/\`
- [x] \`go vet ./...\`
- [x] \`go test ./... -count=1\`