### PR TITLE
refactor(scan): extract long-lived state into Session (#200)

### DIFF
--- a/internal/cli/scan/runner.go
+++ b/internal/cli/scan/runner.go
@@ -28,22 +28,22 @@ func (r *runner) projectInput() pipeline.ProjectInput {
 	host := pipeline.ProjectHostState{
 		Reporter:                r.reporter,
 		Tracker:                 r.tracker,
-		ParseCache:              r.parseCache,
+		ParseCache:              r.sess.ParseCache,
 		PrebuiltResolver:        r.resolver,
-		PrebuiltLibraryFacts:    r.libraryFacts,
-		PrebuiltAndroidProject:  r.androidProject,
+		PrebuiltLibraryFacts:    r.sess.LibraryFacts,
+		PrebuiltAndroidProject:  r.sess.AndroidProject,
 		JavaSemanticFacts:       r.javaSemanticFacts,
 		JavaSemanticFactsLoader: runJavaSemanticFacts,
 		CrossFileCacheDir:       resolveCrossFileCacheDir(r.paths, *r.f.NoCrossFileCache),
 		CrossFindingsCacheDir:   resolveCrossFindingsCacheDir(r.paths, *r.f.NoCrossFileCache),
-		AnalysisCache:           r.analysisCache,
+		AnalysisCache:           r.sess.AnalysisCache,
 		AnalysisCacheFilePath:   r.cacheFilePath,
-		AnalysisCacheLookup:     r.useCache && r.analysisCache != nil,
+		AnalysisCacheLookup:     r.useCache && r.sess.AnalysisCache != nil,
 		AnalysisCacheResult:     r.cacheResult,
 		AnalysisCacheStats:      r.cacheStats,
 		AnalysisCacheRuleHash:   r.ruleHash,
 		Oracle:                  r.typeOracle,
-		OracleDaemon:            r.daemon,
+		OracleDaemon:            r.sess.OracleDaemon,
 		AndroidProviders:        r.androidProviders,
 		AndroidCacheDir:         r.androidCacheDir,
 		AndroidCacheWriter:      r.androidCacheWriter,
@@ -89,7 +89,7 @@ func (r *runner) applyProjectAnalysis(analysis pipeline.ProjectAnalysisResult) {
 	r.dispatchResult = analysis.DispatchResult
 	r.cacheStats = analysis.IndexResult.CacheStats
 	r.cacheResult = analysis.IndexResult.CacheResult
-	r.analysisCache = analysis.IndexResult.Cache
+	r.sess.AnalysisCache = analysis.IndexResult.Cache
 	r.ruleHash = analysis.IndexResult.RuleHash
 	if *r.f.PerfRules {
 		r.perfRuleStats = rules.SortedRuleExecutionStats(analysis.DispatchResult.Stats)

--- a/internal/cli/scan/runner_cache.go
+++ b/internal/cli/scan/runner_cache.go
@@ -22,9 +22,6 @@ func (r *runner) close() {
 	}
 	r.flushCaches()
 	stopCPUProfile(r.cpuProfileFile)
-	if r.daemon != nil {
-		r.daemon.Close()
-	}
 }
 
 func (r *runner) flushCaches() {
@@ -32,9 +29,9 @@ func (r *runner) flushCaches() {
 		return
 	}
 	r.cachesClosed = true
-	hasParseCacheWrites := r.parseCache != nil && r.parseCache.HasWrites()
-	hasXMLParseCacheWrites := r.xmlParseCache != nil && r.xmlParseCache.HasWrites()
-	hasResourceCacheWrites := r.resourceCache != nil && r.resourceCache.HasWrites()
+	hasParseCacheWrites := r.sess.ParseCache != nil && r.sess.ParseCache.HasWrites()
+	hasXMLParseCacheWrites := r.sess.XMLParseCache != nil && r.sess.XMLParseCache.HasWrites()
+	hasResourceCacheWrites := r.sess.ResourceCache != nil && r.sess.ResourceCache.HasWrites()
 	hasOracleCacheWrites := r.oracleCacheWriter != nil && r.oracleCacheWriter.Stats().Queued > 0
 	hasAndroidCacheWrites := r.androidCacheWriter != nil && (r.androidCacheWriter.Stats().Queued+r.androidCacheWriter.Stats().SyncSaves) > 0
 	if !hasParseCacheWrites && !hasXMLParseCacheWrites && !hasResourceCacheWrites && !hasOracleCacheWrites && !hasAndroidCacheWrites {
@@ -79,30 +76,30 @@ func (r *runner) closeIdleCacheWriters() {
 }
 
 func (r *runner) closeIdleParseCache() {
-	if r.parseCache != nil {
-		_ = r.parseCache.CloseIdle()
+	if r.sess.ParseCache != nil {
+		_ = r.sess.ParseCache.CloseIdle()
 	}
 }
 
 func (r *runner) closeIdleXMLParseCache() {
-	if r.xmlParseCache != nil {
-		_ = r.xmlParseCache.CloseIdle()
+	if r.sess.XMLParseCache != nil {
+		_ = r.sess.XMLParseCache.CloseIdle()
 	}
 }
 
 func (r *runner) closeIdleResourceCache() {
-	if r.resourceCache != nil {
-		_ = r.resourceCache.CloseIdle()
+	if r.sess.ResourceCache != nil {
+		_ = r.sess.ResourceCache.CloseIdle()
 	}
 }
 
 func (r *runner) flushParseCache(parent perf.Tracker) {
-	if r.parseCache == nil {
+	if r.sess.ParseCache == nil {
 		return
 	}
 	parseFlushTracker := parent.Serial("parseCacheFlush")
-	closeErr := r.parseCache.Close()
-	r.parseCache.AddPerfEntries(parseFlushTracker)
+	closeErr := r.sess.ParseCache.Close()
+	r.sess.ParseCache.AddPerfEntries(parseFlushTracker)
 	parseFlushTracker.End()
 	if closeErr != nil && *r.f.Verbose {
 		fmt.Fprintf(os.Stderr, "verbose: parse cache flush failed: %v\n", closeErr)
@@ -110,22 +107,22 @@ func (r *runner) flushParseCache(parent perf.Tracker) {
 }
 
 func (r *runner) flushXMLParseCache(parent perf.Tracker) {
-	if r.xmlParseCache == nil {
+	if r.sess.XMLParseCache == nil {
 		return
 	}
 	start := time.Now()
-	if err := r.xmlParseCache.Close(); err != nil && *r.f.Verbose {
+	if err := r.sess.XMLParseCache.Close(); err != nil && *r.f.Verbose {
 		fmt.Fprintf(os.Stderr, "verbose: xml parse cache flush failed: %v\n", err)
 	}
 	perf.AddEntry(parent, "xmlParseCacheFlush", time.Since(start))
 }
 
 func (r *runner) flushResourceCache(parent perf.Tracker) {
-	if r.resourceCache == nil {
+	if r.sess.ResourceCache == nil {
 		return
 	}
 	start := time.Now()
-	if err := r.resourceCache.Close(); err != nil && *r.f.Verbose {
+	if err := r.sess.ResourceCache.Close(); err != nil && *r.f.Verbose {
 		fmt.Fprintf(os.Stderr, "verbose: resource cache flush failed: %v\n", err)
 	}
 	perf.AddEntry(parent, "resourceCacheFlush", time.Since(start))

--- a/internal/cli/scan/runner_state.go
+++ b/internal/cli/scan/runner_state.go
@@ -52,9 +52,12 @@ type runner struct {
 	cpuProfileFile  *os.File
 	trackedFiles    trackedfiles.Index
 
+	// sess owns the long-lived caches, parse caches, project model, and
+	// oracle daemon. One-shot CLI builds a fresh sess in scan.Run; the
+	// daemon will reuse the same sess across requests.
+	sess *Session
+
 	// Project detection
-	androidProject     *android.Project
-	libraryFacts       *librarymodel.Facts
 	androidProviders   *pipeline.AndroidProjectProviders
 	projectModelLoaded bool
 	cacheFilePath      string
@@ -77,20 +80,15 @@ type runner struct {
 	// Resolver / oracle / cache
 	resolver          typeinfer.TypeResolver
 	reporter          *diag.Reporter
-	daemon            *oracle.Daemon
 	typeOracle        *oracle.Oracle
 	oracleStore       *store.FileStore
 	oracleCacheWriter *oracle.CacheWriter
-	analysisCache     *cache.Cache
 	cacheResult       *cache.Result
 	ruleHash          string
 	cacheStats        *cache.Stats
 	useCache          bool
 
 	// Parse caches
-	parseCache         *scanner.ParseCache
-	xmlParseCache      *android.XMLParseCache
-	resourceCache      *android.ResourceIndexCache
 	androidCacheWriter *scanner.AndroidCacheWriter
 	androidCacheDir    string
 	cachesClosed       bool
@@ -132,7 +130,7 @@ type runner struct {
 //
 // Returns ok=false (with an exit code) when CPU profile creation fails;
 // other early-exit guards inside the function call os.Exit directly.
-func newRunner(f *scanFlags) (*runner, int, bool) {
+func newRunner(f *scanFlags, sess *Session) (*runner, int, bool) {
 	effectiveFormat := resolveEffectiveFormat(f)
 
 	runVersionFlag(*f.Version, Version)
@@ -216,7 +214,7 @@ func newRunner(f *scanFlags) (*runner, int, bool) {
 		tracker:         tracker,
 		cpuProfileFile:  cpuProfileFile,
 		trackedFiles:    trackedfiles.NewGitIndex(),
-		libraryFacts:    librarymodel.DefaultFacts(),
+		sess:            sess,
 		cacheFilePath:   cacheFilePath,
 	}
 	r.preloadOracleTypes()
@@ -340,22 +338,22 @@ func (r *runner) ensureProjectModel() {
 		return
 	}
 	r.tracker.TrackVoid("projectModel", func() {
-		r.androidProject = android.DetectProjectWithIndex(r.paths, r.trackedFiles)
-		r.libraryFacts = librarymodel.DefaultFacts()
-		if r.androidProject != nil {
+		r.sess.AndroidProject = android.DetectProjectWithIndex(r.paths, r.trackedFiles)
+		r.sess.LibraryFacts = librarymodel.DefaultFacts()
+		if r.sess.AndroidProject != nil {
 			cacheDir := ""
 			if r.f != nil && r.f.NoCache != nil && !*r.f.NoCache {
 				cacheDir = librarymodel.ProjectProfileCacheDir(oracle.FindRepoDir(r.paths))
 			}
-			profile, ok := librarymodel.LoadProjectProfileCache(cacheDir, r.androidProject.GradlePaths)
+			profile, ok := librarymodel.LoadProjectProfileCache(cacheDir, r.sess.AndroidProject.GradlePaths)
 			if !ok {
-				profile = librarymodel.ProfileFromGradlePaths(r.androidProject.GradlePaths)
-				if err := librarymodel.SaveProjectProfileCache(cacheDir, r.androidProject.GradlePaths, profile); err != nil &&
+				profile = librarymodel.ProfileFromGradlePaths(r.sess.AndroidProject.GradlePaths)
+				if err := librarymodel.SaveProjectProfileCache(cacheDir, r.sess.AndroidProject.GradlePaths, profile); err != nil &&
 					r.f != nil && r.f.Verbose != nil && *r.f.Verbose {
 					fmt.Fprintf(os.Stderr, "verbose: library model cache save failed: %v\n", err)
 				}
 			}
-			r.libraryFacts = librarymodel.FactsForProfile(profile)
+			r.sess.LibraryFacts = librarymodel.FactsForProfile(profile)
 		}
 		r.projectModelLoaded = true
 	})
@@ -383,7 +381,7 @@ func (r *runner) filterRules() (handled bool, code int) {
 				r.javaPathsForDispatch = filterGeneratedPathStrings(r.javaPathsForDispatch)
 			}
 		}
-		androidProjectEmpty := r.androidProject == nil || r.androidProject.IsEmpty()
+		androidProjectEmpty := r.sess.AndroidProject == nil || r.sess.AndroidProject.IsEmpty()
 		if len(r.files) == 0 && len(r.javaPathsForDispatch) == 0 && androidProjectEmpty {
 			if !*r.f.Quiet {
 				fmt.Fprintln(os.Stderr, "info: No Kotlin, Java, or Android project files found.")
@@ -479,13 +477,13 @@ func (r *runner) runOracleIndex() (int, error) {
 		r.resolver = res.Resolver
 	}
 	if res.Daemon != nil {
-		r.daemon = res.Daemon
+		r.sess.OracleDaemon = res.Daemon
 	}
 	r.typeOracle = res.Oracle
 	if r.useCache {
-		r.analysisCache = preloadedCache
-		if r.analysisCache == nil {
-			r.analysisCache = cache.Load(r.cacheFilePath)
+		r.sess.AnalysisCache = preloadedCache
+		if r.sess.AnalysisCache == nil {
+			r.sess.AnalysisCache = cache.Load(r.cacheFilePath)
 		}
 	}
 	return 0, nil
@@ -502,7 +500,7 @@ func (r *runner) setupAndroidProviders() {
 			return
 		}
 		deps := pipeline.CollectAndroidDependenciesV2(r.activeRules)
-		r.androidProviders = pipeline.NewAndroidProjectProviders(r.androidProject, deps, *r.f.Jobs)
+		r.androidProviders = pipeline.NewAndroidProjectProviders(r.sess.AndroidProject, deps, *r.f.Jobs)
 	})
 }
 
@@ -524,14 +522,14 @@ func (r *runner) setupParseCaches() {
 		if !*r.f.NoParseCache {
 			capBytes := resolveParseCacheCap(*r.f.ParseCacheCapMB, r.cfg)
 			if pc, pcErr := scanner.NewParseCacheWithCap(repoDir, capBytes); pcErr == nil {
-				r.parseCache = pc
-				r.parseCache.SetAsyncWriter(newParseCacheAsyncWriter(parseWorkers))
+				r.sess.ParseCache = pc
+				r.sess.ParseCache.SetAsyncWriter(newParseCacheAsyncWriter(parseWorkers))
 			} else if *r.f.Verbose {
 				fmt.Fprintf(os.Stderr, "verbose: parse cache disabled: %v\n", pcErr)
 			}
 			if pipeline.RulesNeedAndroidProject(r.activeRules) {
 				if xmlPC, xmlErr := android.NewXMLParseCacheWithCap(repoDir, capBytes); xmlErr == nil {
-					r.xmlParseCache = xmlPC
+					r.sess.XMLParseCache = xmlPC
 				} else if *r.f.Verbose {
 					fmt.Fprintf(os.Stderr, "verbose: xml parse cache disabled: %v\n", xmlErr)
 				}
@@ -539,7 +537,7 @@ func (r *runner) setupParseCaches() {
 		}
 		if shouldOpenResourceIndexCache(r.activeRules, *r.f.NoResourceCache) {
 			if rc, rcErr := android.NewResourceIndexCache(oracle.FindRepoDir(r.paths)); rcErr == nil {
-				r.resourceCache = rc
+				r.sess.ResourceCache = rc
 				android.SetActiveResourceIndexCache(rc)
 			} else if *r.f.Verbose {
 				fmt.Fprintf(os.Stderr, "verbose: resource cache disabled: %v\n", rcErr)

--- a/internal/cli/scan/scan.go
+++ b/internal/cli/scan/scan.go
@@ -286,36 +286,55 @@ func Run() int {
 		WireFile:    *f.NewExperimentWireFile,
 	})
 
-	r, code, ok := newRunner(f)
+	ctx := context.Background()
+	repoDir := oracle.FindRepoDir(flag.Args())
+	sess, err := NewSession(ctx, repoDir, f)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		return 2
+	}
+	defer sess.Close()
+
+	r, code, ok := newRunner(f, sess)
 	if !ok {
 		return code
 	}
 	defer r.close()
 
+	exitCode, _ := r.run(ctx)
+	return exitCode
+}
+
+// run executes the scan phases against r.sess. Long-lived caches, the
+// project model, and the oracle daemon flow through the session so
+// daemon callers reuse them across requests; one-shot CLI builds a
+// fresh Session and Close drains it on exit.
+func (r *runner) run(ctx context.Context) (int, error) {
+	_ = ctx
 	if code, err := r.collectFiles(); err != nil {
-		return code
+		return code, err
 	}
 	if handled, code := r.filterRules(); handled {
-		return code
+		return code, nil
 	}
 	r.bootstrapResolver()
 	if code, err := r.runOracleIndex(); err != nil {
-		return code
+		return code, err
 	}
 	r.printVerboseBanner()
 	r.setupAndroidProviders()
 	r.setupParseCaches()
 
 	if code, err := r.runProjectAnalysis(); err != nil {
-		return code
+		return code, err
 	}
 	r.firCheckAndCollect()
 
 	if handled, code := r.applyBaselinesAndDiff(); handled {
-		return code
+		return code, nil
 	}
 	if handled, code := r.runFixup(); handled {
-		return code
+		return code, nil
 	}
 
 	// close() is idempotent, so invoking it here flushes once before the
@@ -323,7 +342,7 @@ func Run() int {
 	r.flushCaches()
 
 	if code, err := r.openOutputWriter(); err != nil {
-		return code
+		return code, err
 	}
 	if r.w != nil && r.w != os.Stdout {
 		defer r.w.Close()
@@ -333,7 +352,7 @@ func Run() int {
 	r.flushCaches()
 
 	r.recordTotalTimingAndStopProfiles()
-	return r.outputPhase()
+	return r.outputPhase(), nil
 }
 
 // runLegacy remains as a no-op compile-time reference.

--- a/internal/cli/scan/session.go
+++ b/internal/cli/scan/session.go
@@ -1,0 +1,90 @@
+package scan
+
+import (
+	"context"
+	"errors"
+
+	"github.com/kaeawc/krit/internal/android"
+	"github.com/kaeawc/krit/internal/cache"
+	"github.com/kaeawc/krit/internal/librarymodel"
+	"github.com/kaeawc/krit/internal/oracle"
+	"github.com/kaeawc/krit/internal/pipeline"
+	"github.com/kaeawc/krit/internal/scanner"
+)
+
+// Flags is the bundle of CLI options NewSession may consult. Alias so
+// the same *scanFlags can flow from the one-shot Run path and from the
+// daemon's startup wiring without an additional adapter type.
+type Flags = *scanFlags
+
+// Session owns the long-lived state the daemon constructs once at
+// startup and reuses across every scan request. One-shot CLI builds a
+// fresh Session per request and Close drains it on exit. Runner phases
+// write back into Session so daemon callers skip the rebuild on warm
+// invocations.
+type Session struct {
+	Workspace      *pipeline.WorkspaceState
+	AnalysisCache  *cache.Cache
+	ParseCache     *scanner.ParseCache
+	XMLParseCache  *android.XMLParseCache
+	ResourceCache  *android.ResourceIndexCache
+	AndroidProject *android.Project
+	LibraryFacts   *librarymodel.Facts
+	OracleDaemon   *oracle.Daemon
+	repoDir        string
+	closed         bool
+}
+
+// NewSession returns a Session rooted at repoDir. Caches and project
+// model fields beyond Workspace/LibraryFacts are populated by the scan
+// runner; daemon callers may pre-populate them to skip rebuild work.
+//
+// ctx and flags are accepted for the daemon scaffolding that builds on
+// this refactor; the one-shot CLI path does not consult them yet.
+func NewSession(ctx context.Context, repoDir string, flags Flags) (*Session, error) {
+	_ = ctx
+	_ = flags
+	return &Session{
+		Workspace:    pipeline.NewWorkspaceState(repoDir),
+		LibraryFacts: librarymodel.DefaultFacts(),
+		repoDir:      repoDir,
+	}, nil
+}
+
+// RepoDir reports the repository root the session was constructed against.
+func (s *Session) RepoDir() string {
+	if s == nil {
+		return ""
+	}
+	return s.repoDir
+}
+
+// Close is safe on a nil receiver and idempotent so callers can defer
+// it alongside the runner's mid-scan flushCaches without double-close
+// hazards.
+func (s *Session) Close() error {
+	if s == nil || s.closed {
+		return nil
+	}
+	s.closed = true
+	var errs []error
+	if s.ParseCache != nil {
+		if err := s.ParseCache.Close(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	if s.XMLParseCache != nil {
+		if err := s.XMLParseCache.Close(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	if s.ResourceCache != nil {
+		if err := s.ResourceCache.Close(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	if s.OracleDaemon != nil {
+		s.OracleDaemon.Close()
+	}
+	return errors.Join(errs...)
+}

--- a/internal/cli/scan/session_test.go
+++ b/internal/cli/scan/session_test.go
@@ -1,0 +1,90 @@
+package scan
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/kaeawc/krit/internal/cacheutil"
+	"github.com/kaeawc/krit/internal/scanner"
+)
+
+func TestNewSession_InitializesWorkspaceAndDefaults(t *testing.T) {
+	dir := t.TempDir()
+	sess, err := NewSession(context.Background(), dir, nil)
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	defer sess.Close()
+
+	if sess.Workspace == nil {
+		t.Fatal("expected Workspace to be initialized")
+	}
+	if got := sess.Workspace.RepoRoot(); got != dir {
+		t.Fatalf("Workspace.RepoRoot = %q, want %q", got, dir)
+	}
+	if sess.LibraryFacts == nil {
+		t.Fatal("expected LibraryFacts to be initialized with defaults")
+	}
+	if sess.RepoDir() != dir {
+		t.Fatalf("RepoDir = %q, want %q", sess.RepoDir(), dir)
+	}
+}
+
+func TestSession_CloseIsIdempotent(t *testing.T) {
+	sess, err := NewSession(context.Background(), t.TempDir(), nil)
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	if err := sess.Close(); err != nil {
+		t.Fatalf("first Close: %v", err)
+	}
+	if err := sess.Close(); err != nil {
+		t.Fatalf("second Close: %v", err)
+	}
+	// Calling Close on a nil receiver must also be safe.
+	var nilSess *Session
+	if err := nilSess.Close(); err != nil {
+		t.Fatalf("nil Close: %v", err)
+	}
+}
+
+// TestSession_CloseDrainsParseCacheWriter verifies that Close waits for
+// background parse-cache jobs to finish, which is the contract the daemon
+// relies on so a teardown does not race with in-flight cache persistence.
+func TestSession_CloseDrainsParseCacheWriter(t *testing.T) {
+	dir := t.TempDir()
+	pc, err := scanner.NewParseCacheWithCap(dir, 1024*1024)
+	if err != nil {
+		t.Fatalf("NewParseCacheWithCap: %v", err)
+	}
+	writer := cacheutil.NewAsyncWriter(1, 4)
+	pc.SetAsyncWriter(writer)
+
+	var ran atomic.Bool
+	if !writer.Submit(func() (int64, error) {
+		time.Sleep(20 * time.Millisecond)
+		ran.Store(true)
+		return 0, nil
+	}) {
+		t.Fatal("AsyncWriter.Submit rejected the job")
+	}
+
+	sess, err := NewSession(context.Background(), dir, nil)
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	sess.ParseCache = pc
+
+	if err := sess.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if !ran.Load() {
+		t.Fatal("expected background job to run before Close returned")
+	}
+	stats := writer.Stats()
+	if stats.Queued != stats.Completed+stats.Failed {
+		t.Fatalf("AsyncWriter not drained: stats=%+v", stats)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `internal/cli/scan/session.go` with the `Session` struct (Workspace, AnalysisCache, ParseCache, XMLParseCache, ResourceCache, AndroidProject, LibraryFacts, OracleDaemon, repoDir) plus `NewSession` and idempotent `Close`.
- Moves those 7 long-lived fields off the per-invocation `runner` and refactors phases to read/write them through `r.sess`.
- Adds `runner.run(ctx)` and updates `scan.Run` to construct a Session, defer `Close`, build the runner, and drive the phase pipeline.

Foundational refactor for #200 — no observable behavior change for one-shot CLI use; unblocks daemon scaffolding / watcher / resident cache.

## Validation criteria
- All existing `internal/cli/scan` tests pass unchanged.
- New `internal/cli/scan/session_test.go` covers Session lifecycle, double-`Close` is a no-op (including nil receiver), and `Close` drains the background parse-cache writer.
- `Session` lives in `internal/cli/scan`; no new public types in `internal/pipeline`.
- `Session.Close` owns oracle daemon shutdown so there is a single teardown owner.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run ./internal/cli/scan/...` (0 issues)
- [x] `go test ./... -count=1` (full suite green)
- [x] `go test ./internal/cli/scan/ -run TestSession -v` (new lifecycle / double-close / drain tests pass)

Closes #200