### PR TITLE
feat(precompile): scaffold category + K0101-UnreachableCode

### DIFF
--- a/docs/precompile/taxonomy.md
+++ b/docs/precompile/taxonomy.md
@@ -1,0 +1,129 @@
+# Pre-Compile Diagnostic Taxonomy
+
+Stable catalog of compiler-class diagnostics emitted under `Category: "precompile"`.
+
+Each diagnostic is identified by a stable code embedded in the rule ID (`K####-Name`). The code is the public contract: agents and tooling match on the `K####` prefix; humans read the trailing name. Codes never change once shipped: superseded rules get a new code and the old code is retired with `Maturity: MaturityDeprecated`.
+
+## ID format
+
+```
+^K\d{4}-[A-Z][A-Za-z0-9]+$
+```
+
+- `K0001`-`K0099`: reserved (cross-cutting)
+- `K0100`-`K0199`: function scope
+- `K0200`-`K0299`: file scope
+- `K0300`-`K0399`: module scope (cross-file, source-only)
+- `K0400`-`K0499`: external / binary resolution (Oracle-backed)
+- `K0500`-`K0599`: generated sources / build-system surface
+- `K9000`-`K9999`: meta diagnostics (budget exceeded, oracle unavailable, etc.)
+
+## Severity
+
+Every non-meta rule in this catalog has `Sev: api.SeverityError`. Style-class rules use `warning` or `info` and stay outside this taxonomy. Meta diagnostics in the `K9###` range may use `Sev: api.SeverityWarning` for infrastructure signals. The `precompile` profile floor is enforced by `internal/rules/precompile_conventions_test.go`.
+
+## Default activation
+
+Precompile rules ship with `DefaultActive: false`. Users opt in via:
+
+```yaml
+# krit.yml
+profile: precompile
+```
+
+...or by enabling the `precompile` category explicitly. The profile activation plumbing lands in Phase 1 alongside the first runnable rule.
+
+## Diagnostics
+
+Columns: `code`, `name`, `scope`, `needs`, `kotlinc analog`, `phase`.
+
+`needs` lists the krit `Capabilities` bits the rule consumes. `kotlinc analog` names the closest standard kotlinc diagnostic (informational only; krit is not bug-for-bug compatible).
+
+### Function scope (K0100-K0199)
+
+| Code | Name | Needs | kotlinc analog | Phase |
+|---|---|---|---|---|
+| K0101 | UnreachableCode | - | UNREACHABLE_CODE | 1 |
+| K0102 | NonExhaustiveWhen | NeedsResolver | NO_ELSE_IN_WHEN | 1 |
+| K0103 | UselessElvisOnNonNull | NeedsResolver | USELESS_ELVIS | 1 |
+| K0104 | SmartCastImpossible | NeedsResolver | SMARTCAST_IMPOSSIBLE | 1 |
+| K0105 | TypeMismatchInReturn | NeedsResolver | TYPE_MISMATCH | 1 |
+| K0106 | UnusedParameter | - | UNUSED_PARAMETER | 1 |
+| K0107 | InvalidConstExpression | NeedsResolver | CONST_VAL_NOT_TOP_LEVEL_OR_OBJECT | 1 |
+| K0108 | DuplicateLabel | - | DUPLICATE_LABEL_IN_WHEN | 1 |
+| K0109 | ConditionAlwaysTrue | NeedsResolver | SENSELESS_COMPARISON | 1 |
+| K0110 | ImplicitNothingReturn | NeedsResolver | IMPLICIT_NOTHING_AS_TYPE_PARAMETER | 1 |
+
+### File scope (K0200-K0299)
+
+| Code | Name | Needs | kotlinc analog | Phase |
+|---|---|---|---|---|
+| K0201 | UnresolvedReference | NeedsResolver | UNRESOLVED_REFERENCE | 2 |
+| K0202 | OverrideSignatureMismatch | NeedsResolver | RETURN_TYPE_MISMATCH_ON_OVERRIDE | 2 |
+| K0203 | AbstractMemberNotImplemented | NeedsResolver | ABSTRACT_MEMBER_NOT_IMPLEMENTED | 2 |
+| K0204 | ReturnTypeMismatchOverride | NeedsResolver | RETURN_TYPE_MISMATCH_ON_OVERRIDE | 2 |
+| K0205 | VisibilityViolation | NeedsResolver | INVISIBLE_REFERENCE | 2 |
+| K0206 | DuplicateDeclaration | NeedsResolver | CONFLICTING_OVERLOADS | 2 |
+| K0207 | InvalidImport | NeedsResolver | UNRESOLVED_IMPORT | 2 |
+| K0208 | ConflictingOverloads | NeedsResolver | CONFLICTING_OVERLOADS | 2 |
+| K0209 | SealedSubclassOutsideHierarchy | NeedsResolver | SEALED_INHERITOR_IN_DIFFERENT_FILE | 2 |
+| K0210 | InitializerTypeMismatch | NeedsResolver | INITIALIZER_TYPE_MISMATCH | 2 |
+
+### Module scope (K0300-K0399)
+
+Cross-file, source-only. Use `NeedsCrossFile` and the `scanner.CodeIndex`.
+
+| Code | Name | Needs | kotlinc analog | Phase |
+|---|---|---|---|---|
+| K0301 | UnresolvedReferenceCrossFile | NeedsResolver \| NeedsCrossFile | UNRESOLVED_REFERENCE | 3 |
+| K0302 | OverrideSignatureMismatchCrossFile | NeedsResolver \| NeedsCrossFile | RETURN_TYPE_MISMATCH_ON_OVERRIDE | 3 |
+| K0303 | AbstractMemberNotImplementedCrossFile | NeedsResolver \| NeedsCrossFile | ABSTRACT_MEMBER_NOT_IMPLEMENTED | 3 |
+| K0304 | InternalLeakCrossFile | NeedsResolver \| NeedsCrossFile | INVISIBLE_REFERENCE | 3 |
+| K0305 | NonExhaustiveWhenSealedCrossFile | NeedsResolver \| NeedsCrossFile | NO_ELSE_IN_WHEN | 3 |
+| K0306 | TypeAliasResolutionFailure | NeedsResolver \| NeedsCrossFile | UNRESOLVED_REFERENCE | 3 |
+| K0307 | PrivateExposedInPublicApi | NeedsResolver \| NeedsCrossFile | EXPOSED_PROPERTY_TYPE | 3 |
+
+### External / binary resolution (K0400-K0499)
+
+Backed by the JVM Oracle daemon. Rules declare narrow `NeedsOracle*` bits to keep the extraction profile tight.
+
+| Code | Name | Needs | kotlinc analog | Phase |
+|---|---|---|---|---|
+| K0401 | UnresolvedReferenceExternal | NeedsOracleCallTargets \| NeedsOracleLibraryClasses | UNRESOLVED_REFERENCE | 4 |
+| K0402 | OverrideSignatureMismatchExternal | NeedsOracleSupertypes \| NeedsOracleMemberSignatures | RETURN_TYPE_MISMATCH_ON_OVERRIDE | 4 |
+| K0403 | DeprecatedSymbolUsedError | NeedsOracleMemberAnnotations | DEPRECATION_ERROR | 4 |
+| K0404 | RequiresApiViolation | NeedsOracleMemberAnnotations \| NeedsGradle | NewApi (Android lint analog) | 4 |
+| K0405 | RemovedOverloadCalled | NeedsOracleCallTargets | NONE_APPLICABLE | 4 |
+| K0406 | InvalidNullabilityFromJava | NeedsOracleExprType \| NeedsOracleMemberAnnotations | NULL_FOR_NONNULL_TYPE | 4 |
+
+### Generated sources (K0500-K0599)
+
+| Code | Name | Needs | kotlinc analog | Phase |
+|---|---|---|---|---|
+| K0501 | GeneratedSourceStale | NeedsCrossFile | (no direct analog; pre-compile heuristic) | 5 |
+
+### Meta diagnostics (K9000-K9999)
+
+| Code | Name | Severity | When |
+|---|---|---|---|
+| K9001 | OracleBudgetExceeded | warning | Oracle calls per file exceeded soft cap (200). |
+| K9002 | OracleUnavailable | warning | Oracle daemon could not be reached; external-resolution rules skipped. |
+
+Meta diagnostics intentionally use `warning` (not `error`): they are infrastructure signals, not user defects. They are exempt from the profile severity floor; the convention test allows `Sev: SeverityWarning` only for IDs in the `K9###` range.
+
+## Coverage targets
+
+- **Function scope:** >=10 (achieved: 10).
+- **File scope:** >=10 (achieved: 10).
+- **Module scope:** >=7 (achieved: 7).
+- **Project / external scope:** >=3 (achieved: 7 across K0400 + K0500).
+- **Total:** >=30 (achieved: 36).
+
+## Adding a new diagnostic
+
+1. Pick the lowest unused code in the right band.
+2. Add a row here.
+3. Implement `internal/rules/precompile_<name>.go` + `registry_precompile_<name>.go`.
+4. Add fixtures: `tests/fixtures/precompile/{positive,negative,fixable}/<RuleID>/*.kt` plus `*.diag` companions.
+5. Wire registration from `registry_bootstrap.go`.
+6. `make lint-rules && make test && make integration` must stay green.

--- a/internal/rules/api/precompile.go
+++ b/internal/rules/api/precompile.go
@@ -1,0 +1,24 @@
+package api
+
+import "regexp"
+
+// CategoryPrecompile is the api.Rule.Category for compiler-class
+// diagnostics. See docs/precompile/taxonomy.md for the full contract;
+// precompile_conventions_test.go enforces it.
+const CategoryPrecompile = "precompile"
+
+// PrecompileIDPattern matches every valid precompile rule ID.
+var PrecompileIDPattern = regexp.MustCompile(`^K\d{4}-[A-Z][A-Za-z0-9]+$`)
+
+// PrecompileMetaIDPattern matches the K9000-K9999 meta range, which is
+// exempt from the SeverityError floor (meta diagnostics signal
+// infrastructure conditions, not user defects).
+var PrecompileMetaIDPattern = regexp.MustCompile(`^K9\d{3}-[A-Z][A-Za-z0-9]+$`)
+
+func IsPrecompileID(id string) bool {
+	return PrecompileIDPattern.MatchString(id)
+}
+
+func IsPrecompileMetaID(id string) bool {
+	return PrecompileMetaIDPattern.MatchString(id)
+}

--- a/internal/rules/api/precompile_test.go
+++ b/internal/rules/api/precompile_test.go
@@ -1,0 +1,51 @@
+package api
+
+import "testing"
+
+func TestPrecompileIDPattern(t *testing.T) {
+	good := []string{
+		"K0101-UnreachableCode",
+		"K0201-UnresolvedReference",
+		"K0306-TypeAliasResolutionFailure",
+		"K9001-OracleBudgetExceeded",
+		"K0001-Reserved",
+	}
+	for _, id := range good {
+		if !IsPrecompileID(id) {
+			t.Errorf("IsPrecompileID(%q) = false, want true", id)
+		}
+	}
+	bad := []string{
+		"",
+		"UnreachableCode",
+		"K101-UnreachableCode",
+		"K01010-UnreachableCode",
+		"K0101_UnreachableCode",
+		"K0101-unreachableCode",
+		"K0101-",
+		"k0101-UnreachableCode",
+	}
+	for _, id := range bad {
+		if IsPrecompileID(id) {
+			t.Errorf("IsPrecompileID(%q) = true, want false", id)
+		}
+	}
+}
+
+func TestPrecompileMetaIDPattern(t *testing.T) {
+	if !IsPrecompileMetaID("K9001-OracleBudgetExceeded") {
+		t.Errorf("K9001 should be classified as meta")
+	}
+	if IsPrecompileMetaID("K0101-UnreachableCode") {
+		t.Errorf("K0101 must not be classified as meta")
+	}
+	if IsPrecompileMetaID("K8999-Whatever") {
+		t.Errorf("K8999 must not be classified as meta (out of K9### band)")
+	}
+}
+
+func TestCategoryPrecompileConstant(t *testing.T) {
+	if CategoryPrecompile != "precompile" {
+		t.Errorf("CategoryPrecompile = %q, want %q", CategoryPrecompile, "precompile")
+	}
+}

--- a/internal/rules/fixture_coverage_test.go
+++ b/internal/rules/fixture_coverage_test.go
@@ -47,6 +47,9 @@ func TestFixtureCoverage(t *testing.T) {
 			continue
 		}
 		seenIDs[r.ID] = true
+		if r.Category == api.CategoryPrecompile {
+			continue
+		}
 
 		for _, kind := range []string{"positive", "negative"} {
 			has := posIndex[r.ID]

--- a/internal/rules/precompile_conventions_test.go
+++ b/internal/rules/precompile_conventions_test.go
@@ -1,0 +1,40 @@
+package rules_test
+
+import (
+	"testing"
+
+	api "github.com/kaeawc/krit/internal/rules/api"
+)
+
+// TestPrecompileConventions enforces docs/precompile/taxonomy.md
+// against every registered precompile rule.
+func TestPrecompileConventions(t *testing.T) {
+	for _, r := range api.Registry {
+		if r.Category != api.CategoryPrecompile {
+			continue
+		}
+		r := r
+		t.Run(r.ID, func(t *testing.T) {
+			if !api.IsPrecompileID(r.ID) {
+				t.Errorf("rule ID %q does not match precompile pattern %s", r.ID, api.PrecompileIDPattern)
+			}
+			if api.IsPrecompileMetaID(r.ID) {
+				if r.Sev != api.SeverityError && r.Sev != api.SeverityWarning {
+					t.Errorf("meta rule %s severity %q must be error or warning", r.ID, r.Sev)
+				}
+			} else {
+				if r.Sev != api.SeverityError {
+					t.Errorf("rule %s severity %q must be %q for precompile category",
+						r.ID, r.Sev, api.SeverityError)
+				}
+			}
+			if r.DefaultActive {
+				t.Errorf("rule %s declares DefaultActive=true; precompile rules must be opt-in (DefaultActive=false)",
+					r.ID)
+			}
+			if r.Description == "" {
+				t.Errorf("rule %s has empty Description", r.ID)
+			}
+		})
+	}
+}

--- a/internal/rules/precompile_fixtures_test.go
+++ b/internal/rules/precompile_fixtures_test.go
@@ -1,0 +1,144 @@
+package rules_test
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	api "github.com/kaeawc/krit/internal/rules/api"
+	"github.com/kaeawc/krit/internal/scanner"
+)
+
+// Fixture layout for precompile rules:
+//
+//	tests/fixtures/precompile/positive/<RuleID>/<n>.kt   -> >=1 finding
+//	tests/fixtures/precompile/negative/<RuleID>/<n>.kt   -> 0 findings
+//	tests/fixtures/precompile/fixable/<RuleID>/<n>.kt    -> >=1 finding with Fix
+
+const precompileFixtureRel = "tests/fixtures/precompile"
+
+func precompileFixtureDir(t *testing.T) (string, bool) {
+	t.Helper()
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	root := filepath.Join(wd, "..", "..", precompileFixtureRel)
+	if _, err := os.Stat(root); err != nil {
+		return "", false
+	}
+	return root, true
+}
+
+func precompileRuleIndex() map[string]*api.Rule {
+	idx := make(map[string]*api.Rule)
+	for _, r := range api.Registry {
+		if r.Category == api.CategoryPrecompile {
+			idx[r.ID] = r
+		}
+	}
+	return idx
+}
+
+func walkPrecompileFixtures(t *testing.T, kind string, fn func(t *testing.T, rule *api.Rule, file *scanner.File, findings []scanner.Finding)) {
+	t.Helper()
+	root, ok := precompileFixtureDir(t)
+	if !ok {
+		return
+	}
+	kindDir := filepath.Join(root, kind)
+	if _, err := os.Stat(kindDir); err != nil {
+		return
+	}
+	idx := precompileRuleIndex()
+
+	entries, err := os.ReadDir(kindDir)
+	if err != nil {
+		t.Fatalf("reading %s: %v", kindDir, err)
+	}
+	sort.Slice(entries, func(i, j int) bool { return entries[i].Name() < entries[j].Name() })
+
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		ruleID := entry.Name()
+		rule, ok := idx[ruleID]
+		if !ok {
+			t.Run(kind+"/"+ruleID, func(t *testing.T) {
+				t.Errorf("fixture directory %s/%s has no matching registered precompile rule", kind, ruleID)
+			})
+			continue
+		}
+		// Multi-file rules need a harness that this single-file
+		// runner doesn't provide.
+		if rule.Needs.Has(api.NeedsCrossFile) || rule.Needs.Has(api.NeedsModuleIndex) || rule.Needs.Has(api.NeedsParsedFiles) {
+			t.Run(kind+"/"+ruleID, func(t *testing.T) {
+				t.Skipf("rule %s requires multi-file context not yet wired", rule.ID)
+			})
+			continue
+		}
+		ruleDir := filepath.Join(kindDir, ruleID)
+		fixtures, err := os.ReadDir(ruleDir)
+		if err != nil {
+			t.Errorf("reading %s: %v", ruleDir, err)
+			continue
+		}
+		for _, fx := range fixtures {
+			if fx.IsDir() || !strings.HasSuffix(fx.Name(), ".kt") {
+				continue
+			}
+			path := filepath.Join(ruleDir, fx.Name())
+			name := strings.TrimSuffix(fx.Name(), ".kt")
+			t.Run(kind+"/"+ruleID+"/"+name, func(t *testing.T) {
+				t.Parallel()
+				file, err := scanner.ParseFile(path)
+				if err != nil {
+					t.Fatalf("parse %s: %v", path, err)
+				}
+				findings := runRule(t, rule, file)
+				fn(t, rule, file, findings)
+			})
+		}
+	}
+}
+
+func TestPrecompileFixturesPositive(t *testing.T) {
+	walkPrecompileFixtures(t, "positive", func(t *testing.T, rule *api.Rule, _ *scanner.File, findings []scanner.Finding) {
+		if len(findings) == 0 {
+			t.Errorf("rule %s: expected >=1 finding for positive fixture, got 0", rule.ID)
+		}
+	})
+}
+
+func TestPrecompileFixturesNegative(t *testing.T) {
+	walkPrecompileFixtures(t, "negative", func(t *testing.T, rule *api.Rule, _ *scanner.File, findings []scanner.Finding) {
+		if len(findings) != 0 {
+			t.Errorf("rule %s: expected 0 findings for negative fixture, got %d", rule.ID, len(findings))
+			for _, f := range findings {
+				t.Logf("  unexpected: %s:%d:%d %s", f.File, f.Line, f.Col, f.Message)
+			}
+		}
+	})
+}
+
+func TestPrecompileFixturesFixable(t *testing.T) {
+	walkPrecompileFixtures(t, "fixable", func(t *testing.T, rule *api.Rule, _ *scanner.File, findings []scanner.Finding) {
+		if rule.Fix == api.FixNone {
+			t.Errorf("rule %s: has fixable fixtures but Fix=FixNone in registration", rule.ID)
+			return
+		}
+		if len(findings) == 0 {
+			t.Errorf("rule %s: expected >=1 finding for fixable fixture, got 0", rule.ID)
+			return
+		}
+		for _, f := range findings {
+			if f.Fix != nil || f.BinaryFix != nil {
+				return
+			}
+		}
+		t.Errorf("rule %s: fixable fixture produced no Fix payload", rule.ID)
+	})
+}

--- a/internal/rules/precompile_unreachable_code.go
+++ b/internal/rules/precompile_unreachable_code.go
@@ -1,0 +1,66 @@
+package rules
+
+import (
+	api "github.com/kaeawc/krit/internal/rules/api"
+	"github.com/kaeawc/krit/internal/scanner"
+)
+
+// PrecompileUnreachableCodeRule flags statements that follow an
+// unconditional jump (return/throw/break/continue) in the same
+// statements block. Mirrors kotlinc's UNREACHABLE_CODE.
+//
+// Conservative by construction: fires only when the jump is in
+// statement position (direct child of a `statements` node), so
+// expression-position jumps like `x ?: return` and `if (b) return else
+// ...` are skipped. Looking only at the jump's direct parent keeps the
+// rule local — nested lambdas/anonymous functions cannot escape its
+// scope.
+type PrecompileUnreachableCodeRule struct {
+	FlatDispatchBase
+	BaseRule
+}
+
+func (r *PrecompileUnreachableCodeRule) Confidence() float64 { return 0.95 }
+
+func (r *PrecompileUnreachableCodeRule) check(ctx *api.Context) {
+	idx, file := ctx.Idx, ctx.File
+	parent, ok := file.FlatParent(idx)
+	if !ok || file.FlatType(parent) != "statements" {
+		return
+	}
+	keyword := jumpExpressionKeyword(file, idx)
+	if keyword == "" {
+		return
+	}
+	next := firstNamedStatementSiblingAfter(file, idx)
+	if next == 0 {
+		return
+	}
+	ctx.EmitAt(file.FlatRow(next)+1, file.FlatCol(next)+1,
+		"Unreachable code after `"+keyword+"`. Remove the statements following the unconditional jump.")
+}
+
+func jumpExpressionKeyword(file *scanner.File, idx uint32) string {
+	for child := file.FlatFirstChild(idx); child != 0; child = file.FlatNextSib(child) {
+		t := file.FlatType(child)
+		switch t {
+		case "return", "throw", "break", "continue":
+			return t
+		}
+	}
+	return ""
+}
+
+func firstNamedStatementSiblingAfter(file *scanner.File, idx uint32) uint32 {
+	for child := file.FlatNextSib(idx); child != 0; child = file.FlatNextSib(child) {
+		if !file.FlatIsNamed(child) {
+			continue
+		}
+		switch file.FlatType(child) {
+		case "line_comment", "multiline_comment":
+			continue
+		}
+		return child
+	}
+	return 0
+}

--- a/internal/rules/registry_bootstrap.go
+++ b/internal/rules/registry_bootstrap.go
@@ -93,6 +93,7 @@ func init() {
 	registerPotentialbugsPropertiesRules()
 	registerPotentialbugsSmartCastRules()
 	registerPotentialbugsTypesRules()
+	registerPrecompileUnreachableCodeRules()
 	registerCorrectnessOverrideRules()
 	registerCorrectnessAbstractRules()
 	registerPrivacyAnalyticsRules()

--- a/internal/rules/registry_precompile_unreachable_code.go
+++ b/internal/rules/registry_precompile_unreachable_code.go
@@ -1,0 +1,25 @@
+package rules
+
+import (
+	api "github.com/kaeawc/krit/internal/rules/api"
+)
+
+func registerPrecompileUnreachableCodeRules() {
+	r := &PrecompileUnreachableCodeRule{BaseRule: BaseRule{
+		RuleName:    "K0101-UnreachableCode",
+		RuleSetName: api.CategoryPrecompile,
+		Sev:         string(api.SeverityError),
+		Desc:        "Detects statements that follow an unconditional jump (return, throw, break, continue) in the same block. Mirrors kotlinc's UNREACHABLE_CODE.",
+	}}
+	api.Register(&api.Rule{
+		ID:             r.RuleName,
+		Category:       r.RuleSetName,
+		Description:    r.Desc,
+		Sev:            api.Severity(r.Sev),
+		NodeTypes:      []string{"jump_expression"},
+		Confidence:     r.Confidence(),
+		Implementation: r,
+		Check:          r.check,
+		DefaultActive:  false,
+	})
+}

--- a/internal/rules/rules_test.go
+++ b/internal/rules/rules_test.go
@@ -274,7 +274,7 @@ func fixtureNames(t *testing.T, dir string) map[string]bool {
 // excluded because the existing TestPositiveFixtures/TestNegativeFixtures
 // already skip them. Rules in the "android-lint" category (AndroidDeps != 0
 // or Category == "android-lint") are tracked separately in the android-lint
-// cluster.
+// cluster. Precompile rules have their own category-specific fixture harness.
 func TestNonAndroidRulesHaveFixtures(t *testing.T) {
 	root := fixtureRoot(t)
 	positiveFixtures := fixtureNames(t, filepath.Join(root, "positive"))
@@ -284,6 +284,9 @@ func TestNonAndroidRulesHaveFixtures(t *testing.T) {
 	for _, r := range api.Registry {
 		// Skip Android-specific rules (by explicit deps or category).
 		if r.AndroidDeps != 0 || r.Category == "android-lint" {
+			continue
+		}
+		if r.Category == api.CategoryPrecompile {
 			continue
 		}
 		// Skip rules that require multi-file analysis.

--- a/tests/fixtures/precompile/README.md
+++ b/tests/fixtures/precompile/README.md
@@ -1,0 +1,49 @@
+# Precompile rule fixtures
+
+Fixtures for compiler-class diagnostics under `Category: precompile`.
+
+## Layout
+
+```
+tests/fixtures/precompile/
+  positive/<RuleID>/<n>.kt   -> must produce >=1 finding
+  negative/<RuleID>/<n>.kt   -> must produce 0 findings
+  fixable/<RuleID>/<n>.kt    -> must produce >=1 finding with a Fix payload
+```
+
+`<RuleID>` is the full rule identifier including the `K####-` prefix,
+e.g. `K0101-UnreachableCode`. Fixture filenames are conventional,
+typically `1.kt`, `2.kt`, ..., but any `.kt` file under the rule directory
+is picked up.
+
+## Running
+
+```
+go test ./internal/rules/ -run TestPrecompileFixtures -count=1
+```
+
+## Conventions
+
+- Each rule should have >=3 positive, >=3 negative fixtures. Fixable rules
+  add >=1 fixable fixture.
+- Negative fixtures should cover the obvious "looks similar but isn't"
+  shapes, e.g. `when` with an explicit `else`, `return` followed by a
+  comment block, etc.
+- Fixtures must compile under standard kotlinc unless they are
+  positive examples of a compile-time error the rule catches. In that
+  case, add a leading comment `// EXPECTED-KOTLINC-ERROR: <diagnostic>`
+  documenting which kotlinc diagnostic this fixture mirrors. The
+  taxonomy at `docs/precompile/taxonomy.md` lists the canonical analog
+  per rule.
+- Keep fixtures minimal. A 5-line fixture that exercises a single
+  branch beats a 50-line fixture covering many.
+
+## Adding fixtures for a new rule
+
+1. Add the rule to `docs/precompile/taxonomy.md` with its `K####` code.
+2. Implement the rule under `internal/rules/precompile_<name>.go`.
+3. Create `positive/<RuleID>/`, `negative/<RuleID>/`, and (if fixable)
+   `fixable/<RuleID>/` directories.
+4. Drop in fixtures.
+5. Run `go test ./internal/rules/ -run TestPrecompileFixtures -count=1`
+   to validate.

--- a/tests/fixtures/precompile/negative/K0101-UnreachableCode/1.kt
+++ b/tests/fixtures/precompile/negative/K0101-UnreachableCode/1.kt
@@ -1,0 +1,11 @@
+// Negative: return is the last statement; nothing follows.
+fun tailReturn(x: Int): Int {
+    val y = x + 1
+    return y
+}
+
+// Negative: trailing comments are not statements.
+fun trailingComment(x: Int): Int {
+    return x
+    // this is just a comment, not unreachable code
+}

--- a/tests/fixtures/precompile/negative/K0101-UnreachableCode/2.kt
+++ b/tests/fixtures/precompile/negative/K0101-UnreachableCode/2.kt
@@ -1,0 +1,10 @@
+// Negative: jump used as an expression value, not in statement position.
+fun elvisReturn(x: Int?): Int {
+    val y = x ?: return -1
+    return y + 1
+}
+
+fun ifBranchReturn(b: Boolean, x: Int): Int {
+    val y = if (b) return x else x + 1
+    return y
+}

--- a/tests/fixtures/precompile/negative/K0101-UnreachableCode/3.kt
+++ b/tests/fixtures/precompile/negative/K0101-UnreachableCode/3.kt
@@ -1,0 +1,18 @@
+// Negative: return inside a nested lambda does not make outer statements unreachable.
+fun nestedLambda(xs: List<Int>): Int {
+    xs.forEach {
+        if (it < 0) return@forEach
+        println(it)
+    }
+    return xs.size
+}
+
+// Negative: continue inside a loop branch; following code in the SAME branch
+// stays after it but only when in the same `statements` block. Here the
+// branch body is a single statement, so nothing follows continue.
+fun loopContinue(xs: List<Int>) {
+    for (x in xs) {
+        if (x == 0) continue
+        println(x)
+    }
+}

--- a/tests/fixtures/precompile/positive/K0101-UnreachableCode/1.kt
+++ b/tests/fixtures/precompile/positive/K0101-UnreachableCode/1.kt
@@ -1,0 +1,6 @@
+// EXPECTED-KOTLINC-ERROR: UNREACHABLE_CODE
+fun afterReturn(x: Int): Int {
+    return x
+    val dead = x + 1
+    println(dead)
+}

--- a/tests/fixtures/precompile/positive/K0101-UnreachableCode/2.kt
+++ b/tests/fixtures/precompile/positive/K0101-UnreachableCode/2.kt
@@ -1,0 +1,5 @@
+// EXPECTED-KOTLINC-ERROR: UNREACHABLE_CODE
+fun afterThrow(): Int {
+    throw IllegalStateException("boom")
+    return 0
+}

--- a/tests/fixtures/precompile/positive/K0101-UnreachableCode/3.kt
+++ b/tests/fixtures/precompile/positive/K0101-UnreachableCode/3.kt
@@ -1,0 +1,10 @@
+// EXPECTED-KOTLINC-ERROR: UNREACHABLE_CODE
+fun loopBreakDead(xs: List<Int>): Int {
+    for (x in xs) {
+        if (x > 0) {
+            break
+            println("never")
+        }
+    }
+    return 0
+}


### PR DESCRIPTION
## Summary
- Land the precompile category scaffold: taxonomy doc, `CategoryPrecompile` + `K####-Name` ID helpers, opt-in/severity conventions test, and a category-specific fixture harness under `tests/fixtures/precompile/`.
- Add the first real rule, K0101-UnreachableCode, mirroring kotlinc's UNREACHABLE_CODE. AST-only and conservative: fires only when the jump is in statement position; expression-position jumps (`x ?: return`, `if (b) return else ...`) and trailing comments are skipped; scope stays local to the jump's parent so nested lambdas can't propagate.
- `DefaultActive: false` — precompile rules ship opt-in until profile activation lands.

## Test plan
- [x] \`go build -o krit ./cmd/krit/\`
- [x] \`go vet ./...\`
- [x] \`go test ./... -count=1\` (all packages green)
- [x] 3 positive + 3 negative fixtures covering return/throw/break/continue, expression-position jumps, lambda-scoped returns, and trailing comments