### PR TITLE
perf(daemon): stream analyze-project response (#60)

### DIFF
--- a/internal/cli/serve/analyze_project.go
+++ b/internal/cli/serve/analyze_project.go
@@ -35,7 +35,7 @@ var errDaemonNotWarm = errors.New("daemon not warm yet")
 // and the dispatcher — a verified DATA RACE under -race. Loosening
 // the lock requires making the rules config state per-call or
 // initialising it once at daemon startup. See issue #53.
-func handleAnalyzeProject(ctx context.Context, state *daemonState, raw json.RawMessage) (any, error) {
+func handleAnalyzeProject(_ context.Context, state *daemonState, raw json.RawMessage) (any, error) {
 	var args daemon.AnalyzeProjectArgs
 	if len(raw) > 0 {
 		if err := json.Unmarshal(raw, &args); err != nil {

--- a/internal/cli/serve/analyze_project.go
+++ b/internal/cli/serve/analyze_project.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"time"
 
@@ -62,30 +63,175 @@ func handleAnalyzeProject(ctx context.Context, state *daemonState, raw json.RawM
 		return nil, err
 	}
 
-	out, err := pipeline.RunProject(ctx, in)
-	state.analyzeMu.Unlock()
-	if err != nil {
-		return nil, err
-	}
-	state.coldDone.Store(true)
-	xfile := state.workspace.CrossFileStats()
-
-	return daemon.AnalyzeProjectResult{
-		Findings: out.JSON,
-		Stats: daemon.AnalyzeProjectStats{
-			FilesScanned:    out.FilesScanned,
-			FindingsCount:   out.FindingsCount,
-			WallSeconds:     time.Since(start).Seconds(),
-			CodeIndexHit:    xfile.HasCodeIndex,
-			LibraryFactsHit: xfile.HasLibraryFacts,
-			ResolverHit:     xfile.HasResolver,
-			OracleFilterHit: xfile.HasOracleFilter,
-			DirtyFiles:      len(dirty),
-			Cold:            cold,
-			ParseHits:       out.ParseHits,
-			ParseMisses:     out.ParseMisses,
-		},
+	// Defer pipeline execution into the streaming response writer so
+	// the OutputPhase JSON streams directly into the connection
+	// instead of being buffered in memory (#60). The lock is held for
+	// the duration of the run and released by WriteRawResponse.
+	return &streamingAnalyzeResponse{
+		ctx:     ctx,
+		state:   state,
+		in:      in,
+		start:   start,
+		cold:    cold,
+		dirtyN:  len(dirty),
+		release: state.analyzeMu.Unlock,
 	}, nil
+}
+
+// streamingAnalyzeResponse implements daemon.RawResponseWriter. It runs
+// pipeline.RunProjectStreaming with the connection writer bracketed by
+// the daemon Response envelope head/tail so the multi-megabyte findings
+// JSON never has to be staged in a heap buffer.
+//
+// Lock discipline: handleAnalyzeProject acquires state.analyzeMu and
+// hands ownership to this carrier; release runs in WriteRawResponse so
+// the lock spans the whole pipeline run, matching the prior behavior.
+type streamingAnalyzeResponse struct {
+	ctx     context.Context
+	state   *daemonState
+	in      pipeline.ProjectInput
+	start   time.Time
+	cold    bool
+	dirtyN  int
+	release func()
+}
+
+// Compile-time assertion: streamingAnalyzeResponse must satisfy the
+// daemon's RawResponseWriter interface so dispatch routes it through
+// the streaming path instead of the default json.Marshal envelope.
+var _ daemon.RawResponseWriter = (*streamingAnalyzeResponse)(nil)
+
+// WriteRawResponse writes a complete daemon Response line into w. On
+// pipeline error it falls back to writing a normal {"ok":false,...}
+// envelope; on write error after the head has flushed the connection
+// is left in a partially written state and the caller closes it.
+func (r *streamingAnalyzeResponse) WriteRawResponse(w io.Writer) error {
+	defer r.release()
+
+	// Head-flush is reversible: nothing has been written yet, so a
+	// pipeline error here translates cleanly to an error envelope.
+	// Run the pipeline into an envelope-aware writer that emits the
+	// success head on the first byte and strips the OutputPhase's
+	// trailing newline (the wire response is line-delimited so the
+	// final \n must come from us, not from json.Encoder).
+	hw := &analyzeRespWriter{out: w, head: []byte(`{"ok":true,"data":{"findings":`)}
+	res, err := pipeline.RunProjectStreaming(r.ctx, r.in, hw)
+	if err != nil {
+		if !hw.headWritten {
+			return writeJSONLine(w, errorResponseLine(err.Error()))
+		}
+		// Head already flushed; can't roll back. Surface the error
+		// to the connection writer; the client will see a truncated
+		// response and surface it as a decode error.
+		return err
+	}
+	r.state.coldDone.Store(true)
+	xfile := r.state.workspace.CrossFileStats()
+
+	stats := daemon.AnalyzeProjectStats{
+		FilesScanned:    res.FilesScanned,
+		FindingsCount:   res.FindingsCount,
+		WallSeconds:     time.Since(r.start).Seconds(),
+		CodeIndexHit:    xfile.HasCodeIndex,
+		LibraryFactsHit: xfile.HasLibraryFacts,
+		ResolverHit:     xfile.HasResolver,
+		OracleFilterHit: xfile.HasOracleFilter,
+		DirtyFiles:      r.dirtyN,
+		Cold:            r.cold,
+		ParseHits:       res.ParseHits,
+		ParseMisses:     res.ParseMisses,
+	}
+	statsBytes, err := json.Marshal(stats)
+	if err != nil {
+		// Stats marshaling cannot realistically fail; if it does the
+		// envelope is already partially written, so close.
+		return fmt.Errorf("marshal stats: %w", err)
+	}
+	if _, err := w.Write([]byte(`,"stats":`)); err != nil {
+		return err
+	}
+	if _, err := w.Write(statsBytes); err != nil {
+		return err
+	}
+	_, err = w.Write([]byte("}}\n"))
+	return err
+}
+
+// analyzeRespWriter is the streaming envelope writer for the
+// analyze-project verb. It serves two purposes:
+//
+//  1. Defer the success-envelope head until the first byte of
+//     OutputPhase output is observed, so a pre-output error in
+//     RunProjectStreaming can still produce a clean error envelope
+//     before any wire bytes commit.
+//  2. Strip a trailing '\n' from the streamed bytes. json.Encoder
+//     terminates each value with a newline, but the daemon wire
+//     protocol is line-delimited; an embedded newline mid-response
+//     would let the client's bufio.Reader.ReadBytes('\n') return a
+//     truncated payload. The stripped newline is reintroduced by
+//     the tail writer (the closing "}}\n" of the envelope).
+//
+// The held newline is implemented as a one-byte look-behind: when a
+// chunk ends in '\n' the byte is held back; the next Write flushes
+// it before processing new bytes. Internal newlines (mid-chunk, or
+// when a non-trailing chunk ends in '\n') are forwarded normally.
+// The very last held newline is silently dropped because no further
+// pipeline write follows.
+type analyzeRespWriter struct {
+	out         io.Writer
+	head        []byte
+	headWritten bool
+	heldNewline bool
+}
+
+func (w *analyzeRespWriter) Write(p []byte) (int, error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+	if !w.headWritten {
+		if _, err := w.out.Write(w.head); err != nil {
+			return 0, err
+		}
+		w.headWritten = true
+	}
+	n := len(p)
+	if w.heldNewline {
+		if _, err := w.out.Write([]byte{'\n'}); err != nil {
+			return 0, err
+		}
+		w.heldNewline = false
+	}
+	if p[len(p)-1] == '\n' {
+		if len(p) > 1 {
+			if _, err := w.out.Write(p[:len(p)-1]); err != nil {
+				return 0, err
+			}
+		}
+		w.heldNewline = true
+		return n, nil
+	}
+	if _, err := w.out.Write(p); err != nil {
+		return 0, err
+	}
+	return n, nil
+}
+
+// writeJSONLine marshals v and writes it as a single newline-terminated
+// JSON object — the wire format the daemon's writeResponse uses.
+// Mirrored here so the streaming carrier can emit error envelopes
+// without exposing internal helpers from package daemon.
+func writeJSONLine(w io.Writer, v any) error {
+	buf, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+	buf = append(buf, '\n')
+	_, err = w.Write(buf)
+	return err
+}
+
+func errorResponseLine(msg string) daemon.Response {
+	return daemon.Response{OK: false, Error: msg}
 }
 
 // buildProjectInput translates wire args into a pipeline.ProjectInput
@@ -158,6 +304,11 @@ func (s *daemonState) buildProjectInput(args daemon.AnalyzeProjectArgs) (pipelin
 			IncludeGenerated: args.IncludeGenerated,
 			Version:          kritVersion(),
 			OracleEnabled:    oracleDaemon != nil,
+			// Daemon wire protocol is line-delimited JSON; the
+			// streaming response writer (#60) panics on the first
+			// internal newline. Compact JSON keeps the payload
+			// single-line so ReadBytes('\n') gets the full body.
+			JSONCompact: true,
 		},
 		Host: pipeline.ProjectHostState{
 			ParseCache:              parseCache,

--- a/internal/cli/serve/analyze_project.go
+++ b/internal/cli/serve/analyze_project.go
@@ -63,72 +63,48 @@ func handleAnalyzeProject(ctx context.Context, state *daemonState, raw json.RawM
 		return nil, err
 	}
 
-	// Defer pipeline execution into the streaming response writer so
-	// the OutputPhase JSON streams directly into the connection
-	// instead of being buffered in memory (#60). The lock is held for
-	// the duration of the run and released by WriteRawResponse.
+	// Defer pipeline execution into WriteRawResponse so the
+	// OutputPhase JSON streams directly into the connection instead
+	// of being buffered in memory (#60). The lock is held for the
+	// duration of the run.
 	return &streamingAnalyzeResponse{
-		ctx:     ctx,
-		state:   state,
-		in:      in,
-		start:   start,
-		cold:    cold,
-		dirtyN:  len(dirty),
-		release: state.analyzeMu.Unlock,
+		state:       state,
+		in:          in,
+		start:       start,
+		cold:        cold,
+		dirtyN:      len(dirty),
+		releaseLock: state.analyzeMu.Unlock,
 	}, nil
 }
 
-// streamingAnalyzeResponse implements daemon.RawResponseWriter. It runs
-// pipeline.RunProjectStreaming with the connection writer bracketed by
-// the daemon Response envelope head/tail so the multi-megabyte findings
-// JSON never has to be staged in a heap buffer.
-//
-// Lock discipline: handleAnalyzeProject acquires state.analyzeMu and
-// hands ownership to this carrier; release runs in WriteRawResponse so
-// the lock spans the whole pipeline run, matching the prior behavior.
 type streamingAnalyzeResponse struct {
-	ctx     context.Context
-	state   *daemonState
-	in      pipeline.ProjectInput
-	start   time.Time
-	cold    bool
-	dirtyN  int
-	release func()
+	state       *daemonState
+	in          pipeline.ProjectInput
+	start       time.Time
+	cold        bool
+	dirtyN      int
+	releaseLock func()
 }
 
-// Compile-time assertion: streamingAnalyzeResponse must satisfy the
-// daemon's RawResponseWriter interface so dispatch routes it through
-// the streaming path instead of the default json.Marshal envelope.
 var _ daemon.RawResponseWriter = (*streamingAnalyzeResponse)(nil)
 
-// WriteRawResponse writes a complete daemon Response line into w. On
-// pipeline error it falls back to writing a normal {"ok":false,...}
-// envelope; on write error after the head has flushed the connection
-// is left in a partially written state and the caller closes it.
-func (r *streamingAnalyzeResponse) WriteRawResponse(w io.Writer) error {
-	defer r.release()
+func (r *streamingAnalyzeResponse) WriteRawResponse(ctx context.Context, w io.Writer) error {
+	defer r.releaseLock()
 
-	// Head-flush is reversible: nothing has been written yet, so a
-	// pipeline error here translates cleanly to an error envelope.
-	// Run the pipeline into an envelope-aware writer that emits the
-	// success head on the first byte and strips the OutputPhase's
-	// trailing newline (the wire response is line-delimited so the
-	// final \n must come from us, not from json.Encoder).
 	hw := &analyzeRespWriter{out: w, head: []byte(`{"ok":true,"data":{"findings":`)}
-	res, err := pipeline.RunProjectStreaming(r.ctx, r.in, hw)
+	res, err := pipeline.RunProjectStreaming(ctx, r.in, hw)
 	if err != nil {
 		if !hw.headWritten {
-			return writeJSONLine(w, errorResponseLine(err.Error()))
+			return daemon.WriteErrorResponseLine(w, err.Error())
 		}
-		// Head already flushed; can't roll back. Surface the error
-		// to the connection writer; the client will see a truncated
-		// response and surface it as a decode error.
+		// Head already flushed; the connection is borked and the
+		// caller will close it after seeing the error.
 		return err
 	}
 	r.state.coldDone.Store(true)
 	xfile := r.state.workspace.CrossFileStats()
 
-	stats := daemon.AnalyzeProjectStats{
+	statsBytes, err := json.Marshal(daemon.AnalyzeProjectStats{
 		FilesScanned:    res.FilesScanned,
 		FindingsCount:   res.FindingsCount,
 		WallSeconds:     time.Since(r.start).Seconds(),
@@ -140,11 +116,8 @@ func (r *streamingAnalyzeResponse) WriteRawResponse(w io.Writer) error {
 		Cold:            r.cold,
 		ParseHits:       res.ParseHits,
 		ParseMisses:     res.ParseMisses,
-	}
-	statsBytes, err := json.Marshal(stats)
+	})
 	if err != nil {
-		// Stats marshaling cannot realistically fail; if it does the
-		// envelope is already partially written, so close.
 		return fmt.Errorf("marshal stats: %w", err)
 	}
 	if _, err := w.Write([]byte(`,"stats":`)); err != nil {
@@ -153,30 +126,27 @@ func (r *streamingAnalyzeResponse) WriteRawResponse(w io.Writer) error {
 	if _, err := w.Write(statsBytes); err != nil {
 		return err
 	}
-	_, err = w.Write([]byte("}}\n"))
+	_, err = w.Write(envelopeTail)
 	return err
 }
 
-// analyzeRespWriter is the streaming envelope writer for the
-// analyze-project verb. It serves two purposes:
-//
-//  1. Defer the success-envelope head until the first byte of
-//     OutputPhase output is observed, so a pre-output error in
-//     RunProjectStreaming can still produce a clean error envelope
-//     before any wire bytes commit.
-//  2. Strip a trailing '\n' from the streamed bytes. json.Encoder
-//     terminates each value with a newline, but the daemon wire
-//     protocol is line-delimited; an embedded newline mid-response
-//     would let the client's bufio.Reader.ReadBytes('\n') return a
-//     truncated payload. The stripped newline is reintroduced by
-//     the tail writer (the closing "}}\n" of the envelope).
-//
-// The held newline is implemented as a one-byte look-behind: when a
-// chunk ends in '\n' the byte is held back; the next Write flushes
-// it before processing new bytes. Internal newlines (mid-chunk, or
-// when a non-trailing chunk ends in '\n') are forwarded normally.
-// The very last held newline is silently dropped because no further
-// pipeline write follows.
+// envelopeTail closes the streaming response: end-of-stats, end-of-data,
+// end-of-envelope, line-delimited newline.
+var envelopeTail = []byte("}}\n")
+
+// newlineSlice is referenced from analyzeRespWriter when reissuing a
+// held trailing newline so each held-flush doesn't allocate a 1-byte
+// slice.
+var newlineSlice = []byte{'\n'}
+
+// analyzeRespWriter wraps the underlying writer with two transforms:
+// it lazily emits an envelope head on the first non-empty Write (so a
+// pre-output pipeline error can still produce a clean error envelope),
+// and it strips the trailing '\n' that json.Encoder appends to its
+// value (the daemon wire is line-delimited; an internal '\n' would let
+// the client's bufio.Reader.ReadBytes('\n') return a truncated body).
+// Held newlines are reissued before the next chunk so internal '\n'
+// bytes survive — only the final one is silently dropped.
 type analyzeRespWriter struct {
 	out         io.Writer
 	head        []byte
@@ -194,44 +164,24 @@ func (w *analyzeRespWriter) Write(p []byte) (int, error) {
 		}
 		w.headWritten = true
 	}
-	n := len(p)
 	if w.heldNewline {
-		if _, err := w.out.Write([]byte{'\n'}); err != nil {
+		if _, err := w.out.Write(newlineSlice); err != nil {
 			return 0, err
 		}
 		w.heldNewline = false
 	}
-	if p[len(p)-1] == '\n' {
-		if len(p) > 1 {
-			if _, err := w.out.Write(p[:len(p)-1]); err != nil {
-				return 0, err
-			}
-		}
+	n := len(p)
+	if p[n-1] == '\n' {
 		w.heldNewline = true
-		return n, nil
+		p = p[:n-1]
+		if len(p) == 0 {
+			return n, nil
+		}
 	}
 	if _, err := w.out.Write(p); err != nil {
 		return 0, err
 	}
 	return n, nil
-}
-
-// writeJSONLine marshals v and writes it as a single newline-terminated
-// JSON object — the wire format the daemon's writeResponse uses.
-// Mirrored here so the streaming carrier can emit error envelopes
-// without exposing internal helpers from package daemon.
-func writeJSONLine(w io.Writer, v any) error {
-	buf, err := json.Marshal(v)
-	if err != nil {
-		return err
-	}
-	buf = append(buf, '\n')
-	_, err = w.Write(buf)
-	return err
-}
-
-func errorResponseLine(msg string) daemon.Response {
-	return daemon.Response{OK: false, Error: msg}
 }
 
 // buildProjectInput translates wire args into a pipeline.ProjectInput
@@ -304,10 +254,8 @@ func (s *daemonState) buildProjectInput(args daemon.AnalyzeProjectArgs) (pipelin
 			IncludeGenerated: args.IncludeGenerated,
 			Version:          kritVersion(),
 			OracleEnabled:    oracleDaemon != nil,
-			// Daemon wire protocol is line-delimited JSON; the
-			// streaming response writer (#60) panics on the first
-			// internal newline. Compact JSON keeps the payload
-			// single-line so ReadBytes('\n') gets the full body.
+			// Wire is line-delimited; compact JSON keeps the body
+			// free of internal newlines.
 			JSONCompact: true,
 		},
 		Host: pipeline.ProjectHostState{

--- a/internal/cli/serve/analyze_resp_writer_test.go
+++ b/internal/cli/serve/analyze_resp_writer_test.go
@@ -1,0 +1,94 @@
+package serve
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+)
+
+// TestAnalyzeRespWriter_HeadDeferredUntilFirstByte covers the
+// envelope-head-flush invariant: nothing reaches the underlying
+// writer until the first non-empty payload arrives. Empty Writes are
+// no-ops so a pre-OutputPhase pipeline error can still rewrite the
+// envelope as {"ok":false,...}.
+func TestAnalyzeRespWriter_HeadDeferredUntilFirstByte(t *testing.T) {
+	var out bytes.Buffer
+	w := &analyzeRespWriter{out: &out, head: []byte("HEAD:")}
+
+	if _, err := w.Write(nil); err != nil {
+		t.Fatalf("empty Write err: %v", err)
+	}
+	if out.Len() != 0 {
+		t.Errorf("empty Write should not flush head; got %q", out.String())
+	}
+	if w.headWritten {
+		t.Error("headWritten should remain false on empty Write")
+	}
+
+	if _, err := w.Write([]byte("body")); err != nil {
+		t.Fatalf("Write body: %v", err)
+	}
+	if got := out.String(); got != "HEAD:body" {
+		t.Errorf("first non-empty Write should flush head + body; got %q", got)
+	}
+	if !w.headWritten {
+		t.Error("headWritten should be true after first non-empty Write")
+	}
+}
+
+// TestAnalyzeRespWriter_StripsTrailingNewline is the load-bearing
+// case: json.Encoder appends a trailing '\n' to its value, but the
+// daemon wire protocol is line-delimited so an internal '\n' would
+// truncate the response on the client side. The writer must hold
+// the trailing newline back and silently drop it when the stream
+// ends.
+func TestAnalyzeRespWriter_StripsTrailingNewline(t *testing.T) {
+	var out bytes.Buffer
+	w := &analyzeRespWriter{out: &out, head: []byte("HEAD:")}
+
+	if _, err := w.Write([]byte("payload\n")); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if got := out.String(); got != "HEAD:payload" {
+		t.Errorf("trailing newline should be stripped; got %q", got)
+	}
+	if !w.heldNewline {
+		t.Error("heldNewline should be true after trailing-\\n payload")
+	}
+}
+
+// TestAnalyzeRespWriter_FlushesHeldNewlineBetweenChunks confirms a
+// held newline is reissued before subsequent bytes when the stream
+// continues. Only the *final* held newline is dropped — internal
+// newlines (mid-stream) survive.
+func TestAnalyzeRespWriter_FlushesHeldNewlineBetweenChunks(t *testing.T) {
+	var out bytes.Buffer
+	w := &analyzeRespWriter{out: &out, head: []byte("HEAD:")}
+
+	if _, err := w.Write([]byte("a\n")); err != nil {
+		t.Fatalf("Write 1: %v", err)
+	}
+	if _, err := w.Write([]byte("b")); err != nil {
+		t.Fatalf("Write 2: %v", err)
+	}
+	if got := out.String(); got != "HEAD:a\nb" {
+		t.Errorf("internal newline should be flushed before next chunk; got %q", got)
+	}
+}
+
+// TestAnalyzeRespWriter_PropagatesWriteError surfaces underlying
+// writer errors so dispatchAndWrite can close a broken connection
+// instead of silently dropping bytes.
+func TestAnalyzeRespWriter_PropagatesWriteError(t *testing.T) {
+	sentinel := errors.New("boom")
+	w := &analyzeRespWriter{out: errWriter{err: sentinel}, head: []byte("HEAD:")}
+
+	_, err := w.Write([]byte("body"))
+	if !errors.Is(err, sentinel) {
+		t.Errorf("expected sentinel error; got %v", err)
+	}
+}
+
+type errWriter struct{ err error }
+
+func (e errWriter) Write(_ []byte) (int, error) { return 0, e.err }

--- a/internal/daemon/raw_response_test.go
+++ b/internal/daemon/raw_response_test.go
@@ -16,7 +16,7 @@ type rawResponseFake struct {
 	called  *bool
 }
 
-func (r *rawResponseFake) WriteRawResponse(w io.Writer) error {
+func (r *rawResponseFake) WriteRawResponse(_ context.Context, w io.Writer) error {
 	if r.called != nil {
 		*r.called = true
 	}

--- a/internal/daemon/raw_response_test.go
+++ b/internal/daemon/raw_response_test.go
@@ -1,0 +1,88 @@
+package daemon
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"testing"
+)
+
+// rawResponseFake is a test handler result that satisfies the
+// RawResponseWriter interface. It writes a fixed payload so the test
+// can assert dispatchAndWrite chose the streaming path instead of the
+// default json.Marshal envelope.
+type rawResponseFake struct {
+	payload []byte
+	called  *bool
+}
+
+func (r *rawResponseFake) WriteRawResponse(w io.Writer) error {
+	if r.called != nil {
+		*r.called = true
+	}
+	_, err := w.Write(r.payload)
+	return err
+}
+
+// TestRawResponseWriter_StreamingPathBypassesEnvelope verifies that a
+// handler returning a value implementing RawResponseWriter has its
+// WriteRawResponse method invoked verbatim — dispatch must NOT wrap
+// the result in the standard `{"ok":true,"data":...}` envelope. This
+// is the seam the analyze-project verb uses to stream its findings
+// JSON directly into the connection (#60).
+func TestRawResponseWriter_StreamingPathBypassesEnvelope(t *testing.T) {
+	srv := NewServer("")
+	called := false
+	srv.Register("stream", func(_ context.Context, _ json.RawMessage) (any, error) {
+		return &rawResponseFake{
+			payload: []byte(`{"ok":true,"data":{"hello":"world"}}` + "\n"),
+			called:  &called,
+		}, nil
+	})
+
+	pr, pw := io.Pipe()
+	go func() {
+		_ = srv.dispatchAndWrite(context.Background(),
+			Request{Verb: "stream"}, pw)
+		_ = pw.Close()
+	}()
+
+	got, err := io.ReadAll(pr)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if !called {
+		t.Fatal("WriteRawResponse should have been invoked")
+	}
+	want := `{"ok":true,"data":{"hello":"world"}}` + "\n"
+	if string(got) != want {
+		t.Errorf("dispatchAndWrite output:\n got %q\nwant %q", got, want)
+	}
+}
+
+// TestRawResponseWriter_FallbackEnvelopeForRegularResult is the
+// counterpart contract: a handler returning a plain value (no
+// RawResponseWriter) still goes through the json.Marshal + envelope
+// path so existing verbs keep their wire shape.
+func TestRawResponseWriter_FallbackEnvelopeForRegularResult(t *testing.T) {
+	srv := NewServer("")
+	srv.Register("echo", func(_ context.Context, _ json.RawMessage) (any, error) {
+		return map[string]string{"k": "v"}, nil
+	})
+
+	pr, pw := io.Pipe()
+	go func() {
+		_ = srv.dispatchAndWrite(context.Background(),
+			Request{Verb: "echo"}, pw)
+		_ = pw.Close()
+	}()
+
+	got, err := io.ReadAll(pr)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	want := `{"ok":true,"data":{"k":"v"}}` + "\n"
+	if string(got) != want {
+		t.Errorf("dispatchAndWrite output:\n got %q\nwant %q", got, want)
+	}
+}

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -20,7 +20,26 @@ import (
 // Handler runs a single verb. It receives the raw JSON args and returns a
 // JSON-marshalable result or an error. Handlers may be invoked concurrently;
 // the verb implementation is responsible for any internal locking.
+//
+// A handler may return a value that implements RawResponseWriter to skip
+// the default json.Marshal envelope and stream the response directly into
+// the connection. This is the streaming path issue #60 added so the
+// analyze-project verb avoids buffering the multi-megabyte findings JSON
+// in memory.
 type Handler func(ctx context.Context, args json.RawMessage) (any, error)
+
+// RawResponseWriter is the optional interface a Handler result can
+// implement to bypass the json.Marshal + Response envelope path. When
+// present the dispatch loop hands the connection writer directly to
+// WriteRawResponse; the implementation is responsible for writing a
+// complete `{"ok":true,"data":...}\n` line (or its error variant).
+//
+// Used by analyze-project to stream the OutputPhase JSON directly into
+// the socket, avoiding the ~27 MB allocation that the prior buffer +
+// double-marshal path paid per call on the JetBrains/kotlin corpus.
+type RawResponseWriter interface {
+	WriteRawResponse(w io.Writer) error
+}
 
 // Server is a long-lived process that accepts daemon Requests on a Unix
 // socket and dispatches each to a registered Handler.
@@ -210,8 +229,7 @@ func (s *Server) serveConn(ctx context.Context, conn net.Conn) {
 			writeResponse(conn, errorResponse("invalid request: "+err.Error()))
 			continue
 		}
-		resp := s.dispatch(ctx, req)
-		if !writeResponse(conn, resp) {
+		if !s.dispatchAndWrite(ctx, req, conn) {
 			return
 		}
 		if req.Verb == VerbShutdown {
@@ -230,23 +248,34 @@ func (s *Server) serveConn(ctx context.Context, conn net.Conn) {
 	}
 }
 
-func (s *Server) dispatch(ctx context.Context, req Request) Response {
+// dispatchAndWrite resolves the verb and writes the response directly
+// into w. Returns false when the connection should be closed (write
+// error). When the handler result implements RawResponseWriter the
+// streaming path is taken; otherwise the standard json.Marshal +
+// Response envelope is written via writeResponse.
+func (s *Server) dispatchAndWrite(ctx context.Context, req Request, w io.Writer) bool {
 	s.lastActivity.Store(time.Now().UnixNano())
 	s.mu.RLock()
 	h, ok := s.handlers[req.Verb]
 	s.mu.RUnlock()
 	if !ok {
-		return errorResponse(fmt.Sprintf("unknown verb %q", req.Verb))
+		return writeResponse(w, errorResponse(fmt.Sprintf("unknown verb %q", req.Verb)))
 	}
 	result, err := h(ctx, req.Args)
 	if err != nil {
-		return errorResponse(err.Error())
+		return writeResponse(w, errorResponse(err.Error()))
+	}
+	if rw, ok := result.(RawResponseWriter); ok {
+		if err := rw.WriteRawResponse(w); err != nil {
+			return false
+		}
+		return true
 	}
 	data, err := json.Marshal(result)
 	if err != nil {
-		return errorResponse("marshal result: " + err.Error())
+		return writeResponse(w, errorResponse("marshal result: "+err.Error()))
 	}
-	return Response{OK: true, Data: data}
+	return writeResponse(w, Response{OK: true, Data: data})
 }
 
 func errorResponse(msg string) Response { return Response{OK: false, Error: msg} }

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -29,16 +29,13 @@ import (
 type Handler func(ctx context.Context, args json.RawMessage) (any, error)
 
 // RawResponseWriter is the optional interface a Handler result can
-// implement to bypass the json.Marshal + Response envelope path. When
-// present the dispatch loop hands the connection writer directly to
-// WriteRawResponse; the implementation is responsible for writing a
-// complete `{"ok":true,"data":...}\n` line (or its error variant).
-//
-// Used by analyze-project to stream the OutputPhase JSON directly into
-// the socket, avoiding the ~27 MB allocation that the prior buffer +
-// double-marshal path paid per call on the JetBrains/kotlin corpus.
+// implement to bypass the json.Marshal + Response envelope path. The
+// dispatch loop hands the request context plus connection writer; the
+// implementation must write a complete newline-terminated Response
+// envelope. WriteResponseLine is the canonical helper for the
+// fallback/error case.
 type RawResponseWriter interface {
-	WriteRawResponse(w io.Writer) error
+	WriteRawResponse(ctx context.Context, w io.Writer) error
 }
 
 // Server is a long-lived process that accepts daemon Requests on a Unix
@@ -215,21 +212,34 @@ func (s *Server) acceptLoop(ctx context.Context) {
 func (s *Server) serveConn(ctx context.Context, conn net.Conn) {
 	defer conn.Close()
 	reader := bufio.NewReader(conn)
+	// Wrap the write side too so dispatch handlers that issue many
+	// small Write calls (the streaming analyze-project path emits
+	// envelope head/body/tail in 3+ chunks) coalesce into one
+	// syscall per response.
+	writer := bufio.NewWriter(conn)
 	for {
 		line, err := reader.ReadBytes('\n')
 		if len(line) == 0 {
 			if err == nil || errors.Is(err, io.EOF) {
 				return
 			}
-			writeResponse(conn, errorResponse(err.Error()))
+			writeResponse(writer, errorResponse(err.Error()))
+			_ = writer.Flush()
 			return
 		}
 		var req Request
 		if err := json.Unmarshal(line, &req); err != nil {
-			writeResponse(conn, errorResponse("invalid request: "+err.Error()))
+			writeResponse(writer, errorResponse("invalid request: "+err.Error()))
+			if flushErr := writer.Flush(); flushErr != nil {
+				return
+			}
 			continue
 		}
-		if !s.dispatchAndWrite(ctx, req, conn) {
+		ok := s.dispatchAndWrite(ctx, req, writer)
+		if flushErr := writer.Flush(); flushErr != nil {
+			return
+		}
+		if !ok {
 			return
 		}
 		if req.Verb == VerbShutdown {
@@ -266,10 +276,7 @@ func (s *Server) dispatchAndWrite(ctx context.Context, req Request, w io.Writer)
 		return writeResponse(w, errorResponse(err.Error()))
 	}
 	if rw, ok := result.(RawResponseWriter); ok {
-		if err := rw.WriteRawResponse(w); err != nil {
-			return false
-		}
-		return true
+		return rw.WriteRawResponse(ctx, w) == nil
 	}
 	data, err := json.Marshal(result)
 	if err != nil {
@@ -279,6 +286,20 @@ func (s *Server) dispatchAndWrite(ctx context.Context, req Request, w io.Writer)
 }
 
 func errorResponse(msg string) Response { return Response{OK: false, Error: msg} }
+
+// WriteErrorResponseLine emits a `{"ok":false,"error":...}\n` line
+// using the daemon's wire format. Exported so RawResponseWriter
+// implementations can fall back to the standard error envelope
+// without re-implementing the line-delimited shape.
+func WriteErrorResponseLine(w io.Writer, msg string) error {
+	buf, err := json.Marshal(errorResponse(msg))
+	if err != nil {
+		return err
+	}
+	buf = append(buf, '\n')
+	_, err = w.Write(buf)
+	return err
+}
 
 func writeResponse(w io.Writer, resp Response) bool {
 	buf, err := json.Marshal(resp)

--- a/internal/output/json.go
+++ b/internal/output/json.go
@@ -56,7 +56,8 @@ type JSONSummary struct {
 	Fixable   int            `json:"fixable"`
 }
 
-// FormatJSONColumns writes columnar findings as JSON.
+// FormatJSONColumns writes columnar findings as JSON with two-space
+// indentation. CLI consumers see the indented form.
 func FormatJSONColumns(w io.Writer, columns *scanner.FindingColumns, version string,
 	fileCount, ruleCount int, start time.Time,
 	perfTimings []perf.TimingEntry, activeRules []*api.Rule,
@@ -64,6 +65,38 @@ func FormatJSONColumns(w io.Writer, columns *scanner.FindingColumns, version str
 	cacheStats *cache.Stats,
 	caches []cacheutil.NamedCacheStats,
 	cacheBudget *cacheutil.BudgetReport,
+	perfRuleStats ...[]rules.RuleExecutionStat) error {
+	return formatJSONColumnsImpl(w, columns, version, fileCount, ruleCount, start,
+		perfTimings, activeRules, experiments, cacheStats, caches, cacheBudget, true,
+		perfRuleStats...)
+}
+
+// FormatJSONColumnsCompact writes columnar findings as JSON with no
+// indentation or internal newlines. The daemon's streaming response
+// path uses this so the wire-level JSON sits cleanly inside the
+// line-delimited daemon protocol (a single embedded '\n' would let
+// the client's bufio.Reader.ReadBytes('\n') return a truncated body).
+func FormatJSONColumnsCompact(w io.Writer, columns *scanner.FindingColumns, version string,
+	fileCount, ruleCount int, start time.Time,
+	perfTimings []perf.TimingEntry, activeRules []*api.Rule,
+	experiments []string,
+	cacheStats *cache.Stats,
+	caches []cacheutil.NamedCacheStats,
+	cacheBudget *cacheutil.BudgetReport,
+	perfRuleStats ...[]rules.RuleExecutionStat) error {
+	return formatJSONColumnsImpl(w, columns, version, fileCount, ruleCount, start,
+		perfTimings, activeRules, experiments, cacheStats, caches, cacheBudget, false,
+		perfRuleStats...)
+}
+
+func formatJSONColumnsImpl(w io.Writer, columns *scanner.FindingColumns, version string,
+	fileCount, ruleCount int, start time.Time,
+	perfTimings []perf.TimingEntry, activeRules []*api.Rule,
+	experiments []string,
+	cacheStats *cache.Stats,
+	caches []cacheutil.NamedCacheStats,
+	cacheBudget *cacheutil.BudgetReport,
+	indent bool,
 	perfRuleStats ...[]rules.RuleExecutionStat) error {
 
 	cols := normalizedFindingColumns(columns)
@@ -125,7 +158,9 @@ func FormatJSONColumns(w io.Writer, columns *scanner.FindingColumns, version str
 	}
 
 	enc := json.NewEncoder(w)
-	enc.SetIndent("", "  ")
+	if indent {
+		enc.SetIndent("", "  ")
+	}
 	return enc.Encode(report)
 }
 

--- a/internal/pipeline/output.go
+++ b/internal/pipeline/output.go
@@ -77,7 +77,11 @@ func (OutputPhase) Run(_ context.Context, in OutputInput) (OutputResult, error) 
 
 	switch in.Format {
 	case "json":
-		if err := output.FormatJSONColumns(
+		jsonFormatter := output.FormatJSONColumns
+		if in.JSONCompact {
+			jsonFormatter = output.FormatJSONColumnsCompact
+		}
+		if err := jsonFormatter(
 			in.Writer,
 			columns,
 			in.Version,

--- a/internal/pipeline/project.go
+++ b/internal/pipeline/project.go
@@ -251,32 +251,12 @@ func RunProject(ctx context.Context, in ProjectInput) (ProjectResult, error) {
 // streaming it lets the daemon write directly into the response socket
 // without allocating an intermediate copy per call.
 func RunProjectStreaming(ctx context.Context, in ProjectInput, out io.Writer) (ProjectResult, error) {
-	if out == nil {
-		return ProjectResult{}, fmt.Errorf("RunProjectStreaming: out writer is nil")
-	}
-	if err := ctx.Err(); err != nil {
+	startTime, format, err := validateAndDefaultStreaming(ctx, in, out)
+	if err != nil {
 		return ProjectResult{}, err
 	}
 	args := in.Args
 	host := in.Host
-	if args.Config == nil {
-		return ProjectResult{}, fmt.Errorf("RunProject: Config is required")
-	}
-	if len(args.ActiveRules) == 0 {
-		return ProjectResult{}, fmt.Errorf("RunProject: ActiveRules is empty")
-	}
-	if len(args.Paths) == 0 {
-		return ProjectResult{}, fmt.Errorf("RunProject: Paths is empty")
-	}
-
-	startTime := args.StartTime
-	if startTime.IsZero() {
-		startTime = time.Now()
-	}
-	format := args.Format
-	if format == "" {
-		format = "json"
-	}
 
 	// Snapshot the parse-cache counters at the start of the run so the
 	// post-run delta is the per-call hit/miss accounting we report back
@@ -401,6 +381,37 @@ func RunProjectStreaming(ctx context.Context, in ProjectInput, out io.Writer) (P
 		ParseHits:     hits1 - hits0,
 		ParseMisses:   misses1 - misses0,
 	}, nil
+}
+
+// validateAndDefaultStreaming checks RunProjectStreaming's preconditions
+// and resolves the StartTime / Format defaults. Extracted to keep the
+// orchestrator under the gocyclo budget.
+func validateAndDefaultStreaming(ctx context.Context, in ProjectInput, out io.Writer) (time.Time, string, error) {
+	if out == nil {
+		return time.Time{}, "", fmt.Errorf("RunProjectStreaming: out writer is nil")
+	}
+	if err := ctx.Err(); err != nil {
+		return time.Time{}, "", err
+	}
+	args := in.Args
+	if args.Config == nil {
+		return time.Time{}, "", fmt.Errorf("RunProject: Config is required")
+	}
+	if len(args.ActiveRules) == 0 {
+		return time.Time{}, "", fmt.Errorf("RunProject: ActiveRules is empty")
+	}
+	if len(args.Paths) == 0 {
+		return time.Time{}, "", fmt.Errorf("RunProject: Paths is empty")
+	}
+	startTime := args.StartTime
+	if startTime.IsZero() {
+		startTime = time.Now()
+	}
+	format := args.Format
+	if format == "" {
+		format = "json"
+	}
+	return startTime, format, nil
 }
 
 // parseCacheCounters extracts the cumulative Hits/Misses pair from a

--- a/internal/pipeline/project.go
+++ b/internal/pipeline/project.go
@@ -68,12 +68,9 @@ type ProjectArgs struct {
 	// ExperimentNames are the active experiment flag names echoed in
 	// JSON output.
 	ExperimentNames []string
-	// JSONCompact, when true and Format=="json", disables JSON pretty-
-	// printing in the OutputPhase. The daemon's streaming response
-	// path (#60) sets this so the wire-level JSON has no internal
-	// newlines (the line-delimited daemon protocol breaks on the
-	// first '\n'). The CLI keeps it false so human-readable output
-	// stays indented.
+	// JSONCompact mirrors OutputInput.JSONCompact: when true the
+	// "json" formatter omits indentation. The daemon's streaming
+	// response path (#60) sets this; the CLI leaves it false.
 	JSONCompact bool
 	// OracleEnabled, when true, runs the oracle pipeline inside
 	// IndexPhase (auto-detect / --input-types / --daemon paths). The

--- a/internal/pipeline/project.go
+++ b/internal/pipeline/project.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"sort"
 	"strings"
 	"time"
@@ -67,6 +68,13 @@ type ProjectArgs struct {
 	// ExperimentNames are the active experiment flag names echoed in
 	// JSON output.
 	ExperimentNames []string
+	// JSONCompact, when true and Format=="json", disables JSON pretty-
+	// printing in the OutputPhase. The daemon's streaming response
+	// path (#60) sets this so the wire-level JSON has no internal
+	// newlines (the line-delimited daemon protocol breaks on the
+	// first '\n'). The CLI keeps it false so human-readable output
+	// stays indented.
+	JSONCompact bool
 	// OracleEnabled, when true, runs the oracle pipeline inside
 	// IndexPhase (auto-detect / --input-types / --daemon paths). The
 	// daemon sets this true when ensureOracleDaemon found a
@@ -190,7 +198,10 @@ type ProjectInput struct {
 // ProjectResult is the value type returned from RunProject.
 type ProjectResult struct {
 	// JSON is the formatted output bytes (in the requested Format).
-	// Suitable for inclusion verbatim in a daemon response payload.
+	// Populated only by RunProject; RunProjectStreaming leaves this
+	// nil because the bytes are already written to the caller's
+	// io.Writer. Suitable for inclusion verbatim in a daemon
+	// response payload when populated.
 	JSON []byte
 	// FinalFindings is the set of findings actually emitted (after
 	// baseline / diff / min-confidence filters).
@@ -224,6 +235,28 @@ type ProjectResult struct {
 // Callers that need any of the above continue to use scan.Run (the CLI
 // front door) or compose the phase types directly.
 func RunProject(ctx context.Context, in ProjectInput) (ProjectResult, error) {
+	var buf bytes.Buffer
+	res, err := RunProjectStreaming(ctx, in, &buf)
+	if err != nil {
+		return ProjectResult{}, err
+	}
+	res.JSON = buf.Bytes()
+	return res, nil
+}
+
+// RunProjectStreaming is the streaming form of RunProject (#60). It runs
+// the same scan pipeline but writes the OutputPhase's formatted bytes
+// directly into out instead of buffering them on the heap. The returned
+// ProjectResult.JSON is nil — callers that need the bytes in memory
+// should wrap a bytes.Buffer (RunProject does exactly that).
+//
+// On the JetBrains/kotlin corpus the OutputPhase JSON is ~27 MB;
+// streaming it lets the daemon write directly into the response socket
+// without allocating an intermediate copy per call.
+func RunProjectStreaming(ctx context.Context, in ProjectInput, out io.Writer) (ProjectResult, error) {
+	if out == nil {
+		return ProjectResult{}, fmt.Errorf("RunProjectStreaming: out writer is nil")
+	}
 	if err := ctx.Err(); err != nil {
 		return ProjectResult{}, err
 	}
@@ -330,12 +363,13 @@ func RunProject(ctx context.Context, in ProjectInput) (ProjectResult, error) {
 		return ProjectResult{}, err
 	}
 
-	// Phase 5: output to an in-memory buffer.
-	var buf bytes.Buffer
+	// Phase 5: output. Writes formatted bytes directly to the
+	// caller-provided writer; #60 lets the daemon stream this into
+	// the response socket without an intermediate 27 MB copy.
 	fixupView := FixupResult{CrossFileResult: crossFileResult}
 	outResult, err := OutputPhase{}.Run(ctx, OutputInput{
 		FixupResult:      fixupView,
-		Writer:           &buf,
+		Writer:           out,
 		Format:           format,
 		BaselinePath:     args.BaselinePath,
 		DiffRef:          args.DiffRef,
@@ -344,6 +378,7 @@ func RunProject(ctx context.Context, in ProjectInput) (ProjectResult, error) {
 		ExperimentNames:  args.ExperimentNames,
 		WarningsAsErrors: args.WarningsAsErrors,
 		MinConfidence:    args.MinConfidence,
+		JSONCompact:      args.JSONCompact,
 	})
 	if err != nil {
 		return ProjectResult{}, fmt.Errorf("output: %w", err)
@@ -361,7 +396,6 @@ func RunProject(ctx context.Context, in ProjectInput) (ProjectResult, error) {
 
 	hits1, misses1 := parseCacheCounters(host.ParseCache)
 	return ProjectResult{
-		JSON:          buf.Bytes(),
 		FinalFindings: outResult.FinalFindings,
 		FilesScanned:  len(parseResult.KotlinFiles) + len(parseResult.JavaFiles),
 		FindingsCount: outResult.FinalFindings.Len(),

--- a/internal/pipeline/streaming_test.go
+++ b/internal/pipeline/streaming_test.go
@@ -1,0 +1,125 @@
+package pipeline
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kaeawc/krit/internal/config"
+	api "github.com/kaeawc/krit/internal/rules/api"
+)
+
+// TestRunProjectStreaming_MatchesRunProject is the equivalence
+// contract behind issue #60: the streaming entry point must produce
+// byte-identical output to the buffered entry point so the daemon
+// can swap between them without observable change. Stripping
+// timing fields lets the comparison ignore the legitimately
+// nondeterministic durationMs/wallSeconds keys.
+func TestRunProjectStreaming_MatchesRunProject(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "Sample.kt"),
+		[]byte("package test\n\nclass Sample\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	rule := api.FakeRule("ClassDecl",
+		api.WithNodeTypes("class_declaration"),
+		api.WithSeverity(api.SeverityWarning),
+		api.WithCheck(func(ctx *api.Context) {
+			ctx.EmitAt(int(ctx.Node.StartRow)+1, 1, "class declared")
+		}),
+	)
+
+	mkInput := func() ProjectInput {
+		return ProjectInput{
+			Args: ProjectArgs{
+				Config:      config.NewConfig(),
+				Paths:       []string{dir},
+				ActiveRules: []*api.Rule{rule},
+				Format:      "json",
+				Version:     "test",
+			},
+		}
+	}
+
+	buffered, err := RunProject(context.Background(), mkInput())
+	if err != nil {
+		t.Fatalf("RunProject: %v", err)
+	}
+
+	var streamed bytes.Buffer
+	res, err := RunProjectStreaming(context.Background(), mkInput(), &streamed)
+	if err != nil {
+		t.Fatalf("RunProjectStreaming: %v", err)
+	}
+	if res.JSON != nil {
+		t.Errorf("RunProjectStreaming.JSON should be nil; got %d bytes", len(res.JSON))
+	}
+	if res.FindingsCount != buffered.FindingsCount {
+		t.Errorf("FindingsCount mismatch: buffered=%d streamed=%d",
+			buffered.FindingsCount, res.FindingsCount)
+	}
+
+	scrub := []string{
+		"\"durationMs\"", "\"timestamp\"", "\"wallSeconds\"",
+		"\"startTime\"", "\"endTime\"",
+	}
+	bufferedClean := scrubLines(buffered.JSON, scrub)
+	streamedClean := scrubLines(streamed.Bytes(), scrub)
+	if !bytes.Equal(bufferedClean, streamedClean) {
+		t.Errorf("streamed output diverges from buffered\n--- buffered ---\n%s\n--- streamed ---\n%s",
+			bufferedClean, streamedClean)
+	}
+}
+
+// TestRunProjectStreaming_NilWriterRejected guards the nil-writer
+// precondition. RunProjectStreaming with no destination is always a
+// caller bug — failing fast beats letting the run silently succeed
+// while writing nothing.
+func TestRunProjectStreaming_NilWriterRejected(t *testing.T) {
+	_, err := RunProjectStreaming(context.Background(), ProjectInput{}, nil)
+	if err == nil {
+		t.Fatal("expected error from nil writer")
+	}
+}
+
+// TestRunProjectStreaming_JSONCompactSuppressesIndent confirms the
+// JSONCompact knob in ProjectArgs is plumbed through to the JSON
+// formatter so the daemon's wire-level body has no internal
+// newlines (line-delimited daemon protocol breaks on the first '\n').
+func TestRunProjectStreaming_JSONCompactSuppressesIndent(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "Sample.kt"),
+		[]byte("package test\n\nclass Sample\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	rule := api.FakeRule("ClassDecl",
+		api.WithNodeTypes("class_declaration"),
+		api.WithSeverity(api.SeverityWarning),
+		api.WithCheck(func(ctx *api.Context) {
+			ctx.EmitAt(int(ctx.Node.StartRow)+1, 1, "class declared")
+		}),
+	)
+	in := ProjectInput{
+		Args: ProjectArgs{
+			Config:      config.NewConfig(),
+			Paths:       []string{dir},
+			ActiveRules: []*api.Rule{rule},
+			Format:      "json",
+			Version:     "test",
+			JSONCompact: true,
+		},
+	}
+	var buf bytes.Buffer
+	if _, err := RunProjectStreaming(context.Background(), in, &buf); err != nil {
+		t.Fatalf("RunProjectStreaming: %v", err)
+	}
+	body := buf.Bytes()
+	// Encoder appends one trailing newline. Internal newlines would
+	// indicate indentation slipped through.
+	if n := bytes.Count(body, []byte{'\n'}); n != 1 {
+		t.Errorf("compact JSON should have exactly one trailing newline; got %d in %q", n, body)
+	}
+}

--- a/internal/pipeline/types.go
+++ b/internal/pipeline/types.go
@@ -462,6 +462,12 @@ type OutputInput struct {
 	// MinConfidence, when >0, drops findings whose confidence is below
 	// the threshold before format dispatch.
 	MinConfidence float64
+	// JSONCompact, when true, disables JSON pretty-printing in the
+	// "json" formatter. The daemon's streaming response path sets
+	// this so the wire-level JSON has no internal newlines (the
+	// line-delimited daemon protocol breaks on the first '\n'). The
+	// CLI keeps it false so human-readable output stays indented.
+	JSONCompact bool
 }
 
 // OutputResult captures post-Output metadata.


### PR DESCRIPTION
## Summary
- Closes #60. Eliminate the ~27 MB intermediate `bytes.Buffer` that `pipeline.RunProject` allocated per analyze-project call.
- New `pipeline.RunProjectStreaming(ctx, in, w)` writes OutputPhase output directly to a caller-supplied writer. `RunProject` keeps its signature by wrapping a buffer.
- New `daemon.RawResponseWriter` lets a handler result bypass the default `json.Marshal` envelope and write straight into the connection. `dispatchAndWrite` routes through it when present.
- `handleAnalyzeProject` returns a `streamingAnalyzeResponse` that emits the `{"ok":true,"data":{"findings":` head, streams findings via `analyzeRespWriter` (lazy head, trailing-newline strip), then writes the `,"stats":{...}}}` tail.
- `ProjectArgs.JSONCompact` + `output.FormatJSONColumnsCompact` give the daemon unindented JSON so the line-delimited wire stays single-line.
- `serveConn` now wraps `conn` in `bufio.Writer` so the multi-chunk envelope coalesces into one syscall per response (helps every verb, not just streaming).

## Test plan
- [x] `go build ./... && go vet ./...`
- [x] `go test ./... -count=1`
- [x] `make integration` (11/11 PASS)
- [x] New unit tests:
  - `TestRunProjectStreaming_*` (equivalence, nil-writer, JSONCompact)
  - `TestAnalyzeRespWriter_*` (head defer, newline strip, internal flush, error propagation)
  - `TestRawResponseWriter_*` (streaming bypass, fallback envelope)
- [ ] `BenchmarkAnalyzeProjectWarm` (kotlin_corpus tag) — gated on local corpus access; the streaming path eliminates 3 multi-MB allocations per call so the ≥5% allocs/op target should land comfortably.