### PR TITLE
perf(cache): swap incremental cache JSON for gob+zstd

### DIFF
--- a/internal/cache/binary.go
+++ b/internal/cache/binary.go
@@ -1,0 +1,156 @@
+package cache
+
+import (
+	"bytes"
+	"encoding/binary"
+	"encoding/gob"
+	"fmt"
+	"hash/crc32"
+	"sort"
+
+	"github.com/klauspost/compress/zstd"
+
+	"github.com/kaeawc/krit/internal/scanner"
+)
+
+// Krit File Incremental Cache: a magic-prefixed, zstd-compressed gob frame
+// that replaces the legacy JSON encoding. The legacy JSON path is still used
+// as a fallback in Load so existing on-disk caches remain readable until they
+// are rewritten by the next Save.
+const (
+	binaryMagic   uint32 = 0x4b464943 // "KFIC"
+	binaryVersion uint32 = 1
+	// binaryHeaderLen = magic(4) + version(4) + crc32(4) + payloadLen(8)
+	binaryHeaderLen = 20
+)
+
+var (
+	binaryZstdEncoder *zstd.Encoder
+	binaryZstdDecoder *zstd.Decoder
+)
+
+func init() {
+	enc, err := zstd.NewWriter(nil, zstd.WithEncoderLevel(zstd.SpeedDefault))
+	if err != nil {
+		panic(fmt.Sprintf("init cache zstd encoder: %v", err))
+	}
+	binaryZstdEncoder = enc
+	dec, err := zstd.NewReader(nil)
+	if err != nil {
+		panic(fmt.Sprintf("init cache zstd decoder: %v", err))
+	}
+	binaryZstdDecoder = dec
+}
+
+// binaryEntry is the on-wire representation of a FileEntry. We persist a
+// sorted slice (not a map) so the on-disk bytes are deterministic across
+// runs — gob's map iteration order is unspecified, which would otherwise
+// break the portability guarantees in portability_test.go.
+type binaryEntry struct {
+	Path    string
+	Hash    string
+	ModTime int64
+	Size    int64
+	Columns scanner.FindingColumns
+}
+
+type binaryPayload struct {
+	Version   string
+	RuleHash  string
+	ScanPaths []string
+	Entries   []binaryEntry
+}
+
+// hasBinaryMagic reports whether data is a binary cache frame. It accepts
+// the bytes verbatim (no copy) and returns false for anything shorter than
+// the magic itself, including legacy JSON content (which starts with '{').
+func hasBinaryMagic(data []byte) bool {
+	if len(data) < 4 {
+		return false
+	}
+	return binary.BigEndian.Uint32(data[:4]) == binaryMagic
+}
+
+func encodeBinary(c *Cache) ([]byte, error) {
+	entries := make([]binaryEntry, 0, len(c.Files))
+	for path, entry := range c.Files {
+		entries = append(entries, binaryEntry{
+			Path:    path,
+			Hash:    entry.Hash,
+			ModTime: entry.ModTime,
+			Size:    entry.Size,
+			Columns: entry.Columns,
+		})
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].Path < entries[j].Path
+	})
+
+	scanPaths := append([]string(nil), c.ScanPaths...)
+
+	var gobBuf bytes.Buffer
+	if err := gob.NewEncoder(&gobBuf).Encode(binaryPayload{
+		Version:   c.Version,
+		RuleHash:  c.RuleHash,
+		ScanPaths: scanPaths,
+		Entries:   entries,
+	}); err != nil {
+		return nil, fmt.Errorf("gob encode: %w", err)
+	}
+
+	compressed := binaryZstdEncoder.EncodeAll(gobBuf.Bytes(), nil)
+
+	out := make([]byte, binaryHeaderLen, binaryHeaderLen+len(compressed))
+	binary.BigEndian.PutUint32(out[0:4], binaryMagic)
+	binary.BigEndian.PutUint32(out[4:8], binaryVersion)
+	binary.BigEndian.PutUint32(out[8:12], crc32.ChecksumIEEE(compressed))
+	binary.BigEndian.PutUint64(out[12:20], uint64(len(compressed)))
+	out = append(out, compressed...)
+	return out, nil
+}
+
+func decodeBinary(data []byte) (*Cache, bool) {
+	if len(data) < binaryHeaderLen {
+		return nil, false
+	}
+	if binary.BigEndian.Uint32(data[0:4]) != binaryMagic {
+		return nil, false
+	}
+	if binary.BigEndian.Uint32(data[4:8]) != binaryVersion {
+		return nil, false
+	}
+	wantCRC := binary.BigEndian.Uint32(data[8:12])
+	payloadLen := binary.BigEndian.Uint64(data[12:20])
+	if uint64(len(data)-binaryHeaderLen) != payloadLen {
+		return nil, false
+	}
+	compressed := data[binaryHeaderLen:]
+	if crc32.ChecksumIEEE(compressed) != wantCRC {
+		return nil, false
+	}
+
+	raw, err := binaryZstdDecoder.DecodeAll(compressed, nil)
+	if err != nil {
+		return nil, false
+	}
+	var payload binaryPayload
+	if err := gob.NewDecoder(bytes.NewReader(raw)).Decode(&payload); err != nil {
+		return nil, false
+	}
+
+	files := make(map[string]FileEntry, len(payload.Entries))
+	for _, e := range payload.Entries {
+		files[e.Path] = FileEntry{
+			Hash:    e.Hash,
+			ModTime: e.ModTime,
+			Size:    e.Size,
+			Columns: e.Columns,
+		}
+	}
+	return &Cache{
+		Version:   payload.Version,
+		RuleHash:  payload.RuleHash,
+		ScanPaths: payload.ScanPaths,
+		Files:     files,
+	}, true
+}

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -157,6 +157,15 @@ func Load(cacheFilePath string) *Cache {
 	if err != nil {
 		return &Cache{Files: make(map[string]FileEntry)}
 	}
+	if hasBinaryMagic(data) {
+		if c, ok := decodeBinary(data); ok {
+			if c.Files == nil {
+				c.Files = make(map[string]FileEntry)
+			}
+			return c
+		}
+		return &Cache{Files: make(map[string]FileEntry)}
+	}
 	var c Cache
 	if err := json.Unmarshal(data, &c); err != nil {
 		return &Cache{Files: make(map[string]FileEntry)}
@@ -185,9 +194,9 @@ func (c *Cache) Save(cacheFilePath string) error {
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		return fmt.Errorf("create cache dir: %w", err)
 	}
-	data, err := json.Marshal(c)
+	data, err := encodeBinary(c)
 	if err != nil {
-		return fmt.Errorf("marshal cache: %w", err)
+		return fmt.Errorf("encode cache: %w", err)
 	}
 	if err := fsutil.WriteFileAtomic(cacheFilePath, data, 0644); err != nil {
 		return fmt.Errorf("write cache: %w", err)

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -36,16 +36,6 @@ func TestSaveAndLoad_RoundTrip(t *testing.T) {
 	if err := original.Save(cachePath); err != nil {
 		t.Fatalf("Save failed: %v", err)
 	}
-	raw, err := os.ReadFile(cachePath)
-	if err != nil {
-		t.Fatalf("read cache file: %v", err)
-	}
-	if !strings.Contains(string(raw), `"columns"`) {
-		t.Fatalf("expected cache file to persist columnar findings, got %s", raw)
-	}
-	if strings.Contains(string(raw), `"findings"`) {
-		t.Fatalf("expected cache file to omit legacy findings field, got %s", raw)
-	}
 
 	loaded := Load(cachePath)
 	if loaded.Version != original.Version {
@@ -557,15 +547,13 @@ func TestLoad_LegacyFindingsFieldRewritesAsColumnsOnly(t *testing.T) {
 		t.Fatalf("rewrite cache: %v", err)
 	}
 
-	rewritten, err := os.ReadFile(rewrittenPath)
-	if err != nil {
-		t.Fatalf("read rewritten cache: %v", err)
+	reloaded := Load(rewrittenPath)
+	entry, ok := reloaded.Files["/src/legacy.kt"]
+	if !ok {
+		t.Fatal("legacy entry missing after rewrite")
 	}
-	if !strings.Contains(string(rewritten), `"columns"`) {
-		t.Fatalf("expected rewritten cache to persist columns, got %s", rewritten)
-	}
-	if strings.Contains(string(rewritten), `"findings"`) {
-		t.Fatalf("expected rewritten cache to omit legacy findings field, got %s", rewritten)
+	if entry.Columns.Len() != 1 {
+		t.Fatalf("expected 1 columnar row after rewrite, got %d", entry.Columns.Len())
 	}
 }
 

--- a/internal/cache/portability_test.go
+++ b/internal/cache/portability_test.go
@@ -178,11 +178,42 @@ func TestCacheBytes_PathIndependence(t *testing.T) {
 	a, _ := os.ReadFile(pA)
 	b, _ := os.ReadFile(pB)
 
-	// After substituting the project root, the two caches must be byte-equal.
-	normA := bytes.ReplaceAll(a, []byte(rootA), []byte("<ROOT>"))
-	normB := bytes.ReplaceAll(b, []byte(rootB), []byte("<ROOT>"))
+	// The compressed binary cache is not amenable to byte-level path
+	// substitution, so we normalise at the logical layer: load each cache,
+	// rewrite the project-root prefix in the Files map keys and the
+	// per-file finding columns, save back, and compare the resulting bytes.
+	normalize := func(src string, root string) []byte {
+		loaded := Load(src)
+		rewritten := make(map[string]FileEntry, len(loaded.Files))
+		for path, entry := range loaded.Files {
+			cols := entry.Columns.Clone()
+			for i, fp := range cols.Files {
+				cols.Files[i] = strings.Replace(fp, root, "<ROOT>", 1)
+			}
+			newPath := strings.Replace(path, root, "<ROOT>", 1)
+			rewritten[newPath] = FileEntry{
+				Hash:    entry.Hash,
+				ModTime: entry.ModTime,
+				Size:    entry.Size,
+				Columns: cols,
+			}
+		}
+		loaded.Files = rewritten
+		loaded.ScanPaths = append([]string(nil), loaded.ScanPaths...)
+		for i, p := range loaded.ScanPaths {
+			loaded.ScanPaths[i] = strings.Replace(p, root, "<ROOT>", 1)
+		}
+		out := filepath.Join(dir, "norm-"+filepath.Base(src))
+		if err := loaded.Save(out); err != nil {
+			t.Fatal(err)
+		}
+		data, _ := os.ReadFile(out)
+		return data
+	}
+	normA := normalize(pA, rootA)
+	normB := normalize(pB, rootB)
 	if !bytes.Equal(normA, normB) {
-		t.Fatalf("normalized cache bytes differ across roots\nA=%q\nB=%q", normA, normB)
+		t.Fatalf("normalised cache bytes differ across roots\nA len=%d\nB len=%d", len(normA), len(normB))
 	}
 
 	// Sanity check: the unsubstituted bytes must NOT match (otherwise the
@@ -288,17 +319,32 @@ func TestCache_CrossMachineRoundTrip(t *testing.T) {
 	}
 
 	// Simulate the CI-side path rewrite: load A's cache, rewrite the prefix
-	// onto the new tree, and save it where the new run will read it.
-	raw, err := os.ReadFile(cacheA)
-	if err != nil {
-		t.Fatal(err)
+	// onto the new tree at the logical layer (map keys + interned Files
+	// slice in each column), and save it where the new run will read it.
+	// Byte-level substitution is not safe against the compressed binary
+	// cache format, so callers must go through Load / Save.
+	cached := Load(cacheA)
+	rewritten := make(map[string]FileEntry, len(cached.Files))
+	for path, entry := range cached.Files {
+		cols := entry.Columns.Clone()
+		for i, fp := range cols.Files {
+			cols.Files[i] = strings.Replace(fp, rootA, rootB, 1)
+		}
+		newPath := strings.Replace(path, rootA, rootB, 1)
+		rewritten[newPath] = FileEntry{
+			Hash:    entry.Hash,
+			ModTime: entry.ModTime,
+			Size:    entry.Size,
+			Columns: cols,
+		}
 	}
-	rewritten := bytes.ReplaceAll(raw, []byte(rootA), []byte(rootB))
+	cached.Files = rewritten
+	cached.ScanPaths = []string{rootB}
 	cacheB := filepath.Join(rootB, ".krit", "cache", CacheFileName)
 	if err := os.MkdirAll(filepath.Dir(cacheB), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(cacheB, rewritten, 0644); err != nil {
+	if err := cached.Save(cacheB); err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
## Summary

- Replaces \`encoding/json\` serialisation of the incremental cache (\`.krit/cache/krit-*.cache\`) with a magic-prefixed (\`KFIC\`), zstd-compressed gob frame.
- Legacy JSON caches still load via a fallback path, so existing on-disk caches keep working until the next \`Save\` rewrites them.
- The two portability tests that previously relied on byte-level path substitution now rewrite paths at the logical layer (\`Load\` → mutate \`Files\` map keys + \`Columns.Files\` → \`Save\`), since compressed bytes can't be \`sed\`-substituted in place.

## Why

JSON serialisation dominated the warm cache load path. Measured on a real 16 MB cache from \`~/github/kotlin\` (63 k file entries, 87 k cached findings), Apple M3 Max:

| Format | Disk size | Decode time |
|---|---|---|
| JSON (before) | 15.99 MB | 282 ms |
| Plain gob | 11.01 MB | 30 ms |
| **Gob + zstd (this PR)** | **2.02 MB** | **38 ms** |

End-to-end on \`~/github/kotlin\`:

| Scenario | Before | After |
|---|---|---|
| Warm baseline (3 runs) | 1.17 / 1.01 / 1.02 s | **1.05 / 0.94 / 0.89 s** |
| Warm + 1 kt ABI edit | 1.02 / 1.01 / 1.02 s | **0.91 / 0.83 / 0.83 s** |
| \`cacheLoadAsync\` phase | 546 ms | **42 ms** |
| krit-internal total | 1606 ms | **551 ms** |

## Design notes

- **Frame layout:** magic (4 B, \`0x4b464943\` = \`KFIC\`) · version (4 B) · CRC32 of compressed payload (4 B) · payload length (8 B BE) · zstd-compressed gob payload. Mirrors the existing \`findings_bundle_cache.go\` precedent.
- **Determinism:** the on-wire payload is a \`[]binaryEntry\` sorted by path (not the \`Files\` map directly) — gob iterates maps in unspecified order, which would otherwise break \`TestCacheBytes_DeterministicAcrossInsertOrder\`.
- **Round-trip:** the per-entry \`FindingColumns\` has unexported lex-rank caches that gob skips. They're rebuilt lazily on the next \`SortByFileLine\` call; the cache hot path never reads them from the per-entry columns (they're built fresh on the aggregate output collector), so this is a no-op in practice.
- **Store-backed cache (\`AttachStore\`) is untouched.** That's the separate per-file blob path; this PR only addresses the JSON-backed single-file cache.

## Test plan

- [x] \`go build -o krit ./cmd/krit/\`
- [x] \`go vet ./...\` clean
- [x] \`golangci-lint run ./internal/cache/...\` — 0 issues
- [x] \`go test ./... -count=1\` — all pass
- [x] \`make lint-rules\` clean
- [x] End-to-end warm + 1 kt ABI on \`~/github/kotlin\` repeatedly under 1 s wall
- [x] Legacy JSON cache still loads via the fallback path (verified by \`TestLoad_LegacyFindingsFieldRewritesAsColumnsOnly\`)
- [x] Determinism tests pass: \`TestCacheBytes_DeterministicAcrossSaves\`, \`*AcrossLoadSave\`, \`*AcrossInsertOrder\`, \`*PathIndependence\`, \`*NoEnvLeakage\`