### PR TITLE
RunProject extensions + snapshot redaction + bundle-hit observability

### DIFF
--- a/docs/snapshots.md
+++ b/docs/snapshots.md
@@ -81,6 +81,51 @@ Available metrics depend on scope:
 Snapshots that don't carry the requested target produce a sparse series
 (no zero-fill), mirroring git history rather than fabricating points.
 
+## Redaction
+
+Captured blobs persist `Symbol.FQN`, `Symbol.Owner`, `Symbol.Package`,
+`Symbol.Signature`, and repo-relative `File.Path` — all of which can
+embed proprietary identifiers, secret-shaped strings, or business
+logic implied by names. The findings sidecar additionally records
+per-file rollups keyed by path. Manifests are JSON and greppable.
+
+Snapshots live entirely under `.krit/snapshots/` and are **local-only
+by default**: do not commit the directory, do not sync it across
+machines, and do not include it in build artefacts that leave the
+device. `krit snapshot install-hook` appends the directory to the
+repo's `.gitignore` automatically as a guardrail.
+
+For repos with stricter requirements, capture can run in **redacted
+mode**: every source identifier on the blob and every per-file key on
+the findings sidecar is replaced with a stable one-way hash. Diff,
+timeline, and CI gates still work — the join keys remain stable
+across snapshots — but the snapshot cannot be reverse-engineered to
+a source name.
+
+```go
+snapshot.Capture(snapshot.CaptureOptions{
+    RepoRoot:     repoRoot,
+    CommitSHA:    sha,
+    KritVersion:  kritVersion,
+    Redact:       true,    // hash names and paths before persisting
+    WithFindings: true,    // also redacts the findings sidecar
+})
+```
+
+Redaction is captured into `Blob.Redacted`, `Findings.Redacted`, and
+`Manifest.Redacted` (the latter exposed as `"redacted": true` in the
+JSON manifest). `snapshot.Diff` refuses to compare a redacted
+snapshot against a raw one — the join keys live in different
+namespaces, so a delta would be meaningless. Findings diffs degrade
+gracefully across mixed redaction: per-rule totals still surface,
+but `FindingsRuleSetMismatch` flags the per-file rollup as
+incomparable.
+
+Hashing uses SHA-256 truncated to 64 bits, prefixed with
+`krit-redacted:` so a reader can distinguish a hash from a
+legitimate identifier. Module paths (gradle coordinates) and rule
+IDs (public krit identifiers) stay in clear text.
+
 ## Diff
 
 ```sh

--- a/internal/cli/scan/scan_contract_test.go
+++ b/internal/cli/scan/scan_contract_test.go
@@ -18,26 +18,13 @@ import (
 	"github.com/kaeawc/krit/internal/scanner"
 )
 
-// TestScanRunMatchesAnalyzeProjectVerb is the CLI-vs-RunProject byte-
-// equal contract test that issue #70 calls for. It runs the same
-// fixture through two paths:
-//
-//   - scan.Run (the CLI front door, with caches, FIR, profiling all
-//     disabled so the runner reduces to parse → index → dispatch →
-//     cross-file → android → output — the same shape RunProject
-//     already covers)
-//   - pipeline.RunProject called directly
-//
-// Both findings JSON payloads must be equal after stripping fields
-// that legitimately vary between runs (perf subtree, caches subtree,
-// startTime, durationMs, version). A divergence here means the CLI
-// and the shared pipeline path have drifted on rule output, file
-// enumeration, suppression, or format dispatch.
-//
-// Steps B-E of #70 widen RunProject to cover the remaining runner
-// concerns (fixup, baselines, FIR, output extras). Each of those
-// steps strengthens this test by removing a flag from the "disable"
-// list. The byte-equal harness itself does not change.
+// TestScanRunMatchesAnalyzeProjectVerb pins the CLI-vs-RunProject
+// byte-equal contract: scan.Run (with caches, FIR, profiling, and
+// the oracle disabled — the subset RunProject already covers) and
+// pipeline.RunProject called directly must produce identical
+// findings JSON after stripping the perf/caches/timing/version
+// envelope. A divergence means the two paths have drifted on rule
+// output, file enumeration, suppression, or format dispatch.
 func TestScanRunMatchesAnalyzeProjectVerb(t *testing.T) {
 	dir := t.TempDir()
 	writeContractFile(t, filepath.Join(dir, "Foo.kt"),

--- a/internal/cli/scan/scan_contract_test.go
+++ b/internal/cli/scan/scan_contract_test.go
@@ -1,0 +1,228 @@
+package scan
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"io"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/kaeawc/krit/internal/cacheutil"
+	"github.com/kaeawc/krit/internal/config"
+	"github.com/kaeawc/krit/internal/oracle"
+	"github.com/kaeawc/krit/internal/pipeline"
+	"github.com/kaeawc/krit/internal/rules"
+	"github.com/kaeawc/krit/internal/scanner"
+)
+
+// TestScanRunMatchesAnalyzeProjectVerb is the CLI-vs-RunProject byte-
+// equal contract test that issue #70 calls for. It runs the same
+// fixture through two paths:
+//
+//   - scan.Run (the CLI front door, with caches, FIR, profiling all
+//     disabled so the runner reduces to parse → index → dispatch →
+//     cross-file → android → output — the same shape RunProject
+//     already covers)
+//   - pipeline.RunProject called directly
+//
+// Both findings JSON payloads must be equal after stripping fields
+// that legitimately vary between runs (perf subtree, caches subtree,
+// startTime, durationMs, version). A divergence here means the CLI
+// and the shared pipeline path have drifted on rule output, file
+// enumeration, suppression, or format dispatch.
+//
+// Steps B-E of #70 widen RunProject to cover the remaining runner
+// concerns (fixup, baselines, FIR, output extras). Each of those
+// steps strengthens this test by removing a flag from the "disable"
+// list. The byte-equal harness itself does not change.
+func TestScanRunMatchesAnalyzeProjectVerb(t *testing.T) {
+	dir := t.TempDir()
+	writeContractFile(t, filepath.Join(dir, "Foo.kt"),
+		"package demo\n\nimport kotlin.io.println\n\nclass Foo {\n    fun greet() = println(\"hi\")\n}\n")
+	writeContractFile(t, filepath.Join(dir, "Bar.kt"),
+		"package demo\n\nfun bar(unused: Int): Int { return 42 }\n")
+
+	cliJSON := runScanCLI(t, []string{
+		"krit",
+		"--no-cache",
+		"--no-cross-file-cache",
+		"--no-parse-cache",
+		"--no-fir",
+		"--no-type-oracle",
+		"-f", "json",
+		dir,
+	})
+
+	directJSON := runRunProjectDirect(t, dir)
+
+	cli := stripVariableFields(t, cliJSON)
+	direct := stripVariableFields(t, directJSON)
+
+	// Guard against vacuous equality: both producing empty findings
+	// arrays would pass the DeepEqual below but prove nothing about
+	// the shared pipeline. The fixture is chosen to produce at least
+	// one finding from the default rule set.
+	if findings, ok := cli["findings"].([]any); !ok || len(findings) == 0 {
+		t.Fatalf("CLI produced no findings; test is vacuous. cli=%s", mustPretty(t, cli))
+	}
+
+	if !reflect.DeepEqual(cli, direct) {
+		t.Errorf("CLI output diverges from direct RunProject after strip\n--- cli ---\n%s\n--- direct ---\n%s",
+			mustPretty(t, cli), mustPretty(t, direct))
+	}
+}
+
+// runScanCLI invokes scan.Run() in-process with the supplied argv.
+// It isolates global state (flag.CommandLine, os.Args, os.Stdout/Stderr,
+// BaselineAuditVerb) and returns the captured stdout bytes.
+func runScanCLI(t *testing.T, argv []string) []byte {
+	t.Helper()
+
+	// Save and restore every global scan.Run reaches into.
+	savedArgs := os.Args
+	savedFlagSet := flag.CommandLine
+	savedStdout := os.Stdout
+	savedStderr := os.Stderr
+	savedBaselineVerb := BaselineAuditVerb
+	t.Cleanup(func() {
+		os.Args = savedArgs
+		flag.CommandLine = savedFlagSet
+		os.Stdout = savedStdout
+		os.Stderr = savedStderr
+		BaselineAuditVerb = savedBaselineVerb
+	})
+
+	os.Args = argv
+	flag.CommandLine = flag.NewFlagSet(argv[0], flag.ContinueOnError)
+	BaselineAuditVerb = false
+
+	stdoutR, stdoutW, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("stdout pipe: %v", err)
+	}
+	stderrR, stderrW, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("stderr pipe: %v", err)
+	}
+	os.Stdout = stdoutW
+	os.Stderr = stderrW
+
+	// Run scan.Run in a goroutine so we can drain stderr in parallel.
+	// Without parallel drains the OS pipe buffer can fill and block
+	// scan.Run's verbose writes.
+	doneStderr := make(chan struct{})
+	go func() {
+		_, _ = io.Copy(io.Discard, stderrR)
+		close(doneStderr)
+	}()
+
+	code := Run()
+	_ = stdoutW.Close()
+	_ = stderrW.Close()
+
+	stdoutBytes, err := io.ReadAll(stdoutR)
+	if err != nil {
+		t.Fatalf("read stdout: %v", err)
+	}
+	<-doneStderr
+
+	// scan.Run returns 1 when there are findings, 0 when clean, 2 on
+	// error. Anything other than 0/1 means the run failed before
+	// emitting JSON.
+	if code != 0 && code != 1 {
+		t.Fatalf("scan.Run exit=%d (stdout=%q)", code, string(stdoutBytes))
+	}
+	return stdoutBytes
+}
+
+// runRunProjectDirect invokes pipeline.RunProject against the same
+// fixture root with a config + rule set that mirrors what scan.Run
+// constructs for the chosen flag set.
+func runRunProjectDirect(t *testing.T, root string) []byte {
+	t.Helper()
+
+	cfg := config.NewConfig()
+	rules.ApplyConfig(cfg)
+	activeRules := rules.ActiveRulesV2(map[string]bool{}, map[string]bool{}, false, false)
+
+	repoDir := oracle.FindRepoDir([]string{root})
+	if repoDir == "" {
+		repoDir = root
+	}
+	pc, err := scanner.NewParseCacheWithCap(repoDir, cacheutil.DefaultParseCacheCapBytes)
+	if err != nil {
+		t.Fatalf("ParseCache: %v", err)
+	}
+	t.Cleanup(func() { _ = pc.Close() })
+
+	res, err := pipeline.RunProject(context.Background(), pipeline.ProjectInput{
+		Args: pipeline.ProjectArgs{
+			Config:      cfg,
+			Paths:       []string{root},
+			ActiveRules: activeRules,
+			Format:      "json",
+			Version:     "test",
+		},
+		Host: pipeline.ProjectHostState{ParseCache: pc},
+	})
+	if err != nil {
+		t.Fatalf("RunProject: %v", err)
+	}
+	return res.JSON
+}
+
+// stripVariableFields decodes the JSON envelope, removes fields that
+// legitimately differ between the two paths (perf tree, cache stats,
+// wall-clock timestamps, version stamp), and returns the canonical
+// map. The findings array stays — that's the load-bearing part of the
+// contract.
+func stripVariableFields(t *testing.T, raw []byte) map[string]any {
+	t.Helper()
+	if len(raw) == 0 {
+		t.Fatalf("empty JSON")
+	}
+	var out map[string]any
+	if err := json.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("unmarshal: %v\nraw=%s", err, raw)
+	}
+	for _, key := range []string{
+		"durationMs", "wall_seconds", "wallSeconds",
+		"perf", "perfTimings", "perfRuleStats",
+		"caches", "cacheStats", "cacheBudget",
+		"startTime", "timing", "timings",
+		// version stamp comes from a compile-time var on the CLI side
+		// and is caller-provided on the direct side. The contract is
+		// about findings, not envelope metadata.
+		"version", "kritVersion",
+	} {
+		delete(out, key)
+	}
+	if findings, ok := out["findings"].([]any); ok {
+		for _, f := range findings {
+			if m, ok := f.(map[string]any); ok {
+				delete(m, "timeMs")
+				delete(m, "tookNs")
+			}
+		}
+	}
+	return out
+}
+
+func mustPretty(t *testing.T, v any) string {
+	t.Helper()
+	b, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return string(b)
+}
+
+func writeContractFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}

--- a/internal/cli/serve/analyze_project.go
+++ b/internal/cli/serve/analyze_project.go
@@ -105,17 +105,18 @@ func (r *streamingAnalyzeResponse) WriteRawResponse(ctx context.Context, w io.Wr
 	xfile := r.state.workspace.CrossFileStats()
 
 	statsBytes, err := json.Marshal(daemon.AnalyzeProjectStats{
-		FilesScanned:    res.FilesScanned,
-		FindingsCount:   res.FindingsCount,
-		WallSeconds:     time.Since(r.start).Seconds(),
-		CodeIndexHit:    xfile.HasCodeIndex,
-		LibraryFactsHit: xfile.HasLibraryFacts,
-		ResolverHit:     xfile.HasResolver,
-		OracleFilterHit: xfile.HasOracleFilter,
-		DirtyFiles:      r.dirtyN,
-		Cold:            r.cold,
-		ParseHits:       res.ParseHits,
-		ParseMisses:     res.ParseMisses,
+		FilesScanned:      res.FilesScanned,
+		FindingsCount:     res.FindingsCount,
+		WallSeconds:       time.Since(r.start).Seconds(),
+		CodeIndexHit:      xfile.HasCodeIndex,
+		LibraryFactsHit:   xfile.HasLibraryFacts,
+		ResolverHit:       xfile.HasResolver,
+		OracleFilterHit:   xfile.HasOracleFilter,
+		DirtyFiles:        r.dirtyN,
+		Cold:              r.cold,
+		ParseHits:         res.ParseHits,
+		ParseMisses:       res.ParseMisses,
+		FindingsBundleHit: res.FindingsBundleHit,
 	})
 	if err != nil {
 		return fmt.Errorf("marshal stats: %w", err)

--- a/internal/cli/serve/analyze_project_bundlehit_test.go
+++ b/internal/cli/serve/analyze_project_bundlehit_test.go
@@ -1,0 +1,49 @@
+package serve
+
+import (
+	"testing"
+
+	"github.com/kaeawc/krit/internal/daemon"
+)
+
+// TestAnalyzeProject_BundleHitOnIdenticalSecondCall is observability
+// for #139: the daemon's whole-run findings cache should fire on the
+// second of two byte-identical analyze-project calls. If it doesn't,
+// the warm path is paying full dispatch+cross-file cost every call —
+// the leading hypothesis on the kotlin-corpus regression.
+//
+// The test pins the contract through the wire format
+// (AnalyzeProjectStats.FindingsBundleHit) so a regression in the
+// bundle key derivation surfaces in CI rather than at benchmark
+// time.
+func TestAnalyzeProject_BundleHitOnIdenticalSecondCall(t *testing.T) {
+	socket, state := startServerForTest(t)
+	writeKotlinFile(t, state.root, "A.kt",
+		"package demo\n\nclass A {\n    fun a() {}\n}\n")
+	writeKotlinFile(t, state.root, "B.kt",
+		"package demo\n\nclass B {\n    fun b() {}\n}\n")
+
+	var first daemon.AnalyzeProjectResult
+	if err := daemon.Call(socket, daemon.VerbAnalyzeProject,
+		daemon.AnalyzeProjectArgs{}, &first); err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+	if first.Stats.FindingsBundleHit {
+		t.Errorf("first call (no prior bundle) must report FindingsBundleHit=false; got %+v", first.Stats)
+	}
+
+	var second daemon.AnalyzeProjectResult
+	if err := daemon.Call(socket, daemon.VerbAnalyzeProject,
+		daemon.AnalyzeProjectArgs{}, &second); err != nil {
+		t.Fatalf("second call: %v", err)
+	}
+	if !second.Stats.FindingsBundleHit {
+		t.Errorf("identical second call must report FindingsBundleHit=true; got %+v\n"+
+			"if this fails, the bundle key is drifting across calls — see #139",
+			second.Stats)
+	}
+	if second.Stats.FindingsCount != first.Stats.FindingsCount {
+		t.Errorf("bundle hit must replay the same finding count: first=%d second=%d",
+			first.Stats.FindingsCount, second.Stats.FindingsCount)
+	}
+}

--- a/internal/cli/serve/analyze_project_bundlehit_test.go
+++ b/internal/cli/serve/analyze_project_bundlehit_test.go
@@ -6,16 +6,11 @@ import (
 	"github.com/kaeawc/krit/internal/daemon"
 )
 
-// TestAnalyzeProject_BundleHitOnIdenticalSecondCall is observability
-// for #139: the daemon's whole-run findings cache should fire on the
-// second of two byte-identical analyze-project calls. If it doesn't,
-// the warm path is paying full dispatch+cross-file cost every call —
-// the leading hypothesis on the kotlin-corpus regression.
-//
-// The test pins the contract through the wire format
-// (AnalyzeProjectStats.FindingsBundleHit) so a regression in the
-// bundle key derivation surfaces in CI rather than at benchmark
-// time.
+// TestAnalyzeProject_BundleHitOnIdenticalSecondCall pins the
+// contract that the daemon's whole-run findings cache fires on the
+// second of two byte-identical analyze-project calls. A regression
+// in the bundle key derivation would surface here rather than at
+// benchmark time.
 func TestAnalyzeProject_BundleHitOnIdenticalSecondCall(t *testing.T) {
 	socket, state := startServerForTest(t)
 	writeKotlinFile(t, state.root, "A.kt",
@@ -39,7 +34,7 @@ func TestAnalyzeProject_BundleHitOnIdenticalSecondCall(t *testing.T) {
 	}
 	if !second.Stats.FindingsBundleHit {
 		t.Errorf("identical second call must report FindingsBundleHit=true; got %+v\n"+
-			"if this fails, the bundle key is drifting across calls — see #139",
+			"a false here means the bundle key drifts across identical calls",
 			second.Stats)
 	}
 	if second.Stats.FindingsCount != first.Stats.FindingsCount {

--- a/internal/daemon/protocol.go
+++ b/internal/daemon/protocol.go
@@ -204,4 +204,10 @@ type AnalyzeProjectStats struct {
 	// no parse cache is attached.
 	ParseHits   int64 `json:"parse_hits"`
 	ParseMisses int64 `json:"parse_misses"`
+	// FindingsBundleHit is true when the whole-run findings cache
+	// served the result without redoing dispatch or cross-file work.
+	// A true value means the call was a structural reuse of a prior
+	// identical-input run; #139 uses this to diagnose why warm calls
+	// still cost ~40s on JetBrains/kotlin.
+	FindingsBundleHit bool `json:"findings_bundle_hit"`
 }

--- a/internal/daemon/protocol.go
+++ b/internal/daemon/protocol.go
@@ -207,7 +207,6 @@ type AnalyzeProjectStats struct {
 	// FindingsBundleHit is true when the whole-run findings cache
 	// served the result without redoing dispatch or cross-file work.
 	// A true value means the call was a structural reuse of a prior
-	// identical-input run; #139 uses this to diagnose why warm calls
-	// still cost ~40s on JetBrains/kotlin.
+	// identical-input run.
 	FindingsBundleHit bool `json:"findings_bundle_hit"`
 }

--- a/internal/pipeline/project.go
+++ b/internal/pipeline/project.go
@@ -99,6 +99,24 @@ type ProjectArgs struct {
 	// apply"; the CLI sets this from --fix-level (defaulting to
 	// FixIdiomatic when --fix or --dry-run is set).
 	MaxFixLevel rules.FixLevel
+	// BasePath is the base for relative paths in the formatted
+	// output. Empty (default) means OutputPhase falls back to the
+	// first scan path — sufficient for the daemon, while the CLI
+	// sets this explicitly from --base-path.
+	BasePath string
+	// ShowPerf, when true, snapshots the host tracker + cache state
+	// at OutputPhase time and forwards the result through
+	// OutputInput.PerfTimings/Caches/CacheBudget. False (the daemon
+	// default) keeps the JSON header lean.
+	ShowPerf bool
+	// PerfRules, when true, forwards the dispatcher's sorted per-rule
+	// execution stats through OutputInput.PerfRuleStats. False (the
+	// daemon default) skips the sort and trims the JSON payload.
+	PerfRules bool
+	// ParseCacheCapBytes is the effective parse-cache cap used when
+	// ShowPerf builds OutputInput.CacheBudget. Zero falls back to
+	// cacheutil.DefaultParseCacheCapBytes. Mirrors --parse-cache-cap-mb.
+	ParseCacheCapBytes int64
 }
 
 // ProjectHostState is the long-lived subset of ProjectInput: state a
@@ -377,18 +395,40 @@ func RunProjectStreaming(ctx context.Context, in ProjectInput, out io.Writer) (P
 	// Phase 5: output. Writes formatted bytes directly to the
 	// caller-provided writer; #60 lets the daemon stream this into
 	// the response socket without an intermediate 27 MB copy.
+	perfTimings, caches, budget := capturePerfOutputs(args, host)
+	var perfRuleStats []rules.RuleExecutionStat
+	if args.PerfRules {
+		perfRuleStats = rules.SortedRuleExecutionStats(dispatchResult.Stats)
+	}
+	// CacheStats is gated on ShowPerf rather than auto-forwarded:
+	// today the daemon's analyze-project verb does NOT include the
+	// "cache" JSON key (the verb's tests assume it absent). Exposing
+	// it whenever IndexPhase happens to populate stats would silently
+	// change the daemon's wire format. ShowPerf-gated forwarding lets
+	// the CLI opt in once it migrates to RunProject (Step E).
+	var cacheStatsOut *cache.Stats
+	if args.ShowPerf {
+		cacheStatsOut = indexResult.CacheStats
+	}
 	outResult, err := OutputPhase{}.Run(ctx, OutputInput{
 		FixupResult:      fixupView,
 		Writer:           out,
 		Format:           format,
 		BaselinePath:     args.BaselinePath,
 		DiffRef:          args.DiffRef,
+		BasePath:         args.BasePath,
 		StartTime:        startTime,
 		Version:          args.Version,
 		ExperimentNames:  args.ExperimentNames,
 		WarningsAsErrors: args.WarningsAsErrors,
 		MinConfidence:    args.MinConfidence,
 		JSONCompact:      args.JSONCompact,
+		ShowPerf:         args.ShowPerf,
+		PerfTimings:      perfTimings,
+		PerfRuleStats:    perfRuleStats,
+		CacheStats:       cacheStatsOut,
+		Caches:           caches,
+		CacheBudget:      budget,
 	})
 	if err != nil {
 		return ProjectResult{}, fmt.Errorf("output: %w", err)
@@ -415,6 +455,28 @@ func RunProjectStreaming(ctx context.Context, in ProjectInput, out io.Writer) (P
 		ParseMisses:   misses1 - misses0,
 		Fixup:         fixupView,
 	}, nil
+}
+
+// capturePerfOutputs snapshots the host tracker plus the global
+// cacheutil stats so OutputPhase can emit them in the JSON header.
+// Returns (nil, nil, nil) when args.ShowPerf is false — the daemon's
+// default. Mirrors the CLI's capturePerfSnapshot helper so a daemon
+// caller that opts in sees the same output shape.
+func capturePerfOutputs(args ProjectArgs, host ProjectHostState) ([]perf.TimingEntry, []cacheutil.NamedCacheStats, *cacheutil.BudgetReport) {
+	if !args.ShowPerf {
+		return nil, nil, nil
+	}
+	var timings []perf.TimingEntry
+	if host.Tracker != nil && host.Tracker.IsEnabled() {
+		timings = host.Tracker.GetTimings()
+	}
+	capBytes := args.ParseCacheCapBytes
+	if capBytes == 0 {
+		capBytes = cacheutil.DefaultParseCacheCapBytes
+	}
+	caches := cacheutil.AllStats()
+	b := cacheutil.Budget(capBytes)
+	return timings, caches, &b
 }
 
 // runFixupPhase invokes FixupPhase when the caller opted in via one

--- a/internal/pipeline/project.go
+++ b/internal/pipeline/project.go
@@ -80,42 +80,35 @@ type ProjectArgs struct {
 	// Fix, when true, applies safe text auto-fixes to disk between
 	// cross-file analysis and output. The set of applied fixes is
 	// capped by MaxFixLevel. False (default) leaves files untouched.
-	// Mirrors the CLI's --fix flag.
 	Fix bool
 	// FixBinary, when true, additionally applies binary-format fixes
 	// (file renames, resource moves). Independent of Fix.
 	FixBinary bool
 	// FixSuffix, when non-empty, writes fixed content to
-	// "<path><suffix>" rather than in place. Mirrors --fix-suffix.
+	// "<path><suffix>" rather than in place.
 	FixSuffix string
 	// DryRun, when true, runs FixupPhase in count-only mode: no text
 	// fixes are applied, but FixableCount and StrippedByLevel still
 	// reflect what would have been done. Also forwards a "dry run"
 	// signal to binary fix application via FixupInput.DryRunBinary.
-	// Mirrors --dry-run.
 	DryRun bool
 	// MaxFixLevel caps which fix levels FixupPhase applies. Zero
-	// (default) means "apply everything FixupPhase would otherwise
-	// apply"; the CLI sets this from --fix-level (defaulting to
-	// FixIdiomatic when --fix or --dry-run is set).
+	// means "apply everything FixupPhase would otherwise apply".
 	MaxFixLevel rules.FixLevel
 	// BasePath is the base for relative paths in the formatted
-	// output. Empty (default) means OutputPhase falls back to the
-	// first scan path — sufficient for the daemon, while the CLI
-	// sets this explicitly from --base-path.
+	// output. Empty means OutputPhase falls back to the first scan
+	// path.
 	BasePath string
 	// ShowPerf, when true, snapshots the host tracker + cache state
 	// at OutputPhase time and forwards the result through
-	// OutputInput.PerfTimings/Caches/CacheBudget. False (the daemon
-	// default) keeps the JSON header lean.
+	// OutputInput.PerfTimings/Caches/CacheBudget.
 	ShowPerf bool
 	// PerfRules, when true, forwards the dispatcher's sorted per-rule
-	// execution stats through OutputInput.PerfRuleStats. False (the
-	// daemon default) skips the sort and trims the JSON payload.
+	// execution stats through OutputInput.PerfRuleStats.
 	PerfRules bool
 	// ParseCacheCapBytes is the effective parse-cache cap used when
 	// ShowPerf builds OutputInput.CacheBudget. Zero falls back to
-	// cacheutil.DefaultParseCacheCapBytes. Mirrors --parse-cache-cap-mb.
+	// cacheutil.DefaultParseCacheCapBytes.
 	ParseCacheCapBytes int64
 }
 
@@ -267,7 +260,6 @@ type ProjectResult struct {
 	// dispatch or cross-file analysis. False covers cache-miss runs,
 	// hosts without a bundle store, and runs where the conservative
 	// delta planner ran a partial dispatch instead of a full reuse.
-	// Useful observability for #139 warm-cache investigations.
 	FindingsBundleHit bool
 }
 
@@ -391,10 +383,6 @@ func RunProjectStreaming(ctx context.Context, in ProjectInput, out io.Writer) (P
 		return ProjectResult{}, err
 	}
 
-	// Phase 4.6: fixup. Opt-in via Args.Fix/FixBinary/DryRun. When
-	// none are set, FixupPhase is a no-op and fixupView is a thin
-	// wrapper around crossFileResult — preserving the pre-#70 Step B
-	// behaviour for callers that don't request fixes.
 	fixupView, err := runFixupPhase(ctx, args, crossFileResult)
 	if err != nil {
 		return ProjectResult{}, err
@@ -407,12 +395,9 @@ func RunProjectStreaming(ctx context.Context, in ProjectInput, out io.Writer) (P
 	if args.PerfRules {
 		perfRuleStats = rules.SortedRuleExecutionStats(dispatchResult.Stats)
 	}
-	// CacheStats is gated on ShowPerf rather than auto-forwarded:
-	// today the daemon's analyze-project verb does NOT include the
-	// "cache" JSON key (the verb's tests assume it absent). Exposing
-	// it whenever IndexPhase happens to populate stats would silently
-	// change the daemon's wire format. ShowPerf-gated forwarding lets
-	// the CLI opt in once it migrates to RunProject (Step E).
+	// CacheStats is gated on ShowPerf so the daemon's analyze-project
+	// JSON keeps omitting the "cache" key by default; auto-forwarding
+	// would silently widen the daemon's wire format.
 	var cacheStatsOut *cache.Stats
 	if args.ShowPerf {
 		cacheStatsOut = indexResult.CacheStats
@@ -467,9 +452,7 @@ func RunProjectStreaming(ctx context.Context, in ProjectInput, out io.Writer) (P
 
 // capturePerfOutputs snapshots the host tracker plus the global
 // cacheutil stats so OutputPhase can emit them in the JSON header.
-// Returns (nil, nil, nil) when args.ShowPerf is false — the daemon's
-// default. Mirrors the CLI's capturePerfSnapshot helper so a daemon
-// caller that opts in sees the same output shape.
+// Returns (nil, nil, nil) when args.ShowPerf is false.
 func capturePerfOutputs(args ProjectArgs, host ProjectHostState) ([]perf.TimingEntry, []cacheutil.NamedCacheStats, *cacheutil.BudgetReport) {
 	if !args.ShowPerf {
 		return nil, nil, nil
@@ -487,16 +470,9 @@ func capturePerfOutputs(args ProjectArgs, host ProjectHostState) ([]perf.TimingE
 	return timings, caches, &b
 }
 
-// runFixupPhase invokes FixupPhase when the caller opted in via one
-// of the fix knobs in ProjectArgs (Fix, FixBinary, DryRun). When none
-// are set the function is a no-op: it returns a thin FixupResult
-// wrapper that carries the upstream CrossFileResult unchanged so the
-// OutputPhase sees the same column set as the pre-fixup pipeline.
-//
-// Fix application has on-disk side effects (text edits, file
-// renames). RunProject runs fixup after Android merge so cached /
-// delta findings paths benefit from fixes too — symmetric with the
-// CLI's runFixup ordering.
+// runFixupPhase invokes FixupPhase when one of the fix knobs is set.
+// Fixup runs after Android merge so cached/delta findings paths
+// receive on-disk fixes too — symmetric with the CLI's ordering.
 func runFixupPhase(ctx context.Context, args ProjectArgs, crossFile CrossFileResult) (FixupResult, error) {
 	if !args.Fix && !args.FixBinary && !args.DryRun {
 		return FixupResult{CrossFileResult: crossFile}, nil

--- a/internal/pipeline/project.go
+++ b/internal/pipeline/project.go
@@ -262,6 +262,13 @@ type ProjectResult struct {
 	// the caller set one of the fix knobs in ProjectArgs (Fix,
 	// FixBinary, DryRun). Zero-valued otherwise.
 	Fixup FixupResult
+	// FindingsBundleHit is true when the whole-run findings cache
+	// (host.FindingsBundleStore) served the result without redoing
+	// dispatch or cross-file analysis. False covers cache-miss runs,
+	// hosts without a bundle store, and runs where the conservative
+	// delta planner ran a partial dispatch instead of a full reuse.
+	// Useful observability for #139 warm-cache investigations.
+	FindingsBundleHit bool
 }
 
 // RunProject runs the core scan pipeline against the given input and
@@ -450,10 +457,11 @@ func RunProjectStreaming(ctx context.Context, in ProjectInput, out io.Writer) (P
 		FilesScanned:  len(parseResult.KotlinFiles) + len(parseResult.JavaFiles),
 		FindingsCount: outResult.FinalFindings.Len(),
 		ParseErrors:   parseResult.ParseErrors,
-		Stats:         dispatchResult.Stats,
-		ParseHits:     hits1 - hits0,
-		ParseMisses:   misses1 - misses0,
-		Fixup:         fixupView,
+		Stats:             dispatchResult.Stats,
+		ParseHits:         hits1 - hits0,
+		ParseMisses:       misses1 - misses0,
+		Fixup:             fixupView,
+		FindingsBundleHit: bundleHit,
 	}, nil
 }
 

--- a/internal/pipeline/project.go
+++ b/internal/pipeline/project.go
@@ -77,6 +77,28 @@ type ProjectArgs struct {
 	// daemon sets this true when ensureOracleDaemon found a
 	// krit-types JAR; the CLI sets it from --type-oracle.
 	OracleEnabled bool
+	// Fix, when true, applies safe text auto-fixes to disk between
+	// cross-file analysis and output. The set of applied fixes is
+	// capped by MaxFixLevel. False (default) leaves files untouched.
+	// Mirrors the CLI's --fix flag.
+	Fix bool
+	// FixBinary, when true, additionally applies binary-format fixes
+	// (file renames, resource moves). Independent of Fix.
+	FixBinary bool
+	// FixSuffix, when non-empty, writes fixed content to
+	// "<path><suffix>" rather than in place. Mirrors --fix-suffix.
+	FixSuffix string
+	// DryRun, when true, runs FixupPhase in count-only mode: no text
+	// fixes are applied, but FixableCount and StrippedByLevel still
+	// reflect what would have been done. Also forwards a "dry run"
+	// signal to binary fix application via FixupInput.DryRunBinary.
+	// Mirrors --dry-run.
+	DryRun bool
+	// MaxFixLevel caps which fix levels FixupPhase applies. Zero
+	// (default) means "apply everything FixupPhase would otherwise
+	// apply"; the CLI sets this from --fix-level (defaulting to
+	// FixIdiomatic when --fix or --dry-run is set).
+	MaxFixLevel rules.FixLevel
 }
 
 // ProjectHostState is the long-lived subset of ProjectInput: state a
@@ -218,6 +240,10 @@ type ProjectResult struct {
 	// the input ran without a parse cache.
 	ParseHits   int64
 	ParseMisses int64
+	// Fixup is the FixupPhase output for the run. Populated only when
+	// the caller set one of the fix knobs in ProjectArgs (Fix,
+	// FixBinary, DryRun). Zero-valued otherwise.
+	Fixup FixupResult
 }
 
 // RunProject runs the core scan pipeline against the given input and
@@ -340,10 +366,17 @@ func RunProjectStreaming(ctx context.Context, in ProjectInput, out io.Writer) (P
 		return ProjectResult{}, err
 	}
 
+	// Phase 4.6: fixup. Opt-in via Args.Fix/FixBinary/DryRun. When
+	// none are set, FixupPhase is a no-op and fixupView is a thin
+	// wrapper around crossFileResult — preserving the pre-#70 Step B
+	// behaviour for callers that don't request fixes.
+	fixupView, err := runFixupPhase(ctx, args, crossFileResult)
+	if err != nil {
+		return ProjectResult{}, err
+	}
 	// Phase 5: output. Writes formatted bytes directly to the
 	// caller-provided writer; #60 lets the daemon stream this into
 	// the response socket without an intermediate 27 MB copy.
-	fixupView := FixupResult{CrossFileResult: crossFileResult}
 	outResult, err := OutputPhase{}.Run(ctx, OutputInput{
 		FixupResult:      fixupView,
 		Writer:           out,
@@ -380,7 +413,37 @@ func RunProjectStreaming(ctx context.Context, in ProjectInput, out io.Writer) (P
 		Stats:         dispatchResult.Stats,
 		ParseHits:     hits1 - hits0,
 		ParseMisses:   misses1 - misses0,
+		Fixup:         fixupView,
 	}, nil
+}
+
+// runFixupPhase invokes FixupPhase when the caller opted in via one
+// of the fix knobs in ProjectArgs (Fix, FixBinary, DryRun). When none
+// are set the function is a no-op: it returns a thin FixupResult
+// wrapper that carries the upstream CrossFileResult unchanged so the
+// OutputPhase sees the same column set as the pre-fixup pipeline.
+//
+// Fix application has on-disk side effects (text edits, file
+// renames). RunProject runs fixup after Android merge so cached /
+// delta findings paths benefit from fixes too — symmetric with the
+// CLI's runFixup ordering.
+func runFixupPhase(ctx context.Context, args ProjectArgs, crossFile CrossFileResult) (FixupResult, error) {
+	if !args.Fix && !args.FixBinary && !args.DryRun {
+		return FixupResult{CrossFileResult: crossFile}, nil
+	}
+	res, err := FixupPhase{}.Run(ctx, FixupInput{
+		CrossFileResult: crossFile,
+		Apply:           args.Fix && !args.DryRun,
+		ApplyBinary:     args.FixBinary,
+		Suffix:          args.FixSuffix,
+		MaxFixLevel:     args.MaxFixLevel,
+		DryRunBinary:    args.DryRun,
+		CountOnly:       args.DryRun,
+	})
+	if err != nil {
+		return FixupResult{}, fmt.Errorf("fixup: %w", err)
+	}
+	return res, nil
 }
 
 // validateAndDefaultStreaming checks RunProjectStreaming's preconditions

--- a/internal/pipeline/runproject_fixup_test.go
+++ b/internal/pipeline/runproject_fixup_test.go
@@ -11,19 +11,23 @@ import (
 	api "github.com/kaeawc/krit/internal/rules/api"
 )
 
-// TestRunProject_FixupNoOpByDefault is the contract that the new
-// fixup wiring (#70 Step B) stays inert for callers that don't set
-// any fix knob. The daemon's analyze-project verb relies on this:
-// it must produce identical output before and after Step B.
-func TestRunProject_FixupNoOpByDefault(t *testing.T) {
+const fixupFixtureContent = "package demo\n\nclass Foo : Any()\n"
+
+// setupFixupFixture writes a single-file Kotlin fixture that
+// triggers UnnecessaryInheritance (FixIdiomatic) and returns the
+// tempdir root, the file path, and the active rule.
+func setupFixupFixture(t *testing.T) (string, string, *api.Rule) {
+	t.Helper()
 	root := t.TempDir()
 	file := filepath.Join(root, "Foo.kt")
-	const content = "package demo\n\nclass Foo : Any()\n"
-	if err := os.WriteFile(file, []byte(content), 0o644); err != nil {
+	if err := os.WriteFile(file, []byte(fixupFixtureContent), 0o644); err != nil {
 		t.Fatalf("write fixture: %v", err)
 	}
+	return root, file, findV2RuleForTest(t, "UnnecessaryInheritance")
+}
 
-	rule := findV2RuleForTest(t, "UnnecessaryInheritance")
+func TestRunProject_FixupNoOpByDefault(t *testing.T) {
+	root, file, rule := setupFixupFixture(t)
 	res, err := RunProject(context.Background(), ProjectInput{
 		Args: ProjectArgs{
 			Config:      config.NewConfig(),
@@ -42,28 +46,17 @@ func TestRunProject_FixupNoOpByDefault(t *testing.T) {
 	if res.Fixup.FixableCount != 0 {
 		t.Errorf("default RunProject must not count fixes; FixableCount=%d", res.Fixup.FixableCount)
 	}
-	// Fixture file must be untouched.
 	got, err := os.ReadFile(file)
 	if err != nil {
 		t.Fatalf("read fixture: %v", err)
 	}
-	if string(got) != content {
-		t.Errorf("file was modified without --fix:\nwant=%q\ngot =%q", content, got)
+	if string(got) != fixupFixtureContent {
+		t.Errorf("file was modified without --fix:\nwant=%q\ngot =%q", fixupFixtureContent, got)
 	}
 }
 
-// TestRunProject_DryRunCountsButDoesNotApply asserts that
-// Args.DryRun causes FixupPhase to count fixable findings without
-// touching the filesystem. Mirrors the CLI's `--dry-run` semantics.
 func TestRunProject_DryRunCountsButDoesNotApply(t *testing.T) {
-	root := t.TempDir()
-	file := filepath.Join(root, "Foo.kt")
-	const content = "package demo\n\nclass Foo : Any()\n"
-	if err := os.WriteFile(file, []byte(content), 0o644); err != nil {
-		t.Fatalf("write fixture: %v", err)
-	}
-
-	rule := findV2RuleForTest(t, "UnnecessaryInheritance")
+	root, file, rule := setupFixupFixture(t)
 	res, err := RunProject(context.Background(), ProjectInput{
 		Args: ProjectArgs{
 			Config:      config.NewConfig(),
@@ -89,23 +82,13 @@ func TestRunProject_DryRunCountsButDoesNotApply(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read fixture: %v", err)
 	}
-	if string(got) != content {
-		t.Errorf("file was modified during --dry-run:\nwant=%q\ngot =%q", content, got)
+	if string(got) != fixupFixtureContent {
+		t.Errorf("file was modified during --dry-run:\nwant=%q\ngot =%q", fixupFixtureContent, got)
 	}
 }
 
-// TestRunProject_FixAppliesText confirms that Args.Fix=true causes
-// FixupPhase to actually rewrite the file on disk and report the
-// applied count back through ProjectResult.Fixup.
 func TestRunProject_FixAppliesText(t *testing.T) {
-	root := t.TempDir()
-	file := filepath.Join(root, "Foo.kt")
-	const content = "package demo\n\nclass Foo : Any()\n"
-	if err := os.WriteFile(file, []byte(content), 0o644); err != nil {
-		t.Fatalf("write fixture: %v", err)
-	}
-
-	rule := findV2RuleForTest(t, "UnnecessaryInheritance")
+	root, file, rule := setupFixupFixture(t)
 	res, err := RunProject(context.Background(), ProjectInput{
 		Args: ProjectArgs{
 			Config:      config.NewConfig(),
@@ -127,7 +110,7 @@ func TestRunProject_FixAppliesText(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read fixture: %v", err)
 	}
-	if string(got) == content {
-		t.Errorf("file was NOT modified despite --fix:\n%s", content)
+	if string(got) == fixupFixtureContent {
+		t.Errorf("file was NOT modified despite --fix:\n%s", fixupFixtureContent)
 	}
 }

--- a/internal/pipeline/runproject_fixup_test.go
+++ b/internal/pipeline/runproject_fixup_test.go
@@ -1,0 +1,133 @@
+package pipeline
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kaeawc/krit/internal/config"
+	"github.com/kaeawc/krit/internal/rules"
+	api "github.com/kaeawc/krit/internal/rules/api"
+)
+
+// TestRunProject_FixupNoOpByDefault is the contract that the new
+// fixup wiring (#70 Step B) stays inert for callers that don't set
+// any fix knob. The daemon's analyze-project verb relies on this:
+// it must produce identical output before and after Step B.
+func TestRunProject_FixupNoOpByDefault(t *testing.T) {
+	root := t.TempDir()
+	file := filepath.Join(root, "Foo.kt")
+	const content = "package demo\n\nclass Foo : Any()\n"
+	if err := os.WriteFile(file, []byte(content), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	rule := findV2RuleForTest(t, "UnnecessaryInheritance")
+	res, err := RunProject(context.Background(), ProjectInput{
+		Args: ProjectArgs{
+			Config:      config.NewConfig(),
+			Paths:       []string{root},
+			ActiveRules: []*api.Rule{rule},
+			Format:      "json",
+			Version:     "test",
+		},
+	})
+	if err != nil {
+		t.Fatalf("RunProject: %v", err)
+	}
+	if res.Fixup.AppliedFixes != 0 {
+		t.Errorf("default RunProject must not apply fixes; AppliedFixes=%d", res.Fixup.AppliedFixes)
+	}
+	if res.Fixup.FixableCount != 0 {
+		t.Errorf("default RunProject must not count fixes; FixableCount=%d", res.Fixup.FixableCount)
+	}
+	// Fixture file must be untouched.
+	got, err := os.ReadFile(file)
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	if string(got) != content {
+		t.Errorf("file was modified without --fix:\nwant=%q\ngot =%q", content, got)
+	}
+}
+
+// TestRunProject_DryRunCountsButDoesNotApply asserts that
+// Args.DryRun causes FixupPhase to count fixable findings without
+// touching the filesystem. Mirrors the CLI's `--dry-run` semantics.
+func TestRunProject_DryRunCountsButDoesNotApply(t *testing.T) {
+	root := t.TempDir()
+	file := filepath.Join(root, "Foo.kt")
+	const content = "package demo\n\nclass Foo : Any()\n"
+	if err := os.WriteFile(file, []byte(content), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	rule := findV2RuleForTest(t, "UnnecessaryInheritance")
+	res, err := RunProject(context.Background(), ProjectInput{
+		Args: ProjectArgs{
+			Config:      config.NewConfig(),
+			Paths:       []string{root},
+			ActiveRules: []*api.Rule{rule},
+			Format:      "json",
+			Version:     "test",
+			DryRun:      true,
+			MaxFixLevel: rules.FixIdiomatic,
+		},
+	})
+	if err != nil {
+		t.Fatalf("RunProject: %v", err)
+	}
+	if res.Fixup.FixableCount == 0 {
+		t.Fatalf("expected at least one fixable finding for UnnecessaryInheritance, got 0\nfindings=%#v",
+			res.FinalFindings.Findings())
+	}
+	if res.Fixup.AppliedFixes != 0 {
+		t.Errorf("--dry-run must not apply fixes; AppliedFixes=%d", res.Fixup.AppliedFixes)
+	}
+	got, err := os.ReadFile(file)
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	if string(got) != content {
+		t.Errorf("file was modified during --dry-run:\nwant=%q\ngot =%q", content, got)
+	}
+}
+
+// TestRunProject_FixAppliesText confirms that Args.Fix=true causes
+// FixupPhase to actually rewrite the file on disk and report the
+// applied count back through ProjectResult.Fixup.
+func TestRunProject_FixAppliesText(t *testing.T) {
+	root := t.TempDir()
+	file := filepath.Join(root, "Foo.kt")
+	const content = "package demo\n\nclass Foo : Any()\n"
+	if err := os.WriteFile(file, []byte(content), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	rule := findV2RuleForTest(t, "UnnecessaryInheritance")
+	res, err := RunProject(context.Background(), ProjectInput{
+		Args: ProjectArgs{
+			Config:      config.NewConfig(),
+			Paths:       []string{root},
+			ActiveRules: []*api.Rule{rule},
+			Format:      "json",
+			Version:     "test",
+			Fix:         true,
+			MaxFixLevel: rules.FixIdiomatic,
+		},
+	})
+	if err != nil {
+		t.Fatalf("RunProject: %v", err)
+	}
+	if res.Fixup.AppliedFixes == 0 {
+		t.Fatalf("expected AppliedFixes > 0 with Args.Fix=true; got 0\nfixup=%#v", res.Fixup)
+	}
+	got, err := os.ReadFile(file)
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	if string(got) == content {
+		t.Errorf("file was NOT modified despite --fix:\n%s", content)
+	}
+}

--- a/internal/pipeline/runproject_perf_test.go
+++ b/internal/pipeline/runproject_perf_test.go
@@ -1,0 +1,88 @@
+package pipeline
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kaeawc/krit/internal/config"
+	"github.com/kaeawc/krit/internal/perf"
+	api "github.com/kaeawc/krit/internal/rules/api"
+)
+
+// TestRunProject_ShowPerfPopulatesOutputExtras asserts the #70 Step C
+// wiring: when Args.ShowPerf=true and a tracker is attached, the JSON
+// output carries a perf subtree and a caches subtree. When ShowPerf
+// is false the JSON header omits both — the daemon's default.
+func TestRunProject_ShowPerfPopulatesOutputExtras(t *testing.T) {
+	root := t.TempDir()
+	file := filepath.Join(root, "Foo.kt")
+	if err := os.WriteFile(file, []byte("package demo\n\nclass Foo : Any()\n"), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	rule := findV2RuleForTest(t, "UnnecessaryInheritance")
+
+	// --- ShowPerf=true: extras must be present.
+	tracker := perf.New(true)
+	res, err := RunProject(context.Background(), ProjectInput{
+		Args: ProjectArgs{
+			Config:      config.NewConfig(),
+			Paths:       []string{root},
+			ActiveRules: []*api.Rule{rule},
+			Format:      "json",
+			Version:     "test",
+			ShowPerf:    true,
+			PerfRules:   true,
+		},
+		Host: ProjectHostState{Tracker: tracker},
+	})
+	if err != nil {
+		t.Fatalf("RunProject (ShowPerf=true): %v", err)
+	}
+	got := decodeOutput(t, res.JSON)
+	for _, key := range []string{"perfTiming", "perfRuleStats", "caches", "cacheBudget"} {
+		if _, ok := got[key]; !ok {
+			t.Errorf("ShowPerf=true: missing %q in output keys=%v", key, mapKeys(got))
+		}
+	}
+
+	// --- ShowPerf=false: extras must be absent.
+	res2, err := RunProject(context.Background(), ProjectInput{
+		Args: ProjectArgs{
+			Config:      config.NewConfig(),
+			Paths:       []string{root},
+			ActiveRules: []*api.Rule{rule},
+			Format:      "json",
+			Version:     "test",
+		},
+	})
+	if err != nil {
+		t.Fatalf("RunProject (ShowPerf=false): %v", err)
+	}
+	got2 := decodeOutput(t, res2.JSON)
+	for _, key := range []string{"perfTiming", "perfRuleStats", "caches", "cacheBudget", "cache"} {
+		if _, ok := got2[key]; ok {
+			t.Errorf("ShowPerf=false: %q must be absent from output, got keys=%v", key, mapKeys(got2))
+		}
+	}
+}
+
+func decodeOutput(t *testing.T, raw []byte) map[string]any {
+	t.Helper()
+	var out map[string]any
+	if err := json.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("decode: %v\nraw=%s", err, raw)
+	}
+	return out
+}
+
+func mapKeys(m map[string]any) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
+}

--- a/internal/pipeline/runproject_perf_test.go
+++ b/internal/pipeline/runproject_perf_test.go
@@ -12,10 +12,10 @@ import (
 	api "github.com/kaeawc/krit/internal/rules/api"
 )
 
-// TestRunProject_ShowPerfPopulatesOutputExtras asserts the #70 Step C
-// wiring: when Args.ShowPerf=true and a tracker is attached, the JSON
-// output carries a perf subtree and a caches subtree. When ShowPerf
-// is false the JSON header omits both — the daemon's default.
+// TestRunProject_ShowPerfPopulatesOutputExtras: when Args.ShowPerf
+// is true and a tracker is attached, the JSON output carries perf
+// and caches subtrees. When false, the daemon-default header omits
+// both.
 func TestRunProject_ShowPerfPopulatesOutputExtras(t *testing.T) {
 	root := t.TempDir()
 	file := filepath.Join(root, "Foo.kt")

--- a/internal/snapshot/capture.go
+++ b/internal/snapshot/capture.go
@@ -25,6 +25,18 @@ type CaptureOptions struct {
 	// worktree and attaches a per-rule findings rollup to Result. The
 	// scan dominates capture wall-time, so this is opt-in.
 	WithFindings bool
+	// Redact, when true, post-processes the captured blob (and the
+	// findings rollup, if WithFindings) through RedactBlob /
+	// RedactFindings before returning. Use this for repos with
+	// strict-secrecy requirements: snapshots persist Symbol.FQN /
+	// Owner / Package / Signature plus File.Path, all of which can
+	// embed proprietary identifiers. Redact replaces them with
+	// stable one-way hashes so the snapshot still supports diff /
+	// timeline / metrics but cannot be reverse-engineered to a
+	// source identifier. The flag is captured into Blob.Redacted /
+	// Findings.Redacted / Manifest.Redacted so Diff can guard
+	// against comparing redacted vs raw.
+	Redact bool
 }
 
 // Result pairs the structural blob with the metrics rollup derived from
@@ -97,6 +109,13 @@ func Capture(opts CaptureOptions) (*Result, error) {
 			return nil, fmt.Errorf("snapshot: findings: %w", err)
 		}
 		result.Findings = findings
+	}
+
+	if opts.Redact {
+		RedactBlob(result.Blob)
+		if result.Findings != nil {
+			RedactFindings(result.Findings)
+		}
 	}
 
 	return result, nil

--- a/internal/snapshot/diff.go
+++ b/internal/snapshot/diff.go
@@ -98,6 +98,9 @@ func Diff(root, fromSHA, toSHA string) (*DiffResult, error) {
 	if from.SchemaVersion != to.SchemaVersion {
 		return nil, fmt.Errorf("snapshot: incompatible blob schemas (from=%d, to=%d)", from.SchemaVersion, to.SchemaVersion)
 	}
+	if from.Redacted != to.Redacted {
+		return nil, fmt.Errorf("snapshot: refusing to diff redacted vs raw blob (from.Redacted=%v, to.Redacted=%v)", from.Redacted, to.Redacted)
+	}
 
 	result := &DiffResult{
 		From: DiffSide{CommitSHA: from.CommitSHA, CapturedAt: from.CapturedAt, KritVersion: from.KritVersion, BlobSchema: from.SchemaVersion},
@@ -121,7 +124,13 @@ func Diff(root, fromSHA, toSHA string) (*DiffResult, error) {
 	fromFindings, _ := LoadFindings(root, fromSHA)
 	toFindings, _ := LoadFindings(root, toSHA)
 	if fromFindings != nil && toFindings != nil {
-		if fromFindings.RuleSetHash != "" && toFindings.RuleSetHash != "" && fromFindings.RuleSetHash != toFindings.RuleSetHash {
+		// Mixed redaction is treated like a rule-set mismatch: the
+		// per-rule totals stay comparable (rule IDs are public), but
+		// any per-file rollup would join across incompatible
+		// namespaces. We surface the mismatch and keep ByRule.
+		if fromFindings.Redacted != toFindings.Redacted {
+			result.FindingsRuleSetMismatch = true
+		} else if fromFindings.RuleSetHash != "" && toFindings.RuleSetHash != "" && fromFindings.RuleSetHash != toFindings.RuleSetHash {
 			result.FindingsRuleSetMismatch = true
 		} else {
 			result.FindingsByRule = diffFindingsByRule(fromFindings, toFindings)

--- a/internal/snapshot/findings.go
+++ b/internal/snapshot/findings.go
@@ -36,6 +36,11 @@ type Findings struct {
 	// ByRuleFile maps rule ID -> (repo-relative file path -> count).
 	// Optional; consumers that only need per-rule totals can ignore it.
 	ByRuleFile map[string]map[string]int
+	// Redacted is true when ByRuleFile's path keys have been replaced
+	// with stable one-way hashes by RedactFindings. Rule IDs stay in
+	// clear text because they are public krit identifiers. Mirrors
+	// Blob.Redacted so a snapshot is wholly redacted or wholly raw.
+	Redacted bool
 }
 
 // FindingsPath returns the on-disk location for a snapshot's findings

--- a/internal/snapshot/manifest.go
+++ b/internal/snapshot/manifest.go
@@ -61,6 +61,12 @@ type Manifest struct {
 	Modules     int            `json:"modules"`
 	Counts      ManifestCounts `json:"counts"`
 	RuleSetHash string         `json:"rule_set_hash,omitempty"`
+	// Redacted mirrors Blob.Redacted (and Findings.Redacted, which
+	// must agree). When true the snapshot's symbol names, FQNs,
+	// owners, packages, signatures, and file paths are one-way
+	// hashes rather than source identifiers. Diff refuses to compare
+	// a redacted manifest against a raw one.
+	Redacted bool `json:"redacted,omitempty"`
 }
 
 func manifestPath(root, sha string) (string, error) {
@@ -210,10 +216,11 @@ func buildManifest(res *Result, repoRoot, kritVersion string) *Manifest {
 		KritVersion:   kritVersion,
 		BlobSchema:    res.Blob.SchemaVersion,
 		// Flat fields kept for v1 reader compatibility; mirror Counts.
-		Files:   counts.Files,
-		Symbols: counts.Symbols,
-		Modules: counts.Modules,
-		Counts:  counts,
+		Files:    counts.Files,
+		Symbols:  counts.Symbols,
+		Modules:  counts.Modules,
+		Counts:   counts,
+		Redacted: res.Blob.Redacted,
 	}
 	if res.Metrics != nil {
 		m.MetricsSchema = res.Metrics.SchemaVersion

--- a/internal/snapshot/redact.go
+++ b/internal/snapshot/redact.go
@@ -1,0 +1,137 @@
+package snapshot
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// RedactionMarker is the prefix prepended to every hashed identifier
+// so a reader can tell at a glance that a value was redacted (vs. a
+// legitimate identifier that happens to look like hex). Diff readers
+// that join across snapshots key on the full string so the marker is
+// part of the join key — two redacted snapshots with the same source
+// FQN still match.
+const RedactionMarker = "krit-redacted:"
+
+// hashedNameLen caps the hex-encoded portion of redacted identifiers
+// at 16 characters (64 bits of SHA-256). 64 bits gives ~50% collision
+// probability around 2^32 symbols — well above any real-world Kotlin
+// project. Truncating keeps blob sizes manageable.
+const hashedNameLen = 16
+
+// RedactBlob replaces every source-identifier field on b with a
+// stable one-way hash and flips b.Redacted. Idempotent: a blob that
+// is already Redacted is returned unchanged so a CaptureOptions.Redact
+// caller that runs RedactBlob defensively doesn't double-hash.
+//
+// Fields redacted:
+//
+//   - RepoRoot — absolute path on the capture machine, leaks the
+//     user's directory layout. Cleared (not hashed) because it is
+//     not a join key.
+//   - File.Path — repo-relative path. Each path segment is hashed
+//     individually so the directory shape (depth, fan-out) survives
+//     while names do not.
+//   - Symbol.Name / FQN / Owner / Package / Signature / File — all
+//     source identifiers. Hashing preserves stable join keys for
+//     diff while making reverse lookup infeasible.
+//
+// Fields kept clear: SchemaVersion, KritVersion, CommitSHA,
+// CapturedAt, Symbol.Kind / Visibility / Line / Language /
+// IsOverride / IsTest, File.Language / Lines / Bytes, Module.Path /
+// Dir / Dependencies / Consumers. Module paths are gradle
+// coordinates — public by convention and not a code-secrecy
+// concern; if a downstream user needs them hashed too they can
+// extend this function.
+func RedactBlob(b *Blob) {
+	if b == nil || b.Redacted {
+		return
+	}
+	b.RepoRoot = ""
+	for i := range b.Files {
+		b.Files[i].Path = redactPath(b.Files[i].Path)
+	}
+	for i := range b.Symbols {
+		s := &b.Symbols[i]
+		s.Name = redactName(s.Name)
+		s.FQN = redactName(s.FQN)
+		s.Owner = redactName(s.Owner)
+		s.Package = redactName(s.Package)
+		s.Signature = redactName(s.Signature)
+		s.File = redactPath(s.File)
+	}
+	sort.Slice(b.Symbols, func(i, j int) bool {
+		if b.Symbols[i].FQN != b.Symbols[j].FQN {
+			return b.Symbols[i].FQN < b.Symbols[j].FQN
+		}
+		return b.Symbols[i].Signature < b.Symbols[j].Signature
+	})
+	sort.Slice(b.Files, func(i, j int) bool { return b.Files[i].Path < b.Files[j].Path })
+	b.Redacted = true
+}
+
+// RedactFindings rewrites Findings.ByRuleFile so the per-file path
+// keys are hashed using the same scheme as RedactBlob. Rule IDs in
+// ByRule and ByRuleFile stay in clear text — they are public krit
+// identifiers and contain no caller-controlled content. Idempotent.
+//
+// Callers that pass the result to Diff must redact both snapshots
+// consistently; mixing redacted and raw findings panics the diff
+// guard on Findings.Redacted (see Diff).
+func RedactFindings(f *Findings) {
+	if f == nil || f.Redacted {
+		return
+	}
+	if len(f.ByRuleFile) > 0 {
+		redacted := make(map[string]map[string]int, len(f.ByRuleFile))
+		for rule, perFile := range f.ByRuleFile {
+			if len(perFile) == 0 {
+				continue
+			}
+			rewritten := make(map[string]int, len(perFile))
+			for path, count := range perFile {
+				rewritten[redactPath(path)] += count
+			}
+			redacted[rule] = rewritten
+		}
+		f.ByRuleFile = redacted
+	}
+	f.Redacted = true
+}
+
+// redactName returns a stable hash of s. Empty input returns "" so
+// fields that are legitimately blank (e.g. a symbol with no owner)
+// stay distinguishable from hashed-empty.
+func redactName(s string) string {
+	if s == "" {
+		return ""
+	}
+	sum := sha256.Sum256([]byte(s))
+	return RedactionMarker + hex.EncodeToString(sum[:])[:hashedNameLen]
+}
+
+// redactPath hashes each segment of s individually and rejoins them
+// with forward slashes. Preserves directory depth and fan-out (useful
+// for "tests under module X grew by N" reporting) while hiding the
+// names themselves. Empty input returns "".
+//
+// Paths in snapshots are already repo-relative + forward-slashed
+// (relPath in capture.go enforces that), so segmentation is a
+// trivial Split. If a non-slash separator slips in the result is
+// still deterministic because hash(seg) is independent of the
+// separator choice.
+func redactPath(p string) string {
+	if p == "" {
+		return ""
+	}
+	// Normalise just in case a backslash leaked through on Windows.
+	p = filepath.ToSlash(p)
+	parts := strings.Split(p, "/")
+	for i, seg := range parts {
+		parts[i] = redactName(seg)
+	}
+	return strings.Join(parts, "/")
+}

--- a/internal/snapshot/redact_test.go
+++ b/internal/snapshot/redact_test.go
@@ -1,0 +1,189 @@
+package snapshot
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRedactBlob_HashesIdentifiersAndPaths(t *testing.T) {
+	b := &Blob{
+		SchemaVersion: SchemaVersion,
+		KritVersion:   "1.2.3",
+		CommitSHA:     "abc",
+		CapturedAt:    100,
+		RepoRoot:      "/home/jane/proprietary-project",
+		Files: []File{
+			{Path: "src/main/kotlin/com/secret/Foo.kt", Language: "kotlin", Lines: 10, Bytes: 100, Module: ":app"},
+		},
+		Symbols: []Symbol{
+			{
+				Name: "computeProprietaryThing", Kind: "function", Visibility: "public",
+				File: "src/main/kotlin/com/secret/Foo.kt", Line: 5, Language: "kotlin",
+				Package: "com.secret", FQN: "com.secret.Foo.computeProprietaryThing",
+				Owner: "Foo", Signature: "computeProprietaryThing(Int): String",
+			},
+		},
+	}
+	RedactBlob(b)
+
+	if !b.Redacted {
+		t.Fatalf("Redacted flag must be true after RedactBlob")
+	}
+	if b.RepoRoot != "" {
+		t.Errorf("RepoRoot must be cleared; got %q", b.RepoRoot)
+	}
+	// Preserved fields: kind, visibility, line, language, lines, bytes, module
+	if got := b.Symbols[0].Kind; got != "function" {
+		t.Errorf("Kind must survive redaction; got %q", got)
+	}
+	if got := b.Symbols[0].Line; got != 5 {
+		t.Errorf("Line must survive redaction; got %d", got)
+	}
+	if got := b.Files[0].Lines; got != 10 {
+		t.Errorf("Lines must survive redaction; got %d", got)
+	}
+	if got := b.Files[0].Module; got != ":app" {
+		t.Errorf("Module must survive redaction; got %q", got)
+	}
+	// Hashed fields all start with the marker and contain no source identifier.
+	for _, field := range []string{
+		b.Symbols[0].Name, b.Symbols[0].FQN, b.Symbols[0].Owner,
+		b.Symbols[0].Package, b.Symbols[0].Signature,
+	} {
+		if !strings.HasPrefix(field, RedactionMarker) {
+			t.Errorf("redacted field missing marker: %q", field)
+		}
+		if strings.Contains(field, "Proprietary") || strings.Contains(field, "secret") {
+			t.Errorf("redacted field still contains source identifier: %q", field)
+		}
+	}
+	// Path is per-segment hashed: depth survives, names don't.
+	parts := strings.Split(b.Symbols[0].File, "/")
+	if len(parts) != 6 {
+		t.Errorf("path depth must survive redaction (want 6, got %d): %q", len(parts), b.Symbols[0].File)
+	}
+	for _, p := range parts {
+		if !strings.HasPrefix(p, RedactionMarker) {
+			t.Errorf("path segment missing marker: %q", p)
+		}
+	}
+}
+
+func TestRedactBlob_Idempotent(t *testing.T) {
+	b := &Blob{
+		Symbols: []Symbol{{Name: "x", FQN: "p.x"}},
+		Files:   []File{{Path: "a/b.kt"}},
+	}
+	RedactBlob(b)
+	first := b.Symbols[0].FQN
+	RedactBlob(b) // second call must be a no-op
+	if b.Symbols[0].FQN != first {
+		t.Errorf("RedactBlob not idempotent: got %q, want %q", b.Symbols[0].FQN, first)
+	}
+}
+
+func TestRedactBlob_StableHashAcrossCalls(t *testing.T) {
+	a := &Blob{Symbols: []Symbol{{FQN: "com.example.X"}}}
+	b := &Blob{Symbols: []Symbol{{FQN: "com.example.X"}}}
+	RedactBlob(a)
+	RedactBlob(b)
+	if a.Symbols[0].FQN != b.Symbols[0].FQN {
+		t.Errorf("hashing must be deterministic across blobs: a=%q b=%q",
+			a.Symbols[0].FQN, b.Symbols[0].FQN)
+	}
+}
+
+func TestRedactFindings_HashesPaths(t *testing.T) {
+	f := &Findings{
+		ByRule: map[string]int{"PrintlnInProduction": 3},
+		ByRuleFile: map[string]map[string]int{
+			"PrintlnInProduction": {
+				"src/main/kotlin/com/secret/Foo.kt": 2,
+				"src/main/kotlin/com/secret/Bar.kt": 1,
+			},
+		},
+	}
+	RedactFindings(f)
+
+	if !f.Redacted {
+		t.Fatalf("Findings.Redacted must be true after RedactFindings")
+	}
+	// Rule IDs stay clear.
+	if f.ByRule["PrintlnInProduction"] != 3 {
+		t.Errorf("rule ID totals must survive redaction; got %v", f.ByRule)
+	}
+	per := f.ByRuleFile["PrintlnInProduction"]
+	if per == nil {
+		t.Fatalf("rule per-file map missing after redaction")
+	}
+	totalCount := 0
+	for path, count := range per {
+		if !strings.HasPrefix(path, RedactionMarker) {
+			t.Errorf("ByRuleFile path key missing marker: %q", path)
+		}
+		if strings.Contains(path, "secret") || strings.Contains(path, "Foo") {
+			t.Errorf("ByRuleFile path still contains source identifier: %q", path)
+		}
+		totalCount += count
+	}
+	if totalCount != 3 {
+		t.Errorf("redaction must preserve per-file count sums; got %d want 3", totalCount)
+	}
+}
+
+func TestDiff_RefusesRedactedVsRaw(t *testing.T) {
+	root := t.TempDir()
+	rawSHA := "1111111111111111111111111111111111111111"
+	redSHA := "2222222222222222222222222222222222222222"
+
+	if _, err := Save(root, &Blob{
+		SchemaVersion: SchemaVersion, CommitSHA: rawSHA, CapturedAt: 1,
+		Symbols: []Symbol{{FQN: "p.X"}},
+	}); err != nil {
+		t.Fatalf("save raw: %v", err)
+	}
+	redacted := &Blob{
+		SchemaVersion: SchemaVersion, CommitSHA: redSHA, CapturedAt: 2,
+		Symbols: []Symbol{{FQN: "p.X"}},
+	}
+	RedactBlob(redacted)
+	if _, err := Save(root, redacted); err != nil {
+		t.Fatalf("save redacted: %v", err)
+	}
+
+	_, err := Diff(root, rawSHA, redSHA)
+	if err == nil {
+		t.Fatalf("Diff must refuse to compare redacted vs raw")
+	}
+	if !strings.Contains(err.Error(), "redacted vs raw") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+func TestDiff_AllowsRedactedVsRedacted(t *testing.T) {
+	root := t.TempDir()
+	makeRedacted := func(sha, fqn string, capturedAt int64) {
+		b := &Blob{
+			SchemaVersion: SchemaVersion, CommitSHA: sha, CapturedAt: capturedAt,
+			Symbols: []Symbol{{FQN: fqn}},
+		}
+		RedactBlob(b)
+		if _, err := Save(root, b); err != nil {
+			t.Fatalf("save %s: %v", sha, err)
+		}
+	}
+	from := "1111111111111111111111111111111111111111"
+	to := "2222222222222222222222222222222222222222"
+	makeRedacted(from, "com.example.X", 1)
+	makeRedacted(to, "com.example.X", 2)
+
+	result, err := Diff(root, from, to)
+	if err != nil {
+		t.Fatalf("Diff of two redacted snapshots failed: %v", err)
+	}
+	// Same FQN on both sides → no added/removed symbols.
+	if len(result.AddedSymbols)+len(result.RemovedSymbols) != 0 {
+		t.Errorf("expected no symbol churn for identical inputs; got added=%d removed=%d",
+			len(result.AddedSymbols), len(result.RemovedSymbols))
+	}
+}

--- a/internal/snapshot/types.go
+++ b/internal/snapshot/types.go
@@ -23,6 +23,15 @@ type Blob struct {
 	Modules []Module
 	Files   []File
 	Symbols []Symbol
+
+	// Redacted is true when the blob's symbol names, owner/package
+	// strings, signatures, and file paths have been replaced with
+	// stable one-way hashes via Redact. Snapshots captured with
+	// CaptureOptions.Redact = true (or post-processed through
+	// RedactBlob) flip this flag. Diff guards against comparing
+	// redacted vs non-redacted blobs because the join keys
+	// (FQN / Signature / Path) live in different namespaces.
+	Redacted bool
 }
 
 type Module struct {


### PR DESCRIPTION
## Summary

Six commits across three open issues:

- **#70 Steps A/B/C** — three additive landings toward CLI/daemon pipeline consolidation. Steps D (warm-path migration) and E (runner thinning) deferred to their own PR series; they entangle deeply with CLI-only state and warrant separate review.
- **#77 (closes)** — opt-in snapshot redaction. `CaptureOptions.Redact` post-processes the blob and findings sidecar through stable sha256-truncated hashes, so symbol names / FQNs / owners / packages / signatures / file paths can be persisted without leaking source identifiers.
- **#139 observability** — `FindingsBundleHit` surfaces in `AnalyzeProjectStats` so warm-cache investigations can tell from the wire whether the whole-run findings cache fired.

Plus a simplify pass trimming WHAT-narration and task references from comments.

## Commits

1. `test(cli)`: CLI-vs-RunProject byte-equal contract test — `TestScanRunMatchesAnalyzeProjectVerb` (#70 Step A)
2. `feat(pipeline)`: wire FixupPhase into RunProject (#70 Step B)
3. `feat(pipeline)`: forward perf/cache extras through RunProject (#70 Step C)
4. `feat(snapshot)`: opt-in redaction for symbol names and paths (closes #77)
5. `feat(daemon)`: expose FindingsBundleHit in verb stats
6. `chore`: simplify pass

## Behavior changes

- `ProjectArgs` gains opt-in fix knobs (Fix/FixBinary/FixSuffix/DryRun/MaxFixLevel) and perf-extras knobs (BasePath/ShowPerf/PerfRules/ParseCacheCapBytes). Defaults match the daemon's current wire format — the equivalence test `TestAnalyzeProject_OutputMatchesDirectRunProject` still passes byte-for-byte.
- `Blob`, `Findings`, and `Manifest` gain a `Redacted bool`. Diff refuses to compare a redacted snapshot against a raw one.
- `AnalyzeProjectStats.FindingsBundleHit` (`findings_bundle_hit` in JSON).

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` — all green
- [x] New tests:
  - `TestScanRunMatchesAnalyzeProjectVerb`
  - `TestRunProject_FixupNoOpByDefault` / `DryRunCountsButDoesNotApply` / `FixAppliesText`
  - `TestRunProject_ShowPerfPopulatesOutputExtras`
  - `TestRedactBlob_*`, `TestRedactFindings_HashesPaths`, `TestDiff_RefusesRedactedVsRaw`, `TestDiff_AllowsRedactedVsRedacted`
  - `TestAnalyzeProject_BundleHitOnIdenticalSecondCall`
- [x] Existing equivalence test (`TestAnalyzeProject_OutputMatchesDirectRunProject`) still passes — the daemon's analyze-project wire format is unchanged.