### PR TITLE
feat(rules): classify default-inactive rules with OptInReason

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,8 +19,9 @@ vet:
 #   - capability-declaration: ctx.Resolver / .Oracle() needs NeedsResolver / NeedsOracle
 #   - concurrent-state: go/WaitGroup/MergeCollectors needs NeedsConcurrent
 #   - fix-drift: Fix != FixNone requires an f.Fix assignment in the Check body
+#   - opt-in-reason: DefaultActive: false requires an OptInReason classification
 lint-rules:
-	go test ./internal/ruleslinter/ -run 'TestRulesPackageHasNoCapabilityDrift|TestRulesPackageHasNoNewAdHocCaches' -count=1
+	go test ./internal/ruleslinter/ -run 'TestRulesPackageHasNoCapabilityDrift|TestRulesPackageHasNoNewAdHocCaches|TestRulesPackageHasOptInReasons' -count=1
 
 lint: build
 	./krit .

--- a/internal/rules/api/metadata.go
+++ b/internal/rules/api/metadata.go
@@ -198,6 +198,12 @@ type RuleDescriptor struct {
 	// --all-rules).
 	DefaultActive bool
 
+	// OptInReason classifies *why* a default-inactive rule is off by
+	// default. Required (and only meaningful) when DefaultActive == false;
+	// the ruleslinter gate enforces both directions. See OptInReason for
+	// the enum values and intent.
+	OptInReason OptInReason
+
 	// FixLevel is "", "cosmetic", "idiomatic", or "semantic".
 	// Empty string means the rule does not provide an auto-fix.
 	FixLevel string

--- a/internal/rules/api/rule.go
+++ b/internal/rules/api/rule.go
@@ -405,6 +405,83 @@ func (m Maturity) String() string {
 	}
 }
 
+// OptInReason classifies *why* a default-inactive rule ships off by default.
+// It is required when DefaultActive == false and must remain unset
+// (OptInReasonUnspecified) when DefaultActive == true. The ruleslinter gate
+// enforces both directions so the registry can be analyzed by category
+// (e.g. "how many opinionated rules do we ship?", "which Android-only rules
+// could graduate to default once we detect an Android project?").
+//
+// The reason is orthogonal to Maturity: an Experimental rule still carries
+// a reason describing the *intent* of the rule (Opinionated, AndroidOnly,
+// etc.) — Maturity captures soak status, OptInReason captures intent.
+type OptInReason uint8
+
+const (
+	// OptInReasonUnspecified is the zero value. Required for
+	// DefaultActive == true rules; forbidden for DefaultActive == false.
+	OptInReasonUnspecified OptInReason = iota
+	// OptInReasonOpinionated marks style and house-preference rules that
+	// would generate split votes on review. Examples: braces on
+	// single-line ifs, idiomatic data-class shape, expression style.
+	OptInReasonOpinionated
+	// OptInReasonProjectPolicy marks architectural and conventions rules
+	// that only make sense once a project picks a layering / package /
+	// naming policy. Examples: layer-dependency violations, package
+	// cycles, package-naming drift, public-to-internal leaks.
+	OptInReasonProjectPolicy
+	// OptInReasonThresholdTuning marks rules whose primary signal is a
+	// numeric threshold the team must choose. Examples: cognitive
+	// complexity, complex interface, hotspot allowed-count.
+	OptInReasonThresholdTuning
+	// OptInReasonDomainSpecific marks rules that are real signal for some
+	// project domains and noise for others. Examples: observability,
+	// privacy/analytics, supply-chain, i18n, licensing, framework-specific
+	// (Compose, Coroutines, DI, DB) checks.
+	OptInReasonDomainSpecific
+	// OptInReasonAndroidOnly marks rules that only meaningfully apply to
+	// Android projects (manifest, resources, icons, Android-lint parity).
+	// They ship off so plain Kotlin/JVM projects don't see them.
+	OptInReasonAndroidOnly
+	// OptInReasonRequiresUserConfig marks rules that produce no findings
+	// (or wrong findings) without user-supplied option values. Examples:
+	// forbidden-imports list, recommended versions catalog.
+	OptInReasonRequiresUserConfig
+	// OptInReasonDuplicatesCompiler marks rules that approximate a
+	// kotlinc/javac diagnostic. They ship for IDE/LSP/precompile UX where
+	// running krit is cheaper than a full compile, but stay off by default
+	// so a project that already compiles doesn't see duplicate diagnostics.
+	OptInReasonDuplicatesCompiler
+	// OptInReasonExpensive marks rules whose project-wide analysis is
+	// heavy enough that defaulting them on would noticeably hurt run time
+	// even on projects that want them. Examples: module-aware dead-code.
+	OptInReasonExpensive
+)
+
+// String returns a human-readable label for the OptInReason value.
+func (r OptInReason) String() string {
+	switch r {
+	case OptInReasonOpinionated:
+		return "opinionated"
+	case OptInReasonProjectPolicy:
+		return "project-policy"
+	case OptInReasonThresholdTuning:
+		return "threshold-tuning"
+	case OptInReasonDomainSpecific:
+		return "domain-specific"
+	case OptInReasonAndroidOnly:
+		return "android-only"
+	case OptInReasonRequiresUserConfig:
+		return "requires-user-config"
+	case OptInReasonDuplicatesCompiler:
+		return "duplicates-compiler"
+	case OptInReasonExpensive:
+		return "expensive"
+	default:
+		return "unspecified"
+	}
+}
+
 // OracleFilter declares when a rule needs oracle type information.
 type OracleFilter struct {
 	Identifiers []string
@@ -656,6 +733,11 @@ type Rule struct {
 	// DefaultActive == false are opt-in (must be enabled via config or
 	// --all-rules).
 	DefaultActive bool
+
+	// OptInReason classifies *why* this rule is off by default. Required
+	// (and only meaningful) when DefaultActive == false; the ruleslinter
+	// gate enforces both directions. See OptInReason for enum values.
+	OptInReason OptInReason
 
 	// Options are the configurable fields the rule exposes via YAML.
 	Options []ConfigOption

--- a/internal/rules/meta_accessibility.go
+++ b/internal/rules/meta_accessibility.go
@@ -9,7 +9,7 @@ func (r *AnimatorDurationIgnoresScaleRule) Meta() api.RuleDescriptor {
 		ID:            "AnimatorDurationIgnoresScale",
 		RuleSet:       "a11y",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 

--- a/internal/rules/meta_accessibility.go
+++ b/internal/rules/meta_accessibility.go
@@ -9,6 +9,7 @@ func (r *AnimatorDurationIgnoresScaleRule) Meta() api.RuleDescriptor {
 		ID:            "AnimatorDurationIgnoresScale",
 		RuleSet:       "a11y",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 

--- a/internal/rules/meta_android_correctness.go
+++ b/internal/rules/meta_android_correctness.go
@@ -9,6 +9,7 @@ func (r *AssertRule) Meta() api.RuleDescriptor {
 		ID:            "Assert",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -17,6 +18,7 @@ func (r *CheckResultRule) Meta() api.RuleDescriptor {
 		ID:            "CheckResult",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -25,6 +27,7 @@ func (r *CommitPrefEditsRule) Meta() api.RuleDescriptor {
 		ID:            "CommitPrefEdits",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -33,6 +36,7 @@ func (r *CommitTransactionRule) Meta() api.RuleDescriptor {
 		ID:            "CommitTransaction",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -41,6 +45,7 @@ func (r *DefaultLocaleRule) Meta() api.RuleDescriptor {
 		ID:            "DefaultLocale",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -49,6 +54,7 @@ func (r *NestedScrollingRule) Meta() api.RuleDescriptor {
 		ID:            "NestedScrolling",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -57,6 +63,7 @@ func (r *RegisteredRule) Meta() api.RuleDescriptor {
 		ID:            "Registered",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -65,6 +72,7 @@ func (r *SQLiteStringRule) Meta() api.RuleDescriptor {
 		ID:            "SQLiteString",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -73,6 +81,7 @@ func (r *ScrollViewCountRule) Meta() api.RuleDescriptor {
 		ID:            "ScrollViewCount",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -81,6 +90,7 @@ func (r *SetTextI18nRule) Meta() api.RuleDescriptor {
 		ID:            "SetTextI18n",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -89,6 +99,7 @@ func (r *ShiftFlagsRule) Meta() api.RuleDescriptor {
 		ID:            "ShiftFlags",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -97,6 +108,7 @@ func (r *SimpleDateFormatRule) Meta() api.RuleDescriptor {
 		ID:            "SimpleDateFormat",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -105,6 +117,7 @@ func (r *StopShipRule) Meta() api.RuleDescriptor {
 		ID:            "StopShip",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -113,6 +126,7 @@ func (r *UniqueConstantsRule) Meta() api.RuleDescriptor {
 		ID:            "UniqueConstants",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -121,6 +135,7 @@ func (r *WrongCallRule) Meta() api.RuleDescriptor {
 		ID:            "WrongCall",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -129,5 +144,6 @@ func (r *WrongThreadRule) Meta() api.RuleDescriptor {
 		ID:            "WrongThread",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }

--- a/internal/rules/meta_android_correctness.go
+++ b/internal/rules/meta_android_correctness.go
@@ -9,7 +9,7 @@ func (r *AssertRule) Meta() api.RuleDescriptor {
 		ID:            "Assert",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -18,7 +18,7 @@ func (r *CheckResultRule) Meta() api.RuleDescriptor {
 		ID:            "CheckResult",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -27,7 +27,7 @@ func (r *CommitPrefEditsRule) Meta() api.RuleDescriptor {
 		ID:            "CommitPrefEdits",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -36,7 +36,7 @@ func (r *CommitTransactionRule) Meta() api.RuleDescriptor {
 		ID:            "CommitTransaction",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -45,7 +45,7 @@ func (r *DefaultLocaleRule) Meta() api.RuleDescriptor {
 		ID:            "DefaultLocale",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -54,7 +54,7 @@ func (r *NestedScrollingRule) Meta() api.RuleDescriptor {
 		ID:            "NestedScrolling",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -63,7 +63,7 @@ func (r *RegisteredRule) Meta() api.RuleDescriptor {
 		ID:            "Registered",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -72,7 +72,7 @@ func (r *SQLiteStringRule) Meta() api.RuleDescriptor {
 		ID:            "SQLiteString",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -81,7 +81,7 @@ func (r *ScrollViewCountRule) Meta() api.RuleDescriptor {
 		ID:            "ScrollViewCount",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -90,7 +90,7 @@ func (r *SetTextI18nRule) Meta() api.RuleDescriptor {
 		ID:            "SetTextI18n",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -99,7 +99,7 @@ func (r *ShiftFlagsRule) Meta() api.RuleDescriptor {
 		ID:            "ShiftFlags",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -108,7 +108,7 @@ func (r *SimpleDateFormatRule) Meta() api.RuleDescriptor {
 		ID:            "SimpleDateFormat",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -117,7 +117,7 @@ func (r *StopShipRule) Meta() api.RuleDescriptor {
 		ID:            "StopShip",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -126,7 +126,7 @@ func (r *UniqueConstantsRule) Meta() api.RuleDescriptor {
 		ID:            "UniqueConstants",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -135,7 +135,7 @@ func (r *WrongCallRule) Meta() api.RuleDescriptor {
 		ID:            "WrongCall",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -144,6 +144,6 @@ func (r *WrongThreadRule) Meta() api.RuleDescriptor {
 		ID:            "WrongThread",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }

--- a/internal/rules/meta_android_correctness_checks.go
+++ b/internal/rules/meta_android_correctness_checks.go
@@ -9,7 +9,7 @@ func (r *AccidentalOctalRule) Meta() api.RuleDescriptor {
 		ID:            "AccidentalOctal",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -18,7 +18,7 @@ func (r *AppCompatMethodRule) Meta() api.RuleDescriptor {
 		ID:            "AppCompatMethod",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -27,7 +27,7 @@ func (r *CustomViewStyleableRule) Meta() api.RuleDescriptor {
 		ID:            "CustomViewStyleable",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -36,7 +36,7 @@ func (r *DeprecatedRule) Meta() api.RuleDescriptor {
 		ID:            "Deprecated",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -45,7 +45,7 @@ func (r *InnerclassSeparatorRule) Meta() api.RuleDescriptor {
 		ID:            "InnerclassSeparator",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -54,7 +54,7 @@ func (r *LocalSuppressRule) Meta() api.RuleDescriptor {
 		ID:            "LocalSuppress",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -63,7 +63,7 @@ func (r *ObjectAnimatorBindingRule) Meta() api.RuleDescriptor {
 		ID:            "ObjectAnimatorBinding",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -80,7 +80,7 @@ func (r *OverrideAbstractRule) Meta() api.RuleDescriptor {
 		ID:            "OverrideAbstract",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -89,7 +89,7 @@ func (r *ParcelCreatorRule) Meta() api.RuleDescriptor {
 		ID:            "ParcelCreator",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -98,7 +98,7 @@ func (r *PluralsCandidateRule) Meta() api.RuleDescriptor {
 		ID:            "PluralsCandidate",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -107,7 +107,7 @@ func (r *PropertyEscapeRule) Meta() api.RuleDescriptor {
 		ID:            "PropertyEscape",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -116,7 +116,7 @@ func (r *RangeRule) Meta() api.RuleDescriptor {
 		ID:            "Range",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -125,7 +125,7 @@ func (r *ResourceAsColorRule) Meta() api.RuleDescriptor {
 		ID:            "ResourceAsColor",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -134,7 +134,7 @@ func (r *ResourceTypeRule) Meta() api.RuleDescriptor {
 		ID:            "ResourceType",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -143,7 +143,7 @@ func (r *ShortAlarmRule) Meta() api.RuleDescriptor {
 		ID:            "ShortAlarm",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -152,7 +152,7 @@ func (r *SupportAnnotationUsageRule) Meta() api.RuleDescriptor {
 		ID:            "SupportAnnotationUsage",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -161,7 +161,7 @@ func (r *SwitchIntDefRule) Meta() api.RuleDescriptor {
 		ID:            "SwitchIntDef",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -170,7 +170,7 @@ func (r *TextViewEditsRule) Meta() api.RuleDescriptor {
 		ID:            "TextViewEdits",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -179,6 +179,6 @@ func (r *WrongViewCastRule) Meta() api.RuleDescriptor {
 		ID:            "WrongViewCast",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }

--- a/internal/rules/meta_android_correctness_checks.go
+++ b/internal/rules/meta_android_correctness_checks.go
@@ -9,6 +9,7 @@ func (r *AccidentalOctalRule) Meta() api.RuleDescriptor {
 		ID:            "AccidentalOctal",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -17,6 +18,7 @@ func (r *AppCompatMethodRule) Meta() api.RuleDescriptor {
 		ID:            "AppCompatMethod",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -25,6 +27,7 @@ func (r *CustomViewStyleableRule) Meta() api.RuleDescriptor {
 		ID:            "CustomViewStyleable",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -33,6 +36,7 @@ func (r *DeprecatedRule) Meta() api.RuleDescriptor {
 		ID:            "Deprecated",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -41,6 +45,7 @@ func (r *InnerclassSeparatorRule) Meta() api.RuleDescriptor {
 		ID:            "InnerclassSeparator",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -49,6 +54,7 @@ func (r *LocalSuppressRule) Meta() api.RuleDescriptor {
 		ID:            "LocalSuppress",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -57,6 +63,7 @@ func (r *ObjectAnimatorBindingRule) Meta() api.RuleDescriptor {
 		ID:            "ObjectAnimatorBinding",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -73,6 +80,7 @@ func (r *OverrideAbstractRule) Meta() api.RuleDescriptor {
 		ID:            "OverrideAbstract",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -81,6 +89,7 @@ func (r *ParcelCreatorRule) Meta() api.RuleDescriptor {
 		ID:            "ParcelCreator",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -89,6 +98,7 @@ func (r *PluralsCandidateRule) Meta() api.RuleDescriptor {
 		ID:            "PluralsCandidate",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -97,6 +107,7 @@ func (r *PropertyEscapeRule) Meta() api.RuleDescriptor {
 		ID:            "PropertyEscape",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -105,6 +116,7 @@ func (r *RangeRule) Meta() api.RuleDescriptor {
 		ID:            "Range",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -113,6 +125,7 @@ func (r *ResourceAsColorRule) Meta() api.RuleDescriptor {
 		ID:            "ResourceAsColor",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -121,6 +134,7 @@ func (r *ResourceTypeRule) Meta() api.RuleDescriptor {
 		ID:            "ResourceType",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -129,6 +143,7 @@ func (r *ShortAlarmRule) Meta() api.RuleDescriptor {
 		ID:            "ShortAlarm",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -137,6 +152,7 @@ func (r *SupportAnnotationUsageRule) Meta() api.RuleDescriptor {
 		ID:            "SupportAnnotationUsage",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -145,6 +161,7 @@ func (r *SwitchIntDefRule) Meta() api.RuleDescriptor {
 		ID:            "SwitchIntDef",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -153,6 +170,7 @@ func (r *TextViewEditsRule) Meta() api.RuleDescriptor {
 		ID:            "TextViewEdits",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -161,5 +179,6 @@ func (r *WrongViewCastRule) Meta() api.RuleDescriptor {
 		ID:            "WrongViewCast",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }

--- a/internal/rules/meta_android_gradle.go
+++ b/internal/rules/meta_android_gradle.go
@@ -12,7 +12,7 @@ func (r *AndroidGradlePluginVersionRule) Meta() api.RuleDescriptor {
 		ID:            "AndroidGradlePluginVersion",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -21,7 +21,7 @@ func (r *DeprecatedDependencyRule) Meta() api.RuleDescriptor {
 		ID:            "DeprecatedDependency",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -31,7 +31,7 @@ func (r *DynamicVersionRule) Meta() api.RuleDescriptor {
 		ID:            "DynamicVersion",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -40,7 +40,7 @@ func (r *GradleDeprecatedRule) Meta() api.RuleDescriptor {
 		ID:            "GradleDeprecated",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -49,7 +49,7 @@ func (r *GradleGetterRule) Meta() api.RuleDescriptor {
 		ID:            "GradleGetter",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -58,7 +58,7 @@ func (r *GradleIdeErrorRule) Meta() api.RuleDescriptor {
 		ID:            "GradleIdeError",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -67,7 +67,7 @@ func (r *GradleOldTargetAPIRule) Meta() api.RuleDescriptor {
 		ID:            "OldTargetApi",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 		Options: []api.ConfigOption{
 			api.IntOption(api.IntOptionSpec[GradleOldTargetAPIRule]{
 				Name:        "threshold",
@@ -84,7 +84,7 @@ func (r *GradleOverridesRule) Meta() api.RuleDescriptor {
 		ID:            "GradleOverrides",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -93,7 +93,7 @@ func (r *GradlePathRule) Meta() api.RuleDescriptor {
 		ID:            "GradlePath",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -103,7 +103,7 @@ func (r *GradlePluginCompatibilityRule) Meta() api.RuleDescriptor {
 		ID:            "GradlePluginCompatibility",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -112,7 +112,7 @@ func (r *MavenLocalRule) Meta() api.RuleDescriptor {
 		ID:            "MavenLocal",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -121,7 +121,7 @@ func (r *MinSdkTooLowRule) Meta() api.RuleDescriptor {
 		ID:            "MinSdkTooLow",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 		Options: []api.ConfigOption{
 			api.IntOption(api.IntOptionSpec[MinSdkTooLowRule]{
 				Name:        "threshold",
@@ -138,7 +138,7 @@ func (r *RemoteVersionRule) Meta() api.RuleDescriptor {
 		ID:            "RemoteVersion",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -148,6 +148,6 @@ func (r *StringIntegerRule) Meta() api.RuleDescriptor {
 		ID:            "StringInteger",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }

--- a/internal/rules/meta_android_gradle.go
+++ b/internal/rules/meta_android_gradle.go
@@ -12,6 +12,7 @@ func (r *AndroidGradlePluginVersionRule) Meta() api.RuleDescriptor {
 		ID:            "AndroidGradlePluginVersion",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -20,6 +21,7 @@ func (r *DeprecatedDependencyRule) Meta() api.RuleDescriptor {
 		ID:            "DeprecatedDependency",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -29,6 +31,7 @@ func (r *DynamicVersionRule) Meta() api.RuleDescriptor {
 		ID:            "DynamicVersion",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -37,6 +40,7 @@ func (r *GradleDeprecatedRule) Meta() api.RuleDescriptor {
 		ID:            "GradleDeprecated",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -45,6 +49,7 @@ func (r *GradleGetterRule) Meta() api.RuleDescriptor {
 		ID:            "GradleGetter",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -53,6 +58,7 @@ func (r *GradleIdeErrorRule) Meta() api.RuleDescriptor {
 		ID:            "GradleIdeError",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -61,6 +67,7 @@ func (r *GradleOldTargetAPIRule) Meta() api.RuleDescriptor {
 		ID:            "OldTargetApi",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 		Options: []api.ConfigOption{
 			api.IntOption(api.IntOptionSpec[GradleOldTargetAPIRule]{
 				Name:        "threshold",
@@ -77,6 +84,7 @@ func (r *GradleOverridesRule) Meta() api.RuleDescriptor {
 		ID:            "GradleOverrides",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -85,6 +93,7 @@ func (r *GradlePathRule) Meta() api.RuleDescriptor {
 		ID:            "GradlePath",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -94,6 +103,7 @@ func (r *GradlePluginCompatibilityRule) Meta() api.RuleDescriptor {
 		ID:            "GradlePluginCompatibility",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -102,6 +112,7 @@ func (r *MavenLocalRule) Meta() api.RuleDescriptor {
 		ID:            "MavenLocal",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -110,6 +121,7 @@ func (r *MinSdkTooLowRule) Meta() api.RuleDescriptor {
 		ID:            "MinSdkTooLow",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 		Options: []api.ConfigOption{
 			api.IntOption(api.IntOptionSpec[MinSdkTooLowRule]{
 				Name:        "threshold",
@@ -126,6 +138,7 @@ func (r *RemoteVersionRule) Meta() api.RuleDescriptor {
 		ID:            "RemoteVersion",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -135,5 +148,6 @@ func (r *StringIntegerRule) Meta() api.RuleDescriptor {
 		ID:            "StringInteger",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }

--- a/internal/rules/meta_android_icons.go
+++ b/internal/rules/meta_android_icons.go
@@ -9,7 +9,7 @@ func (r *ConvertToWebpRule) Meta() api.RuleDescriptor {
 		ID:            "ConvertToWebp",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -18,7 +18,7 @@ func (r *GifUsageRule) Meta() api.RuleDescriptor {
 		ID:            "GifUsage",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -27,7 +27,7 @@ func (r *IconDensitiesRule) Meta() api.RuleDescriptor {
 		ID:            "IconDensities",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -36,7 +36,7 @@ func (r *IconDipSizeRule) Meta() api.RuleDescriptor {
 		ID:            "IconDipSize",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -45,7 +45,7 @@ func (r *IconDuplicatesConfigRule) Meta() api.RuleDescriptor {
 		ID:            "IconDuplicatesConfig",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -54,7 +54,7 @@ func (r *IconDuplicatesRule) Meta() api.RuleDescriptor {
 		ID:            "IconDuplicates",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -63,7 +63,7 @@ func (r *IconExpectedSizeRule) Meta() api.RuleDescriptor {
 		ID:            "IconExpectedSize",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -72,7 +72,7 @@ func (r *IconExtensionRule) Meta() api.RuleDescriptor {
 		ID:            "IconExtension",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -81,7 +81,7 @@ func (r *IconLocationRule) Meta() api.RuleDescriptor {
 		ID:            "IconLocation",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -90,7 +90,7 @@ func (r *IconMixedNinePatchRule) Meta() api.RuleDescriptor {
 		ID:            "IconMixedNinePatch",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -99,7 +99,7 @@ func (r *IconMissingDensityFolderRule) Meta() api.RuleDescriptor {
 		ID:            "IconMissingDensityFolder",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -108,7 +108,7 @@ func (r *IconColorsRule) Meta() api.RuleDescriptor {
 		ID:            "IconColors",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -117,7 +117,7 @@ func (r *IconLauncherShapeRule) Meta() api.RuleDescriptor {
 		ID:            "IconLauncherShape",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -126,7 +126,7 @@ func (r *IconXMLAndPngRule) Meta() api.RuleDescriptor {
 		ID:            "IconXmlAndPng",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -135,6 +135,6 @@ func (r *IconNoDpiRule) Meta() api.RuleDescriptor {
 		ID:            "IconNoDpi",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }

--- a/internal/rules/meta_android_icons.go
+++ b/internal/rules/meta_android_icons.go
@@ -9,6 +9,7 @@ func (r *ConvertToWebpRule) Meta() api.RuleDescriptor {
 		ID:            "ConvertToWebp",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -17,6 +18,7 @@ func (r *GifUsageRule) Meta() api.RuleDescriptor {
 		ID:            "GifUsage",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -25,6 +27,7 @@ func (r *IconDensitiesRule) Meta() api.RuleDescriptor {
 		ID:            "IconDensities",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -33,6 +36,7 @@ func (r *IconDipSizeRule) Meta() api.RuleDescriptor {
 		ID:            "IconDipSize",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -41,6 +45,7 @@ func (r *IconDuplicatesConfigRule) Meta() api.RuleDescriptor {
 		ID:            "IconDuplicatesConfig",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -49,6 +54,7 @@ func (r *IconDuplicatesRule) Meta() api.RuleDescriptor {
 		ID:            "IconDuplicates",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -57,6 +63,7 @@ func (r *IconExpectedSizeRule) Meta() api.RuleDescriptor {
 		ID:            "IconExpectedSize",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -65,6 +72,7 @@ func (r *IconExtensionRule) Meta() api.RuleDescriptor {
 		ID:            "IconExtension",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -73,6 +81,7 @@ func (r *IconLocationRule) Meta() api.RuleDescriptor {
 		ID:            "IconLocation",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -81,6 +90,7 @@ func (r *IconMixedNinePatchRule) Meta() api.RuleDescriptor {
 		ID:            "IconMixedNinePatch",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -89,6 +99,7 @@ func (r *IconMissingDensityFolderRule) Meta() api.RuleDescriptor {
 		ID:            "IconMissingDensityFolder",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -97,6 +108,7 @@ func (r *IconColorsRule) Meta() api.RuleDescriptor {
 		ID:            "IconColors",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -105,6 +117,7 @@ func (r *IconLauncherShapeRule) Meta() api.RuleDescriptor {
 		ID:            "IconLauncherShape",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -113,6 +126,7 @@ func (r *IconXMLAndPngRule) Meta() api.RuleDescriptor {
 		ID:            "IconXmlAndPng",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -121,5 +135,6 @@ func (r *IconNoDpiRule) Meta() api.RuleDescriptor {
 		ID:            "IconNoDpi",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }

--- a/internal/rules/meta_android_manifest_features.go
+++ b/internal/rules/meta_android_manifest_features.go
@@ -25,6 +25,7 @@ func (r *DeviceAdminManifestRule) Meta() api.RuleDescriptor {
 		ID:            "DeviceAdminManifest",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -33,6 +34,7 @@ func (r *FullBackupContentManifestRule) Meta() api.RuleDescriptor {
 		ID:            "FullBackupContentManifest",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -73,6 +75,7 @@ func (r *MissingRegisteredManifestRule) Meta() api.RuleDescriptor {
 		ID:            "MissingRegisteredManifest",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 

--- a/internal/rules/meta_android_manifest_features.go
+++ b/internal/rules/meta_android_manifest_features.go
@@ -25,7 +25,7 @@ func (r *DeviceAdminManifestRule) Meta() api.RuleDescriptor {
 		ID:            "DeviceAdminManifest",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -34,7 +34,7 @@ func (r *FullBackupContentManifestRule) Meta() api.RuleDescriptor {
 		ID:            "FullBackupContentManifest",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -75,7 +75,7 @@ func (r *MissingRegisteredManifestRule) Meta() api.RuleDescriptor {
 		ID:            "MissingRegisteredManifest",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 

--- a/internal/rules/meta_android_manifest_i18n.go
+++ b/internal/rules/meta_android_manifest_i18n.go
@@ -9,5 +9,6 @@ func (r *LocaleConfigMissingRule) Meta() api.RuleDescriptor {
 		ID:            "LocaleConfigMissing",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }

--- a/internal/rules/meta_android_manifest_i18n.go
+++ b/internal/rules/meta_android_manifest_i18n.go
@@ -9,6 +9,6 @@ func (r *LocaleConfigMissingRule) Meta() api.RuleDescriptor {
 		ID:            "LocaleConfigMissing",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }

--- a/internal/rules/meta_android_manifest_security.go
+++ b/internal/rules/meta_android_manifest_security.go
@@ -17,6 +17,7 @@ func (r *BackupRulesRule) Meta() api.RuleDescriptor {
 		ID:            "BackupRules",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -25,6 +26,7 @@ func (r *CleartextTrafficRule) Meta() api.RuleDescriptor {
 		ID:            "CleartextTraffic",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -57,6 +59,7 @@ func (r *ExportedServiceManifestRule) Meta() api.RuleDescriptor {
 		ID:            "ExportedServiceManifest",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -97,6 +100,7 @@ func (r *ProtectedPermissionsManifestRule) Meta() api.RuleDescriptor {
 		ID:            "ProtectedPermissionsManifest",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -105,6 +109,7 @@ func (r *ServiceExportedManifestRule) Meta() api.RuleDescriptor {
 		ID:            "ServiceExportedManifest",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 

--- a/internal/rules/meta_android_manifest_security.go
+++ b/internal/rules/meta_android_manifest_security.go
@@ -17,7 +17,7 @@ func (r *BackupRulesRule) Meta() api.RuleDescriptor {
 		ID:            "BackupRules",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -26,7 +26,7 @@ func (r *CleartextTrafficRule) Meta() api.RuleDescriptor {
 		ID:            "CleartextTraffic",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -59,7 +59,7 @@ func (r *ExportedServiceManifestRule) Meta() api.RuleDescriptor {
 		ID:            "ExportedServiceManifest",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -100,7 +100,7 @@ func (r *ProtectedPermissionsManifestRule) Meta() api.RuleDescriptor {
 		ID:            "ProtectedPermissionsManifest",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -109,7 +109,7 @@ func (r *ServiceExportedManifestRule) Meta() api.RuleDescriptor {
 		ID:            "ServiceExportedManifest",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 

--- a/internal/rules/meta_android_manifest_structure.go
+++ b/internal/rules/meta_android_manifest_structure.go
@@ -33,7 +33,7 @@ func (r *IntentFilterExportRequiredRule) Meta() api.RuleDescriptor {
 		ID:            "IntentFilterExportRequired",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -58,7 +58,7 @@ func (r *ManifestTypoRule) Meta() api.RuleDescriptor {
 		ID:            "ManifestTypoManifest",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -67,7 +67,7 @@ func (r *MipmapLauncherRule) Meta() api.RuleDescriptor {
 		ID:            "MipmapLauncher",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -76,7 +76,7 @@ func (r *MissingApplicationIconRule) Meta() api.RuleDescriptor {
 		ID:            "MissingApplicationIconManifest",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -109,7 +109,7 @@ func (r *SystemPermissionRule) Meta() api.RuleDescriptor {
 		ID:            "SystemPermission",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -118,7 +118,7 @@ func (r *TargetNewerRule) Meta() api.RuleDescriptor {
 		ID:            "TargetNewer",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -127,7 +127,7 @@ func (r *UniquePermissionRule) Meta() api.RuleDescriptor {
 		ID:            "UniquePermission",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 

--- a/internal/rules/meta_android_manifest_structure.go
+++ b/internal/rules/meta_android_manifest_structure.go
@@ -33,6 +33,7 @@ func (r *IntentFilterExportRequiredRule) Meta() api.RuleDescriptor {
 		ID:            "IntentFilterExportRequired",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -57,6 +58,7 @@ func (r *ManifestTypoRule) Meta() api.RuleDescriptor {
 		ID:            "ManifestTypoManifest",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -65,6 +67,7 @@ func (r *MipmapLauncherRule) Meta() api.RuleDescriptor {
 		ID:            "MipmapLauncher",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -73,6 +76,7 @@ func (r *MissingApplicationIconRule) Meta() api.RuleDescriptor {
 		ID:            "MissingApplicationIconManifest",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -105,6 +109,7 @@ func (r *SystemPermissionRule) Meta() api.RuleDescriptor {
 		ID:            "SystemPermission",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -113,6 +118,7 @@ func (r *TargetNewerRule) Meta() api.RuleDescriptor {
 		ID:            "TargetNewer",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -121,6 +127,7 @@ func (r *UniquePermissionRule) Meta() api.RuleDescriptor {
 		ID:            "UniquePermission",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 

--- a/internal/rules/meta_android_resource_a11y.go
+++ b/internal/rules/meta_android_resource_a11y.go
@@ -49,7 +49,7 @@ func (r *HardcodedValuesResourceRule) Meta() api.RuleDescriptor {
 		ID:            "HardcodedValuesResource",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -106,7 +106,7 @@ func (r *MissingContentDescriptionResourceRule) Meta() api.RuleDescriptor {
 		ID:            "MissingContentDescriptionResource",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 

--- a/internal/rules/meta_android_resource_a11y.go
+++ b/internal/rules/meta_android_resource_a11y.go
@@ -49,6 +49,7 @@ func (r *HardcodedValuesResourceRule) Meta() api.RuleDescriptor {
 		ID:            "HardcodedValuesResource",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -105,6 +106,7 @@ func (r *MissingContentDescriptionResourceRule) Meta() api.RuleDescriptor {
 		ID:            "MissingContentDescriptionResource",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 

--- a/internal/rules/meta_android_resource_ids.go
+++ b/internal/rules/meta_android_resource_ids.go
@@ -9,6 +9,7 @@ func (r *AppCompatResourceRule) Meta() api.RuleDescriptor {
 		ID:            "AppCompatResource",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -25,6 +26,7 @@ func (r *DuplicateIDsResourceRule) Meta() api.RuleDescriptor {
 		ID:            "DuplicateIdsResource",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -41,6 +43,7 @@ func (r *IllegalResourceRefResourceRule) Meta() api.RuleDescriptor {
 		ID:            "IllegalResourceRefResource",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -57,6 +60,7 @@ func (r *InvalidResourceFolderResourceRule) Meta() api.RuleDescriptor {
 		ID:            "InvalidResourceFolderResource",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -65,6 +69,7 @@ func (r *MissingIDResourceRule) Meta() api.RuleDescriptor {
 		ID:            "MissingIdResource",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -89,6 +94,7 @@ func (r *ResAutoResourceRule) Meta() api.RuleDescriptor {
 		ID:            "ResAutoResource",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -97,6 +103,7 @@ func (r *UnusedNamespaceResourceRule) Meta() api.RuleDescriptor {
 		ID:            "UnusedNamespaceResource",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -105,6 +112,7 @@ func (r *WrongCaseResourceRule) Meta() api.RuleDescriptor {
 		ID:            "WrongCaseResource",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -113,5 +121,6 @@ func (r *WrongFolderResourceRule) Meta() api.RuleDescriptor {
 		ID:            "WrongFolderResource",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }

--- a/internal/rules/meta_android_resource_ids.go
+++ b/internal/rules/meta_android_resource_ids.go
@@ -9,7 +9,7 @@ func (r *AppCompatResourceRule) Meta() api.RuleDescriptor {
 		ID:            "AppCompatResource",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -26,7 +26,7 @@ func (r *DuplicateIDsResourceRule) Meta() api.RuleDescriptor {
 		ID:            "DuplicateIdsResource",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -43,7 +43,7 @@ func (r *IllegalResourceRefResourceRule) Meta() api.RuleDescriptor {
 		ID:            "IllegalResourceRefResource",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -60,7 +60,7 @@ func (r *InvalidResourceFolderResourceRule) Meta() api.RuleDescriptor {
 		ID:            "InvalidResourceFolderResource",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -69,7 +69,7 @@ func (r *MissingIDResourceRule) Meta() api.RuleDescriptor {
 		ID:            "MissingIdResource",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -94,7 +94,7 @@ func (r *ResAutoResourceRule) Meta() api.RuleDescriptor {
 		ID:            "ResAutoResource",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -103,7 +103,7 @@ func (r *UnusedNamespaceResourceRule) Meta() api.RuleDescriptor {
 		ID:            "UnusedNamespaceResource",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -112,7 +112,7 @@ func (r *WrongCaseResourceRule) Meta() api.RuleDescriptor {
 		ID:            "WrongCaseResource",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -121,6 +121,6 @@ func (r *WrongFolderResourceRule) Meta() api.RuleDescriptor {
 		ID:            "WrongFolderResource",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }

--- a/internal/rules/meta_android_resource_layout.go
+++ b/internal/rules/meta_android_resource_layout.go
@@ -25,6 +25,7 @@ func (r *InconsistentLayoutResourceRule) Meta() api.RuleDescriptor {
 		ID:            "InconsistentLayout",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -33,6 +34,7 @@ func (r *NestedScrollingResourceRule) Meta() api.RuleDescriptor {
 		ID:            "NestedScrollingResource",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -65,6 +67,7 @@ func (r *ScrollViewSizeResourceRule) Meta() api.RuleDescriptor {
 		ID:            "ScrollViewSizeResource",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -73,6 +76,7 @@ func (r *TooDeepLayoutResourceRule) Meta() api.RuleDescriptor {
 		ID:            "TooDeepLayoutResource",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -81,6 +85,7 @@ func (r *TooManyViewsResourceRule) Meta() api.RuleDescriptor {
 		ID:            "TooManyViewsResource",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -89,6 +94,7 @@ func (r *UseCompoundDrawablesResourceRule) Meta() api.RuleDescriptor {
 		ID:            "UseCompoundDrawablesResource",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -105,5 +111,6 @@ func (r *UselessParentResourceRule) Meta() api.RuleDescriptor {
 		ID:            "UselessParentResource",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }

--- a/internal/rules/meta_android_resource_layout.go
+++ b/internal/rules/meta_android_resource_layout.go
@@ -25,7 +25,7 @@ func (r *InconsistentLayoutResourceRule) Meta() api.RuleDescriptor {
 		ID:            "InconsistentLayout",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -34,7 +34,7 @@ func (r *NestedScrollingResourceRule) Meta() api.RuleDescriptor {
 		ID:            "NestedScrollingResource",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -67,7 +67,7 @@ func (r *ScrollViewSizeResourceRule) Meta() api.RuleDescriptor {
 		ID:            "ScrollViewSizeResource",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -76,7 +76,7 @@ func (r *TooDeepLayoutResourceRule) Meta() api.RuleDescriptor {
 		ID:            "TooDeepLayoutResource",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -85,7 +85,7 @@ func (r *TooManyViewsResourceRule) Meta() api.RuleDescriptor {
 		ID:            "TooManyViewsResource",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -94,7 +94,7 @@ func (r *UseCompoundDrawablesResourceRule) Meta() api.RuleDescriptor {
 		ID:            "UseCompoundDrawablesResource",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -111,6 +111,6 @@ func (r *UselessParentResourceRule) Meta() api.RuleDescriptor {
 		ID:            "UselessParentResource",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }

--- a/internal/rules/meta_android_resource_style.go
+++ b/internal/rules/meta_android_resource_style.go
@@ -35,7 +35,7 @@ func (r *InefficientWeightResourceRule) Meta() api.RuleDescriptor {
 		ID:            "InefficientWeightResource",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -44,7 +44,7 @@ func (r *MergeRootFrameResourceRule) Meta() api.RuleDescriptor {
 		ID:            "MergeRootFrameResource",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -76,7 +76,7 @@ func (r *ObsoleteLayoutParamsResourceRule) Meta() api.RuleDescriptor {
 		ID:            "ObsoleteLayoutParamsResource",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -93,7 +93,7 @@ func (r *PxUsageResourceRule) Meta() api.RuleDescriptor {
 		ID:            "PxUsageResource",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 

--- a/internal/rules/meta_android_resource_style.go
+++ b/internal/rules/meta_android_resource_style.go
@@ -35,6 +35,7 @@ func (r *InefficientWeightResourceRule) Meta() api.RuleDescriptor {
 		ID:            "InefficientWeightResource",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -43,6 +44,7 @@ func (r *MergeRootFrameResourceRule) Meta() api.RuleDescriptor {
 		ID:            "MergeRootFrameResource",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -74,6 +76,7 @@ func (r *ObsoleteLayoutParamsResourceRule) Meta() api.RuleDescriptor {
 		ID:            "ObsoleteLayoutParamsResource",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -90,6 +93,7 @@ func (r *PxUsageResourceRule) Meta() api.RuleDescriptor {
 		ID:            "PxUsageResource",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 

--- a/internal/rules/meta_android_resource_values.go
+++ b/internal/rules/meta_android_resource_values.go
@@ -9,6 +9,7 @@ func (r *ExtraTextResourceRule) Meta() api.RuleDescriptor {
 		ID:            "ExtraTextResource",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -33,6 +34,7 @@ func (r *InconsistentArraysResourceRule) Meta() api.RuleDescriptor {
 		ID:            "InconsistentArraysResource",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -41,6 +43,7 @@ func (r *LocaleConfigStaleResourceRule) Meta() api.RuleDescriptor {
 		ID:            "LocaleConfigStale",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -97,6 +100,7 @@ func (r *StringTrailingWhitespaceResourceRule) Meta() api.RuleDescriptor {
 		ID:            "StringTrailingWhitespace",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -129,6 +133,7 @@ func (r *UnusedAttributeResourceRule) Meta() api.RuleDescriptor {
 		ID:            "UnusedAttributeResource",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -145,6 +150,7 @@ func (r *WebViewInScrollViewResourceRule) Meta() api.RuleDescriptor {
 		ID:            "WebViewInScrollViewResource",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -153,5 +159,6 @@ func (r *WrongRegionResourceRule) Meta() api.RuleDescriptor {
 		ID:            "WrongRegionResource",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }

--- a/internal/rules/meta_android_resource_values.go
+++ b/internal/rules/meta_android_resource_values.go
@@ -9,7 +9,7 @@ func (r *ExtraTextResourceRule) Meta() api.RuleDescriptor {
 		ID:            "ExtraTextResource",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -34,7 +34,7 @@ func (r *InconsistentArraysResourceRule) Meta() api.RuleDescriptor {
 		ID:            "InconsistentArraysResource",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -43,7 +43,7 @@ func (r *LocaleConfigStaleResourceRule) Meta() api.RuleDescriptor {
 		ID:            "LocaleConfigStale",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -100,7 +100,7 @@ func (r *StringTrailingWhitespaceResourceRule) Meta() api.RuleDescriptor {
 		ID:            "StringTrailingWhitespace",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -133,7 +133,7 @@ func (r *UnusedAttributeResourceRule) Meta() api.RuleDescriptor {
 		ID:            "UnusedAttributeResource",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -150,7 +150,7 @@ func (r *WebViewInScrollViewResourceRule) Meta() api.RuleDescriptor {
 		ID:            "WebViewInScrollViewResource",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -159,6 +159,6 @@ func (r *WrongRegionResourceRule) Meta() api.RuleDescriptor {
 		ID:            "WrongRegionResource",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }

--- a/internal/rules/meta_android_rules.go
+++ b/internal/rules/meta_android_rules.go
@@ -9,7 +9,7 @@ func (r *ContentDescriptionRule) Meta() api.RuleDescriptor {
 		ID:            "ContentDescription",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -18,7 +18,7 @@ func (r *ExportedServiceRule) Meta() api.RuleDescriptor {
 		ID:            "ExportedService",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -27,7 +27,7 @@ func (r *HardcodedTextRule) Meta() api.RuleDescriptor {
 		ID:            "HardcodedText",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -36,7 +36,7 @@ func (r *LogDetectorRule) Meta() api.RuleDescriptor {
 		ID:            "LogConditional",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -45,7 +45,7 @@ func (r *ObsoleteLayoutParamsRule) Meta() api.RuleDescriptor {
 		ID:            "ObsoleteLayoutParam",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -54,7 +54,7 @@ func (r *PrivateKeyRule) Meta() api.RuleDescriptor {
 		ID:            "PackagedPrivateKey",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -63,7 +63,7 @@ func (r *SdCardPathRule) Meta() api.RuleDescriptor {
 		ID:            "SdCardPath",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -72,7 +72,7 @@ func (r *SetJavaScriptEnabledRule) Meta() api.RuleDescriptor {
 		ID:            "SetJavaScriptEnabled",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -81,7 +81,7 @@ func (r *ViewHolderRule) Meta() api.RuleDescriptor {
 		ID:            "ViewHolder",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -90,6 +90,6 @@ func (r *WakelockRule) Meta() api.RuleDescriptor {
 		ID:            "Wakelock",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }

--- a/internal/rules/meta_android_rules.go
+++ b/internal/rules/meta_android_rules.go
@@ -9,6 +9,7 @@ func (r *ContentDescriptionRule) Meta() api.RuleDescriptor {
 		ID:            "ContentDescription",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -17,6 +18,7 @@ func (r *ExportedServiceRule) Meta() api.RuleDescriptor {
 		ID:            "ExportedService",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -25,6 +27,7 @@ func (r *HardcodedTextRule) Meta() api.RuleDescriptor {
 		ID:            "HardcodedText",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -33,6 +36,7 @@ func (r *LogDetectorRule) Meta() api.RuleDescriptor {
 		ID:            "LogConditional",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -41,6 +45,7 @@ func (r *ObsoleteLayoutParamsRule) Meta() api.RuleDescriptor {
 		ID:            "ObsoleteLayoutParam",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -49,6 +54,7 @@ func (r *PrivateKeyRule) Meta() api.RuleDescriptor {
 		ID:            "PackagedPrivateKey",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -57,6 +63,7 @@ func (r *SdCardPathRule) Meta() api.RuleDescriptor {
 		ID:            "SdCardPath",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -65,6 +72,7 @@ func (r *SetJavaScriptEnabledRule) Meta() api.RuleDescriptor {
 		ID:            "SetJavaScriptEnabled",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -73,6 +81,7 @@ func (r *ViewHolderRule) Meta() api.RuleDescriptor {
 		ID:            "ViewHolder",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -81,5 +90,6 @@ func (r *WakelockRule) Meta() api.RuleDescriptor {
 		ID:            "Wakelock",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }

--- a/internal/rules/meta_android_security.go
+++ b/internal/rules/meta_android_security.go
@@ -9,6 +9,7 @@ func (r *AddJavascriptInterfaceRule) Meta() api.RuleDescriptor {
 		ID:            "AddJavascriptInterface",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -17,6 +18,7 @@ func (r *ByteOrderMarkRule) Meta() api.RuleDescriptor {
 		ID:            "ByteOrderMark",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -25,6 +27,7 @@ func (r *DrawAllocationRule) Meta() api.RuleDescriptor {
 		ID:            "DrawAllocation",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -33,6 +36,7 @@ func (r *EasterEggRule) Meta() api.RuleDescriptor {
 		ID:            "EasterEgg",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -41,6 +45,7 @@ func (r *ExportedContentProviderRule) Meta() api.RuleDescriptor {
 		ID:            "ExportedContentProvider",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -49,6 +54,7 @@ func (r *ExportedReceiverRule) Meta() api.RuleDescriptor {
 		ID:            "ExportedReceiver",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -57,6 +63,7 @@ func (r *FieldGetterRule) Meta() api.RuleDescriptor {
 		ID:            "FieldGetter",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -65,6 +72,7 @@ func (r *FloatMathRule) Meta() api.RuleDescriptor {
 		ID:            "FloatMath",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -73,6 +81,7 @@ func (r *GetInstanceRule) Meta() api.RuleDescriptor {
 		ID:            "GetInstance",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -81,6 +90,7 @@ func (r *GrantAllUrisRule) Meta() api.RuleDescriptor {
 		ID:            "GrantAllUris",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -89,6 +99,7 @@ func (r *UnprotectedDynamicReceiverRule) Meta() api.RuleDescriptor {
 		ID:            "UnprotectedDynamicReceiver",
 		RuleSet:       "security",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -113,6 +124,7 @@ func (r *HandlerLeakRule) Meta() api.RuleDescriptor {
 		ID:            "HandlerLeak",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -121,6 +133,7 @@ func (r *RecycleRule) Meta() api.RuleDescriptor {
 		ID:            "Recycle",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -129,6 +142,7 @@ func (r *SecureRandomRule) Meta() api.RuleDescriptor {
 		ID:            "SecureRandom",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -137,6 +151,7 @@ func (r *TrustedServerRule) Meta() api.RuleDescriptor {
 		ID:            "TrustedServer",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -145,6 +160,7 @@ func (r *WorldReadableFilesRule) Meta() api.RuleDescriptor {
 		ID:            "WorldReadableFiles",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -153,6 +169,7 @@ func (r *WorldWriteableFilesRule) Meta() api.RuleDescriptor {
 		ID:            "WorldWriteableFiles",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 

--- a/internal/rules/meta_android_security.go
+++ b/internal/rules/meta_android_security.go
@@ -9,7 +9,7 @@ func (r *AddJavascriptInterfaceRule) Meta() api.RuleDescriptor {
 		ID:            "AddJavascriptInterface",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -18,7 +18,7 @@ func (r *ByteOrderMarkRule) Meta() api.RuleDescriptor {
 		ID:            "ByteOrderMark",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -27,7 +27,7 @@ func (r *DrawAllocationRule) Meta() api.RuleDescriptor {
 		ID:            "DrawAllocation",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -36,7 +36,7 @@ func (r *EasterEggRule) Meta() api.RuleDescriptor {
 		ID:            "EasterEgg",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -45,7 +45,7 @@ func (r *ExportedContentProviderRule) Meta() api.RuleDescriptor {
 		ID:            "ExportedContentProvider",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -54,7 +54,7 @@ func (r *ExportedReceiverRule) Meta() api.RuleDescriptor {
 		ID:            "ExportedReceiver",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -63,7 +63,7 @@ func (r *FieldGetterRule) Meta() api.RuleDescriptor {
 		ID:            "FieldGetter",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -72,7 +72,7 @@ func (r *FloatMathRule) Meta() api.RuleDescriptor {
 		ID:            "FloatMath",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -81,7 +81,7 @@ func (r *GetInstanceRule) Meta() api.RuleDescriptor {
 		ID:            "GetInstance",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -90,7 +90,7 @@ func (r *GrantAllUrisRule) Meta() api.RuleDescriptor {
 		ID:            "GrantAllUris",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -99,7 +99,7 @@ func (r *UnprotectedDynamicReceiverRule) Meta() api.RuleDescriptor {
 		ID:            "UnprotectedDynamicReceiver",
 		RuleSet:       "security",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -124,7 +124,7 @@ func (r *HandlerLeakRule) Meta() api.RuleDescriptor {
 		ID:            "HandlerLeak",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -133,7 +133,7 @@ func (r *RecycleRule) Meta() api.RuleDescriptor {
 		ID:            "Recycle",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -142,7 +142,7 @@ func (r *SecureRandomRule) Meta() api.RuleDescriptor {
 		ID:            "SecureRandom",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -151,7 +151,7 @@ func (r *TrustedServerRule) Meta() api.RuleDescriptor {
 		ID:            "TrustedServer",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -160,7 +160,7 @@ func (r *WorldReadableFilesRule) Meta() api.RuleDescriptor {
 		ID:            "WorldReadableFiles",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -169,7 +169,7 @@ func (r *WorldWriteableFilesRule) Meta() api.RuleDescriptor {
 		ID:            "WorldWriteableFiles",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 

--- a/internal/rules/meta_android_source_extra.go
+++ b/internal/rules/meta_android_source_extra.go
@@ -9,6 +9,7 @@ func (r *GridLayoutRule) Meta() api.RuleDescriptor {
 		ID:            "GridLayout",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -17,6 +18,7 @@ func (r *InstantiatableRule) Meta() api.RuleDescriptor {
 		ID:            "Instantiatable",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -33,6 +35,7 @@ func (r *LibraryCustomViewRule) Meta() api.RuleDescriptor {
 		ID:            "LibraryCustomView",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -41,6 +44,7 @@ func (r *LocaleFolderRule) Meta() api.RuleDescriptor {
 		ID:            "LocaleFolder",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -49,6 +53,7 @@ func (r *MangledCRLFRule) Meta() api.RuleDescriptor {
 		ID:            "MangledCRLF",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -57,6 +62,7 @@ func (r *MissingPermissionRule) Meta() api.RuleDescriptor {
 		ID:            "MissingPermission",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -65,6 +71,7 @@ func (r *NfcTechWhitespaceRule) Meta() api.RuleDescriptor {
 		ID:            "NfcTechWhitespace",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -73,6 +80,7 @@ func (r *ProguardRule) Meta() api.RuleDescriptor {
 		ID:            "Proguard",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -81,6 +89,7 @@ func (r *ProguardSplitRule) Meta() api.RuleDescriptor {
 		ID:            "ProguardSplit",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -89,6 +98,7 @@ func (r *ResourceNameRule) Meta() api.RuleDescriptor {
 		ID:            "ResourceName",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -97,6 +107,7 @@ func (r *RtlAwareRule) Meta() api.RuleDescriptor {
 		ID:            "RtlAware",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -105,6 +116,7 @@ func (r *RtlFieldAccessRule) Meta() api.RuleDescriptor {
 		ID:            "RtlFieldAccess",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -113,6 +125,7 @@ func (r *TrulyRandomRule) Meta() api.RuleDescriptor {
 		ID:            "TrulyRandom",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -121,6 +134,7 @@ func (r *UnknownIDInLayoutRule) Meta() api.RuleDescriptor {
 		ID:            "UnknownIdInLayout",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -129,6 +143,7 @@ func (r *UseAlpha2Rule) Meta() api.RuleDescriptor {
 		ID:            "UseAlpha2",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -153,6 +168,7 @@ func (r *WrongConstantRule) Meta() api.RuleDescriptor {
 		ID:            "WrongConstant",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 

--- a/internal/rules/meta_android_source_extra.go
+++ b/internal/rules/meta_android_source_extra.go
@@ -9,7 +9,7 @@ func (r *GridLayoutRule) Meta() api.RuleDescriptor {
 		ID:            "GridLayout",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -18,7 +18,7 @@ func (r *InstantiatableRule) Meta() api.RuleDescriptor {
 		ID:            "Instantiatable",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -35,7 +35,7 @@ func (r *LibraryCustomViewRule) Meta() api.RuleDescriptor {
 		ID:            "LibraryCustomView",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -44,7 +44,7 @@ func (r *LocaleFolderRule) Meta() api.RuleDescriptor {
 		ID:            "LocaleFolder",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -53,7 +53,7 @@ func (r *MangledCRLFRule) Meta() api.RuleDescriptor {
 		ID:            "MangledCRLF",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -62,7 +62,7 @@ func (r *MissingPermissionRule) Meta() api.RuleDescriptor {
 		ID:            "MissingPermission",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -71,7 +71,7 @@ func (r *NfcTechWhitespaceRule) Meta() api.RuleDescriptor {
 		ID:            "NfcTechWhitespace",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -80,7 +80,7 @@ func (r *ProguardRule) Meta() api.RuleDescriptor {
 		ID:            "Proguard",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -89,7 +89,7 @@ func (r *ProguardSplitRule) Meta() api.RuleDescriptor {
 		ID:            "ProguardSplit",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -98,7 +98,7 @@ func (r *ResourceNameRule) Meta() api.RuleDescriptor {
 		ID:            "ResourceName",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -107,7 +107,7 @@ func (r *RtlAwareRule) Meta() api.RuleDescriptor {
 		ID:            "RtlAware",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -116,7 +116,7 @@ func (r *RtlFieldAccessRule) Meta() api.RuleDescriptor {
 		ID:            "RtlFieldAccess",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -125,7 +125,7 @@ func (r *TrulyRandomRule) Meta() api.RuleDescriptor {
 		ID:            "TrulyRandom",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -134,7 +134,7 @@ func (r *UnknownIDInLayoutRule) Meta() api.RuleDescriptor {
 		ID:            "UnknownIdInLayout",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -143,7 +143,7 @@ func (r *UseAlpha2Rule) Meta() api.RuleDescriptor {
 		ID:            "UseAlpha2",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -168,7 +168,7 @@ func (r *WrongConstantRule) Meta() api.RuleDescriptor {
 		ID:            "WrongConstant",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 

--- a/internal/rules/meta_android_usability.go
+++ b/internal/rules/meta_android_usability.go
@@ -9,6 +9,7 @@ func (r *InlinedAPIRule) Meta() api.RuleDescriptor {
 		ID:            "InlinedApi",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -17,6 +18,7 @@ func (r *NewAPIRule) Meta() api.RuleDescriptor {
 		ID:            "NewApi",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -25,6 +27,7 @@ func (r *OverrideRule) Meta() api.RuleDescriptor {
 		ID:            "Override",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -33,6 +36,7 @@ func (r *RequiresAPIViolationRule) Meta() api.RuleDescriptor {
 		ID:            "RequiresApiViolation",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -41,5 +45,6 @@ func (r *UnusedResourcesRule) Meta() api.RuleDescriptor {
 		ID:            "UnusedResources",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonAndroidOnly,
 	}
 }

--- a/internal/rules/meta_android_usability.go
+++ b/internal/rules/meta_android_usability.go
@@ -9,7 +9,7 @@ func (r *InlinedAPIRule) Meta() api.RuleDescriptor {
 		ID:            "InlinedApi",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -18,7 +18,7 @@ func (r *NewAPIRule) Meta() api.RuleDescriptor {
 		ID:            "NewApi",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -27,7 +27,7 @@ func (r *OverrideRule) Meta() api.RuleDescriptor {
 		ID:            "Override",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -36,7 +36,7 @@ func (r *RequiresAPIViolationRule) Meta() api.RuleDescriptor {
 		ID:            "RequiresApiViolation",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -45,6 +45,6 @@ func (r *UnusedResourcesRule) Meta() api.RuleDescriptor {
 		ID:            "UnusedResources",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonAndroidOnly,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }

--- a/internal/rules/meta_comments.go
+++ b/internal/rules/meta_comments.go
@@ -15,6 +15,7 @@ func (r *AbsentOrWrongFileLicenseRule) Meta() api.RuleDescriptor {
 		ID:            "AbsentOrWrongFileLicense",
 		RuleSet:       "comments",
 		DefaultActive: false,
+		OptInReason:   api.OptInReasonOpinionated,
 		FixLevel:      "cosmetic",
 		Options: []api.ConfigOption{
 			api.StringOption(api.StringOptionSpec[AbsentOrWrongFileLicenseRule]{
@@ -38,6 +39,7 @@ func (r *DeprecatedBlockTagRule) Meta() api.RuleDescriptor {
 		ID:            "DeprecatedBlockTag",
 		RuleSet:       "comments",
 		DefaultActive: false,
+		OptInReason:   api.OptInReasonOpinionated,
 	}
 }
 
@@ -46,6 +48,7 @@ func (r *DocumentationOverPrivateFunctionRule) Meta() api.RuleDescriptor {
 		ID:            "DocumentationOverPrivateFunction",
 		RuleSet:       "comments",
 		DefaultActive: false,
+		OptInReason:   api.OptInReasonOpinionated,
 		FixLevel:      "cosmetic",
 	}
 }
@@ -55,6 +58,7 @@ func (r *DocumentationOverPrivatePropertyRule) Meta() api.RuleDescriptor {
 		ID:            "DocumentationOverPrivateProperty",
 		RuleSet:       "comments",
 		DefaultActive: false,
+		OptInReason:   api.OptInReasonOpinionated,
 		FixLevel:      "cosmetic",
 	}
 }
@@ -64,6 +68,7 @@ func (r *EndOfSentenceFormatRule) Meta() api.RuleDescriptor {
 		ID:            "EndOfSentenceFormat",
 		RuleSet:       "comments",
 		DefaultActive: false,
+		OptInReason:   api.OptInReasonOpinionated,
 		Options: []api.ConfigOption{
 			api.RegexOption(api.RegexOptionSpec[EndOfSentenceFormatRule]{
 				Name:        "endOfSentenceFormat",
@@ -80,6 +85,7 @@ func (r *KDocReferencesNonPublicPropertyRule) Meta() api.RuleDescriptor {
 		ID:            "KDocReferencesNonPublicProperty",
 		RuleSet:       "comments",
 		DefaultActive: false,
+		OptInReason:   api.OptInReasonOpinionated,
 	}
 }
 
@@ -88,6 +94,7 @@ func (r *SampleAnnotationFreshnessRule) Meta() api.RuleDescriptor {
 		ID:            "SampleAnnotationFreshness",
 		RuleSet:       "comments",
 		DefaultActive: false,
+		OptInReason:   api.OptInReasonOpinionated,
 	}
 }
 
@@ -96,6 +103,7 @@ func (r *KdocLinkValidationRule) Meta() api.RuleDescriptor {
 		ID:            "KdocLinkValidation",
 		RuleSet:       "comments",
 		DefaultActive: false,
+		OptInReason:   api.OptInReasonOpinionated,
 	}
 }
 
@@ -104,6 +112,7 @@ func (r *OutdatedDocumentationRule) Meta() api.RuleDescriptor {
 		ID:            "OutdatedDocumentation",
 		RuleSet:       "comments",
 		DefaultActive: false,
+		OptInReason:   api.OptInReasonOpinionated,
 		Options: []api.ConfigOption{
 			api.BoolOption(api.BoolOptionSpec[OutdatedDocumentationRule]{
 				Name:        "matchDeclarationsOrder",
@@ -126,6 +135,7 @@ func (r *UndocumentedPublicClassRule) Meta() api.RuleDescriptor {
 		ID:            "UndocumentedPublicClass",
 		RuleSet:       "comments",
 		DefaultActive: false,
+		OptInReason:   api.OptInReasonOpinionated,
 		Options: []api.ConfigOption{
 			api.BoolOption(api.BoolOptionSpec[UndocumentedPublicClassRule]{
 				Name:        "searchInInnerClass",
@@ -160,6 +170,7 @@ func (r *UndocumentedPublicFunctionRule) Meta() api.RuleDescriptor {
 		ID:            "UndocumentedPublicFunction",
 		RuleSet:       "comments",
 		DefaultActive: false,
+		OptInReason:   api.OptInReasonOpinionated,
 	}
 }
 
@@ -168,5 +179,6 @@ func (r *UndocumentedPublicPropertyRule) Meta() api.RuleDescriptor {
 		ID:            "UndocumentedPublicProperty",
 		RuleSet:       "comments",
 		DefaultActive: false,
+		OptInReason:   api.OptInReasonOpinionated,
 	}
 }

--- a/internal/rules/meta_complexity.go
+++ b/internal/rules/meta_complexity.go
@@ -9,7 +9,7 @@ func (r *CognitiveComplexMethodRule) Meta() api.RuleDescriptor {
 		ID:            "CognitiveComplexMethod",
 		RuleSet:       "complexity",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonThresholdTuning,
+		OptInReason:   api.OptInReasonThresholdTuning,
 		Options: []api.ConfigOption{
 			api.IntOption(api.IntOptionSpec[CognitiveComplexMethodRule]{
 				Name:        "allowedComplexity",
@@ -44,7 +44,7 @@ func (r *ComplexInterfaceRule) Meta() api.RuleDescriptor {
 		ID:            "ComplexInterface",
 		RuleSet:       "complexity",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonThresholdTuning,
+		OptInReason:   api.OptInReasonThresholdTuning,
 		Options: []api.ConfigOption{
 			api.IntOption(api.IntOptionSpec[ComplexInterfaceRule]{
 				Name:        "allowedDefinitions",
@@ -120,7 +120,7 @@ func (r *LabeledExpressionRule) Meta() api.RuleDescriptor {
 		ID:            "LabeledExpression",
 		RuleSet:       "complexity",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonThresholdTuning,
+		OptInReason:   api.OptInReasonThresholdTuning,
 		Options: []api.ConfigOption{
 			api.StringListOption(api.StringListOptionSpec[LabeledExpressionRule]{
 				Name:        "ignoredLabels",
@@ -210,7 +210,7 @@ func (r *MethodOverloadingRule) Meta() api.RuleDescriptor {
 		ID:            "MethodOverloading",
 		RuleSet:       "complexity",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonThresholdTuning,
+		OptInReason:   api.OptInReasonThresholdTuning,
 		Options: []api.ConfigOption{
 			api.IntOption(api.IntOptionSpec[MethodOverloadingRule]{
 				Name:        "allowedOverloads",
@@ -228,7 +228,7 @@ func (r *NamedArgumentsRule) Meta() api.RuleDescriptor {
 		ID:            "NamedArguments",
 		RuleSet:       "complexity",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonThresholdTuning,
+		OptInReason:   api.OptInReasonThresholdTuning,
 		Options: []api.ConfigOption{
 			api.IntOption(api.IntOptionSpec[NamedArgumentsRule]{
 				Name:        "allowedArguments",
@@ -263,7 +263,7 @@ func (r *NestedScopeFunctionsRule) Meta() api.RuleDescriptor {
 		ID:            "NestedScopeFunctions",
 		RuleSet:       "complexity",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonThresholdTuning,
+		OptInReason:   api.OptInReasonThresholdTuning,
 		Options: []api.ConfigOption{
 			api.IntOption(api.IntOptionSpec[NestedScopeFunctionsRule]{
 				Name:        "allowedDepth",
@@ -286,7 +286,7 @@ func (r *ReplaceSafeCallChainWithRunRule) Meta() api.RuleDescriptor {
 		ID:            "ReplaceSafeCallChainWithRun",
 		RuleSet:       "complexity",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonThresholdTuning,
+		OptInReason:   api.OptInReasonThresholdTuning,
 	}
 }
 
@@ -295,7 +295,7 @@ func (r *StringLiteralDuplicationRule) Meta() api.RuleDescriptor {
 		ID:            "StringLiteralDuplication",
 		RuleSet:       "complexity",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonThresholdTuning,
+		OptInReason:   api.OptInReasonThresholdTuning,
 		Options: []api.ConfigOption{
 			api.IntOption(api.IntOptionSpec[StringLiteralDuplicationRule]{
 				Name:        "allowedDuplications",

--- a/internal/rules/meta_complexity.go
+++ b/internal/rules/meta_complexity.go
@@ -9,6 +9,7 @@ func (r *CognitiveComplexMethodRule) Meta() api.RuleDescriptor {
 		ID:            "CognitiveComplexMethod",
 		RuleSet:       "complexity",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonThresholdTuning,
 		Options: []api.ConfigOption{
 			api.IntOption(api.IntOptionSpec[CognitiveComplexMethodRule]{
 				Name:        "allowedComplexity",
@@ -43,6 +44,7 @@ func (r *ComplexInterfaceRule) Meta() api.RuleDescriptor {
 		ID:            "ComplexInterface",
 		RuleSet:       "complexity",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonThresholdTuning,
 		Options: []api.ConfigOption{
 			api.IntOption(api.IntOptionSpec[ComplexInterfaceRule]{
 				Name:        "allowedDefinitions",
@@ -118,6 +120,7 @@ func (r *LabeledExpressionRule) Meta() api.RuleDescriptor {
 		ID:            "LabeledExpression",
 		RuleSet:       "complexity",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonThresholdTuning,
 		Options: []api.ConfigOption{
 			api.StringListOption(api.StringListOptionSpec[LabeledExpressionRule]{
 				Name:        "ignoredLabels",
@@ -207,6 +210,7 @@ func (r *MethodOverloadingRule) Meta() api.RuleDescriptor {
 		ID:            "MethodOverloading",
 		RuleSet:       "complexity",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonThresholdTuning,
 		Options: []api.ConfigOption{
 			api.IntOption(api.IntOptionSpec[MethodOverloadingRule]{
 				Name:        "allowedOverloads",
@@ -224,6 +228,7 @@ func (r *NamedArgumentsRule) Meta() api.RuleDescriptor {
 		ID:            "NamedArguments",
 		RuleSet:       "complexity",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonThresholdTuning,
 		Options: []api.ConfigOption{
 			api.IntOption(api.IntOptionSpec[NamedArgumentsRule]{
 				Name:        "allowedArguments",
@@ -258,6 +263,7 @@ func (r *NestedScopeFunctionsRule) Meta() api.RuleDescriptor {
 		ID:            "NestedScopeFunctions",
 		RuleSet:       "complexity",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonThresholdTuning,
 		Options: []api.ConfigOption{
 			api.IntOption(api.IntOptionSpec[NestedScopeFunctionsRule]{
 				Name:        "allowedDepth",
@@ -280,6 +286,7 @@ func (r *ReplaceSafeCallChainWithRunRule) Meta() api.RuleDescriptor {
 		ID:            "ReplaceSafeCallChainWithRun",
 		RuleSet:       "complexity",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonThresholdTuning,
 	}
 }
 
@@ -288,6 +295,7 @@ func (r *StringLiteralDuplicationRule) Meta() api.RuleDescriptor {
 		ID:            "StringLiteralDuplication",
 		RuleSet:       "complexity",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonThresholdTuning,
 		Options: []api.ConfigOption{
 			api.IntOption(api.IntOptionSpec[StringLiteralDuplicationRule]{
 				Name:        "allowedDuplications",

--- a/internal/rules/meta_compose.go
+++ b/internal/rules/meta_compose.go
@@ -49,7 +49,7 @@ func (r *ComposeModifierBackgroundAfterClipRule) Meta() api.RuleDescriptor {
 		ID:            "ComposeModifierBackgroundAfterClip",
 		RuleSet:       "compose",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonDomainSpecific,
+		OptInReason:   api.OptInReasonDomainSpecific,
 	}
 }
 
@@ -58,7 +58,7 @@ func (r *ComposeModifierClickableBeforePaddingRule) Meta() api.RuleDescriptor {
 		ID:            "ComposeModifierClickableBeforePadding",
 		RuleSet:       "compose",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonDomainSpecific,
+		OptInReason:   api.OptInReasonDomainSpecific,
 	}
 }
 
@@ -67,7 +67,7 @@ func (r *ComposeModifierFillAfterSizeRule) Meta() api.RuleDescriptor {
 		ID:            "ComposeModifierFillAfterSize",
 		RuleSet:       "compose",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonDomainSpecific,
+		OptInReason:   api.OptInReasonDomainSpecific,
 	}
 }
 
@@ -100,7 +100,7 @@ func (r *ComposePreviewAnnotationMissingRule) Meta() api.RuleDescriptor {
 		ID:            "ComposePreviewAnnotationMissing",
 		RuleSet:       "compose",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonDomainSpecific,
+		OptInReason:   api.OptInReasonDomainSpecific,
 	}
 }
 

--- a/internal/rules/meta_compose.go
+++ b/internal/rules/meta_compose.go
@@ -49,6 +49,7 @@ func (r *ComposeModifierBackgroundAfterClipRule) Meta() api.RuleDescriptor {
 		ID:            "ComposeModifierBackgroundAfterClip",
 		RuleSet:       "compose",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonDomainSpecific,
 	}
 }
 
@@ -57,6 +58,7 @@ func (r *ComposeModifierClickableBeforePaddingRule) Meta() api.RuleDescriptor {
 		ID:            "ComposeModifierClickableBeforePadding",
 		RuleSet:       "compose",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonDomainSpecific,
 	}
 }
 
@@ -65,6 +67,7 @@ func (r *ComposeModifierFillAfterSizeRule) Meta() api.RuleDescriptor {
 		ID:            "ComposeModifierFillAfterSize",
 		RuleSet:       "compose",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonDomainSpecific,
 	}
 }
 
@@ -97,6 +100,7 @@ func (r *ComposePreviewAnnotationMissingRule) Meta() api.RuleDescriptor {
 		ID:            "ComposePreviewAnnotationMissing",
 		RuleSet:       "compose",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonDomainSpecific,
 	}
 }
 

--- a/internal/rules/meta_coroutines.go
+++ b/internal/rules/meta_coroutines.go
@@ -17,6 +17,7 @@ func (r *CollectInOnCreateWithoutLifecycleRule) Meta() api.RuleDescriptor {
 		ID:            "CollectInOnCreateWithoutLifecycle",
 		RuleSet:       "coroutines",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonDomainSpecific,
 	}
 }
 
@@ -41,6 +42,7 @@ func (r *CoroutineLaunchedInTestWithoutRunTestRule) Meta() api.RuleDescriptor {
 		ID:            "CoroutineLaunchedInTestWithoutRunTest",
 		RuleSet:       "coroutines",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonDomainSpecific,
 	}
 }
 
@@ -65,6 +67,7 @@ func (r *FlowWithoutFlowOnRule) Meta() api.RuleDescriptor {
 		ID:            "FlowWithoutFlowOn",
 		RuleSet:       "coroutines",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonDomainSpecific,
 	}
 }
 
@@ -73,6 +76,7 @@ func (r *GlobalCoroutineUsageRule) Meta() api.RuleDescriptor {
 		ID:            "GlobalCoroutineUsage",
 		RuleSet:       "coroutines",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonDomainSpecific,
 		FixLevel:      "semantic",
 	}
 }
@@ -106,6 +110,7 @@ func (r *LaunchWithoutCoroutineExceptionHandlerRule) Meta() api.RuleDescriptor {
 		ID:            "LaunchWithoutCoroutineExceptionHandler",
 		RuleSet:       "coroutines",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonDomainSpecific,
 	}
 }
 
@@ -114,6 +119,7 @@ func (r *MainDispatcherInLibraryCodeRule) Meta() api.RuleDescriptor {
 		ID:            "MainDispatcherInLibraryCode",
 		RuleSet:       "coroutines",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonDomainSpecific,
 	}
 }
 
@@ -139,6 +145,7 @@ func (r *SharedFlowWithoutReplayRule) Meta() api.RuleDescriptor {
 		ID:            "SharedFlowWithoutReplay",
 		RuleSet:       "coroutines",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonDomainSpecific,
 	}
 }
 
@@ -156,6 +163,7 @@ func (r *StateFlowCompareByReferenceRule) Meta() api.RuleDescriptor {
 		ID:            "StateFlowCompareByReference",
 		RuleSet:       "coroutines",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonDomainSpecific,
 	}
 }
 
@@ -172,6 +180,7 @@ func (r *SupervisorScopeInEventHandlerRule) Meta() api.RuleDescriptor {
 		ID:            "SupervisorScopeInEventHandler",
 		RuleSet:       "coroutines",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonDomainSpecific,
 	}
 }
 
@@ -180,6 +189,7 @@ func (r *SuspendFunInFinallySectionRule) Meta() api.RuleDescriptor {
 		ID:            "SuspendFunInFinallySection",
 		RuleSet:       "coroutines",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonDomainSpecific,
 	}
 }
 
@@ -188,6 +198,7 @@ func (r *SuspendFunSwallowedCancellationRule) Meta() api.RuleDescriptor {
 		ID:            "SuspendFunSwallowedCancellation",
 		RuleSet:       "coroutines",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonDomainSpecific,
 		FixLevel:      "semantic",
 	}
 }
@@ -197,6 +208,7 @@ func (r *SuspendFunWithCoroutineScopeReceiverRule) Meta() api.RuleDescriptor {
 		ID:            "SuspendFunWithCoroutineScopeReceiver",
 		RuleSet:       "coroutines",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonDomainSpecific,
 		FixLevel:      "idiomatic",
 	}
 }
@@ -238,5 +250,6 @@ func (r *WithContextInSuspendFunctionNoopRule) Meta() api.RuleDescriptor {
 		ID:            "WithContextInSuspendFunctionNoop",
 		RuleSet:       "coroutines",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonDomainSpecific,
 	}
 }

--- a/internal/rules/meta_coroutines.go
+++ b/internal/rules/meta_coroutines.go
@@ -17,7 +17,7 @@ func (r *CollectInOnCreateWithoutLifecycleRule) Meta() api.RuleDescriptor {
 		ID:            "CollectInOnCreateWithoutLifecycle",
 		RuleSet:       "coroutines",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonDomainSpecific,
+		OptInReason:   api.OptInReasonDomainSpecific,
 	}
 }
 
@@ -42,7 +42,7 @@ func (r *CoroutineLaunchedInTestWithoutRunTestRule) Meta() api.RuleDescriptor {
 		ID:            "CoroutineLaunchedInTestWithoutRunTest",
 		RuleSet:       "coroutines",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonDomainSpecific,
+		OptInReason:   api.OptInReasonDomainSpecific,
 	}
 }
 
@@ -67,7 +67,7 @@ func (r *FlowWithoutFlowOnRule) Meta() api.RuleDescriptor {
 		ID:            "FlowWithoutFlowOn",
 		RuleSet:       "coroutines",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonDomainSpecific,
+		OptInReason:   api.OptInReasonDomainSpecific,
 	}
 }
 
@@ -76,7 +76,7 @@ func (r *GlobalCoroutineUsageRule) Meta() api.RuleDescriptor {
 		ID:            "GlobalCoroutineUsage",
 		RuleSet:       "coroutines",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonDomainSpecific,
+		OptInReason:   api.OptInReasonDomainSpecific,
 		FixLevel:      "semantic",
 	}
 }
@@ -110,7 +110,7 @@ func (r *LaunchWithoutCoroutineExceptionHandlerRule) Meta() api.RuleDescriptor {
 		ID:            "LaunchWithoutCoroutineExceptionHandler",
 		RuleSet:       "coroutines",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonDomainSpecific,
+		OptInReason:   api.OptInReasonDomainSpecific,
 	}
 }
 
@@ -119,7 +119,7 @@ func (r *MainDispatcherInLibraryCodeRule) Meta() api.RuleDescriptor {
 		ID:            "MainDispatcherInLibraryCode",
 		RuleSet:       "coroutines",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonDomainSpecific,
+		OptInReason:   api.OptInReasonDomainSpecific,
 	}
 }
 
@@ -145,7 +145,7 @@ func (r *SharedFlowWithoutReplayRule) Meta() api.RuleDescriptor {
 		ID:            "SharedFlowWithoutReplay",
 		RuleSet:       "coroutines",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonDomainSpecific,
+		OptInReason:   api.OptInReasonDomainSpecific,
 	}
 }
 
@@ -163,7 +163,7 @@ func (r *StateFlowCompareByReferenceRule) Meta() api.RuleDescriptor {
 		ID:            "StateFlowCompareByReference",
 		RuleSet:       "coroutines",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonDomainSpecific,
+		OptInReason:   api.OptInReasonDomainSpecific,
 	}
 }
 
@@ -180,7 +180,7 @@ func (r *SupervisorScopeInEventHandlerRule) Meta() api.RuleDescriptor {
 		ID:            "SupervisorScopeInEventHandler",
 		RuleSet:       "coroutines",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonDomainSpecific,
+		OptInReason:   api.OptInReasonDomainSpecific,
 	}
 }
 
@@ -189,7 +189,7 @@ func (r *SuspendFunInFinallySectionRule) Meta() api.RuleDescriptor {
 		ID:            "SuspendFunInFinallySection",
 		RuleSet:       "coroutines",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonDomainSpecific,
+		OptInReason:   api.OptInReasonDomainSpecific,
 	}
 }
 
@@ -198,7 +198,7 @@ func (r *SuspendFunSwallowedCancellationRule) Meta() api.RuleDescriptor {
 		ID:            "SuspendFunSwallowedCancellation",
 		RuleSet:       "coroutines",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonDomainSpecific,
+		OptInReason:   api.OptInReasonDomainSpecific,
 		FixLevel:      "semantic",
 	}
 }
@@ -208,7 +208,7 @@ func (r *SuspendFunWithCoroutineScopeReceiverRule) Meta() api.RuleDescriptor {
 		ID:            "SuspendFunWithCoroutineScopeReceiver",
 		RuleSet:       "coroutines",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonDomainSpecific,
+		OptInReason:   api.OptInReasonDomainSpecific,
 		FixLevel:      "idiomatic",
 	}
 }
@@ -250,6 +250,6 @@ func (r *WithContextInSuspendFunctionNoopRule) Meta() api.RuleDescriptor {
 		ID:            "WithContextInSuspendFunctionNoop",
 		RuleSet:       "coroutines",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonDomainSpecific,
+		OptInReason:   api.OptInReasonDomainSpecific,
 	}
 }

--- a/internal/rules/meta_database.go
+++ b/internal/rules/meta_database.go
@@ -9,7 +9,7 @@ func (r *DaoNotInterfaceRule) Meta() api.RuleDescriptor {
 		ID:            "DaoNotInterface",
 		RuleSet:       "database",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonDomainSpecific,
+		OptInReason:   api.OptInReasonDomainSpecific,
 	}
 }
 
@@ -26,7 +26,7 @@ func (r *EntityMutableColumnRule) Meta() api.RuleDescriptor {
 		ID:            "EntityMutableColumn",
 		RuleSet:       "database",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonDomainSpecific,
+		OptInReason:   api.OptInReasonDomainSpecific,
 	}
 }
 
@@ -83,7 +83,7 @@ func (r *RoomEntityChangedMigrationMissingRule) Meta() api.RuleDescriptor {
 		ID:            "RoomEntityChangedMigrationMissing",
 		RuleSet:       "database",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonDomainSpecific,
+		OptInReason:   api.OptInReasonDomainSpecific,
 	}
 }
 
@@ -108,7 +108,7 @@ func (r *RoomDatabaseVersionNotBumpedRule) Meta() api.RuleDescriptor {
 		ID:            "RoomDatabaseVersionNotBumped",
 		RuleSet:       "database",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonDomainSpecific,
+		OptInReason:   api.OptInReasonDomainSpecific,
 	}
 }
 
@@ -157,7 +157,7 @@ func (r *RoomFlowQueryWithoutDistinctRule) Meta() api.RuleDescriptor {
 		ID:            "RoomFlowQueryWithoutDistinct",
 		RuleSet:       "database",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonDomainSpecific,
+		OptInReason:   api.OptInReasonDomainSpecific,
 	}
 }
 
@@ -166,7 +166,7 @@ func (r *RoomQueryWithLikeMissingEscapeRule) Meta() api.RuleDescriptor {
 		ID:            "RoomQueryWithLikeMissingEscape",
 		RuleSet:       "database",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonDomainSpecific,
+		OptInReason:   api.OptInReasonDomainSpecific,
 	}
 }
 

--- a/internal/rules/meta_database.go
+++ b/internal/rules/meta_database.go
@@ -9,6 +9,7 @@ func (r *DaoNotInterfaceRule) Meta() api.RuleDescriptor {
 		ID:            "DaoNotInterface",
 		RuleSet:       "database",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonDomainSpecific,
 	}
 }
 
@@ -25,6 +26,7 @@ func (r *EntityMutableColumnRule) Meta() api.RuleDescriptor {
 		ID:            "EntityMutableColumn",
 		RuleSet:       "database",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonDomainSpecific,
 	}
 }
 
@@ -81,6 +83,7 @@ func (r *RoomEntityChangedMigrationMissingRule) Meta() api.RuleDescriptor {
 		ID:            "RoomEntityChangedMigrationMissing",
 		RuleSet:       "database",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonDomainSpecific,
 	}
 }
 
@@ -105,6 +108,7 @@ func (r *RoomDatabaseVersionNotBumpedRule) Meta() api.RuleDescriptor {
 		ID:            "RoomDatabaseVersionNotBumped",
 		RuleSet:       "database",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonDomainSpecific,
 	}
 }
 
@@ -153,6 +157,7 @@ func (r *RoomFlowQueryWithoutDistinctRule) Meta() api.RuleDescriptor {
 		ID:            "RoomFlowQueryWithoutDistinct",
 		RuleSet:       "database",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonDomainSpecific,
 	}
 }
 
@@ -161,6 +166,7 @@ func (r *RoomQueryWithLikeMissingEscapeRule) Meta() api.RuleDescriptor {
 		ID:            "RoomQueryWithLikeMissingEscape",
 		RuleSet:       "database",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonDomainSpecific,
 	}
 }
 

--- a/internal/rules/meta_deadcode.go
+++ b/internal/rules/meta_deadcode.go
@@ -9,6 +9,7 @@ func (r *DeadCodeRule) Meta() api.RuleDescriptor {
 		ID:            "DeadCode",
 		RuleSet:       "dead-code",
 		DefaultActive: false,
+		OptInReason:   api.OptInReasonExpensive,
 		FixLevel:      "semantic",
 	}
 }

--- a/internal/rules/meta_di_hygiene.go
+++ b/internal/rules/meta_di_hygiene.go
@@ -33,7 +33,7 @@ func (r *DeadBindingsRule) Meta() api.RuleDescriptor {
 		ID:            "DeadBindings",
 		RuleSet:       "di-hygiene",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonDomainSpecific,
+		OptInReason:   api.OptInReasonDomainSpecific,
 	}
 }
 
@@ -44,7 +44,7 @@ func (r *DiCycleDetectionRule) Meta() api.RuleDescriptor {
 		Severity:      "warning",
 		Description:   "Detects cycles in the constructor-injected DI binding graph.",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonDomainSpecific,
+		OptInReason:   api.OptInReasonDomainSpecific,
 		Confidence:    0.75,
 	}
 }
@@ -106,7 +106,7 @@ func (r *ModuleWithNonStaticProvidesRule) Meta() api.RuleDescriptor {
 		ID:            "ModuleWithNonStaticProvides",
 		RuleSet:       "di-hygiene",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonDomainSpecific,
+		OptInReason:   api.OptInReasonDomainSpecific,
 	}
 }
 
@@ -133,7 +133,7 @@ func (r *SubcomponentNotInstalledRule) Meta() api.RuleDescriptor {
 		Severity:      "warning",
 		Description:   "Detects @Subcomponent declarations not returned from any parent component method; the subcomponent is orphaned.",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonDomainSpecific,
+		OptInReason:   api.OptInReasonDomainSpecific,
 		FixLevel:      "",
 		Confidence:    0.5,
 	}
@@ -170,7 +170,7 @@ func (r *ComponentMissingModuleRule) Meta() api.RuleDescriptor {
 		Severity:      "warning",
 		Description:   "Detects @Component(modules = [...]) declarations whose listed modules do not transitively cover every reachable binding.",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonDomainSpecific,
+		OptInReason:   api.OptInReasonDomainSpecific,
 		FixLevel:      "",
 		Confidence:    0.5,
 	}
@@ -183,7 +183,7 @@ func (r *IntoMapDuplicateKeyRule) Meta() api.RuleDescriptor {
 		Severity:      "warning",
 		Description:   "Detects @IntoMap providers that share the same key in the same module/component; duplicate map keys create conflicting contributions.",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonDomainSpecific,
+		OptInReason:   api.OptInReasonDomainSpecific,
 		FixLevel:      "",
 		Confidence:    0.7,
 	}
@@ -196,7 +196,7 @@ func (r *IntoSetDuplicateTypeRule) Meta() api.RuleDescriptor {
 		Severity:      "info",
 		Description:   "Detects @IntoSet providers that contribute the same concrete impl in the same module/component; the set dedupes, dropping contributions.",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonDomainSpecific,
+		OptInReason:   api.OptInReasonDomainSpecific,
 		FixLevel:      "",
 		Confidence:    0.5,
 	}
@@ -209,7 +209,7 @@ func (r *ProviderInsteadOfLazyRule) Meta() api.RuleDescriptor {
 		Severity:      "info",
 		Description:   "Detects Provider<T> constructor params whose .get() is called exactly once; Lazy<T> matches the intent and is cheaper.",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonDomainSpecific,
+		OptInReason:   api.OptInReasonDomainSpecific,
 		FixLevel:      "",
 		Confidence:    0.6,
 	}
@@ -222,7 +222,7 @@ func (r *LazyInsteadOfDirectRule) Meta() api.RuleDescriptor {
 		Severity:      "info",
 		Description:   "Detects Lazy<T> constructor params whose .get() is called eagerly at class init; direct injection is cheaper.",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonDomainSpecific,
+		OptInReason:   api.OptInReasonDomainSpecific,
 		FixLevel:      "",
 		Confidence:    0.6,
 	}

--- a/internal/rules/meta_di_hygiene.go
+++ b/internal/rules/meta_di_hygiene.go
@@ -33,6 +33,7 @@ func (r *DeadBindingsRule) Meta() api.RuleDescriptor {
 		ID:            "DeadBindings",
 		RuleSet:       "di-hygiene",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonDomainSpecific,
 	}
 }
 
@@ -43,6 +44,7 @@ func (r *DiCycleDetectionRule) Meta() api.RuleDescriptor {
 		Severity:      "warning",
 		Description:   "Detects cycles in the constructor-injected DI binding graph.",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonDomainSpecific,
 		Confidence:    0.75,
 	}
 }
@@ -104,6 +106,7 @@ func (r *ModuleWithNonStaticProvidesRule) Meta() api.RuleDescriptor {
 		ID:            "ModuleWithNonStaticProvides",
 		RuleSet:       "di-hygiene",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonDomainSpecific,
 	}
 }
 
@@ -130,6 +133,7 @@ func (r *SubcomponentNotInstalledRule) Meta() api.RuleDescriptor {
 		Severity:      "warning",
 		Description:   "Detects @Subcomponent declarations not returned from any parent component method; the subcomponent is orphaned.",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonDomainSpecific,
 		FixLevel:      "",
 		Confidence:    0.5,
 	}
@@ -166,6 +170,7 @@ func (r *ComponentMissingModuleRule) Meta() api.RuleDescriptor {
 		Severity:      "warning",
 		Description:   "Detects @Component(modules = [...]) declarations whose listed modules do not transitively cover every reachable binding.",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonDomainSpecific,
 		FixLevel:      "",
 		Confidence:    0.5,
 	}
@@ -178,6 +183,7 @@ func (r *IntoMapDuplicateKeyRule) Meta() api.RuleDescriptor {
 		Severity:      "warning",
 		Description:   "Detects @IntoMap providers that share the same key in the same module/component; duplicate map keys create conflicting contributions.",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonDomainSpecific,
 		FixLevel:      "",
 		Confidence:    0.7,
 	}
@@ -190,6 +196,7 @@ func (r *IntoSetDuplicateTypeRule) Meta() api.RuleDescriptor {
 		Severity:      "info",
 		Description:   "Detects @IntoSet providers that contribute the same concrete impl in the same module/component; the set dedupes, dropping contributions.",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonDomainSpecific,
 		FixLevel:      "",
 		Confidence:    0.5,
 	}
@@ -202,6 +209,7 @@ func (r *ProviderInsteadOfLazyRule) Meta() api.RuleDescriptor {
 		Severity:      "info",
 		Description:   "Detects Provider<T> constructor params whose .get() is called exactly once; Lazy<T> matches the intent and is cheaper.",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonDomainSpecific,
 		FixLevel:      "",
 		Confidence:    0.6,
 	}
@@ -214,6 +222,7 @@ func (r *LazyInsteadOfDirectRule) Meta() api.RuleDescriptor {
 		Severity:      "info",
 		Description:   "Detects Lazy<T> constructor params whose .get() is called eagerly at class init; direct injection is cheaper.",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonDomainSpecific,
 		FixLevel:      "",
 		Confidence:    0.6,
 	}

--- a/internal/rules/meta_exceptions.go
+++ b/internal/rules/meta_exceptions.go
@@ -15,6 +15,7 @@ func (r *ErrorUsageWithThrowableRule) Meta() api.RuleDescriptor {
 		ID:            "ErrorUsageWithThrowable",
 		RuleSet:       "exceptions",
 		DefaultActive: false,
+		OptInReason:   api.OptInReasonOpinionated,
 	}
 }
 
@@ -47,6 +48,7 @@ func (r *NotImplementedDeclarationRule) Meta() api.RuleDescriptor {
 		ID:            "NotImplementedDeclaration",
 		RuleSet:       "exceptions",
 		DefaultActive: false,
+		OptInReason:   api.OptInReasonOpinionated,
 	}
 }
 
@@ -55,6 +57,7 @@ func (r *ObjectExtendsThrowableRule) Meta() api.RuleDescriptor {
 		ID:            "ObjectExtendsThrowable",
 		RuleSet:       "exceptions",
 		DefaultActive: false,
+		OptInReason:   api.OptInReasonOpinionated,
 	}
 }
 
@@ -125,6 +128,7 @@ func (r *ThrowingExceptionInMainRule) Meta() api.RuleDescriptor {
 		ID:            "ThrowingExceptionInMain",
 		RuleSet:       "exceptions",
 		DefaultActive: false,
+		OptInReason:   api.OptInReasonOpinionated,
 	}
 }
 

--- a/internal/rules/meta_forbidden_import.go
+++ b/internal/rules/meta_forbidden_import.go
@@ -16,6 +16,7 @@ func (r *ForbiddenImportRule) Meta() api.RuleDescriptor {
 		ID:            "ForbiddenImport",
 		RuleSet:       "style",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonRequiresUserConfig,
 		FixLevel:      "idiomatic",
 		Options: []api.ConfigOption{
 			api.StringListOption(api.StringListOptionSpec[ForbiddenImportRule]{

--- a/internal/rules/meta_forbidden_import.go
+++ b/internal/rules/meta_forbidden_import.go
@@ -16,7 +16,7 @@ func (r *ForbiddenImportRule) Meta() api.RuleDescriptor {
 		ID:            "ForbiddenImport",
 		RuleSet:       "style",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonRequiresUserConfig,
+		OptInReason:   api.OptInReasonRequiresUserConfig,
 		FixLevel:      "idiomatic",
 		Options: []api.ConfigOption{
 			api.StringListOption(api.StringListOptionSpec[ForbiddenImportRule]{

--- a/internal/rules/meta_hotspot.go
+++ b/internal/rules/meta_hotspot.go
@@ -9,7 +9,7 @@ func (r *FanInFanOutHotspotRule) Meta() api.RuleDescriptor {
 		ID:            "FanInFanOutHotspot",
 		RuleSet:       "architecture",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonThresholdTuning,
+		OptInReason:   api.OptInReasonThresholdTuning,
 		Options: []api.ConfigOption{
 			api.IntOption(api.IntOptionSpec[FanInFanOutHotspotRule]{
 				Name:        "allowedFanIn",
@@ -33,6 +33,6 @@ func (r *GodClassOrModuleRule) Meta() api.RuleDescriptor {
 		ID:            "GodClassOrModule",
 		RuleSet:       "architecture",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonThresholdTuning,
+		OptInReason:   api.OptInReasonThresholdTuning,
 	}
 }

--- a/internal/rules/meta_hotspot.go
+++ b/internal/rules/meta_hotspot.go
@@ -9,6 +9,7 @@ func (r *FanInFanOutHotspotRule) Meta() api.RuleDescriptor {
 		ID:            "FanInFanOutHotspot",
 		RuleSet:       "architecture",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonThresholdTuning,
 		Options: []api.ConfigOption{
 			api.IntOption(api.IntOptionSpec[FanInFanOutHotspotRule]{
 				Name:        "allowedFanIn",
@@ -32,5 +33,6 @@ func (r *GodClassOrModuleRule) Meta() api.RuleDescriptor {
 		ID:            "GodClassOrModule",
 		RuleSet:       "architecture",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonThresholdTuning,
 	}
 }

--- a/internal/rules/meta_layer_dependency_violation.go
+++ b/internal/rules/meta_layer_dependency_violation.go
@@ -23,7 +23,7 @@ func (r *LayerDependencyViolationRule) Meta() api.RuleDescriptor {
 		ID:            "LayerDependencyViolation",
 		RuleSet:       "architecture",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonProjectPolicy,
+		OptInReason:   api.OptInReasonProjectPolicy,
 		Options:       nil,
 		CustomApply: api.TypedCustomApply(func(rule *LayerDependencyViolationRule, cfg api.ConfigSource) {
 			// Only a real *ConfigAdapter can expose the underlying

--- a/internal/rules/meta_layer_dependency_violation.go
+++ b/internal/rules/meta_layer_dependency_violation.go
@@ -23,6 +23,7 @@ func (r *LayerDependencyViolationRule) Meta() api.RuleDescriptor {
 		ID:            "LayerDependencyViolation",
 		RuleSet:       "architecture",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonProjectPolicy,
 		Options:       nil,
 		CustomApply: api.TypedCustomApply(func(rule *LayerDependencyViolationRule, cfg api.ConfigSource) {
 			// Only a real *ConfigAdapter can expose the underlying

--- a/internal/rules/meta_library.go
+++ b/internal/rules/meta_library.go
@@ -9,6 +9,7 @@ func (r *ForbiddenPublicDataClassRule) Meta() api.RuleDescriptor {
 		ID:            "ForbiddenPublicDataClass",
 		RuleSet:       "libraries",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonDomainSpecific,
 	}
 }
 
@@ -17,6 +18,7 @@ func (r *LibraryCodeMustSpecifyReturnTypeRule) Meta() api.RuleDescriptor {
 		ID:            "LibraryCodeMustSpecifyReturnType",
 		RuleSet:       "libraries",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonDomainSpecific,
 	}
 }
 
@@ -25,5 +27,6 @@ func (r *LibraryEntitiesShouldNotBePublicRule) Meta() api.RuleDescriptor {
 		ID:            "LibraryEntitiesShouldNotBePublic",
 		RuleSet:       "libraries",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonDomainSpecific,
 	}
 }

--- a/internal/rules/meta_library.go
+++ b/internal/rules/meta_library.go
@@ -9,7 +9,7 @@ func (r *ForbiddenPublicDataClassRule) Meta() api.RuleDescriptor {
 		ID:            "ForbiddenPublicDataClass",
 		RuleSet:       "libraries",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonDomainSpecific,
+		OptInReason:   api.OptInReasonDomainSpecific,
 	}
 }
 
@@ -18,7 +18,7 @@ func (r *LibraryCodeMustSpecifyReturnTypeRule) Meta() api.RuleDescriptor {
 		ID:            "LibraryCodeMustSpecifyReturnType",
 		RuleSet:       "libraries",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonDomainSpecific,
+		OptInReason:   api.OptInReasonDomainSpecific,
 	}
 }
 
@@ -27,6 +27,6 @@ func (r *LibraryEntitiesShouldNotBePublicRule) Meta() api.RuleDescriptor {
 		ID:            "LibraryEntitiesShouldNotBePublic",
 		RuleSet:       "libraries",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonDomainSpecific,
+		OptInReason:   api.OptInReasonDomainSpecific,
 	}
 }

--- a/internal/rules/meta_naming.go
+++ b/internal/rules/meta_naming.go
@@ -15,6 +15,7 @@ func (r *BooleanPropertyNamingRule) Meta() api.RuleDescriptor {
 		ID:            "BooleanPropertyNaming",
 		RuleSet:       "naming",
 		DefaultActive: false,
+		OptInReason:   api.OptInReasonOpinionated,
 		FixLevel:      "semantic",
 		Options: []api.ConfigOption{
 			api.RegexOption(api.RegexOptionSpec[BooleanPropertyNamingRule]{
@@ -92,6 +93,7 @@ func (r *ForbiddenClassNameRule) Meta() api.RuleDescriptor {
 		ID:            "ForbiddenClassName",
 		RuleSet:       "naming",
 		DefaultActive: false,
+		OptInReason:   api.OptInReasonRequiresUserConfig,
 		Options: []api.ConfigOption{
 			api.StringListOption(api.StringListOptionSpec[ForbiddenClassNameRule]{
 				Name:        "forbiddenName",
@@ -108,6 +110,7 @@ func (r *FunctionNameMaxLengthRule) Meta() api.RuleDescriptor {
 		ID:            "FunctionNameMaxLength",
 		RuleSet:       "naming",
 		DefaultActive: false,
+		OptInReason:   api.OptInReasonThresholdTuning,
 		Options: []api.ConfigOption{
 			api.IntOption(api.IntOptionSpec[FunctionNameMaxLengthRule]{
 				Name:        "maximumFunctionNameLength",
@@ -125,6 +128,7 @@ func (r *FunctionNameMinLengthRule) Meta() api.RuleDescriptor {
 		ID:            "FunctionNameMinLength",
 		RuleSet:       "naming",
 		DefaultActive: false,
+		OptInReason:   api.OptInReasonThresholdTuning,
 		Options: []api.ConfigOption{
 			api.IntOption(api.IntOptionSpec[FunctionNameMinLengthRule]{
 				Name:        "minimumFunctionNameLength",
@@ -224,6 +228,7 @@ func (r *LambdaParameterNamingRule) Meta() api.RuleDescriptor {
 		ID:            "LambdaParameterNaming",
 		RuleSet:       "naming",
 		DefaultActive: false,
+		OptInReason:   api.OptInReasonOpinionated,
 		Options: []api.ConfigOption{
 			api.RegexOption(api.RegexOptionSpec[LambdaParameterNamingRule]{
 				Name:        "parameterPattern",
@@ -286,6 +291,7 @@ func (r *NonBooleanPropertyPrefixedWithIsRule) Meta() api.RuleDescriptor {
 		ID:            "NonBooleanPropertyPrefixedWithIs",
 		RuleSet:       "naming",
 		DefaultActive: false,
+		OptInReason:   api.OptInReasonOpinionated,
 	}
 }
 
@@ -366,6 +372,7 @@ func (r *VariableMaxLengthRule) Meta() api.RuleDescriptor {
 		ID:            "VariableMaxLength",
 		RuleSet:       "naming",
 		DefaultActive: false,
+		OptInReason:   api.OptInReasonThresholdTuning,
 		Options: []api.ConfigOption{
 			api.IntOption(api.IntOptionSpec[VariableMaxLengthRule]{
 				Name:        "maximumVariableNameLength",
@@ -383,6 +390,7 @@ func (r *VariableMinLengthRule) Meta() api.RuleDescriptor {
 		ID:            "VariableMinLength",
 		RuleSet:       "naming",
 		DefaultActive: false,
+		OptInReason:   api.OptInReasonThresholdTuning,
 		Options: []api.ConfigOption{
 			api.IntOption(api.IntOptionSpec[VariableMinLengthRule]{
 				Name:        "minimumVariableNameLength",

--- a/internal/rules/meta_newer_version_available.go
+++ b/internal/rules/meta_newer_version_available.go
@@ -20,7 +20,7 @@ func (r *NewerVersionAvailableRule) Meta() api.RuleDescriptor {
 		ID:            "NewerVersionAvailable",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonRequiresUserConfig,
+		OptInReason:   api.OptInReasonRequiresUserConfig,
 		Options: []api.ConfigOption{
 			// RecommendedVersions is []libMinVersion on the rule struct;
 			// YAML stores a []string of "group:name=version" specs.

--- a/internal/rules/meta_newer_version_available.go
+++ b/internal/rules/meta_newer_version_available.go
@@ -20,6 +20,7 @@ func (r *NewerVersionAvailableRule) Meta() api.RuleDescriptor {
 		ID:            "NewerVersionAvailable",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonRequiresUserConfig,
 		Options: []api.ConfigOption{
 			// RecommendedVersions is []libMinVersion on the rule struct;
 			// YAML stores a []string of "group:name=version" specs.

--- a/internal/rules/meta_observability.go
+++ b/internal/rules/meta_observability.go
@@ -9,6 +9,7 @@ func (r *LogLevelGuardMissingRule) Meta() api.RuleDescriptor {
 		ID:            "LogLevelGuardMissing",
 		RuleSet:       "observability",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonDomainSpecific,
 	}
 }
 
@@ -17,6 +18,7 @@ func (r *LogWithoutCorrelationIDRule) Meta() api.RuleDescriptor {
 		ID:            "LogWithoutCorrelationId",
 		RuleSet:       "observability",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonDomainSpecific,
 	}
 }
 
@@ -25,6 +27,7 @@ func (r *WithContextWithoutTracingContextRule) Meta() api.RuleDescriptor {
 		ID:            "WithContextWithoutTracingContext",
 		RuleSet:       "observability",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonDomainSpecific,
 		Options: []api.ConfigOption{
 			api.StringListOption(api.StringListOptionSpec[WithContextWithoutTracingContextRule]{
 				Name:        "allowedDispatchers",
@@ -49,6 +52,7 @@ func (r *SpanAttributeWithHighCardinalityRule) Meta() api.RuleDescriptor {
 		ID:            "SpanAttributeWithHighCardinality",
 		RuleSet:       "observability",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonDomainSpecific,
 		Options: []api.ConfigOption{
 			api.StringListOption(api.StringListOptionSpec[SpanAttributeWithHighCardinalityRule]{
 				Name:        "keys",
@@ -65,6 +69,7 @@ func (r *NullableStructuredFieldRule) Meta() api.RuleDescriptor {
 		ID:            "NullableStructuredField",
 		RuleSet:       "observability",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonDomainSpecific,
 	}
 }
 
@@ -73,6 +78,7 @@ func (r *MetricTimerOutsideBlockRule) Meta() api.RuleDescriptor {
 		ID:            "MetricTimerOutsideBlock",
 		RuleSet:       "observability",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonDomainSpecific,
 	}
 }
 
@@ -153,6 +159,7 @@ func (r *TraceIDLoggedAsPlainMessageRule) Meta() api.RuleDescriptor {
 		ID:            "TraceIdLoggedAsPlainMessage",
 		RuleSet:       "observability",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonDomainSpecific,
 		Options: []api.ConfigOption{
 			api.StringListOption(api.StringListOptionSpec[TraceIDLoggedAsPlainMessageRule]{
 				Name:        "identifiers",
@@ -169,6 +176,7 @@ func (r *StructuredLogKeyMixedCaseRule) Meta() api.RuleDescriptor {
 		ID:            "StructuredLogKeyMixedCase",
 		RuleSet:       "observability",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonDomainSpecific,
 		Options: []api.ConfigOption{
 			api.IntOption(api.IntOptionSpec[StructuredLogKeyMixedCaseRule]{
 				Name:        "minKeys",

--- a/internal/rules/meta_observability.go
+++ b/internal/rules/meta_observability.go
@@ -9,7 +9,7 @@ func (r *LogLevelGuardMissingRule) Meta() api.RuleDescriptor {
 		ID:            "LogLevelGuardMissing",
 		RuleSet:       "observability",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonDomainSpecific,
+		OptInReason:   api.OptInReasonDomainSpecific,
 	}
 }
 
@@ -18,7 +18,7 @@ func (r *LogWithoutCorrelationIDRule) Meta() api.RuleDescriptor {
 		ID:            "LogWithoutCorrelationId",
 		RuleSet:       "observability",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonDomainSpecific,
+		OptInReason:   api.OptInReasonDomainSpecific,
 	}
 }
 
@@ -27,7 +27,7 @@ func (r *WithContextWithoutTracingContextRule) Meta() api.RuleDescriptor {
 		ID:            "WithContextWithoutTracingContext",
 		RuleSet:       "observability",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonDomainSpecific,
+		OptInReason:   api.OptInReasonDomainSpecific,
 		Options: []api.ConfigOption{
 			api.StringListOption(api.StringListOptionSpec[WithContextWithoutTracingContextRule]{
 				Name:        "allowedDispatchers",
@@ -52,7 +52,7 @@ func (r *SpanAttributeWithHighCardinalityRule) Meta() api.RuleDescriptor {
 		ID:            "SpanAttributeWithHighCardinality",
 		RuleSet:       "observability",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonDomainSpecific,
+		OptInReason:   api.OptInReasonDomainSpecific,
 		Options: []api.ConfigOption{
 			api.StringListOption(api.StringListOptionSpec[SpanAttributeWithHighCardinalityRule]{
 				Name:        "keys",
@@ -69,7 +69,7 @@ func (r *NullableStructuredFieldRule) Meta() api.RuleDescriptor {
 		ID:            "NullableStructuredField",
 		RuleSet:       "observability",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonDomainSpecific,
+		OptInReason:   api.OptInReasonDomainSpecific,
 	}
 }
 
@@ -78,7 +78,7 @@ func (r *MetricTimerOutsideBlockRule) Meta() api.RuleDescriptor {
 		ID:            "MetricTimerOutsideBlock",
 		RuleSet:       "observability",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonDomainSpecific,
+		OptInReason:   api.OptInReasonDomainSpecific,
 	}
 }
 
@@ -159,7 +159,7 @@ func (r *TraceIDLoggedAsPlainMessageRule) Meta() api.RuleDescriptor {
 		ID:            "TraceIdLoggedAsPlainMessage",
 		RuleSet:       "observability",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonDomainSpecific,
+		OptInReason:   api.OptInReasonDomainSpecific,
 		Options: []api.ConfigOption{
 			api.StringListOption(api.StringListOptionSpec[TraceIDLoggedAsPlainMessageRule]{
 				Name:        "identifiers",
@@ -176,7 +176,7 @@ func (r *StructuredLogKeyMixedCaseRule) Meta() api.RuleDescriptor {
 		ID:            "StructuredLogKeyMixedCase",
 		RuleSet:       "observability",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonDomainSpecific,
+		OptInReason:   api.OptInReasonDomainSpecific,
 		Options: []api.ConfigOption{
 			api.IntOption(api.IntOptionSpec[StructuredLogKeyMixedCaseRule]{
 				Name:        "minKeys",

--- a/internal/rules/meta_package_dependency_cycle.go
+++ b/internal/rules/meta_package_dependency_cycle.go
@@ -9,6 +9,6 @@ func (r *PackageDependencyCycleRule) Meta() api.RuleDescriptor {
 		ID:            "PackageDependencyCycle",
 		RuleSet:       "architecture",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonProjectPolicy,
+		OptInReason:   api.OptInReasonProjectPolicy,
 	}
 }

--- a/internal/rules/meta_package_dependency_cycle.go
+++ b/internal/rules/meta_package_dependency_cycle.go
@@ -9,5 +9,6 @@ func (r *PackageDependencyCycleRule) Meta() api.RuleDescriptor {
 		ID:            "PackageDependencyCycle",
 		RuleSet:       "architecture",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonProjectPolicy,
 	}
 }

--- a/internal/rules/meta_package_naming_convention_drift.go
+++ b/internal/rules/meta_package_naming_convention_drift.go
@@ -9,5 +9,6 @@ func (r *PackageNamingConventionDriftRule) Meta() api.RuleDescriptor {
 		ID:            "PackageNamingConventionDrift",
 		RuleSet:       "architecture",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonProjectPolicy,
 	}
 }

--- a/internal/rules/meta_package_naming_convention_drift.go
+++ b/internal/rules/meta_package_naming_convention_drift.go
@@ -9,6 +9,6 @@ func (r *PackageNamingConventionDriftRule) Meta() api.RuleDescriptor {
 		ID:            "PackageNamingConventionDrift",
 		RuleSet:       "architecture",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonProjectPolicy,
+		OptInReason:   api.OptInReasonProjectPolicy,
 	}
 }

--- a/internal/rules/meta_performance.go
+++ b/internal/rules/meta_performance.go
@@ -26,6 +26,7 @@ func (r *CouldBeSequenceRule) Meta() api.RuleDescriptor {
 		ID:            "CouldBeSequence",
 		RuleSet:       "performance",
 		DefaultActive: false,
+		OptInReason:   api.OptInReasonOpinionated,
 		Options: []api.ConfigOption{
 			api.IntOption(api.IntOptionSpec[CouldBeSequenceRule]{
 				Name:        "allowedOperations",
@@ -60,6 +61,7 @@ func (r *UnnecessaryInitOnArrayRule) Meta() api.RuleDescriptor {
 		ID:            "UnnecessaryInitOnArray",
 		RuleSet:       "performance",
 		DefaultActive: false,
+		OptInReason:   api.OptInReasonOpinionated,
 		FixLevel:      "idiomatic",
 	}
 }
@@ -69,6 +71,7 @@ func (r *UnnecessaryPartOfBinaryExpressionRule) Meta() api.RuleDescriptor {
 		ID:            "UnnecessaryPartOfBinaryExpression",
 		RuleSet:       "performance",
 		DefaultActive: false,
+		OptInReason:   api.OptInReasonOpinionated,
 		FixLevel:      "idiomatic",
 	}
 }
@@ -87,6 +90,7 @@ func (r *UnnecessaryTypeCastingRule) Meta() api.RuleDescriptor {
 		ID:            "UnnecessaryTypeCasting",
 		RuleSet:       "performance",
 		DefaultActive: false,
+		OptInReason:   api.OptInReasonOpinionated,
 		FixLevel:      "semantic",
 	}
 }

--- a/internal/rules/meta_potentialbugs_lifecycle.go
+++ b/internal/rules/meta_potentialbugs_lifecycle.go
@@ -15,6 +15,7 @@ func (r *ExitOutsideMainRule) Meta() api.RuleDescriptor {
 		ID:            "ExitOutsideMain",
 		RuleSet:       "potential-bugs",
 		DefaultActive: false,
+		OptInReason:   api.OptInReasonDomainSpecific,
 	}
 }
 
@@ -57,6 +58,7 @@ func (r *LateinitUsageRule) Meta() api.RuleDescriptor {
 		ID:            "LateinitUsage",
 		RuleSet:       "potential-bugs",
 		DefaultActive: false,
+		OptInReason:   api.OptInReasonOpinionated,
 		Options: []api.ConfigOption{
 			api.RegexOption(api.RegexOptionSpec[LateinitUsageRule]{
 				Name:        "ignoreOnClassesPattern",
@@ -73,6 +75,7 @@ func (r *MissingPackageDeclarationRule) Meta() api.RuleDescriptor {
 		ID:            "MissingPackageDeclaration",
 		RuleSet:       "potential-bugs",
 		DefaultActive: false,
+		OptInReason:   api.OptInReasonOpinionated,
 		FixLevel:      "cosmetic",
 	}
 }
@@ -82,6 +85,7 @@ func (r *MissingSuperCallRule) Meta() api.RuleDescriptor {
 		ID:            "MissingSuperCall",
 		RuleSet:       "potential-bugs",
 		DefaultActive: false,
+		OptInReason:   api.OptInReasonOpinionated,
 		FixLevel:      "semantic",
 		Options: []api.ConfigOption{
 			api.StringListOption(api.StringListOptionSpec[MissingSuperCallRule]{
@@ -99,5 +103,6 @@ func (r *MissingUseCallRule) Meta() api.RuleDescriptor {
 		ID:            "MissingUseCall",
 		RuleSet:       "potential-bugs",
 		DefaultActive: false,
+		OptInReason:   api.OptInReasonDomainSpecific,
 	}
 }

--- a/internal/rules/meta_potentialbugs_misc.go
+++ b/internal/rules/meta_potentialbugs_misc.go
@@ -9,6 +9,7 @@ func (r *DeprecationRule) Meta() api.RuleDescriptor {
 		ID:            "Deprecation",
 		RuleSet:       "potential-bugs",
 		DefaultActive: false,
+		OptInReason:   api.OptInReasonDuplicatesCompiler,
 		Options: []api.ConfigOption{
 			api.BoolOption(api.BoolOptionSpec[DeprecationRule]{
 				Name:        "excludeImportStatements",

--- a/internal/rules/meta_potentialbugs_nullsafety_casts.go
+++ b/internal/rules/meta_potentialbugs_nullsafety_casts.go
@@ -9,6 +9,7 @@ func (r *CastNullableToNonNullableTypeRule) Meta() api.RuleDescriptor {
 		ID:            "CastNullableToNonNullableType",
 		RuleSet:       "potential-bugs",
 		DefaultActive: false,
+		OptInReason:   api.OptInReasonOpinionated,
 		FixLevel:      "semantic",
 	}
 }
@@ -18,6 +19,7 @@ func (r *CastToNullableTypeRule) Meta() api.RuleDescriptor {
 		ID:            "CastToNullableType",
 		RuleSet:       "potential-bugs",
 		DefaultActive: false,
+		OptInReason:   api.OptInReasonOpinionated,
 		FixLevel:      "semantic",
 	}
 }

--- a/internal/rules/meta_potentialbugs_nullsafety_redundant.go
+++ b/internal/rules/meta_potentialbugs_nullsafety_redundant.go
@@ -9,6 +9,7 @@ func (r *NullCheckOnMutablePropertyRule) Meta() api.RuleDescriptor {
 		ID:            "NullCheckOnMutableProperty",
 		RuleSet:       "potential-bugs",
 		DefaultActive: false,
+		OptInReason:   api.OptInReasonOpinionated,
 	}
 }
 
@@ -17,6 +18,7 @@ func (r *NullableToStringCallRule) Meta() api.RuleDescriptor {
 		ID:            "NullableToStringCall",
 		RuleSet:       "potential-bugs",
 		DefaultActive: false,
+		OptInReason:   api.OptInReasonOpinionated,
 	}
 }
 
@@ -25,6 +27,7 @@ func (r *UnnecessaryNotNullCheckRule) Meta() api.RuleDescriptor {
 		ID:            "UnnecessaryNotNullCheck",
 		RuleSet:       "potential-bugs",
 		DefaultActive: false,
+		OptInReason:   api.OptInReasonOpinionated,
 		FixLevel:      "semantic",
 	}
 }

--- a/internal/rules/meta_potentialbugs_properties.go
+++ b/internal/rules/meta_potentialbugs_properties.go
@@ -9,6 +9,7 @@ func (r *PropertyUsedBeforeDeclarationRule) Meta() api.RuleDescriptor {
 		ID:            "PropertyUsedBeforeDeclaration",
 		RuleSet:       "potential-bugs",
 		DefaultActive: false,
+		OptInReason:   api.OptInReasonDuplicatesCompiler,
 	}
 }
 
@@ -17,6 +18,7 @@ func (r *UnconditionalJumpStatementInLoopRule) Meta() api.RuleDescriptor {
 		ID:            "UnconditionalJumpStatementInLoop",
 		RuleSet:       "potential-bugs",
 		DefaultActive: false,
+		OptInReason:   api.OptInReasonOpinionated,
 	}
 }
 
@@ -25,6 +27,7 @@ func (r *UnnamedParameterUseRule) Meta() api.RuleDescriptor {
 		ID:            "UnnamedParameterUse",
 		RuleSet:       "potential-bugs",
 		DefaultActive: false,
+		OptInReason:   api.OptInReasonOpinionated,
 		Options: []api.ConfigOption{
 			api.BoolOption(api.BoolOptionSpec[UnnamedParameterUseRule]{
 				Name:        "allowSingleParamUse",

--- a/internal/rules/meta_potentialbugs_types.go
+++ b/internal/rules/meta_potentialbugs_types.go
@@ -25,6 +25,7 @@ func (r *CharArrayToStringCallRule) Meta() api.RuleDescriptor {
 		ID:            "CharArrayToStringCall",
 		RuleSet:       "potential-bugs",
 		DefaultActive: false,
+		OptInReason:   api.OptInReasonOpinionated,
 		FixLevel:      "idiomatic",
 	}
 }
@@ -34,6 +35,7 @@ func (r *DontDowncastCollectionTypesRule) Meta() api.RuleDescriptor {
 		ID:            "DontDowncastCollectionTypes",
 		RuleSet:       "potential-bugs",
 		DefaultActive: false,
+		OptInReason:   api.OptInReasonOpinionated,
 		FixLevel:      "semantic",
 	}
 }
@@ -83,6 +85,7 @@ func (r *ImplicitUnitReturnTypeRule) Meta() api.RuleDescriptor {
 		ID:            "ImplicitUnitReturnType",
 		RuleSet:       "potential-bugs",
 		DefaultActive: false,
+		OptInReason:   api.OptInReasonOpinionated,
 		FixLevel:      "idiomatic",
 	}
 }

--- a/internal/rules/meta_privacy_analytics.go
+++ b/internal/rules/meta_privacy_analytics.go
@@ -9,6 +9,7 @@ func (r *AnalyticsCallWithoutConsentGateRule) Meta() api.RuleDescriptor {
 		ID:            "AnalyticsCallWithoutConsentGate",
 		RuleSet:       "privacy",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonDomainSpecific,
 	}
 }
 
@@ -17,6 +18,7 @@ func (r *AnalyticsEventWithPiiParamNameRule) Meta() api.RuleDescriptor {
 		ID:            "AnalyticsEventWithPiiParamName",
 		RuleSet:       "privacy",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonDomainSpecific,
 	}
 }
 
@@ -25,6 +27,7 @@ func (r *AnalyticsUserIDFromPiiRule) Meta() api.RuleDescriptor {
 		ID:            "AnalyticsUserIdFromPii",
 		RuleSet:       "privacy",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonDomainSpecific,
 	}
 }
 
@@ -33,6 +36,7 @@ func (r *CrashlyticsCustomKeyWithPiiRule) Meta() api.RuleDescriptor {
 		ID:            "CrashlyticsCustomKeyWithPii",
 		RuleSet:       "privacy",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonDomainSpecific,
 	}
 }
 
@@ -41,5 +45,6 @@ func (r *FirebaseRemoteConfigDefaultsWithPiiRule) Meta() api.RuleDescriptor {
 		ID:            "FirebaseRemoteConfigDefaultsWithPii",
 		RuleSet:       "privacy",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonDomainSpecific,
 	}
 }

--- a/internal/rules/meta_privacy_analytics.go
+++ b/internal/rules/meta_privacy_analytics.go
@@ -9,7 +9,7 @@ func (r *AnalyticsCallWithoutConsentGateRule) Meta() api.RuleDescriptor {
 		ID:            "AnalyticsCallWithoutConsentGate",
 		RuleSet:       "privacy",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonDomainSpecific,
+		OptInReason:   api.OptInReasonDomainSpecific,
 	}
 }
 
@@ -18,7 +18,7 @@ func (r *AnalyticsEventWithPiiParamNameRule) Meta() api.RuleDescriptor {
 		ID:            "AnalyticsEventWithPiiParamName",
 		RuleSet:       "privacy",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonDomainSpecific,
+		OptInReason:   api.OptInReasonDomainSpecific,
 	}
 }
 
@@ -27,7 +27,7 @@ func (r *AnalyticsUserIDFromPiiRule) Meta() api.RuleDescriptor {
 		ID:            "AnalyticsUserIdFromPii",
 		RuleSet:       "privacy",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonDomainSpecific,
+		OptInReason:   api.OptInReasonDomainSpecific,
 	}
 }
 
@@ -36,7 +36,7 @@ func (r *CrashlyticsCustomKeyWithPiiRule) Meta() api.RuleDescriptor {
 		ID:            "CrashlyticsCustomKeyWithPii",
 		RuleSet:       "privacy",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonDomainSpecific,
+		OptInReason:   api.OptInReasonDomainSpecific,
 	}
 }
 
@@ -45,6 +45,6 @@ func (r *FirebaseRemoteConfigDefaultsWithPiiRule) Meta() api.RuleDescriptor {
 		ID:            "FirebaseRemoteConfigDefaultsWithPii",
 		RuleSet:       "privacy",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonDomainSpecific,
+		OptInReason:   api.OptInReasonDomainSpecific,
 	}
 }

--- a/internal/rules/meta_privacy_permissions.go
+++ b/internal/rules/meta_privacy_permissions.go
@@ -9,7 +9,7 @@ func (r *AdMobInitializedBeforeConsentRule) Meta() api.RuleDescriptor {
 		ID:            "AdMobInitializedBeforeConsent",
 		RuleSet:       "privacy",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonDomainSpecific,
+		OptInReason:   api.OptInReasonDomainSpecific,
 	}
 }
 
@@ -18,7 +18,7 @@ func (r *BiometricAuthNotFallingBackToDeviceCredentialRule) Meta() api.RuleDescr
 		ID:            "BiometricAuthNotFallingBackToDeviceCredential",
 		RuleSet:       "privacy",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonDomainSpecific,
+		OptInReason:   api.OptInReasonDomainSpecific,
 	}
 }
 
@@ -27,7 +27,7 @@ func (r *ClipboardOnSensitiveInputTypeRule) Meta() api.RuleDescriptor {
 		ID:            "ClipboardOnSensitiveInputType",
 		RuleSet:       "privacy",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonDomainSpecific,
+		OptInReason:   api.OptInReasonDomainSpecific,
 	}
 }
 
@@ -36,7 +36,7 @@ func (r *ContactsAccessWithoutPermissionUIRule) Meta() api.RuleDescriptor {
 		ID:            "ContactsAccessWithoutPermissionUi",
 		RuleSet:       "privacy",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonDomainSpecific,
+		OptInReason:   api.OptInReasonDomainSpecific,
 	}
 }
 
@@ -45,7 +45,7 @@ func (r *LocationBackgroundWithoutRationaleRule) Meta() api.RuleDescriptor {
 		ID:            "LocationBackgroundWithoutRationale",
 		RuleSet:       "privacy",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonDomainSpecific,
+		OptInReason:   api.OptInReasonDomainSpecific,
 	}
 }
 

--- a/internal/rules/meta_privacy_permissions.go
+++ b/internal/rules/meta_privacy_permissions.go
@@ -9,6 +9,7 @@ func (r *AdMobInitializedBeforeConsentRule) Meta() api.RuleDescriptor {
 		ID:            "AdMobInitializedBeforeConsent",
 		RuleSet:       "privacy",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonDomainSpecific,
 	}
 }
 
@@ -17,6 +18,7 @@ func (r *BiometricAuthNotFallingBackToDeviceCredentialRule) Meta() api.RuleDescr
 		ID:            "BiometricAuthNotFallingBackToDeviceCredential",
 		RuleSet:       "privacy",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonDomainSpecific,
 	}
 }
 
@@ -25,6 +27,7 @@ func (r *ClipboardOnSensitiveInputTypeRule) Meta() api.RuleDescriptor {
 		ID:            "ClipboardOnSensitiveInputType",
 		RuleSet:       "privacy",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonDomainSpecific,
 	}
 }
 
@@ -33,6 +36,7 @@ func (r *ContactsAccessWithoutPermissionUIRule) Meta() api.RuleDescriptor {
 		ID:            "ContactsAccessWithoutPermissionUi",
 		RuleSet:       "privacy",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonDomainSpecific,
 	}
 }
 
@@ -41,6 +45,7 @@ func (r *LocationBackgroundWithoutRationaleRule) Meta() api.RuleDescriptor {
 		ID:            "LocationBackgroundWithoutRationale",
 		RuleSet:       "privacy",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonDomainSpecific,
 	}
 }
 

--- a/internal/rules/meta_public_to_internal_leaky_abstraction.go
+++ b/internal/rules/meta_public_to_internal_leaky_abstraction.go
@@ -19,7 +19,7 @@ func (r *PublicToInternalLeakyAbstractionRule) Meta() api.RuleDescriptor {
 		ID:            "PublicToInternalLeakyAbstraction",
 		RuleSet:       "architecture",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonProjectPolicy,
+		OptInReason:   api.OptInReasonProjectPolicy,
 		Options: []api.ConfigOption{
 			// YAML stores an int percent; the rule struct holds a
 			// float64 fraction. Only apply when the configured

--- a/internal/rules/meta_public_to_internal_leaky_abstraction.go
+++ b/internal/rules/meta_public_to_internal_leaky_abstraction.go
@@ -19,6 +19,7 @@ func (r *PublicToInternalLeakyAbstractionRule) Meta() api.RuleDescriptor {
 		ID:            "PublicToInternalLeakyAbstraction",
 		RuleSet:       "architecture",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonProjectPolicy,
 		Options: []api.ConfigOption{
 			// YAML stores an int percent; the rule struct holds a
 			// float64 fraction. Only apply when the configured

--- a/internal/rules/meta_release_engineering.go
+++ b/internal/rules/meta_release_engineering.go
@@ -17,6 +17,7 @@ func (r *BuildConfigDebugInLibraryRule) Meta() api.RuleDescriptor {
 		ID:            "BuildConfigDebugInLibrary",
 		RuleSet:       "release-engineering",
 		DefaultActive: false,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 
@@ -33,6 +34,7 @@ func (r *CommentedOutCodeBlockRule) Meta() api.RuleDescriptor {
 		ID:            "CommentedOutCodeBlock",
 		RuleSet:       "release-engineering",
 		DefaultActive: false,
+		OptInReason:   api.OptInReasonOpinionated,
 	}
 }
 
@@ -49,6 +51,7 @@ func (r *ConventionPluginDeadCodeRule) Meta() api.RuleDescriptor {
 		ID:            "ConventionPluginDeadCode",
 		RuleSet:       "release-engineering",
 		DefaultActive: false,
+		OptInReason:   api.OptInReasonDomainSpecific,
 	}
 }
 
@@ -57,6 +60,7 @@ func (r *ModuleTemplateConformanceRule) Meta() api.RuleDescriptor {
 		ID:            "ModuleTemplateConformance",
 		RuleSet:       "release-engineering",
 		DefaultActive: false,
+		OptInReason:   api.OptInReasonProjectPolicy,
 		CustomApply: api.TypedCustomApply(func(rule *ModuleTemplateConformanceRule, cfg api.ConfigSource) {
 			adapter, ok := cfg.(*ConfigAdapter)
 			if !ok {
@@ -80,6 +84,7 @@ func (r *GradleBuildContainsTodoRule) Meta() api.RuleDescriptor {
 		ID:            "GradleBuildContainsTodo",
 		RuleSet:       "release-engineering",
 		DefaultActive: false,
+		OptInReason:   api.OptInReasonOpinionated,
 	}
 }
 
@@ -104,6 +109,7 @@ func (r *HardcodedLogTagRule) Meta() api.RuleDescriptor {
 		ID:            "HardcodedLogTag",
 		RuleSet:       "release-engineering",
 		DefaultActive: false,
+		OptInReason:   api.OptInReasonOpinionated,
 	}
 }
 
@@ -120,6 +126,7 @@ func (r *NonASCIIIdentifierRule) Meta() api.RuleDescriptor {
 		ID:            "NonAsciiIdentifier",
 		RuleSet:       "release-engineering",
 		DefaultActive: false,
+		OptInReason:   api.OptInReasonOpinionated,
 	}
 }
 
@@ -128,6 +135,7 @@ func (r *OpenForTestingCallerInNonTestRule) Meta() api.RuleDescriptor {
 		ID:            "OpenForTestingCallerInNonTest",
 		RuleSet:       "release-engineering",
 		DefaultActive: false,
+		OptInReason:   api.OptInReasonDomainSpecific,
 	}
 }
 
@@ -168,6 +176,7 @@ func (r *TimberTreeNotPlantedRule) Meta() api.RuleDescriptor {
 		ID:            "TimberTreeNotPlanted",
 		RuleSet:       "release-engineering",
 		DefaultActive: false,
+		OptInReason:   api.OptInReasonDomainSpecific,
 	}
 }
 

--- a/internal/rules/meta_resource_cost.go
+++ b/internal/rules/meta_resource_cost.go
@@ -9,6 +9,7 @@ func (r *BufferedReadWithoutBufferRule) Meta() api.RuleDescriptor {
 		ID:            "BufferedReadWithoutBuffer",
 		RuleSet:       "resource-cost",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonDomainSpecific,
 	}
 }
 
@@ -57,6 +58,7 @@ func (r *ImageLoadedAtFullSizeInListRule) Meta() api.RuleDescriptor {
 		ID:            "ImageLoadedAtFullSizeInList",
 		RuleSet:       "resource-cost",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonDomainSpecific,
 	}
 }
 
@@ -65,6 +67,7 @@ func (r *ImageLoaderNoMemoryCacheRule) Meta() api.RuleDescriptor {
 		ID:            "ImageLoaderNoMemoryCache",
 		RuleSet:       "resource-cost",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonDomainSpecific,
 	}
 }
 
@@ -105,6 +108,7 @@ func (r *RecyclerAdapterStableIDsDefaultRule) Meta() api.RuleDescriptor {
 		ID:            "RecyclerAdapterStableIdsDefault",
 		RuleSet:       "resource-cost",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonDomainSpecific,
 	}
 }
 
@@ -145,6 +149,7 @@ func (r *WorkManagerNoBackoffRule) Meta() api.RuleDescriptor {
 		ID:            "WorkManagerNoBackoff",
 		RuleSet:       "resource-cost",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonDomainSpecific,
 	}
 }
 
@@ -153,5 +158,6 @@ func (r *WorkManagerUniquePolicyKeepButReplaceIntendedRule) Meta() api.RuleDescr
 		ID:            "WorkManagerUniquePolicyKeepButReplaceIntended",
 		RuleSet:       "resource-cost",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonDomainSpecific,
 	}
 }

--- a/internal/rules/meta_resource_cost.go
+++ b/internal/rules/meta_resource_cost.go
@@ -9,7 +9,7 @@ func (r *BufferedReadWithoutBufferRule) Meta() api.RuleDescriptor {
 		ID:            "BufferedReadWithoutBuffer",
 		RuleSet:       "resource-cost",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonDomainSpecific,
+		OptInReason:   api.OptInReasonDomainSpecific,
 	}
 }
 
@@ -58,7 +58,7 @@ func (r *ImageLoadedAtFullSizeInListRule) Meta() api.RuleDescriptor {
 		ID:            "ImageLoadedAtFullSizeInList",
 		RuleSet:       "resource-cost",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonDomainSpecific,
+		OptInReason:   api.OptInReasonDomainSpecific,
 	}
 }
 
@@ -67,7 +67,7 @@ func (r *ImageLoaderNoMemoryCacheRule) Meta() api.RuleDescriptor {
 		ID:            "ImageLoaderNoMemoryCache",
 		RuleSet:       "resource-cost",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonDomainSpecific,
+		OptInReason:   api.OptInReasonDomainSpecific,
 	}
 }
 
@@ -108,7 +108,7 @@ func (r *RecyclerAdapterStableIDsDefaultRule) Meta() api.RuleDescriptor {
 		ID:            "RecyclerAdapterStableIdsDefault",
 		RuleSet:       "resource-cost",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonDomainSpecific,
+		OptInReason:   api.OptInReasonDomainSpecific,
 	}
 }
 
@@ -149,7 +149,7 @@ func (r *WorkManagerNoBackoffRule) Meta() api.RuleDescriptor {
 		ID:            "WorkManagerNoBackoff",
 		RuleSet:       "resource-cost",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonDomainSpecific,
+		OptInReason:   api.OptInReasonDomainSpecific,
 	}
 }
 
@@ -158,6 +158,6 @@ func (r *WorkManagerUniquePolicyKeepButReplaceIntendedRule) Meta() api.RuleDescr
 		ID:            "WorkManagerUniquePolicyKeepButReplaceIntended",
 		RuleSet:       "resource-cost",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonDomainSpecific,
+		OptInReason:   api.OptInReasonDomainSpecific,
 	}
 }

--- a/internal/rules/meta_security.go
+++ b/internal/rules/meta_security.go
@@ -13,7 +13,7 @@ func (r *ContentProviderQueryWithSelectionInterpolationRule) Meta() api.RuleDesc
 		ID:            "ContentProviderQueryWithSelectionInterpolation",
 		RuleSet:       "security",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonDomainSpecific,
+		OptInReason:   api.OptInReasonDomainSpecific,
 	}
 }
 
@@ -22,7 +22,7 @@ func (r *SQLInjectionRawQueryRule) Meta() api.RuleDescriptor {
 		ID:            "SqlInjectionRawQuery",
 		RuleSet:       "security",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonDomainSpecific,
+		OptInReason:   api.OptInReasonDomainSpecific,
 	}
 }
 
@@ -31,7 +31,7 @@ func (r *RuntimeExecUnsafeShapeRule) Meta() api.RuleDescriptor {
 		ID:            "RuntimeExecUnsafeShape",
 		RuleSet:       "security",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonDomainSpecific,
+		OptInReason:   api.OptInReasonDomainSpecific,
 	}
 }
 
@@ -40,7 +40,7 @@ func (r *RoomRawQueryStringConcatRule) Meta() api.RuleDescriptor {
 		ID:            "RoomRawQueryStringConcat",
 		RuleSet:       "security",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonDomainSpecific,
+		OptInReason:   api.OptInReasonDomainSpecific,
 	}
 }
 
@@ -49,7 +49,7 @@ func (r *ProcessBuilderShellArgRule) Meta() api.RuleDescriptor {
 		ID:            "ProcessBuilderShellArg",
 		RuleSet:       "security",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonDomainSpecific,
+		OptInReason:   api.OptInReasonDomainSpecific,
 	}
 }
 
@@ -58,7 +58,7 @@ func (r *LogPiiRule) Meta() api.RuleDescriptor {
 		ID:            "LogPii",
 		RuleSet:       "security",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonDomainSpecific,
+		OptInReason:   api.OptInReasonDomainSpecific,
 		Options: []api.ConfigOption{
 			api.RegexOption(api.RegexOptionSpec[LogPiiRule]{
 				Name:        "piiNamePattern",
@@ -75,7 +75,7 @@ func (r *JdbcStatementExecuteRule) Meta() api.RuleDescriptor {
 		ID:            "JdbcStatementExecute",
 		RuleSet:       "security",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonDomainSpecific,
+		OptInReason:   api.OptInReasonDomainSpecific,
 	}
 }
 
@@ -116,7 +116,7 @@ func (r *FileFromUntrustedPathRule) Meta() api.RuleDescriptor {
 		ID:            "FileFromUntrustedPath",
 		RuleSet:       "security",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonDomainSpecific,
+		OptInReason:   api.OptInReasonDomainSpecific,
 	}
 }
 
@@ -157,7 +157,7 @@ func (r *ZipSlipUncheckedRule) Meta() api.RuleDescriptor {
 		ID:            "ZipSlipUnchecked",
 		RuleSet:       "security",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonDomainSpecific,
+		OptInReason:   api.OptInReasonDomainSpecific,
 	}
 }
 
@@ -166,6 +166,6 @@ func (r *TempFileWorldReadableRule) Meta() api.RuleDescriptor {
 		ID:            "TempFileWorldReadable",
 		RuleSet:       "security",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonDomainSpecific,
+		OptInReason:   api.OptInReasonDomainSpecific,
 	}
 }

--- a/internal/rules/meta_security.go
+++ b/internal/rules/meta_security.go
@@ -13,6 +13,7 @@ func (r *ContentProviderQueryWithSelectionInterpolationRule) Meta() api.RuleDesc
 		ID:            "ContentProviderQueryWithSelectionInterpolation",
 		RuleSet:       "security",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonDomainSpecific,
 	}
 }
 
@@ -21,6 +22,7 @@ func (r *SQLInjectionRawQueryRule) Meta() api.RuleDescriptor {
 		ID:            "SqlInjectionRawQuery",
 		RuleSet:       "security",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonDomainSpecific,
 	}
 }
 
@@ -29,6 +31,7 @@ func (r *RuntimeExecUnsafeShapeRule) Meta() api.RuleDescriptor {
 		ID:            "RuntimeExecUnsafeShape",
 		RuleSet:       "security",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonDomainSpecific,
 	}
 }
 
@@ -37,6 +40,7 @@ func (r *RoomRawQueryStringConcatRule) Meta() api.RuleDescriptor {
 		ID:            "RoomRawQueryStringConcat",
 		RuleSet:       "security",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonDomainSpecific,
 	}
 }
 
@@ -45,6 +49,7 @@ func (r *ProcessBuilderShellArgRule) Meta() api.RuleDescriptor {
 		ID:            "ProcessBuilderShellArg",
 		RuleSet:       "security",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonDomainSpecific,
 	}
 }
 
@@ -53,6 +58,7 @@ func (r *LogPiiRule) Meta() api.RuleDescriptor {
 		ID:            "LogPii",
 		RuleSet:       "security",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonDomainSpecific,
 		Options: []api.ConfigOption{
 			api.RegexOption(api.RegexOptionSpec[LogPiiRule]{
 				Name:        "piiNamePattern",
@@ -69,6 +75,7 @@ func (r *JdbcStatementExecuteRule) Meta() api.RuleDescriptor {
 		ID:            "JdbcStatementExecute",
 		RuleSet:       "security",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonDomainSpecific,
 	}
 }
 
@@ -109,6 +116,7 @@ func (r *FileFromUntrustedPathRule) Meta() api.RuleDescriptor {
 		ID:            "FileFromUntrustedPath",
 		RuleSet:       "security",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonDomainSpecific,
 	}
 }
 
@@ -149,6 +157,7 @@ func (r *ZipSlipUncheckedRule) Meta() api.RuleDescriptor {
 		ID:            "ZipSlipUnchecked",
 		RuleSet:       "security",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonDomainSpecific,
 	}
 }
 
@@ -157,5 +166,6 @@ func (r *TempFileWorldReadableRule) Meta() api.RuleDescriptor {
 		ID:            "TempFileWorldReadable",
 		RuleSet:       "security",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonDomainSpecific,
 	}
 }

--- a/internal/rules/meta_style_braces.go
+++ b/internal/rules/meta_style_braces.go
@@ -9,7 +9,7 @@ func (r *BracesOnIfStatementsRule) Meta() api.RuleDescriptor {
 		ID:            "BracesOnIfStatements",
 		RuleSet:       "style",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonOpinionated,
+		OptInReason:   api.OptInReasonOpinionated,
 		FixLevel:      "cosmetic",
 		Options: []api.ConfigOption{
 			api.StringOption(api.StringOptionSpec[BracesOnIfStatementsRule]{
@@ -33,7 +33,7 @@ func (r *BracesOnWhenStatementsRule) Meta() api.RuleDescriptor {
 		ID:            "BracesOnWhenStatements",
 		RuleSet:       "style",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonOpinionated,
+		OptInReason:   api.OptInReasonOpinionated,
 		FixLevel:      "cosmetic",
 		Options: []api.ConfigOption{
 			api.StringOption(api.StringOptionSpec[BracesOnWhenStatementsRule]{
@@ -57,7 +57,7 @@ func (r *MandatoryBracesLoopsRule) Meta() api.RuleDescriptor {
 		ID:            "MandatoryBracesLoops",
 		RuleSet:       "style",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonOpinionated,
+		OptInReason:   api.OptInReasonOpinionated,
 		FixLevel:      "cosmetic",
 	}
 }

--- a/internal/rules/meta_style_braces.go
+++ b/internal/rules/meta_style_braces.go
@@ -9,6 +9,7 @@ func (r *BracesOnIfStatementsRule) Meta() api.RuleDescriptor {
 		ID:            "BracesOnIfStatements",
 		RuleSet:       "style",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonOpinionated,
 		FixLevel:      "cosmetic",
 		Options: []api.ConfigOption{
 			api.StringOption(api.StringOptionSpec[BracesOnIfStatementsRule]{
@@ -32,6 +33,7 @@ func (r *BracesOnWhenStatementsRule) Meta() api.RuleDescriptor {
 		ID:            "BracesOnWhenStatements",
 		RuleSet:       "style",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonOpinionated,
 		FixLevel:      "cosmetic",
 		Options: []api.ConfigOption{
 			api.StringOption(api.StringOptionSpec[BracesOnWhenStatementsRule]{
@@ -55,6 +57,7 @@ func (r *MandatoryBracesLoopsRule) Meta() api.RuleDescriptor {
 		ID:            "MandatoryBracesLoops",
 		RuleSet:       "style",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonOpinionated,
 		FixLevel:      "cosmetic",
 	}
 }

--- a/internal/rules/meta_style_classes.go
+++ b/internal/rules/meta_style_classes.go
@@ -27,7 +27,7 @@ func (r *ClassOrderingRule) Meta() api.RuleDescriptor {
 		ID:            "ClassOrdering",
 		RuleSet:       "style",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonOpinionated,
+		OptInReason:   api.OptInReasonOpinionated,
 	}
 }
 
@@ -36,7 +36,7 @@ func (r *DataClassContainsFunctionsRule) Meta() api.RuleDescriptor {
 		ID:            "DataClassContainsFunctions",
 		RuleSet:       "style",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonOpinionated,
+		OptInReason:   api.OptInReasonOpinionated,
 		Options: []api.ConfigOption{
 			api.StringListOption(api.StringListOptionSpec[DataClassContainsFunctionsRule]{
 				Name:        "conversionFunctionPrefix",
@@ -52,7 +52,7 @@ func (r *DataClassShouldBeImmutableRule) Meta() api.RuleDescriptor {
 		ID:            "DataClassShouldBeImmutable",
 		RuleSet:       "style",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonOpinionated,
+		OptInReason:   api.OptInReasonOpinionated,
 		FixLevel:      "semantic",
 	}
 }

--- a/internal/rules/meta_style_classes.go
+++ b/internal/rules/meta_style_classes.go
@@ -27,6 +27,7 @@ func (r *ClassOrderingRule) Meta() api.RuleDescriptor {
 		ID:            "ClassOrdering",
 		RuleSet:       "style",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonOpinionated,
 	}
 }
 
@@ -35,6 +36,7 @@ func (r *DataClassContainsFunctionsRule) Meta() api.RuleDescriptor {
 		ID:            "DataClassContainsFunctions",
 		RuleSet:       "style",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonOpinionated,
 		Options: []api.ConfigOption{
 			api.StringListOption(api.StringListOptionSpec[DataClassContainsFunctionsRule]{
 				Name:        "conversionFunctionPrefix",
@@ -50,6 +52,7 @@ func (r *DataClassShouldBeImmutableRule) Meta() api.RuleDescriptor {
 		ID:            "DataClassShouldBeImmutable",
 		RuleSet:       "style",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonOpinionated,
 		FixLevel:      "semantic",
 	}
 }

--- a/internal/rules/meta_style_expressions.go
+++ b/internal/rules/meta_style_expressions.go
@@ -9,7 +9,7 @@ func (r *CollapsibleIfStatementsRule) Meta() api.RuleDescriptor {
 		ID:            "CollapsibleIfStatements",
 		RuleSet:       "style",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonOpinionated,
+		OptInReason:   api.OptInReasonOpinionated,
 		FixLevel:      "idiomatic",
 	}
 }
@@ -37,7 +37,7 @@ func (r *ExpressionBodySyntaxRule) Meta() api.RuleDescriptor {
 		ID:            "ExpressionBodySyntax",
 		RuleSet:       "style",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonOpinionated,
+		OptInReason:   api.OptInReasonOpinionated,
 		FixLevel:      "idiomatic",
 		Options: []api.ConfigOption{
 			api.BoolOption(api.BoolOptionSpec[ExpressionBodySyntaxRule]{

--- a/internal/rules/meta_style_expressions.go
+++ b/internal/rules/meta_style_expressions.go
@@ -9,6 +9,7 @@ func (r *CollapsibleIfStatementsRule) Meta() api.RuleDescriptor {
 		ID:            "CollapsibleIfStatements",
 		RuleSet:       "style",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonOpinionated,
 		FixLevel:      "idiomatic",
 	}
 }
@@ -36,6 +37,7 @@ func (r *ExpressionBodySyntaxRule) Meta() api.RuleDescriptor {
 		ID:            "ExpressionBodySyntax",
 		RuleSet:       "style",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonOpinionated,
 		FixLevel:      "idiomatic",
 		Options: []api.ConfigOption{
 			api.BoolOption(api.BoolOptionSpec[ExpressionBodySyntaxRule]{

--- a/internal/rules/meta_style_expressions_extra.go
+++ b/internal/rules/meta_style_expressions_extra.go
@@ -9,7 +9,7 @@ func (r *CanBeNonNullableRule) Meta() api.RuleDescriptor {
 		ID:            "CanBeNonNullable",
 		RuleSet:       "style",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonOpinionated,
+		OptInReason:   api.OptInReasonOpinionated,
 	}
 }
 
@@ -35,7 +35,7 @@ func (r *DoubleNegativeExpressionRule) Meta() api.RuleDescriptor {
 		ID:            "DoubleNegativeExpression",
 		RuleSet:       "style",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonOpinionated,
+		OptInReason:   api.OptInReasonOpinionated,
 		FixLevel:      "idiomatic",
 	}
 }
@@ -45,7 +45,7 @@ func (r *DoubleNegativeLambdaRule) Meta() api.RuleDescriptor {
 		ID:            "DoubleNegativeLambda",
 		RuleSet:       "style",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonOpinionated,
+		OptInReason:   api.OptInReasonOpinionated,
 		Options: []api.ConfigOption{
 			api.StringListOption(api.StringListOptionSpec[DoubleNegativeLambdaRule]{
 				Name:        "negativeFunctions",
@@ -61,7 +61,7 @@ func (r *MultilineLambdaItParameterRule) Meta() api.RuleDescriptor {
 		ID:            "MultilineLambdaItParameter",
 		RuleSet:       "style",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonOpinionated,
+		OptInReason:   api.OptInReasonOpinionated,
 	}
 }
 
@@ -70,7 +70,7 @@ func (r *MultilineRawStringIndentationRule) Meta() api.RuleDescriptor {
 		ID:            "MultilineRawStringIndentation",
 		RuleSet:       "style",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonOpinionated,
+		OptInReason:   api.OptInReasonOpinionated,
 		Options: []api.ConfigOption{
 			api.IntOption(api.IntOptionSpec[MultilineRawStringIndentationRule]{
 				Name:        "indentSize",
@@ -92,7 +92,7 @@ func (r *NullableBooleanCheckRule) Meta() api.RuleDescriptor {
 		ID:            "NullableBooleanCheck",
 		RuleSet:       "style",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonOpinionated,
+		OptInReason:   api.OptInReasonOpinionated,
 		FixLevel:      "idiomatic",
 	}
 }
@@ -102,7 +102,7 @@ func (r *RangeUntilInsteadOfRangeToRule) Meta() api.RuleDescriptor {
 		ID:            "RangeUntilInsteadOfRangeTo",
 		RuleSet:       "style",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonOpinionated,
+		OptInReason:   api.OptInReasonOpinionated,
 		FixLevel:      "idiomatic",
 	}
 }
@@ -112,7 +112,7 @@ func (r *StringShouldBeRawStringRule) Meta() api.RuleDescriptor {
 		ID:            "StringShouldBeRawString",
 		RuleSet:       "style",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonOpinionated,
+		OptInReason:   api.OptInReasonOpinionated,
 		Options: []api.ConfigOption{
 			api.IntOption(api.IntOptionSpec[StringShouldBeRawStringRule]{
 				Name:        "maxEscapedCharacterCount",
@@ -130,7 +130,7 @@ func (r *TrimMultilineRawStringRule) Meta() api.RuleDescriptor {
 		ID:            "TrimMultilineRawString",
 		RuleSet:       "style",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonOpinionated,
+		OptInReason:   api.OptInReasonOpinionated,
 		FixLevel:      "cosmetic",
 		Options: []api.ConfigOption{
 			api.StringListOption(api.StringListOptionSpec[TrimMultilineRawStringRule]{

--- a/internal/rules/meta_style_expressions_extra.go
+++ b/internal/rules/meta_style_expressions_extra.go
@@ -9,6 +9,7 @@ func (r *CanBeNonNullableRule) Meta() api.RuleDescriptor {
 		ID:            "CanBeNonNullable",
 		RuleSet:       "style",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonOpinionated,
 	}
 }
 
@@ -34,6 +35,7 @@ func (r *DoubleNegativeExpressionRule) Meta() api.RuleDescriptor {
 		ID:            "DoubleNegativeExpression",
 		RuleSet:       "style",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonOpinionated,
 		FixLevel:      "idiomatic",
 	}
 }
@@ -43,6 +45,7 @@ func (r *DoubleNegativeLambdaRule) Meta() api.RuleDescriptor {
 		ID:            "DoubleNegativeLambda",
 		RuleSet:       "style",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonOpinionated,
 		Options: []api.ConfigOption{
 			api.StringListOption(api.StringListOptionSpec[DoubleNegativeLambdaRule]{
 				Name:        "negativeFunctions",
@@ -58,6 +61,7 @@ func (r *MultilineLambdaItParameterRule) Meta() api.RuleDescriptor {
 		ID:            "MultilineLambdaItParameter",
 		RuleSet:       "style",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonOpinionated,
 	}
 }
 
@@ -66,6 +70,7 @@ func (r *MultilineRawStringIndentationRule) Meta() api.RuleDescriptor {
 		ID:            "MultilineRawStringIndentation",
 		RuleSet:       "style",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonOpinionated,
 		Options: []api.ConfigOption{
 			api.IntOption(api.IntOptionSpec[MultilineRawStringIndentationRule]{
 				Name:        "indentSize",
@@ -87,6 +92,7 @@ func (r *NullableBooleanCheckRule) Meta() api.RuleDescriptor {
 		ID:            "NullableBooleanCheck",
 		RuleSet:       "style",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonOpinionated,
 		FixLevel:      "idiomatic",
 	}
 }
@@ -96,6 +102,7 @@ func (r *RangeUntilInsteadOfRangeToRule) Meta() api.RuleDescriptor {
 		ID:            "RangeUntilInsteadOfRangeTo",
 		RuleSet:       "style",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonOpinionated,
 		FixLevel:      "idiomatic",
 	}
 }
@@ -105,6 +112,7 @@ func (r *StringShouldBeRawStringRule) Meta() api.RuleDescriptor {
 		ID:            "StringShouldBeRawString",
 		RuleSet:       "style",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonOpinionated,
 		Options: []api.ConfigOption{
 			api.IntOption(api.IntOptionSpec[StringShouldBeRawStringRule]{
 				Name:        "maxEscapedCharacterCount",
@@ -122,6 +130,7 @@ func (r *TrimMultilineRawStringRule) Meta() api.RuleDescriptor {
 		ID:            "TrimMultilineRawString",
 		RuleSet:       "style",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonOpinionated,
 		FixLevel:      "cosmetic",
 		Options: []api.ConfigOption{
 			api.StringListOption(api.StringListOptionSpec[TrimMultilineRawStringRule]{

--- a/internal/rules/meta_style_forbidden.go
+++ b/internal/rules/meta_style_forbidden.go
@@ -16,7 +16,7 @@ func (r *ForbiddenAnnotationRule) Meta() api.RuleDescriptor {
 		ID:            "ForbiddenAnnotation",
 		RuleSet:       "style",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonOpinionated,
+		OptInReason:   api.OptInReasonOpinionated,
 		FixLevel:      "idiomatic",
 		Options: []api.ConfigOption{
 			api.StringListOption(api.StringListOptionSpec[ForbiddenAnnotationRule]{
@@ -56,7 +56,7 @@ func (r *ForbiddenMethodCallRule) Meta() api.RuleDescriptor {
 		ID:            "ForbiddenMethodCall",
 		RuleSet:       "style",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonOpinionated,
+		OptInReason:   api.OptInReasonOpinionated,
 		FixLevel:      "semantic",
 		Options: []api.ConfigOption{
 			api.StringListOption(api.StringListOptionSpec[ForbiddenMethodCallRule]{
@@ -74,7 +74,7 @@ func (r *ForbiddenNamedParamRule) Meta() api.RuleDescriptor {
 		ID:            "ForbiddenNamedParam",
 		RuleSet:       "style",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonOpinionated,
+		OptInReason:   api.OptInReasonOpinionated,
 		Options: []api.ConfigOption{
 			api.StringListOption(api.StringListOptionSpec[ForbiddenNamedParamRule]{
 				Name:        "methods",
@@ -91,7 +91,7 @@ func (r *ForbiddenOptInRule) Meta() api.RuleDescriptor {
 		ID:            "ForbiddenOptIn",
 		RuleSet:       "style",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonOpinionated,
+		OptInReason:   api.OptInReasonOpinionated,
 		FixLevel:      "semantic",
 		Options: []api.ConfigOption{
 			api.StringListOption(api.StringListOptionSpec[ForbiddenOptInRule]{
@@ -108,7 +108,7 @@ func (r *ForbiddenSuppressRule) Meta() api.RuleDescriptor {
 		ID:            "ForbiddenSuppress",
 		RuleSet:       "style",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonOpinionated,
+		OptInReason:   api.OptInReasonOpinionated,
 		FixLevel:      "semantic",
 		Options: []api.ConfigOption{
 			api.StringListOption(api.StringListOptionSpec[ForbiddenSuppressRule]{

--- a/internal/rules/meta_style_forbidden.go
+++ b/internal/rules/meta_style_forbidden.go
@@ -16,6 +16,7 @@ func (r *ForbiddenAnnotationRule) Meta() api.RuleDescriptor {
 		ID:            "ForbiddenAnnotation",
 		RuleSet:       "style",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonOpinionated,
 		FixLevel:      "idiomatic",
 		Options: []api.ConfigOption{
 			api.StringListOption(api.StringListOptionSpec[ForbiddenAnnotationRule]{
@@ -55,6 +56,7 @@ func (r *ForbiddenMethodCallRule) Meta() api.RuleDescriptor {
 		ID:            "ForbiddenMethodCall",
 		RuleSet:       "style",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonOpinionated,
 		FixLevel:      "semantic",
 		Options: []api.ConfigOption{
 			api.StringListOption(api.StringListOptionSpec[ForbiddenMethodCallRule]{
@@ -72,6 +74,7 @@ func (r *ForbiddenNamedParamRule) Meta() api.RuleDescriptor {
 		ID:            "ForbiddenNamedParam",
 		RuleSet:       "style",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonOpinionated,
 		Options: []api.ConfigOption{
 			api.StringListOption(api.StringListOptionSpec[ForbiddenNamedParamRule]{
 				Name:        "methods",
@@ -88,6 +91,7 @@ func (r *ForbiddenOptInRule) Meta() api.RuleDescriptor {
 		ID:            "ForbiddenOptIn",
 		RuleSet:       "style",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonOpinionated,
 		FixLevel:      "semantic",
 		Options: []api.ConfigOption{
 			api.StringListOption(api.StringListOptionSpec[ForbiddenOptInRule]{
@@ -104,6 +108,7 @@ func (r *ForbiddenSuppressRule) Meta() api.RuleDescriptor {
 		ID:            "ForbiddenSuppress",
 		RuleSet:       "style",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonOpinionated,
 		FixLevel:      "semantic",
 		Options: []api.ConfigOption{
 			api.StringListOption(api.StringListOptionSpec[ForbiddenSuppressRule]{

--- a/internal/rules/meta_style_format.go
+++ b/internal/rules/meta_style_format.go
@@ -9,7 +9,7 @@ func (r *CascadingCallWrappingRule) Meta() api.RuleDescriptor {
 		ID:            "CascadingCallWrapping",
 		RuleSet:       "style",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonOpinionated,
+		OptInReason:   api.OptInReasonOpinionated,
 		Options: []api.ConfigOption{
 			api.BoolOption(api.BoolOptionSpec[CascadingCallWrappingRule]{
 				Name:        "includeElvis",
@@ -26,7 +26,7 @@ func (r *EqualsOnSignatureLineRule) Meta() api.RuleDescriptor {
 		ID:            "EqualsOnSignatureLine",
 		RuleSet:       "style",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonOpinionated,
+		OptInReason:   api.OptInReasonOpinionated,
 		FixLevel:      "cosmetic",
 	}
 }
@@ -36,7 +36,7 @@ func (r *MaxChainedCallsOnSameLineRule) Meta() api.RuleDescriptor {
 		ID:            "MaxChainedCallsOnSameLine",
 		RuleSet:       "style",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonOpinionated,
+		OptInReason:   api.OptInReasonOpinionated,
 		Options: []api.ConfigOption{
 			api.IntOption(api.IntOptionSpec[MaxChainedCallsOnSameLineRule]{
 				Name:        "maxChainedCalls",
@@ -104,7 +104,7 @@ func (r *NoTabsRule) Meta() api.RuleDescriptor {
 		ID:            "NoTabs",
 		RuleSet:       "style",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonOpinionated,
+		OptInReason:   api.OptInReasonOpinionated,
 		FixLevel:      "cosmetic",
 		Options: []api.ConfigOption{
 			api.IntOption(api.IntOptionSpec[NoTabsRule]{
@@ -123,7 +123,7 @@ func (r *SpacingAfterPackageAndImportsRule) Meta() api.RuleDescriptor {
 		ID:            "SpacingAfterPackageAndImports",
 		RuleSet:       "style",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonOpinionated,
+		OptInReason:   api.OptInReasonOpinionated,
 		FixLevel:      "cosmetic",
 	}
 }
@@ -133,7 +133,7 @@ func (r *TrailingWhitespaceRule) Meta() api.RuleDescriptor {
 		ID:            "TrailingWhitespace",
 		RuleSet:       "style",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonOpinionated,
+		OptInReason:   api.OptInReasonOpinionated,
 		FixLevel:      "cosmetic",
 	}
 }
@@ -143,7 +143,7 @@ func (r *UnderscoresInNumericLiteralsRule) Meta() api.RuleDescriptor {
 		ID:            "UnderscoresInNumericLiterals",
 		RuleSet:       "style",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonOpinionated,
+		OptInReason:   api.OptInReasonOpinionated,
 		FixLevel:      "cosmetic",
 		Options: []api.ConfigOption{
 			api.IntOption(api.IntOptionSpec[UnderscoresInNumericLiteralsRule]{

--- a/internal/rules/meta_style_format.go
+++ b/internal/rules/meta_style_format.go
@@ -9,6 +9,7 @@ func (r *CascadingCallWrappingRule) Meta() api.RuleDescriptor {
 		ID:            "CascadingCallWrapping",
 		RuleSet:       "style",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonOpinionated,
 		Options: []api.ConfigOption{
 			api.BoolOption(api.BoolOptionSpec[CascadingCallWrappingRule]{
 				Name:        "includeElvis",
@@ -25,6 +26,7 @@ func (r *EqualsOnSignatureLineRule) Meta() api.RuleDescriptor {
 		ID:            "EqualsOnSignatureLine",
 		RuleSet:       "style",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonOpinionated,
 		FixLevel:      "cosmetic",
 	}
 }
@@ -34,6 +36,7 @@ func (r *MaxChainedCallsOnSameLineRule) Meta() api.RuleDescriptor {
 		ID:            "MaxChainedCallsOnSameLine",
 		RuleSet:       "style",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonOpinionated,
 		Options: []api.ConfigOption{
 			api.IntOption(api.IntOptionSpec[MaxChainedCallsOnSameLineRule]{
 				Name:        "maxChainedCalls",
@@ -101,6 +104,7 @@ func (r *NoTabsRule) Meta() api.RuleDescriptor {
 		ID:            "NoTabs",
 		RuleSet:       "style",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonOpinionated,
 		FixLevel:      "cosmetic",
 		Options: []api.ConfigOption{
 			api.IntOption(api.IntOptionSpec[NoTabsRule]{
@@ -119,6 +123,7 @@ func (r *SpacingAfterPackageAndImportsRule) Meta() api.RuleDescriptor {
 		ID:            "SpacingAfterPackageAndImports",
 		RuleSet:       "style",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonOpinionated,
 		FixLevel:      "cosmetic",
 	}
 }
@@ -128,6 +133,7 @@ func (r *TrailingWhitespaceRule) Meta() api.RuleDescriptor {
 		ID:            "TrailingWhitespace",
 		RuleSet:       "style",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonOpinionated,
 		FixLevel:      "cosmetic",
 	}
 }
@@ -137,6 +143,7 @@ func (r *UnderscoresInNumericLiteralsRule) Meta() api.RuleDescriptor {
 		ID:            "UnderscoresInNumericLiterals",
 		RuleSet:       "style",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonOpinionated,
 		FixLevel:      "cosmetic",
 		Options: []api.ConfigOption{
 			api.IntOption(api.IntOptionSpec[UnderscoresInNumericLiteralsRule]{

--- a/internal/rules/meta_style_idiomatic_data.go
+++ b/internal/rules/meta_style_idiomatic_data.go
@@ -9,6 +9,7 @@ func (r *AlsoCouldBeApplyRule) Meta() api.RuleDescriptor {
 		ID:            "AlsoCouldBeApply",
 		RuleSet:       "style",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonOpinionated,
 		FixLevel:      "semantic",
 	}
 }
@@ -27,6 +28,7 @@ func (r *ExplicitCollectionElementAccessMethodRule) Meta() api.RuleDescriptor {
 		ID:            "ExplicitCollectionElementAccessMethod",
 		RuleSet:       "style",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonOpinionated,
 		FixLevel:      "idiomatic",
 	}
 }
@@ -36,6 +38,7 @@ func (r *UseArrayLiteralsInAnnotationsRule) Meta() api.RuleDescriptor {
 		ID:            "UseArrayLiteralsInAnnotations",
 		RuleSet:       "style",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonOpinionated,
 		FixLevel:      "idiomatic",
 	}
 }
@@ -45,6 +48,7 @@ func (r *UseDataClassRule) Meta() api.RuleDescriptor {
 		ID:            "UseDataClass",
 		RuleSet:       "style",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonOpinionated,
 		FixLevel:      "semantic",
 		Options: []api.ConfigOption{
 			api.BoolOption(api.BoolOptionSpec[UseDataClassRule]{
@@ -62,6 +66,7 @@ func (r *UseIfEmptyOrIfBlankRule) Meta() api.RuleDescriptor {
 		ID:            "UseIfEmptyOrIfBlank",
 		RuleSet:       "style",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonOpinionated,
 		FixLevel:      "idiomatic",
 	}
 }
@@ -71,6 +76,7 @@ func (r *UseIfInsteadOfWhenRule) Meta() api.RuleDescriptor {
 		ID:            "UseIfInsteadOfWhen",
 		RuleSet:       "style",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonOpinionated,
 		FixLevel:      "idiomatic",
 		Options: []api.ConfigOption{
 			api.BoolOption(api.BoolOptionSpec[UseIfInsteadOfWhenRule]{
@@ -88,6 +94,7 @@ func (r *UseLetRule) Meta() api.RuleDescriptor {
 		ID:            "UseLet",
 		RuleSet:       "style",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonOpinionated,
 		FixLevel:      "idiomatic",
 	}
 }
@@ -97,6 +104,7 @@ func (r *UseSumOfInsteadOfFlatMapSizeRule) Meta() api.RuleDescriptor {
 		ID:            "UseSumOfInsteadOfFlatMapSize",
 		RuleSet:       "style",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonOpinionated,
 		FixLevel:      "idiomatic",
 	}
 }

--- a/internal/rules/meta_style_idiomatic_data.go
+++ b/internal/rules/meta_style_idiomatic_data.go
@@ -9,7 +9,7 @@ func (r *AlsoCouldBeApplyRule) Meta() api.RuleDescriptor {
 		ID:            "AlsoCouldBeApply",
 		RuleSet:       "style",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonOpinionated,
+		OptInReason:   api.OptInReasonOpinionated,
 		FixLevel:      "semantic",
 	}
 }
@@ -28,7 +28,7 @@ func (r *ExplicitCollectionElementAccessMethodRule) Meta() api.RuleDescriptor {
 		ID:            "ExplicitCollectionElementAccessMethod",
 		RuleSet:       "style",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonOpinionated,
+		OptInReason:   api.OptInReasonOpinionated,
 		FixLevel:      "idiomatic",
 	}
 }
@@ -38,7 +38,7 @@ func (r *UseArrayLiteralsInAnnotationsRule) Meta() api.RuleDescriptor {
 		ID:            "UseArrayLiteralsInAnnotations",
 		RuleSet:       "style",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonOpinionated,
+		OptInReason:   api.OptInReasonOpinionated,
 		FixLevel:      "idiomatic",
 	}
 }
@@ -48,7 +48,7 @@ func (r *UseDataClassRule) Meta() api.RuleDescriptor {
 		ID:            "UseDataClass",
 		RuleSet:       "style",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonOpinionated,
+		OptInReason:   api.OptInReasonOpinionated,
 		FixLevel:      "semantic",
 		Options: []api.ConfigOption{
 			api.BoolOption(api.BoolOptionSpec[UseDataClassRule]{
@@ -66,7 +66,7 @@ func (r *UseIfEmptyOrIfBlankRule) Meta() api.RuleDescriptor {
 		ID:            "UseIfEmptyOrIfBlank",
 		RuleSet:       "style",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonOpinionated,
+		OptInReason:   api.OptInReasonOpinionated,
 		FixLevel:      "idiomatic",
 	}
 }
@@ -76,7 +76,7 @@ func (r *UseIfInsteadOfWhenRule) Meta() api.RuleDescriptor {
 		ID:            "UseIfInsteadOfWhen",
 		RuleSet:       "style",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonOpinionated,
+		OptInReason:   api.OptInReasonOpinionated,
 		FixLevel:      "idiomatic",
 		Options: []api.ConfigOption{
 			api.BoolOption(api.BoolOptionSpec[UseIfInsteadOfWhenRule]{
@@ -94,7 +94,7 @@ func (r *UseLetRule) Meta() api.RuleDescriptor {
 		ID:            "UseLet",
 		RuleSet:       "style",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonOpinionated,
+		OptInReason:   api.OptInReasonOpinionated,
 		FixLevel:      "idiomatic",
 	}
 }
@@ -104,7 +104,7 @@ func (r *UseSumOfInsteadOfFlatMapSizeRule) Meta() api.RuleDescriptor {
 		ID:            "UseSumOfInsteadOfFlatMapSize",
 		RuleSet:       "style",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonOpinionated,
+		OptInReason:   api.OptInReasonOpinionated,
 		FixLevel:      "idiomatic",
 	}
 }

--- a/internal/rules/meta_style_redundant.go
+++ b/internal/rules/meta_style_redundant.go
@@ -9,6 +9,7 @@ func (r *OptionalUnitRule) Meta() api.RuleDescriptor {
 		ID:            "OptionalUnit",
 		RuleSet:       "style",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonOpinionated,
 		FixLevel:      "cosmetic",
 	}
 }
@@ -18,6 +19,7 @@ func (r *RedundantConstructorKeywordRule) Meta() api.RuleDescriptor {
 		ID:            "RedundantConstructorKeyword",
 		RuleSet:       "style",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonOpinionated,
 		FixLevel:      "cosmetic",
 	}
 }
@@ -27,6 +29,7 @@ func (r *RedundantExplicitTypeRule) Meta() api.RuleDescriptor {
 		ID:            "RedundantExplicitType",
 		RuleSet:       "style",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonOpinionated,
 		FixLevel:      "cosmetic",
 	}
 }
@@ -36,6 +39,7 @@ func (r *RedundantVisibilityModifierRule) Meta() api.RuleDescriptor {
 		ID:            "RedundantVisibilityModifier",
 		RuleSet:       "style",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonOpinionated,
 		FixLevel:      "cosmetic",
 	}
 }
@@ -45,6 +49,7 @@ func (r *UnnecessaryBackticksRule) Meta() api.RuleDescriptor {
 		ID:            "UnnecessaryBackticks",
 		RuleSet:       "style",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonOpinionated,
 		FixLevel:      "cosmetic",
 	}
 }
@@ -63,6 +68,7 @@ func (r *UnnecessaryInnerClassRule) Meta() api.RuleDescriptor {
 		ID:            "UnnecessaryInnerClass",
 		RuleSet:       "style",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonOpinionated,
 		FixLevel:      "idiomatic",
 	}
 }
@@ -72,6 +78,7 @@ func (r *UnnecessaryParenthesesRule) Meta() api.RuleDescriptor {
 		ID:            "UnnecessaryParentheses",
 		RuleSet:       "style",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonOpinionated,
 		FixLevel:      "cosmetic",
 		Options: []api.ConfigOption{
 			api.BoolOption(api.BoolOptionSpec[UnnecessaryParenthesesRule]{

--- a/internal/rules/meta_style_redundant.go
+++ b/internal/rules/meta_style_redundant.go
@@ -9,7 +9,7 @@ func (r *OptionalUnitRule) Meta() api.RuleDescriptor {
 		ID:            "OptionalUnit",
 		RuleSet:       "style",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonOpinionated,
+		OptInReason:   api.OptInReasonOpinionated,
 		FixLevel:      "cosmetic",
 	}
 }
@@ -19,7 +19,7 @@ func (r *RedundantConstructorKeywordRule) Meta() api.RuleDescriptor {
 		ID:            "RedundantConstructorKeyword",
 		RuleSet:       "style",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonOpinionated,
+		OptInReason:   api.OptInReasonOpinionated,
 		FixLevel:      "cosmetic",
 	}
 }
@@ -29,7 +29,7 @@ func (r *RedundantExplicitTypeRule) Meta() api.RuleDescriptor {
 		ID:            "RedundantExplicitType",
 		RuleSet:       "style",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonOpinionated,
+		OptInReason:   api.OptInReasonOpinionated,
 		FixLevel:      "cosmetic",
 	}
 }
@@ -39,7 +39,7 @@ func (r *RedundantVisibilityModifierRule) Meta() api.RuleDescriptor {
 		ID:            "RedundantVisibilityModifier",
 		RuleSet:       "style",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonOpinionated,
+		OptInReason:   api.OptInReasonOpinionated,
 		FixLevel:      "cosmetic",
 	}
 }
@@ -49,7 +49,7 @@ func (r *UnnecessaryBackticksRule) Meta() api.RuleDescriptor {
 		ID:            "UnnecessaryBackticks",
 		RuleSet:       "style",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonOpinionated,
+		OptInReason:   api.OptInReasonOpinionated,
 		FixLevel:      "cosmetic",
 	}
 }
@@ -68,7 +68,7 @@ func (r *UnnecessaryInnerClassRule) Meta() api.RuleDescriptor {
 		ID:            "UnnecessaryInnerClass",
 		RuleSet:       "style",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonOpinionated,
+		OptInReason:   api.OptInReasonOpinionated,
 		FixLevel:      "idiomatic",
 	}
 }
@@ -78,7 +78,7 @@ func (r *UnnecessaryParenthesesRule) Meta() api.RuleDescriptor {
 		ID:            "UnnecessaryParentheses",
 		RuleSet:       "style",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonOpinionated,
+		OptInReason:   api.OptInReasonOpinionated,
 		FixLevel:      "cosmetic",
 		Options: []api.ConfigOption{
 			api.BoolOption(api.BoolOptionSpec[UnnecessaryParenthesesRule]{

--- a/internal/rules/meta_style_unnecessary.go
+++ b/internal/rules/meta_style_unnecessary.go
@@ -18,7 +18,7 @@ func (r *UnnecessaryAnyRule) Meta() api.RuleDescriptor {
 		ID:            "UnnecessaryAny",
 		RuleSet:       "style",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonOpinionated,
+		OptInReason:   api.OptInReasonOpinionated,
 		FixLevel:      "idiomatic",
 	}
 }
@@ -37,7 +37,7 @@ func (r *UnnecessaryBracesAroundTrailingLambdaRule) Meta() api.RuleDescriptor {
 		ID:            "UnnecessaryBracesAroundTrailingLambda",
 		RuleSet:       "style",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonOpinionated,
+		OptInReason:   api.OptInReasonOpinionated,
 		FixLevel:      "cosmetic",
 	}
 }
@@ -56,7 +56,7 @@ func (r *UnnecessaryFullyQualifiedNameRule) Meta() api.RuleDescriptor {
 		ID:            "UnnecessaryFullyQualifiedName",
 		RuleSet:       "style",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonOpinionated,
+		OptInReason:   api.OptInReasonOpinionated,
 		FixLevel:      "idiomatic",
 	}
 }
@@ -66,7 +66,7 @@ func (r *UnnecessaryLetRule) Meta() api.RuleDescriptor {
 		ID:            "UnnecessaryLet",
 		RuleSet:       "style",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonOpinionated,
+		OptInReason:   api.OptInReasonOpinionated,
 		FixLevel:      "idiomatic",
 	}
 }

--- a/internal/rules/meta_style_unnecessary.go
+++ b/internal/rules/meta_style_unnecessary.go
@@ -18,6 +18,7 @@ func (r *UnnecessaryAnyRule) Meta() api.RuleDescriptor {
 		ID:            "UnnecessaryAny",
 		RuleSet:       "style",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonOpinionated,
 		FixLevel:      "idiomatic",
 	}
 }
@@ -36,6 +37,7 @@ func (r *UnnecessaryBracesAroundTrailingLambdaRule) Meta() api.RuleDescriptor {
 		ID:            "UnnecessaryBracesAroundTrailingLambda",
 		RuleSet:       "style",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonOpinionated,
 		FixLevel:      "cosmetic",
 	}
 }
@@ -54,6 +56,7 @@ func (r *UnnecessaryFullyQualifiedNameRule) Meta() api.RuleDescriptor {
 		ID:            "UnnecessaryFullyQualifiedName",
 		RuleSet:       "style",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonOpinionated,
 		FixLevel:      "idiomatic",
 	}
 }
@@ -63,6 +66,7 @@ func (r *UnnecessaryLetRule) Meta() api.RuleDescriptor {
 		ID:            "UnnecessaryLet",
 		RuleSet:       "style",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonOpinionated,
 		FixLevel:      "idiomatic",
 	}
 }

--- a/internal/rules/meta_style_unused.go
+++ b/internal/rules/meta_style_unused.go
@@ -15,7 +15,7 @@ func (r *UnusedImportRule) Meta() api.RuleDescriptor {
 		ID:            "UnusedImport",
 		RuleSet:       "style",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonOpinionated,
+		OptInReason:   api.OptInReasonOpinionated,
 		FixLevel:      "idiomatic",
 	}
 }

--- a/internal/rules/meta_style_unused.go
+++ b/internal/rules/meta_style_unused.go
@@ -15,6 +15,7 @@ func (r *UnusedImportRule) Meta() api.RuleDescriptor {
 		ID:            "UnusedImport",
 		RuleSet:       "style",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonOpinionated,
 		FixLevel:      "idiomatic",
 	}
 }

--- a/internal/rules/meta_supply_chain.go
+++ b/internal/rules/meta_supply_chain.go
@@ -25,6 +25,7 @@ func (r *ConventionPluginAppliedToWrongTargetRule) Meta() api.RuleDescriptor {
 		ID:            "ConventionPluginAppliedToWrongTarget",
 		RuleSet:       "supply-chain",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonDomainSpecific,
 		Options: []api.ConfigOption{
 			api.StringListOption(api.StringListOptionSpec[ConventionPluginAppliedToWrongTargetRule]{
 				Name:        "pluginTargetMap",
@@ -41,6 +42,7 @@ func (r *ConfigurationsAllSideEffectRule) Meta() api.RuleDescriptor {
 		ID:            "ConfigurationsAllSideEffect",
 		RuleSet:       "supply-chain",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonDomainSpecific,
 		Options: []api.ConfigOption{
 			api.BoolOption(api.BoolOptionSpec[ConfigurationsAllSideEffectRule]{
 				Name:        "allowInConventionPlugins",
@@ -139,6 +141,7 @@ func (r *DependencyWithoutGroupRule) Meta() api.RuleDescriptor {
 		ID:            "DependencyWithoutGroup",
 		RuleSet:       "supply-chain",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonDomainSpecific,
 	}
 }
 
@@ -163,6 +166,7 @@ func (r *GradleWrapperValidationActionRule) Meta() api.RuleDescriptor {
 		ID:            "GradleWrapperValidationAction",
 		RuleSet:       "supply-chain",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonDomainSpecific,
 	}
 }
 
@@ -187,6 +191,7 @@ func (r *MissingGradleChecksumsRule) Meta() api.RuleDescriptor {
 		ID:            "MissingGradleChecksums",
 		RuleSet:       "supply-chain",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonDomainSpecific,
 	}
 }
 
@@ -195,6 +200,7 @@ func (r *VersionCatalogBuildSrcMismatchRule) Meta() api.RuleDescriptor {
 		ID:            "VersionCatalogBuildSrcMismatch",
 		RuleSet:       "supply-chain",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonDomainSpecific,
 	}
 }
 
@@ -203,6 +209,7 @@ func (r *VersionCatalogDuplicateVersionRule) Meta() api.RuleDescriptor {
 		ID:            "VersionCatalogDuplicateVersion",
 		RuleSet:       "supply-chain",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonDomainSpecific,
 	}
 }
 
@@ -211,6 +218,7 @@ func (r *VersionCatalogRawVersionInBuildRule) Meta() api.RuleDescriptor {
 		ID:            "VersionCatalogRawVersionInBuild",
 		RuleSet:       "supply-chain",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonDomainSpecific,
 	}
 }
 
@@ -219,6 +227,7 @@ func (r *VersionCatalogUnusedRule) Meta() api.RuleDescriptor {
 		ID:            "VersionCatalogUnused",
 		RuleSet:       "supply-chain",
 		DefaultActive: false,
+		OptInReason: api.OptInReasonDomainSpecific,
 		Options: []api.ConfigOption{
 			api.StringListOption(api.StringListOptionSpec[VersionCatalogUnusedRule]{
 				Name:        "ignoredAliases",

--- a/internal/rules/meta_supply_chain.go
+++ b/internal/rules/meta_supply_chain.go
@@ -25,7 +25,7 @@ func (r *ConventionPluginAppliedToWrongTargetRule) Meta() api.RuleDescriptor {
 		ID:            "ConventionPluginAppliedToWrongTarget",
 		RuleSet:       "supply-chain",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonDomainSpecific,
+		OptInReason:   api.OptInReasonDomainSpecific,
 		Options: []api.ConfigOption{
 			api.StringListOption(api.StringListOptionSpec[ConventionPluginAppliedToWrongTargetRule]{
 				Name:        "pluginTargetMap",
@@ -42,7 +42,7 @@ func (r *ConfigurationsAllSideEffectRule) Meta() api.RuleDescriptor {
 		ID:            "ConfigurationsAllSideEffect",
 		RuleSet:       "supply-chain",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonDomainSpecific,
+		OptInReason:   api.OptInReasonDomainSpecific,
 		Options: []api.ConfigOption{
 			api.BoolOption(api.BoolOptionSpec[ConfigurationsAllSideEffectRule]{
 				Name:        "allowInConventionPlugins",
@@ -141,7 +141,7 @@ func (r *DependencyWithoutGroupRule) Meta() api.RuleDescriptor {
 		ID:            "DependencyWithoutGroup",
 		RuleSet:       "supply-chain",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonDomainSpecific,
+		OptInReason:   api.OptInReasonDomainSpecific,
 	}
 }
 
@@ -166,7 +166,7 @@ func (r *GradleWrapperValidationActionRule) Meta() api.RuleDescriptor {
 		ID:            "GradleWrapperValidationAction",
 		RuleSet:       "supply-chain",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonDomainSpecific,
+		OptInReason:   api.OptInReasonDomainSpecific,
 	}
 }
 
@@ -191,7 +191,7 @@ func (r *MissingGradleChecksumsRule) Meta() api.RuleDescriptor {
 		ID:            "MissingGradleChecksums",
 		RuleSet:       "supply-chain",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonDomainSpecific,
+		OptInReason:   api.OptInReasonDomainSpecific,
 	}
 }
 
@@ -200,7 +200,7 @@ func (r *VersionCatalogBuildSrcMismatchRule) Meta() api.RuleDescriptor {
 		ID:            "VersionCatalogBuildSrcMismatch",
 		RuleSet:       "supply-chain",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonDomainSpecific,
+		OptInReason:   api.OptInReasonDomainSpecific,
 	}
 }
 
@@ -209,7 +209,7 @@ func (r *VersionCatalogDuplicateVersionRule) Meta() api.RuleDescriptor {
 		ID:            "VersionCatalogDuplicateVersion",
 		RuleSet:       "supply-chain",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonDomainSpecific,
+		OptInReason:   api.OptInReasonDomainSpecific,
 	}
 }
 
@@ -218,7 +218,7 @@ func (r *VersionCatalogRawVersionInBuildRule) Meta() api.RuleDescriptor {
 		ID:            "VersionCatalogRawVersionInBuild",
 		RuleSet:       "supply-chain",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonDomainSpecific,
+		OptInReason:   api.OptInReasonDomainSpecific,
 	}
 }
 
@@ -227,7 +227,7 @@ func (r *VersionCatalogUnusedRule) Meta() api.RuleDescriptor {
 		ID:            "VersionCatalogUnused",
 		RuleSet:       "supply-chain",
 		DefaultActive: false,
-		OptInReason: api.OptInReasonDomainSpecific,
+		OptInReason:   api.OptInReasonDomainSpecific,
 		Options: []api.ConfigOption{
 			api.StringListOption(api.StringListOptionSpec[VersionCatalogUnusedRule]{
 				Name:        "ignoredAliases",

--- a/internal/rules/meta_testing_quality.go
+++ b/internal/rules/meta_testing_quality.go
@@ -9,6 +9,7 @@ func (r *AssertEqualsArgumentOrderRule) Meta() api.RuleDescriptor {
 		ID:            "AssertEqualsArgumentOrder",
 		RuleSet:       "testing-quality",
 		DefaultActive: false,
+		OptInReason:   api.OptInReasonDomainSpecific,
 	}
 }
 
@@ -33,6 +34,7 @@ func (r *UntestedPublicAPIRule) Meta() api.RuleDescriptor {
 		ID:            "UntestedPublicApi",
 		RuleSet:       "testing-quality",
 		DefaultActive: false,
+		OptInReason:   api.OptInReasonDomainSpecific,
 	}
 }
 
@@ -41,6 +43,7 @@ func (r *MixedAssertionLibrariesRule) Meta() api.RuleDescriptor {
 		ID:            "MixedAssertionLibraries",
 		RuleSet:       "testing-quality",
 		DefaultActive: false,
+		OptInReason:   api.OptInReasonDomainSpecific,
 	}
 }
 
@@ -97,6 +100,7 @@ func (r *SpyOnDataClassRule) Meta() api.RuleDescriptor {
 		ID:            "SpyOnDataClass",
 		RuleSet:       "testing-quality",
 		DefaultActive: false,
+		OptInReason:   api.OptInReasonDomainSpecific,
 	}
 }
 
@@ -121,6 +125,7 @@ func (r *TestInheritanceDepthRule) Meta() api.RuleDescriptor {
 		ID:            "TestInheritanceDepth",
 		RuleSet:       "testing-quality",
 		DefaultActive: false,
+		OptInReason:   api.OptInReasonThresholdTuning,
 	}
 }
 
@@ -129,6 +134,7 @@ func (r *TestNameContainsUnderscoreRule) Meta() api.RuleDescriptor {
 		ID:            "TestNameContainsUnderscore",
 		RuleSet:       "testing-quality",
 		DefaultActive: false,
+		OptInReason:   api.OptInReasonOpinionated,
 	}
 }
 

--- a/internal/rules/registry_deadcode_module.go
+++ b/internal/rules/registry_deadcode_module.go
@@ -16,7 +16,7 @@ func registerDeadcodeModuleRules() {
 			Needs: api.NeedsModuleIndex, Confidence: r.Confidence(), Implementation: r,
 			Check:         r.check,
 			DefaultActive: false,
-			OptInReason: api.OptInReasonExpensive,
+			OptInReason:   api.OptInReasonExpensive,
 		})
 	}
 }

--- a/internal/rules/registry_deadcode_module.go
+++ b/internal/rules/registry_deadcode_module.go
@@ -16,6 +16,7 @@ func registerDeadcodeModuleRules() {
 			Needs: api.NeedsModuleIndex, Confidence: r.Confidence(), Implementation: r,
 			Check:         r.check,
 			DefaultActive: false,
+			OptInReason: api.OptInReasonExpensive,
 		})
 	}
 }

--- a/internal/rules/registry_i18n_plurals.go
+++ b/internal/rules/registry_i18n_plurals.go
@@ -38,7 +38,7 @@ func registerI18nPluralsRules() {
 			Needs: api.NeedsResources, AndroidDeps: uint32(r.AndroidDependencies()), Confidence: r.Confidence(), Implementation: r,
 			Check:         r.check,
 			DefaultActive: false,
-			OptInReason: api.OptInReasonDomainSpecific,
+			OptInReason:   api.OptInReasonDomainSpecific,
 		})
 	}
 

--- a/internal/rules/registry_i18n_plurals.go
+++ b/internal/rules/registry_i18n_plurals.go
@@ -38,6 +38,7 @@ func registerI18nPluralsRules() {
 			Needs: api.NeedsResources, AndroidDeps: uint32(r.AndroidDependencies()), Confidence: r.Confidence(), Implementation: r,
 			Check:         r.check,
 			DefaultActive: false,
+			OptInReason: api.OptInReasonDomainSpecific,
 		})
 	}
 

--- a/internal/rules/registry_i18n_string_concat.go
+++ b/internal/rules/registry_i18n_string_concat.go
@@ -19,6 +19,7 @@ func registerI18nStringConcatRules() {
 			NodeTypes: []string{"additive_expression"}, Confidence: r.Confidence(), Implementation: r,
 			Check:         r.check,
 			DefaultActive: false,
+			OptInReason: api.OptInReasonDomainSpecific,
 		})
 	}
 }

--- a/internal/rules/registry_i18n_string_concat.go
+++ b/internal/rules/registry_i18n_string_concat.go
@@ -19,7 +19,7 @@ func registerI18nStringConcatRules() {
 			NodeTypes: []string{"additive_expression"}, Confidence: r.Confidence(), Implementation: r,
 			Check:         r.check,
 			DefaultActive: false,
-			OptInReason: api.OptInReasonDomainSpecific,
+			OptInReason:   api.OptInReasonDomainSpecific,
 		})
 	}
 }

--- a/internal/rules/registry_i18n_string_contains_html_without_cdata.go
+++ b/internal/rules/registry_i18n_string_contains_html_without_cdata.go
@@ -22,6 +22,7 @@ func registerI18nStringContainsHTMLWithoutCDATARules() {
 			Needs: api.NeedsResources, AndroidDeps: uint32(r.AndroidDependencies()), Confidence: r.Confidence(), Implementation: r,
 			Check:         r.check,
 			DefaultActive: false,
+			OptInReason: api.OptInReasonDomainSpecific,
 		})
 	}
 }

--- a/internal/rules/registry_i18n_string_contains_html_without_cdata.go
+++ b/internal/rules/registry_i18n_string_contains_html_without_cdata.go
@@ -22,7 +22,7 @@ func registerI18nStringContainsHTMLWithoutCDATARules() {
 			Needs: api.NeedsResources, AndroidDeps: uint32(r.AndroidDependencies()), Confidence: r.Confidence(), Implementation: r,
 			Check:         r.check,
 			DefaultActive: false,
-			OptInReason: api.OptInReasonDomainSpecific,
+			OptInReason:   api.OptInReasonDomainSpecific,
 		})
 	}
 }

--- a/internal/rules/registry_i18n_string_template.go
+++ b/internal/rules/registry_i18n_string_template.go
@@ -21,7 +21,7 @@ func registerI18nStringTemplateRules() {
 			Implementation: r,
 			Check:          r.check,
 			DefaultActive:  false,
-			OptInReason: api.OptInReasonDomainSpecific,
+			OptInReason:    api.OptInReasonDomainSpecific,
 		})
 	}
 }

--- a/internal/rules/registry_i18n_string_template.go
+++ b/internal/rules/registry_i18n_string_template.go
@@ -21,6 +21,7 @@ func registerI18nStringTemplateRules() {
 			Implementation: r,
 			Check:          r.check,
 			DefaultActive:  false,
+			OptInReason: api.OptInReasonDomainSpecific,
 		})
 	}
 }

--- a/internal/rules/registry_i18n_text_direction.go
+++ b/internal/rules/registry_i18n_text_direction.go
@@ -19,6 +19,7 @@ func registerI18nTextDirectionRules() {
 			NodeTypes: []string{"string_literal"}, Confidence: r.Confidence(), Implementation: r,
 			Check:         r.check,
 			DefaultActive: false,
+			OptInReason: api.OptInReasonDomainSpecific,
 		})
 	}
 }

--- a/internal/rules/registry_i18n_text_direction.go
+++ b/internal/rules/registry_i18n_text_direction.go
@@ -19,7 +19,7 @@ func registerI18nTextDirectionRules() {
 			NodeTypes: []string{"string_literal"}, Confidence: r.Confidence(), Implementation: r,
 			Check:         r.check,
 			DefaultActive: false,
-			OptInReason: api.OptInReasonDomainSpecific,
+			OptInReason:   api.OptInReasonDomainSpecific,
 		})
 	}
 }

--- a/internal/rules/registry_i18n_unicode_normalization.go
+++ b/internal/rules/registry_i18n_unicode_normalization.go
@@ -19,6 +19,7 @@ func registerI18nUnicodeNormalizationRules() {
 			NodeTypes: []string{"call_expression"}, Confidence: r.Confidence(), Implementation: r,
 			Check:         r.check,
 			DefaultActive: false,
+			OptInReason: api.OptInReasonDomainSpecific,
 		})
 	}
 }

--- a/internal/rules/registry_i18n_unicode_normalization.go
+++ b/internal/rules/registry_i18n_unicode_normalization.go
@@ -19,7 +19,7 @@ func registerI18nUnicodeNormalizationRules() {
 			NodeTypes: []string{"call_expression"}, Confidence: r.Confidence(), Implementation: r,
 			Check:         r.check,
 			DefaultActive: false,
-			OptInReason: api.OptInReasonDomainSpecific,
+			OptInReason:   api.OptInReasonDomainSpecific,
 		})
 	}
 }

--- a/internal/rules/registry_licensing.go
+++ b/internal/rules/registry_licensing.go
@@ -18,6 +18,7 @@ func registerLicensingRules() {
 			Needs: api.NeedsLinePass, Fix: api.FixCosmetic, Implementation: r,
 			Check:         r.check,
 			DefaultActive: false,
+			OptInReason: api.OptInReasonDomainSpecific,
 		})
 	}
 	{
@@ -30,6 +31,7 @@ func registerLicensingRules() {
 			Needs: api.NeedsLinePass, Implementation: r,
 			Check:         r.check,
 			DefaultActive: false,
+			OptInReason: api.OptInReasonDomainSpecific,
 		})
 	}
 	{
@@ -41,6 +43,7 @@ func registerLicensingRules() {
 			Needs: api.NeedsGradle, AndroidDeps: uint32(AndroidDepGradle), Confidence: r.Confidence(), Implementation: r,
 			Check:         r.check,
 			DefaultActive: false,
+			OptInReason: api.OptInReasonDomainSpecific,
 		})
 	}
 	{
@@ -52,6 +55,7 @@ func registerLicensingRules() {
 			Needs: api.NeedsGradle, AndroidDeps: uint32(AndroidDepGradle), Confidence: r.Confidence(), Implementation: r,
 			Check:         r.check,
 			DefaultActive: false,
+			OptInReason: api.OptInReasonDomainSpecific,
 			Options: []api.ConfigOption{
 				api.StringListOption(api.StringListOptionSpec[NoticeFileOutOfDateRule]{
 					Name:        "noticeRequiredArtifacts",
@@ -71,6 +75,7 @@ func registerLicensingRules() {
 			Needs: api.NeedsGradle, AndroidDeps: uint32(AndroidDepGradle), Confidence: r.Confidence(), Implementation: r,
 			Check:         r.check,
 			DefaultActive: false,
+			OptInReason: api.OptInReasonDomainSpecific,
 		})
 	}
 	{
@@ -82,6 +87,7 @@ func registerLicensingRules() {
 			Needs: api.NeedsGradle, AndroidDeps: uint32(AndroidDepGradle), Confidence: r.Confidence(), Implementation: r,
 			Check:         r.check,
 			DefaultActive: false,
+			OptInReason: api.OptInReasonDomainSpecific,
 			Options: []api.ConfigOption{
 				api.StringOption(api.StringOptionSpec[DependencyLicenseIncompatibleRule]{
 					Name:        "projectLicense",
@@ -101,6 +107,7 @@ func registerLicensingRules() {
 			NodeTypes: []string{"annotation"}, Confidence: r.Confidence(), Implementation: r,
 			Check:         r.check,
 			DefaultActive: false,
+			OptInReason: api.OptInReasonDomainSpecific,
 			Options: []api.ConfigOption{
 				api.StringListOption(api.StringListOptionSpec[OptInMarkerNotRecognisedRule]{
 					Name:        "additionalMarkers",
@@ -150,6 +157,7 @@ func registerLicensingRules() {
 			NodeTypes: []string{"annotation"}, Confidence: r.Confidence(), Implementation: r,
 			Check:         r.check,
 			DefaultActive: false,
+			OptInReason: api.OptInReasonDomainSpecific,
 		})
 	}
 	{
@@ -161,6 +169,7 @@ func registerLicensingRules() {
 			NodeTypes: []string{"annotation"}, Confidence: r.Confidence(), Implementation: r,
 			Check:         r.check,
 			DefaultActive: false,
+			OptInReason: api.OptInReasonDomainSpecific,
 		})
 	}
 	{
@@ -172,6 +181,7 @@ func registerLicensingRules() {
 			NodeTypes: []string{"annotation"}, Confidence: r.Confidence(), Implementation: r,
 			Check:         r.check,
 			DefaultActive: false,
+			OptInReason: api.OptInReasonDomainSpecific,
 		})
 	}
 	{
@@ -183,6 +193,7 @@ func registerLicensingRules() {
 			NodeTypes: []string{"class_declaration"}, Confidence: r.Confidence(), Implementation: r,
 			Check:         r.check,
 			DefaultActive: false,
+			OptInReason: api.OptInReasonDomainSpecific,
 		})
 	}
 	{
@@ -194,6 +205,7 @@ func registerLicensingRules() {
 			Needs: api.NeedsLinePass, Confidence: r.Confidence(), Implementation: r,
 			Check:         r.check,
 			DefaultActive: false,
+			OptInReason: api.OptInReasonDomainSpecific,
 			Options: []api.ConfigOption{
 				api.StringOption(api.StringOptionSpec[SpdxIdentifierMismatchWithProjectRule]{
 					Name:        "projectLicense",
@@ -213,6 +225,7 @@ func registerLicensingRules() {
 			Needs: api.NeedsLinePass, Confidence: r.Confidence(), Implementation: r,
 			Check:         r.check,
 			DefaultActive: false,
+			OptInReason: api.OptInReasonDomainSpecific,
 			Options: []api.ConfigOption{
 				api.StringListOption(api.StringListOptionSpec[SpdxIdentifierInvalidRule]{
 					Name:        "additionalIdentifiers",
@@ -232,6 +245,7 @@ func registerLicensingRules() {
 			Needs: api.NeedsGradle, AndroidDeps: uint32(AndroidDepGradle), Confidence: r.Confidence(), Implementation: r,
 			Check:         r.check,
 			DefaultActive: false,
+			OptInReason: api.OptInReasonDomainSpecific,
 			Options: []api.ConfigOption{
 				api.BoolOption(api.BoolOptionSpec[DependencyLicenseUnknownRule]{
 					Name:        "requireVerification",

--- a/internal/rules/registry_licensing.go
+++ b/internal/rules/registry_licensing.go
@@ -18,7 +18,7 @@ func registerLicensingRules() {
 			Needs: api.NeedsLinePass, Fix: api.FixCosmetic, Implementation: r,
 			Check:         r.check,
 			DefaultActive: false,
-			OptInReason: api.OptInReasonDomainSpecific,
+			OptInReason:   api.OptInReasonDomainSpecific,
 		})
 	}
 	{
@@ -31,7 +31,7 @@ func registerLicensingRules() {
 			Needs: api.NeedsLinePass, Implementation: r,
 			Check:         r.check,
 			DefaultActive: false,
-			OptInReason: api.OptInReasonDomainSpecific,
+			OptInReason:   api.OptInReasonDomainSpecific,
 		})
 	}
 	{
@@ -43,7 +43,7 @@ func registerLicensingRules() {
 			Needs: api.NeedsGradle, AndroidDeps: uint32(AndroidDepGradle), Confidence: r.Confidence(), Implementation: r,
 			Check:         r.check,
 			DefaultActive: false,
-			OptInReason: api.OptInReasonDomainSpecific,
+			OptInReason:   api.OptInReasonDomainSpecific,
 		})
 	}
 	{
@@ -55,7 +55,7 @@ func registerLicensingRules() {
 			Needs: api.NeedsGradle, AndroidDeps: uint32(AndroidDepGradle), Confidence: r.Confidence(), Implementation: r,
 			Check:         r.check,
 			DefaultActive: false,
-			OptInReason: api.OptInReasonDomainSpecific,
+			OptInReason:   api.OptInReasonDomainSpecific,
 			Options: []api.ConfigOption{
 				api.StringListOption(api.StringListOptionSpec[NoticeFileOutOfDateRule]{
 					Name:        "noticeRequiredArtifacts",
@@ -75,7 +75,7 @@ func registerLicensingRules() {
 			Needs: api.NeedsGradle, AndroidDeps: uint32(AndroidDepGradle), Confidence: r.Confidence(), Implementation: r,
 			Check:         r.check,
 			DefaultActive: false,
-			OptInReason: api.OptInReasonDomainSpecific,
+			OptInReason:   api.OptInReasonDomainSpecific,
 		})
 	}
 	{
@@ -87,7 +87,7 @@ func registerLicensingRules() {
 			Needs: api.NeedsGradle, AndroidDeps: uint32(AndroidDepGradle), Confidence: r.Confidence(), Implementation: r,
 			Check:         r.check,
 			DefaultActive: false,
-			OptInReason: api.OptInReasonDomainSpecific,
+			OptInReason:   api.OptInReasonDomainSpecific,
 			Options: []api.ConfigOption{
 				api.StringOption(api.StringOptionSpec[DependencyLicenseIncompatibleRule]{
 					Name:        "projectLicense",
@@ -107,7 +107,7 @@ func registerLicensingRules() {
 			NodeTypes: []string{"annotation"}, Confidence: r.Confidence(), Implementation: r,
 			Check:         r.check,
 			DefaultActive: false,
-			OptInReason: api.OptInReasonDomainSpecific,
+			OptInReason:   api.OptInReasonDomainSpecific,
 			Options: []api.ConfigOption{
 				api.StringListOption(api.StringListOptionSpec[OptInMarkerNotRecognisedRule]{
 					Name:        "additionalMarkers",
@@ -157,7 +157,7 @@ func registerLicensingRules() {
 			NodeTypes: []string{"annotation"}, Confidence: r.Confidence(), Implementation: r,
 			Check:         r.check,
 			DefaultActive: false,
-			OptInReason: api.OptInReasonDomainSpecific,
+			OptInReason:   api.OptInReasonDomainSpecific,
 		})
 	}
 	{
@@ -169,7 +169,7 @@ func registerLicensingRules() {
 			NodeTypes: []string{"annotation"}, Confidence: r.Confidence(), Implementation: r,
 			Check:         r.check,
 			DefaultActive: false,
-			OptInReason: api.OptInReasonDomainSpecific,
+			OptInReason:   api.OptInReasonDomainSpecific,
 		})
 	}
 	{
@@ -181,7 +181,7 @@ func registerLicensingRules() {
 			NodeTypes: []string{"annotation"}, Confidence: r.Confidence(), Implementation: r,
 			Check:         r.check,
 			DefaultActive: false,
-			OptInReason: api.OptInReasonDomainSpecific,
+			OptInReason:   api.OptInReasonDomainSpecific,
 		})
 	}
 	{
@@ -193,7 +193,7 @@ func registerLicensingRules() {
 			NodeTypes: []string{"class_declaration"}, Confidence: r.Confidence(), Implementation: r,
 			Check:         r.check,
 			DefaultActive: false,
-			OptInReason: api.OptInReasonDomainSpecific,
+			OptInReason:   api.OptInReasonDomainSpecific,
 		})
 	}
 	{
@@ -205,7 +205,7 @@ func registerLicensingRules() {
 			Needs: api.NeedsLinePass, Confidence: r.Confidence(), Implementation: r,
 			Check:         r.check,
 			DefaultActive: false,
-			OptInReason: api.OptInReasonDomainSpecific,
+			OptInReason:   api.OptInReasonDomainSpecific,
 			Options: []api.ConfigOption{
 				api.StringOption(api.StringOptionSpec[SpdxIdentifierMismatchWithProjectRule]{
 					Name:        "projectLicense",
@@ -225,7 +225,7 @@ func registerLicensingRules() {
 			Needs: api.NeedsLinePass, Confidence: r.Confidence(), Implementation: r,
 			Check:         r.check,
 			DefaultActive: false,
-			OptInReason: api.OptInReasonDomainSpecific,
+			OptInReason:   api.OptInReasonDomainSpecific,
 			Options: []api.ConfigOption{
 				api.StringListOption(api.StringListOptionSpec[SpdxIdentifierInvalidRule]{
 					Name:        "additionalIdentifiers",
@@ -245,7 +245,7 @@ func registerLicensingRules() {
 			Needs: api.NeedsGradle, AndroidDeps: uint32(AndroidDepGradle), Confidence: r.Confidence(), Implementation: r,
 			Check:         r.check,
 			DefaultActive: false,
-			OptInReason: api.OptInReasonDomainSpecific,
+			OptInReason:   api.OptInReasonDomainSpecific,
 			Options: []api.ConfigOption{
 				api.BoolOption(api.BoolOptionSpec[DependencyLicenseUnknownRule]{
 					Name:        "requireVerification",

--- a/internal/rules/registry_precompile_deprecated_symbol_used_error.go
+++ b/internal/rules/registry_precompile_deprecated_symbol_used_error.go
@@ -30,5 +30,6 @@ func registerPrecompileDeprecatedSymbolUsedErrorRules() {
 		Implementation: r,
 		Check:          r.check,
 		DefaultActive:  false,
+		OptInReason: api.OptInReasonDuplicatesCompiler,
 	})
 }

--- a/internal/rules/registry_precompile_deprecated_symbol_used_error.go
+++ b/internal/rules/registry_precompile_deprecated_symbol_used_error.go
@@ -30,6 +30,6 @@ func registerPrecompileDeprecatedSymbolUsedErrorRules() {
 		Implementation: r,
 		Check:          r.check,
 		DefaultActive:  false,
-		OptInReason: api.OptInReasonDuplicatesCompiler,
+		OptInReason:    api.OptInReasonDuplicatesCompiler,
 	})
 }

--- a/internal/rules/registry_precompile_duplicate_declaration.go
+++ b/internal/rules/registry_precompile_duplicate_declaration.go
@@ -21,6 +21,6 @@ func registerPrecompileDuplicateDeclarationRules() {
 		Implementation: r,
 		Check:          r.check,
 		DefaultActive:  false,
-		OptInReason: api.OptInReasonDuplicatesCompiler,
+		OptInReason:    api.OptInReasonDuplicatesCompiler,
 	})
 }

--- a/internal/rules/registry_precompile_duplicate_declaration.go
+++ b/internal/rules/registry_precompile_duplicate_declaration.go
@@ -21,5 +21,6 @@ func registerPrecompileDuplicateDeclarationRules() {
 		Implementation: r,
 		Check:          r.check,
 		DefaultActive:  false,
+		OptInReason: api.OptInReasonDuplicatesCompiler,
 	})
 }

--- a/internal/rules/registry_precompile_duplicate_label.go
+++ b/internal/rules/registry_precompile_duplicate_label.go
@@ -23,5 +23,6 @@ func registerPrecompileDuplicateLabelRules() {
 		Implementation: r,
 		Check:          r.check,
 		DefaultActive:  false,
+		OptInReason: api.OptInReasonDuplicatesCompiler,
 	})
 }

--- a/internal/rules/registry_precompile_duplicate_label.go
+++ b/internal/rules/registry_precompile_duplicate_label.go
@@ -23,6 +23,6 @@ func registerPrecompileDuplicateLabelRules() {
 		Implementation: r,
 		Check:          r.check,
 		DefaultActive:  false,
-		OptInReason: api.OptInReasonDuplicatesCompiler,
+		OptInReason:    api.OptInReasonDuplicatesCompiler,
 	})
 }

--- a/internal/rules/registry_precompile_unreachable_code.go
+++ b/internal/rules/registry_precompile_unreachable_code.go
@@ -21,6 +21,6 @@ func registerPrecompileUnreachableCodeRules() {
 		Implementation: r,
 		Check:          r.check,
 		DefaultActive:  false,
-		OptInReason: api.OptInReasonDuplicatesCompiler,
+		OptInReason:    api.OptInReasonDuplicatesCompiler,
 	})
 }

--- a/internal/rules/registry_precompile_unreachable_code.go
+++ b/internal/rules/registry_precompile_unreachable_code.go
@@ -21,5 +21,6 @@ func registerPrecompileUnreachableCodeRules() {
 		Implementation: r,
 		Check:          r.check,
 		DefaultActive:  false,
+		OptInReason: api.OptInReasonDuplicatesCompiler,
 	})
 }

--- a/internal/ruleslinter/ruleslinter.go
+++ b/internal/ruleslinter/ruleslinter.go
@@ -871,6 +871,162 @@ func isMergeCollectorsCall(call *ast.CallExpr) bool {
 	return false
 }
 
+// AnalyzeOptInReason scans every .go file in dir for api.Rule and
+// api.RuleDescriptor composite literals and enforces the OptInReason
+// invariant:
+//
+//   - DefaultActive: false  → OptInReason MUST be present and non-zero
+//     (i.e. not api.OptInReasonUnspecified). Every off-by-default rule
+//     must classify *why* it ships off so the registry can be audited.
+//   - DefaultActive: true   → OptInReason MUST be absent or set to
+//     api.OptInReasonUnspecified. The reason field only applies to
+//     opt-in rules; an active rule carrying one is a documentation bug.
+//   - DefaultActive omitted → treated as false (Go zero value).
+//
+// Test files are skipped.
+func AnalyzeOptInReason(dir string) ([]Violation, error) {
+	fset := token.NewFileSet()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, fmt.Errorf("ruleslinter: read dir: %w", err)
+	}
+	var violations []Violation
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".go") {
+			continue
+		}
+		if strings.HasSuffix(e.Name(), "_test.go") {
+			continue
+		}
+		path := filepath.Join(dir, e.Name())
+		f, err := parser.ParseFile(fset, path, nil, parser.SkipObjectResolution)
+		if err != nil {
+			return nil, fmt.Errorf("ruleslinter: parse %s: %w", path, err)
+		}
+		violations = append(violations, scanOptInReason(fset, f)...)
+	}
+	sort.Slice(violations, func(i, j int) bool {
+		if violations[i].Position.Filename != violations[j].Position.Filename {
+			return violations[i].Position.Filename < violations[j].Position.Filename
+		}
+		return violations[i].Position.Offset < violations[j].Position.Offset
+	})
+	return violations, nil
+}
+
+func scanOptInReason(fset *token.FileSet, file *ast.File) []Violation {
+	var out []Violation
+	ast.Inspect(file, func(n ast.Node) bool {
+		lit, ok := n.(*ast.CompositeLit)
+		if !ok {
+			return true
+		}
+		typeName := apiTypeName(lit.Type)
+		if typeName != "Rule" && typeName != "RuleDescriptor" {
+			return true
+		}
+		var (
+			id              string
+			idIsLiteral     bool
+			hasDefaultKey   bool
+			defaultActive   bool
+			hasReasonKey    bool
+			reasonName      string // e.g. "OptInReasonOpinionated"
+			reasonValuePos  token.Pos
+			defaultValuePos token.Pos
+		)
+		for _, elt := range lit.Elts {
+			kv, ok := elt.(*ast.KeyValueExpr)
+			if !ok {
+				continue
+			}
+			key, ok := kv.Key.(*ast.Ident)
+			if !ok {
+				continue
+			}
+			switch key.Name {
+			case "ID":
+				id = identOrLiteralString(kv.Value)
+				if _, ok := kv.Value.(*ast.BasicLit); ok {
+					idIsLiteral = true
+				}
+			case "DefaultActive":
+				hasDefaultKey = true
+				defaultValuePos = kv.Value.Pos()
+				if b, ok := kv.Value.(*ast.Ident); ok {
+					defaultActive = b.Name == "true"
+				}
+			case "OptInReason":
+				hasReasonKey = true
+				reasonValuePos = kv.Value.Pos()
+				reasonName = optInReasonName(kv.Value)
+			}
+		}
+		// Skip literals that are not concrete rule registrations:
+		//   - factory templates (ID is a variable / parameter, not a literal string)
+		//   - zero-value returns like `return api.RuleDescriptor{}` inside helpers
+		// In both cases the OptInReason classification cannot be made statically;
+		// the factory's caller is responsible for supplying it.
+		if !idIsLiteral || id == "" {
+			return true
+		}
+		// Treat omitted DefaultActive as the zero value (false).
+		_ = hasDefaultKey
+		if defaultActive {
+			if hasReasonKey && reasonName != "OptInReasonUnspecified" {
+				out = append(out, Violation{
+					RuleID:   id,
+					Position: fset.Position(reasonValuePos),
+					Message:  "DefaultActive: true must not carry an OptInReason (got api." + reasonName + "); remove the OptInReason field or set DefaultActive: false",
+				})
+			}
+			return true
+		}
+		// DefaultActive is false (explicit or omitted).
+		if !hasReasonKey || reasonName == "OptInReasonUnspecified" {
+			pos := defaultValuePos
+			if pos == token.NoPos {
+				pos = lit.Pos()
+			}
+			out = append(out, Violation{
+				RuleID:   id,
+				Position: fset.Position(pos),
+				Message:  "DefaultActive: false (or omitted) must declare an OptInReason in the same literal; pick one of api.OptInReason{Opinionated,ProjectPolicy,ThresholdTuning,DomainSpecific,AndroidOnly,RequiresUserConfig,DuplicatesCompiler,Expensive}",
+			})
+		}
+		return true
+	})
+	return out
+}
+
+// apiTypeName returns the trailing identifier of an api.<Name> selector
+// (e.g. "Rule" for api.Rule, "RuleDescriptor" for api.RuleDescriptor).
+// Returns "" when expr is not an api-qualified type reference.
+func apiTypeName(expr ast.Expr) string {
+	sel, ok := expr.(*ast.SelectorExpr)
+	if !ok {
+		return ""
+	}
+	id, ok := sel.X.(*ast.Ident)
+	if !ok || id.Name != "api" {
+		return ""
+	}
+	return sel.Sel.Name
+}
+
+// optInReasonName returns the trailing identifier of an api.OptInReason*
+// selector (e.g. "OptInReasonOpinionated"). Returns the empty string
+// when expr is not a recognisable OptInReason constant.
+func optInReasonName(expr ast.Expr) string {
+	switch v := expr.(type) {
+	case *ast.SelectorExpr:
+		return v.Sel.Name
+	case *ast.Ident:
+		return v.Name
+	}
+	return ""
+}
+
 // guessReceiverType looks at sel.X and returns the type name if it
 // resolves through AssignStmt object metadata. Best-effort: returns ""
 // when the type cannot be determined without full type checking.

--- a/internal/ruleslinter/ruleslinter_test.go
+++ b/internal/ruleslinter/ruleslinter_test.go
@@ -674,6 +674,145 @@ func init() {
 	}
 }
 
+// TestRulesPackageHasOptInReasons is the gate: every default-inactive
+// rule (DefaultActive: false, or DefaultActive omitted) in internal/rules
+// must declare an OptInReason in the same composite literal so the
+// registry can be audited by category. Default-active rules must NOT
+// carry a reason.
+func TestRulesPackageHasOptInReasons(t *testing.T) {
+	_, thisFile, _, _ := runtime.Caller(0)
+	rulesDir := filepath.Join(filepath.Dir(thisFile), "..", "rules")
+	violations, err := AnalyzeOptInReason(rulesDir)
+	if err != nil {
+		t.Fatalf("AnalyzeOptInReason(%q): %v", rulesDir, err)
+	}
+	if len(violations) == 0 {
+		return
+	}
+	var b strings.Builder
+	for _, v := range violations {
+		b.WriteString(v.String())
+		b.WriteByte('\n')
+	}
+	t.Fatalf("ruleslinter found %d OptInReason violation(s):\n%s", len(violations), b.String())
+}
+
+func TestAnalyzeOptInReason_FlagsMissingReason(t *testing.T) {
+	dir := t.TempDir()
+	src := `package rules
+
+import api "github.com/kaeawc/krit/internal/rules/api"
+
+func init() {
+	api.Register(&api.Rule{
+		ID:            "OptInNoReason",
+		DefaultActive: false,
+	})
+}
+`
+	if err := os.WriteFile(filepath.Join(dir, "rule.go"), []byte(src), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	violations, err := AnalyzeOptInReason(dir)
+	if err != nil {
+		t.Fatalf("AnalyzeOptInReason: %v", err)
+	}
+	if len(violations) != 1 {
+		t.Fatalf("want 1 violation, got %d: %v", len(violations), violations)
+	}
+	if violations[0].RuleID != "OptInNoReason" {
+		t.Fatalf("want rule ID OptInNoReason, got %q", violations[0].RuleID)
+	}
+	if !strings.Contains(violations[0].Message, "OptInReason") {
+		t.Fatalf("want OptInReason in message, got %q", violations[0].Message)
+	}
+}
+
+func TestAnalyzeOptInReason_AcceptsReason(t *testing.T) {
+	dir := t.TempDir()
+	src := `package rules
+
+import api "github.com/kaeawc/krit/internal/rules/api"
+
+func init() {
+	api.Register(&api.Rule{
+		ID:            "OptInWithReason",
+		DefaultActive: false,
+		OptInReason:   api.OptInReasonOpinionated,
+	})
+}
+`
+	if err := os.WriteFile(filepath.Join(dir, "rule.go"), []byte(src), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	violations, err := AnalyzeOptInReason(dir)
+	if err != nil {
+		t.Fatalf("AnalyzeOptInReason: %v", err)
+	}
+	if len(violations) != 0 {
+		t.Fatalf("want 0 violations, got %d: %v", len(violations), violations)
+	}
+}
+
+func TestAnalyzeOptInReason_FlagsReasonOnActiveRule(t *testing.T) {
+	dir := t.TempDir()
+	src := `package rules
+
+import api "github.com/kaeawc/krit/internal/rules/api"
+
+func init() {
+	api.Register(&api.Rule{
+		ID:            "ActiveButHasReason",
+		DefaultActive: true,
+		OptInReason:   api.OptInReasonOpinionated,
+	})
+}
+`
+	if err := os.WriteFile(filepath.Join(dir, "rule.go"), []byte(src), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	violations, err := AnalyzeOptInReason(dir)
+	if err != nil {
+		t.Fatalf("AnalyzeOptInReason: %v", err)
+	}
+	if len(violations) != 1 {
+		t.Fatalf("want 1 violation, got %d: %v", len(violations), violations)
+	}
+	if !strings.Contains(violations[0].Message, "must not carry") {
+		t.Fatalf("want 'must not carry' in message, got %q", violations[0].Message)
+	}
+}
+
+func TestAnalyzeOptInReason_HandlesRuleDescriptor(t *testing.T) {
+	dir := t.TempDir()
+	src := `package rules
+
+import api "github.com/kaeawc/krit/internal/rules/api"
+
+type FooRule struct{}
+
+func (r *FooRule) Meta() api.RuleDescriptor {
+	return api.RuleDescriptor{
+		ID:            "Foo",
+		DefaultActive: false,
+	}
+}
+`
+	if err := os.WriteFile(filepath.Join(dir, "meta.go"), []byte(src), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	violations, err := AnalyzeOptInReason(dir)
+	if err != nil {
+		t.Fatalf("AnalyzeOptInReason: %v", err)
+	}
+	if len(violations) != 1 {
+		t.Fatalf("want 1 violation, got %d: %v", len(violations), violations)
+	}
+	if violations[0].RuleID != "Foo" {
+		t.Fatalf("want rule ID Foo, got %q", violations[0].RuleID)
+	}
+}
+
 func analyzeSource(t *testing.T, name, src string) []Violation {
 	t.Helper()
 	fset := token.NewFileSet()


### PR DESCRIPTION
## Summary

- Adds `api.OptInReason` enum (8 reasons) + field on both `api.Rule` and `api.RuleDescriptor` so every `DefaultActive: false` rule declares *why* it ships opt-in.
- Adds a hard `TestRulesPackageHasOptInReasons` gate in `internal/ruleslinter/` (wired into `make lint-rules`) enforcing both directions: off-by-default rules must carry a non-zero reason; default-active rules must not carry one. Dynamic factory literals (`custom_pattern.go`) and zero-value helper returns (`MetaForRule`) are excluded via an "ID must be a string literal" filter.
- Backfills 387 sites across 71 files. Final distribution: 159 AndroidOnly, 107 DomainSpecific, 90 Opinionated, 15 ThresholdTuning, 6 DuplicatesCompiler, 5 ProjectPolicy, 3 RequiresUserConfig, 2 Expensive.

The classification lets future improvement plans target a bucket ("which Opinionated rules could become default-on once we ship config defaults?", "which AndroidOnly rules could auto-enable when an Android project is detected?") instead of inspecting each rule.

## Test plan

- [x] `go build -o krit ./cmd/krit/`
- [x] `go vet ./...`
- [x] `make lint-rules` (new gate + the existing capability/ad-hoc/fix-drift gates)
- [x] `go test ./... -count=1`
- [x] `make integration` (CLI/LSP/MCP + playground + SARIF + unit tests, 11/11 pass)