### PR TITLE
fix(rules): ktfmt-compatible brace wraps and postfix rewrites

### DIFF
--- a/internal/rules/potentialbugs_properties.go
+++ b/internal/rules/potentialbugs_properties.go
@@ -164,10 +164,7 @@ func (r *UselessPostfixExpressionRule) checkUselessPostfixFlat(ctx *api.Context)
 	varName := file.FlatNodeText(target)
 	f := r.Finding(file, file.FlatRow(idx)+1, file.FlatCol(idx)+1,
 		"Useless postfix expression in return statement. The increment/decrement has no effect.")
-	indent := ""
-	if row := file.FlatRow(idx); row >= 0 && row < len(file.Lines) {
-		indent = leadingIndent(file.Lines[row])
-	}
+	indent := detectIndent(file.Content, int(file.FlatStartByte(idx)))
 	f.Fix = &scanner.Fix{
 		ByteMode:    true,
 		StartByte:   int(file.FlatStartByte(idx)),

--- a/internal/rules/potentialbugs_properties.go
+++ b/internal/rules/potentialbugs_properties.go
@@ -164,15 +164,15 @@ func (r *UselessPostfixExpressionRule) checkUselessPostfixFlat(ctx *api.Context)
 	varName := file.FlatNodeText(target)
 	f := r.Finding(file, file.FlatRow(idx)+1, file.FlatCol(idx)+1,
 		"Useless postfix expression in return statement. The increment/decrement has no effect.")
-	// Replace the jump_expression's bytes (which start at `return`, so the
-	// leading indent on the line is preserved). The second line is emitted
-	// without indent — matching the rule's original behavior and its fix
-	// fixture, which an external formatter is expected to re-indent.
+	indent := ""
+	if row := file.FlatRow(idx); row >= 0 && row < len(file.Lines) {
+		indent = leadingIndent(file.Lines[row])
+	}
 	f.Fix = &scanner.Fix{
 		ByteMode:    true,
 		StartByte:   int(file.FlatStartByte(idx)),
 		EndByte:     int(file.FlatEndByte(idx)),
-		Replacement: varName + opText + "\n" + "return " + varName,
+		Replacement: varName + opText + "\n" + indent + "return " + varName,
 	}
 	ctx.Emit(f)
 }

--- a/internal/rules/style_braces.go
+++ b/internal/rules/style_braces.go
@@ -16,32 +16,16 @@ func controlBodyHasBraces(file *scanner.File, body uint32) bool {
 	return first != 0 && file.FlatType(first) == "{"
 }
 
-// leadingIndent returns the leading whitespace (spaces and tabs) of s.
-func leadingIndent(s string) string {
-	for i := 0; i < len(s); i++ {
-		if s[i] != ' ' && s[i] != '\t' {
-			return s[:i]
-		}
-	}
-	return s
-}
-
-// buildBraceWrapFix produces a ktfmt-compatible brace wrap around a
-// single-statement control body. It places the opening brace on the control
-// header line, indents the body to its existing column (or one step deeper
-// than the header for inline forms), and aligns the closing brace with the
-// header.
+// buildBraceWrapFix wraps a single-statement control body in braces while
+// preserving the column the body already sits at (or one step deeper than
+// the header for inline forms) so the result stays ktfmt-compatible.
 func buildBraceWrapFix(file *scanner.File, control, body uint32) *scanner.Fix {
 	bodyTrimmed := strings.TrimSpace(file.FlatNodeText(body))
 
-	controlRow := file.FlatRow(control)
-	var parentIndent string
-	if controlRow >= 0 && controlRow < len(file.Lines) {
-		parentIndent = leadingIndent(file.Lines[controlRow])
-	}
+	parentIndent := detectIndent(file.Content, int(file.FlatStartByte(control)))
 	bodyIndent := parentIndent + "    "
-	if bodyRow := file.FlatRow(body); bodyRow != controlRow && bodyRow >= 0 && bodyRow < len(file.Lines) {
-		bodyIndent = leadingIndent(file.Lines[bodyRow])
+	if file.FlatRow(body) != file.FlatRow(control) {
+		bodyIndent = detectIndent(file.Content, int(file.FlatStartByte(body)))
 	}
 
 	startByte := int(file.FlatStartByte(body))

--- a/internal/rules/style_braces.go
+++ b/internal/rules/style_braces.go
@@ -16,6 +16,47 @@ func controlBodyHasBraces(file *scanner.File, body uint32) bool {
 	return first != 0 && file.FlatType(first) == "{"
 }
 
+// leadingIndent returns the leading whitespace (spaces and tabs) of s.
+func leadingIndent(s string) string {
+	for i := 0; i < len(s); i++ {
+		if s[i] != ' ' && s[i] != '\t' {
+			return s[:i]
+		}
+	}
+	return s
+}
+
+// buildBraceWrapFix produces a ktfmt-compatible brace wrap around a
+// single-statement control body. It places the opening brace on the control
+// header line, indents the body to its existing column (or one step deeper
+// than the header for inline forms), and aligns the closing brace with the
+// header.
+func buildBraceWrapFix(file *scanner.File, control, body uint32) *scanner.Fix {
+	bodyTrimmed := strings.TrimSpace(file.FlatNodeText(body))
+
+	controlRow := file.FlatRow(control)
+	var parentIndent string
+	if controlRow >= 0 && controlRow < len(file.Lines) {
+		parentIndent = leadingIndent(file.Lines[controlRow])
+	}
+	bodyIndent := parentIndent + "    "
+	if bodyRow := file.FlatRow(body); bodyRow != controlRow && bodyRow >= 0 && bodyRow < len(file.Lines) {
+		bodyIndent = leadingIndent(file.Lines[bodyRow])
+	}
+
+	startByte := int(file.FlatStartByte(body))
+	if prev, ok := file.FlatPrevSibling(body); ok {
+		startByte = int(file.FlatEndByte(prev))
+	}
+
+	return &scanner.Fix{
+		ByteMode:    true,
+		StartByte:   startByte,
+		EndByte:     int(file.FlatEndByte(body)),
+		Replacement: " {\n" + bodyIndent + bodyTrimmed + "\n" + parentIndent + "}",
+	}
+}
+
 // BracesOnIfStatementsRule enforces braces on if statements.
 type BracesOnIfStatementsRule struct {
 	FlatDispatchBase
@@ -72,12 +113,7 @@ func (r *BracesOnIfStatementsRule) check(ctx *api.Context) {
 		msg = "Single-line if statement should use braces."
 	}
 	f := r.Finding(file, startLine+1, 1, msg)
-	f.Fix = &scanner.Fix{
-		ByteMode:    true,
-		StartByte:   int(file.FlatStartByte(body)),
-		EndByte:     int(file.FlatEndByte(body)),
-		Replacement: "{\n" + strings.TrimSpace(file.FlatNodeText(body)) + "\n}",
-	}
+	f.Fix = buildBraceWrapFix(file, idx, body)
 	ctx.Emit(f)
 }
 
@@ -208,13 +244,7 @@ func (r *BracesOnWhenStatementsRule) check(ctx *api.Context) {
 		msg = "Single-line when branch should use braces."
 	}
 	f := r.Finding(file, startLine+1, 1, msg)
-	raw := file.FlatNodeText(body)
-	f.Fix = &scanner.Fix{
-		ByteMode:    true,
-		StartByte:   int(file.FlatStartByte(body)),
-		EndByte:     int(file.FlatEndByte(body)),
-		Replacement: "{\n" + strings.TrimSpace(raw) + "\n}",
-	}
+	f.Fix = buildBraceWrapFix(file, idx, body)
 	ctx.Emit(f)
 }
 
@@ -292,13 +322,7 @@ func (r *MandatoryBracesLoopsRule) check(ctx *api.Context) {
 	if !controlBodyHasBraces(file, body) {
 		f := r.Finding(file, file.FlatRow(idx)+1, 1,
 			"Loop body should use braces.")
-		raw := file.FlatNodeText(body)
-		f.Fix = &scanner.Fix{
-			ByteMode:    true,
-			StartByte:   int(file.FlatStartByte(body)),
-			EndByte:     int(file.FlatEndByte(body)),
-			Replacement: "{\n" + strings.TrimSpace(raw) + "\n}",
-		}
+		f.Fix = buildBraceWrapFix(file, idx, body)
 		ctx.Emit(f)
 		return
 	}

--- a/tests/fixtures/fixable/per-rule/BracesOnIfStatements.kt.expected
+++ b/tests/fixtures/fixable/per-rule/BracesOnIfStatements.kt.expected
@@ -1,10 +1,9 @@
 package style
 
 fun example(x: Int) {
-    if (x > 0)
-        {
-println("positive")
-}
+    if (x > 0) {
+        println("positive")
+    }
     else
         println("non-positive")
 }

--- a/tests/fixtures/fixable/per-rule/BracesOnWhenStatements.kt.expected
+++ b/tests/fixtures/fixable/per-rule/BracesOnWhenStatements.kt.expected
@@ -2,17 +2,14 @@ package style
 
 fun example(x: Int): String {
     return when (x) {
-        1 ->
-            {
-"one"
-}
-        2 ->
-            {
-"two"
-}
-        else ->
-            {
-"other"
-}
+        1 -> {
+            "one"
+        }
+        2 -> {
+            "two"
+        }
+        else -> {
+            "other"
+        }
     }
 }

--- a/tests/fixtures/fixable/per-rule/MandatoryBracesLoops.kt.expected
+++ b/tests/fixtures/fixable/per-rule/MandatoryBracesLoops.kt.expected
@@ -3,9 +3,9 @@ package style
 fun example() {
     val items = listOf(1, 2, 3)
     for (i in items) {
-println(i)
-}
+        println(i)
+    }
     while (true) {
-break
-}
+        break
+    }
 }

--- a/tests/fixtures/fixable/per-rule/UselessPostfixExpression.kt.expected
+++ b/tests/fixtures/fixable/per-rule/UselessPostfixExpression.kt.expected
@@ -4,6 +4,6 @@ class UselessPostfixExpression {
     fun example(x: Int): Int {
         var value = x
         value++
-return value
+        return value
     }
 }


### PR DESCRIPTION
## Summary
- `BracesOnIfStatements`, `BracesOnWhenStatements`, and `MandatoryBracesLoops` now place `{` on the control header line, indent the body to its existing column (or parent+4 for inline forms), and align the closing `}` with the header. Previously they replaced only the body bytes with `"{\n<trimmed>\n}"`, orphaning the brace and flushing the body to column 0 — a violation of the project rule that auto-fixes must be ktfmt-compatible.
- `UselessPostfixExpression` now prepends the original line's leading whitespace to the rewritten `return` line instead of emitting it at column 0.
- The three brace fixers share a `buildBraceWrapFix` helper. All four fixers route indent extraction through the existing canonical `detectIndent`.
- The four stale `.expected` fixtures that had frozen the broken output are rewritten.

## Test plan
- [x] `go vet ./...`
- [x] `go test ./... -count=1`
- [x] `make lint-rules`
- [x] `make integration` (11/11)