### PR TITLE
fix(compose): require Preview annotation name to end with "Preview"

### DIFF
--- a/internal/rules/compose.go
+++ b/internal/rules/compose.go
@@ -659,7 +659,7 @@ func composeModifierTextHasPreviewAnnotation(text string) bool {
 			}
 			break
 		}
-		if end > start && strings.Contains(text[start:end], "Preview") {
+		if end > start && strings.HasSuffix(text[start:end], "Preview") {
 			return true
 		}
 	}

--- a/internal/rules/compose_internal_test.go
+++ b/internal/rules/compose_internal_test.go
@@ -1,0 +1,28 @@
+package rules
+
+import "testing"
+
+func TestComposeModifierTextHasPreviewAnnotation(t *testing.T) {
+	cases := []struct {
+		name string
+		text string
+		want bool
+	}{
+		{"simple Preview", "@Preview", true},
+		{"qualified Preview", "@androidx.compose.ui.tooling.preview.Preview", true},
+		{"Preview with args", "@Preview(showBackground = true)", true},
+		{"trailing Preview suffix", "@MultiDevicePreview", true},
+		{"PreviewParameter does not match", "@PreviewParameter", false},
+		{"Previewish does not match", "@Previewish", false},
+		{"MyPreviewState does not match", "@MyPreviewState", false},
+		{"unrelated annotation", "@Composable", false},
+		{"no annotation", "public", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := composeModifierTextHasPreviewAnnotation(tc.text); got != tc.want {
+				t.Fatalf("composeModifierTextHasPreviewAnnotation(%q) = %v, want %v", tc.text, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- `composeModifierTextHasPreviewAnnotation` used `strings.Contains(name, "Preview")`, so lookalikes like `@Previewish` or `@MyPreviewState` matched.
- Switch to `strings.HasSuffix` on the parsed annotation name. Qualified names (e.g. `@androidx.compose.ui.tooling.preview.Preview`) still match; `@PreviewParameter`, `@Previewish`, `@MyPreviewState` no longer do.
- Helper is already gated to Kotlin `function_declaration` modifiers by its sole caller, so the "kotlin file / kotlin function" constraint is satisfied.

## Test plan
- [x] New table test `TestComposeModifierTextHasPreviewAnnotation` covers simple, qualified, with-args, suffix positives and `Previewish` / `MyPreviewState` / `PreviewParameter` negatives.
- [x] `go test ./internal/rules/ -run Compose -count=1`
- [x] `go build -o krit ./cmd/krit/ && go vet ./...`