### PR TITLE
feat(daemon): wire ConservativeDeltaPlanner with structural CrossFile (#55)

### DIFF
--- a/internal/pipeline/delta_planner_test.go
+++ b/internal/pipeline/delta_planner_test.go
@@ -1,0 +1,229 @@
+package pipeline
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kaeawc/krit/internal/config"
+	api "github.com/kaeawc/krit/internal/rules/api"
+	"github.com/kaeawc/krit/internal/scanner"
+)
+
+// TestFileStructuralFingerprint_BodyEditStable verifies the core
+// delta-planner invariant: a body-only edit (no Symbol or Reference
+// change) does NOT move the file's structural fingerprint. This
+// stability is what lets the planner take the single-file delta path
+// for the common dev-loop case.
+func TestFileStructuralFingerprint_BodyEditStable(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "Sample.kt")
+
+	v1 := []byte("package test\n\nclass Foo {\n    fun greet() = \"hello\"\n}\n")
+	v2 := []byte("package test\n\nclass Foo {\n    fun greet() = \"world\"\n}\n")
+
+	if err := os.WriteFile(path, v1, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	f1, err := scanner.ParseFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(path, v2, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	f2, err := scanner.ParseFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fp1 := scanner.FileStructuralFingerprint(f1)
+	fp2 := scanner.FileStructuralFingerprint(f2)
+	if fp1 != fp2 {
+		t.Errorf("structural fingerprint moved on body-only edit:\n  v1=%q\n  v2=%q", fp1, fp2)
+	}
+}
+
+// TestFileStructuralFingerprint_DeclarationChangeMoves verifies the
+// opposite invariant: adding/removing/renaming a declaration moves
+// the structural fingerprint. This is the safety side of the gate —
+// declaration changes invalidate cross-file findings, so the planner
+// must fall back to full dispatch.
+func TestFileStructuralFingerprint_DeclarationChangeMoves(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "Sample.kt")
+
+	v1 := []byte("package test\n\nclass Foo\n")
+	v2 := []byte("package test\n\nclass Foo\nclass Bar\n")
+
+	if err := os.WriteFile(path, v1, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	f1, _ := scanner.ParseFile(path)
+
+	if err := os.WriteFile(path, v2, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	f2, _ := scanner.ParseFile(path)
+
+	fp1 := scanner.FileStructuralFingerprint(f1)
+	fp2 := scanner.FileStructuralFingerprint(f2)
+	if fp1 == fp2 {
+		t.Errorf("structural fingerprint stable across declaration add; expected drift")
+	}
+}
+
+// TestRunProject_DeltaPath_BodyEditTakesDelta walks the full delta
+// scenario end-to-end. Two RunProject calls with a body-only edit
+// between them: the second call must hit the delta path (scoped
+// dispatch on just the changed file + ApplyDelta) and produce
+// byte-equal output as if a full dispatch had run.
+func TestRunProject_DeltaPath_BodyEditTakesDelta(t *testing.T) {
+	dir := t.TempDir()
+	cacheRoot := t.TempDir()
+	src := filepath.Join(dir, "Sample.kt")
+
+	if err := os.WriteFile(src, []byte("package test\n\nclass Foo\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	rule := api.FakeRule("ClassDecl",
+		api.WithNodeTypes("class_declaration"),
+		api.WithSeverity(api.SeverityWarning),
+		api.WithCheck(func(ctx *api.Context) {
+			ctx.EmitAt(int(ctx.Node.StartRow)+1, 1, "class declared")
+		}),
+	)
+
+	run := func(t *testing.T) (int, []byte) {
+		t.Helper()
+		res, err := RunProject(context.Background(), ProjectInput{
+			Args: ProjectArgs{
+				Config:      config.NewConfig(),
+				Paths:       []string{dir},
+				ActiveRules: []*api.Rule{rule},
+				Format:      "json",
+				Version:     "test",
+			},
+			Host: ProjectHostState{
+				FindingsBundleStore:     scanner.DiskFindingsBundleStore{},
+				FindingsBundleCacheRoot: cacheRoot,
+			},
+		})
+		if err != nil {
+			t.Fatalf("RunProject: %v", err)
+		}
+		return res.FindingsCount, scrubLines(res.JSON, []string{
+			"\"durationMs\"", "\"timestamp\"", "\"wallSeconds\"",
+			"\"startTime\"", "\"endTime\"",
+		})
+	}
+
+	// First run: full dispatch + Save bundle + Save manifest.
+	count1, _ := run(t)
+	if count1 != 1 {
+		t.Fatalf("first run findings = %d, want 1", count1)
+	}
+
+	// Mutate the file body only (declaration unchanged → structural
+	// fp stable → planner takes delta).
+	if err := os.WriteFile(src, []byte("package test\n\nclass Foo // comment edit\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	count2, _ := run(t)
+	if count2 != 1 {
+		t.Errorf("second run findings = %d, want 1", count2)
+	}
+}
+
+// TestRunProject_DeltaPath_DeclarationChangeFallsBack confirms the
+// safety side: when a file's declaration changes (CrossFile fp moves),
+// the planner refuses the delta and full dispatch runs.
+func TestRunProject_DeltaPath_DeclarationChangeFallsBack(t *testing.T) {
+	dir := t.TempDir()
+	cacheRoot := t.TempDir()
+	src := filepath.Join(dir, "Sample.kt")
+
+	if err := os.WriteFile(src, []byte("package test\n\nclass Foo\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	rule := api.FakeRule("ClassDecl",
+		api.WithNodeTypes("class_declaration"),
+		api.WithSeverity(api.SeverityWarning),
+		api.WithCheck(func(ctx *api.Context) {
+			ctx.EmitAt(int(ctx.Node.StartRow)+1, 1, "class declared")
+		}),
+	)
+
+	run := func(t *testing.T) int {
+		t.Helper()
+		res, err := RunProject(context.Background(), ProjectInput{
+			Args: ProjectArgs{
+				Config:      config.NewConfig(),
+				Paths:       []string{dir},
+				ActiveRules: []*api.Rule{rule},
+				Format:      "json",
+				Version:     "test",
+			},
+			Host: ProjectHostState{
+				FindingsBundleStore:     scanner.DiskFindingsBundleStore{},
+				FindingsBundleCacheRoot: cacheRoot,
+			},
+		})
+		if err != nil {
+			t.Fatalf("RunProject: %v", err)
+		}
+		return res.FindingsCount
+	}
+
+	if got := run(t); got != 1 {
+		t.Fatalf("first run findings = %d, want 1 (one class)", got)
+	}
+
+	// Add a declaration. The new class moves the structural fp →
+	// aggregate CrossFile fp moves → planner refuses delta. Full
+	// dispatch should fire and emit findings for both classes.
+	if err := os.WriteFile(src, []byte("package test\n\nclass Foo\nclass Bar\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := run(t); got != 2 {
+		t.Errorf("after declaration add, findings = %d, want 2 (full dispatch should emit on both)", got)
+	}
+}
+
+// TestDiffContentHashes verifies the small helper used by the delta
+// planner orchestrator to compute changed paths from manifest +
+// current per-file hash maps.
+func TestDiffContentHashes(t *testing.T) {
+	prior := map[string]string{"a.kt": "h1", "b.kt": "h2", "c.kt": "h3"}
+	current := map[string]string{"a.kt": "h1", "b.kt": "DIFF", "c.kt": "h3"}
+	got := diffContentHashes(prior, current)
+	if len(got) != 1 || got[0] != "b.kt" {
+		t.Errorf("diffContentHashes = %v, want [b.kt]", got)
+	}
+
+	// Added file.
+	current2 := map[string]string{"a.kt": "h1", "b.kt": "h2", "c.kt": "h3", "d.kt": "h4"}
+	got2 := diffContentHashes(prior, current2)
+	if len(got2) != 1 || got2[0] != "d.kt" {
+		t.Errorf("diffContentHashes (add) = %v, want [d.kt]", got2)
+	}
+
+	// Removed file.
+	current3 := map[string]string{"a.kt": "h1", "b.kt": "h2"}
+	got3 := diffContentHashes(prior, current3)
+	if len(got3) != 1 || got3[0] != "c.kt" {
+		t.Errorf("diffContentHashes (remove) = %v, want [c.kt]", got3)
+	}
+
+	// Identical → empty.
+	got4 := diffContentHashes(prior, prior)
+	if len(got4) != 0 {
+		t.Errorf("diffContentHashes (identical) = %v, want []", got4)
+	}
+}

--- a/internal/pipeline/project.go
+++ b/internal/pipeline/project.go
@@ -317,7 +317,8 @@ func RunProject(ctx context.Context, in ProjectInput) (ProjectResult, error) {
 	}
 
 	runFP, bundleEnabled := computeRunFingerprint(args, host, parseResult, indexResult)
-	dispatchResult, crossFileResult, bundleHit, err := runDispatchOrLoadBundle(ctx, args, host, indexResult, runFP, bundleEnabled)
+	manifestData := buildManifestData(args, host, parseResult, runFP, bundleEnabled)
+	dispatchResult, crossFileResult, bundleHit, err := runDispatchOrLoadBundle(ctx, args, host, indexResult, parseResult, runFP, bundleEnabled, manifestData)
 	if err != nil {
 		return ProjectResult{}, err
 	}
@@ -348,6 +349,7 @@ func RunProject(ctx context.Context, in ProjectInput) (ProjectResult, error) {
 	// output is unaffected.
 	if bundleEnabled && !bundleHit {
 		_ = host.FindingsBundleStore.Save(host.FindingsBundleCacheRoot, runFP, &crossFileResult.Findings)
+		_ = saveDeltaManifest(host, manifestData, runFP, &crossFileResult.Findings)
 	}
 
 	hits1, misses1 := parseCacheCounters(host.ParseCache)
@@ -439,22 +441,96 @@ func wireOracleHandles(in *IndexInput, args ProjectArgs, host ProjectHostState, 
 	})
 }
 
-// runDispatchOrLoadBundle resolves dispatch + cross-file findings,
-// either by reusing a cached bundle (full RunFingerprint hit) or by
-// running the normal DispatchPhase + CrossFilePhase. Extracted from
-// RunProject to keep cyclomatic budget in check.
+// deltaManifestData carries the precomputed per-file inputs the delta
+// planner needs. Populated by buildManifestData before dispatch so
+// runDispatchOrLoadBundle can quickly compare against the prior run.
+type deltaManifestData struct {
+	enabled       bool
+	manifestKey   string
+	contentHashes map[string]string
+	structuralFPs map[string]string
+}
+
+// buildManifestData prepares per-file content + structural fingerprints
+// for the delta planner. Returns the inputs whether or not the bundle
+// cache is enabled — callers gate on enabled before persisting.
+func buildManifestData(args ProjectArgs, host ProjectHostState, parseResult ParseResult, _ scanner.RunFingerprint, bundleEnabled bool) deltaManifestData {
+	if !bundleEnabled {
+		return deltaManifestData{}
+	}
+	contentHashes := make(map[string]string, len(parseResult.KotlinFiles)+len(parseResult.JavaFiles))
+	structuralFPs := make(map[string]string, len(parseResult.KotlinFiles)+len(parseResult.JavaFiles))
+	for _, f := range parseResult.KotlinFiles {
+		if f == nil {
+			continue
+		}
+		contentHashes[f.Path] = hashutil.Default().HashContent(f.Path, f.Content)
+		structuralFPs[f.Path] = scanner.FileStructuralFingerprint(f)
+	}
+	for _, f := range parseResult.JavaFiles {
+		if f == nil {
+			continue
+		}
+		contentHashes[f.Path] = hashutil.Default().HashContent(f.Path, f.Content)
+		structuralFPs[f.Path] = scanner.FileStructuralFingerprint(f)
+	}
+	return deltaManifestData{
+		enabled:       true,
+		manifestKey:   scanner.FindingsBundleManifestKey(host.FindingsBundleCacheRoot, args.Paths),
+		contentHashes: contentHashes,
+		structuralFPs: structuralFPs,
+	}
+}
+
+// saveDeltaManifest persists the current run's manifest entry so a
+// future run can detect single-file changes for the delta path.
+// Best-effort — manifest write failures don't fail the verb.
+func saveDeltaManifest(host ProjectHostState, m deltaManifestData, runFP scanner.RunFingerprint, _ *scanner.FindingColumns) error {
+	if !m.enabled || m.manifestKey == "" {
+		return nil
+	}
+	return scanner.SaveFindingsBundleManifest(host.FindingsBundleCacheRoot, m.manifestKey, scanner.FindingsBundleManifest{
+		BundleKey:     scanner.FindingsBundleKey(runFP),
+		Fingerprint:   runFP,
+		ContentHashes: m.contentHashes,
+		StructuralFPs: m.structuralFPs,
+	})
+}
+
+// runDispatchOrLoadBundle resolves dispatch + cross-file findings via
+// three increasingly conservative paths:
+//
+//  1. Full-fingerprint Load. RunFingerprint identical to a prior run →
+//     replay cached bundle, skip dispatch + cross-file entirely.
+//  2. Delta path. Prior manifest exists, planner says exactly 1 file
+//     changed + every non-SourceSet fingerprint field is stable →
+//     dispatch only on the changed file, optionally re-run cross-file
+//     rules (no scope savings there), filter replacement to the
+//     changed path, ApplyDelta against the prior bundle.
+//  3. Full dispatch. Normal DispatchPhase + CrossFilePhase.
+//
+// The delta path is the load-bearing #55 perf win for body-only edits:
+// per-file rule dispatch is the dominant warm-call cost and the delta
+// path runs it on just one file.
 func runDispatchOrLoadBundle(
 	ctx context.Context,
 	args ProjectArgs,
 	host ProjectHostState,
 	indexResult IndexResult,
+	parseResult ParseResult,
 	runFP scanner.RunFingerprint,
 	bundleEnabled bool,
+	manifest deltaManifestData,
 ) (DispatchResult, CrossFileResult, bool, error) {
 	if bundleEnabled {
 		if cached, ok := host.FindingsBundleStore.Load(host.FindingsBundleCacheRoot, runFP); ok && cached != nil {
 			d := DispatchResult{IndexResult: indexResult, Findings: *cached}
 			return d, CrossFileResult{DispatchResult: d}, true, nil
+		}
+		if d, c, ok, err := tryDeltaDispatch(ctx, args, host, indexResult, parseResult, runFP, manifest); err != nil {
+			return DispatchResult{}, CrossFileResult{}, false, err
+		} else if ok {
+			return d, c, false, nil
 		}
 	}
 	d, err := DispatchPhase{}.Run(ctx, indexResult)
@@ -466,6 +542,129 @@ func runDispatchOrLoadBundle(
 		return DispatchResult{}, CrossFileResult{}, false, fmt.Errorf("crossfile: %w", err)
 	}
 	return d, c, false, nil
+}
+
+// tryDeltaDispatch attempts the ConservativeDeltaPlanner's single-file
+// delta path. Returns (_, _, false, nil) when the prior manifest is
+// missing, the planner refuses (multi-file change, non-SourceSet
+// fingerprint drift, etc.), or any other safety check fails. The
+// caller falls back to full dispatch in that case.
+//
+// On a successful delta:
+//   - DispatchPhase runs against an IndexResult scoped to just the
+//     changed file. Per-file rules see only the dirty file.
+//   - CrossFilePhase still runs with the full IndexResult.CodeIndex
+//     because cross-file rule outputs depend on the aggregate
+//     structural state, which the planner gate guarantees is stable.
+//     The replacement is filtered to the changed path post-hoc.
+//   - scanner.ApplyDelta(prior, replacement, [changedPath]) produces
+//     the merged FindingColumns.
+func tryDeltaDispatch(
+	ctx context.Context,
+	args ProjectArgs,
+	host ProjectHostState,
+	indexResult IndexResult,
+	parseResult ParseResult,
+	runFP scanner.RunFingerprint,
+	manifest deltaManifestData,
+) (DispatchResult, CrossFileResult, bool, error) {
+	if !manifest.enabled || manifest.manifestKey == "" {
+		return DispatchResult{}, CrossFileResult{}, false, nil
+	}
+	prior, ok := scanner.LoadFindingsBundleManifest(host.FindingsBundleCacheRoot, manifest.manifestKey)
+	if !ok {
+		return DispatchResult{}, CrossFileResult{}, false, nil
+	}
+	changedPaths := diffContentHashes(prior.ContentHashes, manifest.contentHashes)
+	plan := scanner.ConservativeDeltaPlanner{}.Plan(prior.Fingerprint, runFP, changedPaths)
+	if !plan.ReusePrevious || len(plan.ChangedPaths) != 1 {
+		return DispatchResult{}, CrossFileResult{}, false, nil
+	}
+	priorBundle, ok := host.FindingsBundleStore.Load(host.FindingsBundleCacheRoot, prior.Fingerprint)
+	if !ok || priorBundle == nil {
+		return DispatchResult{}, CrossFileResult{}, false, nil
+	}
+
+	changedPath := plan.ChangedPaths[0]
+	changedFile := findFileByPath(parseResult, changedPath)
+	if changedFile == nil {
+		return DispatchResult{}, CrossFileResult{}, false, nil
+	}
+
+	scoped := indexResult
+	scoped.ParseResult = scopeParseResult(parseResult, changedFile)
+	d, err := DispatchPhase{}.Run(ctx, scoped)
+	if err != nil {
+		return DispatchResult{}, CrossFileResult{}, false, fmt.Errorf("dispatch (delta): %w", err)
+	}
+	c, err := CrossFilePhase{Workers: args.Workers}.Run(ctx, d)
+	if err != nil {
+		return DispatchResult{}, CrossFileResult{}, false, fmt.Errorf("crossfile (delta): %w", err)
+	}
+
+	replacement := scanner.FilterColumnsByFilePaths(&c.Findings, map[string]bool{changedPath: true})
+	merged := scanner.ApplyDelta(priorBundle, &replacement, []string{changedPath})
+
+	d.Findings = merged
+	c.DispatchResult = d
+	c.Findings = merged
+	return d, c, true, nil
+}
+
+// diffContentHashes returns the sorted list of paths where the
+// current content hash differs from the prior, OR where a file
+// exists in only one side (treated as a change). Empty if the two
+// maps describe an identical file set with matching hashes.
+func diffContentHashes(prior, current map[string]string) []string {
+	seen := make(map[string]bool, len(prior)+len(current))
+	for path := range prior {
+		seen[path] = true
+	}
+	for path := range current {
+		seen[path] = true
+	}
+	changed := make([]string, 0)
+	for path := range seen {
+		if prior[path] != current[path] {
+			changed = append(changed, path)
+		}
+	}
+	sort.Strings(changed)
+	return changed
+}
+
+func findFileByPath(p ParseResult, path string) *scanner.File {
+	for _, f := range p.KotlinFiles {
+		if f != nil && f.Path == path {
+			return f
+		}
+	}
+	for _, f := range p.JavaFiles {
+		if f != nil && f.Path == path {
+			return f
+		}
+	}
+	return nil
+}
+
+// scopeParseResult returns a copy of p with KotlinFiles + JavaFiles
+// narrowed to the single supplied file. The narrowed result feeds
+// DispatchPhase + CrossFilePhase in the delta path so per-file rules
+// only run on the dirty file. IndexResult.CodeIndex retains the full
+// project index (cross-file rules need the aggregate view).
+func scopeParseResult(p ParseResult, only *scanner.File) ParseResult {
+	scoped := p
+	scoped.KotlinFiles = nil
+	scoped.JavaFiles = nil
+	if only == nil {
+		return scoped
+	}
+	if only.Language == scanner.LangJava {
+		scoped.JavaFiles = []*scanner.File{only}
+	} else {
+		scoped.KotlinFiles = []*scanner.File{only}
+	}
+	return scoped
 }
 
 // computeRunFingerprint builds a scanner.RunFingerprint from the run's
@@ -506,9 +705,7 @@ func computeRunFingerprint(args ProjectArgs, host ProjectHostState, parseResult 
 		Config:    rulesHash,
 		SourceSet: sourceSetFingerprint(parseResult.KotlinFiles, parseResult.JavaFiles),
 	}
-	if indexResult.CodeIndex != nil {
-		fp.CrossFile = indexResult.CodeIndex.Fingerprint
-	}
+	fp.CrossFile = crossFileStructuralFingerprint(parseResult.KotlinFiles, parseResult.JavaFiles)
 	if indexResult.AndroidProject != nil {
 		fp.Android = libraryFactsFingerprint(indexResult.AndroidProject.GradlePaths)
 	}
@@ -516,6 +713,36 @@ func computeRunFingerprint(args ProjectArgs, host ProjectHostState, parseResult 
 		fp.LibraryFacts = indexResult.LibraryFacts.Fingerprint()
 	}
 	return fp, true
+}
+
+// crossFileStructuralFingerprint hashes sorted (path, structural-fp)
+// pairs of every parsed Kotlin and Java file. The per-file structural
+// fingerprint excludes body content (positions, whitespace, comments
+// that aren't KDoc references) so intra-file body edits — the steady-
+// state dev-loop case — keep the aggregate CrossFile fp stable. That
+// stability is the gate the ConservativeDeltaPlanner needs to take
+// the single-file delta path.
+//
+// Any change to a file's Symbols (added/removed/renamed/visibility/
+// signature) or References (added/removed names) moves its structural
+// fp, which moves the aggregate, which makes the planner refuse the
+// delta and fall back to full dispatch. Safe-by-default.
+func crossFileStructuralFingerprint(kotlinFiles, javaFiles []*scanner.File) string {
+	entries := make([]string, 0, len(kotlinFiles)+len(javaFiles))
+	add := func(f *scanner.File) {
+		if f == nil {
+			return
+		}
+		entries = append(entries, f.Path+"\x00"+scanner.FileStructuralFingerprint(f))
+	}
+	for _, f := range kotlinFiles {
+		add(f)
+	}
+	for _, f := range javaFiles {
+		add(f)
+	}
+	sort.Strings(entries)
+	return hashutil.HashHex([]byte(strings.Join(entries, "\x01")))
 }
 
 // sourceSetFingerprint hashes sorted (path, content-hash) tuples of

--- a/internal/scanner/findings_bundle_cache.go
+++ b/internal/scanner/findings_bundle_cache.go
@@ -153,6 +153,109 @@ func ClearFindingsBundleCache(dir string) error {
 	return nil
 }
 
+// FileStructuralFingerprint hashes a single file's contribution to the
+// cross-file CodeIndex: its declared Symbols (sorted by FQN + Name +
+// Kind + Visibility + Signature) and its References (sorted by Name +
+// InComment flag). Per-line positions are deliberately excluded —
+// line-number drift from intra-file body edits should not invalidate
+// cross-file findings for unchanged files.
+//
+// Mismatches are precise: any added/removed/renamed declaration moves
+// the fingerprint, any added/removed reference moves it, but a body
+// edit that touches no Symbols and no References (whitespace, comment,
+// constant value, local variable rename) keeps it stable. The
+// ConservativeDeltaPlanner's "CrossFile stable" gate uses the
+// aggregate of per-file structural fps to decide whether the delta
+// path is safe — see pipeline.crossFileStructuralFingerprint.
+func FileStructuralFingerprint(file *File) string {
+	if file == nil {
+		return ""
+	}
+	symbols, references := indexFileForFingerprint(file)
+	return hashFileStructural(symbols, references)
+}
+
+func indexFileForFingerprint(file *File) ([]Symbol, []Reference) {
+	if file == nil || file.FlatTree == nil {
+		return nil, nil
+	}
+	var symbols []Symbol
+	var references []Reference
+	if file.Language == LangJava {
+		collectJavaDeclarationsFlat(file, &symbols)
+		collectJavaReferencesFlat(file, &references)
+	} else {
+		collectDeclarationsFlat(file, &symbols)
+		collectReferencesFlat(file, &references)
+	}
+	return symbols, references
+}
+
+func hashFileStructural(symbols []Symbol, references []Reference) string {
+	type symKey struct {
+		fqn, name, kind, vis, sig string
+	}
+	symKeys := make([]symKey, 0, len(symbols))
+	for _, s := range symbols {
+		symKeys = append(symKeys, symKey{fqn: s.FQN, name: s.Name, kind: s.Kind, vis: s.Visibility, sig: s.Signature})
+	}
+	sort.Slice(symKeys, func(i, j int) bool {
+		a, b := symKeys[i], symKeys[j]
+		if a.fqn != b.fqn {
+			return a.fqn < b.fqn
+		}
+		if a.name != b.name {
+			return a.name < b.name
+		}
+		if a.kind != b.kind {
+			return a.kind < b.kind
+		}
+		if a.vis != b.vis {
+			return a.vis < b.vis
+		}
+		return a.sig < b.sig
+	})
+
+	type refKey struct {
+		name      string
+		inComment bool
+	}
+	refKeys := make([]refKey, 0, len(references))
+	for _, r := range references {
+		refKeys = append(refKeys, refKey{name: r.Name, inComment: r.InComment})
+	}
+	sort.Slice(refKeys, func(i, j int) bool {
+		a, b := refKeys[i], refKeys[j]
+		if a.name != b.name {
+			return a.name < b.name
+		}
+		return !a.inComment && b.inComment
+	})
+
+	h := hashutil.Hasher().New()
+	for _, k := range symKeys {
+		_, _ = h.Write([]byte(k.fqn))
+		_, _ = h.Write([]byte{0})
+		_, _ = h.Write([]byte(k.name))
+		_, _ = h.Write([]byte{0})
+		_, _ = h.Write([]byte(k.kind))
+		_, _ = h.Write([]byte{0})
+		_, _ = h.Write([]byte(k.vis))
+		_, _ = h.Write([]byte{0})
+		_, _ = h.Write([]byte(k.sig))
+		_, _ = h.Write([]byte{1})
+	}
+	_, _ = h.Write([]byte{2})
+	for _, k := range refKeys {
+		_, _ = h.Write([]byte(k.name))
+		if k.inComment {
+			_, _ = h.Write([]byte{'c'})
+		}
+		_, _ = h.Write([]byte{3})
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}
+
 func FindingsBundleKey(fp RunFingerprint) string {
 	h := hashutil.Hasher().New()
 	var v [4]byte

--- a/internal/scanner/findings_bundle_manifest.go
+++ b/internal/scanner/findings_bundle_manifest.go
@@ -1,0 +1,112 @@
+package scanner
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+
+	"github.com/kaeawc/krit/internal/fsutil"
+	"github.com/kaeawc/krit/internal/hashutil"
+)
+
+// FindingsBundleManifest persists the data the ConservativeDeltaPlanner
+// needs to decide whether a single-file edit can take the delta path:
+//
+//   - The prior run's RunFingerprint (so the planner can compare
+//     stability of each non-SourceSet field).
+//   - The prior run's per-file content hashes (so we can detect
+//     exactly which files changed since last run).
+//   - The prior run's per-file structural fingerprints (informational
+//     today; future PRs may use them for finer-grained delta paths).
+//   - The BundleKey of the prior bundle so we know which findings to
+//     load and merge into.
+//
+// Keyed by a stable run identifier (the project root + sorted scan
+// paths) so distinct projects don't trample each other.
+const findingsBundleManifestVersion = 1
+
+type FindingsBundleManifest struct {
+	Version        int               `json:"version"`
+	Key            string            `json:"key"`
+	BundleKey      string            `json:"bundleKey"`
+	Fingerprint    RunFingerprint    `json:"fingerprint"`
+	ContentHashes  map[string]string `json:"contentHashes"`
+	StructuralFPs  map[string]string `json:"structuralFps,omitempty"`
+}
+
+// FindingsBundleManifestKey derives a stable manifest identifier from
+// a project root + sorted scan paths. The repoDir is included so
+// daemons running against multiple projects don't collide.
+func FindingsBundleManifestKey(repoDir string, scanPaths []string) string {
+	if repoDir == "" {
+		return ""
+	}
+	sorted := append([]string(nil), scanPaths...)
+	for i, p := range sorted {
+		if abs, err := filepath.Abs(p); err == nil {
+			sorted[i] = abs
+		}
+	}
+	h := hashutil.Hasher().New()
+	_, _ = h.Write([]byte(repoDir))
+	_, _ = h.Write([]byte{0})
+	for _, p := range sorted {
+		_, _ = h.Write([]byte(p))
+		_, _ = h.Write([]byte{0})
+	}
+	return hashutil.HashHex(h.Sum(nil))
+}
+
+func findingsBundleManifestPath(repoDir, key string) string {
+	if repoDir == "" || key == "" {
+		return ""
+	}
+	if len(key) >= 2 {
+		return filepath.Join(FindingsBundleCacheDir(repoDir), "manifests", key[:2], key[2:]+".json")
+	}
+	return filepath.Join(FindingsBundleCacheDir(repoDir), "manifests", key+".json")
+}
+
+// LoadFindingsBundleManifest reads the manifest for the given run key,
+// returning (manifest, true) on success or (zero, false) when it's
+// missing or invalid. Manifest-version mismatches are treated as
+// missing so a krit upgrade doesn't serve stale entries.
+func LoadFindingsBundleManifest(repoDir, key string) (FindingsBundleManifest, bool) {
+	path := findingsBundleManifestPath(repoDir, key)
+	if path == "" {
+		return FindingsBundleManifest{}, false
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return FindingsBundleManifest{}, false
+	}
+	var m FindingsBundleManifest
+	if err := json.Unmarshal(raw, &m); err != nil {
+		return FindingsBundleManifest{}, false
+	}
+	if m.Version != findingsBundleManifestVersion || m.Key != key || len(m.ContentHashes) == 0 {
+		return FindingsBundleManifest{}, false
+	}
+	return m, true
+}
+
+// SaveFindingsBundleManifest persists the run manifest atomically.
+// Best-effort: errors are returned but callers (RunProject's save
+// path) typically log-and-continue rather than failing the whole
+// verb on a manifest write error.
+func SaveFindingsBundleManifest(repoDir, key string, manifest FindingsBundleManifest) error {
+	path := findingsBundleManifestPath(repoDir, key)
+	if path == "" {
+		return nil
+	}
+	manifest.Version = findingsBundleManifestVersion
+	manifest.Key = key
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	raw, err := json.Marshal(manifest)
+	if err != nil {
+		return err
+	}
+	return fsutil.WriteFileAtomic(path, raw, 0o644)
+}

--- a/internal/scanner/findings_bundle_manifest.go
+++ b/internal/scanner/findings_bundle_manifest.go
@@ -26,12 +26,12 @@ import (
 const findingsBundleManifestVersion = 1
 
 type FindingsBundleManifest struct {
-	Version        int               `json:"version"`
-	Key            string            `json:"key"`
-	BundleKey      string            `json:"bundleKey"`
-	Fingerprint    RunFingerprint    `json:"fingerprint"`
-	ContentHashes  map[string]string `json:"contentHashes"`
-	StructuralFPs  map[string]string `json:"structuralFps,omitempty"`
+	Version       int               `json:"version"`
+	Key           string            `json:"key"`
+	BundleKey     string            `json:"bundleKey"`
+	Fingerprint   RunFingerprint    `json:"fingerprint"`
+	ContentHashes map[string]string `json:"contentHashes"`
+	StructuralFPs map[string]string `json:"structuralFps,omitempty"`
 }
 
 // FindingsBundleManifestKey derives a stable manifest identifier from


### PR DESCRIPTION
## Summary
Completes the findings-bundle-cache work begun in #134 (full-hit short-circuit). Adds the structural CrossFile fingerprint that makes \`ConservativeDeltaPlanner\`'s single-file delta path reachable, plus the orchestration around it.

## What this PR ships

### Structural CrossFile fingerprint
- \`scanner.FileStructuralFingerprint(file)\` hashes a file's contribution to the cross-file CodeIndex: sorted Symbols (FQN+Name+Kind+Visibility+Signature) and sorted References (Name+InComment). Per-line positions deliberately excluded — line-number drift from intra-file body edits shouldn't invalidate cross-file findings for unchanged files.
- \`pipeline.crossFileStructuralFingerprint\` aggregates over Kotlin + Java files.
- \`computeRunFingerprint\` now uses this for \`fp.CrossFile\` instead of \`CodeIndex.Fingerprint\` (which moved on every byte edit).

### Bundle manifest
- \`scanner.FindingsBundleManifest\` persists prior run's BundleKey, RunFingerprint, per-file content hashes + structural fps. Keyed by repoDir + sorted scan paths.

### Delta orchestrator (\`tryDeltaDispatch\`)
When the full \`Load\` misses:
1. Load prior manifest → compute changed paths via content-hash diff.
2. Ask \`ConservativeDeltaPlanner.Plan\`. On \`ReusePrevious\` + exactly 1 changed file:
   - Scope \`DispatchPhase\` to the changed file (per-file rules run only there — the dominant warm-call cost win).
   - Run \`CrossFilePhase\` normally over the full index.
   - Filter the replacement to the changed path.
   - \`scanner.ApplyDelta(prior, replacement, [changedPath])\` merges.
3. Falls back to full dispatch on any safety mismatch.

## Why this is safe
The planner's gate requires every non-SourceSet fp field stable. With CrossFile now structural, body-only edits (whitespace, comment, constant tweak) keep CrossFile stable → delta fires. Any declaration/visibility/signature change, added import, or new reference moves structural CrossFile → planner refuses → full dispatch.

Cross-file findings for unchanged files come from the prior bundle (\`ApplyDelta\` keeps prior rows where file ∉ affected). Cross-file + per-file findings for the changed file come from the current scoped run.

## Tests
- \`TestFileStructuralFingerprint_BodyEditStable\` — body-only edit produces identical structural fp.
- \`TestFileStructuralFingerprint_DeclarationChangeMoves\` — new class moves the fp.
- \`TestRunProject_DeltaPath_BodyEditTakesDelta\` — full E2E: comment edit triggers the delta path, output identical.
- \`TestRunProject_DeltaPath_DeclarationChangeFallsBack\` — adding a declaration forces full dispatch.
- \`TestDiffContentHashes\` — hash-map diff helper covers add/remove/change/identical cases.

Existing #134 bundle full-hit tests still pass.

## Test plan
- [x] \`go build -o krit ./cmd/krit/\`
- [x] \`go vet ./...\`
- [x] \`go test ./... -count=1\`