### PR TITLE
feat(rules): implement ExportedService Kotlin/Java check

### DIFF
--- a/internal/rules/android.go
+++ b/internal/rules/android.go
@@ -166,9 +166,9 @@ type SetJavaScriptEnabledRule struct {
 // Classified per roadmap/17.
 func (r *SetJavaScriptEnabledRule) Confidence() float64 { return 0.75 }
 
-// ExportedServiceRule detects exported services/receivers without permission.
+// ExportedServiceRule detects exported services without permission.
 type ExportedServiceRule struct {
-	LineBase
+	FlatDispatchBase
 	AndroidRule
 }
 
@@ -180,8 +180,16 @@ type ExportedServiceRule struct {
 // Classified per roadmap/17.
 func (r *ExportedServiceRule) Confidence() float64 { return 0.75 }
 
-func (r *ExportedServiceRule) check(_ *api.Context) {
-	// This is primarily an XML check, but we can detect registration in Kotlin
+func (r *ExportedServiceRule) check(ctx *api.Context) {
+	file, idx := ctx.File, ctx.Idx
+	if !exportedClassExtendsAndroid(file, idx, "Service", "android.app.Service") {
+		return
+	}
+	if exportedPermissionEnforcedInClass(file, idx) {
+		return
+	}
+	ctx.EmitAt(file.FlatRow(idx)+1, file.FlatCol(idx)+1,
+		"Service subclass may be exported without permission. Ensure permissions are enforced.")
 }
 
 // PrivateKeyRule detects private key content in source.

--- a/internal/rules/android_security_test.go
+++ b/internal/rules/android_security_test.go
@@ -1970,6 +1970,58 @@ class MyService {
 	})
 }
 
+func TestExportedService(t *testing.T) {
+	t.Run("triggers on Service subclass", func(t *testing.T) {
+		findings := runRuleByName(t, "ExportedService", `
+package test
+import android.app.Service
+class MyService : Service() {
+    override fun onBind(intent: Intent) = null
+}
+`)
+		if len(findings) == 0 {
+			t.Fatal("expected findings")
+		}
+	})
+	t.Run("permission enforced passes", func(t *testing.T) {
+		findings := runRuleByName(t, "ExportedService", `
+package test
+import android.app.Service
+class SecureService : Service() {
+    override fun onBind(intent: Intent): IBinder? {
+        enforceCallingPermission("p", "no")
+        return null
+    }
+}
+`)
+		if len(findings) != 0 {
+			t.Fatalf("expected 0 findings, got %d", len(findings))
+		}
+	})
+	t.Run("non-service class passes", func(t *testing.T) {
+		findings := runRuleByName(t, "ExportedService", `
+package test
+class NotAService {
+    fun doWork() {}
+}
+`)
+		if len(findings) != 0 {
+			t.Fatalf("expected 0 findings, got %d", len(findings))
+		}
+	})
+	t.Run("missing import passes", func(t *testing.T) {
+		findings := runRuleByName(t, "ExportedService", `
+package test
+class MyService : Service() {
+    override fun onBind(intent: Intent) = null
+}
+`)
+		if len(findings) != 0 {
+			t.Fatalf("expected 0 findings without import, got %d", len(findings))
+		}
+	})
+}
+
 func TestGrantAllUris(t *testing.T) {
 	t.Run("triggers on grantUriPermission", func(t *testing.T) {
 		findings := runRuleByName(t, "GrantAllUris", `

--- a/internal/rules/registry_android_rules.go
+++ b/internal/rules/registry_android_rules.go
@@ -282,7 +282,7 @@ func registerAndroidRules() {
 			Category: ALCSecurity, ALSeverity: ALSWarning, Priority: 5,
 			Origin: "AOSP Android Lint",
 		}}
-		api.Register(&api.Rule{ID: r.RuleName, Category: r.RuleSetName, Description: r.Description(), Sev: api.Severity(r.Sev), Needs: api.NeedsLinePass, Confidence: r.Confidence(), Implementation: r, Check: r.check})
+		api.Register(&api.Rule{ID: r.RuleName, Category: r.RuleSetName, Description: r.Description(), Sev: api.Severity(r.Sev), NodeTypes: []string{"class_declaration"}, Confidence: r.Confidence(), Implementation: r, Check: r.check})
 	}
 	{
 		r := &PrivateKeyRule{AndroidRule: AndroidRule{

--- a/tests/fixtures/.coverage-allowlist.txt
+++ b/tests/fixtures/.coverage-allowlist.txt
@@ -57,7 +57,6 @@ negative DuplicateIncludedIdsResource
 negative DuplicateUsesFeatureManifest
 negative DynamicVersion
 negative ExportedPreferenceActivityManifest
-negative ExportedService
 negative ExportedServiceManifest
 negative ExportedWithoutPermission
 negative ExtraTextResource
@@ -286,7 +285,6 @@ positive DuplicateIncludedIdsResource
 positive DuplicateUsesFeatureManifest
 positive DynamicVersion
 positive ExportedPreferenceActivityManifest
-positive ExportedService
 positive ExportedServiceManifest
 positive ExportedWithoutPermission
 positive ExtraTextResource

--- a/tests/fixtures/negative/android-lint/ExportedService.kt
+++ b/tests/fixtures/negative/android-lint/ExportedService.kt
@@ -1,0 +1,16 @@
+package com.example
+
+import android.app.Service
+import android.content.Intent
+import android.os.IBinder
+
+class SecureService : Service() {
+    override fun onBind(intent: Intent): IBinder? {
+        enforceCallingPermission("com.example.BIND", "No permission")
+        return null
+    }
+}
+
+class NotAService {
+    fun doWork() {}
+}

--- a/tests/fixtures/positive/android-lint/ExportedService.kt
+++ b/tests/fixtures/positive/android-lint/ExportedService.kt
@@ -1,0 +1,9 @@
+package com.example
+
+import android.app.Service
+import android.content.Intent
+import android.os.IBinder
+
+class MyService : Service() {
+    override fun onBind(intent: Intent): IBinder? = null
+}


### PR DESCRIPTION
## Summary
- Wire the previously-stubbed `ExportedServiceRule` to the v2 dispatcher on `class_declaration` nodes, mirroring `ExportedReceiverRule`.
- Detects classes extending `android.app.Service` that don't enforce a permission in the class body (reuses the existing `exportedClassExtendsAndroid` / `exportedPermissionEnforcedInClass` helpers).
- Adds positive/negative fixtures and a `TestExportedService` unit test, and removes the now-satisfied entries from `.coverage-allowlist.txt`.

## Test plan
- [x] `go build -o krit ./cmd/krit/`
- [x] `go vet ./...`
- [x] `go test ./... -count=1`