### PR TITLE
fix(BracesOnIf/When): skip expression-position if/when

### DIFF
--- a/internal/rules/style_braces.go
+++ b/internal/rules/style_braces.go
@@ -7,6 +7,46 @@ import (
 	"github.com/kaeawc/krit/internal/scanner"
 )
 
+// isStatementPositionExpr reports whether the given expression node appears
+// in statement position. Kotlin's grammar uses if_expression / when_expression
+// for both statements (`if (x) foo()`, `when (x) { ... }`) and expression-
+// position uses (`val r = if (...) y else z`, `val r = when (x) { ... }`,
+// `return if (...) ...`, arguments, etc.). Wrapping the body of an
+// expression-position if/when in braces is syntactically valid but visually
+// broken and is never what the brace-wrap rules intend.
+//
+// An expression is in statement position when its parent is a `statements`
+// block. Statement-position control constructs may nest (else-if chains
+// encoded as control_structure_body, or a when inside an if body); walk up
+// through those wrappers and check the outermost parent.
+func isStatementPositionExpr(file *scanner.File, idx uint32) bool {
+	cur := idx
+	for {
+		p, ok := file.FlatParent(cur)
+		if !ok {
+			return false
+		}
+		switch file.FlatType(p) {
+		case "statements":
+			return true
+		case "control_structure_body":
+			gp, ok2 := file.FlatParent(p)
+			if !ok2 {
+				return false
+			}
+			switch file.FlatType(gp) {
+			case "if_expression", "when_expression",
+				"for_statement", "while_statement", "do_while_statement":
+				cur = gp
+			default:
+				return false
+			}
+		default:
+			return false
+		}
+	}
+}
+
 // controlBodyHasBraces returns true when the control_structure_body node
 // at body has an opening brace token as its first child — i.e. the body is
 // a `{ ... }` block. A body without a brace child is a single expression
@@ -102,6 +142,10 @@ func (r *BracesOnIfStatementsRule) Confidence() float64 { return 0.75 }
 func (r *BracesOnIfStatementsRule) check(ctx *api.Context) {
 	idx, file := ctx.Idx, ctx.File
 	if scanner.IsTestFile(file.Path) || isGradleBuildScript(file.Path) {
+		return
+	}
+
+	if !isStatementPositionExpr(file, idx) {
 		return
 	}
 
@@ -234,6 +278,18 @@ func (r *BracesOnWhenStatementsRule) Confidence() float64 { return 0.75 }
 func (r *BracesOnWhenStatementsRule) check(ctx *api.Context) {
 	idx, file := ctx.Idx, ctx.File
 	if scanner.IsTestFile(file.Path) {
+		return
+	}
+
+	// idx is a when_entry; walk up to the enclosing when_expression and
+	// require it to be in statement position. `val r = when (...) { ... }`
+	// must not be flagged — wrapping its branch bodies in braces would
+	// transform the expression-position when into a visually-broken block.
+	whenExpr, ok := file.FlatParent(idx)
+	if !ok || file.FlatType(whenExpr) != "when_expression" {
+		return
+	}
+	if !isStatementPositionExpr(file, whenExpr) {
 		return
 	}
 

--- a/internal/rules/style_braces_test.go
+++ b/internal/rules/style_braces_test.go
@@ -221,8 +221,8 @@ func TestBracesOnWhenStatements_Consistent_MixedFlags(t *testing.T) {
 	// Some entries have braces, some don't -> should flag
 	findings := runBracesWhenRule(t, "consistent", "consistent", `
 package test
-fun example(x: Int): String {
-    return when (x) {
+fun example(x: Int) {
+    when (x) {
         1 -> { "one" }
         2 -> "two"
         else -> { "other" }
@@ -242,8 +242,8 @@ func TestBracesOnWhenStatements_Consistent_AllWithoutBraces(t *testing.T) {
 	// All entries without braces -> consistent, no finding
 	findings := runBracesWhenRule(t, "consistent", "consistent", `
 package test
-fun example(x: Int): String {
-    return when (x) {
+fun example(x: Int) {
+    when (x) {
         1 -> "one"
         2 -> "two"
         else -> "other"
@@ -258,8 +258,8 @@ func TestBracesOnWhenStatements_Consistent_AllWithBraces(t *testing.T) {
 	// All entries with braces -> consistent, no finding
 	findings := runBracesWhenRule(t, "consistent", "consistent", `
 package test
-fun example(x: Int): String {
-    return when (x) {
+fun example(x: Int) {
+    when (x) {
         1 -> { "one" }
         2 -> { "two" }
         else -> { "other" }
@@ -278,8 +278,8 @@ func TestBracesOnWhenStatements_IgnoresTestSources(t *testing.T) {
 	}
 	file := parseBracesPath(t, "src/test/kotlin/FooTest.kt", `
 package test
-fun example(x: Int): String {
-    return when (x) {
+fun example(x: Int) {
+    when (x) {
         1 -> "one"
         else -> "other"
     }
@@ -314,25 +314,20 @@ func applyFixes(src string, cols scanner.FindingColumns) string {
 	return string(out)
 }
 
-// TestBuildBraceWrapFix_InlineRHS_NoFix verifies the helper does not emit a
-// fix when the control header is not the first non-whitespace on its line.
-// Wrapping `val r = if (x) y` with the parent line's indent puts the closing
-// brace flush-left under `val r =` instead of aligned with `if`, which is
-// not ktfmt-compatible — better to flag and let the user resolve.
-func TestBuildBraceWrapFix_InlineRHS_NoFix(t *testing.T) {
+// TestBracesOnIfStatements_ExpressionPosition_NoFinding verifies the rule
+// skips expression-position ifs entirely. `val r = if (x) y else z` is an
+// expression, not a statement — "should use braces" does not apply, and
+// wrapping its body produces visually-broken output regardless of how the
+// fix derives its indentation.
+func TestBracesOnIfStatements_ExpressionPosition_NoFinding(t *testing.T) {
 	findings := runBracesIfRule(t, "always", "always", `
 package test
 fun example(x: Boolean): Int {
     val r = if (x) 1 else 2
     return r
 }`)
-	if findings.Len() == 0 {
-		t.Fatal("expected at least one finding for inline RHS if")
-	}
-	for i := 0; i < findings.Len(); i++ {
-		if findings.FixAt(i) != nil {
-			t.Errorf("expected no fix for inline RHS if at finding %d, got fix=%+v", i, findings.FixAt(i))
-		}
+	if findings.Len() != 0 {
+		t.Errorf("expected no findings for expression-position if, got %d", findings.Len())
 	}
 }
 

--- a/tests/fixtures/fixable/per-rule/BracesOnWhenStatements.kt
+++ b/tests/fixtures/fixable/per-rule/BracesOnWhenStatements.kt
@@ -1,12 +1,12 @@
 package style
 
-fun example(x: Int): String {
-    return when (x) {
+fun example(x: Int) {
+    when (x) {
         1 ->
-            "one"
+            println("one")
         2 ->
-            "two"
+            println("two")
         else ->
-            "other"
+            println("other")
     }
 }

--- a/tests/fixtures/fixable/per-rule/BracesOnWhenStatements.kt.expected
+++ b/tests/fixtures/fixable/per-rule/BracesOnWhenStatements.kt.expected
@@ -1,15 +1,15 @@
 package style
 
-fun example(x: Int): String {
-    return when (x) {
+fun example(x: Int) {
+    when (x) {
         1 -> {
-            "one"
+            println("one")
         }
         2 -> {
-            "two"
+            println("two")
         }
         else -> {
-            "other"
+            println("other")
         }
     }
 }

--- a/tests/fixtures/negative/style/BracesOnIfStatements.kt
+++ b/tests/fixtures/negative/style/BracesOnIfStatements.kt
@@ -7,3 +7,22 @@ fun example(x: Int) {
         println("non-positive")
     }
 }
+
+// Expression-position ifs must not be flagged: wrapping their bodies in
+// braces produces visually-broken (though syntactically valid) output.
+fun expressionPosition(x: Int): Int {
+    val a = if (x > 0) x else -x
+    val b: Int = if (x > 0) x else -x
+    val c = if (x > 0) {
+        x
+    } else {
+        -x
+    }
+    return if (x > 0) x else -x + a + b + c
+}
+
+fun argument(x: Int) {
+    println(if (x > 0) "pos" else "neg")
+}
+
+fun singleExprBody(x: Int): Int = if (x > 0) x else -x

--- a/tests/fixtures/negative/style/BracesOnWhenStatements.kt
+++ b/tests/fixtures/negative/style/BracesOnWhenStatements.kt
@@ -13,3 +13,28 @@ fun example(x: Int): String {
         }
     }
 }
+
+// Expression-position whens must not be flagged — wrapping their branch
+// bodies in braces would transform the assignment into a visually-broken
+// block (the `}` aligns to the outer statement's indent, not the when's).
+fun expressionPosition(x: Int): String {
+    val a = when (x) {
+        1 -> "one"
+        else -> "other"
+    }
+    val b: String = when (x) {
+        1 -> "one"
+        else -> "other"
+    }
+    return a + b + when (x) {
+        1 -> "one"
+        else -> "other"
+    }
+}
+
+fun argument(x: Int) {
+    println(when (x) {
+        1 -> "one"
+        else -> "other"
+    })
+}

--- a/tests/fixtures/positive/style/BracesOnWhenStatements.kt
+++ b/tests/fixtures/positive/style/BracesOnWhenStatements.kt
@@ -1,12 +1,12 @@
 package style
 
-fun example(x: Int): String {
-    return when (x) {
+fun example(x: Int) {
+    when (x) {
         1 ->
-            "one"
+            println("one")
         2 ->
-            "two"
+            println("two")
         else ->
-            "other"
+            println("other")
     }
 }


### PR DESCRIPTION
## Summary

`if_expression` and `when_expression` are emitted by Kotlin tree-sitter for both statement and expression-position uses. `BracesOnIfStatements` and `BracesOnWhenStatements` dispatched without checking context, so

- `val r = if (x) y else z`
- `return if (x) y else -x`
- `println(if (x) "pos" else "neg")`
- `fun f(x: Int) = if (x > 0) x else -x`
- `val r = when (x) { 1 -> "one"; else -> "other" }`

were incorrectly flagged. The auto-fix wrapped expression-position bodies in braces, producing visually broken output (closing `}` aligned to the outer statement's indent, not the inline expression).

Adds `isStatementPositionExpr` which walks up through `control_structure_body` wrappers (handling else-if chains and control bodies whose parent is itself a statement-position if/when/loop) and requires a `statements` parent at the root. Both rules now guard on it.

## Test plan

- [x] `go vet ./...`
- [x] `go test ./... -count=1`
- [x] New negative fixtures cover val/return/argument/single-expr-body for both if and when
- [x] Existing consistent-mode tests updated to use statement-position whens so they continue to exercise the rule
- [x] Manual: `krit --enable-rules BracesOnIfStatements` no longer fires on expression-position ifs but still fires on statement-position ifs