### PR TITLE
feat(pipeline): run AndroidPhase from RunProject (#70 step)

### DIFF
--- a/internal/pipeline/project.go
+++ b/internal/pipeline/project.go
@@ -323,6 +323,13 @@ func RunProject(ctx context.Context, in ProjectInput) (ProjectResult, error) {
 		return ProjectResult{}, err
 	}
 
+	// Phase 4.5: Android project analysis. The findings-bundle hit
+	// returns a pre-merged set (Android findings were merged before the
+	// save on the original miss), so we only run AndroidPhase on misses.
+	if err := runAndroidPhaseAndMerge(ctx, args, indexResult, &crossFileResult, bundleHit); err != nil {
+		return ProjectResult{}, err
+	}
+
 	// Phase 5: output to an in-memory buffer.
 	var buf bytes.Buffer
 	fixupView := FixupResult{CrossFileResult: crossFileResult}
@@ -512,6 +519,45 @@ func saveDeltaManifest(host ProjectHostState, m deltaManifestData, runFP scanner
 // The delta path is the load-bearing #55 perf win for body-only edits:
 // per-file rule dispatch is the dominant warm-call cost and the delta
 // path runs it on just one file.
+
+// runAndroidPhaseAndMerge runs AndroidPhase against the detected
+// project (if any) and folds its findings into crossFileResult.Findings.
+// A nil/empty project, no Android-needing rules, or a dispatcher-less
+// run returns without mutating the findings. Mirrors the CLI runner's
+// androidPhase step.
+func runAndroidPhaseAndMerge(ctx context.Context, args ProjectArgs, indexResult IndexResult, crossFileResult *CrossFileResult, bundleHit bool) error {
+	if bundleHit {
+		return nil
+	}
+	project := indexResult.AndroidProject
+	if project == nil || project.IsEmpty() {
+		return nil
+	}
+	dispatcher := rules.NewDispatcher(args.ActiveRules, indexResult.Resolver)
+	dispatcher.SetLibraryFacts(indexResult.LibraryFacts)
+	dispatcher.SetJavaSemanticFacts(indexResult.JavaSemanticFacts)
+	res, err := (AndroidPhase{}).Run(ctx, AndroidInput{
+		Project:             project,
+		ActiveRules:         args.ActiveRules,
+		Dispatcher:          dispatcher,
+		SourceFiles:         indexResult.SourceFiles(),
+		RuleHash:            indexResult.RuleHash,
+		LibraryFactsFP:      indexResult.LibraryFacts.Fingerprint(),
+		JavaSemanticFactsFP: indexResult.JavaSemanticFacts.Fingerprint(),
+	})
+	if err != nil {
+		return fmt.Errorf("android: %w", err)
+	}
+	if res.Findings.Len() == 0 {
+		return nil
+	}
+	merged := scanner.NewFindingCollector(crossFileResult.Findings.Len() + res.Findings.Len())
+	merged.AppendColumns(&crossFileResult.Findings)
+	merged.AppendColumns(&res.Findings)
+	crossFileResult.Findings = *merged.Columns()
+	return nil
+}
+
 func runDispatchOrLoadBundle(
 	ctx context.Context,
 	args ProjectArgs,

--- a/internal/pipeline/runproject_androidphase_test.go
+++ b/internal/pipeline/runproject_androidphase_test.go
@@ -1,0 +1,71 @@
+package pipeline
+
+import (
+	"context"
+	"image"
+	"image/color"
+	"image/png"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kaeawc/krit/internal/config"
+	api "github.com/kaeawc/krit/internal/rules/api"
+)
+
+// TestRunProject_RunsAndroidPhaseAndMergesFindings is the contract
+// that RunProject (the daemon's entry point) executes the Android
+// phase and folds its findings into the result, mirroring the CLI
+// runner's androidPhase step. Without this wiring, daemon-served
+// runs over Android projects silently drop manifest/resource/gradle
+// findings.
+func TestRunProject_RunsAndroidPhaseAndMergesFindings(t *testing.T) {
+	root := t.TempDir()
+	resDir := filepath.Join(root, "src", "main", "res", "drawable-mdpi")
+	if err := os.MkdirAll(resDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	img := image.NewRGBA(image.Rect(0, 0, 48, 48))
+	for y := 0; y < 48; y++ {
+		for x := 0; x < 48; x++ {
+			img.Set(x, y, color.RGBA{R: 255, G: 0, B: 0, A: 255})
+		}
+	}
+	f, err := os.Create(filepath.Join(resDir, "ic_action_share.png"))
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := png.Encode(f, img); err != nil {
+		f.Close()
+		t.Fatalf("Encode: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	iconColorsRule := findV2RuleForTest(t, "IconColors")
+
+	res, err := RunProject(context.Background(), ProjectInput{
+		Args: ProjectArgs{
+			Config:      config.NewConfig(),
+			Paths:       []string{root},
+			ActiveRules: []*api.Rule{iconColorsRule},
+			Format:      "json",
+			Version:     "test",
+		},
+	})
+	if err != nil {
+		t.Fatalf("RunProject: %v", err)
+	}
+
+	got := res.FinalFindings.Findings()
+	hits := 0
+	for _, f := range got {
+		if f.Rule == "IconColors" {
+			hits++
+		}
+	}
+	if hits == 0 {
+		t.Fatalf("expected at least one IconColors finding via RunProject, got %d findings: %#v", len(got), got)
+	}
+}


### PR DESCRIPTION
## Summary
- Carves the first divergence between the CLI runner and `pipeline.RunProject` (issue #70): the daemon's entry point now runs `AndroidPhase` between cross-file analysis and output, merging manifest/resource/gradle findings into the result the same way the CLI runner does.
- Merge happens before the findings-bundle save (#55), so subsequent bundle hits return the pre-merged set without re-running AndroidPhase.
- Adds a contract test that exercises `RunProject` over a fixture with a `res/drawable-mdpi/ic_action_share.png` and asserts that the `IconColors` rule fires through the daemon entry point.

Closes one of the gaps blocking the byte-equal CLI-vs-verb contract test described in #70. Remaining divergences (FIR check, baselines, fix application, output routing) stay in the CLI runner for now.

## Test plan
- [x] `go build -o krit ./cmd/krit/`
- [x] `go vet ./...`
- [x] `go test ./... -count=1`
- [x] `golangci-lint run ./...` (no new issues)
- [x] New unit test `TestRunProject_RunsAndroidPhaseAndMergesFindings` passes
- [x] Existing `TestAnalyzeProject_OutputMatchesDirectRunProject` still passes