### PR TITLE
fix(K0108-DuplicateLabel): detect duplicate null, normalize integer literals

### DIFF
--- a/internal/rules/precompile_duplicate_label.go
+++ b/internal/rules/precompile_duplicate_label.go
@@ -2,6 +2,7 @@ package rules
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	api "github.com/kaeawc/krit/internal/rules/api"
@@ -58,31 +59,87 @@ func (r *PrecompileDuplicateLabelRule) check(ctx *api.Context) {
 // whenConditionDuplicateKey returns a stable key when cond is a constant
 // label safe to deduplicate without resolver context. Returns "" for
 // non-literal conditions so the rule fails closed.
+//
+// Integer literals are normalized (underscore separators stripped,
+// hex/binary forms canonicalized to decimal) so kotlinc-equivalent forms
+// like `0x01` and `1` dedupe. String, char, and real literals are compared
+// textually, so escape-sequence-equivalent forms (e.g. "a" vs "a")
+// are not deduped — false negatives, not false positives.
 func whenConditionDuplicateKey(file *scanner.File, cond uint32) string {
+	// `null` is emitted as a sole non-named token child of when_condition.
+	first := file.FlatFirstChild(cond)
+	if first != 0 && file.FlatNextSib(first) == 0 && file.FlatType(first) == "null" {
+		return "null"
+	}
 	var named uint32
-	count := 0
-	for child := file.FlatFirstChild(cond); child != 0; child = file.FlatNextSib(child) {
+	namedCount := 0
+	for child := first; child != 0; child = file.FlatNextSib(child) {
 		if !file.FlatIsNamed(child) {
 			continue
 		}
-		count++
+		namedCount++
 		named = child
 	}
-	if count != 1 {
+	if namedCount != 1 {
 		return ""
 	}
 	switch file.FlatType(named) {
-	case "integer_literal", "hex_literal", "bin_literal", "real_literal",
-		"boolean_literal", "character_literal", "long_literal",
-		"unsigned_literal", "null_literal", "null":
-		return strings.TrimSpace(file.FlatNodeText(named))
+	case "integer_literal", "hex_literal", "bin_literal", "long_literal",
+		"unsigned_literal":
+		return normalizeIntegerLiteral(file.FlatNodeText(named))
+	case "real_literal", "boolean_literal", "character_literal",
+		"null_literal":
+		return file.FlatNodeText(named)
 	case "string_literal", "line_string_literal":
 		if stringLiteralHasInterpolation(file, named) {
 			return ""
 		}
-		return strings.TrimSpace(file.FlatNodeText(named))
+		return file.FlatNodeText(named)
 	}
 	return ""
+}
+
+// normalizeIntegerLiteral canonicalizes a Kotlin integer literal so
+// equivalent forms (underscore separators, hex/binary prefixes) produce
+// the same key. The L/u/uL suffix is preserved as a type marker because
+// `1L` and `1` are distinct constants to kotlinc.
+func normalizeIntegerLiteral(raw string) string {
+	if raw == "" {
+		return ""
+	}
+	s := raw
+	suffix := ""
+	for len(s) > 0 {
+		last := s[len(s)-1]
+		if last == 'L' || last == 'u' || last == 'U' {
+			suffix = string(last) + suffix
+			s = s[:len(s)-1]
+			continue
+		}
+		break
+	}
+	if strings.Contains(s, "_") {
+		s = strings.ReplaceAll(s, "_", "")
+	}
+	if s == "" {
+		return raw
+	}
+	var (
+		val uint64
+		err error
+	)
+	switch {
+	case len(s) > 2 && s[0] == '0' && (s[1] == 'x' || s[1] == 'X'):
+		val, err = strconv.ParseUint(s[2:], 16, 64)
+	case len(s) > 2 && s[0] == '0' && (s[1] == 'b' || s[1] == 'B'):
+		val, err = strconv.ParseUint(s[2:], 2, 64)
+	default:
+		val, err = strconv.ParseUint(s, 10, 64)
+	}
+	if err != nil {
+		return raw
+	}
+	return strconv.FormatUint(val, 10) + suffix
 }
 
 func stringLiteralHasInterpolation(file *scanner.File, idx uint32) bool {

--- a/internal/rules/precompile_duplicate_label_test.go
+++ b/internal/rules/precompile_duplicate_label_test.go
@@ -1,0 +1,42 @@
+package rules
+
+import "testing"
+
+func TestNormalizeIntegerLiteral(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"1", "1"},
+		{"1_000", "1000"},
+		{"0x01", "1"},
+		{"0X0a", "10"},
+		{"0b0001", "1"},
+		{"0B1010", "10"},
+		{"1000", "1000"},
+		{"1L", "1L"},
+		{"0x01L", "1L"},
+		{"1u", "1u"},
+		{"1uL", "1uL"},
+	}
+	for _, c := range cases {
+		if got := normalizeIntegerLiteral(c.in); got != c.want {
+			t.Errorf("normalizeIntegerLiteral(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestNormalizeIntegerLiteralEquivalenceClasses(t *testing.T) {
+	groups := [][]string{
+		{"1", "0x01", "0X1", "0b1", "001"},
+		{"1000", "1_000", "0x3E8", "0b1111101000"},
+		{"1L", "0x01L", "1_L"},
+	}
+	for _, g := range groups {
+		first := normalizeIntegerLiteral(g[0])
+		for _, s := range g[1:] {
+			if got := normalizeIntegerLiteral(s); got != first {
+				t.Errorf("expected %q and %q to normalize identically; got %q vs %q", g[0], s, first, got)
+			}
+		}
+	}
+}

--- a/internal/rules/registry_precompile_duplicate_label.go
+++ b/internal/rules/registry_precompile_duplicate_label.go
@@ -2,6 +2,7 @@ package rules
 
 import (
 	api "github.com/kaeawc/krit/internal/rules/api"
+	"github.com/kaeawc/krit/internal/scanner"
 )
 
 func registerPrecompileDuplicateLabelRules() {
@@ -17,6 +18,7 @@ func registerPrecompileDuplicateLabelRules() {
 		Description:    r.Desc,
 		Sev:            api.Severity(r.Sev),
 		NodeTypes:      []string{"when_expression"},
+		Languages:      []scanner.Language{scanner.LangKotlin},
 		Confidence:     r.Confidence(),
 		Implementation: r,
 		Check:          r.check,

--- a/tests/fixtures/precompile/negative/K0108-DuplicateLabel/4.kt
+++ b/tests/fixtures/precompile/negative/K0108-DuplicateLabel/4.kt
@@ -1,0 +1,8 @@
+// Different-typed integer literals are distinct constants to kotlinc:
+// `1` is Int, `1L` is Long, `1u` is UInt — not duplicates.
+fun mixed(x: Any): String = when (x) {
+    1 -> "int"
+    1L -> "long"
+    1u -> "uint"
+    else -> "other"
+}

--- a/tests/fixtures/precompile/positive/K0108-DuplicateLabel/4.kt
+++ b/tests/fixtures/precompile/positive/K0108-DuplicateLabel/4.kt
@@ -1,0 +1,8 @@
+// EXPECTED-KOTLINC-ERROR: DUPLICATE_LABEL_IN_WHEN
+// `null` is parsed as a non-named token child of when_condition.
+fun nullable(x: Int?): String = when (x) {
+    null -> "n1"
+    1 -> "one"
+    null -> "n2"
+    else -> "other"
+}

--- a/tests/fixtures/precompile/positive/K0108-DuplicateLabel/5.kt
+++ b/tests/fixtures/precompile/positive/K0108-DuplicateLabel/5.kt
@@ -1,0 +1,10 @@
+// EXPECTED-KOTLINC-ERROR: DUPLICATE_LABEL_IN_WHEN
+// kotlinc dedupes integer constants regardless of base or separators:
+// `0x01`, `1_000`, and `1000` are all the same Int value.
+fun classify(n: Int): String = when (n) {
+    1 -> "one"
+    0x01 -> "hex one"
+    1_000 -> "thousand"
+    1000 -> "also thousand"
+    else -> "other"
+}


### PR DESCRIPTION
## Summary

Three precision fixes on K0108-DuplicateLabel (#166):

- **Languages declaration.** Add explicit `Languages: []scanner.Language{scanner.LangKotlin}` in [registry_precompile_duplicate_label.go](internal/rules/registry_precompile_duplicate_label.go). Dispatcher already fell back to Kotlin via `RuleLanguages`, but the explicit declaration matches convention and survives future `Needs` changes.
- **Null labels were never detected.** Tree-sitter emits `null` as a non-named token child of `when_condition`. The previous named-only filter dropped it, so duplicate-null branches were silently missed (the `"null"` case in the switch was dead code). Restructured `whenConditionDuplicateKey` to detect a sole non-named `null` token before the named-child loop.
- **Integer keys are now normalized.** kotlinc dedupes `0x01`/`1`/`1_000`/`1000` as the same Int constant; the textual key did not. `normalizeIntegerLiteral` strips underscores, canonicalizes hex/binary to decimal, and preserves the `L`/`u`/`uL` suffix as a type marker (so `1L` and `1` stay distinct, matching kotlinc). Strings, chars, and reals remain textual — documented as a known false-negative class rather than over-promising.

## Test plan

- [x] `go vet ./...`
- [x] `make lint-rules`
- [x] `go test ./... -count=1`
- [x] New positive fixtures: [4.kt](tests/fixtures/precompile/positive/K0108-DuplicateLabel/4.kt) (duplicate null), [5.kt](tests/fixtures/precompile/positive/K0108-DuplicateLabel/5.kt) (`1` / `0x01` / `1_000` / `1000`)
- [x] New negative fixture: [4.kt](tests/fixtures/precompile/negative/K0108-DuplicateLabel/4.kt) (`1` / `1L` / `1u` distinct types)
- [x] Unit tests for `normalizeIntegerLiteral` covering equivalence classes