### PR TITLE
test(java): plug Java fixable-rule coverage gaps + fix System.gc() removal

### DIFF
--- a/internal/rules/emptyblocks_test.go
+++ b/internal/rules/emptyblocks_test.go
@@ -119,6 +119,9 @@ class Foo {
 }
 
 func TestEmptyClassBlock_Java(t *testing.T) {
+	// Java requires `{}` on a class declaration — `class Empty` without a
+	// body is a syntax error, so the rule's "remove the empty body" fix
+	// can't apply. The rule is Kotlin-only.
 	findings := runRuleByNameOnJava(t, "EmptyClassBlock", `
 package test;
 class Empty {}
@@ -126,8 +129,8 @@ class NonEmpty {
   int value;
 }
 `)
-	if len(findings) != 1 {
-		t.Fatalf("expected 1 Java empty class finding, got %d", len(findings))
+	if len(findings) != 0 {
+		t.Fatalf("expected 0 Java empty class findings (rule is Kotlin-only), got %d", len(findings))
 	}
 }
 

--- a/internal/rules/registry_emptyblocks.go
+++ b/internal/rules/registry_emptyblocks.go
@@ -68,7 +68,7 @@ func registerEmptyblocksEmptyClassBlock() {
 	r := &EmptyClassBlockRule{BaseRule: BaseRule{RuleName: "EmptyClassBlock", RuleSetName: "empty-blocks", Sev: "warning", Desc: "Detects class declarations with an empty body that can have their braces removed."}}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"class_body"}, Languages: []scanner.Language{scanner.LangKotlin, scanner.LangJava}, Confidence: 0.95, Fix: api.FixSemantic, Implementation: r,
+		NodeTypes: []string{"class_body"}, Languages: []scanner.Language{scanner.LangKotlin}, Confidence: 0.95, Fix: api.FixSemantic, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			if scanner.IsTestFile(file.Path) {

--- a/internal/rules/registry_potentialbugs_lifecycle.go
+++ b/internal/rules/registry_potentialbugs_lifecycle.go
@@ -59,6 +59,14 @@ func registerPotentialbugsLifecycleRules() {
 				for startByte > 0 && file.Content[startByte-1] != '\n' {
 					startByte--
 				}
+				// Consume trailing whitespace + statement terminator (;) for Java
+				// so removing the call doesn't leave a dangling `;` on its own line.
+				for endByte < len(file.Content) && (file.Content[endByte] == ' ' || file.Content[endByte] == '\t') {
+					endByte++
+				}
+				if endByte < len(file.Content) && file.Content[endByte] == ';' {
+					endByte++
+				}
 				if endByte < len(file.Content) && file.Content[endByte] == '\n' {
 					endByte++
 				}

--- a/tests/fixtures/fixable/per-rule/EmptyCatchBlock.java
+++ b/tests/fixtures/fixable/per-rule/EmptyCatchBlock.java
@@ -1,0 +1,12 @@
+package fixtures.positive.emptyblocks;
+
+class EmptyCatchBlockFixture {
+    void handleError() {
+        try {
+            riskyOperation();
+        } catch (Exception e) { }
+    }
+
+    void riskyOperation() throws Exception {
+    }
+}

--- a/tests/fixtures/fixable/per-rule/EmptyCatchBlock.java.expected
+++ b/tests/fixtures/fixable/per-rule/EmptyCatchBlock.java.expected
@@ -1,0 +1,14 @@
+package fixtures.positive.emptyblocks;
+
+class EmptyCatchBlockFixture {
+    void handleError() {
+        try {
+            riskyOperation();
+        } catch (Exception e) {
+            // TODO: handle exception
+        }
+    }
+
+    void riskyOperation() throws Exception {
+    }
+}

--- a/tests/fixtures/fixable/per-rule/EmptyDoWhileBlock.java
+++ b/tests/fixtures/fixable/per-rule/EmptyDoWhileBlock.java
@@ -1,0 +1,8 @@
+package fixtures.positive.emptyblocks;
+
+class EmptyDoWhileBlockFixture {
+    void run() {
+        int i = 0;
+        do { } while (++i < 10);
+    }
+}

--- a/tests/fixtures/fixable/per-rule/EmptyDoWhileBlock.java.expected
+++ b/tests/fixtures/fixable/per-rule/EmptyDoWhileBlock.java.expected
@@ -1,0 +1,7 @@
+package fixtures.positive.emptyblocks;
+
+class EmptyDoWhileBlockFixture {
+    void run() {
+        int i = 0;
+    }
+}

--- a/tests/fixtures/fixable/per-rule/EmptyElseBlock.java
+++ b/tests/fixtures/fixable/per-rule/EmptyElseBlock.java
@@ -1,0 +1,12 @@
+package fixtures.positive.emptyblocks;
+
+class EmptyElseBlockFixture {
+    void check(int x) {
+        if (x > 0) {
+            doWork();
+        } else { }
+    }
+
+    void doWork() {
+    }
+}

--- a/tests/fixtures/fixable/per-rule/EmptyElseBlock.java.expected
+++ b/tests/fixtures/fixable/per-rule/EmptyElseBlock.java.expected
@@ -1,0 +1,12 @@
+package fixtures.positive.emptyblocks;
+
+class EmptyElseBlockFixture {
+    void check(int x) {
+        if (x > 0) {
+            doWork();
+        }
+    }
+
+    void doWork() {
+    }
+}

--- a/tests/fixtures/fixable/per-rule/EmptyFinallyBlock.java
+++ b/tests/fixtures/fixable/per-rule/EmptyFinallyBlock.java
@@ -1,0 +1,17 @@
+package fixtures.positive.emptyblocks;
+
+class EmptyFinallyBlockFixture {
+    void run() {
+        try {
+            work();
+        } catch (Exception e) {
+            handle(e);
+        } finally { }
+    }
+
+    void work() {
+    }
+
+    void handle(Exception e) {
+    }
+}

--- a/tests/fixtures/fixable/per-rule/EmptyFinallyBlock.java.expected
+++ b/tests/fixtures/fixable/per-rule/EmptyFinallyBlock.java.expected
@@ -1,0 +1,17 @@
+package fixtures.positive.emptyblocks;
+
+class EmptyFinallyBlockFixture {
+    void run() {
+        try {
+            work();
+        } catch (Exception e) {
+            handle(e);
+        }
+    }
+
+    void work() {
+    }
+
+    void handle(Exception e) {
+    }
+}

--- a/tests/fixtures/fixable/per-rule/EmptyForBlock.java
+++ b/tests/fixtures/fixable/per-rule/EmptyForBlock.java
@@ -1,0 +1,7 @@
+package fixtures.positive.emptyblocks;
+
+class EmptyForBlockFixture {
+    void run() {
+        for (int i = 0; i < 10; i++) { }
+    }
+}

--- a/tests/fixtures/fixable/per-rule/EmptyForBlock.java.expected
+++ b/tests/fixtures/fixable/per-rule/EmptyForBlock.java.expected
@@ -1,0 +1,6 @@
+package fixtures.positive.emptyblocks;
+
+class EmptyForBlockFixture {
+    void run() {
+    }
+}

--- a/tests/fixtures/fixable/per-rule/EmptyFunctionBlock.java
+++ b/tests/fixtures/fixable/per-rule/EmptyFunctionBlock.java
@@ -1,0 +1,5 @@
+package fixtures.positive.emptyblocks;
+
+class EmptyFunctionBlockFixture {
+    void doNothing() { }
+}

--- a/tests/fixtures/fixable/per-rule/EmptyFunctionBlock.java.expected
+++ b/tests/fixtures/fixable/per-rule/EmptyFunctionBlock.java.expected
@@ -1,0 +1,7 @@
+package fixtures.positive.emptyblocks;
+
+class EmptyFunctionBlockFixture {
+    void doNothing() {
+        // TODO: implement
+    }
+}

--- a/tests/fixtures/fixable/per-rule/EmptyIfBlock.java
+++ b/tests/fixtures/fixable/per-rule/EmptyIfBlock.java
@@ -1,0 +1,11 @@
+package fixtures.positive.emptyblocks;
+
+class EmptyIfBlockFixture {
+    void check(int x) {
+        if (x > 0) { }
+        doMore();
+    }
+
+    void doMore() {
+    }
+}

--- a/tests/fixtures/fixable/per-rule/EmptyIfBlock.java.expected
+++ b/tests/fixtures/fixable/per-rule/EmptyIfBlock.java.expected
@@ -1,0 +1,10 @@
+package fixtures.positive.emptyblocks;
+
+class EmptyIfBlockFixture {
+    void check(int x) {
+        doMore();
+    }
+
+    void doMore() {
+    }
+}

--- a/tests/fixtures/fixable/per-rule/EmptyTryBlock.java
+++ b/tests/fixtures/fixable/per-rule/EmptyTryBlock.java
@@ -1,0 +1,12 @@
+package fixtures.positive.emptyblocks;
+
+class EmptyTryBlockFixture {
+    void run() {
+        try { } catch (Exception e) {
+            handle(e);
+        }
+    }
+
+    void handle(Exception e) {
+    }
+}

--- a/tests/fixtures/fixable/per-rule/EmptyTryBlock.java.expected
+++ b/tests/fixtures/fixable/per-rule/EmptyTryBlock.java.expected
@@ -1,0 +1,9 @@
+package fixtures.positive.emptyblocks;
+
+class EmptyTryBlockFixture {
+    void run() {
+    }
+
+    void handle(Exception e) {
+    }
+}

--- a/tests/fixtures/fixable/per-rule/EmptyWhileBlock.java
+++ b/tests/fixtures/fixable/per-rule/EmptyWhileBlock.java
@@ -1,0 +1,8 @@
+package fixtures.positive.emptyblocks;
+
+class EmptyWhileBlockFixture {
+    void run() {
+        int i = 0;
+        while (++i < 10) { }
+    }
+}

--- a/tests/fixtures/fixable/per-rule/EmptyWhileBlock.java.expected
+++ b/tests/fixtures/fixable/per-rule/EmptyWhileBlock.java.expected
@@ -1,0 +1,7 @@
+package fixtures.positive.emptyblocks;
+
+class EmptyWhileBlockFixture {
+    void run() {
+        int i = 0;
+    }
+}

--- a/tests/fixtures/fixable/per-rule/ExplicitGarbageCollectionCall.java
+++ b/tests/fixtures/fixable/per-rule/ExplicitGarbageCollectionCall.java
@@ -1,0 +1,7 @@
+package fixtures.positive.potentialbugs;
+
+class ExplicitGarbageCollectionCall {
+    void cleanup() {
+        System.gc();
+    }
+}

--- a/tests/fixtures/fixable/per-rule/ExplicitGarbageCollectionCall.java.expected
+++ b/tests/fixtures/fixable/per-rule/ExplicitGarbageCollectionCall.java.expected
@@ -1,0 +1,6 @@
+package fixtures.positive.potentialbugs;
+
+class ExplicitGarbageCollectionCall {
+    void cleanup() {
+    }
+}

--- a/tests/fixtures/fixable/per-rule/ForbiddenImport.java
+++ b/tests/fixtures/fixable/per-rule/ForbiddenImport.java
@@ -1,0 +1,10 @@
+package style;
+
+import java.util.Date;
+import sun.misc.Unsafe;
+
+class ForbiddenImportFixture {
+    Date when() {
+        return new Date();
+    }
+}

--- a/tests/fixtures/fixable/per-rule/ForbiddenImport.java.expected
+++ b/tests/fixtures/fixable/per-rule/ForbiddenImport.java.expected
@@ -1,0 +1,9 @@
+package style;
+
+import java.util.Date;
+
+class ForbiddenImportFixture {
+    Date when() {
+        return new Date();
+    }
+}

--- a/tests/fixtures/fixable/per-rule/ReturnFromFinally.java
+++ b/tests/fixtures/fixable/per-rule/ReturnFromFinally.java
@@ -1,0 +1,15 @@
+package fixtures.positive.exceptions;
+
+class ReturnFromFinallyFixture {
+    int run() {
+        try {
+            return work();
+        } finally {
+            return 0;
+        }
+    }
+
+    int work() {
+        return 1;
+    }
+}

--- a/tests/fixtures/fixable/per-rule/ReturnFromFinally.java.expected
+++ b/tests/fixtures/fixable/per-rule/ReturnFromFinally.java.expected
@@ -1,0 +1,14 @@
+package fixtures.positive.exceptions;
+
+class ReturnFromFinallyFixture {
+    int run() {
+        try {
+            return work();
+        } finally {
+        }
+    }
+
+    int work() {
+        return 1;
+    }
+}

--- a/tests/fixtures/fixable/per-rule/ThrowingExceptionFromFinally.java
+++ b/tests/fixtures/fixable/per-rule/ThrowingExceptionFromFinally.java
@@ -1,0 +1,14 @@
+package fixtures.positive.exceptions;
+
+class ThrowingExceptionFromFinallyFixture {
+    void run() throws Exception {
+        try {
+            work();
+        } finally {
+            throw new RuntimeException("masked");
+        }
+    }
+
+    void work() {
+    }
+}

--- a/tests/fixtures/fixable/per-rule/ThrowingExceptionFromFinally.java.expected
+++ b/tests/fixtures/fixable/per-rule/ThrowingExceptionFromFinally.java.expected
@@ -1,0 +1,13 @@
+package fixtures.positive.exceptions;
+
+class ThrowingExceptionFromFinallyFixture {
+    void run() throws Exception {
+        try {
+            work();
+        } finally {
+        }
+    }
+
+    void work() {
+    }
+}


### PR DESCRIPTION
## Summary

Audit-driven follow-up that plugs Java coverage gaps in Krit's fixable-rule
test suite. Most empty-block and a few exception/style rules already declared
`scanner.LangJava` but had only `.kt` per-rule fixtures, so the Java fix path
was effectively untested.

- **Java fixtures (12)**: `EmptyCatchBlock`, `EmptyDoWhileBlock`,
  `EmptyElseBlock`, `EmptyFinallyBlock`, `EmptyForBlock`, `EmptyFunctionBlock`,
  `EmptyIfBlock`, `EmptyTryBlock`, `EmptyWhileBlock`, `ReturnFromFinally`,
  `ThrowingExceptionFromFinally`, `ExplicitGarbageCollectionCall`,
  `ForbiddenImport`. Each pair (`<Rule>.java` + `<Rule>.java.expected`)
  exercises the rule in isolation through the per-rule fix harness.
- **`EmptyClassBlock` restricted to Kotlin**: its fix removes the `{}` from
  an empty class body, which produces invalid Java syntax (`class Empty`).
  Drops Java from the rule's `Languages` and updates the existing
  `_Java` unit test to assert no findings.
- **`ExplicitGarbageCollectionCall` fix bug**: the deletion span ended at
  the `call_expression` node and trimmed only a trailing newline, so on
  Java it left a dangling `;` on its own line. Extends the span to consume
  trailing whitespace, an optional `;`, then the newline. Idempotent on
  Kotlin (no semicolon → zero-width consume).

## Test plan
- [x] `go vet ./...`
- [x] `go test ./... -count=1`
- [x] `bash scripts/integration-test.sh`
- [x] `bash scripts/regression-check.sh`