### PR TITLE
feat(android-lint): add RequiresApiViolation

### DIFF
--- a/internal/rules/android_requires_api.go
+++ b/internal/rules/android_requires_api.go
@@ -1,0 +1,252 @@
+package rules
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/kaeawc/krit/internal/filefacts"
+	"github.com/kaeawc/krit/internal/librarymodel"
+	api "github.com/kaeawc/krit/internal/rules/api"
+	"github.com/kaeawc/krit/internal/scanner"
+)
+
+type RequiresApiViolationRule struct {
+	FlatDispatchBase
+	AndroidRule
+}
+
+func (r *RequiresApiViolationRule) Confidence() float64 { return 0.90 }
+
+type requiresApiIndex struct {
+	levels map[string]int
+}
+
+func isRequiresApiDeclType(typ string) bool {
+	switch typ {
+	case "function_declaration", "property_declaration", "class_declaration", "object_declaration":
+		return true
+	}
+	return false
+}
+
+func buildRequiresApiIndex(file *scanner.File) *requiresApiIndex {
+	idx := &requiresApiIndex{levels: map[string]int{}}
+	if file == nil {
+		return idx
+	}
+	file.FlatWalkAllNodes(0, func(decl uint32) {
+		if !isRequiresApiDeclType(file.FlatType(decl)) {
+			return
+		}
+		level := requiresApiLevelForDeclFlat(file, decl)
+		if level <= 0 {
+			// Tree-sitter Kotlin sometimes parses top-level `@RequiresApi(26)`
+			// as a `prefix_expression` sibling rather than a modifier on the
+			// next declaration.
+			level = precedingPrefixAnnotationLevelFlat(file, decl)
+			if level <= 0 {
+				return
+			}
+		}
+		name := extractIdentifierFlat(file, decl)
+		if name == "" {
+			return
+		}
+		if prior, ok := idx.levels[name]; !ok || level > prior {
+			idx.levels[name] = level
+		}
+	})
+	return idx
+}
+
+func precedingPrefixAnnotationLevelFlat(file *scanner.File, decl uint32) int {
+	parent, ok := file.FlatParent(decl)
+	if !ok {
+		return 0
+	}
+	best := 0
+	for c := file.FlatFirstChild(parent); c != 0 && c != decl; c = file.FlatNextSib(c) {
+		typ := file.FlatType(c)
+		if isRequiresApiDeclType(typ) {
+			best = 0
+			continue
+		}
+		if typ != "prefix_expression" {
+			continue
+		}
+		if level := prefixExpressionAnnotationLevel(file, c); level > best {
+			best = level
+		}
+	}
+	return best
+}
+
+func prefixExpressionAnnotationLevel(file *scanner.File, idx uint32) int {
+	var annotationNode, parenNode uint32
+	for c := file.FlatFirstChild(idx); c != 0; c = file.FlatNextSib(c) {
+		switch file.FlatType(c) {
+		case "annotation":
+			annotationNode = c
+		case "parenthesized_expression":
+			parenNode = c
+		}
+	}
+	if annotationNode == 0 {
+		return 0
+	}
+	name := annotationFinalName(file, annotationNode)
+	if name != "RequiresApi" && name != "TargetApi" {
+		return 0
+	}
+	if level := requiresApiAnnotationLevel(file, annotationNode); level > 0 {
+		return level
+	}
+	if parenNode == 0 {
+		return 0
+	}
+	for c := file.FlatFirstChild(parenNode); c != 0; c = file.FlatNextSib(c) {
+		if file.FlatType(c) == "integer_literal" {
+			if n, err := strconv.Atoi(strings.TrimSpace(file.FlatNodeText(c))); err == nil {
+				return n
+			}
+		}
+	}
+	return parseRequiresApiArgText(file.FlatNodeText(parenNode))
+}
+
+func requiresApiLevelForDeclFlat(file *scanner.File, decl uint32) int {
+	best := 0
+	if mods, ok := file.FlatFindChild(decl, "modifiers"); ok {
+		if l := extractRequiresApiLevelFromModifiers(file, mods); l > best {
+			best = l
+		}
+	}
+	for p, ok := file.FlatParent(decl); ok; p, ok = file.FlatParent(p) {
+		switch file.FlatType(p) {
+		case "class_declaration", "object_declaration":
+			if mods, ok := file.FlatFindChild(p, "modifiers"); ok {
+				if l := extractRequiresApiLevelFromModifiers(file, mods); l > best {
+					best = l
+				}
+			}
+		case "source_file":
+			return best
+		}
+	}
+	return best
+}
+
+func extractRequiresApiLevelFromModifiers(file *scanner.File, mods uint32) int {
+	best := 0
+	file.FlatWalkNodes(mods, "annotation", func(ann uint32) {
+		name := annotationFinalName(file, ann)
+		if name != "RequiresApi" && name != "TargetApi" {
+			return
+		}
+		if level := requiresApiAnnotationLevel(file, ann); level > best {
+			best = level
+		}
+	})
+	return best
+}
+
+func requiresApiAnnotationLevel(file *scanner.File, ann uint32) int {
+	if args, ok := file.FlatFindChild(ann, "value_arguments"); ok {
+		for i := 0; i < file.FlatChildCount(args); i++ {
+			arg := file.FlatChild(args, i)
+			if file.FlatType(arg) != "value_argument" {
+				continue
+			}
+			if n := parseRequiresApiArgText(file.FlatNodeText(arg)); n > 0 {
+				return n
+			}
+		}
+		return 0
+	}
+	text := file.FlatNodeText(ann)
+	open := strings.Index(text, "(")
+	if open < 0 {
+		return 0
+	}
+	end := strings.LastIndex(text, ")")
+	if end <= open {
+		return 0
+	}
+	return parseRequiresApiArgText(text[open+1 : end])
+}
+
+func parseRequiresApiArgText(text string) int {
+	text = strings.TrimSpace(text)
+	if eq := strings.Index(text, "="); eq >= 0 {
+		text = strings.TrimSpace(text[eq+1:])
+	}
+	if comma := strings.Index(text, ","); comma >= 0 {
+		text = strings.TrimSpace(text[:comma])
+	}
+	if n, err := strconv.Atoi(text); err == nil {
+		return n
+	}
+	return 0
+}
+
+// projectMinSdk defaults to 1 so fixtures and editor/LSP single-file runs
+// without Gradle metadata still trigger on @RequiresApi-annotated calls.
+func projectMinSdk(ctx *api.Context) int {
+	facts := librarymodel.EnsureFacts(ctx.LibraryFacts)
+	if facts != nil && facts.Profile.MinSdkVersion > 0 {
+		return facts.Profile.MinSdkVersion
+	}
+	return 1
+}
+
+func (r *RequiresApiViolationRule) check(ctx *api.Context) {
+	idx, file := ctx.Idx, ctx.File
+	if file == nil || scanner.IsTestFile(file.Path) {
+		return
+	}
+	if nodeHasAncestorTypeFlat(file, idx, "import_header") {
+		return
+	}
+
+	nodeType := file.FlatType(idx)
+	switch nodeType {
+	case "navigation_expression":
+		if parent, ok := file.FlatParent(idx); ok && file.FlatType(parent) == "call_expression" {
+			return
+		}
+	case "user_type":
+		parent, ok := file.FlatParent(idx)
+		if !ok {
+			return
+		}
+		pt := file.FlatType(parent)
+		if pt != "call_expression" && pt != "constructor_invocation" {
+			return
+		}
+	}
+
+	name := apiNodeNameFlat(file, idx)
+	if name == "" {
+		return
+	}
+
+	index := filefacts.FileFact(ctx.Facts, file, "requiresApiIndex", func() *requiresApiIndex {
+		return buildRequiresApiIndex(file)
+	})
+	level, ok := index.levels[name]
+	if !ok || level <= 0 {
+		return
+	}
+
+	minSdk := projectMinSdk(ctx)
+	if level <= minSdk {
+		return
+	}
+	if apiGuardedByVersionCheckFlat(file, idx) {
+		return
+	}
+	ctx.EmitAt(file.FlatRow(idx)+1, file.FlatCol(idx)+1,
+		fmt.Sprintf("Call to '%s' requires API %d but module minSdk is %d; guard with Build.VERSION.SDK_INT or annotate the caller with @RequiresApi(%d).",
+			name, level, minSdk, level))
+}

--- a/internal/rules/android_requires_api.go
+++ b/internal/rules/android_requires_api.go
@@ -11,18 +11,18 @@ import (
 	"github.com/kaeawc/krit/internal/scanner"
 )
 
-type RequiresApiViolationRule struct {
+type RequiresAPIViolationRule struct {
 	FlatDispatchBase
 	AndroidRule
 }
 
-func (r *RequiresApiViolationRule) Confidence() float64 { return 0.90 }
+func (r *RequiresAPIViolationRule) Confidence() float64 { return 0.90 }
 
-type requiresApiIndex struct {
+type requiresAPIIndex struct {
 	levels map[string]int
 }
 
-func isRequiresApiDeclType(typ string) bool {
+func isRequiresAPIDeclType(typ string) bool {
 	switch typ {
 	case "function_declaration", "property_declaration", "class_declaration", "object_declaration":
 		return true
@@ -30,16 +30,16 @@ func isRequiresApiDeclType(typ string) bool {
 	return false
 }
 
-func buildRequiresApiIndex(file *scanner.File) *requiresApiIndex {
-	idx := &requiresApiIndex{levels: map[string]int{}}
+func buildRequiresAPIIndex(file *scanner.File) *requiresAPIIndex {
+	idx := &requiresAPIIndex{levels: map[string]int{}}
 	if file == nil {
 		return idx
 	}
 	file.FlatWalkAllNodes(0, func(decl uint32) {
-		if !isRequiresApiDeclType(file.FlatType(decl)) {
+		if !isRequiresAPIDeclType(file.FlatType(decl)) {
 			return
 		}
-		level := requiresApiLevelForDeclFlat(file, decl)
+		level := requiresAPILevelForDeclFlat(file, decl)
 		if level <= 0 {
 			// Tree-sitter Kotlin sometimes parses top-level `@RequiresApi(26)`
 			// as a `prefix_expression` sibling rather than a modifier on the
@@ -68,7 +68,7 @@ func precedingPrefixAnnotationLevelFlat(file *scanner.File, decl uint32) int {
 	best := 0
 	for c := file.FlatFirstChild(parent); c != 0 && c != decl; c = file.FlatNextSib(c) {
 		typ := file.FlatType(c)
-		if isRequiresApiDeclType(typ) {
+		if isRequiresAPIDeclType(typ) {
 			best = 0
 			continue
 		}
@@ -99,7 +99,7 @@ func prefixExpressionAnnotationLevel(file *scanner.File, idx uint32) int {
 	if name != "RequiresApi" && name != "TargetApi" {
 		return 0
 	}
-	if level := requiresApiAnnotationLevel(file, annotationNode); level > 0 {
+	if level := requiresAPIAnnotationLevel(file, annotationNode); level > 0 {
 		return level
 	}
 	if parenNode == 0 {
@@ -112,13 +112,13 @@ func prefixExpressionAnnotationLevel(file *scanner.File, idx uint32) int {
 			}
 		}
 	}
-	return parseRequiresApiArgText(file.FlatNodeText(parenNode))
+	return parseRequiresAPIArgText(file.FlatNodeText(parenNode))
 }
 
-func requiresApiLevelForDeclFlat(file *scanner.File, decl uint32) int {
+func requiresAPILevelForDeclFlat(file *scanner.File, decl uint32) int {
 	best := 0
 	if mods, ok := file.FlatFindChild(decl, "modifiers"); ok {
-		if l := extractRequiresApiLevelFromModifiers(file, mods); l > best {
+		if l := extractRequiresAPILevelFromModifiers(file, mods); l > best {
 			best = l
 		}
 	}
@@ -126,7 +126,7 @@ func requiresApiLevelForDeclFlat(file *scanner.File, decl uint32) int {
 		switch file.FlatType(p) {
 		case "class_declaration", "object_declaration":
 			if mods, ok := file.FlatFindChild(p, "modifiers"); ok {
-				if l := extractRequiresApiLevelFromModifiers(file, mods); l > best {
+				if l := extractRequiresAPILevelFromModifiers(file, mods); l > best {
 					best = l
 				}
 			}
@@ -137,28 +137,28 @@ func requiresApiLevelForDeclFlat(file *scanner.File, decl uint32) int {
 	return best
 }
 
-func extractRequiresApiLevelFromModifiers(file *scanner.File, mods uint32) int {
+func extractRequiresAPILevelFromModifiers(file *scanner.File, mods uint32) int {
 	best := 0
 	file.FlatWalkNodes(mods, "annotation", func(ann uint32) {
 		name := annotationFinalName(file, ann)
 		if name != "RequiresApi" && name != "TargetApi" {
 			return
 		}
-		if level := requiresApiAnnotationLevel(file, ann); level > best {
+		if level := requiresAPIAnnotationLevel(file, ann); level > best {
 			best = level
 		}
 	})
 	return best
 }
 
-func requiresApiAnnotationLevel(file *scanner.File, ann uint32) int {
+func requiresAPIAnnotationLevel(file *scanner.File, ann uint32) int {
 	if args, ok := file.FlatFindChild(ann, "value_arguments"); ok {
 		for i := 0; i < file.FlatChildCount(args); i++ {
 			arg := file.FlatChild(args, i)
 			if file.FlatType(arg) != "value_argument" {
 				continue
 			}
-			if n := parseRequiresApiArgText(file.FlatNodeText(arg)); n > 0 {
+			if n := parseRequiresAPIArgText(file.FlatNodeText(arg)); n > 0 {
 				return n
 			}
 		}
@@ -173,10 +173,10 @@ func requiresApiAnnotationLevel(file *scanner.File, ann uint32) int {
 	if end <= open {
 		return 0
 	}
-	return parseRequiresApiArgText(text[open+1 : end])
+	return parseRequiresAPIArgText(text[open+1 : end])
 }
 
-func parseRequiresApiArgText(text string) int {
+func parseRequiresAPIArgText(text string) int {
 	text = strings.TrimSpace(text)
 	if eq := strings.Index(text, "="); eq >= 0 {
 		text = strings.TrimSpace(text[eq+1:])
@@ -200,7 +200,7 @@ func projectMinSdk(ctx *api.Context) int {
 	return 1
 }
 
-func (r *RequiresApiViolationRule) check(ctx *api.Context) {
+func (r *RequiresAPIViolationRule) check(ctx *api.Context) {
 	idx, file := ctx.Idx, ctx.File
 	if file == nil || scanner.IsTestFile(file.Path) {
 		return
@@ -231,8 +231,8 @@ func (r *RequiresApiViolationRule) check(ctx *api.Context) {
 		return
 	}
 
-	index := filefacts.FileFact(ctx.Facts, file, "requiresApiIndex", func() *requiresApiIndex {
-		return buildRequiresApiIndex(file)
+	index := filefacts.FileFact(ctx.Facts, file, "requiresAPIIndex", func() *requiresAPIIndex {
+		return buildRequiresAPIIndex(file)
 	})
 	level, ok := index.levels[name]
 	if !ok || level <= 0 {

--- a/internal/rules/android_requires_api_test.go
+++ b/internal/rules/android_requires_api_test.go
@@ -11,9 +11,9 @@ import (
 	"github.com/kaeawc/krit/internal/scanner"
 )
 
-// findRequiresApiViolationRule looks up the registered RequiresApiViolation
+// findRequiresAPIViolationRule looks up the registered RequiresApiViolation
 // descriptor so tests can run it through the same code path as production.
-func findRequiresApiViolationRule(t *testing.T) *api.Rule {
+func findRequiresAPIViolationRule(t *testing.T) *api.Rule {
 	t.Helper()
 	for _, r := range api.Registry {
 		if r.ID == "RequiresApiViolation" {
@@ -40,7 +40,7 @@ func runRequiresApi(t *testing.T, source string, minSdk int) []scanner.Finding {
 	if err != nil {
 		t.Fatalf("parse failed: %v", err)
 	}
-	rule := findRequiresApiViolationRule(t)
+	rule := findRequiresAPIViolationRule(t)
 	dispatcher := NewDispatcher([]*api.Rule{rule})
 	dispatcher.SetLibraryFacts(librarymodel.FactsForProfile(librarymodel.ProjectProfile{
 		MinSdkVersion: minSdk,
@@ -180,8 +180,8 @@ func TestRequiresApiViolation_ParseRequiresApiAnnotationLevel(t *testing.T) {
 		"value = \"26\"": 0, // non-numeric must not parse
 	}
 	for input, want := range cases {
-		if got := parseRequiresApiArgText(input); got != want {
-			t.Errorf("parseRequiresApiArgText(%q) = %d, want %d", input, got, want)
+		if got := parseRequiresAPIArgText(input); got != want {
+			t.Errorf("parseRequiresAPIArgText(%q) = %d, want %d", input, got, want)
 		}
 	}
 }

--- a/internal/rules/android_requires_api_test.go
+++ b/internal/rules/android_requires_api_test.go
@@ -1,0 +1,187 @@
+package rules
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kaeawc/krit/internal/librarymodel"
+	api "github.com/kaeawc/krit/internal/rules/api"
+	"github.com/kaeawc/krit/internal/scanner"
+)
+
+// findRequiresApiViolationRule looks up the registered RequiresApiViolation
+// descriptor so tests can run it through the same code path as production.
+func findRequiresApiViolationRule(t *testing.T) *api.Rule {
+	t.Helper()
+	for _, r := range api.Registry {
+		if r.ID == "RequiresApiViolation" {
+			return r
+		}
+	}
+	t.Fatalf("RequiresApiViolation not registered")
+	return nil
+}
+
+// runRequiresApi mirrors the dispatcher entry point used by other oracle-aware
+// rule tests so that NeedsOracleCallTargets-decorated rules see a real
+// resolver-less invocation path. The rule falls back to source-level
+// annotation scanning when the oracle is absent, which is the path exercised
+// here.
+func runRequiresApi(t *testing.T, source string, minSdk int) []scanner.Finding {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.kt")
+	if err := os.WriteFile(path, []byte(source), 0o600); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	file, err := scanner.ParseFile(path)
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	rule := findRequiresApiViolationRule(t)
+	dispatcher := NewDispatcher([]*api.Rule{rule})
+	dispatcher.SetLibraryFacts(librarymodel.FactsForProfile(librarymodel.ProjectProfile{
+		MinSdkVersion: minSdk,
+	}))
+	cols := dispatcher.Run(file)
+	return cols.Findings()
+}
+
+func TestRequiresApiViolation_PositionalArgument(t *testing.T) {
+	source := `package test
+import androidx.annotation.RequiresApi
+@RequiresApi(26)
+fun helper() {}
+fun caller() { helper() }
+`
+	findings := runRequiresApi(t, source, 21)
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(findings))
+	}
+	if !strings.Contains(findings[0].Message, "requires API 26") {
+		t.Errorf("unexpected message: %q", findings[0].Message)
+	}
+	if !strings.Contains(findings[0].Message, "minSdk is 21") {
+		t.Errorf("expected minSdk 21 in message: %q", findings[0].Message)
+	}
+}
+
+func TestRequiresApiViolation_NamedValueArgument(t *testing.T) {
+	source := `package test
+import androidx.annotation.RequiresApi
+@RequiresApi(value = 30)
+fun helper() {}
+fun caller() { helper() }
+`
+	findings := runRequiresApi(t, source, 21)
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(findings))
+	}
+	if !strings.Contains(findings[0].Message, "requires API 30") {
+		t.Errorf("unexpected message: %q", findings[0].Message)
+	}
+}
+
+func TestRequiresApiViolation_TargetApiAlsoFlagged(t *testing.T) {
+	source := `package test
+import android.annotation.TargetApi
+@TargetApi(26)
+fun helper() {}
+fun caller() { helper() }
+`
+	findings := runRequiresApi(t, source, 21)
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding for @TargetApi, got %d", len(findings))
+	}
+}
+
+func TestRequiresApiViolation_SkipsWhenMinSdkAtOrAboveRequirement(t *testing.T) {
+	source := `package test
+import androidx.annotation.RequiresApi
+@RequiresApi(26)
+fun helper() {}
+fun caller() { helper() }
+`
+	findings := runRequiresApi(t, source, 26)
+	if len(findings) != 0 {
+		t.Fatalf("expected 0 findings when minSdk meets requirement, got %d", len(findings))
+	}
+}
+
+func TestRequiresApiViolation_SdkIntGuardSuppresses(t *testing.T) {
+	source := `package test
+import android.os.Build
+import androidx.annotation.RequiresApi
+@RequiresApi(26)
+fun helper() {}
+fun caller() {
+    if (Build.VERSION.SDK_INT >= 26) {
+        helper()
+    }
+}
+`
+	findings := runRequiresApi(t, source, 21)
+	if len(findings) != 0 {
+		t.Fatalf("expected 0 findings under SDK_INT guard, got %d: %+v", len(findings), findings)
+	}
+}
+
+func TestRequiresApiViolation_RequiresApiAnnotationOnCallerSuppresses(t *testing.T) {
+	source := `package test
+import androidx.annotation.RequiresApi
+@RequiresApi(26)
+fun helper() {}
+class Caller {
+    @RequiresApi(26)
+    fun guarded() { helper() }
+}
+`
+	findings := runRequiresApi(t, source, 21)
+	if len(findings) != 0 {
+		t.Fatalf("expected 0 findings when caller annotated, got %d", len(findings))
+	}
+}
+
+func TestRequiresApiViolation_InheritsFromEnclosingClassAnnotation(t *testing.T) {
+	source := `package test
+import androidx.annotation.RequiresApi
+@RequiresApi(26)
+class NewApi {
+    fun helper() {}
+}
+fun caller(api: NewApi) { api.helper() }
+`
+	findings := runRequiresApi(t, source, 21)
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding from inherited class @RequiresApi, got %d", len(findings))
+	}
+}
+
+func TestRequiresApiViolation_UnrelatedCallsAreSilent(t *testing.T) {
+	source := `package test
+fun helper() {}
+fun caller() { helper() }
+`
+	findings := runRequiresApi(t, source, 21)
+	if len(findings) != 0 {
+		t.Fatalf("expected 0 findings without @RequiresApi, got %d", len(findings))
+	}
+}
+
+func TestRequiresApiViolation_ParseRequiresApiAnnotationLevel(t *testing.T) {
+	cases := map[string]int{
+		"26":             26,
+		"value = 30":     30,
+		"api = 31":       31,
+		" 21 , extra ":   21,
+		"":               0,
+		"value = \"26\"": 0, // non-numeric must not parse
+	}
+	for input, want := range cases {
+		if got := parseRequiresApiArgText(input); got != want {
+			t.Errorf("parseRequiresApiArgText(%q) = %d, want %d", input, got, want)
+		}
+	}
+}

--- a/internal/rules/meta_android_usability.go
+++ b/internal/rules/meta_android_usability.go
@@ -28,7 +28,7 @@ func (r *OverrideRule) Meta() api.RuleDescriptor {
 	}
 }
 
-func (r *RequiresApiViolationRule) Meta() api.RuleDescriptor {
+func (r *RequiresAPIViolationRule) Meta() api.RuleDescriptor {
 	return api.RuleDescriptor{
 		ID:            "RequiresApiViolation",
 		RuleSet:       "android-lint",

--- a/internal/rules/meta_android_usability.go
+++ b/internal/rules/meta_android_usability.go
@@ -28,6 +28,14 @@ func (r *OverrideRule) Meta() api.RuleDescriptor {
 	}
 }
 
+func (r *RequiresApiViolationRule) Meta() api.RuleDescriptor {
+	return api.RuleDescriptor{
+		ID:            "RequiresApiViolation",
+		RuleSet:       "android-lint",
+		DefaultActive: false,
+	}
+}
+
 func (r *UnusedResourcesRule) Meta() api.RuleDescriptor {
 	return api.RuleDescriptor{
 		ID:            "UnusedResources",

--- a/internal/rules/registry_android_usability.go
+++ b/internal/rules/registry_android_usability.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	api "github.com/kaeawc/krit/internal/rules/api"
+	"github.com/kaeawc/krit/internal/scanner"
 )
 
 func registerAndroidUsabilityRules() {
@@ -100,6 +101,28 @@ func registerAndroidUsabilityRules() {
 				ctx.EmitAt(file.FlatRow(idx)+1, file.FlatCol(idx)+1,
 					"fun "+name+"(...) should be declared with `override` in Activity/Fragment subclasses.")
 			},
+		})
+	}
+	{
+		r := &RequiresApiViolationRule{AndroidRule: AndroidRule{
+			BaseRule: BaseRule{RuleName: "RequiresApiViolation", RuleSetName: androidRuleSet, Sev: "error",
+				Desc: "Detects calls to APIs annotated with @RequiresApi(N) (or @TargetApi(N)) when N is greater than the project's minSdk and the call is not SDK_INT guarded."},
+			IssueID: "RequiresApiViolation", Brief: "Calling an API above the module's minSdk",
+			Category: ALCUnknown, ALSeverity: ALSError, Priority: 6,
+			Origin: "AOSP Android Lint",
+		}}
+		api.Register(&api.Rule{
+			ID: r.RuleName, Category: r.RuleSetName, Description: r.Description(), Sev: api.Severity(r.Sev),
+			NodeTypes:  []string{"call_expression", "navigation_expression", "user_type"},
+			Languages:  []scanner.Language{scanner.LangKotlin},
+			Needs:      api.NeedsTypeInfo | api.NeedsOracleCallTargets,
+			Confidence: r.Confidence(), Implementation: r,
+			NeedsLibraryFacts: true,
+			OracleCallTargets: &api.OracleCallTargetFilter{
+				AnnotatedIdentifiers: []string{"RequiresApi", "TargetApi"},
+			},
+			OracleDeclarationNeeds: &api.OracleDeclarationProfile{},
+			Check:                  r.check,
 		})
 	}
 	{

--- a/internal/rules/registry_android_usability.go
+++ b/internal/rules/registry_android_usability.go
@@ -104,7 +104,7 @@ func registerAndroidUsabilityRules() {
 		})
 	}
 	{
-		r := &RequiresApiViolationRule{AndroidRule: AndroidRule{
+		r := &RequiresAPIViolationRule{AndroidRule: AndroidRule{
 			BaseRule: BaseRule{RuleName: "RequiresApiViolation", RuleSetName: androidRuleSet, Sev: "error",
 				Desc: "Detects calls to APIs annotated with @RequiresApi(N) (or @TargetApi(N)) when N is greater than the project's minSdk and the call is not SDK_INT guarded."},
 			IssueID: "RequiresApiViolation", Brief: "Calling an API above the module's minSdk",

--- a/schemas/krit-config.schema.json
+++ b/schemas/krit-config.schema.json
@@ -3418,6 +3418,25 @@
             }
           }
         },
+        "RequiresApiViolation": {
+          "description": "Calling an API above the module's minSdk",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "active": {
+              "description": "Enable RequiresApiViolation (default: false).",
+              "type": "boolean",
+              "default": false
+            },
+            "excludes": {
+              "description": "Glob patterns for paths to exclude from this rule.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
         "ResAutoResource": {
           "description": "Namespace used in resource files should be res-auto",
           "type": "object",
@@ -11405,6 +11424,25 @@
             }
           }
         },
+        "NonExhaustiveWhen": {
+          "description": "Detects 'when' used as an expression on a sealed/enum/Boolean subject without an else branch and missing one or more variants.",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "active": {
+              "description": "Enable NonExhaustiveWhen (default: false).",
+              "type": "boolean",
+              "default": false
+            },
+            "excludes": {
+              "description": "Glob patterns for paths to exclude from this rule.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
         "NullCheckOnMutableProperty": {
           "description": "Detects null checks on mutable var properties that may be changed by another thread between the check and use.",
           "type": "object",
@@ -11814,6 +11852,25 @@
           "properties": {
             "active": {
               "description": "Enable K0108-DuplicateLabel (default: false).",
+              "type": "boolean",
+              "default": false
+            },
+            "excludes": {
+              "description": "Glob patterns for paths to exclude from this rule.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "K0206-DuplicateDeclaration": {
+          "description": "Detects two top-level fun/class/val declarations in one file with the same name and (for functions) matching parameter type signature. Mirrors kotlinc's CONFLICTING_OVERLOADS / REDECLARATION for the file-local subset.",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "active": {
+              "description": "Enable K0206-DuplicateDeclaration (default: false).",
               "type": "boolean",
               "default": false
             },

--- a/tests/fixtures/negative/android-lint/RequiresApiViolation.kt
+++ b/tests/fixtures/negative/android-lint/RequiresApiViolation.kt
@@ -1,0 +1,29 @@
+package test
+
+import android.os.Build
+import androidx.annotation.RequiresApi
+
+@RequiresApi(26)
+fun newApiHelper() {
+}
+
+class Caller {
+    fun guardedBySdkInt() {
+        if (Build.VERSION.SDK_INT >= 26) {
+            newApiHelper()
+        }
+    }
+
+    @RequiresApi(26)
+    fun guardedByAnnotation() {
+        newApiHelper()
+    }
+
+    fun plainCall() {
+        // No @RequiresApi on the target — must not fire.
+        regularHelper()
+    }
+}
+
+fun regularHelper() {
+}

--- a/tests/fixtures/positive/android-lint/RequiresApiViolation.kt
+++ b/tests/fixtures/positive/android-lint/RequiresApiViolation.kt
@@ -1,0 +1,18 @@
+package test
+
+import androidx.annotation.RequiresApi
+
+@RequiresApi(26)
+fun newApiHelper() {
+}
+
+@RequiresApi(value = 30)
+fun otherHelper() {
+}
+
+class Caller {
+    fun doWork() {
+        newApiHelper()
+        otherHelper()
+    }
+}


### PR DESCRIPTION
## Summary
- New Android-lint rule `RequiresApiViolation` flags Kotlin calls to declarations annotated with `@RequiresApi(N)` / `@TargetApi(N)` when `N` exceeds the project's minSdk and the call is not guarded by `Build.VERSION.SDK_INT` or an enclosing `@RequiresApi`/`@TargetApi`.
- Declares `NeedsTypeInfo | NeedsOracleCallTargets` with `AnnotatedIdentifiers: ["RequiresApi","TargetApi"]` so the KAA bridge narrows resolution; reads minSdk via `NeedsLibraryFacts` (`ctx.LibraryFacts.Profile.MinSdkVersion`, default 1 when absent).
- Handles tree-sitter Kotlin parsing top-level positional `@RequiresApi(26)` as a sibling `prefix_expression`. Dedupes `navigation_expression` children of `call_expression` and limits `user_type` matches to construction sites.
- Ships as opt-in (`DefaultActive: false`).

**Known limitation:** the KAA oracle currently returns annotation FQNs without their argument values, so library-only callees with `@RequiresApi(N)` cannot have their required level resolved. The rule covers same-project annotated declarations (the common in-codebase case) and stays silent on library calls until the bridge carries annotation arguments.

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `make lint-rules` passes
- [x] `make integration` — 11/11 pass
- [x] 9 focused unit tests cover: positional / named arg, `@TargetApi`, minSdk meets requirement, SDK_INT guard, caller `@RequiresApi`, inherited class annotation, unrelated calls, arg parser
- [x] Positive + negative fixtures under `tests/fixtures/{positive,negative}/android-lint/RequiresApiViolation.kt`