### PR TITLE
fix(rules): suppress LogOfSharedPreferenceRead on local Log/Timber shadow

### DIFF
--- a/internal/rules/privacy_storage.go
+++ b/internal/rules/privacy_storage.go
@@ -113,6 +113,9 @@ func (r *LogOfSharedPreferenceReadRule) check(ctx *api.Context) {
 	if !isLogReceiver(receiver) {
 		return
 	}
+	if logReceiverIsLocalShadow(ctx, idx, receiver) {
+		return
+	}
 
 	_, args := flatCallExpressionParts(file, idx)
 	if args == 0 {
@@ -185,4 +188,20 @@ func isLogReceiver(receiver string) bool {
 		return true
 	}
 	return false
+}
+
+// logReceiverIsLocalShadow reports whether `receiver` at `callIdx` is a value
+// (val/var/parameter) that happens to share the simple name of the Log/Timber
+// class. Only consulted when a resolver is available (e.g. --depth=thorough).
+// A class/object named Log or Timber resolves with the same simple name, so
+// only a mismatched Name indicates a real value-shadow.
+func logReceiverIsLocalShadow(ctx *api.Context, callIdx uint32, receiver string) bool {
+	if ctx == nil || ctx.Resolver == nil || ctx.File == nil {
+		return false
+	}
+	t := ctx.Resolver.ResolveByNameFlat(receiver, callIdx, ctx.File)
+	if t == nil {
+		return false
+	}
+	return t.Name != "" && t.Name != receiver
 }

--- a/tests/fixtures/negative/privacy/LogOfSharedPreferenceRead.kt
+++ b/tests/fixtures/negative/privacy/LogOfSharedPreferenceRead.kt
@@ -4,6 +4,24 @@ object Log {
     fun d(tag: String, msg: String) {}
 }
 
+interface SharedPreferences {
+    fun getString(key: String, defValue: String?): String?
+}
+
+class CustomLogger {
+    fun d(tag: String, msg: String) {}
+}
+
+// Log.d with no SharedPreferences read: no finding regardless of receiver.
 fun debug() {
     Log.d("Auth", "token loaded")
+}
+
+// A local val named Log shadows the top-level Log object. In thorough mode
+// the resolver sees Log here refers to a CustomLogger value, not the Log
+// class, and the rule must suppress the finding even though a sensitive
+// getString is passed.
+fun shadowed(prefs: SharedPreferences) {
+    val Log: CustomLogger = CustomLogger()
+    Log.d("Auth", prefs.getString("authToken", null) ?: "")
 }


### PR DESCRIPTION
## Summary
- `isLogReceiver` matched the bare receiver name `Log`/`Timber` with no type proof, so a local `val Log = ...` could trigger a false positive on `LogOfSharedPreferenceRead`.
- The rule already declares `NeedsResolver` + `TypeInfoHint{Required: true}`, so under `--depth=thorough` we now consult `ctx.Resolver.ResolveByNameFlat` and suppress when the receiver resolves to a value whose type's simple name differs from `Log`/`Timber`. Unknown/class resolutions fall through to the existing name match, so balanced/fast mode and the existing `object Log` fixtures are unchanged.
- Extended the negative fixture with a `val Log: CustomLogger = CustomLogger()` shadow that passes a sensitive `prefs.getString("authToken", ...)` — would fire without the gate, suppressed with it.

## Test plan
- [x] `go build -o krit ./cmd/krit/`
- [x] `go vet ./...`
- [x] `go test ./internal/rules/ -count=1`