### PR TITLE
feat(precompile): add K0206-DuplicateDeclaration

### DIFF
--- a/internal/rules/precompile_duplicate_declaration.go
+++ b/internal/rules/precompile_duplicate_declaration.go
@@ -1,0 +1,127 @@
+package rules
+
+import (
+	"fmt"
+	"strings"
+
+	api "github.com/kaeawc/krit/internal/rules/api"
+	"github.com/kaeawc/krit/internal/scanner"
+)
+
+// PrecompileDuplicateDeclarationRule flags two top-level declarations in
+// the same file that share a name and (for functions) a matching parameter
+// type signature. Mirrors kotlinc's CONFLICTING_OVERLOADS / REDECLARATION
+// diagnostics, restricted to the file-local subset:
+//
+//   - Only direct children of source_file are considered.
+//   - Two `fun foo(x: Int)` declarations conflict; `fun foo(x: Int)` and
+//     `fun foo(x: String)` do not (overloads).
+//   - Two top-level `class Foo` declarations conflict.
+//   - Two top-level `val foo` declarations conflict.
+//   - Cross-file redeclaration is out of scope (requires NeedsCrossFile).
+//   - Conflicts across different declaration kinds (e.g. class vs val) are
+//     not flagged here; that case needs broader semantics.
+//
+// Parameter type comparison is textual against the tree-sitter type node.
+// This is conservative: aliases that resolve to the same type read as
+// distinct here, so this rule will sometimes miss real conflicts that a
+// resolver-backed pass would catch. It does not produce false positives.
+type PrecompileDuplicateDeclarationRule struct {
+	FlatDispatchBase
+	BaseRule
+}
+
+func (r *PrecompileDuplicateDeclarationRule) Confidence() float64 { return 0.9 }
+
+func (r *PrecompileDuplicateDeclarationRule) check(ctx *api.Context) {
+	idx, file := ctx.Idx, ctx.File
+	seen := map[string]uint32{}
+	for child := file.FlatFirstChild(idx); child != 0; child = file.FlatNextSib(child) {
+		var kind, name, sig string
+		switch file.FlatType(child) {
+		case "function_declaration":
+			kind = "fun"
+			name = overrideEnclosingClassName(file, child)
+			sig = duplicateDeclFunctionSignature(file, child)
+		case "class_declaration":
+			kind = "class"
+			name = overrideEnclosingClassName(file, child)
+		case "property_declaration":
+			kind = "val"
+			name = duplicateDeclPropertyName(file, child)
+		default:
+			continue
+		}
+		if name == "" {
+			continue
+		}
+		key := kind + "|" + name + "|" + sig
+		if first, dup := seen[key]; dup {
+			ctx.EmitAt(file.FlatRow(child)+1, file.FlatCol(child)+1,
+				fmt.Sprintf("Duplicate top-level %s declaration `%s`; already declared on line %d.",
+					kind, name, file.FlatRow(first)+1))
+			continue
+		}
+		seen[key] = child
+	}
+}
+
+// duplicateDeclPropertyName extracts the bound name from a property
+// declaration. Destructuring declarations (`val (a, b) = pair`) bind
+// multiple names and are skipped to avoid ambiguous keys.
+func duplicateDeclPropertyName(file *scanner.File, idx uint32) string {
+	for child := file.FlatFirstChild(idx); child != 0; child = file.FlatNextSib(child) {
+		switch file.FlatType(child) {
+		case "variable_declaration":
+			for sub := file.FlatFirstChild(child); sub != 0; sub = file.FlatNextSib(sub) {
+				if file.FlatType(sub) == "simple_identifier" {
+					return strings.TrimSpace(file.FlatNodeText(sub))
+				}
+			}
+		case "multi_variable_declaration":
+			return ""
+		}
+	}
+	return ""
+}
+
+// duplicateDeclFunctionSignature returns a normalized text of the
+// parameter type list of a function declaration. Receiver type, return
+// type, default values, and parameter names are ignored — only the
+// ordered parameter type texts determine overload identity.
+func duplicateDeclFunctionSignature(file *scanner.File, idx uint32) string {
+	params, ok := file.FlatFindChild(idx, "function_value_parameters")
+	if !ok {
+		return "()"
+	}
+	var parts []string
+	for child := file.FlatFirstChild(params); child != 0; child = file.FlatNextSib(child) {
+		if file.FlatType(child) != "parameter" {
+			continue
+		}
+		parts = append(parts, duplicateDeclParameterType(file, child))
+	}
+	return "(" + strings.Join(parts, ",") + ")"
+}
+
+// duplicateDeclParameterType returns the trimmed, whitespace-normalized
+// text of a parameter's type node. Returns "?" for unparseable
+// parameters so that two such parameters do not collide by accident.
+func duplicateDeclParameterType(file *scanner.File, paramIdx uint32) string {
+	seenColon := false
+	for sub := file.FlatFirstChild(paramIdx); sub != 0; sub = file.FlatNextSib(sub) {
+		if file.FlatType(sub) == ":" {
+			seenColon = true
+			continue
+		}
+		if !seenColon {
+			continue
+		}
+		if !file.FlatIsNamed(sub) {
+			continue
+		}
+		text := strings.TrimSpace(file.FlatNodeText(sub))
+		return strings.Join(strings.Fields(text), "")
+	}
+	return "?"
+}

--- a/internal/rules/registry_bootstrap.go
+++ b/internal/rules/registry_bootstrap.go
@@ -96,6 +96,7 @@ func init() {
 	registerPrecompileUnreachableCodeRules()
 	registerPrecompileDuplicateLabelRules()
 	registerPrecompileDeprecatedSymbolUsedErrorRules()
+	registerPrecompileDuplicateDeclarationRules()
 	registerCorrectnessOverrideRules()
 	registerCorrectnessAbstractRules()
 	registerPrivacyAnalyticsRules()

--- a/internal/rules/registry_precompile_duplicate_declaration.go
+++ b/internal/rules/registry_precompile_duplicate_declaration.go
@@ -1,0 +1,25 @@
+package rules
+
+import (
+	api "github.com/kaeawc/krit/internal/rules/api"
+)
+
+func registerPrecompileDuplicateDeclarationRules() {
+	r := &PrecompileDuplicateDeclarationRule{BaseRule: BaseRule{
+		RuleName:    "K0206-DuplicateDeclaration",
+		RuleSetName: api.CategoryPrecompile,
+		Sev:         string(api.SeverityError),
+		Desc:        "Detects two top-level fun/class/val declarations in one file with the same name and (for functions) matching parameter type signature. Mirrors kotlinc's CONFLICTING_OVERLOADS / REDECLARATION for the file-local subset.",
+	}}
+	api.Register(&api.Rule{
+		ID:             r.RuleName,
+		Category:       r.RuleSetName,
+		Description:    r.Desc,
+		Sev:            api.Severity(r.Sev),
+		NodeTypes:      []string{"source_file"},
+		Confidence:     r.Confidence(),
+		Implementation: r,
+		Check:          r.check,
+		DefaultActive:  false,
+	})
+}

--- a/tests/fixtures/precompile/negative/K0206-DuplicateDeclaration/1.kt
+++ b/tests/fixtures/precompile/negative/K0206-DuplicateDeclaration/1.kt
@@ -1,0 +1,6 @@
+// Negative: distinct overloads — different parameter types.
+fun greet(name: String): String = "hi $name"
+
+fun greet(name: Int): String = "hi #$name"
+
+fun greet(first: String, last: String): String = "hi $first $last"

--- a/tests/fixtures/precompile/negative/K0206-DuplicateDeclaration/2.kt
+++ b/tests/fixtures/precompile/negative/K0206-DuplicateDeclaration/2.kt
@@ -1,0 +1,11 @@
+// Negative: same-named functions in nested scopes are not top-level
+// duplicates; the rule only walks direct children of source_file.
+class Outer {
+    fun greet(name: String): String = "hi $name"
+}
+
+object Helpers {
+    fun greet(name: String): String = "hello $name"
+}
+
+fun greet(name: String): String = "top-level"

--- a/tests/fixtures/precompile/negative/K0206-DuplicateDeclaration/3.kt
+++ b/tests/fixtures/precompile/negative/K0206-DuplicateDeclaration/3.kt
@@ -1,0 +1,8 @@
+// Negative: distinct top-level declarations.
+class Foo(val n: Int)
+
+val bar: Int = 1
+
+fun baz(): Int = 0
+
+fun baz(label: String): Int = label.length

--- a/tests/fixtures/precompile/positive/K0206-DuplicateDeclaration/1.kt
+++ b/tests/fixtures/precompile/positive/K0206-DuplicateDeclaration/1.kt
@@ -1,0 +1,5 @@
+// EXPECTED-KOTLINC-ERROR: CONFLICTING_OVERLOADS
+// Two top-level functions with identical name and parameter types.
+fun greet(name: String): String = "hi $name"
+
+fun greet(name: String): String = "hello $name"

--- a/tests/fixtures/precompile/positive/K0206-DuplicateDeclaration/2.kt
+++ b/tests/fixtures/precompile/positive/K0206-DuplicateDeclaration/2.kt
@@ -1,0 +1,5 @@
+// EXPECTED-KOTLINC-ERROR: REDECLARATION
+// Two top-level classes with identical name.
+class Holder(val n: Int)
+
+class Holder(val s: String)

--- a/tests/fixtures/precompile/positive/K0206-DuplicateDeclaration/3.kt
+++ b/tests/fixtures/precompile/positive/K0206-DuplicateDeclaration/3.kt
@@ -1,0 +1,5 @@
+// EXPECTED-KOTLINC-ERROR: REDECLARATION
+// Two top-level vals with the same name.
+val limit: Int = 10
+
+val limit: Int = 20


### PR DESCRIPTION
## Summary
- New precompile rule `K0206-DuplicateDeclaration` flags two top-level `fun`/`class`/`val` declarations in the same file that share a name and (for functions) the same parameter type signature.
- File-local subset of kotlinc's CONFLICTING_OVERLOADS / REDECLARATION. Overloads with different parameter types and cross-file redeclaration are out of scope.
- Dispatched once per `source_file`; single pass over top-level children. `DefaultActive: false`, severity `error`, per precompile taxonomy.

## Test plan
- [x] `go build ./...` and `go vet ./...`
- [x] `make lint-rules`
- [x] `go test ./internal/rules/ -count=1` (precompile conventions + positive/negative fixture tests pass for new rule)
- [x] Smoke test: CLI flags duplicates in positive fixtures, none in negatives