### PR TITLE
[codex] Reuse findings bundle for body-only Kotlin edits

### DIFF
--- a/internal/cli/serve/analyze_project_bundlehit_test.go
+++ b/internal/cli/serve/analyze_project_bundlehit_test.go
@@ -42,3 +42,34 @@ func TestAnalyzeProject_BundleHitOnIdenticalSecondCall(t *testing.T) {
 			first.Stats.FindingsCount, second.Stats.FindingsCount)
 	}
 }
+
+func TestAnalyzeProject_BodyOnlyEditReusesFindingsBundle(t *testing.T) {
+	socket, state := startServerForTest(t)
+	writeKotlinFile(t, state.root, "A.kt",
+		"package demo\n\nclass A {\n    fun answer() = 1\n}\n")
+
+	var first daemon.AnalyzeProjectResult
+	if err := daemon.Call(socket, daemon.VerbAnalyzeProject,
+		daemon.AnalyzeProjectArgs{}, &first); err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+	if first.Stats.FindingsBundleHit {
+		t.Fatalf("first call (no prior bundle) must report FindingsBundleHit=false; got %+v", first.Stats)
+	}
+
+	writeKotlinFile(t, state.root, "A.kt",
+		"package demo\n\nclass A {\n    fun answer() = 22\n}\n")
+
+	var second daemon.AnalyzeProjectResult
+	if err := daemon.Call(socket, daemon.VerbAnalyzeProject,
+		daemon.AnalyzeProjectArgs{}, &second); err != nil {
+		t.Fatalf("second call: %v", err)
+	}
+	if !second.Stats.FindingsBundleHit {
+		t.Fatalf("body-only edit with stable structural fingerprint must report FindingsBundleHit=true; got %+v", second.Stats)
+	}
+	if second.Stats.PhaseTimingsMs.Dispatch != 0 || second.Stats.PhaseTimingsMs.CrossFile != 0 {
+		t.Errorf("body-only bundle hit must bypass dispatch+crossfile; got dispatch=%dms crossfile=%dms",
+			second.Stats.PhaseTimingsMs.Dispatch, second.Stats.PhaseTimingsMs.CrossFile)
+	}
+}

--- a/internal/pipeline/findings_bundle_cache_test.go
+++ b/internal/pipeline/findings_bundle_cache_test.go
@@ -228,7 +228,7 @@ func TestRunProject_FindingsBundleCache_ReportsMissComponent(t *testing.T) {
 
 	run(t)
 	verbose.Reset()
-	if err := os.WriteFile(src, []byte("package test\n\nclass Sample { fun value() = 2 }\n"), 0o644); err != nil {
+	if err := os.WriteFile(src, []byte("package test\n\nclass SampleRenamed { fun value() = 1 }\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	run(t)

--- a/internal/pipeline/project.go
+++ b/internal/pipeline/project.go
@@ -1170,22 +1170,6 @@ func saveDeltaManifest(host ProjectHostState, m deltaManifestData, runFP scanner
 	})
 }
 
-// runDispatchOrLoadBundle resolves dispatch + cross-file findings via
-// three increasingly conservative paths:
-//
-//  1. Full-fingerprint Load. RunFingerprint identical to a prior run →
-//     replay cached bundle, skip dispatch + cross-file entirely.
-//  2. Delta path. Prior manifest exists, planner says exactly 1 file
-//     changed + every non-SourceSet fingerprint field is stable →
-//     dispatch only on the changed file, optionally re-run cross-file
-//     rules (no scope savings there), filter replacement to the
-//     changed path, ApplyDelta against the prior bundle.
-//  3. Full dispatch. Normal DispatchPhase + CrossFilePhase.
-//
-// The delta path is the load-bearing #55 perf win for body-only edits:
-// per-file rule dispatch is the dominant warm-call cost and the delta
-// path runs it on just one file.
-
 // runAndroidPhaseAndMerge runs AndroidPhase against the detected
 // project (if any) and folds its findings into crossFileResult.Findings.
 // A nil/empty project, no Android-needing rules, or a dispatcher-less
@@ -1254,6 +1238,25 @@ type dispatchTimings struct {
 	crossFileMs int64
 }
 
+// runDispatchOrLoadBundle resolves dispatch + cross-file findings via
+// four increasingly conservative paths:
+//
+//  1. Full-fingerprint Load. RunFingerprint identical to a prior run →
+//     replay cached bundle, skip dispatch + cross-file entirely.
+//  2. Structural reuse. Prior manifest exists, planner says exactly 1 file
+//     changed + every non-SourceSet fingerprint field is stable →
+//     load the prior bundle, save an alias under the current content
+//     fingerprint, and skip dispatch + cross-file entirely.
+//  3. Delta path fallback. If structural reuse cannot save the alias,
+//     dispatch only on the changed file, re-run cross-file, filter
+//     replacement to the changed path, ApplyDelta against the prior
+//     bundle.
+//  4. Full dispatch. Normal DispatchPhase + CrossFilePhase.
+//
+// Structural reuse is the load-bearing #55 perf win for body-only
+// Kotlin edits: the source content hash moves, but the cross-file
+// structural fingerprint remains stable, so the whole findings bundle
+// can be replayed.
 func runDispatchOrLoadBundle(
 	ctx context.Context,
 	args ProjectArgs,
@@ -1266,6 +1269,10 @@ func runDispatchOrLoadBundle(
 ) (DispatchResult, CrossFileResult, bool, dispatchTimings, error) {
 	if bundleEnabled {
 		if cached, ok := host.FindingsBundleStore.Load(host.FindingsBundleCacheRoot, runFP); ok && cached != nil {
+			d := DispatchResult{IndexResult: indexResult, Findings: *cached}
+			return d, CrossFileResult{DispatchResult: d}, true, dispatchTimings{}, nil
+		}
+		if cached, ok := tryLoadStructurallyStableBundle(host, runFP, manifest); ok && cached != nil {
 			d := DispatchResult{IndexResult: indexResult, Findings: *cached}
 			return d, CrossFileResult{DispatchResult: d}, true, dispatchTimings{}, nil
 		}
@@ -1289,6 +1296,41 @@ func runDispatchOrLoadBundle(
 		return DispatchResult{}, CrossFileResult{}, false, dispatchTimings{}, fmt.Errorf("crossfile: %w", err)
 	}
 	return d, c, false, dispatchTimings{dispatchMs: dispatchMs, crossFileMs: crossMs}, nil
+}
+
+func tryLoadStructurallyStableBundle(host ProjectHostState, runFP scanner.RunFingerprint, manifest deltaManifestData) (*scanner.FindingColumns, bool) {
+	if !manifest.enabled || manifest.manifestKey == "" {
+		return nil, false
+	}
+	prior, ok := scanner.LoadFindingsBundleManifest(host.FindingsBundleCacheRoot, manifest.manifestKey)
+	if !ok {
+		return nil, false
+	}
+	changedPaths := diffContentHashes(prior.ContentHashes, manifest.contentHashes)
+	plan := scanner.ConservativeDeltaPlanner{}.Plan(prior.Fingerprint, runFP, changedPaths)
+	if !plan.ReusePrevious || len(plan.ChangedPaths) != 1 || !bodyOnlyKotlinChange(plan.ChangedPaths[0], prior.StructuralFPs, manifest.structuralFPs) {
+		return nil, false
+	}
+	priorBundle, ok := host.FindingsBundleStore.Load(host.FindingsBundleCacheRoot, prior.Fingerprint)
+	if !ok || priorBundle == nil {
+		return nil, false
+	}
+	if err := host.FindingsBundleStore.Save(host.FindingsBundleCacheRoot, runFP, priorBundle); err != nil {
+		host.Reporter.Verbosef("verbose: Findings bundle structural reuse skipped: save alias failed: %v\n", err)
+		return nil, false
+	}
+	host.Reporter.Verbosef("verbose: Findings bundle cache: HIT (structural reuse: %s)\n", plan.ChangedPaths[0])
+	return priorBundle, true
+}
+
+func bodyOnlyKotlinChange(path string, prior, current map[string]string) bool {
+	if !strings.HasSuffix(path, ".kt") && !strings.HasSuffix(path, ".kts") {
+		return false
+	}
+	if len(prior) == 0 || len(current) == 0 {
+		return false
+	}
+	return prior[path] != "" && prior[path] == current[path]
 }
 
 func reportFindingsBundleMiss(host ProjectHostState, manifest deltaManifestData, runFP scanner.RunFingerprint) {
@@ -1698,12 +1740,10 @@ func scopeParseResult(p ParseResult, only *scanner.File) ParseResult {
 //   - Android: sorted Gradle paths from the detected Android project.
 //   - LibraryFacts: indexResult.LibraryFacts.Fingerprint when present.
 //
-// The function is deliberately conservative: any input change
-// produces a fresh fingerprint and forces a fresh dispatch. The
-// delta planner's "exactly 1 file changed and cross-file is stable"
-// optimisation is out of scope for this PR (#55 PR-A) — that path
-// requires a structural CrossFile fingerprint that doesn't move with
-// every byte change. Pending follow-up.
+// The byte-level SourceSet keeps direct bundle loads precise for
+// identical input. Body-only Kotlin edits that move SourceSet but keep
+// CrossFile stable are handled by runDispatchOrLoadBundle's structural
+// reuse path.
 func computeRunFingerprint(args ProjectArgs, host ProjectHostState, parseResult ParseResult, indexResult IndexResult) (scanner.RunFingerprint, bool) {
 	if host.FindingsBundleStore == nil || host.FindingsBundleCacheRoot == "" {
 		return scanner.RunFingerprint{}, false

--- a/internal/pipeline/runproject_phase_timings_test.go
+++ b/internal/pipeline/runproject_phase_timings_test.go
@@ -105,6 +105,64 @@ func TestRunProject_PhaseTimings_BundleHitSkipsDispatchAndCrossfile(t *testing.T
 	}
 }
 
+func TestRunProject_BodyOnlyEditReusesFindingsBundle(t *testing.T) {
+	root := t.TempDir()
+	src := filepath.Join(root, "Foo.kt")
+	if err := os.WriteFile(src,
+		[]byte("package demo\n\nclass Foo {\n    fun answer() = 1\n}\n"), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	rule := api.FakeRule("ClassDecl",
+		api.WithNodeTypes("class_declaration"),
+		api.WithSeverity(api.SeverityWarning),
+		api.WithCheck(func(ctx *api.Context) {
+			ctx.EmitAt(int(ctx.Node.StartRow)+1, 1, "class declared")
+		}),
+	)
+	host := ProjectHostState{
+		FindingsBundleStore:     scanner.DiskFindingsBundleStore{},
+		FindingsBundleCacheRoot: root,
+	}
+	args := ProjectArgs{
+		Config:      config.NewConfig(),
+		Paths:       []string{root},
+		ActiveRules: []*api.Rule{rule},
+		Format:      "json",
+		Version:     "test",
+	}
+
+	first, err := RunProject(context.Background(), ProjectInput{Args: args, Host: host})
+	if err != nil {
+		t.Fatalf("first RunProject: %v", err)
+	}
+	if first.FindingsBundleHit {
+		t.Fatalf("first call must miss the bundle; got hit=true")
+	}
+	if first.FindingsCount != 1 {
+		t.Fatalf("first call findings = %d, want 1", first.FindingsCount)
+	}
+
+	if err := os.WriteFile(src,
+		[]byte("package demo\n\nclass Foo {\n    fun answer() = 22\n}\n"), 0o644); err != nil {
+		t.Fatalf("write body edit: %v", err)
+	}
+
+	second, err := RunProject(context.Background(), ProjectInput{Args: args, Host: host})
+	if err != nil {
+		t.Fatalf("second RunProject: %v", err)
+	}
+	if !second.FindingsBundleHit {
+		t.Fatalf("body-only edit with stable structural fingerprint must hit the bundle; got timings=%+v", second.PhaseTimingsMs)
+	}
+	if second.FindingsCount != first.FindingsCount {
+		t.Fatalf("body-only bundle replay changed finding count: first=%d second=%d", first.FindingsCount, second.FindingsCount)
+	}
+	if second.PhaseTimingsMs.Dispatch != 0 || second.PhaseTimingsMs.CrossFile != 0 {
+		t.Errorf("body-only bundle hit must bypass dispatch+crossfile; got dispatch=%dms crossfile=%dms",
+			second.PhaseTimingsMs.Dispatch, second.PhaseTimingsMs.CrossFile)
+	}
+}
+
 // TestRunProject_PhaseTimings_BundleHitAtSyntheticScale is the
 // scale-side companion to TestAnalyzeProject_BundleHitOnIdentical
 // SecondCall in the serve package: the 2-file fixture proved the

--- a/internal/scanner/findings_bundle_manifest.go
+++ b/internal/scanner/findings_bundle_manifest.go
@@ -16,8 +16,8 @@ import (
 //     stability of each non-SourceSet field).
 //   - The prior run's per-file content hashes (so we can detect
 //     exactly which files changed since last run).
-//   - The prior run's per-file structural fingerprints (informational
-//     today; future PRs may use them for finer-grained delta paths).
+//   - The prior run's per-file structural fingerprints, used to prove
+//     body-only Kotlin edits can replay the prior findings bundle.
 //   - The BundleKey of the prior bundle so we know which findings to
 //     load and merge into.
 //


### PR DESCRIPTION
## Summary
- Reuse the prior findings bundle when a single body-only Kotlin edit leaves the structural cross-file fingerprint unchanged.
- Save a current-fingerprint alias for the reused bundle so subsequent warm calls hit directly.
- Add RunProject and analyze-project regressions that assert findings_bundle_hit and zero dispatch/crossfile phase timings after a body-only edit.

## Validation
- go build -o krit ./cmd/krit/ && go vet ./...
- go test ./... -count=1
- go test ./internal/pipeline ./internal/cli/serve -run 'TestRunProject_BodyOnlyEditReusesFindingsBundle|TestAnalyzeProject_BodyOnlyEditReusesFindingsBundle' -count=1