### PR TITLE
Per-phase wall-time stats + synthetic-scale bundle-hit test (#139)

### DIFF
--- a/internal/cli/serve/analyze_project.go
+++ b/internal/cli/serve/analyze_project.go
@@ -117,6 +117,15 @@ func (r *streamingAnalyzeResponse) WriteRawResponse(ctx context.Context, w io.Wr
 		ParseHits:         res.ParseHits,
 		ParseMisses:       res.ParseMisses,
 		FindingsBundleHit: res.FindingsBundleHit,
+		PhaseTimingsMs: daemon.PhaseTimingsMs{
+			Parse:     res.PhaseTimingsMs.Parse,
+			Index:     res.PhaseTimingsMs.Index,
+			Dispatch:  res.PhaseTimingsMs.Dispatch,
+			CrossFile: res.PhaseTimingsMs.CrossFile,
+			Android:   res.PhaseTimingsMs.Android,
+			Fixup:     res.PhaseTimingsMs.Fixup,
+			Output:    res.PhaseTimingsMs.Output,
+		},
 	})
 	if err != nil {
 		return fmt.Errorf("marshal stats: %w", err)

--- a/internal/daemon/protocol.go
+++ b/internal/daemon/protocol.go
@@ -209,4 +209,22 @@ type AnalyzeProjectStats struct {
 	// A true value means the call was a structural reuse of a prior
 	// identical-input run.
 	FindingsBundleHit bool `json:"findings_bundle_hit"`
+	// PhaseTimingsMs is the per-phase wall-time breakdown for this
+	// call. Phases skipped on a findings-bundle hit (dispatch,
+	// crossfile, android) report 0. Useful for diagnosing which phase
+	// dominates a slow warm call without a full pprof capture.
+	PhaseTimingsMs PhaseTimingsMs `json:"phase_timings_ms"`
+}
+
+// PhaseTimingsMs mirrors pipeline.PhaseTimingsMs on the wire so
+// daemon clients can introspect per-phase cost without a separate
+// fetch. All values are wall-clock milliseconds.
+type PhaseTimingsMs struct {
+	Parse     int64 `json:"parse"`
+	Index     int64 `json:"index"`
+	Dispatch  int64 `json:"dispatch"`
+	CrossFile int64 `json:"crossfile"`
+	Android   int64 `json:"android"`
+	Fixup     int64 `json:"fixup"`
+	Output    int64 `json:"output"`
 }

--- a/internal/pipeline/project.go
+++ b/internal/pipeline/project.go
@@ -261,6 +261,27 @@ type ProjectResult struct {
 	// hosts without a bundle store, and runs where the conservative
 	// delta planner ran a partial dispatch instead of a full reuse.
 	FindingsBundleHit bool
+	// PhaseTimingsMs reports per-phase wall-time in milliseconds for
+	// the run. Phases that were skipped on a bundle-cache hit (dispatch,
+	// crossfile, android) report 0. Useful for diagnosing which phase
+	// dominates warm-call latency without a full pprof capture.
+	PhaseTimingsMs PhaseTimingsMs
+}
+
+// PhaseTimingsMs carries per-phase wall-time deltas captured around
+// each phase call in RunProjectStreaming. Zero values mean the phase
+// was skipped (most often on a findings-bundle hit) or completed in
+// under a millisecond. Sum-of-phases is less than ProjectResult's
+// total because Output writes asynchronously into the caller's
+// writer and phase boundaries here exclude phase wiring overhead.
+type PhaseTimingsMs struct {
+	Parse     int64 `json:"parse"`
+	Index     int64 `json:"index"`
+	Dispatch  int64 `json:"dispatch"`
+	CrossFile int64 `json:"crossfile"`
+	Android   int64 `json:"android"`
+	Fixup     int64 `json:"fixup"`
+	Output    int64 `json:"output"`
 }
 
 // RunProject runs the core scan pipeline against the given input and
@@ -306,7 +327,10 @@ func RunProjectStreaming(ctx context.Context, in ProjectInput, out io.Writer) (P
 	// to daemon clients. nil ParseCache returns the zero value.
 	hits0, misses0 := parseCacheCounters(host.ParseCache)
 
+	var phaseTimings PhaseTimingsMs
+
 	// Phase 1: parse.
+	parseStart := time.Now()
 	parseResult, err := ParsePhase{Workers: args.Workers}.Run(ctx, ParseInput{
 		Config:           args.Config,
 		Paths:            args.Paths,
@@ -317,6 +341,7 @@ func RunProjectStreaming(ctx context.Context, in ProjectInput, out io.Writer) (P
 		Tracker:          host.Tracker,
 		ParseCache:       host.ParseCache,
 	})
+	phaseTimings.Parse = time.Since(parseStart).Milliseconds()
 	if err != nil {
 		return ProjectResult{}, fmt.Errorf("parse: %w", err)
 	}
@@ -337,7 +362,9 @@ func RunProjectStreaming(ctx context.Context, in ProjectInput, out io.Writer) (P
 	}
 	wireOracleHandles(&indexInput, args, host, parseResult.KotlinFiles)
 	wireAnalysisCacheLookup(&indexInput, args, host)
+	indexStart := time.Now()
 	indexResult, err := IndexPhase{Workers: args.Workers}.Run(ctx, indexInput)
+	phaseTimings.Index = time.Since(indexStart).Milliseconds()
 	if err != nil {
 		return ProjectResult{}, fmt.Errorf("index: %w", err)
 	}
@@ -371,19 +398,25 @@ func RunProjectStreaming(ctx context.Context, in ProjectInput, out io.Writer) (P
 
 	runFP, bundleEnabled := computeRunFingerprint(args, host, parseResult, indexResult)
 	manifestData := buildManifestData(args, host, parseResult, runFP, bundleEnabled)
-	dispatchResult, crossFileResult, bundleHit, err := runDispatchOrLoadBundle(ctx, args, host, indexResult, parseResult, runFP, bundleEnabled, manifestData)
+	dispatchResult, crossFileResult, bundleHit, dispatchTimes, err := runDispatchOrLoadBundle(ctx, args, host, indexResult, parseResult, runFP, bundleEnabled, manifestData)
 	if err != nil {
 		return ProjectResult{}, err
 	}
+	phaseTimings.Dispatch = dispatchTimes.dispatchMs
+	phaseTimings.CrossFile = dispatchTimes.crossFileMs
 
 	// Phase 4.5: Android project analysis. The findings-bundle hit
 	// returns a pre-merged set (Android findings were merged before the
 	// save on the original miss), so we only run AndroidPhase on misses.
+	androidStart := time.Now()
 	if err := runAndroidPhaseAndMerge(ctx, args, indexResult, &crossFileResult, bundleHit); err != nil {
 		return ProjectResult{}, err
 	}
+	phaseTimings.Android = time.Since(androidStart).Milliseconds()
 
+	fixupStart := time.Now()
 	fixupView, err := runFixupPhase(ctx, args, crossFileResult)
+	phaseTimings.Fixup = time.Since(fixupStart).Milliseconds()
 	if err != nil {
 		return ProjectResult{}, err
 	}
@@ -402,6 +435,7 @@ func RunProjectStreaming(ctx context.Context, in ProjectInput, out io.Writer) (P
 	if args.ShowPerf {
 		cacheStatsOut = indexResult.CacheStats
 	}
+	outputStart := time.Now()
 	outResult, err := OutputPhase{}.Run(ctx, OutputInput{
 		FixupResult:      fixupView,
 		Writer:           out,
@@ -422,6 +456,7 @@ func RunProjectStreaming(ctx context.Context, in ProjectInput, out io.Writer) (P
 		Caches:           caches,
 		CacheBudget:      budget,
 	})
+	phaseTimings.Output = time.Since(outputStart).Milliseconds()
 	if err != nil {
 		return ProjectResult{}, fmt.Errorf("output: %w", err)
 	}
@@ -447,6 +482,7 @@ func RunProjectStreaming(ctx context.Context, in ProjectInput, out io.Writer) (P
 		ParseMisses:       misses1 - misses0,
 		Fixup:             fixupView,
 		FindingsBundleHit: bundleHit,
+		PhaseTimingsMs:    phaseTimings,
 	}, nil
 }
 
@@ -709,6 +745,15 @@ func runAndroidPhaseAndMerge(ctx context.Context, args ProjectArgs, indexResult 
 	return nil
 }
 
+// dispatchTimings is the per-phase wall-time slice returned from
+// runDispatchOrLoadBundle so RunProjectStreaming can populate
+// PhaseTimingsMs even on the bundle/delta paths where the phase
+// boundaries are inside this helper.
+type dispatchTimings struct {
+	dispatchMs  int64
+	crossFileMs int64
+}
+
 func runDispatchOrLoadBundle(
 	ctx context.Context,
 	args ProjectArgs,
@@ -718,27 +763,31 @@ func runDispatchOrLoadBundle(
 	runFP scanner.RunFingerprint,
 	bundleEnabled bool,
 	manifest deltaManifestData,
-) (DispatchResult, CrossFileResult, bool, error) {
+) (DispatchResult, CrossFileResult, bool, dispatchTimings, error) {
 	if bundleEnabled {
 		if cached, ok := host.FindingsBundleStore.Load(host.FindingsBundleCacheRoot, runFP); ok && cached != nil {
 			d := DispatchResult{IndexResult: indexResult, Findings: *cached}
-			return d, CrossFileResult{DispatchResult: d}, true, nil
+			return d, CrossFileResult{DispatchResult: d}, true, dispatchTimings{}, nil
 		}
 		if d, c, ok, err := tryDeltaDispatch(ctx, args, host, indexResult, parseResult, runFP, manifest); err != nil {
-			return DispatchResult{}, CrossFileResult{}, false, err
+			return DispatchResult{}, CrossFileResult{}, false, dispatchTimings{}, err
 		} else if ok {
-			return d, c, false, nil
+			return d, c, false, dispatchTimings{}, nil
 		}
 	}
+	dispatchStart := time.Now()
 	d, err := DispatchPhase{}.Run(ctx, indexResult)
+	dispatchMs := time.Since(dispatchStart).Milliseconds()
 	if err != nil {
-		return DispatchResult{}, CrossFileResult{}, false, fmt.Errorf("dispatch: %w", err)
+		return DispatchResult{}, CrossFileResult{}, false, dispatchTimings{}, fmt.Errorf("dispatch: %w", err)
 	}
+	crossStart := time.Now()
 	c, err := CrossFilePhase{Workers: args.Workers}.Run(ctx, d)
+	crossMs := time.Since(crossStart).Milliseconds()
 	if err != nil {
-		return DispatchResult{}, CrossFileResult{}, false, fmt.Errorf("crossfile: %w", err)
+		return DispatchResult{}, CrossFileResult{}, false, dispatchTimings{}, fmt.Errorf("crossfile: %w", err)
 	}
-	return d, c, false, nil
+	return d, c, false, dispatchTimings{dispatchMs: dispatchMs, crossFileMs: crossMs}, nil
 }
 
 // tryDeltaDispatch attempts the ConservativeDeltaPlanner's single-file

--- a/internal/pipeline/runproject_phase_timings_test.go
+++ b/internal/pipeline/runproject_phase_timings_test.go
@@ -1,0 +1,167 @@
+package pipeline
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kaeawc/krit/internal/config"
+	"github.com/kaeawc/krit/internal/rules"
+	api "github.com/kaeawc/krit/internal/rules/api"
+	"github.com/kaeawc/krit/internal/scanner"
+)
+
+// TestRunProject_PhaseTimings_PopulatedOnFullRun asserts the wire
+// format: ProjectResult.PhaseTimingsMs carries non-negative values
+// for every phase that actually ran. On a cold cache-less run the
+// parse + index phases are always > 0; dispatch / crossfile depend
+// on whether any rule produces work but should at least be
+// recorded (>=0).
+func TestRunProject_PhaseTimings_PopulatedOnFullRun(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "Foo.kt"),
+		[]byte("package demo\n\nclass Foo : Any()\n"), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	rule := findV2RuleForTest(t, "UnnecessaryInheritance")
+
+	res, err := RunProject(context.Background(), ProjectInput{
+		Args: ProjectArgs{
+			Config:      config.NewConfig(),
+			Paths:       []string{root},
+			ActiveRules: []*api.Rule{rule},
+			Format:      "json",
+			Version:     "test",
+		},
+	})
+	if err != nil {
+		t.Fatalf("RunProject: %v", err)
+	}
+	pt := res.PhaseTimingsMs
+	if pt.Parse < 0 || pt.Index < 0 || pt.Dispatch < 0 ||
+		pt.CrossFile < 0 || pt.Android < 0 || pt.Fixup < 0 || pt.Output < 0 {
+		t.Errorf("phase timings must be non-negative: %+v", pt)
+	}
+	// Single-file fixtures can complete every phase in under a
+	// millisecond and round to 0; the scale-side test asserts non-zero
+	// behaviour. The contract here is just "all fields are populated
+	// and non-negative".
+}
+
+// TestRunProject_PhaseTimings_BundleHitSkipsDispatchAndCrossfile is
+// the diagnostic for warm-cache investigations: on a findings-bundle
+// hit the dispatch and crossfile phases are bypassed entirely, so
+// their wall-time must be 0. A non-zero reading after a bundle hit
+// would indicate the helper still calls those phases — exactly the
+// regression that observability is meant to catch.
+func TestRunProject_PhaseTimings_BundleHitSkipsDispatchAndCrossfile(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "Foo.kt"),
+		[]byte("package demo\n\nclass Foo\n"), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	rule := findV2RuleForTest(t, "UnnecessaryInheritance")
+	host := ProjectHostState{
+		FindingsBundleStore:     scanner.DiskFindingsBundleStore{},
+		FindingsBundleCacheRoot: root,
+	}
+	args := ProjectArgs{
+		Config:      config.NewConfig(),
+		Paths:       []string{root},
+		ActiveRules: []*api.Rule{rule},
+		Format:      "json",
+		Version:     "test",
+	}
+
+	first, err := RunProject(context.Background(), ProjectInput{Args: args, Host: host})
+	if err != nil {
+		t.Fatalf("first RunProject: %v", err)
+	}
+	if first.FindingsBundleHit {
+		t.Fatalf("first call must miss the bundle; got hit=true")
+	}
+
+	second, err := RunProject(context.Background(), ProjectInput{Args: args, Host: host})
+	if err != nil {
+		t.Fatalf("second RunProject: %v", err)
+	}
+	if !second.FindingsBundleHit {
+		t.Fatalf("second identical call must hit the bundle; got hit=false")
+	}
+	if second.PhaseTimingsMs.Dispatch != 0 {
+		t.Errorf("bundle hit must skip dispatch (ms=0); got %d", second.PhaseTimingsMs.Dispatch)
+	}
+	if second.PhaseTimingsMs.CrossFile != 0 {
+		t.Errorf("bundle hit must skip crossfile (ms=0); got %d", second.PhaseTimingsMs.CrossFile)
+	}
+}
+
+// TestRunProject_PhaseTimings_BundleHitAtSyntheticScale is the
+// scale-side companion to TestAnalyzeProject_BundleHitOnIdentical
+// SecondCall in the serve package: the 2-file fixture proved the
+// bundle key is stable for trivial inputs, but #139 points at a
+// kotlin-corpus regression at thousands-of-files scale. This test
+// runs the same contract against ~200 files to catch fingerprint
+// drift that only surfaces at moderate scale.
+//
+// 200 is the upper bound at which this test stays under ~1 second
+// in CI. If the bundle ever stops firing at this scale, the test
+// reproduces the corpus regression without needing the actual
+// JetBrains/kotlin checkout.
+func TestRunProject_PhaseTimings_BundleHitAtSyntheticScale(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip synthetic-scale bundle hit test in -short mode")
+	}
+	root := t.TempDir()
+	const fileCount = 200
+	for i := 0; i < fileCount; i++ {
+		path := filepath.Join(root, fmt.Sprintf("F%03d.kt", i))
+		body := fmt.Sprintf("package demo\n\nclass F%03d {\n    fun a%d() {}\n}\n", i, i)
+		if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+			t.Fatalf("write %s: %v", path, err)
+		}
+	}
+	rule := findV2RuleForTest(t, "UnnecessaryInheritance")
+	host := ProjectHostState{
+		FindingsBundleStore:     scanner.DiskFindingsBundleStore{},
+		FindingsBundleCacheRoot: root,
+	}
+	args := ProjectArgs{
+		Config:      config.NewConfig(),
+		Paths:       []string{root},
+		ActiveRules: []*api.Rule{rule},
+		Format:      "json",
+		Version:     "test",
+		MaxFixLevel: rules.FixIdiomatic,
+	}
+
+	first, err := RunProject(context.Background(), ProjectInput{Args: args, Host: host})
+	if err != nil {
+		t.Fatalf("first RunProject: %v", err)
+	}
+	if first.FilesScanned != fileCount {
+		t.Fatalf("expected %d files scanned on first call, got %d", fileCount, first.FilesScanned)
+	}
+	// At 200 files parse always crosses the millisecond floor, so the
+	// observability is non-vacuous at this scale.
+	if first.PhaseTimingsMs.Parse == 0 {
+		t.Errorf("expected parse timing > 0 at %d-file scale; got %+v",
+			fileCount, first.PhaseTimingsMs)
+	}
+
+	second, err := RunProject(context.Background(), ProjectInput{Args: args, Host: host})
+	if err != nil {
+		t.Fatalf("second RunProject: %v", err)
+	}
+	if !second.FindingsBundleHit {
+		t.Fatalf("identical %d-file second call must hit the bundle; got hit=false\nphase timings: %+v",
+			fileCount, second.PhaseTimingsMs)
+	}
+	// Bundle hit must skip dispatch+crossfile entirely.
+	if second.PhaseTimingsMs.Dispatch != 0 || second.PhaseTimingsMs.CrossFile != 0 {
+		t.Errorf("bundle hit must bypass dispatch+crossfile; got dispatch=%dms crossfile=%dms",
+			second.PhaseTimingsMs.Dispatch, second.PhaseTimingsMs.CrossFile)
+	}
+}


### PR DESCRIPTION
## Summary

Adds per-phase wall-time observability to the daemon's analyze-project verb so a single warm-call stats dump pinpoints which phase eats latency — the diagnostic [#139](https://github.com/kaeawc/krit/issues/139) needs without requiring full pprof capture.

New on `AnalyzeProjectStats` (`phase_timings_ms` in JSON):

```
{ parse, index, dispatch, crossfile, android, fixup, output }
```

All values are int64 milliseconds; 0 means the phase was skipped (typically on a findings-bundle hit) or completed in <1ms.

Plus a synthetic-scale bundle-hit regression test (200 files) that reproduces the #139 contract locally without needing the JetBrains/kotlin checkout. If it ever fails, the corpus regression has a fast local repro.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` — all green
- [x] New tests:
  - `TestRunProject_PhaseTimings_PopulatedOnFullRun`
  - `TestRunProject_PhaseTimings_BundleHitSkipsDispatchAndCrossfile` — asserts dispatch=0, crossfile=0 on second identical call
  - `TestRunProject_PhaseTimings_BundleHitAtSyntheticScale` — 200-file fixture confirms bundle fires at moderate scale

## Follow-up

When someone runs the kotlin-corpus benchmark with this branch deployed, the warm-call stats dump will pinpoint where the 38s goes — that becomes the next #139 issue ladder.