### PR TITLE
test(scan): keep parse cache in contract path

### DIFF
--- a/internal/cli/scan/scan_contract_test.go
+++ b/internal/cli/scan/scan_contract_test.go
@@ -36,7 +36,6 @@ func TestScanRunMatchesAnalyzeProjectVerb(t *testing.T) {
 		"krit",
 		"--no-cache",
 		"--no-cross-file-cache",
-		"--no-parse-cache",
 		"--no-fir",
 		"--no-type-oracle",
 		"-f", "json",


### PR DESCRIPTION
## Summary
- keep parse caching enabled in the CLI side of the scan-vs-RunProject contract
- preserves byte-equal findings output while shrinking the disabled surface for #70

## Test plan
- [x] go test ./internal/cli/scan/ -run TestScanRunMatchesAnalyzeProjectVerb -count=1
- [x] go test ./internal/pipeline/ ./internal/cli/scan/ ./internal/cli/serve/ -count=1
- [x] go build -o krit ./cmd/krit/ && go vet ./...
- [x] go test ./... -count=1
- [x] make integration

Refs #70