### PR TITLE
fix(rules): scope @Deprecated level extraction to the level value

### DIFF
--- a/internal/rules/potentialbugs_misc.go
+++ b/internal/rules/potentialbugs_misc.go
@@ -178,6 +178,12 @@ func extractDeprecationLevel(annText string) string {
 		return ""
 	}
 	rest = strings.TrimSpace(rest[eqIdx+1:])
+	// Confine the scan to the level value itself; otherwise sibling
+	// arguments like `replaceWith = ReplaceWith("... WARNING ...")` or
+	// the deprecation message could shadow the actual level.
+	if end := levelArgumentEnd(rest); end >= 0 {
+		rest = rest[:end]
+	}
 	// Could be DeprecationLevel.WARNING or just WARNING
 	for _, level := range []string{"WARNING", "ERROR", "HIDDEN"} {
 		if strings.Contains(rest, level) {
@@ -185,6 +191,45 @@ func extractDeprecationLevel(annText string) string {
 		}
 	}
 	return ""
+}
+
+// levelArgumentEnd returns the index in s at which the level value ends —
+// the first top-level `,` or `)`. The legitimate level values
+// (`DeprecationLevel.WARNING|ERROR|HIDDEN`, or the unqualified variants)
+// contain no parens, brackets, or string literals, so a depth/quote walk
+// is enough.
+func levelArgumentEnd(s string) int {
+	depth := 0
+	inStr := false
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if inStr {
+			if c == '\\' && i+1 < len(s) {
+				i++
+				continue
+			}
+			if c == '"' {
+				inStr = false
+			}
+			continue
+		}
+		switch c {
+		case '"':
+			inStr = true
+		case '(', '[', '{':
+			depth++
+		case ')', ']', '}':
+			if depth == 0 {
+				return i
+			}
+			depth--
+		case ',':
+			if depth == 0 {
+				return i
+			}
+		}
+	}
+	return -1
 }
 
 // extractReplaceWith extracts the replaceWith expression from @Deprecated.

--- a/internal/rules/potentialbugs_misc_internal_test.go
+++ b/internal/rules/potentialbugs_misc_internal_test.go
@@ -1,0 +1,60 @@
+package rules
+
+import "testing"
+
+func TestExtractDeprecationLevel(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "simple warning",
+			in:   `@Deprecated("old", level = DeprecationLevel.WARNING)`,
+			want: "WARNING",
+		},
+		{
+			name: "simple error",
+			in:   `@Deprecated("old", level = DeprecationLevel.ERROR)`,
+			want: "ERROR",
+		},
+		{
+			name: "simple hidden",
+			in:   `@Deprecated("old", level = DeprecationLevel.HIDDEN)`,
+			want: "HIDDEN",
+		},
+		{
+			name: "unqualified value",
+			in:   `@Deprecated("old", level = ERROR)`,
+			want: "ERROR",
+		},
+		{
+			name: "level before message containing another level word",
+			in:   `@Deprecated("see ERROR cases", level = DeprecationLevel.WARNING)`,
+			want: "WARNING",
+		},
+		{
+			name: "level followed by replaceWith referencing another level keyword",
+			in:   `@Deprecated("old", level = DeprecationLevel.HIDDEN, replaceWith = ReplaceWith("newApi() // WARNING-style cleanup"))`,
+			want: "HIDDEN",
+		},
+		{
+			name: "level followed by replaceWith with ERROR substring",
+			in:   `@Deprecated("old", level = DeprecationLevel.WARNING, replaceWith = ReplaceWith("handleERRORLater()"))`,
+			want: "WARNING",
+		},
+		{
+			name: "no level argument",
+			in:   `@Deprecated("old")`,
+			want: "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := extractDeprecationLevel(tc.in)
+			if got != tc.want {
+				t.Fatalf("extractDeprecationLevel(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- `extractDeprecationLevel` scanned the entire annotation tail with `strings.Contains` for `WARNING`/`ERROR`/`HIDDEN`, so a sibling argument containing one of those words could shadow the real level value.
- Realistic trigger: `@Deprecated("...", level = DeprecationLevel.HIDDEN, replaceWith = ReplaceWith("newApi() // WARNING-style cleanup"))` was read as `WARNING`, causing `PrecompileDeprecatedSymbolUsedError` to mis-categorize the severity.
- Fix: terminate the scan at the first top-level `,` or `)` so only the level argument's value is inspected. Legitimate level values contain no parens, brackets, or string literals, so a small depth/quote walk is sufficient.

## Test plan
- [x] `go test ./internal/rules/ -run TestExtractDeprecationLevel -v` — new internal unit test covers simple, unqualified, and sibling-shadowing cases.
- [x] `go build ./cmd/krit/`, `go vet ./...`, `go test ./internal/rules/ -count=1`.