### PR TITLE
docs(claude): add krit workflow skills and commands

### DIFF
--- a/.claude/commands/krit-add-rule.md
+++ b/.claude/commands/krit-add-rule.md
@@ -1,0 +1,27 @@
+# Krit Add Rule
+
+Add a new built-in Krit rule end to end.
+
+ARGUMENTS: `$ARGUMENTS` — typically the rule name (e.g. `UselessElvisOnNonNull`) and optional hint about category or kotlinc analog.
+
+## Instructions
+
+Invoke the `krit-add-rule` skill and walk it end to end for the rule named in ARGUMENTS.
+
+1. **Qualify the rule.** Open `docs/rule-scope.md` and confirm the rule meets every qualification (documented standard, agreed-upon problem, high confidence achievable, evidence local enough). If any fails, surface the gap and stop before writing code.
+2. **Pick the base and capability.** Choose `FlatDispatchBase` / `LineBase` / `ManifestBase` / `ResourceBase` / `GradleBase` based on where evidence lives. Declare the narrowest `Needs*` capability. For precompile (kotlinc-mirror) rules, use `api.CategoryPrecompile`, set `Level`, and set `KotlincAnalog`.
+3. **Implement the rule** in `internal/rules/<category>.go` and register it in `internal/rules/registry_<category>.go`. Include `Languages`, `Confidence`, `DefaultActive=false` by default, and a `Meta()` descriptor for any user-facing options.
+4. **Fixtures.** Add at least one positive and one negative fixture under `tests/fixtures/<category>/`. Include at least one local-lookalike negative. If the rule supports Java, add both Java positive and Java local-lookalike negative.
+5. **Autofix (optional).** If adding a fix, invoke `krit-autofix-safety` to pick the tier and add fixable fixtures with `.expected` partners.
+6. **Schema regen.** If `Meta()` changed, run `make schema` to regenerate `schemas/krit-config.schema.json`.
+7. **Validate.** Run focused tests first, then full validation. Do not skip any of these — CI fails on all four:
+   ```bash
+   go build -o krit ./cmd/krit/
+   go vet ./...
+   golangci-lint run ./...
+   make lint-rules
+   go test ./... -count=1
+   ```
+8. **Integration.** Run `make integration` before pushing if the rule touches dispatch, suppression, output, or daemon code.
+
+Report the rule ID, the category, the capability declaration, the fixture counts (positive/negative/fixable, Kotlin/Java), and the validation result.

--- a/.claude/commands/krit-ci.md
+++ b/.claude/commands/krit-ci.md
@@ -1,0 +1,31 @@
+# Krit CI
+
+Run a complete pre-push pass that mirrors what GitHub CI enforces.
+
+GitHub CI runs `make ci` (build + vet + test + integration + regression), `golangci-lint run ./...`, and `make lint-rules` in separate jobs. Running `make ci` alone is not enough — it does not invoke golangci-lint or lint-rules. This command runs both.
+
+## Instructions
+
+Run the lint pass and the CI pass. Both are required for a faithful pre-push check:
+
+```bash
+golangci-lint run ./...
+make lint-rules
+make ci
+```
+
+If the user has uncommitted changes that may affect validation, run `git status` first and surface them.
+
+When something fails, identify the failing step:
+
+- **golangci-lint** — most common failures are gofmt drift, unused functions/imports, gosec. Fix and re-run from `golangci-lint`.
+- **lint-rules** — capability-declaration gate or ad-hoc-cache gate caught drift. Update the rule's registry entry or remove the unused construct.
+- **build** — fix compile errors first.
+- **vet** — fix and re-run.
+- **test** — run focused package tests to isolate. Report the failing package and test names.
+- **integration** — the LSP/MCP/CLI integration suite caught a regression. Investigate `tests/integration/` or the playground harness.
+- **regression** — playground regression expectations diverged. Inspect `playground/` expected outputs and confirm whether the divergence is intended (snapshot update needed) or a real regression.
+
+For faster feedback during iteration that skips integration/regression, use `/krit-validate`.
+
+Report a one-line pass/fail summary for each step and surface the first failing log lines.

--- a/.claude/commands/krit-dogfood.md
+++ b/.claude/commands/krit-dogfood.md
@@ -1,0 +1,38 @@
+# Krit Dogfood
+
+Run Krit against an external Kotlin/Android repo and triage findings.
+
+ARGUMENTS: `$ARGUMENTS` — target repo path (e.g. `~/github/metro`, `playground`, `kotlin-corpus`). Required.
+
+## Instructions
+
+Invoke the `krit-dogfood` skill against the target path in ARGUMENTS.
+
+1. **Build a fresh binary.**
+   ```bash
+   go build -o krit ./cmd/krit/
+   ```
+2. **Scan with cache disabled.** Correctness checks must not trust cached findings.
+   ```bash
+   TARGET="$ARGUMENTS"
+   ./krit -no-cache -perf -perf-rules -f json -q -o /tmp/krit_dogfood.json "$TARGET" || true
+   ```
+   Pass `--config` if the target's `krit.yml` is not auto-discovered.
+3. **Check project profile first.**
+   ```bash
+   jq '.projectProfile | {hasGradle, dependencyExtractionComplete, hasUnresolvedDependencyRefs, catalogCompleteness}' /tmp/krit_dogfood.json
+   ```
+   If dependency extraction is incomplete, library-absence findings are suspect — route those through `krit-project-analysis`.
+4. **Group findings by rule.**
+   ```bash
+   jq -r '.findings[] | .rule' /tmp/krit_dogfood.json | sort | uniq -c | sort -rn | head -30
+   ```
+5. **For each rule with surprising volume**, sample 5–10 findings and classify each cluster:
+   - likely FP → route to `/krit-tighten <RuleName>`
+   - correct but undesired policy → propose `DefaultActive` / `Confidence` change
+   - project-context bug → route to `krit-project-analysis`
+   - true positive → leave, file external issue if applicable
+6. **Produce a triage table** in the response: rule | count | verdict | next action. Do not fix everything in one pass — propose one branch per fix (matches user preference).
+7. **After any landing fixes**, re-scan the same target revision and report before/after finding counts.
+
+Always include in the report: Krit revision, target revision, scan command, cache flags, whether config was applied.

--- a/.claude/commands/krit-tighten.md
+++ b/.claude/commands/krit-tighten.md
@@ -1,0 +1,32 @@
+# Krit Tighten Rule
+
+Fix a false positive (or missed positive) in an existing Krit rule.
+
+ARGUMENTS: `$ARGUMENTS` — typically the rule name and optionally the offending file or fixture path / external repo path.
+
+## Instructions
+
+Invoke the `krit-tighten-rule` skill for the rule named in ARGUMENTS.
+
+1. **Reproduce.** Add a minimal failing fixture under `tests/fixtures/negative/<category>/<RuleName>/` (or `positive/` for a missed positive) before changing rule code. Run `go test ./internal/rules/ -run TestNegativeFixtures -v` and confirm it fails on the pre-fix code.
+2. **Diagnose.** Identify which evidence-gap bucket this is:
+   - lexical state ignored (comments, KDoc, strings)
+   - identifier overlap without receiver proof
+   - local lookalike shadow
+   - body walk crossed a scope boundary
+   - first-child bias
+   - wrong parser shape
+   - config / runtime drift
+3. **Narrow.** Replace the broken evidence with the narrowest available: flat AST → source-level type inference → library/profile facts → KAA. Do not broaden when a project-profile guard is the real missing condition (see `krit-project-analysis`).
+4. **Java parity.** If the rule supports Java, add the Java version of the same negative/positive case.
+5. **If a corpus surfaced the FP**, re-run `krit-dogfood` against that corpus and confirm the FP cluster dropped.
+6. **Validate.**
+   ```bash
+   go build -o krit ./cmd/krit/
+   go vet ./...
+   golangci-lint run ./...
+   make lint-rules
+   go test ./... -count=1
+   ```
+
+Report: rule name, FP bucket, fixture(s) added, evidence change, before/after finding counts if a corpus was involved.

--- a/.claude/commands/krit-validate.md
+++ b/.claude/commands/krit-validate.md
@@ -1,0 +1,30 @@
+# Krit Validate
+
+Run Krit's fast local validation pass: build, vet, golangci-lint, lint-rules, full unit tests. CLAUDE.md flags that `golangci-lint run ./...` and `make lint-rules` are easy to forget — this command bundles all of them so you never push a CI round-trip you could have caught locally.
+
+## Instructions
+
+Run the four required validations in sequence. Do not skip any of them; CI enforces all four.
+
+```bash
+go build -o krit ./cmd/krit/
+go vet ./...
+golangci-lint run ./...
+make lint-rules
+go test ./... -count=1
+```
+
+If any step fails:
+
+- **`go build` fails** — fix the compile error, then re-run from the failing step.
+- **`go vet` fails** — fix and re-run from `go vet`.
+- **`golangci-lint` fails** — most common failures are gofmt drift, unused functions/imports, gosec. Fix and re-run from `golangci-lint`.
+- **`make lint-rules` fails** — the capability-declaration gate (`NeedsResolver` / `NeedsOracle`) caught a drift. Update the rule's registry entry to declare the missing capability or remove the unused use. Re-run from `make lint-rules`.
+- **`go test` fails** — investigate the failing package with focused tests:
+  ```bash
+  go test ./internal/rules/ -run <TestName> -v
+  ```
+
+Report a one-line summary of each step's pass/fail status. Do NOT report success until all five steps pass.
+
+This command does NOT run `make integration` or `make regression` — for those, use `/krit-ci`.

--- a/.claude/skills/krit-add-rule/SKILL.md
+++ b/.claude/skills/krit-add-rule/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: krit-add-rule
+description: Use when adding a new built-in Krit rule end to end — picking the category and base, declaring capabilities, registering the rule, writing positive/negative fixtures, adding an autofix when applicable, and ensuring Java parity when the rule covers both languages. Covers precompile (kotlinc-mirror) rules as a Level-tagged variant of the same workflow.
+---
+
+# Krit Add Rule
+
+Use this when introducing a new built-in rule. Cross-link with `krit-autofix-safety` for fix work, `krit-capability-migration` for `Needs*` choice, `krit-project-analysis` for library/profile guards, and `krit-rule-vetting` for the FP audit before broadening.
+
+## Qualify The Rule First
+
+Before writing code, confirm the rule belongs in the built-in registry. The checklist in `docs/rule-scope.md` is canonical:
+
+- enforces a documented standard (Kotlin/Android style guides, Compose/Coroutines/Jetpack guidance, JEPs, CVEs, release notes)
+- detects something a reasonable team agrees is a problem
+- implementable at a high `Confidence` tier
+- evidence is local enough for the hot path, or declares the capability honestly
+
+If any of these fail, it belongs as an opt-in (`DefaultActive=false`), `MaturityExperimental`, project-local, or simply outside Krit. Do not skip this.
+
+## Pick The Base And Dispatch Shape
+
+Choose the base by where evidence lives:
+
+- **`FlatDispatchBase`** — structural AST checks. Declare `NodeTypes`.
+- **`LineBase`** — line-oriented text checks (rare; must be lexical-state aware).
+- **`ManifestBase`** — AndroidManifest.xml.
+- **`ResourceBase`** — Android resources (XML).
+- **`GradleBase`** — Gradle build files / settings / catalogs.
+
+Never write a standalone `Check(file)` tree walk. Always go through the v2 dispatcher.
+
+## Capability Declaration
+
+Declare the narrowest capability that proves the finding. See `krit-capability-migration` for the full menu. The default-deny gates enforced by `make lint-rules` are `NeedsResolver` and `NeedsOracle` — declare them when used, omit them when not.
+
+Other capabilities to consider: `NeedsCrossFile`, `NeedsModuleIndex`, `NeedsParsedFiles`, `NeedsManifest`, `NeedsResources`, `NeedsGradle`, `NeedsTypeInfo`. Library facts (`ctx.LibraryFacts`) need no extra `Needs` flag.
+
+## Registry Entry
+
+Rules live in `internal/rules/<category>.go` (or `<category>_*.go`). Register them in the matching `internal/rules/registry_<category>.go`. Fields:
+
+- `ID`, `Category`, `Description`, `Sev`
+- `NodeTypes` (for FlatDispatch) or omit (for line/manifest/resource/gradle bases)
+- `Languages` — `LanguageKotlin`, `LanguageJava`, or both
+- `Needs` — capabilities declared above
+- `Confidence` — `ConfidenceHigh` is the bar for `DefaultActive=true`
+- `Fix` — omit when no autofix; otherwise `FixCosmetic` / `FixIdiomatic` / `FixSemantic` (see `krit-autofix-safety`)
+- `DefaultActive` — `false` until vetted on real corpora
+- `Implementation` — pointer to the rule struct
+- `Check` — the local `check` method
+
+### Precompile Rules
+
+Precompile rules (kotlinc-mirror diagnostics) are regular rules with two extras:
+
+- `Level: api.LevelFunction | LevelFile | LevelModule` — scope hint for the analyzer
+- `KotlincAnalog: "UNREACHABLE_CODE"` — the kotlinc diagnostic name being mirrored
+
+Use `api.CategoryPrecompile`. They live in `internal/rules/registry_precompile_*.go` and follow every other convention in this skill. There is no K#### prefix anymore — name them by what they detect.
+
+## Meta() And Config
+
+If the rule has user-facing options, add a `Meta()` descriptor with the option schema and defaults. Keep schema validation and runtime matching in sync — especially for regex options and implicit anchoring. Run `make schema` to regenerate `schemas/krit-config.schema.json`.
+
+## Fixtures
+
+Create paired fixtures under `tests/fixtures/<category>/`:
+
+- `positive/` — must fire
+- `negative/` — must not fire (include local-lookalike negatives: shadowed identifiers, comments, KDoc, escaped strings, raw strings)
+- `fixable/` — for autofix rules; each fixture has a `.expected` partner showing the fixed output
+
+For each fixture, run focused tests first:
+
+```bash
+go test ./internal/rules/ -run TestPositiveFixtures -v
+go test ./internal/rules/ -run TestNegativeFixtures -v
+go test ./internal/rules/ -run TestFixableFixtures -v
+```
+
+## Java Parity
+
+If the rule declares Java support (`Languages` includes `LanguageJava`):
+
+1. Add at least one Java positive fixture.
+2. Add at least one Java local-lookalike negative (shadowed name, nested scope, unrelated method with the same identifier).
+3. Use Java AST evidence (tree-sitter Java nodes, Java imports, Java type inference). Do not rely on Kotlin-only helpers.
+4. Verify Java participates in every pipeline phase the rule depends on: parse discovery, generated-source filtering, suppression indexing, dispatch, cross-file references, and module grouping.
+
+If the rule is Kotlin-only today but the underlying problem exists in Java, file a follow-up rather than silently leaving Java out.
+
+## Evidence Guardrails
+
+Before considering the rule done, walk the "Rule Implementation Guardrails" checklist from `CLAUDE.md`:
+
+- prefer flat AST, identifiers, navigation chains, imports, source-index facts over `strings.Contains` and broad regexes
+- if line/text scanning is unavoidable, skip comments, KDoc, escaped strings, raw strings, Gradle string literals
+- require receiver/owner proof for common method names (`System.out`, Android `Context`/`Activity`, lifecycle, DB, logging)
+- stop body walks at nested functions, lambdas, anonymous functions, classes/objects, local declarations that shadow names
+- walk all relevant operands/siblings/ancestors, not just the first child
+- verify parser shape (`!!`, Elvis, safe calls, infix, raw strings) with focused parser/helper tests
+
+## Validation
+
+Iterate with focused tests, then run the full validation set before pushing:
+
+```bash
+go build -o krit ./cmd/krit/
+go vet ./...
+golangci-lint run ./...
+make lint-rules
+go test ./... -count=1
+```
+
+`golangci-lint run ./...` and `make lint-rules` are both required — `go vet` alone misses gofmt drift, unused helpers, and the capability-declaration gate. Run `make integration` before pushing if the change touches dispatch, pipeline, output, or daemon code.

--- a/.claude/skills/krit-autofix-safety/SKILL.md
+++ b/.claude/skills/krit-autofix-safety/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: krit-autofix-safety
+description: Use when writing, broadening, or fixing a Krit autofix. Covers the FixCosmetic / FixIdiomatic / FixSemantic safety tiers, ktfmt-compatible output, comment and inline preservation, the fix-drift lint gate, and when to neuter an unsafe autofix rather than ship it.
+---
+
+# Krit Autofix Safety
+
+Use this when a rule has a `Fix` field, when adding an autofix to an existing rule, or when investigating a regression from an autofix in production. Cross-link with `krit-tighten-rule` when the underlying rule logic is also wrong, and `krit-add-rule` when scaffolding a brand-new fixable rule.
+
+## Safety Tiers
+
+Every fix must declare exactly one:
+
+- **`FixCosmetic`** — whitespace, indentation, brace placement, trailing commas. Never changes program behavior. Must produce ktfmt-compatible output.
+- **`FixIdiomatic`** — replaces a construct with an equivalent more-idiomatic one (e.g. `if (x) a else b` → `if (x) { a } else { b }` when style demands, `!= null` → `?.let`). Semantics are preserved, but the rewrite is observable in source.
+- **`FixSemantic`** — changes runtime behavior in a way the rule has proven is safe (e.g. removing a redundant null check, removing `System.gc()`). Hardest to justify. Must clear the highest evidence bar.
+
+If you cannot prove the fix belongs in the declared tier, drop a tier or remove the fix entirely. Production data shows unsafe fixes are how Krit loses trust the fastest — see `fix(rules): neuter unsafe autofixes and add fix-drift lint gate` (#172).
+
+## The Fix-Drift Gate
+
+`make lint-rules` enforces a fix-drift check: rules that declare a `Fix` tier must produce output compatible with that tier's contract. The gate runs as part of `make lint-rules` and `make ci`. If a fix lands that violates its tier (e.g. a `FixCosmetic` that changes brace semantics), the gate blocks it. Treat a gate failure as a real bug, not a lint-config problem.
+
+## ktfmt Compatibility
+
+Cosmetic and idiomatic fixes must produce output that survives a subsequent ktfmt pass without diff. The recurring failure modes from recent commits:
+
+- **Brace wraps that lose comments.** Wrapping `if (x) a else b` into a block must preserve any trailing/inline comments and any inline RHS that ktfmt would keep on one line. See `fix(rules) tighten brace-wrap fix to preserve comments and inline RHS` (#173) and `fix(rules) ktfmt-compatible brace wraps and postfix rewrites` (#162).
+- **Shared-line and in-expression positions.** Removing a statement that shares a line with another statement, or sits inside an expression, must guard against breaking the surrounding line. See `fix(ExplicitGarbageCollectionCall) guard autofix against in-expression and shared-line positions` (#171).
+- **Postfix rewrites.** Postfix operators (`!!`, `?.`, infix chains) have non-obvious parser shapes — verify with focused parser/helper tests before rewriting them.
+
+When in doubt, run ktfmt on the post-fix output of the fixable fixture and diff against `.expected`. If ktfmt produces a different result, the fix is not ktfmt-compatible.
+
+## Fixable Fixtures
+
+Every autofix rule needs paired fixtures under `tests/fixtures/fixable/<category>/<RuleName>/`:
+
+- `case.kt` — input
+- `case.kt.expected` — expected output after the fix
+
+Run:
+
+```bash
+go test ./internal/rules/ -run TestFixableFixtures -v
+```
+
+Add Java fixable fixtures when the rule declares Java support — Java autofix gaps are easy to miss. See `test(java) plug Java fixable-rule coverage gaps + fix System.gc() removal` (#163).
+
+## When To Neuter A Fix
+
+Remove the `Fix` field (or downgrade the tier) when:
+
+- the fix cannot prove tier compliance on real corpora
+- the fix breaks ktfmt-compat on common idioms
+- the fix would require evidence the rule does not currently gather (e.g. a `FixSemantic` that needs type info the rule does not have)
+
+A rule without a fix is a flag; a rule with a wrong fix is a bug. Prefer the flag.
+
+## Validation
+
+```bash
+go build -o krit ./cmd/krit/
+go vet ./...
+golangci-lint run ./...
+make lint-rules
+go test ./... -count=1
+```
+
+Run `make integration` if the fix changes how the fixer writes output paths or coordinates with the snapshot sidecar.

--- a/.claude/skills/krit-daemon-pipeline/SKILL.md
+++ b/.claude/skills/krit-daemon-pipeline/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: krit-daemon-pipeline
+description: Use when working on Krit's daemon mode, analysis pipeline, cross-file cache, bundle/findings cache, WorkspaceState residency, conservative delta planner, or invalidation semantics. Covers cold vs warm correctness, per-phase timings, and the cache flags used to verify behavior vs cached output.
+---
+
+# Krit Daemon and Pipeline
+
+Use this when changing how the analyzer runs end-to-end — daemon residency, cache wiring, bundle reuse, delta planning, or phase timings. Cross-link with `krit-kaa-benchmarking` when the change touches the oracle's daemon lifecycle.
+
+## Mental Model
+
+Each scan flows through phases the dispatcher schedules after the required indexes are built: parse, suppression indexing, AST dispatch, project-scope phases (cross-file, module-aware, parsed-file, Android, Gradle), aggregate, then output. Daemon mode keeps long-lived state alive across scans in `WorkspaceState`:
+
+- `CodeIndex` — source symbol/reference index
+- `TypeResolver` — source-level type resolution
+- `AnalysisCache` — per-file analysis output (write-back, lookup-side)
+- Oracle (KAA) lifecycle — resident JVM, oracle call filter classification cache
+- Findings-bundle cache — full-hit short-circuit when a bundle has not changed
+
+The `ConservativeDeltaPlanner` decides which files genuinely need rework after an edit. "Body-only" edits should reuse the prior bundle rather than re-running cross-file.
+
+## Cold vs Warm Correctness
+
+Two failure modes recur:
+
+- **Warm cache returns stale findings after a rule or config change.** Always use cache-disabling flags when verifying behavior, not when measuring perf:
+  ```bash
+  ./krit -no-cache -perf -f json -q -o /tmp/krit.json /path/to/project || true
+  ```
+- **Invalidation does not cover every resident piece of state.** When a config or rule registration changes, invalidation must cover resident resolver, oracle filter, code index, and bundle cache. See `fix(pipeline) InvalidateAll covers resident resolver + oracle filter` (#133).
+
+When changing any resident state, walk every `InvalidateAll` / shutdown path and confirm the new state is included.
+
+## Per-Phase Timings
+
+Daemon mode exposes per-phase wall-time stats. They are the first thing to inspect when latency regresses:
+
+```bash
+./krit -perf -f json -q -o /tmp/krit.json /path/to/project || true
+jq '.perfPhaseStats' /tmp/krit.json
+jq '.perfRuleStats' /tmp/krit.json
+```
+
+Useful fields:
+
+- total duration vs per-phase duration (parse, dispatch, cross-file, android, gradle, aggregate, output)
+- KAA-related: type-oracle phase, JVM analyze phase, KAA files analyzed
+- daemon-only: ResolverHit, OracleFilterHit, bundle hit/miss components
+
+When a bundle misses, `diag(pipeline) report bundle miss components` (#144) emits the reason. Read that before guessing.
+
+## Bundle Reuse And Delta Planning
+
+The findings-bundle cache short-circuits scans whose inputs match a prior bundle. Two invariants:
+
+- **Body-only edits reuse the bundle.** See `fix(pipeline) reuse bundle for body-only edits` (#154). If a body-only edit forces a full scan, the planner has lost precision — diagnose at the planner, not at the rules.
+- **Conservative delta planner pairs with structural cross-file.** A delta that touches structural API must invalidate cross-file dependents; a delta that does not, must not. See `feat(daemon) wire ConservativeDeltaPlanner with structural CrossFile` (#135).
+
+## When To Add Daemon State
+
+Promote state into `WorkspaceState` when:
+
+1. it is expensive to rebuild
+2. it is keyed on inputs that change less often than file edits
+3. its invalidation rules are clear and survive the `InvalidateAll` audit
+
+If any of those fails, prefer rebuilding per scan. Daemon state with unclear invalidation is the biggest source of warm-cache correctness bugs in this codebase.
+
+## Validation
+
+```bash
+go build -o krit ./cmd/krit/
+go vet ./...
+golangci-lint run ./...
+go test ./... -count=1
+make integration
+make regression
+```
+
+`make integration` and `make regression` are required for daemon/pipeline changes — `go test ./...` does not exercise the CLI/LSP/MCP integration paths or the playground regression expectations.
+
+## Reporting Standard For Perf Changes
+
+When reporting daemon perf changes, include:
+
+- Krit revision and target revision
+- scan command and cache flags
+- whether the config was applied
+- cold vs warm per-phase timings
+- the bundle hit/miss components from the diag output
+- whether `InvalidateAll` was audited for any new state
+
+Treat cached warm findings as performance evidence only — never as behavioral truth after rule or config changes.

--- a/.claude/skills/krit-dogfood/SKILL.md
+++ b/.claude/skills/krit-dogfood/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: krit-dogfood
+description: Use when running Krit against an external Kotlin/Android repo (metro, kotlin-corpus, playground, or any user-provided path) to harvest false positives, find missed positives, or validate that a rule change behaves correctly on real code. Produces a triage list of rule findings worth fixing vs ignoring vs deferring.
+---
+
+# Krit Dogfood
+
+Use this when validating Krit against a real codebase, not just fixtures. Cross-link with `krit-rule-vetting` for the per-rule audit step, `krit-tighten-rule` to land the fixes, and `krit-project-analysis` when the cause is a missing project-profile guard rather than rule logic.
+
+## Pick A Target
+
+Useful targets, in rough order of cost/coverage trade-off:
+
+- **playground** (`playground/` in this repo) — fastest, regression-locked via `make regression`. Use first for any pipeline/rule change.
+- **kotlin-corpus** — broader Kotlin coverage, used by `scripts/benchmark-oracle.sh` and `test(serve): report per-phase timings in kotlin-corpus benches`.
+- **`~/github/metro`** or similar large Android app — real Android/Gradle/Compose surface, real catalog, real DI.
+- **user-supplied path** — when investigating a reported FP on the reporter's codebase.
+
+Record both the Krit revision and the target revision in any output you share.
+
+## Run With Cache Disabled
+
+For correctness checks, never trust cached findings. Use:
+
+```bash
+go build -o krit ./cmd/krit/
+
+TARGET=/path/to/project
+./krit -no-cache -perf -perf-rules -f json -q -o /tmp/krit_dogfood.json "$TARGET" || true
+```
+
+If the target's `krit.yml` is not auto-discovered, pass `--config`. The project profile drives most library-aware rule behavior — check it first:
+
+```bash
+jq '.projectProfile | {hasGradle, dependencyExtractionComplete, hasUnresolvedDependencyRefs, catalogCompleteness}' /tmp/krit_dogfood.json
+```
+
+If dependency extraction is incomplete, library-absence is not proof, and many "FPs" are actually project-context bugs — see `krit-project-analysis`.
+
+## Triage
+
+Group findings by rule, then by suspected verdict:
+
+```bash
+jq -r '.findings[] | .rule' /tmp/krit_dogfood.json | sort | uniq -c | sort -rn | head -30
+
+jq -r '.findings[] | select(.rule=="<RuleName>") | [.file,.line,.message] | @tsv' /tmp/krit_dogfood.json | head -50
+```
+
+For each rule with surprising volume:
+
+- **Likely FP cluster** — sample 5–10 findings, look for a single evidence-gap bucket (lexical state, local lookalike, missing receiver proof, scope boundary). Route to `krit-tighten-rule`.
+- **Likely correct but undesired** — rule is firing as designed but the team disagrees with the policy. Downgrade `DefaultActive` or `Confidence`, or re-evaluate against `docs/rule-scope.md`.
+- **Likely project-context bug** — library-absence-based finding on a project with incomplete dependency extraction. Route to `krit-project-analysis`.
+- **Likely true positive** — leave the finding, file an issue if external.
+
+Don't fix everything in one pass. Produce a triage list with explicit verdicts and tackle them as separate PRs (matches the user's preference for one branch per fix).
+
+## Lock The Regression
+
+For every FP you decide to fix, add the minimal negative fixture to `tests/fixtures/negative/<category>/<RuleName>/` *before* changing rule code. The fixture must fail on the pre-fix code and pass after. Same workflow as `krit-tighten-rule`.
+
+For project-context bugs, additionally add a project-profile fixture if the missing fact is something `librarymodel` should expose.
+
+## Re-Run After Changes
+
+After landing fixes, re-run the dogfood scan against the same target revision and confirm:
+
+- the FP cluster on that rule dropped to the expected count
+- no other rule regressed (compare finding counts per rule before/after)
+- per-phase timings did not regress meaningfully (use `krit-kaa-benchmarking` for the rigorous version)
+
+## Reporting
+
+When sharing dogfood results, always include:
+
+- Krit revision and target revision
+- the exact scan command and flags (especially `-no-cache`)
+- whether project config was applied
+- the per-rule finding counts before and after any change
+- one representative example per rule cluster
+
+Findings without revisions and flags are not reproducible and should not be acted on.

--- a/.claude/skills/krit-tighten-rule/SKILL.md
+++ b/.claude/skills/krit-tighten-rule/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: krit-tighten-rule
+description: Use when fixing a false positive (or a missed positive) in an existing Krit rule. Distilled from the "Rule Implementation Guardrails" section of CLAUDE.md. Drives the regression-fixture-first workflow: reproduce on a fixture, identify the missing evidence, lock the regression with a failing test, narrow the rule, re-run.
+---
+
+# Krit Tighten Rule
+
+Use this when an existing rule fires wrongly (false positive), misses a clear positive, or needs its evidence narrowed before being broadened. Cross-link with `krit-rule-vetting` for the audit step that produces the candidate list, and `krit-project-analysis` when the cause is missing project context rather than rule logic.
+
+## Reproduce First
+
+Confirm the rule actually fires (or fails to fire) on a representative input. Add a minimal fixture under the rule's category that reproduces the problem before changing any rule code:
+
+```bash
+mkdir -p tests/fixtures/negative/<category>/<RuleName>
+$EDITOR tests/fixtures/negative/<category>/<RuleName>/local_lookalike.kt
+```
+
+Run the focused fixture test to confirm the failure exists:
+
+```bash
+go test ./internal/rules/ -run TestNegativeFixtures -v
+```
+
+The regression test must fail *before* the fix lands. If it passes immediately, you have not actually reproduced the issue — go narrower.
+
+## Diagnose The Evidence Gap
+
+Identify which class of bug this is. Most FP fixes in the last 3 months landed in one of these buckets:
+
+- **Lexical state ignored.** Rule matched inside a comment, KDoc, escaped string, raw string, or Gradle string literal.
+- **Identifier overlap without receiver proof.** `System.out`, Android `Context`, lifecycle, DB, logging APIs have common method names. The rule needs structural receiver, owner, import, source-index, or type evidence — not just the method name.
+- **Local lookalike shadow.** A local `val Log = ...`, parameter named `Context`, or nested class shadows the global identifier. The walk did not stop at the shadowing scope.
+- **Body walk crossed a scope boundary.** Body walks must stop at nested functions, lambdas, anonymous functions, classes/objects, and shadowing declarations.
+- **First-child bias.** The rule looked at only the first operand/sibling/ancestor and missed where the real evidence lived.
+- **Wrong parser shape.** `!!`, Elvis, safe calls, infix, raw strings have specific flat-AST node kinds. Verify with a focused parser/helper test.
+- **Config/runtime drift.** Schema metadata, validation, defaults, and runtime matching disagree — especially with implicit-anchor regex options.
+
+Pick the bucket before writing the fix. If you cannot, the fixture is not minimal enough.
+
+## Narrow With The Right Evidence
+
+Prefer, in order:
+
+1. flat AST node kinds, identifiers, navigation chains, imports, source-index facts
+2. source-level type inference (`NeedsResolver`)
+3. library/project profile facts (`ctx.LibraryFacts`) — see `krit-project-analysis`
+4. Kotlin Analysis API (`NeedsOracle`) — only when source-visible evidence cannot prove it
+
+Do not broaden a heuristic when a project-profile guard or a receiver check is the real missing condition.
+
+## Lock The Regression
+
+Every fix lands with the fixture that would have failed before the fix. For FPs this means a negative fixture; for missed positives, a positive fixture; for autofix bugs, a fixable fixture plus its `.expected` partner.
+
+If the rule supports Java, add the Java parity case for the same bug class — Java local-lookalike negatives are the single most common gap.
+
+## Validate
+
+Focused tests first, then full validation:
+
+```bash
+go test ./internal/rules/ -run TestPositiveFixtures -v
+go test ./internal/rules/ -run TestNegativeFixtures -v
+
+go build -o krit ./cmd/krit/
+go vet ./...
+golangci-lint run ./...
+make lint-rules
+go test ./... -count=1
+```
+
+Run `make integration` before pushing if the fix touches dispatch, suppression, or pipeline behavior.
+
+## When To Stop
+
+A rule tightening is done when:
+
+- the new fixture fails on the pre-fix code and passes on the post-fix code
+- no existing positive fixture regressed
+- the rule's `Confidence` and `DefaultActive` still match reality (downgrade them if the FP class was widespread)
+- if a project corpus surfaced the FP, the rule's findings on that corpus dropped to expected — see `krit-dogfood`


### PR DESCRIPTION
## Summary

Adds five project skills and five slash commands to cover the most-trafficked krit workflows that weren't yet documented.

**New skills** (`.claude/skills/`):
- `krit-add-rule` — end-to-end new rule (base/capability/registry/fixtures/Java parity/precompile Level)
- `krit-tighten-rule` — false-positive fix workflow, regression-fixture-first
- `krit-autofix-safety` — Cosmetic/Idiomatic/Semantic tiers, ktfmt-compat, fix-drift gate
- `krit-daemon-pipeline` — WorkspaceState, bundle cache, conservative delta planner, cold/warm correctness
- `krit-dogfood` — run on external repo (metro / kotlin-corpus / playground), triage findings

**New commands** (`.claude/commands/`):
- `/krit-add-rule <name>` — invokes the add-rule skill
- `/krit-tighten <RuleName>` — invokes the tighten skill
- `/krit-dogfood <repo-path>` — scan + triage external repo
- `/krit-validate` — fast pass: build + vet + golangci-lint + lint-rules + test
- `/krit-ci` — complete pre-push: lint pass + `make ci` (GitHub CI runs golangci-lint and lint-rules in separate jobs from `make ci`, so `make ci` alone isn't a true CI equivalent)

Java parity is folded into `krit-add-rule` rather than its own skill; precompile rules are treated as Level-tagged regular rules per #182. Existing krit skills (capability-migration, kaa-benchmarking, project-analysis, rule-vetting) are unchanged and cross-linked from the new ones.

## Test plan

- [x] Skills appear in the available-skills list (verified in session)
- [x] Slash commands are loadable from `.claude/commands/`
- [x] All PR/commit references in skill bodies are accurate (spot-checked #172, #173, #162, #171, #163, #133, #144, #154, #135)
- [ ] No code changes — docs-only PR