### PR TITLE
feat(precompile): add K0403-DeprecatedSymbolUsedError

### DIFF
--- a/internal/rules/precompile_deprecated_symbol_used_error.go
+++ b/internal/rules/precompile_deprecated_symbol_used_error.go
@@ -1,0 +1,62 @@
+package rules
+
+import (
+	"fmt"
+
+	api "github.com/kaeawc/krit/internal/rules/api"
+)
+
+// PrecompileDeprecatedSymbolUsedErrorRule flags references to symbols
+// whose @Deprecated annotation specifies level = DeprecationLevel.ERROR.
+// Mirrors kotlinc's DEPRECATION_ERROR.
+//
+// Library symbols are not yet classified by level: the oracle exposes
+// kotlin.Deprecated FQNs but no annotation arguments, and firing on
+// every @Deprecated would flood ordinary (default WARNING) call sites.
+// The rule declares NeedsOracleMemberAnnotations so the oracle profile
+// is already sized for the library path once the JVM tools surface the
+// `level` argument.
+type PrecompileDeprecatedSymbolUsedErrorRule struct {
+	FlatDispatchBase
+	BaseRule
+}
+
+func (r *PrecompileDeprecatedSymbolUsedErrorRule) Confidence() float64 { return 0.95 }
+
+func (r *PrecompileDeprecatedSymbolUsedErrorRule) check(ctx *api.Context) {
+	idx, file := ctx.Idx, ctx.File
+
+	deprecated := deprecatedDeclIndex(file)
+	if len(deprecated) == 0 {
+		return
+	}
+
+	nodeType := file.FlatType(idx)
+	if file.FlatHasAncestorOfType(idx, "import_header") {
+		return
+	}
+	if nodeType == "navigation_expression" {
+		if parent, ok := file.FlatParent(idx); ok && file.FlatType(parent) == "call_expression" {
+			return
+		}
+	}
+	if nodeType == "user_type" && file.FlatHasAncestorOfType(idx, "annotation") {
+		return
+	}
+
+	name := flatDeprecationRefName(file, idx)
+	if name == "" {
+		return
+	}
+
+	info := deprecated[name]
+	if info == nil || info.level != "ERROR" {
+		return
+	}
+
+	msg := fmt.Sprintf("'%s' is deprecated with level ERROR and must not be used.", name)
+	if info.message != "" {
+		msg = fmt.Sprintf("'%s' is deprecated with level ERROR: %s", name, info.message)
+	}
+	ctx.EmitAt(file.FlatRow(idx)+1, file.FlatCol(idx)+1, msg)
+}

--- a/internal/rules/registry_bootstrap.go
+++ b/internal/rules/registry_bootstrap.go
@@ -95,6 +95,7 @@ func init() {
 	registerPotentialbugsTypesRules()
 	registerPrecompileUnreachableCodeRules()
 	registerPrecompileDuplicateLabelRules()
+	registerPrecompileDeprecatedSymbolUsedErrorRules()
 	registerCorrectnessOverrideRules()
 	registerCorrectnessAbstractRules()
 	registerPrivacyAnalyticsRules()

--- a/internal/rules/registry_precompile_deprecated_symbol_used_error.go
+++ b/internal/rules/registry_precompile_deprecated_symbol_used_error.go
@@ -1,0 +1,34 @@
+package rules
+
+import (
+	api "github.com/kaeawc/krit/internal/rules/api"
+)
+
+func registerPrecompileDeprecatedSymbolUsedErrorRules() {
+	r := &PrecompileDeprecatedSymbolUsedErrorRule{BaseRule: BaseRule{
+		RuleName:    "K0403-DeprecatedSymbolUsedError",
+		RuleSetName: api.CategoryPrecompile,
+		Sev:         string(api.SeverityError),
+		Desc:        "Detects references to symbols annotated with @Deprecated(level = DeprecationLevel.ERROR). Mirrors kotlinc's DEPRECATION_ERROR.",
+	}}
+	api.Register(&api.Rule{
+		ID:          r.RuleName,
+		Category:    r.RuleSetName,
+		Description: r.Desc,
+		Sev:         api.Severity(r.Sev),
+		NodeTypes:   []string{"call_expression", "navigation_expression", "user_type"},
+		Confidence:  r.Confidence(),
+		Needs:       api.NeedsOracleMembers | api.NeedsOracleMemberAnnotations,
+		Oracle: &api.OracleFilter{
+			Identifiers: []string{"Deprecated"},
+		},
+		OracleDeclarationNeeds: &api.OracleDeclarationProfile{
+			ClassShell:        true,
+			Members:           true,
+			MemberAnnotations: true,
+		},
+		Implementation: r,
+		Check:          r.check,
+		DefaultActive:  false,
+	})
+}

--- a/schemas/krit-config.schema.json
+++ b/schemas/krit-config.schema.json
@@ -5390,7 +5390,7 @@
           }
         },
         "DeprecatedBlockTag": {
-          "description": "Detects @deprecated KDoc tags that should use the @Deprecated annotation instead.",
+          "description": "Detects @deprecated KDoc tags that should use the @Deprecated annotation instead. [fixable: idiomatic]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -5447,7 +5447,7 @@
           }
         },
         "EndOfSentenceFormat": {
-          "description": "Detects KDoc first sentences that do not end with proper punctuation.",
+          "description": "Detects KDoc first sentences that do not end with proper punctuation. [fixable: cosmetic]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -5510,7 +5510,7 @@
           }
         },
         "OutdatedDocumentation": {
-          "description": "Detects @param tags in KDoc that do not match the actual function parameters.",
+          "description": "Detects @param tags in KDoc that do not match the actual function parameters. [fixable: cosmetic]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -9137,7 +9137,7 @@
       "additionalProperties": false,
       "properties": {
         "CopyrightYearOutdated": {
-          "description": "Detects stale copyright years in file header comments.",
+          "description": "Detects stale copyright years in file header comments. [fixable: cosmetic]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -10939,7 +10939,7 @@
           }
         },
         "ElseCaseInsteadOfExhaustiveWhen": {
-          "description": "Detects when expressions on sealed classes or enums that use an else branch instead of exhaustive matching.",
+          "description": "Detects when expressions on sealed classes or enums that use an else branch instead of exhaustive matching. [fixable: idiomatic]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -11034,7 +11034,7 @@
           }
         },
         "HardcodedDateFormat": {
-          "description": "Detects DateTimeFormatter.ofPattern constructed without an explicit Locale.",
+          "description": "Detects DateTimeFormatter.ofPattern constructed without an explicit Locale. [fixable: semantic]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -11053,7 +11053,7 @@
           }
         },
         "HardcodedNumberFormat": {
-          "description": "Detects DecimalFormat or NumberFormat.getInstance constructed without an explicit Locale.",
+          "description": "Detects DecimalFormat or NumberFormat.getInstance constructed without an explicit Locale. [fixable: semantic]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -11143,7 +11143,7 @@
           }
         },
         "ImplicitDefaultLocale": {
-          "description": "Detects locale-sensitive string methods called without an explicit Locale argument.",
+          "description": "Detects locale-sensitive string methods called without an explicit Locale argument. [fixable: semantic]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -11701,7 +11701,7 @@
           }
         },
         "UnusedUnaryOperator": {
-          "description": "Detects standalone unary +x or -x expressions whose result is never used.",
+          "description": "Detects standalone unary +x or -x expressions whose result is never used. [fixable: semantic]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -11814,6 +11814,25 @@
           "properties": {
             "active": {
               "description": "Enable K0108-DuplicateLabel (default: false).",
+              "type": "boolean",
+              "default": false
+            },
+            "excludes": {
+              "description": "Glob patterns for paths to exclude from this rule.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "K0403-DeprecatedSymbolUsedError": {
+          "description": "Detects references to symbols annotated with @Deprecated(level = DeprecationLevel.ERROR). Mirrors kotlinc's DEPRECATION_ERROR.",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "active": {
+              "description": "Enable K0403-DeprecatedSymbolUsedError (default: false).",
               "type": "boolean",
               "default": false
             },
@@ -12174,7 +12193,7 @@
           }
         },
         "CommentedOutCodeBlock": {
-          "description": "Detects consecutive lines of commented-out Kotlin code that should be deleted or restored.",
+          "description": "Detects consecutive lines of commented-out Kotlin code that should be deleted or restored. [fixable: idiomatic]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -12193,7 +12212,7 @@
           }
         },
         "CommentedOutImport": {
-          "description": "Detects commented-out import statements that are either dead code or incomplete refactors.",
+          "description": "Detects commented-out import statements that are either dead code or incomplete refactors. [fixable: idiomatic]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -13862,7 +13881,7 @@
           }
         },
         "DataClassContainsFunctions": {
-          "description": "Detects data classes that contain function members.",
+          "description": "Detects data classes that contain function members. [fixable: semantic]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -14737,7 +14756,7 @@
           }
         },
         "NestedClassesVisibility": {
-          "description": "Detects nested classes with explicit public modifier inside internal parent classes.",
+          "description": "Detects nested classes with explicit public modifier inside internal parent classes. [fixable: cosmetic]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -16008,7 +16027,7 @@
       "additionalProperties": false,
       "properties": {
         "ApplyPluginTwice": {
-          "description": "Detects a Gradle plugin applied in both plugins { } and apply(plugin = ...) in the same build file.",
+          "description": "Detects a Gradle plugin applied in both plugins { } and apply(plugin = ...) in the same build file. [fixable: idiomatic]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -16732,7 +16751,7 @@
           }
         },
         "TestNameContainsUnderscore": {
-          "description": "Detects test function names using underscores where backtick-quoted names are preferred.",
+          "description": "Detects test function names using underscores where backtick-quoted names are preferred. [fixable: cosmetic]",
           "type": "object",
           "additionalProperties": false,
           "properties": {

--- a/tests/fixtures/precompile/negative/K0403-DeprecatedSymbolUsedError/1.kt
+++ b/tests/fixtures/precompile/negative/K0403-DeprecatedSymbolUsedError/1.kt
@@ -1,0 +1,7 @@
+// Negative: default level is WARNING, not ERROR — kotlinc accepts the call.
+@Deprecated("Prefer newApi")
+fun oldApi() {}
+
+fun callsOldApi() {
+    oldApi()
+}

--- a/tests/fixtures/precompile/negative/K0403-DeprecatedSymbolUsedError/2.kt
+++ b/tests/fixtures/precompile/negative/K0403-DeprecatedSymbolUsedError/2.kt
@@ -1,0 +1,10 @@
+// Negative: WARNING and HIDDEN are not the ERROR target.
+@Deprecated("Soft warning", level = DeprecationLevel.WARNING)
+fun warnApi() {}
+
+@Deprecated("Hidden", level = DeprecationLevel.HIDDEN)
+fun hiddenApi() {}
+
+fun callsThem() {
+    warnApi()
+}

--- a/tests/fixtures/precompile/negative/K0403-DeprecatedSymbolUsedError/3.kt
+++ b/tests/fixtures/precompile/negative/K0403-DeprecatedSymbolUsedError/3.kt
@@ -1,0 +1,8 @@
+// Negative: the annotation declaration site is not a use site, and
+// imports are skipped.
+import kotlin.DeprecationLevel
+
+@Deprecated("Use newApi", level = DeprecationLevel.ERROR)
+fun oldApi() {}
+
+fun unrelated(): Int = 1

--- a/tests/fixtures/precompile/positive/K0403-DeprecatedSymbolUsedError/1.kt
+++ b/tests/fixtures/precompile/positive/K0403-DeprecatedSymbolUsedError/1.kt
@@ -1,0 +1,7 @@
+// EXPECTED-KOTLINC-ERROR: DEPRECATION_ERROR
+@Deprecated("Use newApi instead", level = DeprecationLevel.ERROR)
+fun oldApi() {}
+
+fun callsOldApi() {
+    oldApi()
+}

--- a/tests/fixtures/precompile/positive/K0403-DeprecatedSymbolUsedError/2.kt
+++ b/tests/fixtures/precompile/positive/K0403-DeprecatedSymbolUsedError/2.kt
@@ -1,0 +1,7 @@
+// EXPECTED-KOTLINC-ERROR: DEPRECATION_ERROR
+@Deprecated(message = "Removed", level = DeprecationLevel.ERROR)
+class OldType
+
+fun makeOne(): OldType {
+    return OldType()
+}

--- a/tests/fixtures/precompile/positive/K0403-DeprecatedSymbolUsedError/3.kt
+++ b/tests/fixtures/precompile/positive/K0403-DeprecatedSymbolUsedError/3.kt
@@ -1,0 +1,9 @@
+// EXPECTED-KOTLINC-ERROR: DEPRECATION_ERROR
+class Container {
+    @Deprecated("Use newCount", level = DeprecationLevel.ERROR)
+    val oldCount: Int = 0
+
+    fun read(other: Container): Int {
+        return other.oldCount
+    }
+}


### PR DESCRIPTION
## Summary
- Detect references to symbols annotated with `@Deprecated(level = DeprecationLevel.ERROR)`, mirroring kotlinc's `DEPRECATION_ERROR`.
- Source-level detection reuses the cached per-file deprecated-decl index from `DeprecationRule`, filtered to declarations whose extracted level is exactly `ERROR`.
- Declares `NeedsOracleMembers | NeedsOracleMemberAnnotations` so the oracle declaration profile is already sized to expose library member annotations once the JVM tools surface annotation arguments. Until then, oracle-only `@Deprecated` hits are not flagged because `kotlin.Deprecated` FQN without args defaults to WARNING and would flood ordinary call sites.
- `DefaultActive: false` (precompile rules ship opt-in).

## Test plan
- [x] `go test ./internal/rules/ -run TestPrecompileFixtures -count=1`
- [x] `go test ./... -count=1`
- [x] `go vet ./...`
- [x] `make lint-rules`
- [x] `make schema` (regenerated)