### PR TITLE
feat(precompile): add NonExhaustiveWhen rule

### DIFF
--- a/internal/rules/potentialbugs_types.go
+++ b/internal/rules/potentialbugs_types.go
@@ -1455,3 +1455,123 @@ func missingEnumEntries(covered map[string]bool, entries []string) []string {
 	}
 	return missing
 }
+
+// NonExhaustiveWhenRule flags `when` expressions used in a value-consuming
+// position on a sealed/enum/Boolean subject when one or more branches are
+// missing and there is no `else`. The statement form is left to
+// NoElseInWhenSealed.
+type NonExhaustiveWhenRule struct {
+	FlatDispatchBase
+	BaseRule
+}
+
+func (r *NonExhaustiveWhenRule) Confidence() float64 { return 0.9 }
+
+// whenIsUsedAsExpression walks parents through transparent wrappers
+// (parenthesized_expression, annotated_expression) and inspects the
+// enclosing context. Returns false for statement positions (statements,
+// control_structure_body, block-bodied function_body) and true for value-
+// consuming positions (initializers, return, arguments, operands, ...).
+func whenIsUsedAsExpression(file *scanner.File, idx uint32) bool {
+	cur := idx
+	for {
+		parent, ok := file.FlatParent(cur)
+		if !ok {
+			return false
+		}
+		switch file.FlatType(parent) {
+		case "parenthesized_expression", "annotated_expression":
+			cur = parent
+			continue
+		case "statements", "control_structure_body":
+			return false
+		case "function_body":
+			// Expression body iff `=` precedes the when; block bodies start with `{`.
+			for c := file.FlatFirstChild(parent); c != 0; c = file.FlatNextSib(c) {
+				if c == cur {
+					return false
+				}
+				switch file.FlatType(c) {
+				case "=":
+					return true
+				case "{":
+					return false
+				}
+			}
+			return false
+		case "property_declaration", "variable_declaration",
+			"jump_expression", "value_argument", "value_arguments",
+			"assignment", "directly_assignable_expression",
+			"disjunction", "conjunction", "equality", "comparison",
+			"additive_expression", "multiplicative_expression", "range_expression",
+			"infix_expression", "as_expression", "elvis_expression",
+			"prefix_expression", "postfix_unary_expression", "spread_expression",
+			"check_expression",
+			"indexing_suffix", "call_suffix", "navigation_suffix",
+			"lambda_literal", "anonymous_function":
+			return true
+		default:
+			return false
+		}
+	}
+}
+
+func whenSubjectResolvesToBoolean(file *scanner.File, idx uint32, resolver typeinfer.TypeResolver) bool {
+	if resolver == nil {
+		return false
+	}
+	subject := whenSubjectExpressionFlat(file, idx)
+	if subject == 0 {
+		return false
+	}
+	for _, name := range whenSubjectTypeCandidatesFlat(file, subject, resolver) {
+		if name == "Boolean" || name == "kotlin.Boolean" {
+			return true
+		}
+	}
+	return false
+}
+
+func collectBooleanCoveredLiterals(file *scanner.File, idx uint32) (hasTrue, hasFalse bool) {
+	file.FlatForEachChild(idx, func(entry uint32) {
+		if file.FlatType(entry) != "when_entry" {
+			return
+		}
+		file.FlatForEachChild(entry, func(cond uint32) {
+			if file.FlatType(cond) != "when_condition" {
+				return
+			}
+			for c := file.FlatFirstChild(cond); c != 0; c = file.FlatNextSib(c) {
+				if file.FlatType(c) != "boolean_literal" {
+					continue
+				}
+				switch strings.TrimSpace(file.FlatNodeText(c)) {
+				case "true":
+					hasTrue = true
+				case "false":
+					hasFalse = true
+				}
+			}
+		})
+	})
+	return hasTrue, hasFalse
+}
+
+// missingWhenSealedOrEnumVariants resolves the subject's sealed/enum kind
+// and returns the missing variant/entry names. Returns ("", "", nil) when
+// the subject doesn't resolve to a sealed hierarchy or enum, or when all
+// branches are covered.
+func missingWhenSealedOrEnumVariants(file *scanner.File, idx uint32, resolver typeinfer.TypeResolver) (kind, subjectName string, missing []string) {
+	kind, subjectName, variants := whenSubjectExhaustiveKindFlat(file, idx, resolver)
+	if kind == "" || len(variants) == 0 {
+		return "", "", nil
+	}
+	typeNames, entryNames := collectWhenCoveredVariants(file, idx)
+	switch kind {
+	case "sealed":
+		missing = missingSealedVariants(typeNames, variants)
+	case "enum":
+		missing = missingEnumEntries(entryNames, variants)
+	}
+	return kind, subjectName, missing
+}

--- a/internal/rules/potentialbugs_types_test.go
+++ b/internal/rules/potentialbugs_types_test.go
@@ -988,3 +988,176 @@ fun classify(x: Int): String = when {
 		t.Fatalf("expected no findings on subject-less when, got %d", len(findings))
 	}
 }
+
+// --- NonExhaustiveWhen ---
+
+func TestNonExhaustiveWhen_ExpressionBody_MissingSealed_Positive(t *testing.T) {
+	findings := runRuleByNameWithResolver(t, "NonExhaustiveWhen", `
+package test
+
+sealed class Result {
+    object Loading : Result()
+    data class Success(val v: String) : Result()
+    data class Failure(val e: Throwable) : Result()
+}
+
+fun render(r: Result): String = when (r) {
+    is Result.Loading -> "loading"
+    is Result.Success -> r.v
+}
+`)
+	if len(findings) == 0 {
+		t.Fatal("expected finding for non-exhaustive when used as expression body")
+	}
+}
+
+func TestNonExhaustiveWhen_StatementForm_Negative(t *testing.T) {
+	findings := runRuleByNameWithResolver(t, "NonExhaustiveWhen", `
+package test
+
+sealed class Result {
+    object Loading : Result()
+    data class Success(val v: String) : Result()
+    data class Failure(val e: Throwable) : Result()
+}
+
+fun handle(r: Result) {
+    when (r) {
+        is Result.Loading -> println("loading")
+        is Result.Success -> println(r.v)
+    }
+}
+`)
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings for statement-form when, got %d", len(findings))
+	}
+}
+
+func TestNonExhaustiveWhen_PropertyInit_MissingEnum_Positive(t *testing.T) {
+	findings := runRuleByNameWithResolver(t, "NonExhaustiveWhen", `
+package test
+
+enum class Color { RED, GREEN, BLUE }
+
+fun describe(c: Color): String {
+    val label: String = when (c) {
+        Color.RED -> "warm"
+        Color.BLUE -> "cool"
+    }
+    return label
+}
+`)
+	if len(findings) == 0 {
+		t.Fatal("expected finding for non-exhaustive when in property initializer")
+	}
+}
+
+func TestNonExhaustiveWhen_Return_Positive(t *testing.T) {
+	findings := runRuleByNameWithResolver(t, "NonExhaustiveWhen", `
+package test
+
+sealed class Result {
+    object Loading : Result()
+    data class Success(val v: String) : Result()
+    data class Failure(val e: Throwable) : Result()
+}
+
+fun pick(r: Result): Int {
+    return when (r) {
+        is Result.Loading -> 1
+    }
+}
+`)
+	if len(findings) == 0 {
+		t.Fatal("expected finding for non-exhaustive when in return")
+	}
+}
+
+func TestNonExhaustiveWhen_BooleanMissingFalse_Positive(t *testing.T) {
+	findings := runRuleByNameWithResolver(t, "NonExhaustiveWhen", `
+package test
+
+fun toInt(b: Boolean): Int = when (b) {
+    true -> 1
+}
+`)
+	if len(findings) == 0 {
+		t.Fatal("expected finding for Boolean when missing false branch")
+	}
+}
+
+func TestNonExhaustiveWhen_BooleanFullyCovered_Negative(t *testing.T) {
+	findings := runRuleByNameWithResolver(t, "NonExhaustiveWhen", `
+package test
+
+fun toInt(b: Boolean): Int = when (b) {
+    true -> 1
+    false -> 0
+}
+`)
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings when both Boolean branches present, got %d", len(findings))
+	}
+}
+
+func TestNonExhaustiveWhen_HasElse_Negative(t *testing.T) {
+	findings := runRuleByNameWithResolver(t, "NonExhaustiveWhen", `
+package test
+
+sealed class Result {
+    object Loading : Result()
+    data class Success(val v: String) : Result()
+    data class Failure(val e: Throwable) : Result()
+}
+
+fun pick(r: Result): Int = when (r) {
+    is Result.Loading -> 1
+    else -> 0
+}
+`)
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings when else present, got %d", len(findings))
+	}
+}
+
+func TestNonExhaustiveWhen_AllVariantsCovered_Negative(t *testing.T) {
+	findings := runRuleByNameWithResolver(t, "NonExhaustiveWhen", `
+package test
+
+sealed class Result {
+    object Loading : Result()
+    data class Success(val v: String) : Result()
+    data class Failure(val e: Throwable) : Result()
+}
+
+fun pick(r: Result): Int = when (r) {
+    is Result.Loading -> 1
+    is Result.Success -> 2
+    is Result.Failure -> 3
+}
+`)
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings when all sealed variants covered, got %d", len(findings))
+	}
+}
+
+func TestNonExhaustiveWhen_CallArgument_Positive(t *testing.T) {
+	findings := runRuleByNameWithResolver(t, "NonExhaustiveWhen", `
+package test
+
+sealed class Result {
+    object Loading : Result()
+    data class Success(val v: String) : Result()
+    data class Failure(val e: Throwable) : Result()
+}
+
+fun log(r: Result) {
+    println(when (r) {
+        is Result.Loading -> "a"
+    })
+}
+`)
+	if len(findings) == 0 {
+		t.Fatal("expected finding for when used as call argument")
+	}
+}

--- a/internal/rules/registry_potentialbugs_types.go
+++ b/internal/rules/registry_potentialbugs_types.go
@@ -369,23 +369,61 @@ func registerPotentialbugsTypesRules() {
 				if _, ok := file.FlatFindChild(idx, "when_subject"); !ok {
 					return
 				}
-				kind, subjectName, variants := whenSubjectExhaustiveKindFlat(file, idx, ctx.Resolver)
-				if kind == "" || len(variants) == 0 {
-					return
-				}
-				typeNames, entryNames := collectWhenCoveredVariants(file, idx)
-				var missing []string
-				switch kind {
-				case "sealed":
-					missing = missingSealedVariants(typeNames, variants)
-				case "enum":
-					missing = missingEnumEntries(entryNames, variants)
-				}
-				if len(missing) == 0 {
+				kind, subjectName, missing := missingWhenSealedOrEnumVariants(file, idx, ctx.Resolver)
+				if kind == "" || len(missing) == 0 {
 					return
 				}
 				ctx.EmitAt(file.FlatRow(idx)+1, file.FlatCol(idx)+1,
 					fmt.Sprintf("'when' on %s '%s' is not exhaustive: missing %s. Add the missing branches or an 'else' clause.",
+						kind, subjectName, strings.Join(missing, ", ")))
+			},
+		})
+	}
+	{
+		r := &NonExhaustiveWhenRule{BaseRule: BaseRule{RuleName: "NonExhaustiveWhen", RuleSetName: "potential-bugs", Sev: "warning", Desc: "Detects 'when' used as an expression on a sealed/enum/Boolean subject without an else branch and missing one or more variants."}}
+		api.Register(&api.Rule{
+			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
+			NodeTypes: []string{"when_expression"}, Confidence: 0.9, Implementation: r,
+			Needs: api.NeedsResolver,
+			Tags:  []string{"precompile"},
+			Check: func(ctx *api.Context) {
+				idx, file := ctx.Idx, ctx.File
+				if ctx.Resolver == nil {
+					return
+				}
+				if whenHasElseBranchFlat(file, idx) {
+					return
+				}
+				if _, ok := file.FlatFindChild(idx, "when_subject"); !ok {
+					return
+				}
+				if !whenIsUsedAsExpression(file, idx) {
+					return
+				}
+				// Boolean subject: must cover both `true` and `false`.
+				if whenSubjectResolvesToBoolean(file, idx, ctx.Resolver) {
+					hasTrue, hasFalse := collectBooleanCoveredLiterals(file, idx)
+					if hasTrue && hasFalse {
+						return
+					}
+					var missing []string
+					if !hasTrue {
+						missing = append(missing, "true")
+					}
+					if !hasFalse {
+						missing = append(missing, "false")
+					}
+					ctx.EmitAt(file.FlatRow(idx)+1, file.FlatCol(idx)+1,
+						fmt.Sprintf("'when' used as an expression on Boolean is not exhaustive: missing %s. Add the missing branches or an 'else' clause.",
+							strings.Join(missing, ", ")))
+					return
+				}
+				kind, subjectName, missing := missingWhenSealedOrEnumVariants(file, idx, ctx.Resolver)
+				if kind == "" || len(missing) == 0 {
+					return
+				}
+				ctx.EmitAt(file.FlatRow(idx)+1, file.FlatCol(idx)+1,
+					fmt.Sprintf("'when' used as an expression on %s '%s' is not exhaustive: missing %s. Add the missing branches or an 'else' clause.",
 						kind, subjectName, strings.Join(missing, ", ")))
 			},
 		})

--- a/tests/fixtures/negative/potential-bugs/NonExhaustiveWhen.kt
+++ b/tests/fixtures/negative/potential-bugs/NonExhaustiveWhen.kt
@@ -1,0 +1,68 @@
+package fixtures.negative.potentialbugs
+
+sealed class Result {
+    object Loading : Result()
+    data class Success(val value: String) : Result()
+    data class Failure(val error: Throwable) : Result()
+}
+
+enum class Color { RED, GREEN, BLUE }
+
+class NonExhaustiveWhen {
+    // Statement form — handled by NoElseInWhenSealed, not this rule.
+    fun handle(r: Result) {
+        when (r) {
+            is Result.Loading -> println("loading")
+            is Result.Success -> println(r.value)
+            // missing: Failure — but this is a statement, not an expression
+        }
+    }
+
+    // Expression context, all sealed variants covered.
+    fun render(r: Result): String = when (r) {
+        is Result.Loading -> "loading"
+        is Result.Success -> r.value
+        is Result.Failure -> r.error.message ?: "error"
+    }
+
+    // Expression context, all enum entries covered.
+    fun describe(c: Color): String = when (c) {
+        Color.RED -> "warm"
+        Color.GREEN -> "fresh"
+        Color.BLUE -> "cool"
+    }
+
+    // Expression context with else — else makes it exhaustive (out of scope).
+    fun describeWithElse(r: Result): String = when (r) {
+        is Result.Loading -> "loading"
+        else -> "ready"
+    }
+
+    // when{} without subject — out of scope.
+    fun classify(x: Int): String = when {
+        x > 0 -> "positive"
+        x < 0 -> "negative"
+        else -> "zero"
+    }
+
+    // Subject type isn't sealed/enum/Boolean — rule is silent.
+    fun describeAny(x: Any): String = when (x) {
+        is Int -> "int"
+        is String -> "string"
+        else -> "other"
+    }
+
+    // Boolean subject as expression body, both branches covered.
+    fun toIntFull(b: Boolean): Int = when (b) {
+        true -> 1
+        false -> 0
+    }
+
+    // Boolean subject in statement context — not flagged.
+    fun handleBool(b: Boolean) {
+        when (b) {
+            true -> println("yes")
+            // not flagged: statement form
+        }
+    }
+}

--- a/tests/fixtures/positive/potential-bugs/NonExhaustiveWhen.kt
+++ b/tests/fixtures/positive/potential-bugs/NonExhaustiveWhen.kt
@@ -1,0 +1,52 @@
+package fixtures.positive.potentialbugs
+
+sealed class Result {
+    object Loading : Result()
+    data class Success(val value: String) : Result()
+    data class Failure(val error: Throwable) : Result()
+}
+
+enum class Color { RED, GREEN, BLUE }
+
+class NonExhaustiveWhen {
+    // Expression body — when consumed as expression, missing Failure variant.
+    fun renderResult(r: Result): String = when (r) {
+        is Result.Loading -> "loading"
+        is Result.Success -> r.value
+        // missing: Failure
+    }
+
+    // Property initializer — expression context, missing GREEN entry.
+    fun describe(c: Color): String {
+        val label: String = when (c) {
+            Color.RED -> "warm"
+            Color.BLUE -> "cool"
+            // missing: GREEN
+        }
+        return label
+    }
+
+    // `return when` — expression context, missing Failure.
+    fun summarize(r: Result): String {
+        return when (r) {
+            is Result.Loading -> "loading"
+            is Result.Success -> "ok"
+            // missing: Failure
+        }
+    }
+
+    // Boolean subject as expression body — missing `false`.
+    fun toInt(b: Boolean): Int = when (b) {
+        true -> 1
+        // missing: false
+    }
+
+    // when as call argument — expression context, missing Failure.
+    fun log(r: Result) {
+        println(when (r) {
+            is Result.Loading -> "loading"
+            is Result.Success -> "ok"
+            // missing: Failure
+        })
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `NonExhaustiveWhen`: flags `when` used as an expression on a sealed/enum/Boolean subject that is missing branches and has no `else`. Statement form is still handled by `NoElseInWhenSealed`.
- Resolver-backed: uses `SealedVariants`/`EnumEntries` for sealed and enum subjects; checks `true`/`false` literal coverage for Boolean subjects.
- Extracts a shared `missingWhenSealedOrEnumVariants` helper so `NoElseInWhenSealed` and `NonExhaustiveWhen` no longer duplicate the kind/variant resolution + missing-branch computation.

## Test plan
- [x] `go test ./internal/rules/ -run "TestNonExhaustiveWhen|TestNoElseInWhenSealed"` — passes
- [x] Positive + negative fixtures under `tests/fixtures/{positive,negative}/potential-bugs/NonExhaustiveWhen.kt` — pass via `TestPositiveFixtures` / `TestNegativeFixtures`
- [x] `go test ./... -count=1` — green
- [x] `go vet ./...` — clean
- [x] `make lint-rules` — clean