### PR TITLE
feat(rules): add UselessElvisOnNonNull (KAA-backed)

### DIFF
--- a/internal/rules/meta_potentialbugs_nullsafety_redundant.go
+++ b/internal/rules/meta_potentialbugs_nullsafety_redundant.go
@@ -46,3 +46,12 @@ func (r *UnnecessarySafeCallRule) Meta() api.RuleDescriptor {
 		FixLevel:      "semantic",
 	}
 }
+
+func (r *UselessElvisOnNonNullRule) Meta() api.RuleDescriptor {
+	return api.RuleDescriptor{
+		ID:            "UselessElvisOnNonNull",
+		RuleSet:       "potential-bugs",
+		DefaultActive: true,
+		FixLevel:      "semantic",
+	}
+}

--- a/internal/rules/potentialbugs_nullsafety_redundant.go
+++ b/internal/rules/potentialbugs_nullsafety_redundant.go
@@ -1737,3 +1737,131 @@ func flatTemplateExpressionIsResolvedNullable(file *scanner.File, resolver typei
 	resolved, ok := flatKnownResolvedType(file, resolver, flatUnwrapParenExpr(file, expr))
 	return ok && resolved.IsNullable()
 }
+
+// UselessElvisOnNonNullRule detects `expr ?: fallback` where `expr` is
+// already non-null. Resolves the left operand via ctx.Resolver, which under
+// the KAA oracle recovers platform types and substituted generics (e.g.
+// getOrDefault) that source-only inference cannot.
+type UselessElvisOnNonNullRule struct {
+	FlatDispatchBase
+	BaseRule
+}
+
+func (r *UselessElvisOnNonNullRule) Confidence() float64 { return 0.85 }
+
+func (r *UselessElvisOnNonNullRule) check(ctx *api.Context) {
+	idx, file := ctx.Idx, ctx.File
+	if ctx.Resolver == nil {
+		return
+	}
+	left, operand, ok := uselessElvisOperand(file, idx)
+	if !ok {
+		return
+	}
+	resolved := ctx.Resolver.ResolveFlatNode(operand, file)
+	if resolved == nil {
+		return
+	}
+	if resolved.Kind == typeinfer.TypeUnknown || resolved.Kind == typeinfer.TypeGeneric {
+		return
+	}
+	if resolved.IsNullable() {
+		return
+	}
+	leftEnd := int(file.FlatEndByte(left))
+	elvisEnd := int(file.FlatEndByte(idx))
+	leftText := strings.TrimSpace(file.FlatNodeText(left))
+	f := r.Finding(file, file.FlatRow(idx)+1, file.FlatCol(idx)+1,
+		fmt.Sprintf("Useless elvis (?:) on non-nullable '%s'. The fallback is dead code.", leftText))
+	f.Fix = &scanner.Fix{
+		ByteMode:    true,
+		StartByte:   leftEnd,
+		EndByte:     elvisEnd,
+		Replacement: "",
+	}
+	ctx.Emit(f)
+}
+
+// ExpressionPositions enumerates left operands the rule wants resolved by
+// the KAA pre-pass under --depth=thorough. Selector mirrors check's gates
+// so the batched resolveExpressionTypes RPC stays tight.
+func (r *UselessElvisOnNonNullRule) ExpressionPositions(file *scanner.File) []uint32 {
+	if file == nil {
+		return nil
+	}
+	var out []uint32
+	file.FlatWalkNodes(0, "elvis_expression", func(idx uint32) {
+		if _, operand, ok := uselessElvisOperand(file, idx); ok {
+			out = append(out, operand)
+		}
+	})
+	return out
+}
+
+// uselessElvisOperand returns (left child, unwrapped operand) when the
+// elvis at idx has a resolver-friendly shape and no obvious source-level
+// disqualifier. ok=false means the rule should skip this elvis.
+func uselessElvisOperand(file *scanner.File, idx uint32) (left, operand uint32, ok bool) {
+	if file == nil || file.FlatType(idx) != "elvis_expression" || file.FlatChildCount(idx) < 3 {
+		return 0, 0, false
+	}
+	left = file.FlatChild(idx, 0)
+	if left == 0 {
+		return 0, 0, false
+	}
+	operand = flatUnwrapParenExpr(file, left)
+	if !uselessElvisOperandResolvable(file, operand) {
+		return 0, 0, false
+	}
+	if uselessElvisOperandShouldSkip(file, operand) {
+		return 0, 0, false
+	}
+	return left, operand, true
+}
+
+func uselessElvisOperandResolvable(file *scanner.File, operand uint32) bool {
+	if file == nil || operand == 0 {
+		return false
+	}
+	switch file.FlatType(operand) {
+	case "string_literal", "line_string_literal", "multi_line_string_literal",
+		"integer_literal", "long_literal", "real_literal",
+		"boolean_literal", "character_literal":
+		return true
+	case "simple_identifier":
+		return flatReferenceHasSameFileTarget(file, operand)
+	case "this_expression":
+		return true
+	case "navigation_expression":
+		return !flatNavigationHasSafeCall(file, operand)
+	case "call_expression":
+		return true
+	case "postfix_expression":
+		return flatPostfixHasNotNullAssertion(file, operand)
+	case "as_expression":
+		return true
+	default:
+		return false
+	}
+}
+
+// uselessElvisOperandShouldSkip guards against false positives the
+// resolver alone cannot rule out: mutable `var` (no smart-cast across
+// statements), framework-nullable inherited properties the source
+// resolver would widen to non-null, and initializers that can produce
+// null at runtime.
+func uselessElvisOperandShouldSkip(file *scanner.File, operand uint32) bool {
+	if file == nil || operand == 0 || file.FlatType(operand) != "simple_identifier" {
+		return false
+	}
+	name := strings.TrimSpace(file.FlatNodeText(operand))
+	if name == "" {
+		return true
+	}
+	summary := nullSafetySummaryFor(file)
+	return summary.mutableVar[name] ||
+		summary.memberAccessInitializer[name] ||
+		summary.uncertainCallInitializer[name] ||
+		summary.branchNullInitializer[name] ||
+		isFrameworkNullableProperty(name)
+}

--- a/internal/rules/registry_potentialbugs_nullsafety_redundant.go
+++ b/internal/rules/registry_potentialbugs_nullsafety_redundant.go
@@ -45,6 +45,20 @@ func registerPotentialbugsNullsafetyRedundantRules() {
 		})
 	}
 	{
+		r := &UselessElvisOnNonNullRule{BaseRule: BaseRule{RuleName: "UselessElvisOnNonNull", RuleSetName: "potential-bugs", Sev: "warning", Desc: "Detects the ?: elvis operator applied to expressions that are already non-nullable, making the fallback dead code."}}
+		api.Register(&api.Rule{
+			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
+			NodeTypes:              []string{"elvis_expression"},
+			Confidence:             0.85,
+			Fix:                    api.FixSemantic,
+			Needs:                  api.NeedsTypeInfo | api.NeedsOracleExprType,
+			OracleDeclarationNeeds: &api.OracleDeclarationProfile{},
+			Implementation:         r,
+			Check:                  r.check,
+			ExprPositions:          r.ExpressionPositions,
+		})
+	}
+	{
 		r := &NullableToStringCallRule{BaseRule: BaseRule{RuleName: "NullableToStringCall", RuleSetName: "potential-bugs", Sev: "warning", Desc: "Detects .toString() calls on nullable receivers that may produce the string \"null\"."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),

--- a/schemas/krit-config.schema.json
+++ b/schemas/krit-config.schema.json
@@ -10767,6 +10767,25 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "AbstractMemberNotImplemented": {
+          "description": "Detects concrete classes that fail to implement abstract members declared on a supertype.",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "active": {
+              "description": "Enable AbstractMemberNotImplemented (default: false).",
+              "type": "boolean",
+              "default": false
+            },
+            "excludes": {
+              "description": "Glob patterns for paths to exclude from this rule.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
         "AvoidReferentialEquality": {
           "description": "Detects usage of referential equality operators === or !== which compare object identity instead of value. [fixable: semantic]",
           "type": "object",
@@ -11300,6 +11319,25 @@
             }
           }
         },
+        "MissingReturn": {
+          "description": "Detects block-bodied functions with a non-Unit return type whose body does not terminate on every path.",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "active": {
+              "description": "Enable MissingReturn (default: false).",
+              "type": "boolean",
+              "default": false
+            },
+            "excludes": {
+              "description": "Glob patterns for paths to exclude from this rule.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
         "MissingSuperCall": {
           "description": "Detects override functions that do not call the corresponding super method. [fixable: semantic]",
           "type": "object",
@@ -11336,6 +11374,25 @@
           "properties": {
             "active": {
               "description": "Enable MissingUseCall (default: false).",
+              "type": "boolean",
+              "default": false
+            },
+            "excludes": {
+              "description": "Glob patterns for paths to exclude from this rule.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "NoElseInWhenSealed": {
+          "description": "Detects when expressions on sealed classes or enums that are missing variants and have no else branch.",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "active": {
+              "description": "Enable NoElseInWhenSealed (default: false).",
               "type": "boolean",
               "default": false
             },
@@ -11386,6 +11443,25 @@
             }
           }
         },
+        "OverrideSignatureMismatch": {
+          "description": "Detects 'override' functions whose parameter count does not match any supertype member with the same name.",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "active": {
+              "description": "Enable OverrideSignatureMismatch (default: false).",
+              "type": "boolean",
+              "default": false
+            },
+            "excludes": {
+              "description": "Glob patterns for paths to exclude from this rule.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
         "PropertyUsedBeforeDeclaration": {
           "description": "Detects class properties referenced in initializers or init blocks before they are declared.",
           "type": "object",
@@ -11393,6 +11469,25 @@
           "properties": {
             "active": {
               "description": "Enable PropertyUsedBeforeDeclaration (default: false).",
+              "type": "boolean",
+              "default": false
+            },
+            "excludes": {
+              "description": "Glob patterns for paths to exclude from this rule.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "SmartCastInvalidated": {
+          "description": "Detects smart-cast variables that are reassigned and then used without re-checking, which the compiler reports as SMARTCAST_IMPOSSIBLE.",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "active": {
+              "description": "Enable SmartCastInvalidated (default: false).",
               "type": "boolean",
               "default": false
             },
@@ -11624,6 +11719,25 @@
             }
           }
         },
+        "UselessElvisOnNonNull": {
+          "description": "Detects the ?: elvis operator applied to expressions that are already non-nullable, making the fallback dead code. [fixable: semantic]",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "active": {
+              "description": "Enable UselessElvisOnNonNull (default: true).",
+              "type": "boolean",
+              "default": true
+            },
+            "excludes": {
+              "description": "Glob patterns for paths to exclude from this rule.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
         "UselessPostfixExpression": {
           "description": "Detects postfix increment or decrement in return statements where the operation has no effect. [fixable: idiomatic]",
           "type": "object",
@@ -11664,6 +11778,56 @@
         },
         "active": {
           "description": "Enable or disable the entire potential-bugs ruleset.",
+          "type": "boolean",
+          "default": true
+        }
+      }
+    },
+    "precompile": {
+      "description": "Configuration for the precompile ruleset.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "K0101-UnreachableCode": {
+          "description": "Detects statements that follow an unconditional jump (return, throw, break, continue) in the same block. Mirrors kotlinc's UNREACHABLE_CODE.",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "active": {
+              "description": "Enable K0101-UnreachableCode (default: false).",
+              "type": "boolean",
+              "default": false
+            },
+            "excludes": {
+              "description": "Glob patterns for paths to exclude from this rule.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "K0108-DuplicateLabel": {
+          "description": "Detects repeated constant labels in a subject-bearing `when` expression. Mirrors kotlinc's DUPLICATE_LABEL_IN_WHEN.",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "active": {
+              "description": "Enable K0108-DuplicateLabel (default: false).",
+              "type": "boolean",
+              "default": false
+            },
+            "excludes": {
+              "description": "Glob patterns for paths to exclude from this rule.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "active": {
+          "description": "Enable or disable the entire precompile ruleset.",
           "type": "boolean",
           "default": true
         }
@@ -13790,7 +13954,7 @@
           }
         },
         "DoubleNegativeLambda": {
-          "description": "Detects double negative lambda patterns like filterNot { !predicate } that should use filter.",
+          "description": "Detects double negative lambda patterns like filterNot { !predicate } that should use filter. [fixable: idiomatic]",
           "type": "object",
           "additionalProperties": false,
           "properties": {

--- a/tests/fixtures/fixable/per-rule/UselessElvisOnNonNull.kt
+++ b/tests/fixtures/fixable/per-rule/UselessElvisOnNonNull.kt
@@ -1,0 +1,8 @@
+package fixtures.positive.potentialbugs
+
+class UselessElvisOnNonNull {
+    fun example() {
+        val x: String = "hello"
+        val y = x ?: "fallback"
+    }
+}

--- a/tests/fixtures/fixable/per-rule/UselessElvisOnNonNull.kt.expected
+++ b/tests/fixtures/fixable/per-rule/UselessElvisOnNonNull.kt.expected
@@ -1,0 +1,8 @@
+package fixtures.positive.potentialbugs
+
+class UselessElvisOnNonNull {
+    fun example() {
+        val x: String = "hello"
+        val y = x
+    }
+}

--- a/tests/fixtures/negative/potential-bugs/UselessElvisOnNonNull.kt
+++ b/tests/fixtures/negative/potential-bugs/UselessElvisOnNonNull.kt
@@ -1,0 +1,35 @@
+package fixtures.negative.potentialbugs
+
+class UselessElvisOnNonNull {
+    // Nullable parameter — elvis is meaningful.
+    fun nullableParam(s: String?) {
+        val y = s ?: "fallback"
+    }
+
+    // Mutable var — Kotlin cannot smart-cast; the source resolver should not
+    // claim non-null even when initialized with a non-null literal.
+    var name: String = "hello"
+    fun mutableVar() {
+        val y = name ?: "fallback"
+    }
+
+    // Safe call chain — left side is nullable.
+    fun safeCallChain(s: String?) {
+        val y = s?.length ?: 0
+    }
+
+    // Dotted member access on unresolved receiver — bare-name resolver
+    // cannot prove non-null.
+    fun dottedAccess(harness: TestHarness?) {
+        val y = harness?.group ?: "fallback"
+    }
+
+    // Function call that may return null by convention.
+    fun findOrFallback(items: List<String>) {
+        val y = items.find { it.isEmpty() } ?: "fallback"
+    }
+}
+
+class TestHarness {
+    val group: String? = null
+}

--- a/tests/fixtures/positive/potential-bugs/UselessElvisOnNonNull.kt
+++ b/tests/fixtures/positive/potential-bugs/UselessElvisOnNonNull.kt
@@ -1,0 +1,17 @@
+package fixtures.positive.potentialbugs
+
+class UselessElvisOnNonNull {
+    fun nonNullLocal() {
+        val x: String = "hello"
+        val y = x ?: "fallback"
+    }
+
+    fun nonNullLiteral() {
+        val y = "always" ?: "dead"
+    }
+
+    fun nonNullInt() {
+        val n: Int = 42
+        val m = n ?: 0
+    }
+}


### PR DESCRIPTION
## Summary
- New `UselessElvisOnNonNull` rule detects `expr ?: fallback` where the left operand is already non-null, making the fallback dead code. One of the most common dead-code patterns in real Kotlin codebases.
- Declares `NeedsTypeInfo | NeedsOracleExprType` and supplies an `ExpressionPositions` selector so the targeted-resolution pre-pass under `--depth=thorough` batches elvis left operands into a single `resolveExpressionTypes` RPC. Under KAA the rule sees platform types and substituted generics (e.g. `getOrDefault`) that source-only inference cannot recover.
- Conservative gates skip mutable `var` receivers, framework-nullable inherited properties, and initializers that can produce null — reusing the existing `nullSafetyFileSummary` cache shared with `UnnecessarySafeCall` / `UnnecessaryNotNullOperator`.
- Fix removes `?: fallback` bytes; declared `FixSemantic`.

## Test plan
- [x] `go test ./... -count=1` (all green)
- [x] `make lint-rules` (capability declarations satisfied)
- [x] `make schema` regenerated
- [x] Positive fixture: non-null local, literal, primitive — all flagged
- [x] Negative fixture: nullable param, mutable var, safe-call chain, dotted access, `find { … }` — none flagged
- [x] Fixable per-rule fixture round-trips through `UPDATE_FIXABLE_EXPECTED=1`