### PR TITLE
test: cover manifest/diag and LSP/MCP protocol surfaces

### DIFF
--- a/internal/diag/reporter_test.go
+++ b/internal/diag/reporter_test.go
@@ -1,0 +1,126 @@
+package diag
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestNilReporterIsSilent(t *testing.T) {
+	var r *Reporter
+	r.Verbosef("should not panic %d", 1)
+	r.Warnf("should not panic %d", 2)
+	if r.VerboseEnabled() {
+		t.Fatal("VerboseEnabled() on nil receiver should be false")
+	}
+}
+
+func TestVerbosef_RoutesToVerboseWriter(t *testing.T) {
+	var v, w bytes.Buffer
+	r := &Reporter{Verbose: &v, Warning: &w}
+	r.Verbosef("hello %s\n", "world")
+
+	if got := v.String(); got != "hello world\n" {
+		t.Fatalf("verbose buffer = %q, want %q", got, "hello world\n")
+	}
+	if w.Len() != 0 {
+		t.Fatalf("warning buffer should be empty, got %q", w.String())
+	}
+}
+
+func TestWarnf_RoutesToWarningWriter(t *testing.T) {
+	var v, w bytes.Buffer
+	r := &Reporter{Verbose: &v, Warning: &w}
+	r.Warnf("uh oh %d\n", 42)
+
+	if got := w.String(); got != "uh oh 42\n" {
+		t.Fatalf("warning buffer = %q, want %q", got, "uh oh 42\n")
+	}
+	if v.Len() != 0 {
+		t.Fatalf("verbose buffer should be empty, got %q", v.String())
+	}
+}
+
+func TestVerbosef_NilVerboseStreamIsSilent(t *testing.T) {
+	var w bytes.Buffer
+	r := &Reporter{Warning: &w}
+	r.Verbosef("ignored")
+
+	if w.Len() != 0 {
+		t.Fatalf("warning buffer should be empty when only verbose stream is silenced, got %q", w.String())
+	}
+	if r.VerboseEnabled() {
+		t.Fatal("VerboseEnabled() should be false when Verbose writer is nil")
+	}
+}
+
+func TestWarnf_NilWarningStreamIsSilent(t *testing.T) {
+	var v bytes.Buffer
+	r := &Reporter{Verbose: &v}
+	r.Warnf("ignored")
+
+	if v.Len() != 0 {
+		t.Fatalf("verbose buffer should not capture warnings, got %q", v.String())
+	}
+}
+
+func TestVerboseEnabled(t *testing.T) {
+	cases := []struct {
+		name string
+		r    *Reporter
+		want bool
+	}{
+		{"nil receiver", nil, false},
+		{"no writers", &Reporter{}, false},
+		{"only warning", &Reporter{Warning: &bytes.Buffer{}}, false},
+		{"only verbose", &Reporter{Verbose: &bytes.Buffer{}}, true},
+		{"both", &Reporter{Verbose: &bytes.Buffer{}, Warning: &bytes.Buffer{}}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.r.VerboseEnabled(); got != tc.want {
+				t.Fatalf("VerboseEnabled() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestNewStderr_VerboseFalse(t *testing.T) {
+	r := NewStderr(false)
+	if r == nil {
+		t.Fatal("NewStderr returned nil")
+	}
+	if r.Warning == nil {
+		t.Fatal("NewStderr(false) should set Warning to stderr")
+	}
+	if r.Verbose != nil {
+		t.Fatal("NewStderr(false) should leave Verbose nil")
+	}
+	if r.VerboseEnabled() {
+		t.Fatal("NewStderr(false) should not enable verbose")
+	}
+}
+
+func TestNewStderr_VerboseTrue(t *testing.T) {
+	r := NewStderr(true)
+	if r == nil {
+		t.Fatal("NewStderr returned nil")
+	}
+	if r.Warning == nil {
+		t.Fatal("NewStderr(true) should set Warning to stderr")
+	}
+	if r.Verbose == nil {
+		t.Fatal("NewStderr(true) should set Verbose to stderr")
+	}
+	if !r.VerboseEnabled() {
+		t.Fatal("NewStderr(true) should enable verbose")
+	}
+}
+
+func TestFormatArgsPassedThroughVerbatim(t *testing.T) {
+	var v bytes.Buffer
+	r := &Reporter{Verbose: &v}
+	r.Verbosef("no newline, no prefix")
+	if got := v.String(); got != "no newline, no prefix" {
+		t.Fatalf("Verbosef should not add newline or prefix, got %q", got)
+	}
+}

--- a/internal/lsp/codelens_test.go
+++ b/internal/lsp/codelens_test.go
@@ -1,0 +1,193 @@
+package lsp
+
+import (
+	"testing"
+
+	"github.com/kaeawc/krit/internal/scanner"
+)
+
+func TestFunctionComplexity_BaseIsOne(t *testing.T) {
+	// A linear function with no branches should have cyclomatic complexity 1.
+	lines := []string{
+		"fun greet(): String {",
+		"    return \"hello\"",
+		"}",
+	}
+	got := functionComplexity(lines, 1, len(lines)+1)
+	if got != 1 {
+		t.Errorf("linear function complexity = %d, want 1", got)
+	}
+}
+
+func TestFunctionComplexity_BranchesIncrement(t *testing.T) {
+	// Each if/else-if/when/for/while/catch/&&/||/?: adds one. The line
+	// scanner is the same one used by the real CodeLens provider, so this
+	// guards the regex against accidental drift.
+	lines := []string{
+		"fun pick(x: Int, y: Int?): Int {",   // 1: base
+		"    if (x > 0 && y != null) {",      // 2: if + &&
+		"        for (i in 0..x) print(i)",   // 3: for
+		"    } else if (x < 0 || y == null) { ", // 4: else if + ||
+		"        return -1",
+		"    }",
+		"    return y ?: 0",                  // 5: ?:
+		"}",
+	}
+	got := functionComplexity(lines, 1, len(lines)+1)
+	want := 1 + 6 // base + if + && + for + else-if + || + ?:
+	if got != want {
+		t.Errorf("complexity = %d, want %d", got, want)
+	}
+}
+
+func TestFunctionComplexity_SkipsLineComments(t *testing.T) {
+	lines := []string{
+		"fun f() {",
+		"    // if (x) { for (y) {} }  -- commented out branches",
+		"    return",
+		"}",
+	}
+	if got := functionComplexity(lines, 1, len(lines)+1); got != 1 {
+		t.Errorf("complexity with commented branches = %d, want 1", got)
+	}
+}
+
+func TestFunctionComplexity_HandlesOutOfRangeArgs(t *testing.T) {
+	lines := []string{"fun f() {}"}
+	// Caller passes nonsense bounds; helper must clamp rather than panic.
+	if got := functionComplexity(lines, 0, 999); got != 1 {
+		t.Errorf("complexity with bad bounds = %d, want 1", got)
+	}
+	if got := functionComplexity(lines, -5, -1); got != 1 {
+		t.Errorf("complexity with negative bounds = %d, want 1", got)
+	}
+}
+
+func TestSymbolName_PrefersFQN(t *testing.T) {
+	sym := scanner.Symbol{Name: "doThing", Owner: "Foo", FQN: "com.example.Foo.doThing"}
+	if got := symbolName(sym); got != "com.example.Foo.doThing" {
+		t.Errorf("symbolName = %q, want FQN", got)
+	}
+}
+
+func TestSymbolName_FallsBackToOwnerDotName(t *testing.T) {
+	sym := scanner.Symbol{Name: "doThing", Owner: "Foo"}
+	if got := symbolName(sym); got != "Foo.doThing" {
+		t.Errorf("symbolName = %q, want Foo.doThing", got)
+	}
+}
+
+func TestSymbolName_BareName(t *testing.T) {
+	sym := scanner.Symbol{Name: "topLevel"}
+	if got := symbolName(sym); got != "topLevel" {
+		t.Errorf("symbolName = %q, want topLevel", got)
+	}
+}
+
+func TestFunctionsInFile_FiltersByPathAndKind(t *testing.T) {
+	idx := &scanner.CodeIndex{
+		Symbols: []scanner.Symbol{
+			{Name: "a", Kind: "function", File: "main.kt", Line: 10},
+			{Name: "b", Kind: "function", File: "other.kt", Line: 5},
+			{Name: "MyClass", Kind: "class", File: "main.kt", Line: 1},
+			{Name: "c", Kind: "function", File: "main.kt", Line: 3},
+		},
+	}
+	got := functionsInFile(idx, "main.kt")
+	if len(got) != 2 {
+		t.Fatalf("got %d functions, want 2", len(got))
+	}
+	// Sorted by line ascending.
+	if got[0].Name != "c" || got[1].Name != "a" {
+		t.Errorf("ordering: got [%s, %s], want [c, a]", got[0].Name, got[1].Name)
+	}
+}
+
+func TestFunctionsInFile_SortsByNameWhenLineTies(t *testing.T) {
+	idx := &scanner.CodeIndex{
+		Symbols: []scanner.Symbol{
+			{Name: "zeta", Kind: "function", File: "f.kt", Line: 5},
+			{Name: "alpha", Kind: "function", File: "f.kt", Line: 5},
+		},
+	}
+	got := functionsInFile(idx, "f.kt")
+	if len(got) != 2 || got[0].Name != "alpha" || got[1].Name != "zeta" {
+		t.Errorf("tie-break ordering wrong: %+v", got)
+	}
+}
+
+func TestBuildFunctionCodeLenses_NilInputsReturnEmpty(t *testing.T) {
+	if got := buildFunctionCodeLenses("file:///x.kt", nil, nil); len(got) != 0 {
+		t.Errorf("nil file/index should yield empty lenses, got %d", len(got))
+	}
+}
+
+func TestBuildFunctionCodeLenses_TitleAndRange(t *testing.T) {
+	file := &scanner.File{
+		Path: "src/Main.kt",
+		Lines: []string{
+			"fun greet() {",
+			"    if (x) print()",
+			"}",
+		},
+	}
+	idx := &scanner.CodeIndex{
+		Symbols: []scanner.Symbol{
+			{Name: "greet", Kind: "function", File: "src/Main.kt", Line: 1, FQN: "com.example.greet"},
+		},
+	}
+	lenses := buildFunctionCodeLenses("file:///src/Main.kt", file, idx)
+	if len(lenses) != 1 {
+		t.Fatalf("want 1 lens, got %d", len(lenses))
+	}
+
+	got := lenses[0]
+	if got.Range.Start.Line != 0 || got.Range.End.Line != 0 {
+		t.Errorf("lens should anchor to line 0 (0-based), got start=%d end=%d",
+			got.Range.Start.Line, got.Range.End.Line)
+	}
+	if got.Command == nil || got.Command.Command != "krit.showReferences" {
+		t.Errorf("expected command krit.showReferences, got %+v", got.Command)
+	}
+	// "if" branch -> complexity 2; no consumers populated -> 0.
+	wantTitle := "complexity=2 | 0 consumers"
+	if got.Command.Title != wantTitle {
+		t.Errorf("title = %q, want %q", got.Command.Title, wantTitle)
+	}
+}
+
+func TestBuildFunctionCodeLenses_NeighborLimitsScanRange(t *testing.T) {
+	// Two functions in one file. The first lens's complexity must only
+	// count branches inside its own body, stopping at the second
+	// function's start line.
+	file := &scanner.File{
+		Path: "src/Two.kt",
+		Lines: []string{
+			"fun a() {",     // 1
+			"    val x = 1", // 2
+			"}",             // 3
+			"fun b() {",     // 4
+			"    if (x) {",  // 5
+			"        if (y) {}", // 6
+			"    }",
+			"}",
+		},
+	}
+	idx := &scanner.CodeIndex{
+		Symbols: []scanner.Symbol{
+			{Name: "a", Kind: "function", File: "src/Two.kt", Line: 1},
+			{Name: "b", Kind: "function", File: "src/Two.kt", Line: 4},
+		},
+	}
+	lenses := buildFunctionCodeLenses("file:///src/Two.kt", file, idx)
+	if len(lenses) != 2 {
+		t.Fatalf("want 2 lenses, got %d", len(lenses))
+	}
+	// Functions are sorted by line; lenses[0] is `a`, lenses[1] is `b`.
+	if lenses[0].Command.Title != "complexity=1 | 0 consumers" {
+		t.Errorf("a's title = %q, want complexity=1", lenses[0].Command.Title)
+	}
+	if lenses[1].Command.Title != "complexity=3 | 0 consumers" {
+		t.Errorf("b's title = %q, want complexity=3", lenses[1].Command.Title)
+	}
+}

--- a/internal/lsp/codelens_test.go
+++ b/internal/lsp/codelens_test.go
@@ -7,7 +7,6 @@ import (
 )
 
 func TestFunctionComplexity_BaseIsOne(t *testing.T) {
-	// A linear function with no branches should have cyclomatic complexity 1.
 	lines := []string{
 		"fun greet(): String {",
 		"    return \"hello\"",
@@ -20,17 +19,14 @@ func TestFunctionComplexity_BaseIsOne(t *testing.T) {
 }
 
 func TestFunctionComplexity_BranchesIncrement(t *testing.T) {
-	// Each if/else-if/when/for/while/catch/&&/||/?: adds one. The line
-	// scanner is the same one used by the real CodeLens provider, so this
-	// guards the regex against accidental drift.
 	lines := []string{
-		"fun pick(x: Int, y: Int?): Int {",   // 1: base
-		"    if (x > 0 && y != null) {",      // 2: if + &&
-		"        for (i in 0..x) print(i)",   // 3: for
-		"    } else if (x < 0 || y == null) { ", // 4: else if + ||
+		"fun pick(x: Int, y: Int?): Int {",
+		"    if (x > 0 && y != null) {",
+		"        for (i in 0..x) print(i)",
+		"    } else if (x < 0 || y == null) { ",
 		"        return -1",
 		"    }",
-		"    return y ?: 0",                  // 5: ?:
+		"    return y ?: 0",
 		"}",
 	}
 	got := functionComplexity(lines, 1, len(lines)+1)
@@ -54,7 +50,6 @@ func TestFunctionComplexity_SkipsLineComments(t *testing.T) {
 
 func TestFunctionComplexity_HandlesOutOfRangeArgs(t *testing.T) {
 	lines := []string{"fun f() {}"}
-	// Caller passes nonsense bounds; helper must clamp rather than panic.
 	if got := functionComplexity(lines, 0, 999); got != 1 {
 		t.Errorf("complexity with bad bounds = %d, want 1", got)
 	}
@@ -157,18 +152,17 @@ func TestBuildFunctionCodeLenses_TitleAndRange(t *testing.T) {
 }
 
 func TestBuildFunctionCodeLenses_NeighborLimitsScanRange(t *testing.T) {
-	// Two functions in one file. The first lens's complexity must only
-	// count branches inside its own body, stopping at the second
-	// function's start line.
+	// The first lens's complexity must stop at the second function's
+	// start line; otherwise b's branches leak into a's score.
 	file := &scanner.File{
 		Path: "src/Two.kt",
 		Lines: []string{
-			"fun a() {",     // 1
-			"    val x = 1", // 2
-			"}",             // 3
-			"fun b() {",     // 4
-			"    if (x) {",  // 5
-			"        if (y) {}", // 6
+			"fun a() {",
+			"    val x = 1",
+			"}",
+			"fun b() {",
+			"    if (x) {",
+			"        if (y) {}",
 			"    }",
 			"}",
 		},

--- a/internal/lsp/protocol_test.go
+++ b/internal/lsp/protocol_test.go
@@ -1,0 +1,299 @@
+package lsp
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// These tests pin down the JSON wire shape and LSP-spec constants. Editors
+// rely on exact field names ("rangeLength", "selectionRange", numeric
+// SymbolKind values per spec); a silent rename would break them.
+
+func TestPosition_JSONShape(t *testing.T) {
+	p := Position{Line: 4, Character: 12}
+	data, err := json.Marshal(p)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	want := `{"line":4,"character":12}`
+	if string(data) != want {
+		t.Fatalf("Position JSON = %s, want %s", string(data), want)
+	}
+}
+
+func TestRange_RoundTrip(t *testing.T) {
+	in := Range{
+		Start: Position{Line: 1, Character: 0},
+		End:   Position{Line: 1, Character: 10},
+	}
+	data, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	var back Range
+	if err := json.Unmarshal(data, &back); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if back != in {
+		t.Errorf("Range round-trip mismatch: got %+v, want %+v", back, in)
+	}
+}
+
+func TestDiagnostic_OmitsOptionalWhenEmpty(t *testing.T) {
+	d := Diagnostic{
+		Range:   Range{Start: Position{}, End: Position{}},
+		Message: "msg",
+	}
+	data, err := json.Marshal(d)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	got := string(data)
+	for _, banned := range []string{`"severity"`, `"code"`, `"source"`} {
+		if strings.Contains(got, banned) {
+			t.Errorf("empty %s should be omitted, got %s", banned, got)
+		}
+	}
+	if !strings.Contains(got, `"message":"msg"`) {
+		t.Errorf("message must always be present, got %s", got)
+	}
+}
+
+func TestServerCapabilities_OmitsZeroProviders(t *testing.T) {
+	c := ServerCapabilities{HoverProvider: false, CodeActionProvider: false}
+	data, err := json.Marshal(c)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	got := string(data)
+	if strings.Contains(got, "hoverProvider") || strings.Contains(got, "codeActionProvider") {
+		t.Errorf("false-valued bool providers should be omitted, got %s", got)
+	}
+}
+
+func TestServerCapabilities_IncludesTrueProviders(t *testing.T) {
+	c := ServerCapabilities{HoverProvider: true, DefinitionProvider: true}
+	data, err := json.Marshal(c)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	got := string(data)
+	for _, want := range []string{`"hoverProvider":true`, `"definitionProvider":true`} {
+		if !strings.Contains(got, want) {
+			t.Errorf("expected %s in JSON, got %s", want, got)
+		}
+	}
+}
+
+func TestTextDocumentSyncOptions_AlwaysIncludesOpenCloseAndChange(t *testing.T) {
+	// Unlike most server capability fields, OpenClose and Change must
+	// always appear so the client knows whether to send didOpen/didClose
+	// and which sync kind to use.
+	o := TextDocumentSyncOptions{OpenClose: false, Change: 0}
+	data, err := json.Marshal(o)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	got := string(data)
+	if !strings.Contains(got, `"openClose":false`) || !strings.Contains(got, `"change":0`) {
+		t.Errorf("openClose and change must always be present, got %s", got)
+	}
+}
+
+func TestInitializeParams_NullProcessID(t *testing.T) {
+	// LSP spec: processId may be null (parentless server). The Go shape
+	// uses *int so the field can be null on the wire.
+	data := []byte(`{"processId":null,"capabilities":{}}`)
+	var p InitializeParams
+	if err := json.Unmarshal(data, &p); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if p.ProcessID != nil {
+		t.Errorf("ProcessID should be nil for null processId, got %v", *p.ProcessID)
+	}
+}
+
+func TestInitializeParams_ProcessID(t *testing.T) {
+	data := []byte(`{"processId":1234,"capabilities":{}}`)
+	var p InitializeParams
+	if err := json.Unmarshal(data, &p); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if p.ProcessID == nil || *p.ProcessID != 1234 {
+		t.Errorf("ProcessID = %v, want 1234", p.ProcessID)
+	}
+}
+
+func TestInitOptions_OmitsOptional(t *testing.T) {
+	o := InitOptions{}
+	data, err := json.Marshal(o)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if string(data) != `{}` {
+		t.Errorf("empty InitOptions should marshal to {}, got %s", string(data))
+	}
+}
+
+func TestInitOptions_BoolPointerFields(t *testing.T) {
+	// IndexOnInitialize and UseOracleDaemon use *bool so the client can
+	// distinguish "not set" from "explicitly false".
+	tru := true
+	o := InitOptions{IndexOnInitialize: &tru}
+	data, err := json.Marshal(o)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if !strings.Contains(string(data), `"indexOnInitialize":true`) {
+		t.Errorf("expected indexOnInitialize:true, got %s", string(data))
+	}
+
+	in := []byte(`{"indexOnInitialize":false}`)
+	var back InitOptions
+	if err := json.Unmarshal(in, &back); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if back.IndexOnInitialize == nil || *back.IndexOnInitialize {
+		t.Errorf("IndexOnInitialize = %v, want explicit false", back.IndexOnInitialize)
+	}
+}
+
+func TestSymbolKindConstantsMatchLSPSpec(t *testing.T) {
+	// LSP spec values: Class=5, Property=7, Function=12. If these drift,
+	// every editor renders the wrong icon.
+	cases := []struct {
+		name string
+		got  int
+		want int
+	}{
+		{"SymbolKindClass", SymbolKindClass, 5},
+		{"SymbolKindProperty", SymbolKindProperty, 7},
+		{"SymbolKindFunction", SymbolKindFunction, 12},
+	}
+	for _, tc := range cases {
+		if tc.got != tc.want {
+			t.Errorf("%s = %d, LSP spec value is %d", tc.name, tc.got, tc.want)
+		}
+	}
+}
+
+func TestMessageTypeConstantsMatchLSPSpec(t *testing.T) {
+	cases := []struct {
+		name string
+		got  int
+		want int
+	}{
+		{"Error", MessageTypeError, 1},
+		{"Warning", MessageTypeWarning, 2},
+		{"Info", MessageTypeInfo, 3},
+		{"Log", MessageTypeLog, 4},
+	}
+	for _, tc := range cases {
+		if tc.got != tc.want {
+			t.Errorf("MessageType%s = %d, LSP spec value is %d", tc.name, tc.got, tc.want)
+		}
+	}
+}
+
+func TestCompletionItemKindConstantsMatchLSPSpec(t *testing.T) {
+	cases := []struct {
+		name string
+		got  int
+		want int
+	}{
+		{"Text", CompletionKindText, 1},
+		{"Class", CompletionKindClass, 7},
+		{"Keyword", CompletionKindKeyword, 14},
+	}
+	for _, tc := range cases {
+		if tc.got != tc.want {
+			t.Errorf("CompletionKind%s = %d, LSP spec value is %d", tc.name, tc.got, tc.want)
+		}
+	}
+}
+
+func TestCodeAction_OmitsAbsentFields(t *testing.T) {
+	a := CodeAction{Title: "Fix", Kind: "quickfix"}
+	data, err := json.Marshal(a)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	got := string(data)
+	for _, banned := range []string{"description", "diagnostics", "edit", "command", "data"} {
+		if strings.Contains(got, banned) {
+			t.Errorf("empty %s should be omitted, got %s", banned, got)
+		}
+	}
+}
+
+func TestWorkspaceEdit_ChangesKeyAlwaysPresent(t *testing.T) {
+	// "changes" is the top-level map clients look at; even when empty it
+	// helps clients distinguish "no changes" from a missing field.
+	e := WorkspaceEdit{Changes: map[string][]TextEdit{}}
+	data, err := json.Marshal(e)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if !strings.Contains(string(data), `"changes":{}`) {
+		t.Errorf("expected changes:{}, got %s", string(data))
+	}
+}
+
+func TestPublishDiagnosticsParams_RoundTrip(t *testing.T) {
+	in := PublishDiagnosticsParams{
+		URI: "file:///a/b.kt",
+		Diagnostics: []Diagnostic{
+			{
+				Range:    Range{Start: Position{Line: 0, Character: 0}, End: Position{Line: 0, Character: 5}},
+				Severity: 1,
+				Code:     "X.Y",
+				Source:   "krit",
+				Message:  "broken",
+			},
+		},
+	}
+	data, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	var back PublishDiagnosticsParams
+	if err := json.Unmarshal(data, &back); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if back.URI != in.URI {
+		t.Errorf("URI lost in round-trip")
+	}
+	if len(back.Diagnostics) != 1 || back.Diagnostics[0].Code != "X.Y" {
+		t.Errorf("Diagnostic lost in round-trip: %+v", back.Diagnostics)
+	}
+}
+
+func TestDocumentSymbol_SelectionRangeFieldName(t *testing.T) {
+	// LSP spec uses "selectionRange" (camelCase, single word). A typo here
+	// silently breaks symbol navigation in editors.
+	d := DocumentSymbol{
+		Name:           "Foo",
+		Kind:           SymbolKindClass,
+		Range:          Range{},
+		SelectionRange: Range{},
+	}
+	data, err := json.Marshal(d)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if !strings.Contains(string(data), `"selectionRange"`) {
+		t.Errorf("selectionRange field name missing, got %s", string(data))
+	}
+}
+
+func TestHover_OptionalRange(t *testing.T) {
+	h := Hover{Contents: MarkupContent{Kind: "markdown", Value: "hi"}}
+	data, err := json.Marshal(h)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if strings.Contains(string(data), `"range"`) {
+		t.Errorf("nil range should be omitted, got %s", string(data))
+	}
+}

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -1,0 +1,66 @@
+package manifest
+
+import "testing"
+
+func TestAllComponents_Nil(t *testing.T) {
+	if got := AllComponents(nil); got != nil {
+		t.Fatalf("AllComponents(nil) = %v, want nil", got)
+	}
+}
+
+func TestAllComponents_Empty(t *testing.T) {
+	got := AllComponents(&Application{})
+	if len(got) != 0 {
+		t.Fatalf("AllComponents(&Application{}) len = %d, want 0", len(got))
+	}
+}
+
+func TestAllComponents_OrderActivitiesServicesReceiversProviders(t *testing.T) {
+	app := &Application{
+		Activities: []Component{{Tag: "activity", Name: "A1"}, {Tag: "activity", Name: "A2"}},
+		Services:   []Component{{Tag: "service", Name: "S1"}},
+		Receivers:  []Component{{Tag: "receiver", Name: "R1"}, {Tag: "receiver", Name: "R2"}},
+		Providers:  []Component{{Tag: "provider", Name: "P1"}},
+	}
+	got := AllComponents(app)
+
+	wantTags := []string{"activity", "activity", "service", "receiver", "receiver", "provider"}
+	if len(got) != len(wantTags) {
+		t.Fatalf("AllComponents len = %d, want %d", len(got), len(wantTags))
+	}
+	for i, c := range got {
+		if c.Tag != wantTags[i] {
+			t.Errorf("index %d: tag = %q, want %q", i, c.Tag, wantTags[i])
+		}
+	}
+
+	wantNames := []string{"A1", "A2", "S1", "R1", "R2", "P1"}
+	for i, c := range got {
+		if c.Name != wantNames[i] {
+			t.Errorf("index %d: name = %q, want %q", i, c.Name, wantNames[i])
+		}
+	}
+}
+
+func TestAllComponents_DoesNotAliasInputSlices(t *testing.T) {
+	app := &Application{
+		Activities: []Component{{Tag: "activity", Name: "A1"}},
+		Services:   []Component{{Tag: "service", Name: "S1"}},
+	}
+	got := AllComponents(app)
+
+	got[0].Name = "mutated"
+	if app.Activities[0].Name != "A1" {
+		t.Fatalf("mutating result aliased back into Activities: got %q", app.Activities[0].Name)
+	}
+}
+
+func TestManifestZeroValueIsUsable(t *testing.T) {
+	var m Manifest
+	if m.Package != "" || m.MinSDK != 0 || m.Application != nil {
+		t.Fatalf("zero-value Manifest unexpectedly populated: %+v", m)
+	}
+	if got := AllComponents(m.Application); got != nil {
+		t.Fatalf("AllComponents on zero-value app pointer = %v, want nil", got)
+	}
+}

--- a/internal/mcp/discriminators_test.go
+++ b/internal/mcp/discriminators_test.go
@@ -1,6 +1,9 @@
 package mcp
 
-import "testing"
+import (
+	"slices"
+	"testing"
+)
 
 func TestFormatList(t *testing.T) {
 	cases := []struct {
@@ -27,15 +30,6 @@ func TestFormatList(t *testing.T) {
 // The slices are the source of truth for tool schemas; a missing entry
 // silently breaks the dispatcher's enum validation.
 func TestDiscriminatorSlicesIncludeAllConstants(t *testing.T) {
-	contains := func(list []string, want string) bool {
-		for _, v := range list {
-			if v == want {
-				return true
-			}
-		}
-		return false
-	}
-
 	cases := []struct {
 		name  string
 		slice []string
@@ -55,7 +49,7 @@ func TestDiscriminatorSlicesIncludeAllConstants(t *testing.T) {
 				t.Fatalf("%s has %d entries, want %d", tc.name, len(tc.slice), len(tc.want))
 			}
 			for _, w := range tc.want {
-				if !contains(tc.slice, w) {
+				if !slices.Contains(tc.slice, w) {
 					t.Errorf("%s missing %q", tc.name, w)
 				}
 			}

--- a/internal/mcp/discriminators_test.go
+++ b/internal/mcp/discriminators_test.go
@@ -1,0 +1,95 @@
+package mcp
+
+import "testing"
+
+func TestFormatList(t *testing.T) {
+	cases := []struct {
+		name string
+		in   []string
+		want string
+	}{
+		{"nil", nil, ""},
+		{"empty", []string{}, ""},
+		{"single", []string{"foo"}, "foo"},
+		{"multi", []string{"a", "b", "c"}, "a, b, c"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := formatList(tc.in); got != tc.want {
+				t.Fatalf("formatList(%v) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestDiscriminatorSlicesIncludeAllConstants guards against the common bug
+// where a new constant is added but the corresponding slice isn't updated.
+// The slices are the source of truth for tool schemas; a missing entry
+// silently breaks the dispatcher's enum validation.
+func TestDiscriminatorSlicesIncludeAllConstants(t *testing.T) {
+	contains := func(list []string, want string) bool {
+		for _, v := range list {
+			if v == want {
+				return true
+			}
+		}
+		return false
+	}
+
+	cases := []struct {
+		name  string
+		slice []string
+		want  []string
+	}{
+		{"analyzeModes", analyzeModes, []string{modeCode, modeProject, modeAndroid, modeImpact}},
+		{"fixOperations", fixOperations, []string{opFixSuggest, opFixSuppress}},
+		{"rulesOperations", rulesOperations, []string{opRulesExplain, opRulesSearch, opRulesCategories, opRulesConfigure}},
+		{"symbolsOperations", symbolsOperations, []string{opSymbolsOutline, opSymbolsReferences}},
+		{"typesQueries", typesQueries, []string{queryTypesClasses, queryTypesHierarchy, queryTypesImports, queryTypesSealedVariants, queryTypesEnumEntries, queryTypesFunctionSigs}},
+		{"structureOperations", structureOperations, []string{opStructureModules, opStructureProfile, opStructureHotspots, opStructureBreadth, opStructurePkgDrift}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if len(tc.slice) != len(tc.want) {
+				t.Fatalf("%s has %d entries, want %d", tc.name, len(tc.slice), len(tc.want))
+			}
+			for _, w := range tc.want {
+				if !contains(tc.slice, w) {
+					t.Errorf("%s missing %q", tc.name, w)
+				}
+			}
+		})
+	}
+}
+
+// TestDiscriminatorConstantsDoNotCollide guards against a copy-paste mistake
+// where two operations within the same tool accidentally share a string value.
+func TestDiscriminatorConstantsDoNotCollide(t *testing.T) {
+	cases := []struct {
+		name  string
+		slice []string
+	}{
+		{"analyzeModes", analyzeModes},
+		{"fixOperations", fixOperations},
+		{"rulesOperations", rulesOperations},
+		{"symbolsOperations", symbolsOperations},
+		{"typesQueries", typesQueries},
+		{"structureOperations", structureOperations},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			seen := make(map[string]struct{}, len(tc.slice))
+			for _, v := range tc.slice {
+				if v == "" {
+					t.Errorf("%s has empty string entry", tc.name)
+				}
+				if _, dup := seen[v]; dup {
+					t.Errorf("%s has duplicate value %q", tc.name, v)
+				}
+				seen[v] = struct{}{}
+			}
+		})
+	}
+}

--- a/internal/mcp/protocol_test.go
+++ b/internal/mcp/protocol_test.go
@@ -1,0 +1,195 @@
+package mcp
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// These tests guard the JSON wire shape of the MCP protocol types. Field
+// names, omitempty behaviour, and the precise envelope of tool/resource
+// responses are part of the public contract with MCP clients (Claude
+// Desktop, IDE extensions); silent changes there break every consumer.
+
+func TestInitializeResult_JSONShape(t *testing.T) {
+	r := InitializeResult{
+		ProtocolVersion: "2024-11-05",
+		Capabilities: ServerCaps{
+			Tools:     &ToolsCap{},
+			Resources: &ResourcesCap{},
+			Prompts:   &PromptsCap{},
+		},
+		ServerInfo: ServerInfo{Name: "krit-mcp", Version: "0.1.0"},
+	}
+	data, err := json.Marshal(r)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	got := string(data)
+	for _, want := range []string{
+		`"protocolVersion":"2024-11-05"`,
+		`"tools":{}`,
+		`"resources":{}`,
+		`"prompts":{}`,
+		`"serverInfo":{"name":"krit-mcp","version":"0.1.0"}`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("InitializeResult JSON missing %q\nfull: %s", want, got)
+		}
+	}
+}
+
+func TestServerCaps_OmitsNilCapabilities(t *testing.T) {
+	r := InitializeResult{
+		ProtocolVersion: "v1",
+		Capabilities:    ServerCaps{Tools: &ToolsCap{}},
+		ServerInfo:      ServerInfo{Name: "x", Version: "y"},
+	}
+	data, err := json.Marshal(r)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	got := string(data)
+	if !strings.Contains(got, `"tools":{}`) {
+		t.Errorf("expected tools cap to be present, got %s", got)
+	}
+	if strings.Contains(got, `"resources"`) {
+		t.Errorf("nil Resources cap should be omitted, got %s", got)
+	}
+	if strings.Contains(got, `"prompts"`) {
+		t.Errorf("nil Prompts cap should be omitted, got %s", got)
+	}
+}
+
+func TestToolDefinition_RoundTrip(t *testing.T) {
+	def := ToolDefinition{
+		Name:        "analyze",
+		Description: "Run static analysis",
+		InputSchema: map[string]any{"type": "object"},
+	}
+	data, err := json.Marshal(def)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	var back ToolDefinition
+	if err := json.Unmarshal(data, &back); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if back.Name != def.Name || back.Description != def.Description {
+		t.Errorf("round-trip mismatch: got %+v, want %+v", back, def)
+	}
+	if back.InputSchema == nil {
+		t.Errorf("InputSchema lost in round-trip")
+	}
+}
+
+func TestToolResult_IsErrorOmittedWhenFalse(t *testing.T) {
+	ok := ToolResult{Content: []ContentBlock{{Type: "text", Text: "hi"}}}
+	data, err := json.Marshal(ok)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if strings.Contains(string(data), "isError") {
+		t.Errorf("isError should be omitted when false, got %s", string(data))
+	}
+
+	bad := ToolResult{Content: []ContentBlock{{Type: "text", Text: "boom"}}, IsError: true}
+	data, err = json.Marshal(bad)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if !strings.Contains(string(data), `"isError":true`) {
+		t.Errorf("isError should be present when true, got %s", string(data))
+	}
+}
+
+func TestToolCallParams_ArgumentsRawMessageIsPreserved(t *testing.T) {
+	raw := `{"path":"src/Main.kt","ruleId":"X.Y"}`
+	in := []byte(`{"name":"analyze","arguments":` + raw + `}`)
+
+	var p ToolCallParams
+	if err := json.Unmarshal(in, &p); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if p.Name != "analyze" {
+		t.Errorf("Name = %q, want analyze", p.Name)
+	}
+	// Arguments are passed through as RawMessage so each tool can decode
+	// into its own schema. Round-trip should preserve the exact bytes.
+	var roundtrip map[string]string
+	if err := json.Unmarshal(p.Arguments, &roundtrip); err != nil {
+		t.Fatalf("decode arguments: %v", err)
+	}
+	if roundtrip["path"] != "src/Main.kt" || roundtrip["ruleId"] != "X.Y" {
+		t.Errorf("arguments lost: %+v", roundtrip)
+	}
+}
+
+func TestResourceDefinition_OmitsOptional(t *testing.T) {
+	minimal := ResourceDefinition{URI: "krit://rules", Name: "rules"}
+	data, err := json.Marshal(minimal)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	got := string(data)
+	if strings.Contains(got, "description") || strings.Contains(got, "mimeType") {
+		t.Errorf("optional fields should be omitted when empty, got %s", got)
+	}
+}
+
+func TestResourceContent_OmitsEmptyFields(t *testing.T) {
+	c := ResourceContent{URI: "krit://x"}
+	data, err := json.Marshal(c)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	got := string(data)
+	if strings.Contains(got, "mimeType") || strings.Contains(got, `"text":`) {
+		t.Errorf("empty optional fields should be omitted, got %s", got)
+	}
+}
+
+func TestPromptGetResult_RoundTrip(t *testing.T) {
+	r := PromptGetResult{
+		Description: "explain a rule",
+		Messages: []PromptMessage{
+			{Role: "user", Content: ContentBlock{Type: "text", Text: "Why?"}},
+		},
+	}
+	data, err := json.Marshal(r)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	var back PromptGetResult
+	if err := json.Unmarshal(data, &back); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if back.Description != r.Description {
+		t.Errorf("description lost in round-trip")
+	}
+	if len(back.Messages) != 1 || back.Messages[0].Content.Text != "Why?" {
+		t.Errorf("messages lost in round-trip: %+v", back.Messages)
+	}
+}
+
+func TestPromptDefinition_OmitsEmptyArguments(t *testing.T) {
+	d := PromptDefinition{Name: "p", Description: "d"}
+	data, err := json.Marshal(d)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if strings.Contains(string(data), "arguments") {
+		t.Errorf("empty arguments slice should be omitted, got %s", string(data))
+	}
+}
+
+func TestClientInfo_OmittedWhenAbsent(t *testing.T) {
+	p := InitializeParams{ProtocolVersion: "v1"}
+	data, err := json.Marshal(p)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if strings.Contains(string(data), "clientInfo") {
+		t.Errorf("nil ClientInfo should be omitted, got %s", string(data))
+	}
+}


### PR DESCRIPTION
## Summary

Adds first-time test coverage for the weakest spots flagged by a survey of
`internal/`:

- **`internal/manifest`** — was 98 LOC with zero tests. Now covers
  `AllComponents` ordering, aliasing-safety, and zero-value behaviour.
- **`internal/diag`** — was 60 LOC with zero tests. Now covers nil-receiver
  no-ops, per-stream silencing, format-string passthrough, and `NewStderr`.
- **`internal/mcp/discriminators`** — guards every tool's operation enum
  (analyze/fix/rules/symbols/types/structure) against drift between
  constants and the slices used by tool schemas. Also catches duplicates.
- **`internal/mcp/protocol`** — JSON wire shape: `omitempty` correctness on
  `ServerCaps`, `ToolResult.IsError`, `ResourceDefinition`,
  `PromptDefinition`; `ToolCallParams.Arguments` `RawMessage` passthrough;
  round-trips for `ToolDefinition` and `PromptGetResult`.
- **`internal/lsp/protocol`** — pins LSP-spec numeric constants
  (`SymbolKind`, `MessageType`, `CompletionItemKind`); pins always-present
  fields on `TextDocumentSyncOptions`; verifies `*int` null handling for
  `InitializeParams.ProcessID`, `*bool` tri-state on `InitOptions`,
  `selectionRange` field name, and `omitempty` on `Diagnostic`,
  `ServerCapabilities`, `CodeAction`, and `Hover.Range`.
- **`internal/lsp/codelens`** — pure-helper tests: `functionComplexity`
  (base/branches/comments/clamped bounds), `symbolName` precedence,
  `functionsInFile` filter+sort, and end-to-end `buildFunctionCodeLenses`
  including neighbour-bounded scan windows for adjacent functions.

No production code changed.

## Test plan
- [x] `go vet ./...`
- [x] `go test ./internal/manifest/ ./internal/diag/ ./internal/mcp/ ./internal/lsp/ -count=1`
- [ ] `make integration` (not run locally; CI will exercise it)

Note: a few pre-existing tests in `internal/cache`, `internal/cli/blastradius`,
and `internal/cli/riskmap` fail in this sandbox due to commit-signing
infrastructure issues unrelated to these changes.

https://claude.ai/code/session_012dKSVYTRyFAjNzzGsFzzmp

---
_Generated by [Claude Code](https://claude.ai/code/session_012dKSVYTRyFAjNzzGsFzzmp)_