### PR TITLE
docs(PluralsBuiltWithIfElse): document precision-over-recall identifier set

### DIFF
--- a/internal/rules/i18n_plurals.go
+++ b/internal/rules/i18n_plurals.go
@@ -12,6 +12,12 @@ import (
 	"github.com/kaeawc/krit/internal/scanner"
 )
 
+// pluralsIfElseCountNames is intentionally narrower than pluralsCountNames:
+// this rule only fires on identifiers that strongly imply a localizable
+// count. Compound names like itemCount, userCount, or messageQuantity are
+// not matched — we prefer precision over recall here because the
+// if/else-to-getQuantityString suggestion is intrusive and noisy when
+// wrong (DB row counts, log tags, JSON sizes).
 var pluralsIfElseCountNames = map[string]bool{
 	"count": true, "quantity": true,
 }


### PR DESCRIPTION
## Summary
- Addresses review feedback on #165: document why `pluralsIfElseCountNames` is intentionally narrower than `pluralsCountNames` and why compound names like `itemCount`/`messageQuantity` are not matched.

## Test plan
- [x] `go build -o krit ./cmd/krit/`
- [x] `go vet ./...`
- Comment-only change; no behavior impact.