### PR TITLE
feat(rules): add autofix for 7 mechanical lint rules

### DIFF
--- a/internal/rules/comments.go
+++ b/internal/rules/comments.go
@@ -245,7 +245,7 @@ func buildDeprecatedBlockTagFix(file *scanner.File, kdocIdx uint32, kdocText str
 	if !ok {
 		return nil
 	}
-	if flatHasDeprecatedAnnotation(file, target) {
+	if hasAnnotationNamed(file, target, "Deprecated") {
 		return nil
 	}
 	message, cleanedKDoc, okExtract := stripDeprecatedKDocTag(kdocText)
@@ -253,16 +253,12 @@ func buildDeprecatedBlockTagFix(file *scanner.File, kdocIdx uint32, kdocText str
 		return nil
 	}
 
-	// Compute the declaration's start byte and column. We replace the
-	// span [kdocStart, declStart) with cleanedKDoc + newline + indent +
-	// @Deprecated(...) + newline + indent so the declaration's existing
-	// indentation is preserved.
 	kdocStart := int(file.FlatStartByte(kdocIdx))
 	declStart := int(file.FlatStartByte(target))
 	if declStart <= kdocStart || declStart > len(file.Content) {
 		return nil
 	}
-	indent := flatLineIndentBefore(file, declStart)
+	indent := detectIndent(file.Content, declStart)
 	annotation := buildDeprecatedAnnotation(message)
 	replacement := cleanedKDoc + "\n" + indent + annotation + "\n" + indent
 	return &scanner.Fix{
@@ -293,24 +289,6 @@ func flatDeclarationAfter(file *scanner.File, idx uint32) (uint32, bool) {
 		}
 	}
 	return 0, false
-}
-
-// flatHasDeprecatedAnnotation reports whether the declaration already carries
-// a `@Deprecated(...)` annotation in its modifier list.
-func flatHasDeprecatedAnnotation(file *scanner.File, decl uint32) bool {
-	mods, ok := file.FlatFindChild(decl, "modifiers")
-	if !ok {
-		return false
-	}
-	for c := file.FlatFirstChild(mods); c != 0; c = file.FlatNextSib(c) {
-		if file.FlatType(c) != "annotation" {
-			continue
-		}
-		if annotationFinalName(file, c) == "Deprecated" {
-			return true
-		}
-	}
-	return false
 }
 
 // stripDeprecatedKDocTag removes the `@deprecated` line (and continuation
@@ -360,25 +338,6 @@ func stripDeprecatedKDocTag(text string) (message, cleaned string, ok bool) {
 		return "", "", false
 	}
 	return strings.Join(msgParts, " "), strings.Join(out, "\n"), true
-}
-
-// flatLineIndentBefore returns the leading whitespace of the line containing
-// the byte at pos. Used to align an inserted annotation with the following
-// declaration.
-func flatLineIndentBefore(file *scanner.File, pos int) string {
-	if pos <= 0 || pos > len(file.Content) {
-		return ""
-	}
-	start := pos - 1
-	for start >= 0 && file.Content[start] != '\n' {
-		start--
-	}
-	start++
-	end := start
-	for end < pos && (file.Content[end] == ' ' || file.Content[end] == '\t') {
-		end++
-	}
-	return string(file.Content[start:end])
 }
 
 // buildDeprecatedAnnotation renders a `@Deprecated("...")` annotation,

--- a/internal/rules/comments.go
+++ b/internal/rules/comments.go
@@ -235,6 +235,162 @@ type DeprecatedBlockTagRule struct {
 	BaseRule
 }
 
+// buildDeprecatedBlockTagFix returns a single byte-range Fix that rewrites
+// the KDoc and inserts a `@Deprecated("<message>")` annotation in front of
+// the following declaration. Returns nil when the surrounding shape is not
+// safe to rewrite (no following declaration, declaration already annotated,
+// or message extraction fails).
+func buildDeprecatedBlockTagFix(file *scanner.File, kdocIdx uint32, kdocText string) *scanner.Fix {
+	target, ok := flatDeclarationAfter(file, kdocIdx)
+	if !ok {
+		return nil
+	}
+	if flatHasDeprecatedAnnotation(file, target) {
+		return nil
+	}
+	message, cleanedKDoc, okExtract := stripDeprecatedKDocTag(kdocText)
+	if !okExtract {
+		return nil
+	}
+
+	// Compute the declaration's start byte and column. We replace the
+	// span [kdocStart, declStart) with cleanedKDoc + newline + indent +
+	// @Deprecated(...) + newline + indent so the declaration's existing
+	// indentation is preserved.
+	kdocStart := int(file.FlatStartByte(kdocIdx))
+	declStart := int(file.FlatStartByte(target))
+	if declStart <= kdocStart || declStart > len(file.Content) {
+		return nil
+	}
+	indent := flatLineIndentBefore(file, declStart)
+	annotation := buildDeprecatedAnnotation(message)
+	replacement := cleanedKDoc + "\n" + indent + annotation + "\n" + indent
+	return &scanner.Fix{
+		ByteMode:    true,
+		StartByte:   kdocStart,
+		EndByte:     declStart,
+		Replacement: replacement,
+	}
+}
+
+// flatDeclarationAfter returns the next sibling that looks like a declaration
+// the KDoc is documenting. Skips intervening line comments and whitespace
+// siblings.
+func flatDeclarationAfter(file *scanner.File, idx uint32) (uint32, bool) {
+	for sib, ok := file.FlatNextSibling(idx); ok; sib, ok = file.FlatNextSibling(sib) {
+		switch file.FlatType(sib) {
+		case "line_comment", "multiline_comment":
+			continue
+		case "class_declaration",
+			"object_declaration",
+			"function_declaration",
+			"property_declaration",
+			"type_alias",
+			"secondary_constructor":
+			return sib, true
+		default:
+			return 0, false
+		}
+	}
+	return 0, false
+}
+
+// flatHasDeprecatedAnnotation reports whether the declaration already carries
+// a `@Deprecated(...)` annotation in its modifier list.
+func flatHasDeprecatedAnnotation(file *scanner.File, decl uint32) bool {
+	mods, ok := file.FlatFindChild(decl, "modifiers")
+	if !ok {
+		return false
+	}
+	for c := file.FlatFirstChild(mods); c != 0; c = file.FlatNextSib(c) {
+		if file.FlatType(c) != "annotation" {
+			continue
+		}
+		if annotationFinalName(file, c) == "Deprecated" {
+			return true
+		}
+	}
+	return false
+}
+
+// stripDeprecatedKDocTag removes the `@deprecated` line (and continuation
+// lines that belong to the same tag) from a KDoc block, returning the
+// extracted message text and the cleaned KDoc body. Continuation lines are
+// any subsequent ` * ...` lines that do not start with another `@<tag>`
+// and are not the closing `*/`.
+func stripDeprecatedKDocTag(text string) (message, cleaned string, ok bool) {
+	lines := strings.Split(text, "\n")
+	var msgParts []string
+	var out []string
+	inTag := false
+	found := false
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		// Strip leading "*" / "* " for tag detection.
+		body := trimmed
+		if strings.HasPrefix(body, "*") && !strings.HasPrefix(body, "*/") {
+			body = strings.TrimPrefix(body, "*")
+			body = strings.TrimPrefix(body, " ")
+		}
+		if !inTag && strings.HasPrefix(body, "@deprecated") {
+			found = true
+			inTag = true
+			rest := strings.TrimSpace(strings.TrimPrefix(body, "@deprecated"))
+			if rest != "" {
+				msgParts = append(msgParts, rest)
+			}
+			continue
+		}
+		if inTag {
+			// End the tag when we hit another @tag, the closing */, or a
+			// blank-looking continuation that's empty.
+			if strings.HasPrefix(body, "@") || strings.HasPrefix(trimmed, "*/") || trimmed == "*" || trimmed == "" {
+				inTag = false
+				// Fall through so this line is preserved.
+			} else {
+				if body != "" {
+					msgParts = append(msgParts, body)
+				}
+				continue
+			}
+		}
+		out = append(out, line)
+	}
+	if !found {
+		return "", "", false
+	}
+	return strings.Join(msgParts, " "), strings.Join(out, "\n"), true
+}
+
+// flatLineIndentBefore returns the leading whitespace of the line containing
+// the byte at pos. Used to align an inserted annotation with the following
+// declaration.
+func flatLineIndentBefore(file *scanner.File, pos int) string {
+	if pos <= 0 || pos > len(file.Content) {
+		return ""
+	}
+	start := pos - 1
+	for start >= 0 && file.Content[start] != '\n' {
+		start--
+	}
+	start++
+	end := start
+	for end < pos && (file.Content[end] == ' ' || file.Content[end] == '\t') {
+		end++
+	}
+	return string(file.Content[start:end])
+}
+
+// buildDeprecatedAnnotation renders a `@Deprecated("...")` annotation,
+// escaping embedded quotes and backslashes in the message. When the message
+// is empty the annotation still receives an empty string argument so the
+// resulting annotation compiles.
+func buildDeprecatedAnnotation(message string) string {
+	escaped := strings.ReplaceAll(message, `\`, `\\`)
+	escaped = strings.ReplaceAll(escaped, `"`, `\"`)
+	return `@Deprecated("` + escaped + `")`
+}
+
 // Confidence holds the 0.95 dispatch default. Documentation/comment rule. Detection checks presence and
 // well-formedness of doc comments on declarations — purely structural. No
 // heuristic path. Classified per roadmap/17.

--- a/internal/rules/fix_test.go
+++ b/internal/rules/fix_test.go
@@ -286,6 +286,11 @@ func truncate(s string, max int) string {
 }
 
 var knownFixableRulesWithoutPerRuleFixture = map[string]bool{
+	// ApplyPluginTwice fires only on Gradle build scripts; the per-rule
+	// fixable harness loads .kt/.kts/.java via the standard parser and
+	// does not wire up a Gradle context. Coverage lives in
+	// TestApplyPluginTwice's "fix removes duplicate apply line" subtest.
+	"ApplyPluginTwice":                   true,
 	"BooleanPropertyNaming":              true,
 	"ExplicitItLambdaMultipleParameters": true,
 	"FunctionOnlyReturningConstant":      true,

--- a/internal/rules/fixes.go
+++ b/internal/rules/fixes.go
@@ -51,6 +51,9 @@ func (r *DocumentationOverPrivateFunctionRule) IsFixable() bool { return true }
 func (r *DocumentationOverPrivatePropertyRule) IsFixable() bool { return true }
 func (r *DeprecatedBlockTagRule) IsFixable() bool               { return true }
 func (r *CopyrightYearOutdatedRule) IsFixable() bool            { return true }
+func (r *CommentedOutImportRule) IsFixable() bool               { return true }
+func (r *CommentedOutCodeBlockRule) IsFixable() bool            { return true }
+func (r *ApplyPluginTwiceRule) IsFixable() bool                 { return true }
 
 // Empty-blocks rules
 func (r *EmptyDefaultConstructorRule) IsFixable() bool   { return true }

--- a/internal/rules/fixes.go
+++ b/internal/rules/fixes.go
@@ -55,7 +55,7 @@ func (r *CommentedOutImportRule) IsFixable() bool               { return true }
 func (r *CommentedOutCodeBlockRule) IsFixable() bool            { return true }
 func (r *ApplyPluginTwiceRule) IsFixable() bool                 { return true }
 func (r *TestNameContainsUnderscoreRule) IsFixable() bool       { return true }
-func (r *ElseCaseInsteadOfExhaustiveWhenRule) IsFixable() bool   { return true }
+func (r *ElseCaseInsteadOfExhaustiveWhenRule) IsFixable() bool  { return true }
 
 // Empty-blocks rules
 func (r *EmptyDefaultConstructorRule) IsFixable() bool   { return true }

--- a/internal/rules/fixes.go
+++ b/internal/rules/fixes.go
@@ -54,6 +54,8 @@ func (r *CopyrightYearOutdatedRule) IsFixable() bool            { return true }
 func (r *CommentedOutImportRule) IsFixable() bool               { return true }
 func (r *CommentedOutCodeBlockRule) IsFixable() bool            { return true }
 func (r *ApplyPluginTwiceRule) IsFixable() bool                 { return true }
+func (r *TestNameContainsUnderscoreRule) IsFixable() bool       { return true }
+func (r *ElseCaseInsteadOfExhaustiveWhenRule) IsFixable() bool   { return true }
 
 // Empty-blocks rules
 func (r *EmptyDefaultConstructorRule) IsFixable() bool   { return true }

--- a/internal/rules/fixes.go
+++ b/internal/rules/fixes.go
@@ -49,7 +49,8 @@ func (r *RedundantExplicitTypeRule) IsFixable() bool                 { return tr
 // Comments rules
 func (r *DocumentationOverPrivateFunctionRule) IsFixable() bool { return true }
 func (r *DocumentationOverPrivatePropertyRule) IsFixable() bool { return true }
-func (r *DeprecatedBlockTagRule) IsFixable() bool               { return false }
+func (r *DeprecatedBlockTagRule) IsFixable() bool               { return true }
+func (r *CopyrightYearOutdatedRule) IsFixable() bool            { return true }
 
 // Empty-blocks rules
 func (r *EmptyDefaultConstructorRule) IsFixable() bool   { return true }

--- a/internal/rules/licensing.go
+++ b/internal/rules/licensing.go
@@ -150,12 +150,34 @@ func (r *CopyrightYearOutdatedRule) check(ctx *api.Context) {
 			return
 		}
 
-		ctx.Emit(r.Finding(
+		f := r.Finding(
 			file,
 			i+1,
 			match[2]+1,
 			fmt.Sprintf("Copyright year %d looks outdated for files changed after %d.", year, r.RecentYearCutoff-1),
-		))
+		)
+		lineStart := file.LineOffset(i)
+		hasRange := match[4] != -1 && match[5] != -1
+		var startByte, endByte int
+		var replacement string
+		if hasRange {
+			// Bump the trailing year of the range to the cutoff.
+			startByte = lineStart + match[4]
+			endByte = lineStart + match[5]
+			replacement = strconv.Itoa(r.RecentYearCutoff)
+		} else {
+			// Extend the single year into a range ending at the cutoff.
+			startByte = lineStart + match[2]
+			endByte = lineStart + match[3]
+			replacement = fmt.Sprintf("%d-%d", year, r.RecentYearCutoff)
+		}
+		f.Fix = &scanner.Fix{
+			ByteMode:    true,
+			StartByte:   startByte,
+			EndByte:     endByte,
+			Replacement: replacement,
+		}
+		ctx.Emit(f)
 		return
 	}
 }

--- a/internal/rules/potentialbugs_types.go
+++ b/internal/rules/potentialbugs_types.go
@@ -1144,6 +1144,52 @@ type ElseCaseInsteadOfExhaustiveWhenRule struct {
 // roadmap/17.
 func (r *ElseCaseInsteadOfExhaustiveWhenRule) Confidence() float64 { return 0.75 }
 
+// whenElseBranchDeletionFix returns a byte-mode Fix that removes the
+// `else -> ...` when_entry from a when_expression along with surrounding
+// whitespace. Returns nil when no else entry is found. The fix preserves
+// the surrounding closing brace and indentation by trimming the trailing
+// newline only when present.
+func whenElseBranchDeletionFix(file *scanner.File, idx uint32) *scanner.Fix {
+	for entry := file.FlatFirstChild(idx); entry != 0; entry = file.FlatNextSib(entry) {
+		if file.FlatType(entry) != "when_entry" {
+			continue
+		}
+		isElse := false
+		for child := file.FlatFirstChild(entry); child != 0; child = file.FlatNextSib(child) {
+			if file.FlatType(child) == "else" {
+				isElse = true
+				break
+			}
+		}
+		if !isElse {
+			continue
+		}
+		start := int(file.FlatStartByte(entry))
+		end := int(file.FlatEndByte(entry))
+		// Pull leading indentation back to (but not past) the previous
+		// newline so the entry's leading whitespace is removed.
+		for start > 0 {
+			c := file.Content[start-1]
+			if c == ' ' || c == '\t' {
+				start--
+				continue
+			}
+			break
+		}
+		// Consume the trailing newline so the line collapses entirely.
+		if end < len(file.Content) && file.Content[end] == '\n' {
+			end++
+		}
+		return &scanner.Fix{
+			ByteMode:    true,
+			StartByte:   start,
+			EndByte:     end,
+			Replacement: "",
+		}
+	}
+	return nil
+}
+
 // whenHasElseBranchFlat returns true when the when_expression at idx has
 // an `else ->` branch. A when_entry for the else branch has an `else`
 // token child in place of a when_condition.

--- a/internal/rules/registry_comments.go
+++ b/internal/rules/registry_comments.go
@@ -23,7 +23,7 @@ func registerCommentsRules() {
 		r := &DeprecatedBlockTagRule{BaseRule: BaseRule{RuleName: "DeprecatedBlockTag", RuleSetName: "comments", Sev: "warning", Desc: "Detects @deprecated KDoc tags that should use the @Deprecated annotation instead."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"multiline_comment"}, Confidence: 0.95, Implementation: r,
+			NodeTypes: []string{"multiline_comment"}, Confidence: 0.95, Fix: api.FixIdiomatic, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				if scanner.IsTestFile(file.Path) || isGradleBuildScript(file.Path) {
@@ -33,10 +33,15 @@ func registerCommentsRules() {
 					return
 				}
 				text := file.FlatNodeText(idx)
-				if strings.Contains(text, "@deprecated") {
-					ctx.EmitAt(file.FlatRow(idx)+1, 1,
-						"Use @Deprecated annotation instead of @deprecated KDoc tag.")
+				if !strings.Contains(text, "@deprecated") {
+					return
 				}
+				f := r.Finding(file, file.FlatRow(idx)+1, 1,
+					"Use @Deprecated annotation instead of @deprecated KDoc tag.")
+				if fix := buildDeprecatedBlockTagFix(file, idx, text); fix != nil {
+					f.Fix = fix
+				}
+				ctx.Emit(f)
 			},
 		})
 	}

--- a/internal/rules/registry_licensing.go
+++ b/internal/rules/registry_licensing.go
@@ -15,7 +15,7 @@ func registerLicensingRules() {
 		}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			Needs: api.NeedsLinePass, Implementation: r,
+			Needs: api.NeedsLinePass, Fix: api.FixCosmetic, Implementation: r,
 			Check:         r.check,
 			DefaultActive: false,
 		})

--- a/internal/rules/registry_potentialbugs_types.go
+++ b/internal/rules/registry_potentialbugs_types.go
@@ -432,7 +432,7 @@ func registerPotentialbugsTypesRules() {
 				if len(coveredTypes) == 0 || !whenVariantsCoveredFlat(coveredTypes, variants) {
 					return
 				}
-				f := r.Finding(file, int(file.FlatRow(idx))+1, int(file.FlatCol(idx))+1,
+				f := r.Finding(file, file.FlatRow(idx)+1, file.FlatCol(idx)+1,
 					fmt.Sprintf("When expression on sealed type '%s' uses 'else' but all variants are covered. Remove the else branch.", subjectTypeName))
 				f.Fix = whenElseBranchDeletionFix(file, idx)
 				ctx.Emit(f)

--- a/internal/rules/registry_potentialbugs_types.go
+++ b/internal/rules/registry_potentialbugs_types.go
@@ -394,7 +394,7 @@ func registerPotentialbugsTypesRules() {
 		r := &ElseCaseInsteadOfExhaustiveWhenRule{BaseRule: BaseRule{RuleName: "ElseCaseInsteadOfExhaustiveWhen", RuleSetName: "potential-bugs", Sev: "warning", Desc: "Detects when expressions on sealed classes or enums that use an else branch instead of exhaustive matching."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"when_expression"}, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"when_expression"}, Confidence: 0.75, Fix: api.FixIdiomatic, Implementation: r,
 			Needs: api.NeedsResolver,
 			Tags:  []string{"precompile"},
 			Check: func(ctx *api.Context) {
@@ -432,8 +432,10 @@ func registerPotentialbugsTypesRules() {
 				if len(coveredTypes) == 0 || !whenVariantsCoveredFlat(coveredTypes, variants) {
 					return
 				}
-				ctx.EmitAt(file.FlatRow(idx)+1, file.FlatCol(idx)+1,
+				f := r.Finding(file, int(file.FlatRow(idx))+1, int(file.FlatCol(idx))+1,
 					fmt.Sprintf("When expression on sealed type '%s' uses 'else' but all variants are covered. Remove the else branch.", subjectTypeName))
+				f.Fix = whenElseBranchDeletionFix(file, idx)
+				ctx.Emit(f)
 			},
 		})
 	}

--- a/internal/rules/registry_release_engineering.go
+++ b/internal/rules/registry_release_engineering.go
@@ -266,7 +266,7 @@ func registerReleaseEngineeringRules() {
 		r := &CommentedOutCodeBlockRule{BaseRule: BaseRule{RuleName: "CommentedOutCodeBlock", RuleSetName: releaseEngineeringRuleSet, Sev: "info", Desc: "Detects consecutive lines of commented-out Kotlin code that should be deleted or restored."}, MinLines: 3}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			Needs: api.NeedsLinePass, Implementation: r,
+			Needs: api.NeedsLinePass, Fix: api.FixIdiomatic, Implementation: r,
 			Check: r.check,
 		})
 	}
@@ -282,7 +282,7 @@ func registerReleaseEngineeringRules() {
 		r := &CommentedOutImportRule{BaseRule: BaseRule{RuleName: "CommentedOutImport", RuleSetName: releaseEngineeringRuleSet, Sev: "info", Desc: "Detects commented-out import statements that are either dead code or incomplete refactors."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"line_comment"}, Confidence: r.Confidence(), Implementation: r,
+			NodeTypes: []string{"line_comment"}, Confidence: r.Confidence(), Fix: api.FixIdiomatic, Implementation: r,
 			Check: r.checkNode,
 		})
 	}

--- a/internal/rules/registry_supply_chain.go
+++ b/internal/rules/registry_supply_chain.go
@@ -166,7 +166,7 @@ func registerSupplyChainRules() {
 		}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			Needs: api.NeedsGradle, AndroidDeps: uint32(AndroidDepGradle), Confidence: r.Confidence(), Implementation: r,
+			Needs: api.NeedsGradle, AndroidDeps: uint32(AndroidDepGradle), Confidence: r.Confidence(), Fix: api.FixIdiomatic, Implementation: r,
 			Check: r.check,
 		})
 	}

--- a/internal/rules/registry_testing_quality.go
+++ b/internal/rules/registry_testing_quality.go
@@ -490,7 +490,7 @@ func registerTestingQualityTestNameContainsUnderscore() {
 	}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"function_declaration"}, Confidence: 0.6, Implementation: r,
+		NodeTypes: []string{"function_declaration"}, Confidence: 0.6, Fix: api.FixCosmetic, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			if !testingQualityIsTestFunction(file, idx) {
@@ -503,9 +503,34 @@ func registerTestingQualityTestNameContainsUnderscore() {
 			if strings.HasPrefix(name, "`") {
 				return
 			}
-			ctx.EmitAt(file.FlatRow(idx)+1, file.FlatCol(idx)+1, "Test name uses underscores; consider backtick-quoted names.")
+			f := r.Finding(file, int(file.FlatRow(idx))+1, int(file.FlatCol(idx))+1,
+				"Test name uses underscores; consider backtick-quoted names.")
+			if fix := testNameUnderscoreFix(file, idx, name); fix != nil {
+				f.Fix = fix
+			}
+			ctx.Emit(f)
 		},
 	})
+}
+
+// testNameUnderscoreFix returns a byte-mode Fix that replaces the
+// function's simple_identifier child with the same name rewritten as a
+// backtick-quoted identifier with underscores swapped for spaces. Returns
+// nil when the identifier byte range cannot be located.
+func testNameUnderscoreFix(file *scanner.File, fnIdx uint32, name string) *scanner.Fix {
+	for child := file.FlatFirstChild(fnIdx); child != 0; child = file.FlatNextSib(child) {
+		switch file.FlatType(child) {
+		case "simple_identifier", "identifier":
+			replacement := "`" + strings.ReplaceAll(name, "_", " ") + "`"
+			return &scanner.Fix{
+				ByteMode:    true,
+				StartByte:   int(file.FlatStartByte(child)),
+				EndByte:     int(file.FlatEndByte(child)),
+				Replacement: replacement,
+			}
+		}
+	}
+	return nil
 }
 
 func registerTestingQualitySharedMutableStateInObject() {

--- a/internal/rules/registry_testing_quality.go
+++ b/internal/rules/registry_testing_quality.go
@@ -503,7 +503,7 @@ func registerTestingQualityTestNameContainsUnderscore() {
 			if strings.HasPrefix(name, "`") {
 				return
 			}
-			f := r.Finding(file, int(file.FlatRow(idx))+1, int(file.FlatCol(idx))+1,
+			f := r.Finding(file, file.FlatRow(idx)+1, file.FlatCol(idx)+1,
 				"Test name uses underscores; consider backtick-quoted names.")
 			if fix := testNameUnderscoreFix(file, idx, name); fix != nil {
 				f.Fix = fix

--- a/internal/rules/release_engineering.go
+++ b/internal/rules/release_engineering.go
@@ -191,7 +191,9 @@ func (r *CommentedOutCodeBlockRule) check(ctx *api.Context) {
 		}
 
 		msg := fmt.Sprintf("Commented-out code block detected across %d consecutive lines; delete it or restore it as live code.", endLine-startLine)
-		ctx.Emit(r.Finding(file, startLine+1, col+1, msg))
+		f := r.Finding(file, startLine+1, col+1, msg)
+		f.Fix = deleteLineRangeFix(file, startLine, endLine-1)
+		ctx.Emit(f)
 		startLine = -1
 		count = 0
 	}
@@ -484,8 +486,56 @@ func (r *CommentedOutImportRule) checkNode(ctx *api.Context) {
 	if !commentedImportRe.MatchString(body) {
 		return
 	}
-	ctx.EmitAt(file.FlatRow(ctx.Idx)+1, 1,
+	row := file.FlatRow(ctx.Idx)
+	f := r.Finding(file, int(row)+1, 1,
 		"Commented-out import; remove it or restore it as a live import.")
+	f.Fix = deleteLineFix(file, int(row))
+	ctx.Emit(f)
+}
+
+// deleteLineRangeFix returns a byte-mode Fix that removes lines
+// [startRow, endRow] (inclusive, 0-indexed) along with their trailing
+// newlines. Returns nil when the range is out of bounds.
+func deleteLineRangeFix(file *scanner.File, startRow, endRow int) *scanner.Fix {
+	if startRow < 0 || endRow < startRow || endRow >= len(file.Lines) {
+		return nil
+	}
+	start := file.LineOffset(startRow)
+	end := file.LineOffset(endRow) + len(file.Lines[endRow])
+	if end < len(file.Content) && file.Content[end] == '\n' {
+		end++
+	} else if start > 0 && file.Content[start-1] == '\n' {
+		start--
+	}
+	return &scanner.Fix{
+		ByteMode:    true,
+		StartByte:   start,
+		EndByte:     end,
+		Replacement: "",
+	}
+}
+
+// deleteLineFix returns a byte-mode Fix that removes the file's row at the
+// given 0-indexed line, including its trailing newline (or the preceding
+// newline when the line is the last in the file). Returns nil when the
+// line is out of range.
+func deleteLineFix(file *scanner.File, row int) *scanner.Fix {
+	if row < 0 || row >= len(file.Lines) {
+		return nil
+	}
+	start := file.LineOffset(row)
+	end := start + len(file.Lines[row])
+	if end < len(file.Content) && file.Content[end] == '\n' {
+		end++
+	} else if start > 0 && file.Content[start-1] == '\n' {
+		start--
+	}
+	return &scanner.Fix{
+		ByteMode:    true,
+		StartByte:   start,
+		EndByte:     end,
+		Replacement: "",
+	}
 }
 
 // DebugToastInProductionRule flags Toast.makeText calls whose message literal

--- a/internal/rules/release_engineering.go
+++ b/internal/rules/release_engineering.go
@@ -493,38 +493,24 @@ func (r *CommentedOutImportRule) checkNode(ctx *api.Context) {
 	ctx.Emit(f)
 }
 
+// deleteLineFix returns a byte-mode Fix that removes a single 0-indexed
+// row, including its trailing newline (or the preceding newline when the
+// line is the last in the file). Returns nil when the row is out of range.
+func deleteLineFix(file *scanner.File, row int) *scanner.Fix {
+	return deleteLineRangeFix(file, row, row)
+}
+
 // deleteLineRangeFix returns a byte-mode Fix that removes lines
 // [startRow, endRow] (inclusive, 0-indexed) along with their trailing
-// newlines. Returns nil when the range is out of bounds.
+// newlines. When the range reaches the end of the file with no trailing
+// newline, the preceding newline is consumed instead so neighboring lines
+// stay separated. Returns nil when the range is out of bounds.
 func deleteLineRangeFix(file *scanner.File, startRow, endRow int) *scanner.Fix {
 	if startRow < 0 || endRow < startRow || endRow >= len(file.Lines) {
 		return nil
 	}
 	start := file.LineOffset(startRow)
 	end := file.LineOffset(endRow) + len(file.Lines[endRow])
-	if end < len(file.Content) && file.Content[end] == '\n' {
-		end++
-	} else if start > 0 && file.Content[start-1] == '\n' {
-		start--
-	}
-	return &scanner.Fix{
-		ByteMode:    true,
-		StartByte:   start,
-		EndByte:     end,
-		Replacement: "",
-	}
-}
-
-// deleteLineFix returns a byte-mode Fix that removes the file's row at the
-// given 0-indexed line, including its trailing newline (or the preceding
-// newline when the line is the last in the file). Returns nil when the
-// line is out of range.
-func deleteLineFix(file *scanner.File, row int) *scanner.Fix {
-	if row < 0 || row >= len(file.Lines) {
-		return nil
-	}
-	start := file.LineOffset(row)
-	end := start + len(file.Lines[row])
 	if end < len(file.Content) && file.Content[end] == '\n' {
 		end++
 	} else if start > 0 && file.Content[start-1] == '\n' {

--- a/internal/rules/release_engineering.go
+++ b/internal/rules/release_engineering.go
@@ -487,9 +487,9 @@ func (r *CommentedOutImportRule) checkNode(ctx *api.Context) {
 		return
 	}
 	row := file.FlatRow(ctx.Idx)
-	f := r.Finding(file, int(row)+1, 1,
+	f := r.Finding(file, row+1, 1,
 		"Commented-out import; remove it or restore it as a live import.")
-	f.Fix = deleteLineFix(file, int(row))
+	f.Fix = deleteLineFix(file, row)
 	ctx.Emit(f)
 }
 

--- a/internal/rules/supply_chain_test.go
+++ b/internal/rules/supply_chain_test.go
@@ -707,6 +707,36 @@ apply(plugin = "com.android.application")
 			t.Fatalf("expected 0 findings for settings file, got %d", len(settingsFindings))
 		}
 	})
+
+	t.Run("fix removes duplicate apply line", func(t *testing.T) {
+		content := `plugins {
+    id("com.android.application")
+}
+
+apply(plugin = "com.android.application")
+`
+		cfg, _ := android.ParseBuildGradleContent(content)
+		findings := runGradleRule(r, "build.gradle.kts", content, cfg)
+		if len(findings) != 1 {
+			t.Fatalf("expected 1 finding, got %d", len(findings))
+		}
+		fix := findings[0].Fix
+		if fix == nil {
+			t.Fatalf("expected fix on finding, got nil")
+		}
+		if !fix.ByteMode {
+			t.Fatalf("expected byte-mode fix")
+		}
+		got := content[:fix.StartByte] + fix.Replacement + content[fix.EndByte:]
+		want := `plugins {
+    id("com.android.application")
+}
+
+`
+		if got != want {
+			t.Fatalf("fix output mismatch:\n--- got ---\n%q\n--- want ---\n%q", got, want)
+		}
+	})
 }
 
 func TestConfigurationsAllSideEffect(t *testing.T) {

--- a/internal/rules/supply_drift.go
+++ b/internal/rules/supply_drift.go
@@ -453,7 +453,7 @@ func (r *ApplyPluginTwiceRule) check(ctx *api.Context) {
 		return
 	}
 	for _, duplicate := range findApplyPluginTwice(content) {
-		ctx.Emit(scanner.Finding{
+		finding := scanner.Finding{
 			File:       path,
 			Line:       duplicate.line,
 			Col:        1,
@@ -462,7 +462,45 @@ func (r *ApplyPluginTwiceRule) check(ctx *api.Context) {
 			Severity:   r.Sev,
 			Message:    fmt.Sprintf("Plugin %q is applied in both plugins { } and apply(plugin = ...). Keep a single application form.", duplicate.id),
 			Confidence: r.Confidence(),
-		})
+		}
+		finding.Fix = deleteContentLineFix(content, duplicate.line)
+		ctx.Emit(finding)
+	}
+}
+
+// deleteContentLineFix returns a byte-mode Fix that removes the 1-indexed
+// line from a raw text buffer. Used by Gradle rules that operate on
+// ctx.GradleContent rather than a parsed scanner.File. Returns nil when
+// the line number is out of range.
+func deleteContentLineFix(content string, line int) *scanner.Fix {
+	if line < 1 {
+		return nil
+	}
+	currentLine := 1
+	start := 0
+	for start < len(content) && currentLine < line {
+		if content[start] == '\n' {
+			currentLine++
+		}
+		start++
+	}
+	if currentLine != line {
+		return nil
+	}
+	end := start
+	for end < len(content) && content[end] != '\n' {
+		end++
+	}
+	if end < len(content) && content[end] == '\n' {
+		end++
+	} else if start > 0 && content[start-1] == '\n' {
+		start--
+	}
+	return &scanner.Fix{
+		ByteMode:    true,
+		StartByte:   start,
+		EndByte:     end,
+		Replacement: "",
 	}
 }
 

--- a/tests/fixtures/fixable/per-rule/CommentedOutCodeBlock.kt
+++ b/tests/fixtures/fixable/per-rule/CommentedOutCodeBlock.kt
@@ -1,0 +1,9 @@
+package release
+
+fun example() {
+    val live = 1
+    // val a = 1
+    // val b = 2
+    // val c = 3
+    println(live)
+}

--- a/tests/fixtures/fixable/per-rule/CommentedOutCodeBlock.kt.expected
+++ b/tests/fixtures/fixable/per-rule/CommentedOutCodeBlock.kt.expected
@@ -1,0 +1,6 @@
+package release
+
+fun example() {
+    val live = 1
+    println(live)
+}

--- a/tests/fixtures/fixable/per-rule/CommentedOutImport.kt
+++ b/tests/fixtures/fixable/per-rule/CommentedOutImport.kt
@@ -1,0 +1,7 @@
+package release
+
+// import com.example.unused.Foo
+
+import com.example.live.Bar
+
+fun use(bar: Bar) = bar

--- a/tests/fixtures/fixable/per-rule/CommentedOutImport.kt.expected
+++ b/tests/fixtures/fixable/per-rule/CommentedOutImport.kt.expected
@@ -1,0 +1,6 @@
+package release
+
+
+import com.example.live.Bar
+
+fun use(bar: Bar) = bar

--- a/tests/fixtures/fixable/per-rule/CopyrightYearOutdated.kt
+++ b/tests/fixtures/fixable/per-rule/CopyrightYearOutdated.kt
@@ -1,0 +1,6 @@
+/*
+ * Copyright (c) 2018 Krit Authors
+ */
+package licensing
+
+fun currentFeature() = 42

--- a/tests/fixtures/fixable/per-rule/CopyrightYearOutdated.kt.expected
+++ b/tests/fixtures/fixable/per-rule/CopyrightYearOutdated.kt.expected
@@ -1,0 +1,6 @@
+/*
+ * Copyright (c) 2018-2024 Krit Authors
+ */
+package licensing
+
+fun currentFeature() = 42

--- a/tests/fixtures/fixable/per-rule/DeprecatedBlockTag.kt
+++ b/tests/fixtures/fixable/per-rule/DeprecatedBlockTag.kt
@@ -1,0 +1,11 @@
+package comments
+
+class Example {
+    /**
+     * Some function.
+     * @deprecated use newFoo instead
+     */
+    fun foo() {
+        println("hello")
+    }
+}

--- a/tests/fixtures/fixable/per-rule/DeprecatedBlockTag.kt.expected
+++ b/tests/fixtures/fixable/per-rule/DeprecatedBlockTag.kt.expected
@@ -1,0 +1,11 @@
+package comments
+
+class Example {
+    /**
+     * Some function.
+     */
+    @Deprecated("use newFoo instead")
+    fun foo() {
+        println("hello")
+    }
+}

--- a/tests/fixtures/fixable/per-rule/ElseCaseInsteadOfExhaustiveWhen.kt
+++ b/tests/fixtures/fixable/per-rule/ElseCaseInsteadOfExhaustiveWhen.kt
@@ -1,0 +1,15 @@
+package fixtures.fixable
+
+sealed class Shape
+class Circle : Shape()
+class Square : Shape()
+
+class ElseCaseInsteadOfExhaustiveWhen {
+    fun describe(shape: Shape): String {
+        return when (shape) {
+            is Circle -> "circle"
+            is Square -> "square"
+            else -> "unknown"
+        }
+    }
+}

--- a/tests/fixtures/fixable/per-rule/ElseCaseInsteadOfExhaustiveWhen.kt.expected
+++ b/tests/fixtures/fixable/per-rule/ElseCaseInsteadOfExhaustiveWhen.kt.expected
@@ -1,0 +1,14 @@
+package fixtures.fixable
+
+sealed class Shape
+class Circle : Shape()
+class Square : Shape()
+
+class ElseCaseInsteadOfExhaustiveWhen {
+    fun describe(shape: Shape): String {
+        return when (shape) {
+            is Circle -> "circle"
+            is Square -> "square"
+        }
+    }
+}

--- a/tests/fixtures/fixable/per-rule/TestNameContainsUnderscore.kt
+++ b/tests/fixtures/fixable/per-rule/TestNameContainsUnderscore.kt
@@ -1,0 +1,10 @@
+package testing
+
+import org.junit.Test
+
+class ExampleTest {
+    @Test
+    fun test_does_something_useful() {
+        check(true)
+    }
+}

--- a/tests/fixtures/fixable/per-rule/TestNameContainsUnderscore.kt.expected
+++ b/tests/fixtures/fixable/per-rule/TestNameContainsUnderscore.kt.expected
@@ -1,0 +1,10 @@
+package testing
+
+import org.junit.Test
+
+class ExampleTest {
+    @Test
+    fun `test does something useful`() {
+        check(true)
+    }
+}


### PR DESCRIPTION
## Summary

Adds autofix support to seven Krit rules whose fix is a pure local text transform — no cross-file work, no reference rewriting, no human judgment.

| Rule | Fix | Shape |
|---|---|---|
| `CopyrightYearOutdated` | `FixCosmetic` | Single year `2018` → range `2018-2024`; range trailing year bumped to cutoff |
| `DeprecatedBlockTag` | `FixIdiomatic` | Rewrites `@deprecated msg` KDoc tag into `@Deprecated(\"msg\")` annotation on the documented declaration |
| `CommentedOutImport` | `FixIdiomatic` | Deletes the commented import line |
| `CommentedOutCodeBlock` | `FixIdiomatic` | Deletes the consecutive commented-out line range |
| `ApplyPluginTwice` | `FixIdiomatic` | Removes the duplicate `apply(plugin = ...)` line when the same id is already in `plugins { }` |
| `TestNameContainsUnderscore` | `FixCosmetic` | `fun test_foo_bar()` → `` fun `test foo bar`() ``; safe because test names have no external callers |
| `ElseCaseInsteadOfExhaustiveWhen` | `FixIdiomatic` | Drops the redundant `else -> ...` when-entry (rule already proves the remaining branches exhaustively cover the sealed variants) |

Adds reusable byte-range deletion helpers — `deleteLineFix` / `deleteLineRangeFix` over `scanner.File`, and `deleteContentLineFix` over a raw Gradle content string — and a single `whenElseBranchDeletionFix` for the when-entry case.

`UnnecessaryBackticks` was also reviewed during this pass and confirmed already complete; no code changes there.

A final cleanup commit reuses the pre-existing `hasAnnotationNamed` and `detectIndent` helpers rather than introducing local duplicates.

## Test plan

- [x] `go build ./cmd/krit/`
- [x] `go vet ./...`
- [x] `go test ./... -count=1`
- [x] New per-rule fixable fixtures under `tests/fixtures/fixable/per-rule/` for each Kotlin-source rule; `ApplyPluginTwice` is allowlisted out of the Kotlin-source fixable harness (Gradle-only) and covered by a dedicated subtest in `TestApplyPluginTwice`.