### PR TITLE
fix(rules): tighten brace-wrap fix to preserve comments and inline RHS

### DIFF
--- a/internal/rules/style_braces.go
+++ b/internal/rules/style_braces.go
@@ -19,18 +19,34 @@ func controlBodyHasBraces(file *scanner.File, body uint32) bool {
 // buildBraceWrapFix wraps a single-statement control body in braces while
 // preserving the column the body already sits at (or one step deeper than
 // the header for inline forms) so the result stays ktfmt-compatible.
+// Returns nil when the control header is not the first non-whitespace on
+// its line (e.g. inline RHS `val r = if (x) y else z`): the surrounding
+// indentation is not strong enough to derive a safe placement for the
+// closing brace, so we emit only the finding without a fix.
 func buildBraceWrapFix(file *scanner.File, control, body uint32) *scanner.Fix {
+	controlStart := int(file.FlatStartByte(control))
+	if !isFirstNonWSOnLine(file.Content, controlStart) {
+		return nil
+	}
 	bodyTrimmed := strings.TrimSpace(file.FlatNodeText(body))
 
-	parentIndent := detectIndent(file.Content, int(file.FlatStartByte(control)))
-	bodyIndent := parentIndent + "    "
+	parentIndent := detectIndent(file.Content, controlStart)
+	bodyIndent := parentIndent + indentStep(parentIndent)
 	if file.FlatRow(body) != file.FlatRow(control) {
 		bodyIndent = detectIndent(file.Content, int(file.FlatStartByte(body)))
 	}
 
+	// Extend the replacement range back from body's start byte over plain
+	// whitespace only so the new `{` lands on the header line. Stop at any
+	// non-whitespace byte (including the end of a comment that sits between
+	// the header `)` and the body) so we never delete that text.
 	startByte := int(file.FlatStartByte(body))
-	if prev, ok := file.FlatPrevSibling(body); ok {
-		startByte = int(file.FlatEndByte(prev))
+	for startByte > 0 {
+		c := file.Content[startByte-1]
+		if c != ' ' && c != '\t' && c != '\n' && c != '\r' {
+			break
+		}
+		startByte--
 	}
 
 	return &scanner.Fix{
@@ -39,6 +55,35 @@ func buildBraceWrapFix(file *scanner.File, control, body uint32) *scanner.Fix {
 		EndByte:     int(file.FlatEndByte(body)),
 		Replacement: " {\n" + bodyIndent + bodyTrimmed + "\n" + parentIndent + "}",
 	}
+}
+
+// isFirstNonWSOnLine distinguishes statement-position control flow from
+// inline RHS forms where wrapping with our derived indent would misalign.
+func isFirstNonWSOnLine(content []byte, byteOffset int) bool {
+	if byteOffset < 0 || byteOffset >= len(content) {
+		return false
+	}
+	for i := byteOffset - 1; i >= 0; i-- {
+		c := content[i]
+		if c == '\n' {
+			return true
+		}
+		if c != ' ' && c != '\t' {
+			return false
+		}
+	}
+	return true
+}
+
+// indentStep returns the indentation unit (tab or 4 spaces) to add for one
+// nesting level. Uses tab when the parent indent itself is tab-based so we
+// stay consistent with the file's indentation style; otherwise defaults to
+// 4 spaces (ktfmt-kotlinlang default).
+func indentStep(parentIndent string) string {
+	if strings.ContainsRune(parentIndent, '\t') {
+		return "\t"
+	}
+	return "    "
 }
 
 // BracesOnIfStatementsRule enforces braces on if statements.

--- a/internal/rules/style_braces_test.go
+++ b/internal/rules/style_braces_test.go
@@ -3,6 +3,7 @@ package rules
 import (
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
 
@@ -288,6 +289,88 @@ fun example(x: Int): String {
 	findings := d.Run(file)
 	if findings.Len() != 0 {
 		t.Fatalf("expected no findings for test sources, got %d", findings.Len())
+	}
+}
+
+func applyFixes(src string, cols scanner.FindingColumns) string {
+	type edit struct {
+		start, end int
+		repl       string
+	}
+	var edits []edit
+	for i := 0; i < cols.Len(); i++ {
+		fx := cols.FixAt(i)
+		if fx == nil || !fx.ByteMode {
+			continue
+		}
+		edits = append(edits, edit{fx.StartByte, fx.EndByte, fx.Replacement})
+	}
+	// Descending order so earlier edits don't shift later byte offsets.
+	sort.Slice(edits, func(i, j int) bool { return edits[i].start > edits[j].start })
+	out := []byte(src)
+	for _, e := range edits {
+		out = append(out[:e.start], append([]byte(e.repl), out[e.end:]...)...)
+	}
+	return string(out)
+}
+
+// TestBuildBraceWrapFix_InlineRHS_NoFix verifies the helper does not emit a
+// fix when the control header is not the first non-whitespace on its line.
+// Wrapping `val r = if (x) y` with the parent line's indent puts the closing
+// brace flush-left under `val r =` instead of aligned with `if`, which is
+// not ktfmt-compatible — better to flag and let the user resolve.
+func TestBuildBraceWrapFix_InlineRHS_NoFix(t *testing.T) {
+	findings := runBracesIfRule(t, "always", "always", `
+package test
+fun example(x: Boolean): Int {
+    val r = if (x) 1 else 2
+    return r
+}`)
+	if findings.Len() == 0 {
+		t.Fatal("expected at least one finding for inline RHS if")
+	}
+	for i := 0; i < findings.Len(); i++ {
+		if findings.FixAt(i) != nil {
+			t.Errorf("expected no fix for inline RHS if at finding %d, got fix=%+v", i, findings.FixAt(i))
+		}
+	}
+}
+
+// TestBuildBraceWrapFix_PreservesCommentBetweenHeaderAndBody verifies that a
+// comment sitting between `)` and the body is not swallowed by the
+// replacement range. Previously the helper extended back to the prev
+// sibling's end byte, which deleted any intervening comment.
+func TestBuildBraceWrapFix_PreservesCommentBetweenHeaderAndBody(t *testing.T) {
+	src := `package test
+fun example(x: Boolean) {
+    if (x) /* keep me */
+        println("ok")
+}
+`
+	findings := runBracesIfRule(t, "always", "always", src)
+	if findings.Len() == 0 {
+		t.Fatal("expected finding for unbraced if")
+	}
+	out := applyFixes(src, findings)
+	if !strings.Contains(out, "/* keep me */") {
+		t.Errorf("comment between header and body was lost. Output:\n%s", out)
+	}
+}
+
+// TestBuildBraceWrapFix_TabIndentedFile verifies the body indent uses a tab
+// step when the surrounding file is tab-indented, instead of hardcoding
+// four spaces (which would mix tabs and spaces).
+func TestBuildBraceWrapFix_TabIndentedFile(t *testing.T) {
+	src := "package test\nfun example(x: Boolean) {\n\tif (x) println(\"ok\")\n}\n"
+	findings := runBracesIfRule(t, "always", "always", src)
+	if findings.Len() == 0 {
+		t.Fatal("expected finding for unbraced if")
+	}
+	out := applyFixes(src, findings)
+	// Body line should start with two tabs (one for the surrounding fun, one
+	// for the new brace nesting), not a tab followed by spaces.
+	if !strings.Contains(out, "\n\t\tprintln(") {
+		t.Errorf("expected tab-stepped body indent in tab-indented file. Output:\n%q", out)
 	}
 }
 


### PR DESCRIPTION
## Summary
- `buildBraceWrapFix` previously used `FlatPrevSibling` to extend the replacement range back to the header, which silently deleted any comment sitting between `)` and the body. Replaced with a backward whitespace-only walk so comments are preserved.
- Hardcoded `parentIndent + \"    \"` mixed spaces into tab-indented files. Added `indentStep(parentIndent)` that picks `\t` when the parent indent contains tabs, else 4 spaces (ktfmt-kotlinlang default).
- For inline RHS (`val r = if (x) y else z`) and `} else if` chains the derived indent placed the closing `}` flush-left under the outer statement, not aligned with the `if`. The helper now returns `nil` when the control header is not the first non-whitespace on its line, so the finding still fires but no broken fix is offered.

## Test plan
- [x] `go test ./internal/rules/ -count=1`
- [x] `go test ./... -count=1`
- [x] `go vet ./...`
- [x] Three new regression tests: inline RHS yields no fix, comment between header and body is preserved, tab-indented file gets tab-stepped body indent.