### PR TITLE
feat(precompile): add K0108-DuplicateLabel

### DIFF
--- a/internal/rules/precompile_duplicate_label.go
+++ b/internal/rules/precompile_duplicate_label.go
@@ -1,0 +1,98 @@
+package rules
+
+import (
+	"fmt"
+	"strings"
+
+	api "github.com/kaeawc/krit/internal/rules/api"
+	"github.com/kaeawc/krit/internal/scanner"
+)
+
+// PrecompileDuplicateLabelRule flags repeated constant labels in a
+// subject-bearing `when` expression. Mirrors kotlinc's
+// DUPLICATE_LABEL_IN_WHEN: when (x) { 1 -> a; 1 -> b } — the second `1`
+// branch is unreachable.
+//
+// Conservative by construction: only literal labels (numeric, boolean,
+// char, null, and string literals without interpolation) form a key.
+// Identifiers, qualified references, range tests, and type tests are
+// skipped because they need resolver context to deduplicate safely.
+// Subject-less `when` (free boolean conditions) is also skipped — those
+// are not labels.
+type PrecompileDuplicateLabelRule struct {
+	FlatDispatchBase
+	BaseRule
+}
+
+func (r *PrecompileDuplicateLabelRule) Confidence() float64 { return 0.95 }
+
+func (r *PrecompileDuplicateLabelRule) check(ctx *api.Context) {
+	idx, file := ctx.Idx, ctx.File
+	if _, ok := file.FlatFindChild(idx, "when_subject"); !ok {
+		return
+	}
+	seen := map[string]uint32{}
+	for entry := file.FlatFirstChild(idx); entry != 0; entry = file.FlatNextSib(entry) {
+		if file.FlatType(entry) != "when_entry" {
+			continue
+		}
+		for cond := file.FlatFirstChild(entry); cond != 0; cond = file.FlatNextSib(cond) {
+			if file.FlatType(cond) != "when_condition" {
+				continue
+			}
+			key := whenConditionDuplicateKey(file, cond)
+			if key == "" {
+				continue
+			}
+			if first, dup := seen[key]; dup {
+				ctx.EmitAt(file.FlatRow(cond)+1, file.FlatCol(cond)+1,
+					fmt.Sprintf("Duplicate `when` label `%s`; already covered on line %d.",
+						key, file.FlatRow(first)+1))
+				continue
+			}
+			seen[key] = cond
+		}
+	}
+}
+
+// whenConditionDuplicateKey returns a stable key when cond is a constant
+// label safe to deduplicate without resolver context. Returns "" for
+// non-literal conditions so the rule fails closed.
+func whenConditionDuplicateKey(file *scanner.File, cond uint32) string {
+	var named uint32
+	count := 0
+	for child := file.FlatFirstChild(cond); child != 0; child = file.FlatNextSib(child) {
+		if !file.FlatIsNamed(child) {
+			continue
+		}
+		count++
+		named = child
+	}
+	if count != 1 {
+		return ""
+	}
+	switch file.FlatType(named) {
+	case "integer_literal", "hex_literal", "bin_literal", "real_literal",
+		"boolean_literal", "character_literal", "long_literal",
+		"unsigned_literal", "null_literal", "null":
+		return strings.TrimSpace(file.FlatNodeText(named))
+	case "string_literal", "line_string_literal":
+		if stringLiteralHasInterpolation(file, named) {
+			return ""
+		}
+		return strings.TrimSpace(file.FlatNodeText(named))
+	}
+	return ""
+}
+
+func stringLiteralHasInterpolation(file *scanner.File, idx uint32) bool {
+	for child := file.FlatFirstChild(idx); child != 0; child = file.FlatNextSib(child) {
+		switch file.FlatType(child) {
+		case "interpolated_identifier", "interpolated_expression",
+			"line_str_ref", "line_string_expression",
+			"multi_line_str_ref", "multi_line_string_expression":
+			return true
+		}
+	}
+	return false
+}

--- a/internal/rules/registry_bootstrap.go
+++ b/internal/rules/registry_bootstrap.go
@@ -94,6 +94,7 @@ func init() {
 	registerPotentialbugsSmartCastRules()
 	registerPotentialbugsTypesRules()
 	registerPrecompileUnreachableCodeRules()
+	registerPrecompileDuplicateLabelRules()
 	registerCorrectnessOverrideRules()
 	registerCorrectnessAbstractRules()
 	registerPrivacyAnalyticsRules()

--- a/internal/rules/registry_precompile_duplicate_label.go
+++ b/internal/rules/registry_precompile_duplicate_label.go
@@ -1,0 +1,25 @@
+package rules
+
+import (
+	api "github.com/kaeawc/krit/internal/rules/api"
+)
+
+func registerPrecompileDuplicateLabelRules() {
+	r := &PrecompileDuplicateLabelRule{BaseRule: BaseRule{
+		RuleName:    "K0108-DuplicateLabel",
+		RuleSetName: api.CategoryPrecompile,
+		Sev:         string(api.SeverityError),
+		Desc:        "Detects repeated constant labels in a subject-bearing `when` expression. Mirrors kotlinc's DUPLICATE_LABEL_IN_WHEN.",
+	}}
+	api.Register(&api.Rule{
+		ID:             r.RuleName,
+		Category:       r.RuleSetName,
+		Description:    r.Desc,
+		Sev:            api.Severity(r.Sev),
+		NodeTypes:      []string{"when_expression"},
+		Confidence:     r.Confidence(),
+		Implementation: r,
+		Check:          r.check,
+		DefaultActive:  false,
+	})
+}

--- a/tests/fixtures/precompile/negative/K0108-DuplicateLabel/1.kt
+++ b/tests/fixtures/precompile/negative/K0108-DuplicateLabel/1.kt
@@ -1,0 +1,23 @@
+// Negative: each literal label is unique.
+fun describe(n: Int): String {
+    return when (n) {
+        1 -> "one"
+        2 -> "two"
+        3 -> "three"
+        else -> "other"
+    }
+}
+
+// Negative: same literal across two different when expressions is fine —
+// scope is per-when.
+fun two(n: Int, m: Int): Int {
+    val a = when (n) {
+        1 -> 10
+        else -> 0
+    }
+    val b = when (m) {
+        1 -> 20
+        else -> 0
+    }
+    return a + b
+}

--- a/tests/fixtures/precompile/negative/K0108-DuplicateLabel/2.kt
+++ b/tests/fixtures/precompile/negative/K0108-DuplicateLabel/2.kt
@@ -1,0 +1,23 @@
+// Negative: subject-less `when` uses arbitrary boolean conditions, not
+// labels. The rule deliberately skips this shape because the conditions
+// require resolver context to deduplicate safely.
+fun describeBool(n: Int): String {
+    return when {
+        n > 0 -> "positive"
+        n > 0 -> "still positive"
+        else -> "non-positive"
+    }
+}
+
+// Negative: identifier labels (enum entries, qualified references) need
+// resolution to know whether two names refer to the same constant, so
+// the rule skips them.
+enum class Color { RED, GREEN, BLUE }
+
+fun describe(c: Color): String {
+    return when (c) {
+        Color.RED -> "r"
+        Color.GREEN -> "g"
+        Color.BLUE -> "b"
+    }
+}

--- a/tests/fixtures/precompile/negative/K0108-DuplicateLabel/3.kt
+++ b/tests/fixtures/precompile/negative/K0108-DuplicateLabel/3.kt
@@ -1,0 +1,22 @@
+// Negative: range and type tests are not literal labels; the rule skips
+// them because deduplicating overlapping ranges requires resolver
+// context.
+fun bucket(n: Int): String {
+    return when (n) {
+        in 0..9 -> "single"
+        in 10..99 -> "double"
+        in 0..9 -> "single again"
+        else -> "more"
+    }
+}
+
+// Negative: interpolated string literals are dynamic; their runtime
+// value differs even when the source text matches.
+fun classify(tag: String, suffix: String): Int {
+    return when (tag) {
+        "yes-$suffix" -> 1
+        "no-$suffix" -> 0
+        "yes-$suffix" -> 2
+        else -> -1
+    }
+}

--- a/tests/fixtures/precompile/positive/K0108-DuplicateLabel/1.kt
+++ b/tests/fixtures/precompile/positive/K0108-DuplicateLabel/1.kt
@@ -1,0 +1,9 @@
+// EXPECTED-KOTLINC-ERROR: DUPLICATE_LABEL_IN_WHEN
+fun describeInt(n: Int): String {
+    return when (n) {
+        1 -> "one"
+        2 -> "two"
+        1 -> "also one"
+        else -> "other"
+    }
+}

--- a/tests/fixtures/precompile/positive/K0108-DuplicateLabel/2.kt
+++ b/tests/fixtures/precompile/positive/K0108-DuplicateLabel/2.kt
@@ -1,0 +1,8 @@
+// EXPECTED-KOTLINC-ERROR: DUPLICATE_LABEL_IN_WHEN
+// Same literal appears twice in a single comma-separated branch.
+fun describe(n: Int): String {
+    return when (n) {
+        1, 2, 1 -> "one or two"
+        else -> "other"
+    }
+}

--- a/tests/fixtures/precompile/positive/K0108-DuplicateLabel/3.kt
+++ b/tests/fixtures/precompile/positive/K0108-DuplicateLabel/3.kt
@@ -1,0 +1,10 @@
+// EXPECTED-KOTLINC-ERROR: DUPLICATE_LABEL_IN_WHEN
+// String literal labels: same constant string repeated.
+fun classify(tag: String): Int {
+    return when (tag) {
+        "yes" -> 1
+        "no" -> 0
+        "yes" -> 2
+        else -> -1
+    }
+}


### PR DESCRIPTION
## Summary
- Second precompile rule on the K0101 scaffold: `K0108-DuplicateLabel` flags repeated constant labels in a subject-bearing `when` expression, mirroring kotlinc's `DUPLICATE_LABEL_IN_WHEN`. `when (x) { 1 -> a; 1 -> b }` reports the second `1` as unreachable, including the first branch's line number in the message.
- AST-only and conservative by construction: only numeric, char, boolean, null, and non-interpolated string literals form a dedup key. Identifiers, qualified references, range tests, type tests, interpolated strings, and subject-less `when` are deliberately skipped — they need resolver context to deduplicate safely, so the rule fails closed.
- `DefaultActive: false` — precompile rules continue to ship opt-in until profile activation lands.

## Files
- `internal/rules/precompile_duplicate_label.go` — rule + `whenConditionDuplicateKey` helper
- `internal/rules/registry_precompile_duplicate_label.go` — registration
- `internal/rules/registry_bootstrap.go` — wire into init
- `tests/fixtures/precompile/{positive,negative}/K0108-DuplicateLabel/{1,2,3}.kt`

## Test plan
- [x] `go build -o krit ./cmd/krit/`
- [x] `go vet ./...`
- [x] `go test ./internal/rules/ ./internal/rules/api/ -count=1` (precompile conventions + positive/negative fixtures green)
- [x] 3 positive + 3 negative fixtures: numeric/string/comma-list duplicates, plus negatives for subject-less `when`, enum entries (identifier-shape), range tests, and interpolated strings
- [ ] `make integration` (skipped here; cache/blastradius/riskmap tests in this sandbox fail on pre-existing git-signing issues unrelated to the rule)

https://claude.ai/code/session_01ANL6LC1pJQfA9HxzBfnMU4

---
_Generated by [Claude Code](https://claude.ai/code/session_01ANL6LC1pJQfA9HxzBfnMU4)_