### PR TITLE
diag(pipeline): report bundle miss components

### DIFF
--- a/internal/pipeline/findings_bundle_cache_test.go
+++ b/internal/pipeline/findings_bundle_cache_test.go
@@ -1,12 +1,15 @@
 package pipeline
 
 import (
+	"bytes"
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/kaeawc/krit/internal/config"
+	"github.com/kaeawc/krit/internal/diag"
 	api "github.com/kaeawc/krit/internal/rules/api"
 	"github.com/kaeawc/krit/internal/scanner"
 )
@@ -184,5 +187,57 @@ func TestRunProject_FindingsBundleCache_RebuildsOnEdit(t *testing.T) {
 	run(t) // fingerprint differs → miss → save again
 	if bundle.saveCalls != 2 {
 		t.Errorf("after content edit, saveCalls = %d, want 2 (fingerprint mismatch should force a fresh save)", bundle.saveCalls)
+	}
+}
+
+func TestRunProject_FindingsBundleCache_ReportsMissComponent(t *testing.T) {
+	dir := t.TempDir()
+	cacheRoot := t.TempDir()
+	src := filepath.Join(dir, "Sample.kt")
+	if err := os.WriteFile(src, []byte("package test\n\nclass Sample { fun value() = 1 }\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	rule := api.FakeRule("ClassDecl",
+		api.WithNodeTypes("class_declaration"),
+		api.WithSeverity(api.SeverityWarning),
+		api.WithCheck(func(ctx *api.Context) {
+			ctx.EmitAt(int(ctx.Node.StartRow)+1, 1, "class declared")
+		}),
+	)
+
+	var verbose bytes.Buffer
+	run := func(t *testing.T) {
+		t.Helper()
+		if _, err := RunProject(context.Background(), ProjectInput{
+			Args: ProjectArgs{
+				Config:      config.NewConfig(),
+				Paths:       []string{dir},
+				ActiveRules: []*api.Rule{rule},
+				Format:      "json",
+				Version:     "test",
+			},
+			Host: ProjectHostState{
+				Reporter:                &diag.Reporter{Verbose: &verbose},
+				FindingsBundleStore:     scanner.DiskFindingsBundleStore{},
+				FindingsBundleCacheRoot: cacheRoot,
+			},
+		}); err != nil {
+			t.Fatalf("RunProject: %v", err)
+		}
+	}
+
+	run(t)
+	verbose.Reset()
+	if err := os.WriteFile(src, []byte("package test\n\nclass Sample { fun value() = 2 }\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	run(t)
+
+	got := verbose.String()
+	if !strings.Contains(got, "Findings bundle cache: MISS") {
+		t.Fatalf("verbose output missing bundle miss: %q", got)
+	}
+	if !strings.Contains(got, "sourceSet") {
+		t.Fatalf("verbose output missing changed component: %q", got)
 	}
 }

--- a/internal/pipeline/project.go
+++ b/internal/pipeline/project.go
@@ -473,10 +473,10 @@ func RunProjectStreaming(ctx context.Context, in ProjectInput, out io.Writer) (P
 
 	hits1, misses1 := parseCacheCounters(host.ParseCache)
 	return ProjectResult{
-		FinalFindings: outResult.FinalFindings,
-		FilesScanned:  len(parseResult.KotlinFiles) + len(parseResult.JavaFiles),
-		FindingsCount: outResult.FinalFindings.Len(),
-		ParseErrors:   parseResult.ParseErrors,
+		FinalFindings:     outResult.FinalFindings,
+		FilesScanned:      len(parseResult.KotlinFiles) + len(parseResult.JavaFiles),
+		FindingsCount:     outResult.FinalFindings.Len(),
+		ParseErrors:       parseResult.ParseErrors,
 		Stats:             dispatchResult.Stats,
 		ParseHits:         hits1 - hits0,
 		ParseMisses:       misses1 - misses0,
@@ -769,6 +769,7 @@ func runDispatchOrLoadBundle(
 			d := DispatchResult{IndexResult: indexResult, Findings: *cached}
 			return d, CrossFileResult{DispatchResult: d}, true, dispatchTimings{}, nil
 		}
+		reportFindingsBundleMiss(host, manifest, runFP)
 		if d, c, ok, err := tryDeltaDispatch(ctx, args, host, indexResult, parseResult, runFP, manifest); err != nil {
 			return DispatchResult{}, CrossFileResult{}, false, dispatchTimings{}, err
 		} else if ok {
@@ -788,6 +789,40 @@ func runDispatchOrLoadBundle(
 		return DispatchResult{}, CrossFileResult{}, false, dispatchTimings{}, fmt.Errorf("crossfile: %w", err)
 	}
 	return d, c, false, dispatchTimings{dispatchMs: dispatchMs, crossFileMs: crossMs}, nil
+}
+
+func reportFindingsBundleMiss(host ProjectHostState, manifest deltaManifestData, runFP scanner.RunFingerprint) {
+	if host.Reporter == nil || !host.Reporter.VerboseEnabled() || !manifest.enabled || manifest.manifestKey == "" {
+		return
+	}
+	prior, ok := scanner.LoadFindingsBundleManifest(host.FindingsBundleCacheRoot, manifest.manifestKey)
+	if !ok {
+		host.Reporter.Verbosef("verbose: Findings bundle cache: MISS (no prior manifest)\n")
+		return
+	}
+	changed := runFingerprintDiffFields(prior.Fingerprint, runFP)
+	if len(changed) == 0 {
+		host.Reporter.Verbosef("verbose: Findings bundle cache: MISS (prior bundle missing)\n")
+		return
+	}
+	host.Reporter.Verbosef("verbose: Findings bundle cache: MISS (changed: %s)\n", strings.Join(changed, ","))
+}
+
+func runFingerprintDiffFields(prior, current scanner.RunFingerprint) []string {
+	var changed []string
+	add := func(name, a, b string) {
+		if a != b {
+			changed = append(changed, name)
+		}
+	}
+	add("version", prior.Version, current.Version)
+	add("rules", prior.Rules, current.Rules)
+	add("config", prior.Config, current.Config)
+	add("sourceSet", prior.SourceSet, current.SourceSet)
+	add("crossFile", prior.CrossFile, current.CrossFile)
+	add("android", prior.Android, current.Android)
+	add("libraryFacts", prior.LibraryFacts, current.LibraryFacts)
+	return changed
 }
 
 // tryDeltaDispatch attempts the ConservativeDeltaPlanner's single-file


### PR DESCRIPTION
## Summary
- report verbose findings-bundle miss reasons from the prior manifest fingerprint
- cover source-set drift diagnostics with a pipeline regression test

## Test plan
- [x] go test ./internal/pipeline/ -run 'TestRunProject_FindingsBundleCache' -count=1
- [x] go test ./internal/pipeline/ ./internal/cli/scan/ ./internal/cli/serve/ -count=1
- [x] go build -o krit ./cmd/krit/ && go vet ./...
- [x] go test ./... -count=1
- [x] make integration

Refs #139