### PR TITLE
refactor(pipeline): share warm cache planning

### DIFF
--- a/internal/cli/scan/runner.go
+++ b/internal/cli/scan/runner.go
@@ -340,7 +340,7 @@ func (r *runner) filterRules() (handled bool, code int) {
 		enabledSet := clishared.ParseRuleNameSetCSV(*r.f.EnableRules)
 		experimental := *r.f.Experimental || r.cfg.GetTopLevelBool("experimental", false)
 		r.activeRules = rules.ActiveRulesV2(disabledSet, enabledSet, *r.f.AllRules, experimental)
-		if rulesNeedProjectModel(r.activeRules) {
+		if pipeline.RulesNeedProjectModel(r.activeRules) {
 			r.ensureProjectModel()
 		}
 
@@ -472,7 +472,7 @@ func (r *runner) runOracleIndex() (int, error) {
 // setupAndroidProviders builds the project providers used by AndroidPhase.
 func (r *runner) setupAndroidProviders() {
 	r.tracker.TrackVoid("setupAndroidProviders", func() {
-		if !rulesNeedAndroidProject(r.activeRules) {
+		if !pipeline.RulesNeedAndroidProject(r.activeRules) {
 			return
 		}
 		deps := pipeline.CollectAndroidDependenciesV2(r.activeRules)
@@ -490,7 +490,7 @@ func (r *runner) setupParseCaches() {
 
 		// Android findings cache is needed even when the source parse is skipped:
 		// AndroidPhase uses the writer as the cacheability gate for cache loads.
-		if rulesNeedAndroidProject(r.activeRules) && !*r.f.NoCache && repoDir != "" {
+		if pipeline.RulesNeedAndroidProject(r.activeRules) && !*r.f.NoCache && repoDir != "" {
 			r.androidCacheDir = scanner.AndroidFindingsCacheDir(repoDir)
 			r.androidCacheWriter = scanner.NewAndroidCacheWriter(*r.f.Jobs)
 		}
@@ -504,7 +504,7 @@ func (r *runner) setupParseCaches() {
 			} else if *r.f.Verbose {
 				fmt.Fprintf(os.Stderr, "verbose: parse cache disabled: %v\n", pcErr)
 			}
-			if rulesNeedAndroidProject(r.activeRules) {
+			if pipeline.RulesNeedAndroidProject(r.activeRules) {
 				if xmlPC, xmlErr := android.NewXMLParseCacheWithCap(repoDir, capBytes); xmlErr == nil {
 					r.xmlParseCache = xmlPC
 				} else if *r.f.Verbose {
@@ -550,8 +550,8 @@ func (r *runner) parsePhase() (int, error) {
 	kotlinPaths := r.files
 	allowCrossFileDelta := r.canUseWarmCrossFindingsDelta()
 	allowResourceSourceDelta := r.canUseWarmAndroidResourceSourceDelta()
-	if canParseOnlyCacheMisses(r.activeRules, r.cacheResult, r.useCache, allowCrossFileDelta, allowResourceSourceDelta) {
-		kotlinPaths = cacheMissPaths(r.files, r.cacheResult)
+	if pipeline.CanParseOnlyCacheMisses(r.activeRules, r.cacheResult, r.useCache, allowCrossFileDelta, allowResourceSourceDelta) {
+		kotlinPaths = pipeline.CacheMissPaths(r.files, r.cacheResult)
 		if *r.f.Verbose {
 			fmt.Fprintf(os.Stderr, "verbose: Parsing %d cache-miss files; findings cache covers %d/%d files\n", len(kotlinPaths), r.cacheResult.TotalCached, r.cacheResult.TotalFiles)
 		}
@@ -628,11 +628,11 @@ func (r *runner) canSkipParsePhase() bool {
 	}
 	canUseCrossFileCache := resolveCrossFileCacheDir(r.paths, noCrossFileCache) != ""
 	warmAndroidSourceCache := r.canUseWarmAndroidResourceSourceCache()
-	if rulesNeedParsedSource(r.activeRules, canUseCrossFileCache, warmAndroidSourceCache) {
-		r.logParseSkipBlocked("active rule requires parsed source: " + parsedSourceBlockReason(r.activeRules, canUseCrossFileCache, warmAndroidSourceCache))
+	if pipeline.RulesNeedParsedSource(r.activeRules, canUseCrossFileCache, warmAndroidSourceCache) {
+		r.logParseSkipBlocked("active rule requires parsed source: " + pipeline.ParsedSourceBlockReason(r.activeRules, canUseCrossFileCache, warmAndroidSourceCache))
 		return false
 	}
-	if canUseCrossFileCache && rulesNeedCrossOrParsedFiles(r.activeRules) {
+	if canUseCrossFileCache && pipeline.RulesNeedCrossOrParsedFiles(r.activeRules) {
 		if !r.loadWarmCrossFindings() {
 			r.logParseSkipBlocked("cross-file findings cache miss")
 			return false
@@ -652,7 +652,7 @@ func (r *runner) canUseWarmAndroidResourceSourceCache() bool {
 	if r == nil || r.androidProject == nil || r.androidProject.IsEmpty() || r.androidCacheDir == "" || r.androidCacheWriter == nil || r.ruleHash == "" {
 		return false
 	}
-	if !hasResourceSourceRulesForSkip(r.activeRules) {
+	if !pipeline.HasResourceSourceRules(r.activeRules) {
 		return true
 	}
 	if r.cacheResult != nil && len(r.cacheResult.CachedHashes) > 0 {
@@ -680,7 +680,7 @@ func (r *runner) canUseWarmAndroidResourceSourceDelta() bool {
 	if r == nil || r.androidProject == nil || r.androidProject.IsEmpty() || r.androidCacheDir == "" || r.androidCacheWriter == nil || r.ruleHash == "" {
 		return false
 	}
-	if !hasResourceSourceRulesForSkip(r.activeRules) {
+	if !pipeline.HasResourceSourceRules(r.activeRules) {
 		return true
 	}
 	return pipeline.HasWarmResourceSourceBundleManifest(
@@ -694,7 +694,7 @@ func (r *runner) canUseWarmAndroidResourceSourceDelta() bool {
 }
 
 func (r *runner) canUseWarmCrossFindingsDelta() bool {
-	if r == nil || !rulesNeedCrossOrParsedFiles(r.activeRules) {
+	if r == nil || !pipeline.RulesNeedCrossOrParsedFiles(r.activeRules) {
 		return true
 	}
 	if r.f != nil && r.f.NoCrossFileCache != nil && *r.f.NoCrossFileCache {
@@ -896,7 +896,7 @@ func (r *runner) dispatch() (int, error) {
 // nesting both indexing children from IndexPhase and rule-execution
 // siblings from CrossFilePhase) is preserved bit-for-bit.
 func (r *runner) crossFile() (int, error) {
-	hasIndexBackedCrossFileRule, hasParsedFilesRule, hasModuleAwareRule := classifyCrossFileNeeds(r.activeRules)
+	hasIndexBackedCrossFileRule, hasParsedFilesRule, hasModuleAwareRule := pipeline.ClassifyCrossFileNeeds(r.activeRules)
 	crossFindingsCacheHit := r.prepareCrossFileTrackers(hasIndexBackedCrossFileRule, hasParsedFilesRule, hasModuleAwareRule)
 
 	scanRoot := "."
@@ -961,7 +961,7 @@ func (r *runner) crossFile() (int, error) {
 	dispatchForCross.IndexResult = idx2
 	dispatchForCross.ActiveRules = r.activeRules
 	if crossFindingsCacheHit {
-		dispatchForCross.ActiveRules = moduleOnlyRules(r.activeRules)
+		dispatchForCross.ActiveRules = pipeline.ModuleOnlyRules(r.activeRules)
 	}
 	dispatchForCross.Reporter = r.reporter
 	dispatchForCross.Tracker = r.tracker
@@ -1030,7 +1030,7 @@ func (r *runner) mergeWarmCrossFindings() {
 // androidPhase runs the project-level AndroidPhase (manifests, res
 // dirs, Gradle, icons) and merges its findings into r.allFindings.
 func (r *runner) androidPhase() (int, error) {
-	if !rulesNeedAndroidProject(r.activeRules) || r.androidProject == nil || r.androidProject.IsEmpty() {
+	if !pipeline.RulesNeedAndroidProject(r.activeRules) || r.androidProject == nil || r.androidProject.IsEmpty() {
 		return 0, nil
 	}
 	androidStart := time.Now()
@@ -1044,7 +1044,7 @@ func (r *runner) androidPhase() (int, error) {
 		Dispatcher:          dispatcher,
 		SourceFiles:         r.sourceFiles,
 		SourcePaths:         r.cacheFilePaths,
-		SourceHashes:        cachedHashesOrNil(r.cacheResult),
+		SourceHashes:        pipeline.CachedHashesOrNil(r.cacheResult),
 		Providers:           r.androidProviders,
 		Tracker:             androidTracker,
 		RuleHash:            r.ruleHash,

--- a/internal/cli/scan/runner_phasegate.go
+++ b/internal/cli/scan/runner_phasegate.go
@@ -2,12 +2,12 @@ package scan
 
 import (
 	"github.com/kaeawc/krit/internal/cache"
+	"github.com/kaeawc/krit/internal/pipeline"
 	api "github.com/kaeawc/krit/internal/rules/api"
-	"github.com/kaeawc/krit/internal/scanner"
 )
 
 func shouldOpenResourceIndexCache(activeRules []*api.Rule, noResourceCache bool, skipSourceParse bool, androidFindingsCacheable bool) bool {
-	if noResourceCache || !rulesNeedAndroidProject(activeRules) {
+	if noResourceCache || !pipeline.RulesNeedAndroidProject(activeRules) {
 		return false
 	}
 	if skipSourceParse && androidFindingsCacheable {
@@ -17,177 +17,21 @@ func shouldOpenResourceIndexCache(activeRules []*api.Rule, noResourceCache bool,
 }
 
 func canParseOnlyCacheMisses(activeRules []*api.Rule, cacheResult *cache.Result, useCache bool, allowCrossFileDelta bool, allowResourceSourceDelta bool) bool {
-	if !useCache || cacheResult == nil || cacheResult.TotalCached == 0 {
-		return false
-	}
-	return !rulesNeedParsedSource(activeRules, allowCrossFileDelta, allowResourceSourceDelta)
+	return pipeline.CanParseOnlyCacheMisses(activeRules, cacheResult, useCache, allowCrossFileDelta, allowResourceSourceDelta)
 }
 
 func cacheMissPaths(paths []string, cacheResult *cache.Result) []string {
-	if cacheResult == nil || len(cacheResult.CachedPaths) == 0 {
-		return append([]string(nil), paths...)
-	}
-	capHint := len(paths) - len(cacheResult.CachedPaths)
-	if capHint < 0 {
-		capHint = 0
-	}
-	misses := make([]string, 0, capHint)
-	for _, path := range paths {
-		if !cacheResult.CachedPaths[path] {
-			misses = append(misses, path)
-		}
-	}
-	return misses
-}
-
-func parsedSourceBlockReason(activeRules []*api.Rule, allowCrossFileWithoutParsed bool, allowResourceSourceWithoutParsed bool) string {
-	for _, ru := range activeRules {
-		if ru == nil {
-			continue
-		}
-		if resourceBackedSourceRule(ru) && !allowResourceSourceWithoutParsed {
-			return ru.ID + " needs resource-backed source"
-		}
-		if !allowCrossFileWithoutParsed && ru.Needs.Has(api.NeedsParsedFiles) {
-			return ru.ID + " needs parsed files"
-		}
-		if !allowCrossFileWithoutParsed && ru.Needs.Has(api.NeedsCrossFile) {
-			return ru.ID + " needs cross-file source"
-		}
-		if ru.Needs.Has(api.NeedsAggregate) {
-			return ru.ID + " is aggregate"
-		}
-		if ru.JavaFacts != nil {
-			return ru.ID + " needs Java semantic facts"
-		}
-	}
-	if api.NeedsJavaFacts(activeRules) {
-		return "Java semantic facts"
-	}
-	return "unknown"
-}
-
-func rulesNeedParsedSource(activeRules []*api.Rule, allowCrossFileWithoutParsed bool, allowResourceSourceWithoutParsed bool) bool {
-	caps := api.Capabilities(0)
-	for _, ru := range activeRules {
-		if ru == nil {
-			continue
-		}
-		caps |= ru.Needs
-		if resourceBackedSourceRule(ru) && !allowResourceSourceWithoutParsed {
-			return true
-		}
-	}
-	if (!allowCrossFileWithoutParsed && caps.Has(api.NeedsParsedFiles)) ||
-		(!allowCrossFileWithoutParsed && caps.Has(api.NeedsCrossFile)) ||
-		caps.Has(api.NeedsAggregate) {
-		return true
-	}
-	return api.NeedsJavaFacts(activeRules)
-}
-
-func hasResourceSourceRulesForSkip(activeRules []*api.Rule) bool {
-	for _, ru := range activeRules {
-		if resourceBackedSourceRule(ru) {
-			return true
-		}
-	}
-	return false
-}
-
-func rulesNeedCrossOrParsedFiles(activeRules []*api.Rule) bool {
-	for _, ru := range activeRules {
-		if ru == nil {
-			continue
-		}
-		if ru.Needs.Has(api.NeedsCrossFile) || ru.Needs.Has(api.NeedsParsedFiles) {
-			return true
-		}
-	}
-	return false
-}
-
-func resourceBackedSourceRule(ru *api.Rule) bool {
-	if ru == nil || !ru.Needs.Has(api.NeedsResources) || len(ru.NodeTypes) == 0 {
-		return false
-	}
-	for _, lang := range api.RuleLanguages(ru) {
-		if lang != scanner.LangXML {
-			return true
-		}
-	}
-	return false
+	return pipeline.CacheMissPaths(paths, cacheResult)
 }
 
 func rulesNeedAndroidProject(activeRules []*api.Rule) bool {
-	for _, ru := range activeRules {
-		if ru == nil {
-			continue
-		}
-		if ru.AndroidDeps != 0 ||
-			ru.Needs.Has(api.NeedsManifest) ||
-			ru.Needs.Has(api.NeedsResources) ||
-			ru.Needs.Has(api.NeedsGradle) {
-			return true
-		}
-	}
-	return false
+	return pipeline.RulesNeedAndroidProject(activeRules)
 }
 
 func rulesNeedProjectModel(activeRules []*api.Rule) bool {
-	if rulesNeedAndroidProject(activeRules) {
-		return true
-	}
-	for _, ru := range activeRules {
-		if ru == nil {
-			continue
-		}
-		if ru.NeedsLibraryFacts || ru.JavaFacts != nil {
-			return true
-		}
-	}
-	return false
+	return pipeline.RulesNeedProjectModel(activeRules)
 }
 
-func moduleOnlyRules(activeRules []*api.Rule) []*api.Rule {
-	out := make([]*api.Rule, 0, len(activeRules))
-	for _, ru := range activeRules {
-		if ru != nil && ru.Needs.Has(api.NeedsModuleIndex) {
-			out = append(out, ru)
-		}
-	}
-	return out
-}
-
-// classifyCrossFileNeeds inspects activeRules and reports whether any
-// require an index-backed cross-file pass, a parsed-files pass, or a
-// module-aware pass. Pure helper so the cross-file gating can be
-// unit-tested in isolation.
 func classifyCrossFileNeeds(activeRules []*api.Rule) (hasIndexBacked, hasParsedFiles, hasModuleAware bool) {
-	for _, ru := range activeRules {
-		if ru == nil {
-			continue
-		}
-		if ru.Needs.Has(api.NeedsParsedFiles) {
-			hasParsedFiles = true
-			continue
-		}
-		if ru.Needs.Has(api.NeedsCrossFile) {
-			hasIndexBacked = true
-		}
-	}
-	for _, ru := range activeRules {
-		if ru != nil && ru.Needs.Has(api.NeedsModuleIndex) {
-			hasModuleAware = true
-			break
-		}
-	}
-	return
-}
-
-func cachedHashesOrNil(result *cache.Result) map[string]string {
-	if result == nil || len(result.CachedHashes) == 0 {
-		return nil
-	}
-	return result.CachedHashes
+	return pipeline.ClassifyCrossFileNeeds(activeRules)
 }

--- a/internal/cli/scan/scan_contract_test.go
+++ b/internal/cli/scan/scan_contract_test.go
@@ -19,8 +19,8 @@ import (
 )
 
 // TestScanRunMatchesAnalyzeProjectVerb pins the CLI-vs-RunProject
-// byte-equal contract: scan.Run (with caches, FIR, profiling, and
-// the oracle disabled — the subset RunProject already covers) and
+// byte-equal contract: scan.Run (with FIR, profiling, cross-file cache,
+// and the oracle disabled — the subset RunProject already covers) and
 // pipeline.RunProject called directly must produce identical
 // findings JSON after stripping the perf/caches/timing/version
 // envelope. A divergence means the two paths have drifted on rule
@@ -34,7 +34,6 @@ func TestScanRunMatchesAnalyzeProjectVerb(t *testing.T) {
 
 	cliJSON := runScanCLI(t, []string{
 		"krit",
-		"--no-cache",
 		"--no-cross-file-cache",
 		"--no-fir",
 		"--no-type-oracle",
@@ -177,7 +176,7 @@ func stripVariableFields(t *testing.T, raw []byte) map[string]any {
 	for _, key := range []string{
 		"durationMs", "wall_seconds", "wallSeconds",
 		"perf", "perfTimings", "perfRuleStats",
-		"caches", "cacheStats", "cacheBudget",
+		"cache", "caches", "cacheStats", "cacheBudget",
 		"startTime", "timing", "timings",
 		// version stamp comes from a compile-time var on the CLI side
 		// and is caller-provided on the direct side. The contract is

--- a/internal/cli/serve/analyze_project.go
+++ b/internal/cli/serve/analyze_project.go
@@ -276,6 +276,7 @@ func (s *daemonState) buildProjectInput(args daemon.AnalyzeProjectArgs) (pipelin
 			ResolverCache:           s.workspace,
 			OracleFilterCache:       s.workspace,
 			CrossFileCacheDir:       scanner.CrossFileCacheDir(repoDir),
+			CrossFindingsCacheDir:   scanner.CrossFindingsCacheDir(repoDir),
 			TypeIndexCacheDir:       typeinfer.TypeIndexCacheDir(repoDir),
 			AnalysisCache:           analysisCache,
 			AnalysisCacheFilePath:   analysisCachePath,

--- a/internal/pipeline/analysis_cache_lookup_test.go
+++ b/internal/pipeline/analysis_cache_lookup_test.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
 
 	"github.com/kaeawc/krit/internal/cache"
 	"github.com/kaeawc/krit/internal/config"
 	api "github.com/kaeawc/krit/internal/rules/api"
+	"github.com/kaeawc/krit/internal/scanner"
 )
 
 // TestRunProject_AnalysisCacheLookup_ByteEqualAcrossRuns is the
@@ -117,6 +119,164 @@ func TestRunProject_AnalysisCacheLookup_DisabledByDefault(t *testing.T) {
 	}
 	if res.FindingsCount != 1 {
 		t.Errorf("FindingsCount = %d, want 1 (rule must dispatch when lookup disabled)", res.FindingsCount)
+	}
+}
+
+func TestRunProject_AnalysisCacheLookup_FullyWarmSkipsParseAndDispatch(t *testing.T) {
+	dir := t.TempDir()
+	cachePath := filepath.Join(dir, "krit.cache")
+	for _, name := range []string{"A.kt", "B.kt"} {
+		if err := os.WriteFile(filepath.Join(dir, name),
+			[]byte("package test\n\nclass "+name[:1]+"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	var calls int64
+	rule := api.FakeRule("ClassDecl",
+		api.WithNodeTypes("class_declaration"),
+		api.WithSeverity(api.SeverityWarning),
+		api.WithCheck(func(ctx *api.Context) {
+			atomic.AddInt64(&calls, 1)
+			ctx.EmitAt(int(ctx.Node.StartRow)+1, 1, "class declared")
+		}),
+	)
+
+	run := func(t *testing.T) ProjectResult {
+		t.Helper()
+		res, err := RunProject(context.Background(), ProjectInput{
+			Args: ProjectArgs{
+				Config:      config.NewConfig(),
+				Paths:       []string{dir},
+				ActiveRules: []*api.Rule{rule},
+				Format:      "json",
+				Version:     "test",
+			},
+			Host: ProjectHostState{
+				AnalysisCache:         cache.Load(cachePath),
+				AnalysisCacheFilePath: cachePath,
+				AnalysisCacheLookup:   true,
+			},
+		})
+		if err != nil {
+			t.Fatalf("RunProject: %v", err)
+		}
+		return res
+	}
+
+	first := run(t)
+	if first.FilesScanned != 2 || atomic.LoadInt64(&calls) != 2 {
+		t.Fatalf("cold run scanned=%d calls=%d, want scanned=2 calls=2", first.FilesScanned, calls)
+	}
+	second := run(t)
+	if second.FilesScanned != 2 {
+		t.Fatalf("warm run FilesScanned=%d, want 2", second.FilesScanned)
+	}
+	if got := atomic.LoadInt64(&calls); got != 2 {
+		t.Fatalf("warm run dispatched cached files; calls=%d want 2", got)
+	}
+}
+
+func TestRunProject_AnalysisCacheLookup_ParsesOnlyMisses(t *testing.T) {
+	dir := t.TempDir()
+	cachePath := filepath.Join(dir, "krit.cache")
+	aPath := filepath.Join(dir, "A.kt")
+	bPath := filepath.Join(dir, "B.kt")
+	if err := os.WriteFile(aPath, []byte("package test\n\nclass A\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(bPath, []byte("package test\n\nclass B\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var calls int64
+	rule := api.FakeRule("ClassDecl",
+		api.WithNodeTypes("class_declaration"),
+		api.WithSeverity(api.SeverityWarning),
+		api.WithCheck(func(ctx *api.Context) {
+			atomic.AddInt64(&calls, 1)
+			ctx.EmitAt(int(ctx.Node.StartRow)+1, 1, "class declared")
+		}),
+	)
+	run := func(t *testing.T) {
+		t.Helper()
+		_, err := RunProject(context.Background(), ProjectInput{
+			Args: ProjectArgs{
+				Config:      config.NewConfig(),
+				Paths:       []string{dir},
+				ActiveRules: []*api.Rule{rule},
+				Format:      "json",
+				Version:     "test",
+			},
+			Host: ProjectHostState{
+				AnalysisCache:         cache.Load(cachePath),
+				AnalysisCacheFilePath: cachePath,
+				AnalysisCacheLookup:   true,
+			},
+		})
+		if err != nil {
+			t.Fatalf("RunProject: %v", err)
+		}
+	}
+
+	run(t)
+	if err := os.WriteFile(bPath, []byte("package test\n\nclass B2\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	run(t)
+	if got := atomic.LoadInt64(&calls); got != 3 {
+		t.Fatalf("second run should dispatch only the edited file; calls=%d want 3", got)
+	}
+}
+
+func TestRunProject_WarmCrossFindingsSkipCrossRules(t *testing.T) {
+	dir := t.TempDir()
+	cachePath := filepath.Join(dir, "krit.cache")
+	crossCacheDir := scanner.CrossFileCacheDir(dir)
+	crossFindingsDir := scanner.CrossFindingsCacheDir(dir)
+	if err := os.WriteFile(filepath.Join(dir, "A.kt"), []byte("package test\n\nclass A\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var crossCalls int64
+	rule := api.FakeRule("CrossRule", api.WithNeeds(api.NeedsCrossFile), api.WithCheck(func(ctx *api.Context) {
+		atomic.AddInt64(&crossCalls, 1)
+		ctx.Emit(scanner.Finding{File: filepath.Join(dir, "A.kt"), Line: 1, Col: 1, Message: "cross"})
+	}))
+	run := func(t *testing.T) ProjectResult {
+		t.Helper()
+		res, err := RunProject(context.Background(), ProjectInput{
+			Args: ProjectArgs{
+				Config:      config.NewConfig(),
+				Paths:       []string{dir},
+				ActiveRules: []*api.Rule{rule},
+				Format:      "json",
+				Version:     "test",
+			},
+			Host: ProjectHostState{
+				AnalysisCache:         cache.Load(cachePath),
+				AnalysisCacheFilePath: cachePath,
+				AnalysisCacheLookup:   true,
+				CrossFileCacheDir:     crossCacheDir,
+				CrossFindingsCacheDir: crossFindingsDir,
+			},
+		})
+		if err != nil {
+			t.Fatalf("RunProject: %v", err)
+		}
+		return res
+	}
+
+	first := run(t)
+	if first.FindingsCount != 1 || atomic.LoadInt64(&crossCalls) != 1 {
+		t.Fatalf("cold run findings=%d crossCalls=%d, want 1/1", first.FindingsCount, crossCalls)
+	}
+	second := run(t)
+	if second.FindingsCount != 1 {
+		t.Fatalf("warm run findings=%d, want 1", second.FindingsCount)
+	}
+	if got := atomic.LoadInt64(&crossCalls); got != 1 {
+		t.Fatalf("warm run re-ran cross rule; calls=%d want 1", got)
 	}
 }
 

--- a/internal/pipeline/crossfile.go
+++ b/internal/pipeline/crossfile.go
@@ -152,7 +152,13 @@ func (p CrossFilePhase) runCrossPhase(ctx context.Context, in DispatchResult, co
 
 	crossFindingsKey, crossFindingsCacheable := crossFindingsCacheKey(codeIndex, parsedFiles, in.RuleHash)
 	var crossFindingsCacheHit bool
-	if crossFindingsCacheable && in.CrossFindingsCacheDir != "" {
+	if in.WarmCrossFindings != nil {
+		crossCollector.AppendColumns(in.WarmCrossFindings)
+		crossFindingsCacheHit = true
+		if in.Reporter != nil {
+			in.Reporter.Verbosef("verbose: Cross-file findings cache: HIT (%d findings)\n", in.WarmCrossFindings.Len())
+		}
+	} else if crossFindingsCacheable && in.CrossFindingsCacheDir != "" {
 		if cached, ok := scanner.LoadCrossFindings(in.CrossFindingsCacheDir, crossFindingsKey); ok {
 			crossCollector.AppendColumns(&cached)
 			crossFindingsCacheHit = true

--- a/internal/pipeline/project.go
+++ b/internal/pipeline/project.go
@@ -42,6 +42,14 @@ type ProjectArgs struct {
 	Config *config.Config
 	// Paths are the scan target paths (files or directories). Required.
 	Paths []string
+	// KotlinPaths, when non-nil, are the already-collected Kotlin
+	// sources for this run. Supplying them lets RunProject perform
+	// pre-parse cache lookup and parse only cache misses.
+	KotlinPaths []string
+	// JavaPaths, when non-nil, are the already-collected Java sources
+	// for this run. Supplying them keeps Java cache lookup and parse
+	// inputs aligned with the caller's file walk.
+	JavaPaths []string
 	// ActiveRules is the rule set to dispatch. Required and non-empty.
 	ActiveRules []*api.Rule
 	// Format is the output format ("json", "plain", "sarif",
@@ -60,6 +68,10 @@ type ProjectArgs struct {
 	WarningsAsErrors bool
 	// IncludeGenerated retains files under */generated/* during parse.
 	IncludeGenerated bool
+	// EditorConfigEnabled participates in the analysis-cache rule hash.
+	// CLI callers set this from --editorconfig; false preserves the
+	// daemon's existing hash contract.
+	EditorConfigEnabled bool
 	// Workers overrides per-phase worker counts. Zero falls back to
 	// runtime.NumCPU().
 	Workers int
@@ -166,6 +178,10 @@ type ProjectHostState struct {
 	// daemon restarts, while the in-memory cache survives within a
 	// single daemon's lifetime.
 	CrossFileCacheDir string
+	// CrossFindingsCacheDir, when non-empty, enables the on-disk
+	// cross-rule findings cache. RunProject can replay it on fully warm
+	// analysis-cache runs without parsing source files.
+	CrossFindingsCacheDir string
 	// TypeIndexCacheDir, when non-empty, enables the per-file
 	// FileTypeInfo on-disk cache so warm runs skip per-file
 	// extraction for unchanged files. Empty disables the cache (the
@@ -219,6 +235,17 @@ type ProjectHostState struct {
 	// changes skip source discovery on a manifest-backed bundle hit.
 	// False keeps RunProject conservative by re-collecting source paths.
 	SourceSetClean bool
+}
+
+type warmAnalysisCachePlan struct {
+	cache       *cache.Cache
+	result      *cache.Result
+	stats       *cache.Stats
+	ruleHash    string
+	filePaths   []string
+	kotlinPaths []string
+	javaPaths   []string
+	cross       *scanner.FindingColumns
 }
 
 // ProjectInput is the value type that drives RunProject. The split
@@ -343,72 +370,24 @@ func RunProjectStreaming(ctx context.Context, in ProjectInput, out io.Writer) (P
 		return res, err
 	}
 	host = awaitAnalysisCacheFuture(host)
+	warmPlan := buildWarmAnalysisCachePlan(args, host)
+	if warmPlan.cache != nil {
+		host.AnalysisCache = warmPlan.cache
+	}
 
 	// Phase 1: parse.
 	parseStart := time.Now()
-	parseResult, err := ParsePhase{Workers: args.Workers}.Run(ctx, ParseInput{
-		Config:           args.Config,
-		Paths:            args.Paths,
-		ActiveRules:      args.ActiveRules,
-		IncludeGenerated: args.IncludeGenerated,
-		Workers:          args.Workers,
-		Reporter:         host.Reporter,
-		Tracker:          host.Tracker,
-		ParseCache:       host.ParseCache,
-	})
+	parseResult, err := runProjectParsePhase(ctx, args, host, warmPlan)
 	phaseTimings.Parse = time.Since(parseStart).Milliseconds()
 	if err != nil {
 		return ProjectResult{}, fmt.Errorf("parse: %w", err)
 	}
 
-	// Phase 2: index. Builds resolver, library facts, code index, module
-	// graph, and (when an oracle handle is supplied) wires it through.
-	indexInput := IndexInput{
-		ParseResult:          parseResult,
-		PrebuiltResolver:     host.PrebuiltResolver,
-		PrebuiltLibraryFacts: host.PrebuiltLibraryFacts,
-		LibraryFactsCache:    host.LibraryFactsCache,
-		CodeIndexCache:       host.CodeIndexCache,
-		ResolverCache:        host.ResolverCache,
-		CrossFileCacheDir:    host.CrossFileCacheDir,
-		TypeIndexCacheDir:    host.TypeIndexCacheDir,
-		Reporter:             host.Reporter,
-		Tracker:              host.Tracker,
-	}
-	wireOracleHandles(&indexInput, args, host, parseResult.KotlinFiles)
-	wireAnalysisCacheLookup(&indexInput, args, host)
 	indexStart := time.Now()
-	indexResult, err := IndexPhase{Workers: args.Workers}.Run(ctx, indexInput)
+	indexResult, err := runProjectIndexPhase(ctx, args, host, warmPlan, parseResult)
 	phaseTimings.Index = time.Since(indexStart).Milliseconds()
 	if err != nil {
 		return ProjectResult{}, fmt.Errorf("index: %w", err)
-	}
-	// The daemon-resident oracle handle is wired in here rather than
-	// reconstructed inside IndexPhase. Today IndexPhase does not accept
-	// a prebuilt oracle on its input; expose the handles via the result
-	// so DispatchPhase / CrossFilePhase see the resident state. When
-	// IndexInput is later extended to accept a prebuilt oracle this
-	// fallback becomes obsolete.
-	if host.Oracle != nil && indexResult.Oracle == nil {
-		indexResult.Oracle = host.Oracle
-	}
-	if host.OracleDaemon != nil && indexResult.Daemon == nil {
-		indexResult.Daemon = host.OracleDaemon
-	}
-	indexResult.Cache = host.AnalysisCache
-	if host.AnalysisCache != nil {
-		// Wire the dispatch-side write-back fields so writeCacheBack
-		// can update the cache and persist it on each call. Lookup-side
-		// (file-skip on hit) requires CacheResult population in
-		// IndexPhase.runCacheLoad and stays out of scope for this
-		// promotion — populating the cache without skipping is safe
-		// (no output drift) and benefits subsequent CLI runs.
-		indexResult.CacheFilePath = host.AnalysisCacheFilePath
-		indexResult.CacheScanPaths = args.Paths
-		indexResult.Version = args.Version
-		if indexResult.RuleHash == "" {
-			indexResult.RuleHash = projectRuleHash(args.ActiveRules, args.Config)
-		}
 	}
 
 	runFP, bundleEnabled := computeRunFingerprint(args, host, parseResult, indexResult)
@@ -538,6 +517,210 @@ func awaitAnalysisCacheFuture(host ProjectHostState) ProjectHostState {
 	return host
 }
 
+func runProjectIndexPhase(ctx context.Context, args ProjectArgs, host ProjectHostState, warm warmAnalysisCachePlan, parseResult ParseResult) (IndexResult, error) {
+	indexInput := IndexInput{
+		ParseResult:           parseResult,
+		PrebuiltResolver:      host.PrebuiltResolver,
+		PrebuiltLibraryFacts:  host.PrebuiltLibraryFacts,
+		LibraryFactsCache:     host.LibraryFactsCache,
+		CodeIndexCache:        host.CodeIndexCache,
+		ResolverCache:         host.ResolverCache,
+		CrossFileCacheDir:     host.CrossFileCacheDir,
+		CrossFindingsCacheDir: host.CrossFindingsCacheDir,
+		TypeIndexCacheDir:     host.TypeIndexCacheDir,
+		Reporter:              host.Reporter,
+		Tracker:               host.Tracker,
+	}
+	wireOracleHandles(&indexInput, args, host, parseResult.KotlinFiles)
+	if warm.result == nil {
+		wireAnalysisCacheLookup(&indexInput, args, host)
+	}
+	indexResult, err := IndexPhase{Workers: args.Workers}.Run(ctx, indexInput)
+	if err != nil {
+		return IndexResult{}, err
+	}
+	completeRunProjectIndexResult(args, host, warm, &indexResult)
+	return indexResult, nil
+}
+
+func completeRunProjectIndexResult(args ProjectArgs, host ProjectHostState, warm warmAnalysisCachePlan, indexResult *IndexResult) {
+	if host.Oracle != nil && indexResult.Oracle == nil {
+		indexResult.Oracle = host.Oracle
+	}
+	if host.OracleDaemon != nil && indexResult.Daemon == nil {
+		indexResult.Daemon = host.OracleDaemon
+	}
+	indexResult.Cache = host.AnalysisCache
+	if warm.result != nil {
+		indexResult.CacheResult = warm.result
+		indexResult.RuleHash = warm.ruleHash
+		indexResult.CacheFilePath = host.AnalysisCacheFilePath
+		indexResult.CacheStats = warm.stats
+		indexResult.WarmCrossFindings = warm.cross
+	}
+	if host.AnalysisCache == nil {
+		return
+	}
+	indexResult.CacheFilePath = host.AnalysisCacheFilePath
+	indexResult.CacheScanPaths = args.Paths
+	indexResult.Version = args.Version
+	if indexResult.RuleHash == "" {
+		indexResult.RuleHash = projectRuleHash(args.ActiveRules, args.Config)
+	}
+}
+
+func runProjectParsePhase(ctx context.Context, args ProjectArgs, host ProjectHostState, warm warmAnalysisCachePlan) (ParseResult, error) {
+	kotlinPaths := args.KotlinPaths
+	if kotlinPaths == nil {
+		kotlinPaths = warm.kotlinPaths
+	}
+	javaPaths := args.JavaPaths
+	if javaPaths == nil {
+		javaPaths = warm.javaPaths
+	}
+	if canSkipRunProjectParse(args, host, warm) {
+		host.Reporter.Verbosef("verbose: Skipped parse; findings cache covers %d files and no active phase needs parsed sources\n", len(warm.filePaths))
+		if host.Tracker != nil {
+			host.Tracker.TrackVoid("parse", func() {})
+		}
+		return ParseResult{
+			Config:      args.Config,
+			ActiveRules: args.ActiveRules,
+			KotlinFiles: filesForPaths(kotlinPaths, scanner.LangKotlin),
+			KotlinPaths: append([]string(nil), kotlinPaths...),
+			JavaFiles:   filesForPaths(javaPaths, scanner.LangJava),
+			Paths:       args.Paths,
+		}, nil
+	}
+	allowCrossFile, _ := loadWarmCrossFindings(args, host, warm)
+	if CanParseOnlyCacheMisses(args.ActiveRules, warm.result, warm.result != nil, allowCrossFile, false) {
+		kotlinPaths = CacheMissPaths(kotlinPaths, warm.result)
+		host.Reporter.Verbosef("verbose: Parsing %d cache-miss files; findings cache covers %d/%d files\n", len(kotlinPaths), warm.result.TotalCached, warm.result.TotalFiles)
+	}
+	return ParsePhase{Workers: args.Workers}.Run(ctx, ParseInput{
+		Config:             args.Config,
+		Paths:              args.Paths,
+		ActiveRules:        args.ActiveRules,
+		IncludeGenerated:   args.IncludeGenerated,
+		KotlinPaths:        kotlinPaths,
+		JavaPaths:          javaPaths,
+		Workers:            args.Workers,
+		SkipJavaCollection: !NeedsJavaBeforeDispatch(args.ActiveRules),
+		Reporter:           host.Reporter,
+		Tracker:            host.Tracker,
+		ParseCache:         host.ParseCache,
+	})
+}
+
+func buildWarmAnalysisCachePlan(args ProjectArgs, host ProjectHostState) warmAnalysisCachePlan {
+	if host.AnalysisCache == nil || !host.AnalysisCacheLookup {
+		return warmAnalysisCachePlan{}
+	}
+	kotlinPaths, javaPaths := warmSourcePaths(args)
+	filePaths := warmCacheFilePaths(args, kotlinPaths, javaPaths)
+	ruleHash := projectRuleHashWithEditorConfig(args.ActiveRules, args.Config, args.EditorConfigEnabled)
+	start := time.Now()
+	result := host.AnalysisCache.CheckFiles(filePaths, ruleHash, args.Paths...)
+	stats := &cache.Stats{
+		Cached:    result.TotalCached,
+		Total:     result.TotalFiles,
+		LoadDurMs: 0,
+	}
+	if result.TotalFiles > 0 {
+		stats.HitRate = float64(result.TotalCached) / float64(result.TotalFiles)
+	}
+	host.Reporter.Verbosef("verbose: Cache: %d/%d files cached (%d%% hit rate)\n",
+		result.TotalCached, result.TotalFiles, cacheHitPercent(result))
+	if host.Tracker != nil {
+		perf.AddEntry(host.Tracker, "cacheCheck", time.Since(start))
+	}
+	plan := warmAnalysisCachePlan{
+		cache:       host.AnalysisCache,
+		result:      result,
+		stats:       stats,
+		ruleHash:    ruleHash,
+		filePaths:   filePaths,
+		kotlinPaths: kotlinPaths,
+		javaPaths:   javaPaths,
+	}
+	if ok, cols := loadWarmCrossFindings(args, host, plan); ok {
+		plan.cross = cols
+	}
+	return plan
+}
+
+func cacheHitPercent(result *cache.Result) int {
+	if result == nil || result.TotalFiles == 0 {
+		return 0
+	}
+	return 100 * result.TotalCached / result.TotalFiles
+}
+
+func warmSourcePaths(args ProjectArgs) ([]string, []string) {
+	kotlinPaths := args.KotlinPaths
+	if kotlinPaths == nil {
+		if collected, err := scanner.CollectKotlinFiles(args.Paths, nil); err == nil {
+			kotlinPaths = collected
+		}
+	}
+	kotlinPaths = filterGeneratedSourcePaths(kotlinPaths, args.IncludeGenerated)
+	javaPaths := args.JavaPaths
+	if javaPaths == nil && NeedsJavaBeforeDispatch(args.ActiveRules) {
+		if collected, err := scanner.CollectJavaFiles(args.Paths, nil); err == nil {
+			javaPaths = collected
+		}
+	}
+	javaPaths = filterGeneratedSourcePaths(javaPaths, args.IncludeGenerated)
+	return kotlinPaths, javaPaths
+}
+
+func warmCacheFilePaths(args ProjectArgs, kotlinPaths, javaPaths []string) []string {
+	filePaths := make([]string, 0, len(kotlinPaths)+len(javaPaths))
+	filePaths = append(filePaths, kotlinPaths...)
+	if NeedsJavaBeforeDispatch(args.ActiveRules) {
+		filePaths = append(filePaths, javaPaths...)
+	}
+	return filePaths
+}
+
+func canSkipRunProjectParse(args ProjectArgs, host ProjectHostState, warm warmAnalysisCachePlan) bool {
+	if warm.result == nil || warm.result.TotalFiles == 0 || warm.result.TotalCached != warm.result.TotalFiles {
+		return false
+	}
+	if len(warm.result.CachedPaths) != len(warm.filePaths) {
+		return false
+	}
+	allowCrossFile := warm.cross != nil
+	if !allowCrossFile {
+		var loaded *scanner.FindingColumns
+		allowCrossFile, loaded = loadWarmCrossFindings(args, host, warm)
+		warm.cross = loaded
+	}
+	if RulesNeedParsedSource(args.ActiveRules, allowCrossFile, false) {
+		host.Reporter.Verbosef("verbose: Parse skip unavailable: active rule requires parsed source: %s\n", ParsedSourceBlockReason(args.ActiveRules, allowCrossFile, false))
+		return false
+	}
+	return true
+}
+
+func loadWarmCrossFindings(args ProjectArgs, host ProjectHostState, warm warmAnalysisCachePlan) (bool, *scanner.FindingColumns) {
+	if !RulesNeedCrossOrParsedFiles(args.ActiveRules) {
+		return true, nil
+	}
+	if host.CrossFileCacheDir == "" || host.CrossFindingsCacheDir == "" || warm.ruleHash == "" {
+		return false, nil
+	}
+	meta, ok := scanner.LoadCurrentCrossFileCacheMeta(host.CrossFileCacheDir)
+	if !ok {
+		return false, nil
+	}
+	cols, ok := scanner.LoadCrossFindings(host.CrossFindingsCacheDir, scanner.CrossFindingsKey(meta.Fingerprint, warm.ruleHash))
+	if !ok {
+		return false, nil
+	}
+	return true, &cols
+}
+
 // runFixupPhase invokes FixupPhase when one of the fix knobs is set.
 // Fixup runs after Android merge so cached/delta findings paths
 // receive on-disk fixes too — symmetric with the CLI's ordering.
@@ -607,13 +790,17 @@ func parseCacheCounters(pc *scanner.ParseCache) (int64, int64) {
 // subsequent CLI lookups reject the cache when the rule set / config
 // has drifted.
 func projectRuleHash(activeRules []*api.Rule, cfg *config.Config) string {
+	return projectRuleHashWithEditorConfig(activeRules, cfg, false)
+}
+
+func projectRuleHashWithEditorConfig(activeRules []*api.Rule, cfg *config.Config, editorConfigEnabled bool) string {
 	ruleNames := make([]string, 0, len(activeRules))
 	for _, r := range activeRules {
 		if r != nil {
 			ruleNames = append(ruleNames, r.ID)
 		}
 	}
-	return cache.ComputeConfigHash(ruleNames, cfg, false)
+	return cache.ComputeConfigHash(ruleNames, cfg, editorConfigEnabled)
 }
 
 // wireAnalysisCacheLookup turns on IndexPhase.runCacheLoad when the
@@ -636,6 +823,7 @@ func wireAnalysisCacheLookup(in *IndexInput, args ProjectArgs, host ProjectHostS
 	in.CacheFilePath = host.AnalysisCacheFilePath
 	in.CacheScanPaths = args.Paths
 	in.CacheConfig = args.Config
+	in.CacheEditorConfigEnabled = args.EditorConfigEnabled
 	ruleNames := make([]string, 0, len(args.ActiveRules))
 	for _, r := range args.ActiveRules {
 		if r != nil {

--- a/internal/pipeline/types.go
+++ b/internal/pipeline/types.go
@@ -295,6 +295,9 @@ type IndexResult struct {
 	// pass on warm calls. Nil means no in-memory cache. *WorkspaceState
 	// satisfies this interface.
 	CodeIndexCache CodeIndexCache
+	// WarmCrossFindings carries cross-rule findings loaded before
+	// parsing on an all-files analysis-cache hit.
+	WarmCrossFindings *scanner.FindingColumns
 }
 
 // CodeIndexCache lets a long-lived host (typically *WorkspaceState)

--- a/internal/pipeline/warm_path.go
+++ b/internal/pipeline/warm_path.go
@@ -1,0 +1,179 @@
+package pipeline
+
+import (
+	"github.com/kaeawc/krit/internal/cache"
+	api "github.com/kaeawc/krit/internal/rules/api"
+	"github.com/kaeawc/krit/internal/scanner"
+)
+
+func CanParseOnlyCacheMisses(activeRules []*api.Rule, cacheResult *cache.Result, useCache bool, allowCrossFileDelta bool, allowResourceSourceDelta bool) bool {
+	if !useCache || cacheResult == nil || cacheResult.TotalCached == 0 {
+		return false
+	}
+	return !RulesNeedParsedSource(activeRules, allowCrossFileDelta, allowResourceSourceDelta)
+}
+
+func CacheMissPaths(paths []string, cacheResult *cache.Result) []string {
+	if cacheResult == nil || len(cacheResult.CachedPaths) == 0 {
+		return append([]string(nil), paths...)
+	}
+	capHint := len(paths) - len(cacheResult.CachedPaths)
+	if capHint < 0 {
+		capHint = 0
+	}
+	misses := make([]string, 0, capHint)
+	for _, path := range paths {
+		if !cacheResult.CachedPaths[path] {
+			misses = append(misses, path)
+		}
+	}
+	return misses
+}
+
+func ParsedSourceBlockReason(activeRules []*api.Rule, allowCrossFileWithoutParsed bool, allowResourceSourceWithoutParsed bool) string {
+	for _, ru := range activeRules {
+		if ru == nil {
+			continue
+		}
+		if resourceBackedSourceRule(ru) && !allowResourceSourceWithoutParsed {
+			return ru.ID + " needs resource-backed source"
+		}
+		if !allowCrossFileWithoutParsed && ru.Needs.Has(api.NeedsParsedFiles) {
+			return ru.ID + " needs parsed files"
+		}
+		if !allowCrossFileWithoutParsed && ru.Needs.Has(api.NeedsCrossFile) {
+			return ru.ID + " needs cross-file source"
+		}
+		if ru.Needs.Has(api.NeedsAggregate) {
+			return ru.ID + " is aggregate"
+		}
+		if ru.JavaFacts != nil {
+			return ru.ID + " needs Java semantic facts"
+		}
+	}
+	if api.NeedsJavaFacts(activeRules) {
+		return "Java semantic facts"
+	}
+	return "unknown"
+}
+
+func RulesNeedParsedSource(activeRules []*api.Rule, allowCrossFileWithoutParsed bool, allowResourceSourceWithoutParsed bool) bool {
+	caps := api.Capabilities(0)
+	for _, ru := range activeRules {
+		if ru == nil {
+			continue
+		}
+		caps |= ru.Needs
+		if resourceBackedSourceRule(ru) && !allowResourceSourceWithoutParsed {
+			return true
+		}
+	}
+	if (!allowCrossFileWithoutParsed && caps.Has(api.NeedsParsedFiles)) ||
+		(!allowCrossFileWithoutParsed && caps.Has(api.NeedsCrossFile)) ||
+		caps.Has(api.NeedsAggregate) {
+		return true
+	}
+	return api.NeedsJavaFacts(activeRules)
+}
+
+func RulesNeedCrossOrParsedFiles(activeRules []*api.Rule) bool {
+	for _, ru := range activeRules {
+		if ru == nil {
+			continue
+		}
+		if ru.Needs.Has(api.NeedsCrossFile) || ru.Needs.Has(api.NeedsParsedFiles) {
+			return true
+		}
+	}
+	return false
+}
+
+func RulesNeedAndroidProject(activeRules []*api.Rule) bool {
+	for _, ru := range activeRules {
+		if ru == nil {
+			continue
+		}
+		if ru.AndroidDeps != 0 ||
+			ru.Needs.Has(api.NeedsManifest) ||
+			ru.Needs.Has(api.NeedsResources) ||
+			ru.Needs.Has(api.NeedsGradle) {
+			return true
+		}
+	}
+	return false
+}
+
+func RulesNeedProjectModel(activeRules []*api.Rule) bool {
+	if RulesNeedAndroidProject(activeRules) {
+		return true
+	}
+	for _, ru := range activeRules {
+		if ru == nil {
+			continue
+		}
+		if ru.NeedsLibraryFacts || ru.JavaFacts != nil {
+			return true
+		}
+	}
+	return false
+}
+
+func ModuleOnlyRules(activeRules []*api.Rule) []*api.Rule {
+	out := make([]*api.Rule, 0, len(activeRules))
+	for _, ru := range activeRules {
+		if ru != nil && ru.Needs.Has(api.NeedsModuleIndex) {
+			out = append(out, ru)
+		}
+	}
+	return out
+}
+
+func ClassifyCrossFileNeeds(activeRules []*api.Rule) (hasIndexBacked, hasParsedFiles, hasModuleAware bool) {
+	for _, ru := range activeRules {
+		if ru == nil {
+			continue
+		}
+		if ru.Needs.Has(api.NeedsParsedFiles) {
+			hasParsedFiles = true
+			continue
+		}
+		if ru.Needs.Has(api.NeedsCrossFile) {
+			hasIndexBacked = true
+		}
+	}
+	for _, ru := range activeRules {
+		if ru != nil && ru.Needs.Has(api.NeedsModuleIndex) {
+			hasModuleAware = true
+			break
+		}
+	}
+	return
+}
+
+func CachedHashesOrNil(result *cache.Result) map[string]string {
+	if result == nil || len(result.CachedHashes) == 0 {
+		return nil
+	}
+	return result.CachedHashes
+}
+
+func HasResourceSourceRules(activeRules []*api.Rule) bool {
+	for _, ru := range activeRules {
+		if resourceBackedSourceRule(ru) {
+			return true
+		}
+	}
+	return false
+}
+
+func resourceBackedSourceRule(ru *api.Rule) bool {
+	if ru == nil || !ru.Needs.Has(api.NeedsResources) || len(ru.NodeTypes) == 0 {
+		return false
+	}
+	for _, lang := range api.RuleLanguages(ru) {
+		if lang != scanner.LangXML {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Summary:
- move warm parse/cache gating helpers into pipeline and point the CLI runner at them
- let RunProject perform pre-parse analysis-cache lookup, parse only cache misses, and replay warm cross-rule findings
- widen the CLI-vs-RunProject contract by keeping CLI analysis cache enabled

Test plan:
- [x] golangci-lint run ./...
- [x] go build -o krit ./cmd/krit/ && go vet ./...
- [x] go test ./internal/pipeline/ ./internal/cli/scan/ ./internal/cli/serve/ -count=1
- [x] go test ./... -count=1
- [x] make integration

Refs #70