### PR TITLE
feat(rules): add autofixes for 8 mechanical-rewrite rules

### DIFF
--- a/internal/rules/comments.go
+++ b/internal/rules/comments.go
@@ -28,6 +28,53 @@ func flatKdocText(file *scanner.File, idx uint32) string {
 	return strings.Join(lines, "\n")
 }
 
+// endOfSentenceInsertOffsetFlat finds the byte offset (within file.Content)
+// where a `.` should be inserted to terminate the KDoc's first sentence. It
+// walks the raw KDoc text line by line, skipping blank/asterisk-only lines and
+// `@tag` lines, then returns the offset just after the last non-whitespace
+// character of the first content line — placed before any trailing ` */` or
+// newline. Returns -1 if no suitable line is found.
+func endOfSentenceInsertOffsetFlat(file *scanner.File, idx uint32) int {
+	startByte := int(file.FlatStartByte(idx))
+	endByte := int(file.FlatEndByte(idx))
+	if startByte < 0 || endByte > len(file.Content) || startByte >= endByte {
+		return -1
+	}
+	raw := file.Content[startByte:endByte]
+	pos := 0
+	for pos < len(raw) {
+		nl := pos
+		for nl < len(raw) && raw[nl] != '\n' {
+			nl++
+		}
+		line := raw[pos:nl]
+		stripped := strings.TrimSpace(string(line))
+		stripped = strings.TrimPrefix(stripped, "/**")
+		stripped = strings.TrimSpace(stripped)
+		stripped = strings.TrimPrefix(stripped, "*")
+		stripped = strings.TrimSuffix(stripped, "*/")
+		stripped = strings.TrimSpace(stripped)
+		if stripped == "" || strings.HasPrefix(stripped, "@") {
+			pos = nl + 1
+			continue
+		}
+		// Compute insertion offset within `line`: skip trailing whitespace,
+		// then strip a trailing `*/` and any whitespace before it.
+		e := len(line)
+		for e > 0 && (line[e-1] == ' ' || line[e-1] == '\t') {
+			e--
+		}
+		if e >= 2 && line[e-2] == '*' && line[e-1] == '/' {
+			e -= 2
+			for e > 0 && (line[e-1] == ' ' || line[e-1] == '\t') {
+				e--
+			}
+		}
+		return startByte + pos + e
+	}
+	return -1
+}
+
 type kdocLinkToken struct {
 	Target string
 	Offset int

--- a/internal/rules/comments.go
+++ b/internal/rules/comments.go
@@ -28,12 +28,6 @@ func flatKdocText(file *scanner.File, idx uint32) string {
 	return strings.Join(lines, "\n")
 }
 
-// endOfSentenceInsertOffsetFlat finds the byte offset (within file.Content)
-// where a `.` should be inserted to terminate the KDoc's first sentence. It
-// walks the raw KDoc text line by line, skipping blank/asterisk-only lines and
-// `@tag` lines, then returns the offset just after the last non-whitespace
-// character of the first content line — placed before any trailing ` */` or
-// newline. Returns -1 if no suitable line is found.
 func endOfSentenceInsertOffsetFlat(file *scanner.File, idx uint32) int {
 	startByte := int(file.FlatStartByte(idx))
 	endByte := int(file.FlatEndByte(idx))

--- a/internal/rules/fixes.go
+++ b/internal/rules/fixes.go
@@ -248,7 +248,7 @@ func (r *MissingSuperCallRule) IsFixable() bool              { return true }
 func (r *ForEachOnRangeRule) IsFixable() bool { return true }
 
 // Style classes / data class (new fixable)
-func (r *NestedClassesVisibilityRule) IsFixable() bool   { return true }
+func (r *NestedClassesVisibilityRule) IsFixable() bool    { return true }
 func (r *DataClassContainsFunctionsRule) IsFixable() bool { return true }
 
 // Comments quality (new fixable)

--- a/internal/rules/fixes.go
+++ b/internal/rules/fixes.go
@@ -256,7 +256,10 @@ func (r *EndOfSentenceFormatRule) IsFixable() bool   { return true }
 func (r *OutdatedDocumentationRule) IsFixable() bool { return true }
 
 // Potential-bugs (new fixable)
-func (r *UnusedUnaryOperatorRule) IsFixable() bool { return true }
+func (r *UnusedUnaryOperatorRule) IsFixable() bool   { return true }
+func (r *ImplicitDefaultLocaleRule) IsFixable() bool { return true }
+func (r *HardcodedDateFormatRule) IsFixable() bool   { return true }
+func (r *HardcodedNumberFormatRule) IsFixable() bool { return true }
 
 // Style2 not fixable — too many edge cases
 func (r *StringShouldBeRawStringRule) IsFixable() bool    { return false } // too complex: escape handling edge cases

--- a/internal/rules/fixes.go
+++ b/internal/rules/fixes.go
@@ -247,6 +247,17 @@ func (r *MissingSuperCallRule) IsFixable() bool              { return true }
 // Performance rules (new fixable)
 func (r *ForEachOnRangeRule) IsFixable() bool { return true }
 
+// Style classes / data class (new fixable)
+func (r *NestedClassesVisibilityRule) IsFixable() bool   { return true }
+func (r *DataClassContainsFunctionsRule) IsFixable() bool { return true }
+
+// Comments quality (new fixable)
+func (r *EndOfSentenceFormatRule) IsFixable() bool   { return true }
+func (r *OutdatedDocumentationRule) IsFixable() bool { return true }
+
+// Potential-bugs (new fixable)
+func (r *UnusedUnaryOperatorRule) IsFixable() bool { return true }
+
 // Style2 not fixable — too many edge cases
 func (r *StringShouldBeRawStringRule) IsFixable() bool    { return false } // too complex: escape handling edge cases
 func (r *MultilineLambdaItParameterRule) IsFixable() bool { return false } // too complex: it-reference disambiguation

--- a/internal/rules/potentialbugs_misc.go
+++ b/internal/rules/potentialbugs_misc.go
@@ -1398,6 +1398,25 @@ var implicitLocaleMethods = map[string]bool{
 	"decapitalize": true,
 }
 
+// implicitLocaleAcceptsLocaleArg lists the methods in implicitLocaleMethods
+// that have a Locale-taking overload on String. `capitalize` / `decapitalize`
+// do not, so they cannot be autofixed by appending `Locale.ROOT`.
+var implicitLocaleAcceptsLocaleArg = map[string]bool{
+	"toLowerCase": true,
+	"toUpperCase": true,
+}
+
+// implicitLocaleFileHasLocaleImport returns true when the file imports
+// java.util.Locale (or a wildcard that covers it). Used to gate the
+// `Locale.ROOT` autofix so we never reference an unimported symbol.
+func implicitLocaleFileHasLocaleImport(file *scanner.File) bool {
+	if file == nil {
+		return false
+	}
+	return sourceImportsOrMentions(file, "java.util.Locale") ||
+		sourceImportsOrMentions(file, "java.util.*")
+}
+
 func fileDeclaresStringFormatExtension(file *scanner.File) bool {
 	if file == nil {
 		return false

--- a/internal/rules/registry_comments.go
+++ b/internal/rules/registry_comments.go
@@ -100,7 +100,7 @@ func registerCommentsRules() {
 		r := &EndOfSentenceFormatRule{BaseRule: BaseRule{RuleName: "EndOfSentenceFormat", RuleSetName: "comments", Sev: "warning", Desc: "Detects KDoc first sentences that do not end with proper punctuation."}, Pattern: regexp.MustCompile(`([.?!][ \t\n\r])|([.?!]$)`)}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"multiline_comment"}, Confidence: 0.95, Implementation: r,
+			NodeTypes: []string{"multiline_comment"}, Confidence: 0.95, Fix: api.FixCosmetic, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				if scanner.IsTestFile(file.Path) || isGradleBuildScript(file.Path) {
@@ -117,10 +117,20 @@ func registerCommentsRules() {
 				if strings.HasPrefix(firstLine, "@") {
 					return
 				}
-				if !r.Pattern.MatchString(firstLine) {
-					ctx.EmitAt(file.FlatRow(idx)+1, 1,
-						"KDoc first sentence should end with proper punctuation.")
+				if r.Pattern.MatchString(firstLine) {
+					return
 				}
+				f := r.Finding(file, file.FlatRow(idx)+1, 1,
+					"KDoc first sentence should end with proper punctuation.")
+				if insertAt := endOfSentenceInsertOffsetFlat(file, idx); insertAt >= 0 {
+					f.Fix = &scanner.Fix{
+						ByteMode:    true,
+						StartByte:   insertAt,
+						EndByte:     insertAt,
+						Replacement: ".",
+					}
+				}
+				ctx.Emit(f)
 			},
 		})
 	}
@@ -183,7 +193,7 @@ func registerCommentsRules() {
 		r := &OutdatedDocumentationRule{BaseRule: BaseRule{RuleName: "OutdatedDocumentation", RuleSetName: "comments", Sev: "warning", Desc: "Detects @param tags in KDoc that do not match the actual function parameters."}, MatchDeclarationsOrder: true, MatchTypeParameters: true}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"function_declaration"}, Confidence: 0.95, Implementation: r,
+			NodeTypes: []string{"function_declaration"}, Confidence: 0.95, Fix: api.FixCosmetic, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				prev, ok := flatPrecedingKDoc(file, idx)
@@ -191,8 +201,8 @@ func registerCommentsRules() {
 					return
 				}
 				kdoc := file.FlatNodeText(prev)
-				docParams := paramTagRe.FindAllStringSubmatch(kdoc, -1)
-				if len(docParams) == 0 {
+				docParamIdx := paramTagRe.FindAllStringSubmatchIndex(kdoc, -1)
+				if len(docParamIdx) == 0 {
 					return
 				}
 				summary := getFunctionDeclSummaryFlat(file, idx)
@@ -214,12 +224,38 @@ func registerCommentsRules() {
 						orderedNames = append(orderedNames, param.name)
 					}
 				}
-				for _, dp := range docParams {
-					name := dp[1]
-					if !actualParams[name] {
-						ctx.EmitAt(file.FlatRow(prev)+1, 1,
-							"KDoc @param \""+name+"\" does not match any actual parameter.")
+				kdocStart := int(file.FlatStartByte(prev))
+				for _, m := range docParamIdx {
+					name := kdoc[m[2]:m[3]]
+					if actualParams[name] {
+						continue
 					}
+					f := r.Finding(file, file.FlatRow(prev)+1, 1,
+						"KDoc @param \""+name+"\" does not match any actual parameter.")
+					// Delete the full line containing this @param tag from the KDoc.
+					tagStart := m[0]
+					lineStart := tagStart
+					for lineStart > 0 && kdoc[lineStart-1] != '\n' {
+						lineStart--
+					}
+					lineEnd := m[1]
+					for lineEnd < len(kdoc) && kdoc[lineEnd] != '\n' {
+						lineEnd++
+					}
+					if lineEnd < len(kdoc) && kdoc[lineEnd] == '\n' {
+						lineEnd++
+					}
+					f.Fix = &scanner.Fix{
+						ByteMode:    true,
+						StartByte:   kdocStart + lineStart,
+						EndByte:     kdocStart + lineEnd,
+						Replacement: "",
+					}
+					ctx.Emit(f)
+				}
+				docParams := make([][]string, 0, len(docParamIdx))
+				for _, m := range docParamIdx {
+					docParams = append(docParams, []string{kdoc[m[0]:m[1]], kdoc[m[2]:m[3]]})
 				}
 				// MatchDeclarationsOrder: ensure the @param tags that
 				// reference real (or — when MatchTypeParameters is on —

--- a/internal/rules/registry_potentialbugs_misc.go
+++ b/internal/rules/registry_potentialbugs_misc.go
@@ -353,10 +353,7 @@ func registerPotentialbugsMiscRules() {
 					if args != 0 && implicitLocaleAcceptsLocaleArg[methodName] && implicitLocaleFileHasLocaleImport(file) {
 						argsEnd := int(file.FlatEndByte(args))
 						if argsEnd > 0 && argsEnd <= len(file.Content) && file.Content[argsEnd-1] == ')' {
-							// Use Locale.getDefault() to preserve the
-							// pre-fix runtime behavior (Locale.ROOT would
-							// silently change formatting/case behavior on
-							// non-default locales).
+							// getDefault() preserves pre-fix behavior; ROOT would silently change case rules.
 							f.Fix = &scanner.Fix{
 								ByteMode:    true,
 								StartByte:   argsEnd - 1,

--- a/internal/rules/registry_potentialbugs_misc.go
+++ b/internal/rules/registry_potentialbugs_misc.go
@@ -311,7 +311,7 @@ func registerPotentialbugsMiscRules() {
 		r := &ImplicitDefaultLocaleRule{BaseRule: BaseRule{RuleName: "ImplicitDefaultLocale", RuleSetName: "potential-bugs", Sev: "warning", Desc: "Detects locale-sensitive string methods called without an explicit Locale argument."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"call_expression"}, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"call_expression"}, Confidence: 0.75, Fix: api.FixSemantic, Implementation: r,
 			Needs: api.NeedsTypeInfo,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
@@ -348,8 +348,24 @@ func registerPotentialbugsMiscRules() {
 							return
 						}
 					}
-					ctx.EmitAt(file.FlatRow(idx)+1, file.FlatCol(idx)+1,
+					f := r.Finding(file, file.FlatRow(idx)+1, file.FlatCol(idx)+1,
 						fmt.Sprintf("'%s()' called without explicit Locale. Use '%s(Locale.ROOT)' or '%s(Locale.getDefault())' to be explicit.", methodName, methodName, methodName))
+					if args != 0 && implicitLocaleAcceptsLocaleArg[methodName] && implicitLocaleFileHasLocaleImport(file) {
+						argsEnd := int(file.FlatEndByte(args))
+						if argsEnd > 0 && argsEnd <= len(file.Content) && file.Content[argsEnd-1] == ')' {
+							// Use Locale.getDefault() to preserve the
+							// pre-fix runtime behavior (Locale.ROOT would
+							// silently change formatting/case behavior on
+							// non-default locales).
+							f.Fix = &scanner.Fix{
+								ByteMode:    true,
+								StartByte:   argsEnd - 1,
+								EndByte:     argsEnd - 1,
+								Replacement: "Locale.getDefault()",
+							}
+						}
+					}
+					ctx.Emit(f)
 					return
 				}
 
@@ -462,7 +478,7 @@ func registerPotentialbugsMiscRules() {
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
 			NodeTypes:  []string{"call_expression"},
 			Languages:  []scanner.Language{scanner.LangKotlin},
-			Confidence: r.Confidence(), Implementation: r,
+			Confidence: r.Confidence(), Fix: api.FixSemantic, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				navExpr, args := flatCallExpressionParts(file, idx)
@@ -487,8 +503,20 @@ func registerPotentialbugsMiscRules() {
 				if receiverText == "DateTimeFormatter" && !sourceImportsOrMentions(file, "java.time.format.DateTimeFormatter") {
 					return
 				}
-				ctx.EmitAt(file.FlatRow(idx)+1, file.FlatCol(idx)+1,
+				f := r.Finding(file, file.FlatRow(idx)+1, file.FlatCol(idx)+1,
 					"DateTimeFormatter.ofPattern(pattern) without explicit Locale. Pass Locale.ROOT for machine-readable formats or Locale.getDefault() to be explicit.")
+				if implicitLocaleFileHasLocaleImport(file) {
+					argsEnd := int(file.FlatEndByte(args))
+					if argsEnd > 0 && argsEnd <= len(file.Content) && file.Content[argsEnd-1] == ')' {
+						f.Fix = &scanner.Fix{
+							ByteMode:    true,
+							StartByte:   argsEnd - 1,
+							EndByte:     argsEnd - 1,
+							Replacement: ", Locale.getDefault()",
+						}
+					}
+				}
+				ctx.Emit(f)
 			},
 		})
 	}
@@ -498,7 +526,7 @@ func registerPotentialbugsMiscRules() {
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
 			NodeTypes:  []string{"call_expression"},
 			Languages:  []scanner.Language{scanner.LangKotlin},
-			Confidence: r.Confidence(), Implementation: r,
+			Confidence: r.Confidence(), Fix: api.FixSemantic, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				navExpr, args := flatCallExpressionParts(file, idx)
@@ -522,8 +550,20 @@ func registerPotentialbugsMiscRules() {
 					if argCount != 0 {
 						return
 					}
-					ctx.EmitAt(file.FlatRow(idx)+1, file.FlatCol(idx)+1,
+					f := r.Finding(file, file.FlatRow(idx)+1, file.FlatCol(idx)+1,
 						"NumberFormat.getInstance() without explicit Locale. Pass a Locale to produce stable, locale-aware formatting.")
+					if args != 0 && implicitLocaleFileHasLocaleImport(file) {
+						argsEnd := int(file.FlatEndByte(args))
+						if argsEnd > 0 && argsEnd <= len(file.Content) && file.Content[argsEnd-1] == ')' {
+							f.Fix = &scanner.Fix{
+								ByteMode:    true,
+								StartByte:   argsEnd - 1,
+								EndByte:     argsEnd - 1,
+								Replacement: "Locale.getDefault()",
+							}
+						}
+					}
+					ctx.Emit(f)
 					return
 				}
 

--- a/internal/rules/registry_potentialbugs_properties.go
+++ b/internal/rules/registry_potentialbugs_properties.go
@@ -193,7 +193,7 @@ func registerPotentialbugsPropertiesRules() {
 		r := &UnusedUnaryOperatorRule{BaseRule: BaseRule{RuleName: "UnusedUnaryOperator", RuleSetName: "potential-bugs", Sev: "warning", Desc: "Detects standalone unary +x or -x expressions whose result is never used."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"prefix_expression"}, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"prefix_expression"}, Confidence: 0.75, Fix: api.FixSemantic, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				if file.FlatChildCount(idx) < 2 {
@@ -233,8 +233,17 @@ func registerPotentialbugsPropertiesRules() {
 
 				row := file.FlatRow(idx) + 1
 				col := file.FlatCol(idx) + 1
-				ctx.EmitAt(row, col,
+				f := r.Finding(file, row, col,
 					fmt.Sprintf("Unused unary operator. The result of '%s' is not used.", text))
+				lineStart, lineEnd := nodeLineRange(file.Content,
+					int(file.FlatStartByte(topExpr)), int(file.FlatEndByte(topExpr)))
+				f.Fix = &scanner.Fix{
+					ByteMode:    true,
+					StartByte:   lineStart,
+					EndByte:     lineEnd,
+					Replacement: "",
+				}
+				ctx.Emit(f)
 			},
 		})
 	}

--- a/internal/rules/registry_style_classes.go
+++ b/internal/rules/registry_style_classes.go
@@ -315,7 +315,7 @@ func registerStyleDataClassContainsFunctions() {
 	r := &DataClassContainsFunctionsRule{BaseRule: BaseRule{RuleName: "DataClassContainsFunctions", RuleSetName: "style", Sev: "warning", Desc: "Detects data classes that contain function members."}, ConversionFunctionPrefix: []string{"to"}}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"class_declaration"}, Confidence: 0.75, Implementation: r,
+		NodeTypes: []string{"class_declaration"}, Confidence: 0.75, Fix: api.FixSemantic, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			if !file.FlatHasModifier(idx, "data") {
@@ -327,8 +327,22 @@ func registerStyleDataClassContainsFunctions() {
 			}
 			if dataClassHasNonConversionFunctionFlat(file, body, r.ConversionFunctionPrefix) {
 				name := extractIdentifierFlat(file, idx)
-				ctx.EmitAt(file.FlatRow(idx)+1, 1,
+				f := r.Finding(file, file.FlatRow(idx)+1, 1,
 					fmt.Sprintf("Data class '%s' contains functions. Consider using a regular class.", name))
+				if modNode := file.FlatFindModifierNode(idx, "data"); modNode != 0 {
+					startByte := int(file.FlatStartByte(modNode))
+					endByte := int(file.FlatEndByte(modNode))
+					for endByte < len(file.Content) && (file.Content[endByte] == ' ' || file.Content[endByte] == '\t') {
+						endByte++
+					}
+					f.Fix = &scanner.Fix{
+						ByteMode:    true,
+						StartByte:   startByte,
+						EndByte:     endByte,
+						Replacement: "",
+					}
+				}
+				ctx.Emit(f)
 			}
 		},
 	})
@@ -392,7 +406,7 @@ func registerStyleNestedClassesVisibility() {
 	r := &NestedClassesVisibilityRule{BaseRule: BaseRule{RuleName: "NestedClassesVisibility", RuleSetName: "style", Sev: "warning", Desc: "Detects nested classes with explicit public modifier inside internal parent classes."}}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"class_declaration"}, Confidence: 0.75, Implementation: r,
+		NodeTypes: []string{"class_declaration"}, Confidence: 0.75, Fix: api.FixCosmetic, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			parent, ok := file.FlatParent(idx)
@@ -433,8 +447,22 @@ func registerStyleNestedClassesVisibility() {
 					continue
 				}
 				name := extractIdentifierFlat(file, child)
-				ctx.EmitAt(file.FlatRow(child)+1, 1,
+				f := r.Finding(file, file.FlatRow(child)+1, 1,
 					fmt.Sprintf("The nested class '%s' has an explicit public modifier. Within an internal class this is misleading, as the nested class is still internal.", name))
+				if modNode := file.FlatFindModifierNode(child, "public"); modNode != 0 {
+					startByte := int(file.FlatStartByte(modNode))
+					endByte := int(file.FlatEndByte(modNode))
+					for endByte < len(file.Content) && (file.Content[endByte] == ' ' || file.Content[endByte] == '\t') {
+						endByte++
+					}
+					f.Fix = &scanner.Fix{
+						ByteMode:    true,
+						StartByte:   startByte,
+						EndByte:     endByte,
+						Replacement: "",
+					}
+				}
+				ctx.Emit(f)
 			}
 		},
 	})

--- a/tests/fixtures/fixable/per-rule/DataClassContainsFunctions.kt
+++ b/tests/fixtures/fixable/per-rule/DataClassContainsFunctions.kt
@@ -1,0 +1,5 @@
+package style
+
+data class User(val name: String, val age: Int) {
+    fun greet() = "Hello, $name"
+}

--- a/tests/fixtures/fixable/per-rule/DataClassContainsFunctions.kt.expected
+++ b/tests/fixtures/fixable/per-rule/DataClassContainsFunctions.kt.expected
@@ -1,0 +1,5 @@
+package style
+
+class User(val name: String, val age: Int) {
+    fun greet() = "Hello, $name"
+}

--- a/tests/fixtures/fixable/per-rule/EndOfSentenceFormat.kt
+++ b/tests/fixtures/fixable/per-rule/EndOfSentenceFormat.kt
@@ -1,0 +1,11 @@
+package comments
+
+/** This does something */
+fun doSomething() {
+    println("hello")
+}
+
+/**
+ * Returns the user
+ */
+fun getUser(): String = "user"

--- a/tests/fixtures/fixable/per-rule/EndOfSentenceFormat.kt.expected
+++ b/tests/fixtures/fixable/per-rule/EndOfSentenceFormat.kt.expected
@@ -1,0 +1,11 @@
+package comments
+
+/** This does something. */
+fun doSomething() {
+    println("hello")
+}
+
+/**
+ * Returns the user.
+ */
+fun getUser(): String = "user"

--- a/tests/fixtures/fixable/per-rule/HardcodedDateFormat.kt
+++ b/tests/fixtures/fixable/per-rule/HardcodedDateFormat.kt
@@ -1,0 +1,8 @@
+package potentialbugs
+
+import java.time.format.DateTimeFormatter
+import java.util.Locale
+
+class HardcodedDateFormat {
+    val formatter: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd")
+}

--- a/tests/fixtures/fixable/per-rule/HardcodedDateFormat.kt.expected
+++ b/tests/fixtures/fixable/per-rule/HardcodedDateFormat.kt.expected
@@ -1,0 +1,8 @@
+package potentialbugs
+
+import java.time.format.DateTimeFormatter
+import java.util.Locale
+
+class HardcodedDateFormat {
+    val formatter: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd", Locale.getDefault())
+}

--- a/tests/fixtures/fixable/per-rule/HardcodedNumberFormat.kt
+++ b/tests/fixtures/fixable/per-rule/HardcodedNumberFormat.kt
@@ -1,0 +1,8 @@
+package potentialbugs
+
+import java.text.NumberFormat
+import java.util.Locale
+
+class HardcodedNumberFormat {
+    val formatter: NumberFormat = NumberFormat.getInstance()
+}

--- a/tests/fixtures/fixable/per-rule/HardcodedNumberFormat.kt.expected
+++ b/tests/fixtures/fixable/per-rule/HardcodedNumberFormat.kt.expected
@@ -1,0 +1,8 @@
+package potentialbugs
+
+import java.text.NumberFormat
+import java.util.Locale
+
+class HardcodedNumberFormat {
+    val formatter: NumberFormat = NumberFormat.getInstance(Locale.getDefault())
+}

--- a/tests/fixtures/fixable/per-rule/ImplicitDefaultLocale.kt
+++ b/tests/fixtures/fixable/per-rule/ImplicitDefaultLocale.kt
@@ -1,0 +1,13 @@
+package potentialbugs
+
+import java.util.Locale
+
+class ImplicitDefaultLocale {
+    fun shout(s: String): String {
+        return s.toUpperCase()
+    }
+
+    fun whisper(s: String): String {
+        return s.toLowerCase()
+    }
+}

--- a/tests/fixtures/fixable/per-rule/ImplicitDefaultLocale.kt.expected
+++ b/tests/fixtures/fixable/per-rule/ImplicitDefaultLocale.kt.expected
@@ -1,0 +1,13 @@
+package potentialbugs
+
+import java.util.Locale
+
+class ImplicitDefaultLocale {
+    fun shout(s: String): String {
+        return s.toUpperCase(Locale.getDefault())
+    }
+
+    fun whisper(s: String): String {
+        return s.toLowerCase(Locale.getDefault())
+    }
+}

--- a/tests/fixtures/fixable/per-rule/NestedClassesVisibility.kt
+++ b/tests/fixtures/fixable/per-rule/NestedClassesVisibility.kt
@@ -1,0 +1,6 @@
+package style
+
+internal class Outer {
+    public class Nested
+    public object NestedObject
+}

--- a/tests/fixtures/fixable/per-rule/NestedClassesVisibility.kt.expected
+++ b/tests/fixtures/fixable/per-rule/NestedClassesVisibility.kt.expected
@@ -1,0 +1,6 @@
+package style
+
+internal class Outer {
+    class Nested
+    object NestedObject
+}

--- a/tests/fixtures/fixable/per-rule/OutdatedDocumentation.kt
+++ b/tests/fixtures/fixable/per-rule/OutdatedDocumentation.kt
@@ -1,0 +1,11 @@
+package comments
+
+class Example {
+    /**
+     * Processes the input.
+     * @param x the input value.
+     */
+    fun process(y: Int): Int {
+        return y * 2
+    }
+}

--- a/tests/fixtures/fixable/per-rule/OutdatedDocumentation.kt.expected
+++ b/tests/fixtures/fixable/per-rule/OutdatedDocumentation.kt.expected
@@ -1,0 +1,10 @@
+package comments
+
+class Example {
+    /**
+     * Processes the input.
+     */
+    fun process(y: Int): Int {
+        return y * 2
+    }
+}

--- a/tests/fixtures/fixable/per-rule/UnusedUnaryOperator.kt
+++ b/tests/fixtures/fixable/per-rule/UnusedUnaryOperator.kt
@@ -1,0 +1,11 @@
+package fixtures.positive.potentialbugs
+
+class UnusedUnaryOperator {
+    fun standalone(x: Int) {
+        +x
+    }
+
+    fun standaloneMinus(x: Int) {
+        -x
+    }
+}

--- a/tests/fixtures/fixable/per-rule/UnusedUnaryOperator.kt.expected
+++ b/tests/fixtures/fixable/per-rule/UnusedUnaryOperator.kt.expected
@@ -1,0 +1,9 @@
+package fixtures.positive.potentialbugs
+
+class UnusedUnaryOperator {
+    fun standalone(x: Int) {
+    }
+
+    fun standaloneMinus(x: Int) {
+    }
+}


### PR DESCRIPTION
## Summary
- Adds autofixes for 5 mechanical-rewrite rules: NestedClassesVisibility (remove `public`), DataClassContainsFunctions (remove `data`), UnusedUnaryOperator (delete statement), EndOfSentenceFormat (append `.`), OutdatedDocumentation (delete stale `@param` line)
- Adds autofixes for 3 locale-explicit rules: ImplicitDefaultLocale, HardcodedDateFormat, HardcodedNumberFormat — inserts `Locale.getDefault()` to make locale usage explicit while preserving runtime behavior
- All fixes use byte-mode spans; locale fixes are gated on `java.util.Locale` import presence

## Test plan
- [x] `go build` compiles
- [x] `go test ./... -count=1` passes
- [x] `make integration` passes (11/11)
- [x] Per-rule fixable fixtures added for all 8 rules with `.kt` and `.kt.expected` pairs
- [x] `TestFixableRulesHavePerRuleFixture` passes