### PR TITLE
fix(rules): tighten TrustedServer X509TrustManager supertype detection

### DIFF
--- a/internal/rules/android_security_misc.go
+++ b/internal/rules/android_security_misc.go
@@ -94,19 +94,17 @@ func trustedServerDeclaresX509(file *scanner.File, decl uint32) bool {
 		if file.FlatType(child) != "delegation_specifier" {
 			continue
 		}
-		found := false
-		file.FlatWalkAllNodes(child, func(n uint32) {
-			if found {
-				return
+		userType, _ := file.FlatFindChild(child, "user_type")
+		if userType == 0 {
+			if ctor, ok := file.FlatFindChild(child, "constructor_invocation"); ok {
+				userType, _ = file.FlatFindChild(ctor, "user_type")
 			}
-			switch file.FlatType(n) {
-			case "type_identifier", "simple_identifier":
-				if file.FlatNodeText(n) == "X509TrustManager" {
-					found = true
-				}
-			}
-		})
-		if found {
+		}
+		if userType == 0 {
+			continue
+		}
+		ident := flatLastChildOfType(file, userType, "type_identifier")
+		if ident != 0 && file.FlatNodeText(ident) == "X509TrustManager" {
 			return true
 		}
 	}

--- a/internal/rules/android_security_test.go
+++ b/internal/rules/android_security_test.go
@@ -2261,6 +2261,64 @@ class HttpClient {
 			t.Fatalf("expected 0 findings, got %d", len(findings))
 		}
 	})
+	t.Run("triggers on empty X509TrustManager object", func(t *testing.T) {
+		findings := runRuleByName(t, "TrustedServer", `
+package test
+import javax.net.ssl.X509TrustManager
+class HttpClient {
+    val tm = object : X509TrustManager {
+        override fun checkClientTrusted(chain: Array<out java.security.cert.X509Certificate>?, authType: String?) {}
+        override fun checkServerTrusted(chain: Array<out java.security.cert.X509Certificate>?, authType: String?) {}
+        override fun getAcceptedIssuers(): Array<java.security.cert.X509Certificate> = arrayOf()
+    }
+}
+`)
+		if len(findings) == 0 {
+			t.Fatal("expected finding for empty X509TrustManager override")
+		}
+	})
+	t.Run("X509TrustManager as generic argument is not a supertype", func(t *testing.T) {
+		findings := runRuleByName(t, "TrustedServer", `
+package test
+import javax.net.ssl.X509TrustManager
+interface Provider<T>
+class GenericArgOnly : Provider<X509TrustManager> {
+    fun checkClientTrusted() {}
+    fun checkServerTrusted() {}
+}
+`)
+		if len(findings) != 0 {
+			t.Fatalf("expected 0 findings for generic-arg-only X509TrustManager, got %d", len(findings))
+		}
+	})
+	t.Run("qualified X509TrustManager as generic argument is not a supertype", func(t *testing.T) {
+		findings := runRuleByName(t, "TrustedServer", `
+package test
+interface Provider<T>
+class GenericArgOnly : Provider<javax.net.ssl.X509TrustManager> {
+    fun checkClientTrusted() {}
+    fun checkServerTrusted() {}
+}
+`)
+		if len(findings) != 0 {
+			t.Fatalf("expected 0 findings for qualified generic-arg-only X509TrustManager, got %d", len(findings))
+		}
+	})
+	t.Run("qualified X509TrustManager supertype with empty overrides still fires", func(t *testing.T) {
+		findings := runRuleByName(t, "TrustedServer", `
+package test
+class HttpClient {
+    val tm = object : javax.net.ssl.X509TrustManager {
+        override fun checkClientTrusted(chain: Array<out java.security.cert.X509Certificate>?, authType: String?) {}
+        override fun checkServerTrusted(chain: Array<out java.security.cert.X509Certificate>?, authType: String?) {}
+        override fun getAcceptedIssuers(): Array<java.security.cert.X509Certificate> = arrayOf()
+    }
+}
+`)
+		if len(findings) == 0 {
+			t.Fatal("expected finding for qualified X509TrustManager supertype with empty overrides")
+		}
+	})
 }
 
 func TestWorldReadableFiles(t *testing.T) {

--- a/tests/fixtures/negative/android-lint/TrustedServer.kt
+++ b/tests/fixtures/negative/android-lint/TrustedServer.kt
@@ -20,3 +20,10 @@ class SecureClient {
         override fun getAcceptedIssuers(): Array<java.security.cert.X509Certificate> = arrayOf()
     }
 }
+
+// X509TrustManager appearing only as a generic argument is not a declaration of it.
+interface Provider<T>
+class GenericArgOnly : Provider<javax.net.ssl.X509TrustManager> {
+    fun checkClientTrusted() {}
+    fun checkServerTrusted() {}
+}


### PR DESCRIPTION
## Summary
- `trustedServerDeclaresX509` previously walked the entire `delegation_specifier` subtree, so `class Foo : Provider<X509TrustManager>` would be treated as declaring `X509TrustManager` and then evaluated for empty `checkClientTrusted` / `checkServerTrusted`.
- Now we look at `user_type` directly under `delegation_specifier` (or via `constructor_invocation` for the `: Foo()` form) and only the last direct `type_identifier` of that `user_type`, so generic arguments are ignored.

## Test plan
- [x] `go build -o krit ./cmd/krit/`
- [x] `go vet ./...`
- [x] `go test ./internal/rules/ -run TestTrustedServer -v`
- [x] Added regression negative fixture `Provider<javax.net.ssl.X509TrustManager>` in `tests/fixtures/negative/android-lint/TrustedServer.kt`
- [x] Added subtests for generic-arg-only (simple + qualified) and qualified supertype positives in `android_security_test.go`