### PR TITLE
fix(PluralsBuiltWithIfElse): reduce false positives and improve metadata

### DIFF
--- a/internal/rules/i18n_plurals.go
+++ b/internal/rules/i18n_plurals.go
@@ -12,6 +12,10 @@ import (
 	"github.com/kaeawc/krit/internal/scanner"
 )
 
+var pluralsIfElseCountNames = map[string]bool{
+	"count": true, "quantity": true,
+}
+
 // PluralsBuiltWithIfElseRule detects manual pluralization built with an
 // if/else over `count == 1` whose branches produce string literals or
 // templates instead of using getQuantityString / pluralStringResource.
@@ -63,7 +67,7 @@ func identityVsOne(file *scanner.File, idExpr, litExpr uint32) bool {
 	if file.FlatType(idExpr) != "simple_identifier" {
 		return false
 	}
-	if !pluralsCountNames[file.FlatNodeText(idExpr)] {
+	if !pluralsIfElseCountNames[file.FlatNodeText(idExpr)] {
 		return false
 	}
 	if file.FlatType(litExpr) != "integer_literal" {

--- a/internal/rules/registry_i18n_plurals.go
+++ b/internal/rules/registry_i18n_plurals.go
@@ -2,6 +2,7 @@ package rules
 
 import (
 	api "github.com/kaeawc/krit/internal/rules/api"
+	"github.com/kaeawc/krit/internal/scanner"
 )
 
 func registerI18nPluralsRules() {
@@ -16,7 +17,7 @@ func registerI18nPluralsRules() {
 		}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"if_expression"}, Confidence: r.Confidence(), Implementation: r,
+			NodeTypes: []string{"if_expression"}, Languages: []scanner.Language{scanner.LangKotlin}, Confidence: r.Confidence(), Implementation: r,
 			Check:         r.check,
 			DefaultActive: true,
 		})

--- a/tests/fixtures/negative/i18n/PluralsBuiltWithIfElse.kt
+++ b/tests/fixtures/negative/i18n/PluralsBuiltWithIfElse.kt
@@ -7,3 +7,37 @@ class CartLabeler(private val resources: Resources) {
         return resources.getQuantityString(R.plurals.item_count, count, count)
     }
 }
+
+// Generic identifiers: size, amount, number, num are not strong
+// enough pluralization signals for this rule.
+class GenericIdentifiers {
+    fun tableName(size: Int): String {
+        return if (size == 1) "user" else "users"
+    }
+
+    fun logTag(num: Int): String {
+        return if (num == 1) "SINGLE" else "BATCH"
+    }
+
+    fun jsonKey(amount: Int): String {
+        return if (amount == 1) "item" else "items"
+    }
+
+    fun describe(number: Int): String {
+        return if (number == 1) "expected one" else "expected many"
+    }
+}
+
+// Reversed condition: != is intentionally not matched.
+class ReversedCondition {
+    fun label(count: Int): String {
+        return if (count != 1) "$count items" else "1 item"
+    }
+}
+
+// else-if chain: outer else body is another if_expression, not a string.
+class MultiQuantity {
+    fun label(count: Int): String {
+        return if (count == 1) "one" else if (count == 2) "a couple" else "many"
+    }
+}

--- a/tests/fixtures/positive/i18n/PluralsBuiltWithIfElse.kt
+++ b/tests/fixtures/positive/i18n/PluralsBuiltWithIfElse.kt
@@ -4,4 +4,12 @@ class CartLabeler {
     fun label(count: Int): String {
         return if (count == 1) "1 item" else "$count items"
     }
+
+    fun quantityLabel(quantity: Int): String {
+        return if (quantity == 1) "1 thing" else "$quantity things"
+    }
+
+    fun reversedOperand(count: Int): String {
+        return if (1 == count) "1 widget" else "$count widgets"
+    }
 }


### PR DESCRIPTION
## Summary
- **Narrow identifier set**: Create `pluralsIfElseCountNames` with only `count` and `quantity` (instead of sharing the broad 6-entry `pluralsCountNames` with `PluralsCandidateRule`). Generic identifiers like `size`, `num`, `amount`, `number` caused false positives on non-localized strings (DB table names, log tags, JSON keys, assertion messages).
- **Declare `Languages: [LangKotlin]`**: The rule uses Kotlin-specific AST nodes (`if_expression`, `equality_expression`, `simple_identifier`). Declaring the language lets the dispatcher skip Java files.
- **Expand fixtures**: Add negative fixtures for generic identifiers, reversed conditions (`!=`), and else-if chains. Add positive fixtures for `quantity` identifier and reversed operand (`1 == count`).

## Test plan
- [x] `go build -o krit ./cmd/krit/`
- [x] `go vet ./...`
- [x] `go test ./... -count=1` — all pass
- [x] Verified positive fixture fires on all 3 cases (count, quantity, reversed operand)
- [x] Verified negative fixture produces 0 findings