### PR TITLE
feat(snapshot): persist per-rule findings sidecar (closes #72)

### DIFF
--- a/internal/cli/snapshot/snapshot.go
+++ b/internal/cli/snapshot/snapshot.go
@@ -36,6 +36,7 @@ const usage = `usage: krit snapshot <capture|backfill|status|timeline|info|diff|
 Capture flags:
   --repo PATH       repo root (default: cwd)
   --output PATH     write blob path on success to PATH (default: stderr)
+  --with-findings   run rules and persist per-rule findings sidecar (slower)
 
 Timeline flags:
   --repo PATH       repo root (default: cwd)
@@ -104,6 +105,7 @@ func runCapture(args []string) int {
 	fs.SetOutput(os.Stderr)
 	repoFlag := fs.String("repo", "", "repository root (default: cwd)")
 	outputFlag := fs.String("output", "", "write blob path to this file on success")
+	withFindings := fs.Bool("with-findings", false, "also run rules and persist a per-rule findings sidecar")
 
 	positional, rest := clishared.SplitPositional(args, 1)
 	if err := fs.Parse(rest); err != nil {
@@ -126,9 +128,10 @@ func runCapture(args []string) int {
 	}
 
 	res, err := snap.Capture(snap.CaptureOptions{
-		RepoRoot:    repoRoot,
-		CommitSHA:   sha,
-		KritVersion: Version,
+		RepoRoot:     repoRoot,
+		CommitSHA:    sha,
+		KritVersion:  Version,
+		WithFindings: *withFindings,
 	})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)

--- a/internal/snapshot/capture.go
+++ b/internal/snapshot/capture.go
@@ -25,9 +25,6 @@ type CaptureOptions struct {
 	// worktree and attaches a per-rule findings rollup to Result. The
 	// scan dominates capture wall-time, so this is opt-in.
 	WithFindings bool
-	// FindingsRun, when non-nil, overrides the FindingsRunOptions passed
-	// to RunFindings. Ignored when WithFindings is false.
-	FindingsRun *FindingsRunOptions
 }
 
 // Result pairs the structural blob with the metrics rollup derived from
@@ -92,17 +89,10 @@ func Capture(opts CaptureOptions) (*Result, error) {
 	result := &Result{Blob: blob, Metrics: metrics}
 
 	if opts.WithFindings {
-		runOpts := FindingsRunOptions{RepoRelativeTo: root, Workers: workers}
-		if opts.FindingsRun != nil {
-			runOpts = *opts.FindingsRun
-			if runOpts.RepoRelativeTo == "" {
-				runOpts.RepoRelativeTo = root
-			}
-			if runOpts.Workers == 0 {
-				runOpts.Workers = workers
-			}
-		}
-		findings, err := RunFindings(context.Background(), root, opts.CommitSHA, runOpts)
+		findings, err := RunFindings(context.Background(), root, opts.CommitSHA, FindingsRunOptions{
+			RepoRelativeTo: root,
+			Workers:        workers,
+		})
 		if err != nil {
 			return nil, fmt.Errorf("snapshot: findings: %w", err)
 		}

--- a/internal/snapshot/capture.go
+++ b/internal/snapshot/capture.go
@@ -1,6 +1,7 @@
 package snapshot
 
 import (
+	"context"
 	"fmt"
 	"path/filepath"
 	"runtime"
@@ -20,13 +21,22 @@ type CaptureOptions struct {
 	Workers     int
 	// Now allows tests to inject a deterministic capture time.
 	Now func() time.Time
+	// WithFindings, when true, runs krit's rule pipeline against the
+	// worktree and attaches a per-rule findings rollup to Result. The
+	// scan dominates capture wall-time, so this is opt-in.
+	WithFindings bool
+	// FindingsRun, when non-nil, overrides the FindingsRunOptions passed
+	// to RunFindings. Ignored when WithFindings is false.
+	FindingsRun *FindingsRunOptions
 }
 
 // Result pairs the structural blob with the metrics rollup derived from
-// the same parse.
+// the same parse. Findings is populated only when CaptureOptions.WithFindings
+// is set.
 type Result struct {
-	Blob    *Blob
-	Metrics *Metrics
+	Blob     *Blob
+	Metrics  *Metrics
+	Findings *Findings
 }
 
 func Capture(opts CaptureOptions) (*Result, error) {
@@ -79,7 +89,27 @@ func Capture(opts CaptureOptions) (*Result, error) {
 	allFiles = append(allFiles, ktFiles...)
 	allFiles = append(allFiles, javaFiles...)
 	metrics := computeMetrics(blob, allFiles)
-	return &Result{Blob: blob, Metrics: metrics}, nil
+	result := &Result{Blob: blob, Metrics: metrics}
+
+	if opts.WithFindings {
+		runOpts := FindingsRunOptions{RepoRelativeTo: root, Workers: workers}
+		if opts.FindingsRun != nil {
+			runOpts = *opts.FindingsRun
+			if runOpts.RepoRelativeTo == "" {
+				runOpts.RepoRelativeTo = root
+			}
+			if runOpts.Workers == 0 {
+				runOpts.Workers = workers
+			}
+		}
+		findings, err := RunFindings(context.Background(), root, opts.CommitSHA, runOpts)
+		if err != nil {
+			return nil, fmt.Errorf("snapshot: findings: %w", err)
+		}
+		result.Findings = findings
+	}
+
+	return result, nil
 }
 
 // collectSources walks each module's source roots once via

--- a/internal/snapshot/diff.go
+++ b/internal/snapshot/diff.go
@@ -25,6 +25,16 @@ type DiffResult struct {
 
 	RepoMetrics   map[string]MetricDelta            `json:"repo_metrics,omitempty"`
 	ModuleMetrics map[string]map[string]MetricDelta `json:"module_metrics,omitempty"`
+
+	// FindingsByRule is populated only when both snapshots carry a
+	// findings sidecar AND share a RuleSetHash. Cross-rule-set
+	// comparisons stay nil so callers don't mistake an apples-to-oranges
+	// delta for a real drift signal.
+	FindingsByRule map[string]MetricDelta `json:"findings_by_rule,omitempty"`
+	// FindingsRuleSetMismatch is set when both sides have findings
+	// sidecars whose RuleSetHash differs. Consumers should refuse to
+	// report a findings delta in that case.
+	FindingsRuleSetMismatch bool `json:"findings_rule_set_mismatch,omitempty"`
 }
 
 // DiffSide identifies one end of a diff and tags it with the krit and
@@ -108,7 +118,37 @@ func Diff(root, fromSHA, toSHA string) (*DiffResult, error) {
 		result.ModuleMetrics = diffModuleMetrics(fromMetrics, toMetrics)
 	}
 
+	fromFindings, _ := LoadFindings(root, fromSHA)
+	toFindings, _ := LoadFindings(root, toSHA)
+	if fromFindings != nil && toFindings != nil {
+		if fromFindings.RuleSetHash != "" && toFindings.RuleSetHash != "" && fromFindings.RuleSetHash != toFindings.RuleSetHash {
+			result.FindingsRuleSetMismatch = true
+		} else {
+			result.FindingsByRule = diffFindingsByRule(fromFindings, toFindings)
+		}
+	}
+
 	return result, nil
+}
+
+func diffFindingsByRule(from, to *Findings) map[string]MetricDelta {
+	rules := make(map[string]bool, len(from.ByRule)+len(to.ByRule))
+	for r := range from.ByRule {
+		rules[r] = true
+	}
+	for r := range to.ByRule {
+		rules[r] = true
+	}
+	out := make(map[string]MetricDelta, len(rules))
+	for r := range rules {
+		fv := float64(from.ByRule[r])
+		tv := float64(to.ByRule[r])
+		if fv == 0 && tv == 0 {
+			continue
+		}
+		out[r] = MetricDelta{From: fv, To: tv, Delta: tv - fv}
+	}
+	return out
 }
 
 func diffFiles(from, to []File) (added, removed []FileRef) {

--- a/internal/snapshot/findings.go
+++ b/internal/snapshot/findings.go
@@ -1,0 +1,202 @@
+package snapshot
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/kaeawc/krit/internal/cache"
+	"github.com/kaeawc/krit/internal/cacheutil"
+	"github.com/kaeawc/krit/internal/config"
+	"github.com/kaeawc/krit/internal/fsutil"
+	"github.com/kaeawc/krit/internal/pipeline"
+	"github.com/kaeawc/krit/internal/rules"
+	api "github.com/kaeawc/krit/internal/rules/api"
+	"github.com/kaeawc/krit/internal/scanner"
+)
+
+// FindingsSchemaVersion versions the findings sidecar wire format. Bump
+// when ByRule/ByRuleFile semantics change in a way that breaks decode of
+// previously written sidecars.
+const FindingsSchemaVersion = 1
+
+const findingsFileName = "findings.gob.zst"
+
+// Findings is the per-commit per-rule findings rollup persisted next to
+// the structural blob. simulate reads it as a Timeline; diff uses
+// RuleSetHash to refuse cross-rule-set comparisons.
+type Findings struct {
+	SchemaVersion int
+	CommitSHA     string
+	RuleSetHash   string
+	// ByRule maps rule ID -> total finding count across the snapshot.
+	ByRule map[string]int
+	// ByRuleFile maps rule ID -> (repo-relative file path -> count).
+	// Optional; consumers that only need per-rule totals can ignore it.
+	ByRuleFile map[string]map[string]int
+}
+
+// FindingsPath returns the on-disk location for a snapshot's findings
+// sidecar. Mirrors BlobPath / MetricsPath layout (sharded by sha[:2]).
+func FindingsPath(root, sha string) (string, error) {
+	dir, err := shaDir(root, sha)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, findingsFileName), nil
+}
+
+func SaveFindings(root string, f *Findings) (string, error) {
+	if f == nil {
+		return "", errors.New("snapshot: nil findings")
+	}
+	if f.CommitSHA == "" {
+		return "", errors.New("snapshot: findings has no CommitSHA")
+	}
+	path, err := FindingsPath(root, f.CommitSHA)
+	if err != nil {
+		return "", err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return "", fmt.Errorf("snapshot: mkdir %s: %w", filepath.Dir(path), err)
+	}
+	payload, err := cacheutil.EncodeZstdGob(f)
+	if err != nil {
+		return "", fmt.Errorf("snapshot: encode findings: %w", err)
+	}
+	if err := fsutil.WriteFileAtomic(path, payload, 0o644); err != nil {
+		return "", fmt.Errorf("snapshot: write %s: %w", path, err)
+	}
+	return path, nil
+}
+
+func LoadFindings(root, sha string) (*Findings, error) {
+	path, err := FindingsPath(root, sha)
+	if err != nil {
+		return nil, err
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("snapshot: open %s: %w", path, err)
+	}
+	defer file.Close()
+	var f Findings
+	if err := cacheutil.DecodeZstdGob(file, &f); err != nil {
+		return nil, fmt.Errorf("snapshot: decode %s: %w", path, err)
+	}
+	return &f, nil
+}
+
+// FindingsRunOptions tunes RunFindings without forcing every caller to
+// build a full pipeline.ProjectArgs.
+type FindingsRunOptions struct {
+	// Config is the resolved krit.yml; nil falls back to defaults.
+	Config *config.Config
+	// ActiveRules is the rule set dispatched against the worktree. When
+	// empty, RunFindings selects the default active set.
+	ActiveRules []*api.Rule
+	// Workers overrides per-phase worker counts.
+	Workers int
+	// IncludeGenerated forwards through to ParsePhase.
+	IncludeGenerated bool
+	// RepoRelativeTo, when non-empty, rewrites the absolute file paths
+	// returned in ByRuleFile to be repo-relative. Empty leaves paths
+	// untouched.
+	RepoRelativeTo string
+}
+
+// RunFindings runs the full rule pipeline against repoRoot once and
+// returns a populated Findings ready to persist alongside the structural
+// blob. The function exists so internal/snapshot can keep the heavy
+// pipeline import contained and so Capture can opt in via a single call.
+func RunFindings(ctx context.Context, repoRoot, commitSHA string, opts FindingsRunOptions) (*Findings, error) {
+	if repoRoot == "" {
+		return nil, errors.New("snapshot: RunFindings: repoRoot required")
+	}
+	if commitSHA == "" {
+		return nil, errors.New("snapshot: RunFindings: commitSHA required")
+	}
+	cfg := opts.Config
+	if cfg == nil {
+		cfg = config.NewConfig()
+	}
+	activeRules := opts.ActiveRules
+	if len(activeRules) == 0 {
+		activeRules = rules.ActiveRulesV2(nil, nil, false, false)
+	}
+	if len(activeRules) == 0 {
+		// Empty registry — nothing to dispatch, but still emit a sidecar
+		// so simulate / diff can detect an explicit zero rather than a
+		// missing capture.
+		return &Findings{
+			SchemaVersion: FindingsSchemaVersion,
+			CommitSHA:     commitSHA,
+			RuleSetHash:   ruleSetHash(activeRules, cfg),
+			ByRule:        map[string]int{},
+			ByRuleFile:    map[string]map[string]int{},
+		}, nil
+	}
+
+	res, err := pipeline.RunProject(ctx, pipeline.ProjectInput{
+		Args: pipeline.ProjectArgs{
+			Config:           cfg,
+			Paths:            []string{repoRoot},
+			ActiveRules:      activeRules,
+			Format:           "json",
+			IncludeGenerated: opts.IncludeGenerated,
+			Workers:          opts.Workers,
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("snapshot: RunFindings: %w", err)
+	}
+
+	out := &Findings{
+		SchemaVersion: FindingsSchemaVersion,
+		CommitSHA:     commitSHA,
+		RuleSetHash:   ruleSetHash(activeRules, cfg),
+		ByRule:        make(map[string]int),
+		ByRuleFile:    make(map[string]map[string]int),
+	}
+	collectFindings(&res.FinalFindings, opts.RepoRelativeTo, out)
+	return out, nil
+}
+
+func collectFindings(cols *scanner.FindingColumns, repoRoot string, dst *Findings) {
+	if cols == nil {
+		return
+	}
+	for i := 0; i < cols.Len(); i++ {
+		rule := cols.RuleAt(i)
+		if rule == "" {
+			continue
+		}
+		dst.ByRule[rule]++
+		path := cols.FileAt(i)
+		if repoRoot != "" {
+			path = relPath(path, repoRoot)
+		}
+		perFile := dst.ByRuleFile[rule]
+		if perFile == nil {
+			perFile = make(map[string]int)
+			dst.ByRuleFile[rule] = perFile
+		}
+		perFile[path]++
+	}
+}
+
+// ruleSetHash computes the same fingerprint the cache layer uses so a
+// findings sidecar can be cross-checked against a fresh active set.
+func ruleSetHash(activeRules []*api.Rule, cfg *config.Config) string {
+	names := make([]string, 0, len(activeRules))
+	for _, r := range activeRules {
+		if r != nil {
+			names = append(names, r.ID)
+		}
+	}
+	sort.Strings(names)
+	return cache.ComputeConfigHash(names, cfg, false)
+}

--- a/internal/snapshot/findings.go
+++ b/internal/snapshot/findings.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"sort"
 
 	"github.com/kaeawc/krit/internal/cache"
 	"github.com/kaeawc/krit/internal/cacheutil"
@@ -127,18 +126,6 @@ func RunFindings(ctx context.Context, repoRoot, commitSHA string, opts FindingsR
 	if len(activeRules) == 0 {
 		activeRules = rules.ActiveRulesV2(nil, nil, false, false)
 	}
-	if len(activeRules) == 0 {
-		// Empty registry — nothing to dispatch, but still emit a sidecar
-		// so simulate / diff can detect an explicit zero rather than a
-		// missing capture.
-		return &Findings{
-			SchemaVersion: FindingsSchemaVersion,
-			CommitSHA:     commitSHA,
-			RuleSetHash:   ruleSetHash(activeRules, cfg),
-			ByRule:        map[string]int{},
-			ByRuleFile:    map[string]map[string]int{},
-		}, nil
-	}
 
 	res, err := pipeline.RunProject(ctx, pipeline.ProjectInput{
 		Args: pipeline.ProjectArgs{
@@ -190,6 +177,7 @@ func collectFindings(cols *scanner.FindingColumns, repoRoot string, dst *Finding
 
 // ruleSetHash computes the same fingerprint the cache layer uses so a
 // findings sidecar can be cross-checked against a fresh active set.
+// ComputeConfigHash sorts its input, so we don't need to here.
 func ruleSetHash(activeRules []*api.Rule, cfg *config.Config) string {
 	names := make([]string, 0, len(activeRules))
 	for _, r := range activeRules {
@@ -197,6 +185,5 @@ func ruleSetHash(activeRules []*api.Rule, cfg *config.Config) string {
 			names = append(names, r.ID)
 		}
 	}
-	sort.Strings(names)
 	return cache.ComputeConfigHash(names, cfg, false)
 }

--- a/internal/snapshot/findings_test.go
+++ b/internal/snapshot/findings_test.go
@@ -1,0 +1,150 @@
+package snapshot
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSaveLoadFindingsRoundTrip(t *testing.T) {
+	root := t.TempDir()
+	in := &Findings{
+		SchemaVersion: FindingsSchemaVersion,
+		CommitSHA:     "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+		RuleSetHash:   "ruleset-1",
+		ByRule:        map[string]int{"MagicNumber": 3, "LongMethod": 1},
+		ByRuleFile: map[string]map[string]int{
+			"MagicNumber": {"src/Foo.kt": 2, "src/Bar.kt": 1},
+			"LongMethod":  {"src/Foo.kt": 1},
+		},
+	}
+	path, err := SaveFindings(root, in)
+	if err != nil {
+		t.Fatalf("SaveFindings: %v", err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("stat sidecar: %v", err)
+	}
+	if !filepath.IsAbs(path) && filepath.Base(path) != findingsFileName {
+		t.Fatalf("unexpected path: %s", path)
+	}
+
+	got, err := LoadFindings(root, in.CommitSHA)
+	if err != nil {
+		t.Fatalf("LoadFindings: %v", err)
+	}
+	if got.RuleSetHash != in.RuleSetHash {
+		t.Fatalf("RuleSetHash: got %q want %q", got.RuleSetHash, in.RuleSetHash)
+	}
+	if got.ByRule["MagicNumber"] != 3 || got.ByRule["LongMethod"] != 1 {
+		t.Fatalf("ByRule mismatch: %+v", got.ByRule)
+	}
+	if got.ByRuleFile["MagicNumber"]["src/Foo.kt"] != 2 {
+		t.Fatalf("ByRuleFile mismatch: %+v", got.ByRuleFile)
+	}
+}
+
+func TestSaveFindingsRejectsEmptySHA(t *testing.T) {
+	if _, err := SaveFindings(t.TempDir(), &Findings{}); err == nil {
+		t.Fatal("expected error for empty CommitSHA")
+	}
+	if _, err := SaveFindings(t.TempDir(), nil); err == nil {
+		t.Fatal("expected error for nil findings")
+	}
+}
+
+func TestLoadFindingsMissingFile(t *testing.T) {
+	root := t.TempDir()
+	if _, err := LoadFindings(root, "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"); err == nil {
+		t.Fatal("expected error when sidecar missing")
+	}
+}
+
+func TestDiffFindingsByRule(t *testing.T) {
+	root := t.TempDir()
+	from := &Findings{
+		SchemaVersion: FindingsSchemaVersion,
+		CommitSHA:     "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		RuleSetHash:   "ruleset-1",
+		ByRule:        map[string]int{"MagicNumber": 5, "Dead": 2},
+	}
+	to := &Findings{
+		SchemaVersion: FindingsSchemaVersion,
+		CommitSHA:     "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+		RuleSetHash:   "ruleset-1",
+		ByRule:        map[string]int{"MagicNumber": 3, "New": 1},
+	}
+	// Write minimal blobs so Diff can run.
+	mustSaveStubBlob(t, root, from.CommitSHA)
+	mustSaveStubBlob(t, root, to.CommitSHA)
+	if _, err := SaveFindings(root, from); err != nil {
+		t.Fatalf("save from: %v", err)
+	}
+	if _, err := SaveFindings(root, to); err != nil {
+		t.Fatalf("save to: %v", err)
+	}
+
+	d, err := Diff(root, from.CommitSHA, to.CommitSHA)
+	if err != nil {
+		t.Fatalf("Diff: %v", err)
+	}
+	if d.FindingsRuleSetMismatch {
+		t.Fatalf("unexpected rule-set mismatch on identical hashes")
+	}
+	if d.FindingsByRule["MagicNumber"].Delta != -2 {
+		t.Fatalf("MagicNumber delta: %+v", d.FindingsByRule["MagicNumber"])
+	}
+	if d.FindingsByRule["Dead"].Delta != -2 || d.FindingsByRule["Dead"].To != 0 {
+		t.Fatalf("Dead delta: %+v", d.FindingsByRule["Dead"])
+	}
+	if d.FindingsByRule["New"].From != 0 || d.FindingsByRule["New"].To != 1 {
+		t.Fatalf("New delta: %+v", d.FindingsByRule["New"])
+	}
+}
+
+func TestDiffFindingsRuleSetMismatch(t *testing.T) {
+	root := t.TempDir()
+	from := &Findings{
+		SchemaVersion: FindingsSchemaVersion,
+		CommitSHA:     "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		RuleSetHash:   "ruleset-1",
+		ByRule:        map[string]int{"MagicNumber": 5},
+	}
+	to := &Findings{
+		SchemaVersion: FindingsSchemaVersion,
+		CommitSHA:     "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+		RuleSetHash:   "ruleset-2",
+		ByRule:        map[string]int{"MagicNumber": 3},
+	}
+	mustSaveStubBlob(t, root, from.CommitSHA)
+	mustSaveStubBlob(t, root, to.CommitSHA)
+	if _, err := SaveFindings(root, from); err != nil {
+		t.Fatalf("save from: %v", err)
+	}
+	if _, err := SaveFindings(root, to); err != nil {
+		t.Fatalf("save to: %v", err)
+	}
+
+	d, err := Diff(root, from.CommitSHA, to.CommitSHA)
+	if err != nil {
+		t.Fatalf("Diff: %v", err)
+	}
+	if !d.FindingsRuleSetMismatch {
+		t.Fatal("expected FindingsRuleSetMismatch=true on differing RuleSetHash")
+	}
+	if len(d.FindingsByRule) != 0 {
+		t.Fatalf("expected no findings delta when rule sets differ, got %+v", d.FindingsByRule)
+	}
+}
+
+func mustSaveStubBlob(t *testing.T, root, sha string) {
+	t.Helper()
+	blob := &Blob{
+		SchemaVersion: SchemaVersion,
+		CommitSHA:     sha,
+		CapturedAt:    1,
+	}
+	if _, err := Save(root, blob); err != nil {
+		t.Fatalf("save stub blob: %v", err)
+	}
+}

--- a/internal/snapshot/manifest.go
+++ b/internal/snapshot/manifest.go
@@ -178,6 +178,11 @@ func SaveResult(root string, res *Result, repoRoot, kritVersion string) (string,
 			return "", err
 		}
 	}
+	if res.Findings != nil {
+		if _, err := SaveFindings(root, res.Findings); err != nil {
+			return "", err
+		}
+	}
 	if _, err := CaptureManifest(root, res, repoRoot, kritVersion); err != nil {
 		return "", err
 	}
@@ -212,6 +217,9 @@ func buildManifest(res *Result, repoRoot, kritVersion string) *Manifest {
 	}
 	if res.Metrics != nil {
 		m.MetricsSchema = res.Metrics.SchemaVersion
+	}
+	if res.Findings != nil {
+		m.RuleSetHash = res.Findings.RuleSetHash
 	}
 	return m
 }

--- a/internal/snapshot/simulate.go
+++ b/internal/snapshot/simulate.go
@@ -47,14 +47,21 @@ type SimulateEvent struct {
 	Error     error
 }
 
+// SimulateSource identifies how a SimulatePoint was scored.
+type SimulateSource string
+
+const (
+	// SimulateSourceSidecar marks counts read from a persisted findings.gob.zst.
+	SimulateSourceSidecar SimulateSource = "sidecar"
+	// SimulateSourceScan marks counts produced by the shell-out fallback.
+	SimulateSourceScan SimulateSource = "scan"
+)
+
 type SimulatePoint struct {
-	CommitSHA   string `json:"commit_sha"`
-	CommittedAt int64  `json:"committed_at"`
-	Findings    int    `json:"findings"`
-	// Source identifies where the count came from: "sidecar" when read
-	// from a persisted findings.gob.zst, "scan" when produced by a
-	// shell-out fallback.
-	Source string `json:"source,omitempty"`
+	CommitSHA   string         `json:"commit_sha"`
+	CommittedAt int64          `json:"committed_at"`
+	Findings    int            `json:"findings"`
+	Source      SimulateSource `json:"source,omitempty"`
 }
 
 type SimulateResult struct {
@@ -109,14 +116,13 @@ func Simulate(opts SimulateOptions) (*SimulateResult, error) {
 	var sidecarPoints []SimulatePoint
 	var remaining []commitMeta
 	if !opts.NoSidecar {
-		sidecarPoints, remaining = collectSidecarPoints(root, opts.Rule, commits, opts.Reporter)
+		sidecarPoints, remaining = collectSidecarPoints(root, opts.Rule, commits, workers, opts.Reporter)
 	} else {
 		remaining = commits
 	}
 	if len(remaining) == 0 {
-		points := append([]SimulatePoint{}, sidecarPoints...)
-		sort.Slice(points, func(i, j int) bool { return points[i].CommittedAt > points[j].CommittedAt })
-		return &SimulateResult{Rule: opts.Rule, Points: points}, nil
+		sort.Slice(sidecarPoints, func(i, j int) bool { return sidecarPoints[i].CommittedAt > sidecarPoints[j].CommittedAt })
+		return &SimulateResult{Rule: opts.Rule, Points: sidecarPoints}, nil
 	}
 
 	scratch, err := os.MkdirTemp("", "krit-simulate-*")
@@ -179,7 +185,7 @@ func Simulate(opts SimulateOptions) (*SimulateResult, error) {
 			CommitSHA:   sha,
 			CommittedAt: timestampBySHA[sha],
 			Findings:    count,
-			Source:      "scan",
+			Source:      SimulateSourceScan,
 		})
 	}
 	points = append(points, sidecarPoints...)
@@ -189,34 +195,71 @@ func Simulate(opts SimulateOptions) (*SimulateResult, error) {
 }
 
 // collectSidecarPoints opens each commit's findings sidecar (if any)
-// and reads opts.Rule's count. Commits without a sidecar — or with one
-// missing the rule's RuleSetHash — fall through unmodified so the
-// caller can shell out for them.
-//
-// snapshotsRoot is .krit/snapshots under repoRoot; we recompute it
-// locally because the caller has only the absolute repo path.
-func collectSidecarPoints(repoRoot, rule string, commits []commitMeta, reporter func(SimulateEvent)) ([]SimulatePoint, []commitMeta) {
+// and reads rule's count. Commits without a sidecar fall through
+// unmodified so the caller can shell out for them. LoadFindings is
+// IO + zstd-decompress + gob-decode bound, so we fan out across
+// workers.
+func collectSidecarPoints(repoRoot, rule string, commits []commitMeta, workers int, reporter func(SimulateEvent)) ([]SimulatePoint, []commitMeta) {
 	root := SnapshotsDir(repoRoot)
 	if _, err := os.Stat(root); err != nil {
 		return nil, commits
 	}
-	points := make([]SimulatePoint, 0)
-	remaining := make([]commitMeta, 0, len(commits))
-	for _, c := range commits {
-		f, err := LoadFindings(root, c.SHA)
-		if err != nil || f == nil {
-			remaining = append(remaining, c)
-			continue
-		}
-		count := f.ByRule[rule]
-		points = append(points, SimulatePoint{
-			CommitSHA:   c.SHA,
-			CommittedAt: c.CommittedAt,
-			Findings:    count,
-			Source:      "sidecar",
-		})
-		if reporter != nil {
-			reporter(SimulateEvent{Kind: "scored", CommitSHA: c.SHA, Findings: count})
+	if workers <= 0 {
+		workers = runtime.NumCPU()
+	}
+	if workers > len(commits) {
+		workers = len(commits)
+	}
+	if workers < 1 {
+		workers = 1
+	}
+
+	type slot struct {
+		point *SimulatePoint
+		miss  *commitMeta
+	}
+	slots := make([]slot, len(commits))
+	jobs := make(chan int)
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for w := 0; w < workers; w++ {
+		go func() {
+			defer wg.Done()
+			for i := range jobs {
+				c := commits[i]
+				f, err := LoadFindings(root, c.SHA)
+				if err != nil || f == nil {
+					m := c
+					slots[i] = slot{miss: &m}
+					continue
+				}
+				count := f.ByRule[rule]
+				slots[i] = slot{point: &SimulatePoint{
+					CommitSHA:   c.SHA,
+					CommittedAt: c.CommittedAt,
+					Findings:    count,
+					Source:      SimulateSourceSidecar,
+				}}
+			}
+		}()
+	}
+	for i := range commits {
+		jobs <- i
+	}
+	close(jobs)
+	wg.Wait()
+
+	points := make([]SimulatePoint, 0, len(commits))
+	remaining := make([]commitMeta, 0)
+	for _, s := range slots {
+		switch {
+		case s.point != nil:
+			points = append(points, *s.point)
+			if reporter != nil {
+				reporter(SimulateEvent{Kind: "scored", CommitSHA: s.point.CommitSHA, Findings: s.point.Findings})
+			}
+		case s.miss != nil:
+			remaining = append(remaining, *s.miss)
 		}
 	}
 	return points, remaining

--- a/internal/snapshot/simulate.go
+++ b/internal/snapshot/simulate.go
@@ -30,8 +30,12 @@ type SimulateOptions struct {
 	Workers    int
 	// KritBin is the krit executable to invoke against each captured
 	// worktree. Empty defaults to argv[0]; tests inject a path.
-	KritBin  string
-	Reporter func(SimulateEvent)
+	KritBin string
+	// NoSidecar forces the shell-out path even when persisted findings
+	// sidecars are available. Tests use this to exercise the legacy
+	// path explicitly; production callers should leave it false.
+	NoSidecar bool
+	Reporter  func(SimulateEvent)
 }
 
 // SimulateEvent is one commit's outcome. Kind is "scored" or "failed".
@@ -47,6 +51,10 @@ type SimulatePoint struct {
 	CommitSHA   string `json:"commit_sha"`
 	CommittedAt int64  `json:"committed_at"`
 	Findings    int    `json:"findings"`
+	// Source identifies where the count came from: "sidecar" when read
+	// from a persisted findings.gob.zst, "scan" when produced by a
+	// shell-out fallback.
+	Source string `json:"source,omitempty"`
 }
 
 type SimulateResult struct {
@@ -95,21 +103,37 @@ func Simulate(opts SimulateOptions) (*SimulateResult, error) {
 		return &SimulateResult{Rule: opts.Rule}, nil
 	}
 
+	// Carve off any commits whose findings sidecar is on disk; those
+	// become near-instant Timeline reads. The remaining shas fall
+	// through to the existing shell-out path.
+	var sidecarPoints []SimulatePoint
+	var remaining []commitMeta
+	if !opts.NoSidecar {
+		sidecarPoints, remaining = collectSidecarPoints(root, opts.Rule, commits, opts.Reporter)
+	} else {
+		remaining = commits
+	}
+	if len(remaining) == 0 {
+		points := append([]SimulatePoint{}, sidecarPoints...)
+		sort.Slice(points, func(i, j int) bool { return points[i].CommittedAt > points[j].CommittedAt })
+		return &SimulateResult{Rule: opts.Rule, Points: points}, nil
+	}
+
 	scratch, err := os.MkdirTemp("", "krit-simulate-*")
 	if err != nil {
 		return nil, fmt.Errorf("snapshot: scratch dir: %w", err)
 	}
 	defer os.RemoveAll(scratch)
 
-	timestampBySHA := make(map[string]int64, len(commits))
-	shas := make([]string, len(commits))
-	for i, c := range commits {
+	timestampBySHA := make(map[string]int64, len(remaining))
+	shas := make([]string, len(remaining))
+	for i, c := range remaining {
 		shas[i] = c.SHA
 		timestampBySHA[c.SHA] = c.CommittedAt
 	}
 
-	starts := make(map[string]time.Time, len(commits))
-	findings := make(map[string]int, len(commits))
+	starts := make(map[string]time.Time, len(remaining))
+	findings := make(map[string]int, len(remaining))
 	var resultsMu sync.Mutex
 	var failed []string
 
@@ -149,17 +173,53 @@ func Simulate(opts SimulateOptions) (*SimulateResult, error) {
 		},
 	)
 
-	points := make([]SimulatePoint, 0, len(findings))
+	points := make([]SimulatePoint, 0, len(findings)+len(sidecarPoints))
 	for sha, count := range findings {
 		points = append(points, SimulatePoint{
 			CommitSHA:   sha,
 			CommittedAt: timestampBySHA[sha],
 			Findings:    count,
+			Source:      "scan",
 		})
 	}
+	points = append(points, sidecarPoints...)
 	sort.Slice(points, func(i, j int) bool { return points[i].CommittedAt > points[j].CommittedAt })
 	sort.Strings(failed)
 	return &SimulateResult{Rule: opts.Rule, Points: points, Failed: failed}, nil
+}
+
+// collectSidecarPoints opens each commit's findings sidecar (if any)
+// and reads opts.Rule's count. Commits without a sidecar — or with one
+// missing the rule's RuleSetHash — fall through unmodified so the
+// caller can shell out for them.
+//
+// snapshotsRoot is .krit/snapshots under repoRoot; we recompute it
+// locally because the caller has only the absolute repo path.
+func collectSidecarPoints(repoRoot, rule string, commits []commitMeta, reporter func(SimulateEvent)) ([]SimulatePoint, []commitMeta) {
+	root := SnapshotsDir(repoRoot)
+	if _, err := os.Stat(root); err != nil {
+		return nil, commits
+	}
+	points := make([]SimulatePoint, 0)
+	remaining := make([]commitMeta, 0, len(commits))
+	for _, c := range commits {
+		f, err := LoadFindings(root, c.SHA)
+		if err != nil || f == nil {
+			remaining = append(remaining, c)
+			continue
+		}
+		count := f.ByRule[rule]
+		points = append(points, SimulatePoint{
+			CommitSHA:   c.SHA,
+			CommittedAt: c.CommittedAt,
+			Findings:    count,
+			Source:      "sidecar",
+		})
+		if reporter != nil {
+			reporter(SimulateEvent{Kind: "scored", CommitSHA: c.SHA, Findings: count})
+		}
+	}
+	return points, remaining
 }
 
 // runKritForRule invokes krit -f json -enable-rules <rule> against

--- a/internal/snapshot/simulate_sidecar_test.go
+++ b/internal/snapshot/simulate_sidecar_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -61,7 +62,7 @@ func TestSimulateUsesSidecarFastPath(t *testing.T) {
 		t.Fatalf("expected %d points, got %d", len(shas), len(res.Points))
 	}
 	for _, p := range res.Points {
-		if p.Source != "sidecar" {
+		if p.Source != SimulateSourceSidecar {
 			t.Fatalf("expected source=sidecar, got %q for %s", p.Source, p.CommitSHA)
 		}
 		if p.Findings == 0 {
@@ -110,7 +111,7 @@ func TestSimulateNoSidecarHonored(t *testing.T) {
 		t.Fatalf("Simulate: %v", err)
 	}
 	for _, p := range res.Points {
-		if p.Source == "sidecar" {
+		if p.Source == SimulateSourceSidecar {
 			t.Fatalf("expected NoSidecar to bypass sidecar, got %+v", p)
 		}
 		if p.Findings == 999 {
@@ -128,22 +129,5 @@ func listAllSHAs(t *testing.T, repo string) []string {
 	if err != nil {
 		t.Fatalf("git log: %v", err)
 	}
-	return splitNonEmptyLines(string(out))
-}
-
-func splitNonEmptyLines(s string) []string {
-	var out []string
-	start := 0
-	for i := 0; i < len(s); i++ {
-		if s[i] == '\n' {
-			if i > start {
-				out = append(out, s[start:i])
-			}
-			start = i + 1
-		}
-	}
-	if start < len(s) {
-		out = append(out, s[start:])
-	}
-	return out
+	return strings.Fields(string(out))
 }

--- a/internal/snapshot/simulate_sidecar_test.go
+++ b/internal/snapshot/simulate_sidecar_test.go
@@ -1,0 +1,149 @@
+package snapshot
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// TestSimulateUsesSidecarFastPath confirms that when every walked commit
+// has a persisted findings sidecar, Simulate returns from the in-process
+// Timeline read and never has to spin up a worktree. We assert that by
+// supplying a bogus KritBin path — if the shell-out fallback fired, it
+// would error.
+func TestSimulateUsesSidecarFastPath(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	repo := initSimulateRepo(t)
+
+	// Persist sidecars for every commit in history so the sidecar fast
+	// path covers the full walk.
+	shas := listAllSHAs(t, repo)
+	if len(shas) < 3 {
+		t.Fatalf("expected 3 commits in fixture repo, got %d", len(shas))
+	}
+	root := SnapshotsDir(repo)
+	for i, sha := range shas {
+		blob := &Blob{SchemaVersion: SchemaVersion, CommitSHA: sha, CapturedAt: int64(i + 1)}
+		if _, err := Save(root, blob); err != nil {
+			t.Fatalf("save blob: %v", err)
+		}
+		f := &Findings{
+			SchemaVersion: FindingsSchemaVersion,
+			CommitSHA:     sha,
+			RuleSetHash:   "test-ruleset",
+			ByRule:        map[string]int{"MagicNumber": (i + 1) * 5},
+		}
+		if _, err := SaveFindings(root, f); err != nil {
+			t.Fatalf("save findings: %v", err)
+		}
+	}
+
+	res, err := Simulate(SimulateOptions{
+		RepoRoot: repo,
+		Rule:     "MagicNumber",
+		Workers:  2,
+		// Intentionally invalid: the shell-out path would fail to invoke
+		// this, surfacing as a non-empty Failed list. A clean run proves
+		// the sidecar fast path covered every commit.
+		KritBin: filepath.Join(repo, "does-not-exist"),
+	})
+	if err != nil {
+		t.Fatalf("Simulate: %v", err)
+	}
+	if len(res.Failed) != 0 {
+		t.Fatalf("expected no failed commits with sidecar fast path, got %v", res.Failed)
+	}
+	if len(res.Points) != len(shas) {
+		t.Fatalf("expected %d points, got %d", len(shas), len(res.Points))
+	}
+	for _, p := range res.Points {
+		if p.Source != "sidecar" {
+			t.Fatalf("expected source=sidecar, got %q for %s", p.Source, p.CommitSHA)
+		}
+		if p.Findings == 0 {
+			t.Fatalf("expected nonzero findings count for %s", p.CommitSHA)
+		}
+	}
+	// Newest-first ordering still holds.
+	for i := 1; i < len(res.Points); i++ {
+		if res.Points[i-1].CommittedAt < res.Points[i].CommittedAt {
+			t.Fatalf("points not sorted newest-first: %+v", res.Points)
+		}
+	}
+}
+
+// TestSimulateNoSidecarHonored ensures the NoSidecar opt-out bypasses
+// persisted findings even when they exist on disk. Useful for callers
+// that want to validate the shell-out path keeps working.
+func TestSimulateNoSidecarHonored(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	repo := initSimulateRepo(t)
+	shas := listAllSHAs(t, repo)
+	root := SnapshotsDir(repo)
+	for _, sha := range shas {
+		f := &Findings{
+			SchemaVersion: FindingsSchemaVersion,
+			CommitSHA:     sha,
+			RuleSetHash:   "test-ruleset",
+			ByRule:        map[string]int{"MagicNumber": 999},
+		}
+		if _, err := SaveFindings(root, f); err != nil {
+			t.Fatalf("save findings: %v", err)
+		}
+	}
+
+	kritBin := buildKritForTest(t)
+	res, err := Simulate(SimulateOptions{
+		RepoRoot:  repo,
+		Rule:      "MagicNumber",
+		Workers:   2,
+		KritBin:   kritBin,
+		NoSidecar: true,
+	})
+	if err != nil {
+		t.Fatalf("Simulate: %v", err)
+	}
+	for _, p := range res.Points {
+		if p.Source == "sidecar" {
+			t.Fatalf("expected NoSidecar to bypass sidecar, got %+v", p)
+		}
+		if p.Findings == 999 {
+			t.Fatalf("got stub-sidecar count 999 despite NoSidecar: %+v", p)
+		}
+	}
+}
+
+func listAllSHAs(t *testing.T, repo string) []string {
+	t.Helper()
+	cmd := exec.CommandContext(context.Background(), "git", "log", "--format=%H")
+	cmd.Dir = repo
+	cmd.Stderr = os.Stderr
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("git log: %v", err)
+	}
+	return splitNonEmptyLines(string(out))
+}
+
+func splitNonEmptyLines(s string) []string {
+	var out []string
+	start := 0
+	for i := 0; i < len(s); i++ {
+		if s[i] == '\n' {
+			if i > start {
+				out = append(out, s[start:i])
+			}
+			start = i + 1
+		}
+	}
+	if start < len(s) {
+		out = append(out, s[start:])
+	}
+	return out
+}


### PR DESCRIPTION
## Summary
- Adds a `findings.gob.zst` sidecar written alongside the structural blob when `snapshot capture --with-findings` is set. Sidecar carries per-rule + per-rule-per-file counts plus the `RuleSetHash` used to produce them.
- `Simulate` now reads sidecars as a Timeline first and only shells out for commits without persisted findings — turning `simulate` on fully-captured history from seconds-per-commit into milliseconds.
- `Diff` surfaces a `findings_by_rule` delta when both snapshots share a `RuleSetHash`, and flags `findings_rule_set_mismatch` when they differ so callers don't compare incomparable counts.

Closes #72.

## Test plan
- [x] `go test ./internal/snapshot/ -count=1`
- [x] `go test ./... -count=1`
- [x] `go vet ./...`
- [x] `golangci-lint run ./internal/snapshot/... ./internal/cli/snapshot/...`
- [x] Unit tests cover Save/Load round-trip, Diff with shared and mismatched RuleSetHash, and Simulate sidecar fast-path (with a bogus `KritBin` to prove no shell-out happens) plus `NoSidecar` opt-out.