### PR TITLE
feat(rules): expose Precision tier on Rule metadata

### DIFF
--- a/internal/mcp/resources.go
+++ b/internal/mcp/resources.go
@@ -65,7 +65,7 @@ func rulesResource() (string, string, error) {
 			Description: r.Description,
 			RuleSet:     r.Category,
 			Severity:    string(r.Sev),
-			Precision:   string(rules.V2RulePrecision(r)),
+			Precision:   rules.V2RulePrecision(r).String(),
 			Active:      rules.IsDefaultActive(r.ID),
 			Fixable:     fixable,
 			FixLevel:    fixLevel,

--- a/internal/mcp/tool_rules.go
+++ b/internal/mcp/tool_rules.go
@@ -18,8 +18,9 @@ type rulesArgs struct {
 	Rule string `json:"rule"`
 
 	// operation=search
-	Query    string `json:"query"`
-	Category string `json:"category"`
+	Query     string `json:"query"`
+	Category  string `json:"category"`
+	Precision string `json:"precision"`
 
 	// operation=configure
 	Active   *bool  `json:"active"`
@@ -77,6 +78,7 @@ func (s *Server) rulesExplain(args rulesArgs) ToolResult {
 		"severity":    string(r.Sev),
 		"active":      active,
 		"fixable":     fixable,
+		"precision":   rules.V2RulePrecision(r).String(),
 	}
 	if fixLevel != "" {
 		info["fixLevel"] = fixLevel
@@ -89,12 +91,22 @@ func (s *Server) rulesExplain(args rulesArgs) ToolResult {
 // description, and category. Results are ranked by where the match landed
 // (name > description > category) then alphabetical.
 func (s *Server) rulesSearch(args rulesArgs) ToolResult {
-	if args.Query == "" {
-		return errorResult("'query' argument is required for operation=search")
+	if args.Query == "" && args.Precision == "" {
+		return errorResult("'query' or 'precision' argument is required for operation=search")
 	}
 
 	q := strings.ToLower(args.Query)
 	categoryFilter := strings.ToLower(args.Category)
+
+	var precisionFilter api.Precision
+	if args.Precision != "" {
+		p, ok := api.ParsePrecision(args.Precision)
+		if !ok {
+			return errorResult("unknown precision: " + args.Precision +
+				"; valid: heuristic/text-backed, ast-backed, project-structure-aware, type-aware, policy")
+		}
+		precisionFilter = p
+	}
 
 	type hit struct {
 		Name        string `json:"name"`
@@ -102,6 +114,7 @@ func (s *Server) rulesSearch(args rulesArgs) ToolResult {
 		Severity    string `json:"severity"`
 		Active      bool   `json:"active"`
 		Fixable     bool   `json:"fixable"`
+		Precision   string `json:"precision"`
 		Description string `json:"description"`
 		Score       int    `json:"-"`
 	}
@@ -112,12 +125,23 @@ func (s *Server) rulesSearch(args rulesArgs) ToolResult {
 			continue
 		}
 
+		precision := rules.V2RulePrecision(r)
+		if precisionFilter != api.PrecisionUnset && precision != precisionFilter {
+			continue
+		}
+
 		score := 0
 		nameMatch := strings.Contains(strings.ToLower(r.ID), q)
 		descMatch := strings.Contains(strings.ToLower(r.Description), q)
 		catMatch := strings.Contains(strings.ToLower(r.Category), q)
 
 		switch {
+		case q == "":
+			// Precision-only filter: no query text required.
+			if precisionFilter == api.PrecisionUnset {
+				continue
+			}
+			score = 1
 		case nameMatch:
 			score = 3
 		case descMatch:
@@ -135,6 +159,7 @@ func (s *Server) rulesSearch(args rulesArgs) ToolResult {
 			Severity:    string(r.Sev),
 			Active:      rules.IsDefaultActive(r.ID),
 			Fixable:     fixable,
+			Precision:   precision.String(),
 			Description: r.Description,
 			Score:       score,
 		})
@@ -160,9 +185,10 @@ func (s *Server) rulesSearch(args rulesArgs) ToolResult {
 	})
 }
 
-// rulesCategories returns each category with its rule count.
+// rulesCategories returns each category with its rule count, plus a
+// per-precision-tier breakdown of the registry.
 func (s *Server) rulesCategories(_ rulesArgs) ToolResult {
-	type categoryRow struct {
+	type bucketRow struct {
 		Name      string `json:"name"`
 		RuleCount int    `json:"ruleCount"`
 		Active    int    `json:"activeByDefault"`
@@ -170,16 +196,24 @@ func (s *Server) rulesCategories(_ rulesArgs) ToolResult {
 
 	counts := map[string]int{}
 	active := map[string]int{}
+	precCounts := map[api.Precision]int{}
+	precActive := map[api.Precision]int{}
 	for _, r := range api.Registry {
 		counts[r.Category]++
-		if rules.IsDefaultActive(r.ID) {
+		isActive := rules.IsDefaultActive(r.ID)
+		if isActive {
 			active[r.Category]++
+		}
+		p := rules.V2RulePrecision(r)
+		precCounts[p]++
+		if isActive {
+			precActive[p]++
 		}
 	}
 
-	rows := make([]categoryRow, 0, len(counts))
+	rows := make([]bucketRow, 0, len(counts))
 	for name, count := range counts {
-		rows = append(rows, categoryRow{
+		rows = append(rows, bucketRow{
 			Name:      name,
 			RuleCount: count,
 			Active:    active[name],
@@ -192,14 +226,35 @@ func (s *Server) rulesCategories(_ rulesArgs) ToolResult {
 		return rows[i].Name < rows[j].Name
 	})
 
+	tierOrder := []api.Precision{
+		api.PrecisionPolicy,
+		api.PrecisionTypeAware,
+		api.PrecisionProjectStructure,
+		api.PrecisionASTBacked,
+		api.PrecisionHeuristicTextBacked,
+	}
+	precisions := make([]bucketRow, 0, len(tierOrder))
+	for _, p := range tierOrder {
+		if precCounts[p] == 0 {
+			continue
+		}
+		precisions = append(precisions, bucketRow{
+			Name:      p.String(),
+			RuleCount: precCounts[p],
+			Active:    precActive[p],
+		})
+	}
+
 	type categoriesResult struct {
-		Total      int           `json:"total"`
-		Categories []categoryRow `json:"categories"`
+		Total      int         `json:"total"`
+		Categories []bucketRow `json:"categories"`
+		Precisions []bucketRow `json:"precisions"`
 	}
 
 	return jsonResult(categoriesResult{
 		Total:      len(rows),
 		Categories: rows,
+		Precisions: precisions,
 	})
 }
 

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -115,11 +115,12 @@ func rulesToolDef() ToolDefinition {
 			"operation": jsonschema.StringEnum(rulesOperations,
 				"explain: rule metadata; search: full-text concept search; categories: rule counts per category; configure: krit.yml YAML").
 				WithDefault(opRulesExplain),
-			"rule":     jsonschema.String("Rule name (operation=explain/configure)"),
-			"query":    jsonschema.String("Free-text search query (operation=search)"),
-			"category": jsonschema.String("Filter to one category (operation=search)"),
-			"active":   jsonschema.Boolean("Override active flag (operation=configure)"),
-			"severity": jsonschema.StringEnum([]string{"error", "warning", "info"}, "Override severity (operation=configure)"),
+			"rule":      jsonschema.String("Rule name (operation=explain/configure)"),
+			"query":     jsonschema.String("Free-text search query (operation=search)"),
+			"category":  jsonschema.String("Filter to one category (operation=search)"),
+			"precision": jsonschema.StringEnum([]string{"heuristic/text-backed", "ast-backed", "project-structure-aware", "type-aware", "policy"}, "Filter by precision tier (operation=search)"),
+			"active":    jsonschema.Boolean("Override active flag (operation=configure)"),
+			"severity":  jsonschema.StringEnum([]string{"error", "warning", "info"}, "Override severity (operation=configure)"),
 		}),
 	}
 }

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/kaeawc/krit/internal/rules"
 	api "github.com/kaeawc/krit/internal/rules/api"
 	"github.com/kaeawc/krit/internal/scanner"
 )
@@ -136,7 +137,8 @@ type sarifRegion struct {
 }
 
 type sarifProperties struct {
-	Confidence float64 `json:"confidence"`
+	Confidence float64 `json:"confidence,omitempty"`
+	Precision  string  `json:"precision,omitempty"`
 }
 
 // FormatSARIFColumns writes columnar findings as SARIF 2.1.0 JSON.
@@ -145,11 +147,13 @@ func FormatSARIFColumns(w io.Writer, columns *scanner.FindingColumns, version st
 
 	// Build description map from rule registry.
 	descMap := make(map[string]string)
+	precisionMap := make(map[string]string)
 	for _, r := range api.Registry {
 		key := r.Category + "/" + r.ID
 		if r.Description != "" {
 			descMap[key] = r.Description
 		}
+		precisionMap[key] = rules.V2RulePrecision(r).String()
 	}
 
 	rulesSeen := make(map[string]bool)
@@ -189,8 +193,9 @@ func FormatSARIFColumns(w io.Writer, columns *scanner.FindingColumns, version st
 				},
 			}},
 		}
-		if confidence := cols.ConfidenceAt(row); confidence > 0 {
-			r.Properties = &sarifProperties{Confidence: confidence}
+		precision := precisionMap[ruleID]
+		if confidence := cols.ConfidenceAt(row); confidence > 0 || precision != "" {
+			r.Properties = &sarifProperties{Confidence: confidence, Precision: precision}
 		}
 		results = append(results, r)
 	})

--- a/internal/rules/api/fake.go
+++ b/internal/rules/api/fake.go
@@ -78,6 +78,11 @@ func WithMaturity(m Maturity) FakeOption {
 	return func(r *Rule) { r.Maturity = m }
 }
 
+// WithPrecision sets the rule's evidence tier override.
+func WithPrecision(p Precision) FakeOption {
+	return func(r *Rule) { r.Precision = p }
+}
+
 // FakeContext creates a minimal context for testing with the given file.
 // A FindingCollector is pre-allocated; use ContextFindings(ctx) to read results.
 func FakeContext(file *scanner.File) *Context {

--- a/internal/rules/api/metadata.go
+++ b/internal/rules/api/metadata.go
@@ -211,6 +211,12 @@ type RuleDescriptor struct {
 	// Confidence is the base confidence tier (0 = use family default).
 	Confidence float64
 
+	// Precision mirrors Rule.Precision — the rule's evidence tier
+	// (heuristic / AST-backed / project-structure / type-aware /
+	// policy). PrecisionUnset means MetaForRule should derive the tier
+	// from rule shape; otherwise this value is authoritative.
+	Precision Precision
+
 	// LanguageSupport records per-source-language support status for a rule.
 	// It is product/support metadata rather than dispatcher routing: Languages
 	// on Rule controls where a rule runs, while LanguageSupport explains whether

--- a/internal/rules/api/precision.go
+++ b/internal/rules/api/precision.go
@@ -1,0 +1,86 @@
+package api
+
+// Precision is a rule's evidence tier — the dominant signal class the
+// rule uses to draw conclusions. It is the single most useful
+// signal-to-noise axis: heuristic / text-backed rules tend to be the
+// noisiest, AST-backed and project-structure rules trade more context
+// for more precision, type-aware rules consume resolver/oracle facts,
+// and policy rules report opinions independent of source content.
+//
+// Values are ordered from noisiest to cleanest so callers can filter
+// with comparisons (e.g. "default-active should be Precision >= PrecisionASTBacked").
+// Zero (PrecisionUnset) means the rule has not declared a precision tier
+// and consumers should derive one — the dispatcher's V2RulePrecision
+// helper does this via Needs / NodeTypes / known overrides.
+type Precision uint8
+
+const (
+	// PrecisionUnset is the zero value. The rule has not declared an
+	// explicit tier; derive one from rule shape via V2RulePrecision.
+	PrecisionUnset Precision = iota
+	// PrecisionHeuristicTextBacked covers regex / lexical scanning rules
+	// without AST or type evidence. Highest noise tier.
+	PrecisionHeuristicTextBacked
+	// PrecisionASTBacked covers rules that base findings on tree-sitter
+	// AST structure for the current file.
+	PrecisionASTBacked
+	// PrecisionProjectStructure covers rules that consult project-wide
+	// indexes (cross-file, module graph, manifest, resources, Gradle).
+	PrecisionProjectStructure
+	// PrecisionTypeAware covers rules that consume resolver or oracle
+	// type information.
+	PrecisionTypeAware
+	// PrecisionPolicy covers rules that report opinions independent of
+	// the source under analysis (SDK version policy, version freshness).
+	PrecisionPolicy
+)
+
+// String returns the stable, kebab-cased label for the precision tier.
+// Used by CLI output, MCP responses, SARIF properties, and config docs.
+// The labels match the historical string-typed Precision values so
+// downstream consumers do not see a wire-format change.
+func (p Precision) String() string {
+	switch p {
+	case PrecisionHeuristicTextBacked:
+		return "heuristic/text-backed"
+	case PrecisionASTBacked:
+		return "ast-backed"
+	case PrecisionProjectStructure:
+		return "project-structure-aware"
+	case PrecisionTypeAware:
+		return "type-aware"
+	case PrecisionPolicy:
+		return "policy"
+	default:
+		return "unset"
+	}
+}
+
+// ParsePrecision returns the Precision matching the given label. The
+// labels accepted are exactly the canonical strings emitted by String(),
+// keeping the MCP schema enum and the parser in lockstep. Unknown labels
+// (and the empty string) return PrecisionUnset, false.
+func ParsePrecision(s string) (Precision, bool) {
+	switch s {
+	case "heuristic/text-backed":
+		return PrecisionHeuristicTextBacked, true
+	case "ast-backed":
+		return PrecisionASTBacked, true
+	case "project-structure-aware":
+		return PrecisionProjectStructure, true
+	case "type-aware":
+		return PrecisionTypeAware, true
+	case "policy":
+		return PrecisionPolicy, true
+	default:
+		return PrecisionUnset, false
+	}
+}
+
+// PrecisionProvider lets tests stub a precision value without
+// constructing a full Rule. The dispatcher and MetaForRule check for
+// this interface on Rule.Implementation before falling back to the
+// derived value.
+type PrecisionProvider interface {
+	Precision() Precision
+}

--- a/internal/rules/api/precision_test.go
+++ b/internal/rules/api/precision_test.go
@@ -1,0 +1,64 @@
+package api
+
+import "testing"
+
+func TestPrecisionString(t *testing.T) {
+	cases := []struct {
+		in   Precision
+		want string
+	}{
+		{PrecisionUnset, "unset"},
+		{PrecisionHeuristicTextBacked, "heuristic/text-backed"},
+		{PrecisionASTBacked, "ast-backed"},
+		{PrecisionProjectStructure, "project-structure-aware"},
+		{PrecisionTypeAware, "type-aware"},
+		{PrecisionPolicy, "policy"},
+	}
+	for _, c := range cases {
+		if got := c.in.String(); got != c.want {
+			t.Errorf("Precision(%d).String() = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestPrecisionOrdering(t *testing.T) {
+	// Values must be ordered noisiest -> cleanest so callers can filter
+	// with comparisons (e.g. >= PrecisionASTBacked).
+	ordered := []Precision{
+		PrecisionUnset,
+		PrecisionHeuristicTextBacked,
+		PrecisionASTBacked,
+		PrecisionProjectStructure,
+		PrecisionTypeAware,
+		PrecisionPolicy,
+	}
+	for i := 1; i < len(ordered); i++ {
+		if ordered[i-1] >= ordered[i] {
+			t.Fatalf("ordering broken at index %d: %v not before %v", i, ordered[i-1], ordered[i])
+		}
+	}
+}
+
+func TestParsePrecision(t *testing.T) {
+	cases := []struct {
+		in   string
+		want Precision
+		ok   bool
+	}{
+		{"heuristic/text-backed", PrecisionHeuristicTextBacked, true},
+		{"ast-backed", PrecisionASTBacked, true},
+		{"project-structure-aware", PrecisionProjectStructure, true},
+		{"type-aware", PrecisionTypeAware, true},
+		{"policy", PrecisionPolicy, true},
+		{"", PrecisionUnset, false},
+		{"bogus", PrecisionUnset, false},
+		{"heuristic", PrecisionUnset, false},
+		{"ast", PrecisionUnset, false},
+	}
+	for _, c := range cases {
+		got, ok := ParsePrecision(c.in)
+		if ok != c.ok || got != c.want {
+			t.Errorf("ParsePrecision(%q) = (%v, %v), want (%v, %v)", c.in, got, ok, c.want, c.ok)
+		}
+	}
+}

--- a/internal/rules/api/rule.go
+++ b/internal/rules/api/rule.go
@@ -686,6 +686,15 @@ type Rule struct {
 	// not declared a level.
 	Level RuleLevel
 
+	// Precision is the rule's evidence tier. When PrecisionUnset (the
+	// zero value), MetaForRule derives the tier from Needs / NodeTypes
+	// using V2RulePrecision. Rules may override when the derived value
+	// misclassifies them — for example, a rule keyed on AST shape but
+	// reporting a project policy decision can set PrecisionPolicy
+	// explicitly. The dispatcher does not key behavior on this field;
+	// it is filterable metadata for CLI, MCP, SARIF, and IDE consumers.
+	Precision Precision
+
 	// KotlincAnalog names the closest standard kotlinc diagnostic that
 	// this rule approximates, e.g. "UNREACHABLE_CODE". Informational
 	// only — krit is not bug-for-bug compatible with kotlinc. Empty

--- a/internal/rules/meta_lookup.go
+++ b/internal/rules/meta_lookup.go
@@ -95,7 +95,21 @@ func mergeRuleDescriptor(r *api.Rule, extra api.RuleDescriptor) api.RuleDescript
 	} else {
 		out.Tags = extra.Tags
 	}
+	out.Precision = resolvePrecision(r, extra)
 	return out
+}
+
+// resolvePrecision picks the tier returned in a descriptor. A
+// MetaProvider-supplied extra.Precision only wins when the rule itself
+// declared no explicit override; otherwise V2RulePrecision is the
+// single source of truth (it already honors Rule.Precision and
+// PrecisionProvider). V2RulePrecision never returns PrecisionUnset, so
+// MetaForRule always emits a populated tier.
+func resolvePrecision(r *api.Rule, extra api.RuleDescriptor) api.Precision {
+	if r.Precision == api.PrecisionUnset && extra.Precision != api.PrecisionUnset {
+		return extra.Precision
+	}
+	return V2RulePrecision(r)
 }
 
 func withRuleLanguageSupport(r *api.Rule, m api.RuleDescriptor) api.RuleDescriptor {
@@ -138,9 +152,26 @@ func HasV2Implementation(r *api.Rule) bool {
 }
 
 // V2RulePrecision returns the dominant precision class for a rule.
+//
+// Resolution order:
+//  1. Rule.Precision when set (non-zero) — the rule has overridden the
+//     derived tier.
+//  2. Rule.Implementation when it implements api.PrecisionProvider —
+//     lets tests stub a tier without touching the Rule literal.
+//  3. Derived from rule shape (Needs / NodeTypes / known override maps).
 func V2RulePrecision(r *api.Rule) Precision {
 	if r == nil {
 		return PrecisionHeuristicTextBacked
+	}
+	if r.Precision != PrecisionUnset {
+		return r.Precision
+	}
+	if r.Implementation != nil {
+		if pp, ok := r.Implementation.(api.PrecisionProvider); ok {
+			if p := pp.Precision(); p != PrecisionUnset {
+				return p
+			}
+		}
 	}
 	if policyRuleNames[r.ID] {
 		return PrecisionPolicy

--- a/internal/rules/precision.go
+++ b/internal/rules/precision.go
@@ -1,22 +1,34 @@
 package rules
 
-// Precision labels the dominant implementation model for a rule.
-type Precision string
+import api "github.com/kaeawc/krit/internal/rules/api"
+
+// Precision is re-exported from the api package so existing callers
+// (`rules.Precision`, `rules.PrecisionASTBacked`, …) keep compiling.
+// New code should reference api.Precision directly.
+type Precision = api.Precision
 
 const (
-	PrecisionASTBacked           Precision = "ast-backed"
-	PrecisionTypeAware           Precision = "type-aware"
-	PrecisionProjectStructure    Precision = "project-structure-aware"
-	PrecisionHeuristicTextBacked Precision = "heuristic/text-backed"
-	PrecisionPolicy              Precision = "policy"
+	PrecisionUnset               = api.PrecisionUnset
+	PrecisionASTBacked           = api.PrecisionASTBacked
+	PrecisionTypeAware           = api.PrecisionTypeAware
+	PrecisionProjectStructure    = api.PrecisionProjectStructure
+	PrecisionHeuristicTextBacked = api.PrecisionHeuristicTextBacked
+	PrecisionPolicy              = api.PrecisionPolicy
 )
 
+// policyRuleNames lists rules whose dominant signal is policy
+// (SDK version freshness, target-API recency) rather than source
+// content. These rules report opinions independent of code shape, so
+// the precision derivation tags them as PrecisionPolicy.
 var policyRuleNames = map[string]bool{
 	"OldTargetApi":          true,
 	"MinSdkTooLow":          true,
 	"NewerVersionAvailable": true,
 }
 
+// heuristicRuleNames lists rules whose dominant signal is lexical /
+// text-shaped rather than AST/type-aware. They are the noisiest tier
+// and surfaced separately from AST-backed rules.
 var heuristicRuleNames = map[string]bool{
 	"ArrayPrimitive":                   true,
 	"CouldBeSequence":                  true,

--- a/internal/rules/precision_override_test.go
+++ b/internal/rules/precision_override_test.go
@@ -1,0 +1,113 @@
+package rules
+
+import (
+	"testing"
+
+	api "github.com/kaeawc/krit/internal/rules/api"
+)
+
+// TestV2RulePrecision_Override verifies that an explicit Rule.Precision
+// wins over the derived classification.
+func TestV2RulePrecision_Override(t *testing.T) {
+	// Derived precision for a Needs-Resolver rule is PrecisionTypeAware;
+	// the explicit override should flip it to PrecisionPolicy.
+	r := &api.Rule{
+		ID:          "OverrideRule",
+		Category:    "test",
+		Description: "override test",
+		Sev:         api.SeverityWarning,
+		Needs:       api.NeedsResolver,
+		Check:       func(*api.Context) {},
+		Precision:   api.PrecisionPolicy,
+	}
+	if got := V2RulePrecision(r); got != api.PrecisionPolicy {
+		t.Fatalf("override ignored: V2RulePrecision = %q, want %q", got, api.PrecisionPolicy)
+	}
+
+	// Sanity: without the override, the same rule shape derives type-aware.
+	r.Precision = api.PrecisionUnset
+	if got := V2RulePrecision(r); got != api.PrecisionTypeAware {
+		t.Fatalf("derivation regressed: V2RulePrecision = %q, want %q", got, api.PrecisionTypeAware)
+	}
+}
+
+// stubPrecisionProvider exercises the PrecisionProvider fallback path.
+type stubPrecisionProvider struct{ p api.Precision }
+
+func (s stubPrecisionProvider) Precision() api.Precision { return s.p }
+
+// TestV2RulePrecision_ProviderFallback verifies a PrecisionProvider
+// implementation on Rule.Implementation is consulted before the
+// Needs/NodeTypes derivation.
+func TestV2RulePrecision_ProviderFallback(t *testing.T) {
+	r := &api.Rule{
+		ID:             "ProviderRule",
+		Category:       "test",
+		Description:    "provider test",
+		Sev:            api.SeverityWarning,
+		NodeTypes:      []string{"call_expression"},
+		Check:          func(*api.Context) {},
+		Implementation: stubPrecisionProvider{p: api.PrecisionPolicy},
+	}
+	if got := V2RulePrecision(r); got != api.PrecisionPolicy {
+		t.Fatalf("provider ignored: V2RulePrecision = %q, want %q", got, api.PrecisionPolicy)
+	}
+}
+
+// TestMetaForRule_PrecisionFallback verifies that MetaForRule emits the
+// derived tier when the rule has no explicit Precision set.
+func TestMetaForRule_PrecisionFallback(t *testing.T) {
+	r := &api.Rule{
+		ID:          "FallbackRule",
+		Category:    "test",
+		Description: "fallback test",
+		Sev:         api.SeverityWarning,
+		NodeTypes:   []string{"call_expression"},
+		Check:       func(*api.Context) {},
+	}
+	desc, ok := MetaForRule(r)
+	if !ok {
+		t.Fatal("MetaForRule returned ok=false")
+	}
+	if desc.Precision != api.PrecisionASTBacked {
+		t.Fatalf("fallback descriptor precision = %q, want %q",
+			desc.Precision, api.PrecisionASTBacked)
+	}
+}
+
+// TestMetaForRule_PrecisionExplicit verifies that an explicit
+// Rule.Precision is mirrored on the descriptor without re-deriving.
+func TestMetaForRule_PrecisionExplicit(t *testing.T) {
+	r := &api.Rule{
+		ID:          "ExplicitRule",
+		Category:    "test",
+		Description: "explicit test",
+		Sev:         api.SeverityWarning,
+		NodeTypes:   []string{"call_expression"},
+		Check:       func(*api.Context) {},
+		Precision:   api.PrecisionPolicy,
+	}
+	desc, ok := MetaForRule(r)
+	if !ok {
+		t.Fatal("MetaForRule returned ok=false")
+	}
+	if desc.Precision != api.PrecisionPolicy {
+		t.Fatalf("explicit descriptor precision = %q, want %q",
+			desc.Precision, api.PrecisionPolicy)
+	}
+}
+
+// TestMetaForRule_PrecisionAlwaysSet verifies that every registered
+// rule has a non-zero precision once MetaForRule has resolved it. This
+// is the no-zero-leakage invariant from the issue's evaluation criteria.
+func TestMetaForRule_PrecisionAlwaysSet(t *testing.T) {
+	for _, r := range api.Registry {
+		desc, ok := MetaForRule(r)
+		if !ok {
+			t.Fatalf("MetaForRule(%s) returned ok=false", r.ID)
+		}
+		if desc.Precision == api.PrecisionUnset {
+			t.Fatalf("rule %s: descriptor precision is PrecisionUnset", r.ID)
+		}
+	}
+}

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -17,6 +17,7 @@ type RuleMeta struct {
 	Active          bool // default active state
 	Fixable         bool
 	FixLevel        string // cosmetic/idiomatic/semantic or ""
+	Precision       string // heuristic/ast-backed/project-structure/type-aware/policy
 	LanguageSupport map[string]api.LanguageSupport
 	Options         []OptionMeta
 }
@@ -46,9 +47,11 @@ func CollectRuleMeta() []RuleMeta {
 
 		var opts []OptionMeta
 		var languageSupport map[string]api.LanguageSupport
+		precision := ""
 		if desc, ok := rules.MetaForRule(r); ok {
 			opts = descriptorOptions(desc)
 			languageSupport = copyLanguageSupport(desc.LanguageSupport)
+			precision = desc.Precision.String()
 		}
 
 		metas = append(metas, RuleMeta{
@@ -58,6 +61,7 @@ func CollectRuleMeta() []RuleMeta {
 			Active:          active,
 			Fixable:         fixable,
 			FixLevel:        fixLevel,
+			Precision:       precision,
 			LanguageSupport: languageSupport,
 			Options:         opts,
 		})
@@ -229,6 +233,9 @@ func ruleSchema(m RuleMeta) *jsonschema.Schema {
 	}
 	if m.Fixable {
 		desc += fmt.Sprintf(" [fixable: %s]", m.FixLevel)
+	}
+	if m.Precision != "" && m.Precision != "unset" {
+		desc += fmt.Sprintf(" [precision: %s]", m.Precision)
 	}
 
 	return jsonschema.Object(ruleProps).

--- a/schemas/krit-config.schema.json
+++ b/schemas/krit-config.schema.json
@@ -12,7 +12,7 @@
       "additionalProperties": false,
       "properties": {
         "AnimatorDurationIgnoresScale": {
-          "description": "Detects animator durations that ignore the system ANIMATOR_DURATION_SCALE accessibility setting.",
+          "description": "Detects animator durations that ignore the system ANIMATOR_DURATION_SCALE accessibility setting. [precision: type-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -31,7 +31,7 @@
           }
         },
         "ComposeClickableWithoutMinTouchTarget": {
-          "description": "Detects clickable Compose modifiers with explicit touch target dimensions below the 48dp minimum.",
+          "description": "Detects clickable Compose modifiers with explicit touch target dimensions below the 48dp minimum. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -50,7 +50,7 @@
           }
         },
         "ComposeDecorativeImageContentDescription": {
-          "description": "Detects decorative images with null contentDescription that are not hidden from TalkBack.",
+          "description": "Detects decorative images with null contentDescription that are not hidden from TalkBack. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -69,7 +69,7 @@
           }
         },
         "ComposeIconButtonMissingContentDescription": {
-          "description": "Detects Icon or IconButton composables missing a contentDescription for screen readers.",
+          "description": "Detects Icon or IconButton composables missing a contentDescription for screen readers. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -88,7 +88,7 @@
           }
         },
         "ComposeRawTextLiteral": {
-          "description": "Detects Compose Text() calls using hardcoded string literals instead of stringResource() for i18n.",
+          "description": "Detects Compose Text() calls using hardcoded string literals instead of stringResource() for i18n. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -119,7 +119,7 @@
           }
         },
         "ComposeSemanticsMissingRole": {
-          "description": "Detects interactive Compose modifiers (clickable, toggleable, selectable) without an explicit accessibility role.",
+          "description": "Detects interactive Compose modifiers (clickable, toggleable, selectable) without an explicit accessibility role. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -150,7 +150,7 @@
           }
         },
         "ComposeTextFieldMissingLabel": {
-          "description": "Detects TextField or OutlinedTextField composables missing a label parameter for accessibility.",
+          "description": "Detects TextField or OutlinedTextField composables missing a label parameter for accessibility. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -169,7 +169,7 @@
           }
         },
         "ToastForAccessibilityAnnouncement": {
-          "description": "Detects Toast.makeText used in accessibility-related functions instead of announceForAccessibility.",
+          "description": "Detects Toast.makeText used in accessibility-related functions instead of announceForAccessibility. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -200,7 +200,7 @@
       "additionalProperties": false,
       "properties": {
         "AccidentalOctal": {
-          "description": "Accidental octal interpretation",
+          "description": "Accidental octal interpretation [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -219,7 +219,7 @@
           }
         },
         "AdapterViewChildrenResource": {
-          "description": "AdapterView cannot have children in XML",
+          "description": "AdapterView cannot have children in XML [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -238,7 +238,7 @@
           }
         },
         "AddJavascriptInterface": {
-          "description": "addJavascriptInterface called",
+          "description": "addJavascriptInterface called [precision: type-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -257,7 +257,7 @@
           }
         },
         "AllowBackupManifest": {
-          "description": "Missing or true allowBackup attribute",
+          "description": "Missing or true allowBackup attribute [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -276,7 +276,7 @@
           }
         },
         "AlwaysShowActionResource": {
-          "description": "showAsAction=always can crowd the action bar",
+          "description": "showAsAction=always can crowd the action bar [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -295,7 +295,7 @@
           }
         },
         "AndroidGradlePluginVersion": {
-          "description": "AGP version too old",
+          "description": "AGP version too old [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -314,7 +314,7 @@
           }
         },
         "AppCompatMethod": {
-          "description": "Using Wrong AppCompat Method",
+          "description": "Using Wrong AppCompat Method [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -333,7 +333,7 @@
           }
         },
         "AppCompatResource": {
-          "description": "Using android:showAsAction instead of app:showAsAction",
+          "description": "Using android:showAsAction instead of app:showAsAction [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -352,7 +352,7 @@
           }
         },
         "AppIndexingErrorManifest": {
-          "description": "VIEW intent filter missing http/https data scheme",
+          "description": "VIEW intent filter missing http/https data scheme [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -371,7 +371,7 @@
           }
         },
         "AppIndexingWarningManifest": {
-          "description": "Browsable intent filter missing VIEW action",
+          "description": "Browsable intent filter missing VIEW action [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -390,7 +390,7 @@
           }
         },
         "Assert": {
-          "description": "Assertions are unreliable on Android",
+          "description": "Assertions are unreliable on Android [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -409,7 +409,7 @@
           }
         },
         "BackButtonResource": {
-          "description": "Explicit back button in layout",
+          "description": "Explicit back button in layout [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -428,7 +428,7 @@
           }
         },
         "BackupRules": {
-          "description": "Missing backup configuration",
+          "description": "Missing backup configuration [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -447,7 +447,7 @@
           }
         },
         "ButtonCaseResource": {
-          "description": "OK/Cancel button with wrong capitalization",
+          "description": "OK/Cancel button with wrong capitalization [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -466,7 +466,7 @@
           }
         },
         "ButtonOrderResource": {
-          "description": "Cancel button should appear before OK button",
+          "description": "Cancel button should appear before OK button [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -485,7 +485,7 @@
           }
         },
         "ButtonStyleResource": {
-          "description": "Dialog button without borderless style",
+          "description": "Dialog button without borderless style [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -504,7 +504,7 @@
           }
         },
         "ByteOrderMark": {
-          "description": "Byte order mark (BOM) found in file",
+          "description": "Byte order mark (BOM) found in file [precision: heuristic/text-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -523,7 +523,7 @@
           }
         },
         "CheckResult": {
-          "description": "Ignoring results",
+          "description": "Ignoring results [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -542,7 +542,7 @@
           }
         },
         "CleartextTraffic": {
-          "description": "usesCleartextTraffic enabled",
+          "description": "usesCleartextTraffic enabled [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -561,7 +561,7 @@
           }
         },
         "ClickableViewAccessibilityResource": {
-          "description": "Clickable view missing contentDescription",
+          "description": "Clickable view missing contentDescription [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -580,7 +580,7 @@
           }
         },
         "CommitPrefEdits": {
-          "description": "Missing commit() on SharedPreferences editor",
+          "description": "Missing commit() on SharedPreferences editor [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -599,7 +599,7 @@
           }
         },
         "CommitTransaction": {
-          "description": "Missing commit() on FragmentTransaction",
+          "description": "Missing commit() on FragmentTransaction [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -618,7 +618,7 @@
           }
         },
         "ContentDescription": {
-          "description": "Image without contentDescription",
+          "description": "Image without contentDescription [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -637,7 +637,7 @@
           }
         },
         "ConvertToWebp": {
-          "description": "Large PNG could be smaller as WebP",
+          "description": "Large PNG could be smaller as WebP [precision: heuristic/text-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -656,7 +656,7 @@
           }
         },
         "CustomViewStyleable": {
-          "description": "Mismatched Styleable/Custom View Name",
+          "description": "Mismatched Styleable/Custom View Name [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -675,7 +675,7 @@
           }
         },
         "CutPasteIdResource": {
-          "description": "Likely cut \u0026 paste mistakes",
+          "description": "Likely cut \u0026 paste mistakes [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -694,7 +694,7 @@
           }
         },
         "DebuggableManifest": {
-          "description": "Hardcoded value of android:debuggable in manifest",
+          "description": "Hardcoded value of android:debuggable in manifest [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -713,7 +713,7 @@
           }
         },
         "DefaultLocale": {
-          "description": "Implied default locale in case conversion",
+          "description": "Implied default locale in case conversion [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -732,7 +732,7 @@
           }
         },
         "Deprecated": {
-          "description": "Using deprecated API",
+          "description": "Using deprecated API [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -751,7 +751,7 @@
           }
         },
         "DeprecatedDependency": {
-          "description": "Deprecated library dependency",
+          "description": "Deprecated library dependency [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -770,7 +770,7 @@
           }
         },
         "DeviceAdminManifest": {
-          "description": "Malformed Device Admin",
+          "description": "Malformed Device Admin [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -789,7 +789,7 @@
           }
         },
         "DisableBaselineAlignmentResource": {
-          "description": "Missing baselineAligned=false on weighted LinearLayout",
+          "description": "Missing baselineAligned=false on weighted LinearLayout [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -808,7 +808,7 @@
           }
         },
         "DrawAllocation": {
-          "description": "Memory allocations within drawing code",
+          "description": "Memory allocations within drawing code [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -827,7 +827,7 @@
           }
         },
         "DuplicateActivityManifest": {
-          "description": "Activity registered more than once",
+          "description": "Activity registered more than once [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -846,7 +846,7 @@
           }
         },
         "DuplicateIdsResource": {
-          "description": "Duplicate android:id in layout",
+          "description": "Duplicate android:id in layout [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -865,7 +865,7 @@
           }
         },
         "DuplicateIncludedIdsResource": {
-          "description": "Duplicate ids across included layouts",
+          "description": "Duplicate ids across included layouts [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -884,7 +884,7 @@
           }
         },
         "DuplicateUsesFeatureManifest": {
-          "description": "Duplicate \u003cuses-feature\u003e declaration",
+          "description": "Duplicate \u003cuses-feature\u003e declaration [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -903,7 +903,7 @@
           }
         },
         "DynamicVersion": {
-          "description": "Dynamic dependency version with partial wildcard",
+          "description": "Dynamic dependency version with partial wildcard [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -922,7 +922,7 @@
           }
         },
         "EasterEgg": {
-          "description": "Code contains easter egg references",
+          "description": "Code contains easter egg references [precision: heuristic/text-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -941,7 +941,7 @@
           }
         },
         "ExportedContentProvider": {
-          "description": "Exported content provider does not require permission",
+          "description": "Exported content provider does not require permission [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -960,7 +960,7 @@
           }
         },
         "ExportedPreferenceActivityManifest": {
-          "description": "Exported PreferenceActivity is vulnerable to fragment injection",
+          "description": "Exported PreferenceActivity is vulnerable to fragment injection [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -979,7 +979,7 @@
           }
         },
         "ExportedReceiver": {
-          "description": "Exported receiver does not require permission",
+          "description": "Exported receiver does not require permission [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -998,7 +998,7 @@
           }
         },
         "ExportedService": {
-          "description": "Exported service does not require permission",
+          "description": "Exported service does not require permission [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -1017,7 +1017,7 @@
           }
         },
         "ExportedServiceManifest": {
-          "description": "Exported service without required permission",
+          "description": "Exported service without required permission [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -1036,7 +1036,7 @@
           }
         },
         "ExportedWithoutPermission": {
-          "description": "Exported component without required permission",
+          "description": "Exported component without required permission [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -1055,7 +1055,7 @@
           }
         },
         "ExtraTextResource": {
-          "description": "Extraneous text in resource files",
+          "description": "Extraneous text in resource files [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -1074,7 +1074,7 @@
           }
         },
         "FieldGetter": {
-          "description": "Using getter instead of field access",
+          "description": "Using getter instead of field access [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -1093,7 +1093,7 @@
           }
         },
         "FloatMath": {
-          "description": "Using FloatMath instead of Math",
+          "description": "Using FloatMath instead of Math [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -1112,7 +1112,7 @@
           }
         },
         "FragmentConstructor": {
-          "description": "Fragment not instantiatable",
+          "description": "Fragment not instantiatable [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -1131,7 +1131,7 @@
           }
         },
         "FullBackupContentManifest": {
-          "description": "Invalid fullBackupContent or dataExtractionRules",
+          "description": "Invalid fullBackupContent or dataExtractionRules [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -1150,7 +1150,7 @@
           }
         },
         "GetInstance": {
-          "description": "Cipher.getInstance with insecure algorithm",
+          "description": "Cipher.getInstance with insecure algorithm [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -1169,7 +1169,7 @@
           }
         },
         "GetSignatures": {
-          "description": "Using deprecated GET_SIGNATURES",
+          "description": "Using deprecated GET_SIGNATURES [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -1188,7 +1188,7 @@
           }
         },
         "GifUsage": {
-          "description": "GIF file in resources",
+          "description": "GIF file in resources [precision: heuristic/text-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -1207,7 +1207,7 @@
           }
         },
         "GoogleAppIndexingDeepLinkErrorManifest": {
-          "description": "Deep link data element with scheme but no host",
+          "description": "Deep link data element with scheme but no host [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -1226,7 +1226,7 @@
           }
         },
         "GoogleAppIndexingWarningManifest": {
-          "description": "No activity with deep link support",
+          "description": "No activity with deep link support [precision: heuristic/text-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -1245,7 +1245,7 @@
           }
         },
         "GradleCompatible": {
-          "description": "Incompatible Gradle versions",
+          "description": "Incompatible Gradle versions [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -1264,7 +1264,7 @@
           }
         },
         "GradleDependency": {
-          "description": "Obsolete Gradle dependency",
+          "description": "Obsolete Gradle dependency [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -1289,7 +1289,7 @@
           }
         },
         "GradleDeprecated": {
-          "description": "Deprecated Gradle construct",
+          "description": "Deprecated Gradle construct [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -1308,7 +1308,7 @@
           }
         },
         "GradleDynamicVersion": {
-          "description": "Gradle dynamic version",
+          "description": "Gradle dynamic version [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -1327,7 +1327,7 @@
           }
         },
         "GradleGetter": {
-          "description": "Gradle implicit getter call",
+          "description": "Gradle implicit getter call [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -1346,7 +1346,7 @@
           }
         },
         "GradleIdeError": {
-          "description": "Gradle IDE Support Issues",
+          "description": "Gradle IDE Support Issues [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -1365,7 +1365,7 @@
           }
         },
         "GradleOverrides": {
-          "description": "Value overridden by Gradle build script",
+          "description": "Value overridden by Gradle build script [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -1384,7 +1384,7 @@
           }
         },
         "GradleOverridesManifest": {
-          "description": "SDK version in manifest overridden by Gradle",
+          "description": "SDK version in manifest overridden by Gradle [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -1403,7 +1403,7 @@
           }
         },
         "GradlePath": {
-          "description": "Gradle path issues",
+          "description": "Gradle path issues [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -1422,7 +1422,7 @@
           }
         },
         "GradlePluginCompatibility": {
-          "description": "AGP version incompatible with Gradle version",
+          "description": "AGP version incompatible with Gradle version [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -1441,7 +1441,7 @@
           }
         },
         "GrantAllUris": {
-          "description": "Overly broad URI permissions",
+          "description": "Overly broad URI permissions [precision: type-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -1460,7 +1460,7 @@
           }
         },
         "GridLayout": {
-          "description": "GridLayout without columnCount",
+          "description": "GridLayout without columnCount [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -1479,7 +1479,7 @@
           }
         },
         "HandlerLeak": {
-          "description": "Handler reference leaks",
+          "description": "Handler reference leaks [precision: type-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -1498,7 +1498,7 @@
           }
         },
         "HardcodedText": {
-          "description": "Hardcoded text",
+          "description": "Hardcoded text [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -1517,7 +1517,7 @@
           }
         },
         "HardcodedValuesResource": {
-          "description": "Hardcoded text in layout XML",
+          "description": "Hardcoded text in layout XML [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -1536,7 +1536,7 @@
           }
         },
         "IconColors": {
-          "description": "Icon colors do not follow the recommended visual style",
+          "description": "Icon colors do not follow the recommended visual style [precision: heuristic/text-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -1555,7 +1555,7 @@
           }
         },
         "IconDensities": {
-          "description": "Missing density variants for icon",
+          "description": "Missing density variants for icon [precision: heuristic/text-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -1574,7 +1574,7 @@
           }
         },
         "IconDipSize": {
-          "description": "Icon dimensions don't match expected DPI ratios",
+          "description": "Icon dimensions don't match expected DPI ratios [precision: heuristic/text-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -1593,7 +1593,7 @@
           }
         },
         "IconDuplicates": {
-          "description": "Same image across densities without scaling",
+          "description": "Same image across densities without scaling [precision: heuristic/text-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -1612,7 +1612,7 @@
           }
         },
         "IconDuplicatesConfig": {
-          "description": "Identical icons across configuration folders",
+          "description": "Identical icons across configuration folders [precision: heuristic/text-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -1631,7 +1631,7 @@
           }
         },
         "IconExpectedSize": {
-          "description": "Launcher icon not at expected size",
+          "description": "Launcher icon not at expected size [precision: heuristic/text-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -1650,7 +1650,7 @@
           }
         },
         "IconExtension": {
-          "description": "Icon format does not match the file extension",
+          "description": "Icon format does not match the file extension [precision: heuristic/text-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -1669,7 +1669,7 @@
           }
         },
         "IconLauncherShape": {
-          "description": "Launcher icon has transparent corners",
+          "description": "Launcher icon has transparent corners [precision: heuristic/text-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -1688,7 +1688,7 @@
           }
         },
         "IconLocation": {
-          "description": "Image defined in density-independent drawable folder",
+          "description": "Image defined in density-independent drawable folder [precision: heuristic/text-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -1707,7 +1707,7 @@
           }
         },
         "IconMissingDensityFolder": {
-          "description": "Missing density folder",
+          "description": "Missing density folder [precision: heuristic/text-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -1726,7 +1726,7 @@
           }
         },
         "IconMixedNinePatch": {
-          "description": "Clashing PNG and 9-PNG files",
+          "description": "Clashing PNG and 9-PNG files [precision: heuristic/text-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -1745,7 +1745,7 @@
           }
         },
         "IconNoDpi": {
-          "description": "Icon in both nodpi and density-specific folder",
+          "description": "Icon in both nodpi and density-specific folder [precision: heuristic/text-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -1764,7 +1764,7 @@
           }
         },
         "IconXmlAndPng": {
-          "description": "Icon is specified both as .xml file and as a bitmap",
+          "description": "Icon is specified both as .xml file and as a bitmap [precision: heuristic/text-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -1783,7 +1783,7 @@
           }
         },
         "IllegalResourceRefResource": {
-          "description": "Name is not a valid resource reference format",
+          "description": "Name is not a valid resource reference format [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -1802,7 +1802,7 @@
           }
         },
         "ImpliedQuantityResource": {
-          "description": "Plural 'one' without %d placeholder",
+          "description": "Plural 'one' without %d placeholder [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -1821,7 +1821,7 @@
           }
         },
         "InOrMmUsageResource": {
-          "description": "Using in or mm dimension units",
+          "description": "Using in or mm dimension units [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -1840,7 +1840,7 @@
           }
         },
         "IncludeLayoutParamResource": {
-          "description": "\u003cinclude\u003e with layout_width/height is ignored",
+          "description": "\u003cinclude\u003e with layout_width/height is ignored [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -1859,7 +1859,7 @@
           }
         },
         "InconsistentArraysResource": {
-          "description": "Inconsistencies in array element counts",
+          "description": "Inconsistencies in array element counts [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -1878,7 +1878,7 @@
           }
         },
         "InconsistentLayout": {
-          "description": "Inconsistent layouts in different configurations",
+          "description": "Inconsistent layouts in different configurations [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -1897,7 +1897,7 @@
           }
         },
         "InefficientWeightResource": {
-          "description": "LinearLayout with weights missing orientation",
+          "description": "LinearLayout with weights missing orientation [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -1916,7 +1916,7 @@
           }
         },
         "InlinedApi": {
-          "description": "Using inlined constants from newer API",
+          "description": "Using inlined constants from newer API [precision: type-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -1935,7 +1935,7 @@
           }
         },
         "InnerclassSeparator": {
-          "description": "Inner classes should use '$' not '/'",
+          "description": "Inner classes should use '$' not '/' [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -1954,7 +1954,7 @@
           }
         },
         "InsecureBaseConfigurationManifest": {
-          "description": "Missing networkSecurityConfig on API 28+",
+          "description": "Missing networkSecurityConfig on API 28+ [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -1973,7 +1973,7 @@
           }
         },
         "Instantiatable": {
-          "description": "Registered class not instantiatable",
+          "description": "Registered class not instantiatable [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -1992,7 +1992,7 @@
           }
         },
         "IntentFilterExportRequired": {
-          "description": "Component with intent-filter missing android:exported (API 31+)",
+          "description": "Component with intent-filter missing android:exported (API 31+) [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -2011,7 +2011,7 @@
           }
         },
         "InvalidIdResource": {
-          "description": "Malformed android:id value",
+          "description": "Malformed android:id value [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -2030,7 +2030,7 @@
           }
         },
         "InvalidResourceFolderResource": {
-          "description": "Invalid resource folder name",
+          "description": "Invalid resource folder name [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -2049,7 +2049,7 @@
           }
         },
         "InvalidUsesTagAttributeManifest": {
-          "description": "Invalid android:required value on \u003cuses-feature\u003e",
+          "description": "Invalid android:required value on \u003cuses-feature\u003e [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -2068,7 +2068,7 @@
           }
         },
         "LabelForResource": {
-          "description": "EditText without a corresponding labelFor",
+          "description": "EditText without a corresponding labelFor [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -2087,7 +2087,7 @@
           }
         },
         "LayoutAutofillHintMismatch": {
-          "description": "inputType without matching autofillHints",
+          "description": "inputType without matching autofillHints [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -2106,7 +2106,7 @@
           }
         },
         "LayoutClickableWithoutMinSize": {
-          "description": "Clickable view below 48dp",
+          "description": "Clickable view below 48dp [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -2125,7 +2125,7 @@
           }
         },
         "LayoutEditTextMissingImportance": {
-          "description": "EditText missing importantForAutofill",
+          "description": "EditText missing importantForAutofill [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -2144,7 +2144,7 @@
           }
         },
         "LayoutImportantForAccessibilityNo": {
-          "description": "Interactive view hidden from accessibility",
+          "description": "Interactive view hidden from accessibility [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -2163,7 +2163,7 @@
           }
         },
         "LayoutInflation": {
-          "description": "Layout inflation without parent",
+          "description": "Layout inflation without parent [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -2182,7 +2182,7 @@
           }
         },
         "LayoutMinTouchTargetInButtonRow": {
-          "description": "Button in row without 48dp min height",
+          "description": "Button in row without 48dp min height [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -2201,7 +2201,7 @@
           }
         },
         "LibraryCustomView": {
-          "description": "Custom view using hardcoded namespace",
+          "description": "Custom view using hardcoded namespace [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -2220,7 +2220,7 @@
           }
         },
         "LocalSuppress": {
-          "description": "@SuppressLint misuse",
+          "description": "@SuppressLint misuse [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -2239,7 +2239,7 @@
           }
         },
         "LocaleConfigMissing": {
-          "description": "android:localeConfig points at a missing XML resource",
+          "description": "android:localeConfig points at a missing XML resource [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -2258,7 +2258,7 @@
           }
         },
         "LocaleConfigStale": {
-          "description": "locales_config.xml is out of sync with locale-specific values folders",
+          "description": "locales_config.xml is out of sync with locale-specific values folders [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -2277,7 +2277,7 @@
           }
         },
         "LocaleFolder": {
-          "description": "Wrong locale folder naming",
+          "description": "Wrong locale folder naming [precision: heuristic/text-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -2296,7 +2296,7 @@
           }
         },
         "LogConditional": {
-          "description": "Unconditional logging calls",
+          "description": "Unconditional logging calls [precision: type-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -2315,7 +2315,7 @@
           }
         },
         "LogTagMismatch": {
-          "description": "Mismatched Log tag",
+          "description": "Mismatched Log tag [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -2334,7 +2334,7 @@
           }
         },
         "LongLogTag": {
-          "description": "Log tag exceeds 23 characters",
+          "description": "Log tag exceeds 23 characters [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -2353,7 +2353,7 @@
           }
         },
         "MangledCRLF": {
-          "description": "Mixed line endings in file",
+          "description": "Mixed line endings in file [precision: heuristic/text-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -2372,7 +2372,7 @@
           }
         },
         "ManifestOrderManifest": {
-          "description": "\u003capplication\u003e appears before \u003cuses-permission\u003e or \u003cuses-sdk\u003e",
+          "description": "\u003capplication\u003e appears before \u003cuses-permission\u003e or \u003cuses-sdk\u003e [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -2391,7 +2391,7 @@
           }
         },
         "ManifestTypoManifest": {
-          "description": "Typos in manifest element tags",
+          "description": "Typos in manifest element tags [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -2410,7 +2410,7 @@
           }
         },
         "MavenLocal": {
-          "description": "mavenLocal() causes unreproducible builds",
+          "description": "mavenLocal() causes unreproducible builds [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -2429,7 +2429,7 @@
           }
         },
         "MergeRootFrameResource": {
-          "description": "Root FrameLayout replaceable with merge tag",
+          "description": "Root FrameLayout replaceable with merge tag [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -2448,7 +2448,7 @@
           }
         },
         "MinSdkTooLow": {
-          "description": "minSdkVersion below recommended minimum",
+          "description": "minSdkVersion below recommended minimum [precision: policy]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -2471,7 +2471,7 @@
           }
         },
         "MipmapLauncher": {
-          "description": "Launcher icon should use @mipmap/ not @drawable/",
+          "description": "Launcher icon should use @mipmap/ not @drawable/ [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -2490,7 +2490,7 @@
           }
         },
         "MissingApplicationIconManifest": {
-          "description": "Missing android:icon on \u003capplication\u003e",
+          "description": "Missing android:icon on \u003capplication\u003e [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -2509,7 +2509,7 @@
           }
         },
         "MissingContentDescriptionResource": {
-          "description": "Image without contentDescription",
+          "description": "Image without contentDescription [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -2528,7 +2528,7 @@
           }
         },
         "MissingExportedFlag": {
-          "description": "Component with intent-filter missing android:exported (API 31+)",
+          "description": "Component with intent-filter missing android:exported (API 31+) [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -2547,7 +2547,7 @@
           }
         },
         "MissingIdResource": {
-          "description": "Fragments should specify an id or tag",
+          "description": "Fragments should specify an id or tag [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -2566,7 +2566,7 @@
           }
         },
         "MissingLeanbackLauncherManifest": {
-          "description": "Leanback feature without LEANBACK_LAUNCHER activity",
+          "description": "Leanback feature without LEANBACK_LAUNCHER activity [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -2585,7 +2585,7 @@
           }
         },
         "MissingLeanbackSupportManifest": {
-          "description": "Leanback feature without touchscreen opt-out",
+          "description": "Leanback feature without touchscreen opt-out [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -2604,7 +2604,7 @@
           }
         },
         "MissingPermission": {
-          "description": "Missing permission check before API call",
+          "description": "Missing permission check before API call [precision: type-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -2623,7 +2623,7 @@
           }
         },
         "MissingPrefixResource": {
-          "description": "Attribute missing android: namespace prefix",
+          "description": "Attribute missing android: namespace prefix [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -2642,7 +2642,7 @@
           }
         },
         "MissingQuantityResource": {
-          "description": "Plural missing required quantity",
+          "description": "Plural missing required quantity [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -2661,7 +2661,7 @@
           }
         },
         "MissingRegisteredManifest": {
-          "description": "Missing registered class",
+          "description": "Missing registered class [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -2680,7 +2680,7 @@
           }
         },
         "MissingVersionManifest": {
-          "description": "Missing versionCode or versionName on \u003cmanifest\u003e",
+          "description": "Missing versionCode or versionName on \u003cmanifest\u003e [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -2699,7 +2699,7 @@
           }
         },
         "MockLocationManifest": {
-          "description": "ACCESS_MOCK_LOCATION in non-debug manifest",
+          "description": "ACCESS_MOCK_LOCATION in non-debug manifest [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -2718,7 +2718,7 @@
           }
         },
         "MultipleUsesSdkManifest": {
-          "description": "More than one \u003cuses-sdk\u003e element",
+          "description": "More than one \u003cuses-sdk\u003e element [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -2737,7 +2737,7 @@
           }
         },
         "NamespaceTypoResource": {
-          "description": "Misspelled namespace URI",
+          "description": "Misspelled namespace URI [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -2756,7 +2756,7 @@
           }
         },
         "NegativeMarginResource": {
-          "description": "Negative margin value",
+          "description": "Negative margin value [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -2782,7 +2782,7 @@
           }
         },
         "NestedScrolling": {
-          "description": "Nested scrolling widgets",
+          "description": "Nested scrolling widgets [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -2801,7 +2801,7 @@
           }
         },
         "NestedScrollingResource": {
-          "description": "ScrollView inside ScrollView",
+          "description": "ScrollView inside ScrollView [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -2820,7 +2820,7 @@
           }
         },
         "NestedWeightsResource": {
-          "description": "Nested layout_weight causes exponential measure passes",
+          "description": "Nested layout_weight causes exponential measure passes [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -2839,7 +2839,7 @@
           }
         },
         "NewApi": {
-          "description": "Calling new APIs on older versions",
+          "description": "Calling new APIs on older versions [precision: type-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -2858,7 +2858,7 @@
           }
         },
         "NewerVersionAvailable": {
-          "description": "Newer library version available",
+          "description": "Newer library version available [precision: policy]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -2883,7 +2883,7 @@
           }
         },
         "NfcTechWhitespace": {
-          "description": "Whitespace in NFC tech-list",
+          "description": "Whitespace in NFC tech-list [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -2902,7 +2902,7 @@
           }
         },
         "NonInternationalizedSms": {
-          "description": "SMS with non-i18n considerations",
+          "description": "SMS with non-i18n considerations [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -2921,7 +2921,7 @@
           }
         },
         "NotSiblingResource": {
-          "description": "RelativeLayout Invalid Constraints",
+          "description": "RelativeLayout Invalid Constraints [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -2940,7 +2940,7 @@
           }
         },
         "ObjectAnimatorBinding": {
-          "description": "Incorrect ObjectAnimator Property",
+          "description": "Incorrect ObjectAnimator Property [precision: type-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -2959,7 +2959,7 @@
           }
         },
         "ObsoleteLayoutParam": {
-          "description": "Obsolete layout params",
+          "description": "Obsolete layout params [precision: type-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -2978,7 +2978,7 @@
           }
         },
         "ObsoleteLayoutParamsResource": {
-          "description": "layout_weight on non-LinearLayout child",
+          "description": "layout_weight on non-LinearLayout child [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -2997,7 +2997,7 @@
           }
         },
         "OldTargetApi": {
-          "description": "targetSdkVersion below recommended minimum",
+          "description": "targetSdkVersion below recommended minimum [precision: policy]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -3020,7 +3020,7 @@
           }
         },
         "OnClick": {
-          "description": "android:onClick handler missing or has wrong signature",
+          "description": "android:onClick handler missing or has wrong signature [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -3039,7 +3039,7 @@
           }
         },
         "OnClickResource": {
-          "description": "android:onClick in layout XML is discouraged",
+          "description": "android:onClick in layout XML is discouraged [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -3058,7 +3058,7 @@
           }
         },
         "OrientationResource": {
-          "description": "LinearLayout missing explicit orientation",
+          "description": "LinearLayout missing explicit orientation [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -3077,7 +3077,7 @@
           }
         },
         "OverdrawResource": {
-          "description": "Root and child layout both have background (overdraw)",
+          "description": "Root and child layout both have background (overdraw) [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -3096,7 +3096,7 @@
           }
         },
         "Override": {
-          "description": "Method override errors",
+          "description": "Method override errors [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -3115,7 +3115,7 @@
           }
         },
         "OverrideAbstract": {
-          "description": "Missing abstract method overrides",
+          "description": "Missing abstract method overrides [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -3134,7 +3134,7 @@
           }
         },
         "PackagedPrivateKey": {
-          "description": "Packaged private key",
+          "description": "Packaged private key [precision: heuristic/text-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -3153,7 +3153,7 @@
           }
         },
         "ParcelCreator": {
-          "description": "Missing Parcelable CREATOR field",
+          "description": "Missing Parcelable CREATOR field [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -3172,7 +3172,7 @@
           }
         },
         "PermissionImpliesUnsupportedHardwareManifest": {
-          "description": "Permission implies hardware feature not declared optional",
+          "description": "Permission implies hardware feature not declared optional [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -3191,7 +3191,7 @@
           }
         },
         "PluralsCandidate": {
-          "description": "Potential plurals",
+          "description": "Potential plurals [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -3210,7 +3210,7 @@
           }
         },
         "Proguard": {
-          "description": "Obsolete proguard.cfg reference",
+          "description": "Obsolete proguard.cfg reference [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -3229,7 +3229,7 @@
           }
         },
         "ProguardSplit": {
-          "description": "Proguard config should be split",
+          "description": "Proguard config should be split [precision: heuristic/text-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -3248,7 +3248,7 @@
           }
         },
         "PropertyEscape": {
-          "description": "Invalid property file escapes",
+          "description": "Invalid property file escapes [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -3267,7 +3267,7 @@
           }
         },
         "ProtectedPermissionsManifest": {
-          "description": "Using system app permission",
+          "description": "Using system app permission [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -3286,7 +3286,7 @@
           }
         },
         "PxUsageResource": {
-          "description": "Using px instead of dp in dimensions",
+          "description": "Using px instead of dp in dimensions [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -3305,7 +3305,7 @@
           }
         },
         "Range": {
-          "description": "Outside allowed range",
+          "description": "Outside allowed range [precision: type-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -3324,7 +3324,7 @@
           }
         },
         "Recycle": {
-          "description": "Missing recycle() calls",
+          "description": "Missing recycle() calls [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -3343,7 +3343,7 @@
           }
         },
         "Registered": {
-          "description": "Class is not registered in the manifest",
+          "description": "Class is not registered in the manifest [precision: type-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -3362,7 +3362,7 @@
           }
         },
         "RelativeOverlapResource": {
-          "description": "Views in RelativeLayout may overlap",
+          "description": "Views in RelativeLayout may overlap [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -3381,7 +3381,7 @@
           }
         },
         "RemoteVersion": {
-          "description": "Non-deterministic dependency version (+ or latest)",
+          "description": "Non-deterministic dependency version (+ or latest) [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -3400,7 +3400,7 @@
           }
         },
         "RequiredSizeResource": {
-          "description": "View missing layout_width or layout_height",
+          "description": "View missing layout_width or layout_height [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -3419,7 +3419,7 @@
           }
         },
         "RequiresApiViolation": {
-          "description": "Calling an API above the module's minSdk",
+          "description": "Calling an API above the module's minSdk [precision: type-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -3438,7 +3438,7 @@
           }
         },
         "ResAutoResource": {
-          "description": "Namespace used in resource files should be res-auto",
+          "description": "Namespace used in resource files should be res-auto [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -3457,7 +3457,7 @@
           }
         },
         "ResourceAsColor": {
-          "description": "Should pass resolved color instead of resource id",
+          "description": "Should pass resolved color instead of resource id [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -3476,7 +3476,7 @@
           }
         },
         "ResourceName": {
-          "description": "Resource name not in snake_case",
+          "description": "Resource name not in snake_case [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -3495,7 +3495,7 @@
           }
         },
         "ResourceType": {
-          "description": "Wrong resource type",
+          "description": "Wrong resource type [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -3514,7 +3514,7 @@
           }
         },
         "RtlAware": {
-          "description": "Using non-RTL-aware View methods",
+          "description": "Using non-RTL-aware View methods [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -3533,7 +3533,7 @@
           }
         },
         "RtlCompatManifest": {
-          "description": "Missing supportsRtl with targetSdkVersion \u003e= 17",
+          "description": "Missing supportsRtl with targetSdkVersion \u003e= 17 [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -3552,7 +3552,7 @@
           }
         },
         "RtlEnabledManifest": {
-          "description": "Missing supportsRtl=true on \u003capplication\u003e",
+          "description": "Missing supportsRtl=true on \u003capplication\u003e [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -3571,7 +3571,7 @@
           }
         },
         "RtlFieldAccess": {
-          "description": "Direct field access of non-RTL-aware View fields",
+          "description": "Direct field access of non-RTL-aware View fields [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -3590,7 +3590,7 @@
           }
         },
         "RtlHardcodedResource": {
-          "description": "Using left/right instead of start/end for RTL",
+          "description": "Using left/right instead of start/end for RTL [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -3609,7 +3609,7 @@
           }
         },
         "RtlSuperscriptResource": {
-          "description": "Superscript/subscript may break in RTL",
+          "description": "Superscript/subscript may break in RTL [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -3628,7 +3628,7 @@
           }
         },
         "RtlSymmetryResource": {
-          "description": "Asymmetric padding or margin (Left without Right or vice versa)",
+          "description": "Asymmetric padding or margin (Left without Right or vice versa) [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -3647,7 +3647,7 @@
           }
         },
         "SQLiteString": {
-          "description": "Using STRING instead of TEXT in SQLite",
+          "description": "Using STRING instead of TEXT in SQLite [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -3666,7 +3666,7 @@
           }
         },
         "ScrollViewCount": {
-          "description": "ScrollViews can have only one child",
+          "description": "ScrollViews can have only one child [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -3685,7 +3685,7 @@
           }
         },
         "ScrollViewCountResource": {
-          "description": "ScrollView with more than one child",
+          "description": "ScrollView with more than one child [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -3704,7 +3704,7 @@
           }
         },
         "ScrollViewSizeResource": {
-          "description": "ScrollView size validation",
+          "description": "ScrollView size validation [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -3723,7 +3723,7 @@
           }
         },
         "SdCardPath": {
-          "description": "Hardcoded reference to /sdcard",
+          "description": "Hardcoded reference to /sdcard [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -3742,7 +3742,7 @@
           }
         },
         "SecureRandom": {
-          "description": "Insecure random source or deterministic SecureRandom seed",
+          "description": "Insecure random source or deterministic SecureRandom seed [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -3761,7 +3761,7 @@
           }
         },
         "ServiceCast": {
-          "description": "Wrong system service cast",
+          "description": "Wrong system service cast [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -3780,7 +3780,7 @@
           }
         },
         "ServiceExportedManifest": {
-          "description": "Exported service does not require permission",
+          "description": "Exported service does not require permission [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -3799,7 +3799,7 @@
           }
         },
         "SetJavaScriptEnabled": {
-          "description": "Using setJavaScriptEnabled",
+          "description": "Using setJavaScriptEnabled [precision: type-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -3818,7 +3818,7 @@
           }
         },
         "SetTextI18n": {
-          "description": "TextView with internationalization issues",
+          "description": "TextView with internationalization issues [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -3837,7 +3837,7 @@
           }
         },
         "ShiftFlags": {
-          "description": "Suspicious flag constant declarations",
+          "description": "Suspicious flag constant declarations [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -3856,7 +3856,7 @@
           }
         },
         "ShortAlarm": {
-          "description": "Short or frequent alarm",
+          "description": "Short or frequent alarm [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -3875,7 +3875,7 @@
           }
         },
         "ShowToast": {
-          "description": "Toast created but not shown",
+          "description": "Toast created but not shown [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -3894,7 +3894,7 @@
           }
         },
         "SimpleDateFormat": {
-          "description": "Using SimpleDateFormat directly without Locale",
+          "description": "Using SimpleDateFormat directly without Locale [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -3913,7 +3913,7 @@
           }
         },
         "SmallSpResource": {
-          "description": "Text size below 12sp",
+          "description": "Text size below 12sp [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -3932,7 +3932,7 @@
           }
         },
         "SpUsageResource": {
-          "description": "Using dp instead of sp for textSize",
+          "description": "Using dp instead of sp for textSize [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -3951,7 +3951,7 @@
           }
         },
         "StateListReachableResource": {
-          "description": "Unreachable item in selector drawable",
+          "description": "Unreachable item in selector drawable [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -3970,7 +3970,7 @@
           }
         },
         "StopShip": {
-          "description": "STOPSHIP comment found",
+          "description": "STOPSHIP comment found [precision: heuristic/text-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -3989,7 +3989,7 @@
           }
         },
         "StringFormatCountResource": {
-          "description": "Formatting argument types incomplete or inconsistent",
+          "description": "Formatting argument types incomplete or inconsistent [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -4008,7 +4008,7 @@
           }
         },
         "StringFormatInvalidResource": {
-          "description": "Invalid format string",
+          "description": "Invalid format string [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -4027,7 +4027,7 @@
           }
         },
         "StringFormatMatchesResource": {
-          "description": "String.format string doesn't match the XML format string",
+          "description": "String.format string doesn't match the XML format string [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -4046,7 +4046,7 @@
           }
         },
         "StringFormatTrivialResource": {
-          "description": "Placeholder-only string format",
+          "description": "Placeholder-only string format [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -4065,7 +4065,7 @@
           }
         },
         "StringInteger": {
-          "description": "String value where integer expected in Gradle DSL",
+          "description": "String value where integer expected in Gradle DSL [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -4084,7 +4084,7 @@
           }
         },
         "StringNotLocalizableResource": {
-          "description": "String resource should not be localized",
+          "description": "String resource should not be localized [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -4103,7 +4103,7 @@
           }
         },
         "StringNotSelectable": {
-          "description": "Non-selectable text with URLs or phone numbers",
+          "description": "Non-selectable text with URLs or phone numbers [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -4122,7 +4122,7 @@
           }
         },
         "StringRepeatedInContentDescription": {
-          "description": "contentDescription duplicates visible text",
+          "description": "contentDescription duplicates visible text [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -4141,7 +4141,7 @@
           }
         },
         "StringResourceMissingPositional": {
-          "description": "String resource has multiple non-positional format specifiers",
+          "description": "String resource has multiple non-positional format specifiers [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -4160,7 +4160,7 @@
           }
         },
         "StringShouldBeInt": {
-          "description": "String value where integer expected in Gradle DSL",
+          "description": "String value where integer expected in Gradle DSL [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -4179,7 +4179,7 @@
           }
         },
         "StringSpanInContentDescription": {
-          "description": "String with HTML used in contentDescription",
+          "description": "String with HTML used in contentDescription [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -4198,7 +4198,7 @@
           }
         },
         "StringTrailingWhitespace": {
-          "description": "String resource has trailing whitespace",
+          "description": "String resource has trailing whitespace [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -4217,7 +4217,7 @@
           }
         },
         "SupportAnnotationUsage": {
-          "description": "Incorrect support annotation usage",
+          "description": "Incorrect support annotation usage [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -4236,7 +4236,7 @@
           }
         },
         "Suspicious0dpResource": {
-          "description": "0dp dimension on wrong axis in LinearLayout",
+          "description": "0dp dimension on wrong axis in LinearLayout [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -4255,7 +4255,7 @@
           }
         },
         "SwitchIntDef": {
-          "description": "Missing @IntDef constants in switch",
+          "description": "Missing @IntDef constants in switch [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -4274,7 +4274,7 @@
           }
         },
         "SystemPermission": {
-          "description": "Requesting dangerous system permission",
+          "description": "Requesting dangerous system permission [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -4293,7 +4293,7 @@
           }
         },
         "TargetNewer": {
-          "description": "Target SDK version is too old",
+          "description": "Target SDK version is too old [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -4312,7 +4312,7 @@
           }
         },
         "TextFieldsResource": {
-          "description": "EditText missing inputType or hint",
+          "description": "EditText missing inputType or hint [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -4331,7 +4331,7 @@
           }
         },
         "TextViewEdits": {
-          "description": "Calling setText on an EditText",
+          "description": "Calling setText on an EditText [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -4350,7 +4350,7 @@
           }
         },
         "TooDeepLayoutResource": {
-          "description": "Layout nesting too deep",
+          "description": "Layout nesting too deep [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -4369,7 +4369,7 @@
           }
         },
         "TooManyViewsResource": {
-          "description": "Layout has too many views",
+          "description": "Layout has too many views [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -4388,7 +4388,7 @@
           }
         },
         "TrulyRandom": {
-          "description": "Hardcoded seed defeats SecureRandom",
+          "description": "Hardcoded seed defeats SecureRandom [precision: heuristic/text-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -4407,7 +4407,7 @@
           }
         },
         "TrustedServer": {
-          "description": "Trusting all certificates",
+          "description": "Trusting all certificates [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -4426,7 +4426,7 @@
           }
         },
         "UniqueConstants": {
-          "description": "Overlapping enumeration constants",
+          "description": "Overlapping enumeration constants [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -4445,7 +4445,7 @@
           }
         },
         "UniquePermission": {
-          "description": "Custom permission collides with system permission",
+          "description": "Custom permission collides with system permission [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -4464,7 +4464,7 @@
           }
         },
         "UnknownIdInLayout": {
-          "description": "Reference to unknown @id in layout",
+          "description": "Reference to unknown @id in layout [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -4483,7 +4483,7 @@
           }
         },
         "UnpackedNativeCodeManifest": {
-          "description": "Missing extractNativeLibs=false with native libraries",
+          "description": "Missing extractNativeLibs=false with native libraries [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -4502,7 +4502,7 @@
           }
         },
         "UnprotectedSMSBroadcastReceiverManifest": {
-          "description": "SMS receiver without permission protection",
+          "description": "SMS receiver without permission protection [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -4521,7 +4521,7 @@
           }
         },
         "UnsafeProtectedBroadcastReceiverManifest": {
-          "description": "Exported receiver for protected broadcast without permission",
+          "description": "Exported receiver for protected broadcast without permission [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -4540,7 +4540,7 @@
           }
         },
         "UnsupportedChromeOsHardwareManifest": {
-          "description": "Hardware feature unsupported on Chrome OS not marked optional",
+          "description": "Hardware feature unsupported on Chrome OS not marked optional [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -4559,7 +4559,7 @@
           }
         },
         "UnusedAttributeResource": {
-          "description": "Attribute unused on older platforms",
+          "description": "Attribute unused on older platforms [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -4578,7 +4578,7 @@
           }
         },
         "UnusedNamespaceResource": {
-          "description": "Unused namespace",
+          "description": "Unused namespace [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -4597,7 +4597,7 @@
           }
         },
         "UnusedQuantityResource": {
-          "description": "Plural defines quantity unused for language",
+          "description": "Plural defines quantity unused for language [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -4616,7 +4616,7 @@
           }
         },
         "UnusedResources": {
-          "description": "Unused resources",
+          "description": "Unused resources [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -4635,7 +4635,7 @@
           }
         },
         "UseAlpha2": {
-          "description": "3-letter ISO code in locale folder",
+          "description": "3-letter ISO code in locale folder [precision: heuristic/text-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -4654,7 +4654,7 @@
           }
         },
         "UseCheckPermissionManifest": {
-          "description": "Exported service with sensitive action but no permission",
+          "description": "Exported service with sensitive action but no permission [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -4673,7 +4673,7 @@
           }
         },
         "UseCompoundDrawablesResource": {
-          "description": "Node can be replaced by a TextView with compound drawables",
+          "description": "Node can be replaced by a TextView with compound drawables [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -4692,7 +4692,7 @@
           }
         },
         "UseSparseArrays": {
-          "description": "HashMap can be replaced with SparseArray",
+          "description": "HashMap can be replaced with SparseArray [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -4711,7 +4711,7 @@
           }
         },
         "UseValueOf": {
-          "description": "Should use valueOf instead of constructor [fixable: idiomatic]",
+          "description": "Should use valueOf instead of constructor [fixable: idiomatic] [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -4730,7 +4730,7 @@
           }
         },
         "UselessLeafResource": {
-          "description": "Empty ViewGroup with no background or id",
+          "description": "Empty ViewGroup with no background or id [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -4749,7 +4749,7 @@
           }
         },
         "UselessParentResource": {
-          "description": "Useless parent layout with single child",
+          "description": "Useless parent layout with single child [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -4768,7 +4768,7 @@
           }
         },
         "UsesSdkManifest": {
-          "description": "Missing \u003cuses-sdk\u003e element in manifest",
+          "description": "Missing \u003cuses-sdk\u003e element in manifest [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -4787,7 +4787,7 @@
           }
         },
         "ViewConstructor": {
-          "description": "Missing View constructors",
+          "description": "Missing View constructors [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -4806,7 +4806,7 @@
           }
         },
         "ViewHolder": {
-          "description": "View holder candidates",
+          "description": "View holder candidates [precision: type-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -4825,7 +4825,7 @@
           }
         },
         "ViewTag": {
-          "description": "Tagged object may leak",
+          "description": "Tagged object may leak [precision: heuristic/text-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -4844,7 +4844,7 @@
           }
         },
         "Wakelock": {
-          "description": "Incorrect WakeLock usage",
+          "description": "Incorrect WakeLock usage [precision: heuristic/text-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -4863,7 +4863,7 @@
           }
         },
         "WebViewAllowContentAccess": {
-          "description": "WebSettings.allowContentAccess explicitly enabled",
+          "description": "WebSettings.allowContentAccess explicitly enabled [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -4882,7 +4882,7 @@
           }
         },
         "WebViewAllowFileAccess": {
-          "description": "WebSettings.allowFileAccess explicitly enabled",
+          "description": "WebSettings.allowFileAccess explicitly enabled [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -4901,7 +4901,7 @@
           }
         },
         "WebViewDebuggingEnabled": {
-          "description": "WebView remote debugging explicitly enabled",
+          "description": "WebView remote debugging explicitly enabled [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -4920,7 +4920,7 @@
           }
         },
         "WebViewFileAccessFromFileUrls": {
-          "description": "WebSettings.allowFileAccessFromFileURLs explicitly enabled",
+          "description": "WebSettings.allowFileAccessFromFileURLs explicitly enabled [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -4939,7 +4939,7 @@
           }
         },
         "WebViewInScrollViewResource": {
-          "description": "WebView inside ScrollView",
+          "description": "WebView inside ScrollView [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -4958,7 +4958,7 @@
           }
         },
         "WebViewMixedContentAllowAll": {
-          "description": "WebSettings.mixedContentMode set to MIXED_CONTENT_ALWAYS_ALLOW",
+          "description": "WebSettings.mixedContentMode set to MIXED_CONTENT_ALWAYS_ALLOW [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -4977,7 +4977,7 @@
           }
         },
         "WebViewUniversalAccessFromFileUrls": {
-          "description": "WebSettings.allowUniversalAccessFromFileURLs explicitly enabled",
+          "description": "WebSettings.allowUniversalAccessFromFileURLs explicitly enabled [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -4996,7 +4996,7 @@
           }
         },
         "WorldReadableFiles": {
-          "description": "Using MODE_WORLD_READABLE",
+          "description": "Using MODE_WORLD_READABLE [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -5015,7 +5015,7 @@
           }
         },
         "WorldWriteableFiles": {
-          "description": "Using MODE_WORLD_WRITEABLE",
+          "description": "Using MODE_WORLD_WRITEABLE [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -5034,7 +5034,7 @@
           }
         },
         "WrongCall": {
-          "description": "Using wrong draw/layout method",
+          "description": "Using wrong draw/layout method [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -5053,7 +5053,7 @@
           }
         },
         "WrongCaseResource": {
-          "description": "Wrong case in view tag",
+          "description": "Wrong case in view tag [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -5072,7 +5072,7 @@
           }
         },
         "WrongConstant": {
-          "description": "Wrong constant passed to API",
+          "description": "Wrong constant passed to API [precision: type-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -5091,7 +5091,7 @@
           }
         },
         "WrongFolderResource": {
-          "description": "Resource file in the wrong res folder",
+          "description": "Resource file in the wrong res folder [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -5110,7 +5110,7 @@
           }
         },
         "WrongImport": {
-          "description": "Importing android.R instead of app R [fixable: idiomatic]",
+          "description": "Importing android.R instead of app R [fixable: idiomatic] [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -5129,7 +5129,7 @@
           }
         },
         "WrongManifestParentManifest": {
-          "description": "Element declared under wrong parent in manifest",
+          "description": "Element declared under wrong parent in manifest [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -5148,7 +5148,7 @@
           }
         },
         "WrongRegionResource": {
-          "description": "Suspicious Language/Region Combination",
+          "description": "Suspicious Language/Region Combination [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -5167,7 +5167,7 @@
           }
         },
         "WrongThread": {
-          "description": "Wrong thread",
+          "description": "Wrong thread [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -5186,7 +5186,7 @@
           }
         },
         "WrongViewCast": {
-          "description": "Mismatched view type",
+          "description": "Mismatched view type [precision: type-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -5217,7 +5217,7 @@
       "additionalProperties": false,
       "properties": {
         "FanInFanOutHotspot": {
-          "description": "Detects class-like declarations with unusually high fan-in across the project.",
+          "description": "Detects class-like declarations with unusually high fan-in across the project. [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -5250,7 +5250,7 @@
           }
         },
         "GodClassOrModule": {
-          "description": "Detects source files that import from an unusually broad set of packages, suggesting too many responsibilities.",
+          "description": "Detects source files that import from an unusually broad set of packages, suggesting too many responsibilities. [precision: heuristic/text-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -5269,7 +5269,7 @@
           }
         },
         "LayerDependencyViolation": {
-          "description": "Flags Gradle module dependencies that cross architectural layer boundaries not permitted by the configured layer matrix.",
+          "description": "Flags Gradle module dependencies that cross architectural layer boundaries not permitted by the configured layer matrix. [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -5288,7 +5288,7 @@
           }
         },
         "ModuleDependencyCycle": {
-          "description": "Detects cycles in the Gradle module dependency graph (e.g. :a → :b → :c → :a).",
+          "description": "Detects cycles in the Gradle module dependency graph (e.g. :a → :b → :c → :a). [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -5307,7 +5307,7 @@
           }
         },
         "PackageDependencyCycle": {
-          "description": "Detects cycles in the package-level import graph within a single Gradle module.",
+          "description": "Detects cycles in the package-level import graph within a single Gradle module. [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -5326,7 +5326,7 @@
           }
         },
         "PackageNamingConventionDrift": {
-          "description": "Detects Kotlin source files whose package declaration does not match the directory path under src/main/kotlin.",
+          "description": "Detects Kotlin source files whose package declaration does not match the directory path under src/main/kotlin. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -5345,7 +5345,7 @@
           }
         },
         "PublicToInternalLeakyAbstraction": {
-          "description": "Flags public classes that are thin wrappers delegating to a single private or internal field, which leak internal abstractions through a nominally public API.",
+          "description": "Flags public classes that are thin wrappers delegating to a single private or internal field, which leak internal abstractions through a nominally public API. [precision: heuristic/text-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -5380,7 +5380,7 @@
       "additionalProperties": false,
       "properties": {
         "AbsentOrWrongFileLicense": {
-          "description": "Detects files that are missing a valid license header comment. [fixable: cosmetic]",
+          "description": "Detects files that are missing a valid license header comment. [fixable: cosmetic] [precision: heuristic/text-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -5409,7 +5409,7 @@
           }
         },
         "DeprecatedBlockTag": {
-          "description": "Detects @deprecated KDoc tags that should use the @Deprecated annotation instead. [fixable: idiomatic]",
+          "description": "Detects @deprecated KDoc tags that should use the @Deprecated annotation instead. [fixable: idiomatic] [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -5428,7 +5428,7 @@
           }
         },
         "DocumentationOverPrivateFunction": {
-          "description": "Detects KDoc documentation on private functions where it is unnecessary. [fixable: idiomatic]",
+          "description": "Detects KDoc documentation on private functions where it is unnecessary. [fixable: idiomatic] [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -5447,7 +5447,7 @@
           }
         },
         "DocumentationOverPrivateProperty": {
-          "description": "Detects KDoc documentation on private properties where it is unnecessary. [fixable: idiomatic]",
+          "description": "Detects KDoc documentation on private properties where it is unnecessary. [fixable: idiomatic] [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -5466,7 +5466,7 @@
           }
         },
         "EndOfSentenceFormat": {
-          "description": "Detects KDoc first sentences that do not end with proper punctuation. [fixable: cosmetic]",
+          "description": "Detects KDoc first sentences that do not end with proper punctuation. [fixable: cosmetic] [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -5491,7 +5491,7 @@
           }
         },
         "KDocReferencesNonPublicProperty": {
-          "description": "Detects KDoc bracket references that point to non-public properties.",
+          "description": "Detects KDoc bracket references that point to non-public properties. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -5510,7 +5510,7 @@
           }
         },
         "KdocLinkValidation": {
-          "description": "Detects KDoc bracket links that do not resolve to source symbols.",
+          "description": "Detects KDoc bracket links that do not resolve to source symbols. [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -5529,7 +5529,7 @@
           }
         },
         "OutdatedDocumentation": {
-          "description": "Detects @param tags in KDoc that do not match the actual function parameters. [fixable: cosmetic]",
+          "description": "Detects @param tags in KDoc that do not match the actual function parameters. [fixable: cosmetic] [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -5558,7 +5558,7 @@
           }
         },
         "SampleAnnotationFreshness": {
-          "description": "Detects KDoc @sample tags whose fully-qualified target function is not present in analysed sources.",
+          "description": "Detects KDoc @sample tags whose fully-qualified target function is not present in analysed sources. [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -5577,7 +5577,7 @@
           }
         },
         "UndocumentedPublicClass": {
-          "description": "Detects public classes that are missing KDoc documentation.",
+          "description": "Detects public classes that are missing KDoc documentation. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -5616,7 +5616,7 @@
           }
         },
         "UndocumentedPublicFunction": {
-          "description": "Detects public functions that are missing KDoc documentation.",
+          "description": "Detects public functions that are missing KDoc documentation. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -5635,7 +5635,7 @@
           }
         },
         "UndocumentedPublicProperty": {
-          "description": "Detects public properties that are missing KDoc documentation.",
+          "description": "Detects public properties that are missing KDoc documentation. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -5666,7 +5666,7 @@
       "additionalProperties": false,
       "properties": {
         "CognitiveComplexMethod": {
-          "description": "Detects functions whose cognitive complexity exceeds a configurable threshold, weighting nesting depth.",
+          "description": "Detects functions whose cognitive complexity exceeds a configurable threshold, weighting nesting depth. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -5694,7 +5694,7 @@
           }
         },
         "ComplexCondition": {
-          "description": "Detects conditions with too many mixed logical operators.",
+          "description": "Detects conditions with too many mixed logical operators. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -5722,7 +5722,7 @@
           }
         },
         "ComplexInterface": {
-          "description": "Detects interfaces with too many member declarations.",
+          "description": "Detects interfaces with too many member declarations. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -5760,7 +5760,7 @@
           }
         },
         "CyclomaticComplexMethod": {
-          "description": "Counts independent paths through a function (branches, loops, catches). High cyclomatic complexity predicts defect density and makes code harder to test exhaustively.",
+          "description": "Counts independent paths through a function (branches, loops, catches). High cyclomatic complexity predicts defect density and makes code harder to test exhaustively. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -5815,7 +5815,7 @@
           }
         },
         "LabeledExpression": {
-          "description": "Detects labeled expressions such as return@label, break@label, and continue@label.",
+          "description": "Detects labeled expressions such as return@label, break@label, and continue@label. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -5841,7 +5841,7 @@
           }
         },
         "LargeClass": {
-          "description": "Detects classes that exceed a configurable line count threshold.",
+          "description": "Detects classes that exceed a configurable line count threshold. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -5869,7 +5869,7 @@
           }
         },
         "LongMethod": {
-          "description": "Flags functions that exceed the configured line limit. Long functions are harder to test and understand — consider extracting logical sub-steps into named helpers.",
+          "description": "Flags functions that exceed the configured line limit. Long functions are harder to test and understand — consider extracting logical sub-steps into named helpers. [precision: heuristic/text-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -5897,7 +5897,7 @@
           }
         },
         "LongParameterList": {
-          "description": "Detects functions or constructors with too many parameters.",
+          "description": "Detects functions or constructors with too many parameters. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -5947,7 +5947,7 @@
           }
         },
         "MethodOverloading": {
-          "description": "Detects methods with too many overloads of the same name in a scope.",
+          "description": "Detects methods with too many overloads of the same name in a scope. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -5975,7 +5975,7 @@
           }
         },
         "NamedArguments": {
-          "description": "Detects function calls with too many unnamed positional arguments.",
+          "description": "Detects function calls with too many unnamed positional arguments. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -6003,7 +6003,7 @@
           }
         },
         "NestedBlockDepth": {
-          "description": "Detects functions with excessive nesting depth of control flow blocks.",
+          "description": "Detects functions with excessive nesting depth of control flow blocks. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -6031,7 +6031,7 @@
           }
         },
         "NestedScopeFunctions": {
-          "description": "Detects excessively nested Kotlin scope functions like apply, also, let, run, and with.",
+          "description": "Detects excessively nested Kotlin scope functions like apply, also, let, run, and with. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -6066,7 +6066,7 @@
           }
         },
         "ReplaceSafeCallChainWithRun": {
-          "description": "Detects chains of three or more safe calls (?.) that could be simplified with ?.run { }.",
+          "description": "Detects chains of three or more safe calls (?.) that could be simplified with ?.run { }. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -6085,7 +6085,7 @@
           }
         },
         "StringLiteralDuplication": {
-          "description": "Detects string literals that appear more than a configurable number of times in a file.",
+          "description": "Detects string literals that appear more than a configurable number of times in a file. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -6128,7 +6128,7 @@
           }
         },
         "TooManyFunctions": {
-          "description": "Detects files or classes that declare too many functions.",
+          "description": "Detects files or classes that declare too many functions. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -6208,7 +6208,7 @@
       "additionalProperties": false,
       "properties": {
         "ComposeColumnRowInScrollable": {
-          "description": "Detects nested same-axis scroll containers such as Column with verticalScroll containing LazyColumn.",
+          "description": "Detects nested same-axis scroll containers such as Column with verticalScroll containing LazyColumn. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -6227,7 +6227,7 @@
           }
         },
         "ComposeDerivedStateMisuse": {
-          "description": "Detects unnecessary derivedStateOf wrapping a direct boolean comparison of Compose state reads.",
+          "description": "Detects unnecessary derivedStateOf wrapping a direct boolean comparison of Compose state reads. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -6246,7 +6246,7 @@
           }
         },
         "ComposeDisposableEffectMissingDispose": {
-          "description": "Detects DisposableEffect blocks whose body does not end with onDispose, causing resource leaks.",
+          "description": "Detects DisposableEffect blocks whose body does not end with onDispose, causing resource leaks. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -6265,7 +6265,7 @@
           }
         },
         "ComposeLambdaCapturesUnstableState": {
-          "description": "Detects inline onClick lambdas in lazy item builders that capture the current item without hoisting through remember.",
+          "description": "Detects inline onClick lambdas in lazy item builders that capture the current item without hoisting through remember. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -6284,7 +6284,7 @@
           }
         },
         "ComposeLaunchedEffectWithoutKeys": {
-          "description": "Detects LaunchedEffect blocks keyed only on constants whose body reads enclosing parameters that change.",
+          "description": "Detects LaunchedEffect blocks keyed only on constants whose body reads enclosing parameters that change. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -6303,7 +6303,7 @@
           }
         },
         "ComposeModifierBackgroundAfterClip": {
-          "description": "Detects Modifier chains where background() is applied before clip(), painting outside the clip shape.",
+          "description": "Detects Modifier chains where background() is applied before clip(), painting outside the clip shape. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -6322,7 +6322,7 @@
           }
         },
         "ComposeModifierClickableBeforePadding": {
-          "description": "Detects Modifier chains where clickable is applied before padding, excluding the padding region from the click area.",
+          "description": "Detects Modifier chains where clickable is applied before padding, excluding the padding region from the click area. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -6341,7 +6341,7 @@
           }
         },
         "ComposeModifierFillAfterSize": {
-          "description": "Detects Modifier chains where fillMaxWidth/Height/Size follows size(), overriding the explicit size.",
+          "description": "Detects Modifier chains where fillMaxWidth/Height/Size follows size(), overriding the explicit size. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -6360,7 +6360,7 @@
           }
         },
         "ComposeModifierPassedThenChained": {
-          "description": "Detects @Composable functions that declare a modifier parameter but never use it, starting fresh Modifier chains instead.",
+          "description": "Detects @Composable functions that declare a modifier parameter but never use it, starting fresh Modifier chains instead. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -6379,7 +6379,7 @@
           }
         },
         "ComposeMutableDefaultArgument": {
-          "description": "Detects @Composable parameters with mutable collection defaults that re-evaluate on each recomposition.",
+          "description": "Detects @Composable parameters with mutable collection defaults that re-evaluate on each recomposition. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -6398,7 +6398,7 @@
           }
         },
         "ComposeMutableStateInComposition": {
-          "description": "Detects mutableStateOf() used as a plain local without remember, causing state loss on every recomposition.",
+          "description": "Detects mutableStateOf() used as a plain local without remember, causing state loss on every recomposition. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -6417,7 +6417,7 @@
           }
         },
         "ComposePreviewAnnotationMissing": {
-          "description": "Detects @Composable functions whose name ends in Preview but lack the @Preview annotation.",
+          "description": "Detects @Composable functions whose name ends in Preview but lack the @Preview annotation. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -6436,7 +6436,7 @@
           }
         },
         "ComposePreviewWithBackingState": {
-          "description": "Detects @Preview functions that call runtime state holders like hiltViewModel() or collectAsState() which fail in the preview renderer.",
+          "description": "Detects @Preview functions that call runtime state holders like hiltViewModel() or collectAsState() which fail in the preview renderer. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -6455,7 +6455,7 @@
           }
         },
         "ComposeRememberSaveableNonParcelable": {
-          "description": "Detects rememberSaveable blocks constructing non-primitive types without an explicit saver argument.",
+          "description": "Detects rememberSaveable blocks constructing non-primitive types without an explicit saver argument. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -6474,7 +6474,7 @@
           }
         },
         "ComposeRememberWithoutKey": {
-          "description": "Detects remember blocks that reference enclosing parameters but have no keys, causing stale cached values.",
+          "description": "Detects remember blocks that reference enclosing parameters but have no keys, causing stale cached values. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -6493,7 +6493,7 @@
           }
         },
         "ComposeSideEffectInComposition": {
-          "description": "Detects direct assignments inside @Composable function bodies that are not wrapped in a recognized effect scope.",
+          "description": "Detects direct assignments inside @Composable function bodies that are not wrapped in a recognized effect scope. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -6524,7 +6524,7 @@
           }
         },
         "ComposeStatefulDefaultParameter": {
-          "description": "Detects @Composable parameters with constructor-call defaults that allocate fresh instances every recomposition.",
+          "description": "Detects @Composable parameters with constructor-call defaults that allocate fresh instances every recomposition. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -6543,7 +6543,7 @@
           }
         },
         "ComposeStringResourceInsideLambda": {
-          "description": "Detects stringResource() calls inside callback lambdas where the composition-only API will crash at runtime.",
+          "description": "Detects stringResource() calls inside callback lambdas where the composition-only API will crash at runtime. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -6562,7 +6562,7 @@
           }
         },
         "ComposeUnstableParameter": {
-          "description": "Detects @Composable function parameters using mutable collection types that prevent recomposition skipping.",
+          "description": "Detects @Composable function parameters using mutable collection types that prevent recomposition skipping. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -6608,7 +6608,7 @@
       "additionalProperties": false,
       "properties": {
         "ChannelReceiveWithoutClose": {
-          "description": "Detects Channel properties in a class that are never closed, leaking the receiver coroutine.",
+          "description": "Detects Channel properties in a class that are never closed, leaking the receiver coroutine. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -6627,7 +6627,7 @@
           }
         },
         "CollectInOnCreateWithoutLifecycle": {
-          "description": "Detects Flow.collect calls in lifecycle callbacks that are not wrapped by repeatOnLifecycle.",
+          "description": "Detects Flow.collect calls in lifecycle callbacks that are not wrapped by repeatOnLifecycle. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -6646,7 +6646,7 @@
           }
         },
         "CollectionsSynchronizedListIteration": {
-          "description": "Detects iteration over Collections.synchronized* wrappers without external synchronization.",
+          "description": "Detects iteration over Collections.synchronized* wrappers without external synchronization. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -6665,7 +6665,7 @@
           }
         },
         "ConcurrentModificationIteration": {
-          "description": "Detects collection mutation inside for loops that causes ConcurrentModificationException.",
+          "description": "Detects collection mutation inside for loops that causes ConcurrentModificationException. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -6684,7 +6684,7 @@
           }
         },
         "CoroutineLaunchedInTestWithoutRunTest": {
-          "description": "Detects launch/async calls in @Test functions that are not wrapped in runTest.",
+          "description": "Detects launch/async calls in @Test functions that are not wrapped in runTest. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -6703,7 +6703,7 @@
           }
         },
         "CoroutineScopeCreatedButNeverCancelled": {
-          "description": "Detects CoroutineScope properties in a class that are never cancelled, leaking coroutines.",
+          "description": "Detects CoroutineScope properties in a class that are never cancelled, leaking coroutines. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -6722,7 +6722,7 @@
           }
         },
         "DeferredAwaitInFinally": {
-          "description": "Detects Deferred.await() calls inside finally blocks that can throw and mask the original exception.",
+          "description": "Detects Deferred.await() calls inside finally blocks that can throw and mask the original exception. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -6741,7 +6741,7 @@
           }
         },
         "FlowWithoutFlowOn": {
-          "description": "Detects flow chains with a terminal operator but no flowOn, risking execution on the wrong dispatcher.",
+          "description": "Detects flow chains with a terminal operator but no flowOn, risking execution on the wrong dispatcher. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -6760,7 +6760,7 @@
           }
         },
         "GlobalCoroutineUsage": {
-          "description": "Flags use of GlobalScope for launching coroutines. Coroutines in GlobalScope are not tied to any lifecycle and can leak if not cancelled. Prefer a structured CoroutineScope. [fixable: idiomatic]",
+          "description": "Flags use of GlobalScope for launching coroutines. Coroutines in GlobalScope are not tied to any lifecycle and can leak if not cancelled. Prefer a structured CoroutineScope. [fixable: idiomatic] [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -6779,7 +6779,7 @@
           }
         },
         "GlobalScopeLaunchInViewModel": {
-          "description": "Detects GlobalScope.launch/async inside ViewModel or Presenter classes instead of viewModelScope.",
+          "description": "Detects GlobalScope.launch/async inside ViewModel or Presenter classes instead of viewModelScope. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -6798,7 +6798,7 @@
           }
         },
         "InjectDispatcher": {
-          "description": "Detects hardcoded Dispatchers.IO/Default/Unconfined passed as arguments instead of injected dispatchers.",
+          "description": "Detects hardcoded Dispatchers.IO/Default/Unconfined passed as arguments instead of injected dispatchers. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -6830,7 +6830,7 @@
           }
         },
         "LaunchWithoutCoroutineExceptionHandler": {
-          "description": "Detects launch blocks containing throw statements but no CoroutineExceptionHandler to catch uncaught exceptions.",
+          "description": "Detects launch blocks containing throw statements but no CoroutineExceptionHandler to catch uncaught exceptions. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -6849,7 +6849,7 @@
           }
         },
         "MainDispatcherInLibraryCode": {
-          "description": "Detects Dispatchers.Main usage in library modules that lack the kotlinx-coroutines-android dependency.",
+          "description": "Detects Dispatchers.Main usage in library modules that lack the kotlinx-coroutines-android dependency. [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -6868,7 +6868,7 @@
           }
         },
         "MutableStateInObject": {
-          "description": "Detects mutable var properties inside object declarations that are shared mutable state without synchronization.",
+          "description": "Detects mutable var properties inside object declarations that are shared mutable state without synchronization. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -6887,7 +6887,7 @@
           }
         },
         "RedundantSuspendModifier": {
-          "description": "Detects suspend functions that contain no suspend calls in their body. [fixable: idiomatic]",
+          "description": "Detects suspend functions that contain no suspend calls in their body. [fixable: idiomatic] [precision: type-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -6906,7 +6906,7 @@
           }
         },
         "SharedFlowWithoutReplay": {
-          "description": "Detects MutableSharedFlow() created with default configuration that has no replay or buffer capacity.",
+          "description": "Detects MutableSharedFlow() created with default configuration that has no replay or buffer capacity. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -6925,7 +6925,7 @@
           }
         },
         "SleepInsteadOfDelay": {
-          "description": "Detects Thread.sleep() usage inside suspend functions or coroutine builder lambdas instead of delay(). [fixable: idiomatic]",
+          "description": "Detects Thread.sleep() usage inside suspend functions or coroutine builder lambdas instead of delay(). [fixable: idiomatic] [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -6944,7 +6944,7 @@
           }
         },
         "StateFlowCompareByReference": {
-          "description": "Detects redundant .distinctUntilChanged() after .map{} on StateFlow, which already deduplicates by equality.",
+          "description": "Detects redundant .distinctUntilChanged() after .map{} on StateFlow, which already deduplicates by equality. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -6963,7 +6963,7 @@
           }
         },
         "StateFlowMutableLeak": {
-          "description": "Detects publicly exposed MutableStateFlow properties that should be private with a read-only StateFlow accessor.",
+          "description": "Detects publicly exposed MutableStateFlow properties that should be private with a read-only StateFlow accessor. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -6982,7 +6982,7 @@
           }
         },
         "SupervisorScopeInEventHandler": {
-          "description": "Detects supervisorScope with a single child operation where supervisor semantics provide no benefit.",
+          "description": "Detects supervisorScope with a single child operation where supervisor semantics provide no benefit. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -7001,7 +7001,7 @@
           }
         },
         "SuspendFunInFinallySection": {
-          "description": "Detects suspend function calls inside finally blocks that may not execute if the coroutine is cancelled.",
+          "description": "Detects suspend function calls inside finally blocks that may not execute if the coroutine is cancelled. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -7020,7 +7020,7 @@
           }
         },
         "SuspendFunSwallowedCancellation": {
-          "description": "Detects catch blocks that catch CancellationException without rethrowing, breaking structured concurrency. [fixable: idiomatic]",
+          "description": "Detects catch blocks that catch CancellationException without rethrowing, breaking structured concurrency. [fixable: idiomatic] [precision: type-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -7039,7 +7039,7 @@
           }
         },
         "SuspendFunWithCoroutineScopeReceiver": {
-          "description": "Detects functions that are both suspend and extension on CoroutineScope, which should be one or the other. [fixable: idiomatic]",
+          "description": "Detects functions that are both suspend and extension on CoroutineScope, which should be one or the other. [fixable: idiomatic] [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -7058,7 +7058,7 @@
           }
         },
         "SuspendFunWithFlowReturnType": {
-          "description": "Detects suspend functions that return a Flow type, since Flow builders are cold and do not require suspend. [fixable: idiomatic]",
+          "description": "Detects suspend functions that return a Flow type, since Flow builders are cold and do not require suspend. [fixable: idiomatic] [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -7077,7 +7077,7 @@
           }
         },
         "SynchronizedOnBoxedPrimitive": {
-          "description": "Detects synchronized() blocks using a boxed primitive value as the lock monitor.",
+          "description": "Detects synchronized() blocks using a boxed primitive value as the lock monitor. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -7096,7 +7096,7 @@
           }
         },
         "SynchronizedOnNonFinal": {
-          "description": "Detects synchronized() blocks using a var property as the lock, which can change the monitor object.",
+          "description": "Detects synchronized() blocks using a var property as the lock, which can change the monitor object. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -7115,7 +7115,7 @@
           }
         },
         "SynchronizedOnString": {
-          "description": "Detects synchronized() blocks using a string literal as the lock monitor.",
+          "description": "Detects synchronized() blocks using a string literal as the lock monitor. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -7134,7 +7134,7 @@
           }
         },
         "VolatileMissingOnDcl": {
-          "description": "Detects double-checked locking patterns on a var property without @Volatile annotation.",
+          "description": "Detects double-checked locking patterns on a var property without @Volatile annotation. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -7153,7 +7153,7 @@
           }
         },
         "WithContextInSuspendFunctionNoop": {
-          "description": "Detects nested withContext calls using the same dispatcher as the parent, which is redundant.",
+          "description": "Detects nested withContext calls using the same dispatcher as the parent, which is redundant. [precision: type-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -7269,7 +7269,7 @@
       "additionalProperties": false,
       "properties": {
         "DaoNotInterface": {
-          "description": "Detects Room DAOs declared as abstract classes instead of interfaces.",
+          "description": "Detects Room DAOs declared as abstract classes instead of interfaces. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -7288,7 +7288,7 @@
           }
         },
         "DaoWithoutAnnotations": {
-          "description": "Detects Room DAO member functions missing required annotations like @Query, @Insert, @Update, or @Delete.",
+          "description": "Detects Room DAO member functions missing required annotations like @Query, @Insert, @Update, or @Delete. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -7307,7 +7307,7 @@
           }
         },
         "EntityMutableColumn": {
-          "description": "Detects Room @Entity class primary-constructor parameters declared as var, which prevents straightforward copy-on-write.",
+          "description": "Detects Room @Entity class primary-constructor parameters declared as var, which prevents straightforward copy-on-write. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -7326,7 +7326,7 @@
           }
         },
         "EntityPrimaryKeyNotStable": {
-          "description": "Detects @Entity @PrimaryKey declared as var without autoGenerate = true; mutable primary keys break equals/hashCode.",
+          "description": "Detects @Entity @PrimaryKey declared as var without autoGenerate = true; mutable primary keys break equals/hashCode. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -7345,7 +7345,7 @@
           }
         },
         "ForeignKeyWithoutOnDelete": {
-          "description": "Detects Room @ForeignKey(...) without an onDelete argument; the default NO_ACTION usually leaves stale rows.",
+          "description": "Detects Room @ForeignKey(...) without an onDelete argument; the default NO_ACTION usually leaves stale rows. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -7364,7 +7364,7 @@
           }
         },
         "JdbcPreparedStatementNotClosed": {
-          "description": "Detects JDBC prepared statements assigned to local properties without .use {} or .close() in the same scope.",
+          "description": "Detects JDBC prepared statements assigned to local properties without .use {} or .close() in the same scope. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -7383,7 +7383,7 @@
           }
         },
         "JdbcResultSetLeakedFromFunction": {
-          "description": "Detects functions whose declared return type is java.sql.ResultSet; callers almost always forget to close the ResultSet.",
+          "description": "Detects functions whose declared return type is java.sql.ResultSet; callers almost always forget to close the ResultSet. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -7402,7 +7402,7 @@
           }
         },
         "RoomConflictStrategyReplaceOnFk": {
-          "description": "Detects @Insert(onConflict = REPLACE) on a Room entity that declares foreign keys; REPLACE deletes and re-inserts, cascading FK deletes.",
+          "description": "Detects @Insert(onConflict = REPLACE) on a Room entity that declares foreign keys; REPLACE deletes and re-inserts, cascading FK deletes. [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -7421,7 +7421,7 @@
           }
         },
         "RoomDatabaseVersionNotBumped": {
-          "description": "Detects @Database whose version is unchanged while @Entity sources have changed since HEAD. CI-only: skipped unless KRIT_CI_MODE=1.",
+          "description": "Detects @Database whose version is unchanged while @Entity sources have changed since HEAD. CI-only: skipped unless KRIT_CI_MODE=1. [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -7440,7 +7440,7 @@
           }
         },
         "RoomEntityChangedMigrationMissing": {
-          "description": "Detects @Entity columns whose names do not appear in any Room Migration(M, N) declaration in the project.",
+          "description": "Detects @Entity columns whose names do not appear in any Room Migration(M, N) declaration in the project. [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -7459,7 +7459,7 @@
           }
         },
         "RoomExportSchemaDisabled": {
-          "description": "Detects Room @Database(exportSchema = false); disabling schema export loses migration history.",
+          "description": "Detects Room @Database(exportSchema = false); disabling schema export loses migration history. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -7478,7 +7478,7 @@
           }
         },
         "RoomFallbackToDestructiveMigration": {
-          "description": "Detects Room database builders calling fallbackToDestructiveMigration outside debug source sets; silent data loss on schema version bump.",
+          "description": "Detects Room database builders calling fallbackToDestructiveMigration outside debug source sets; silent data loss on schema version bump. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -7497,7 +7497,7 @@
           }
         },
         "RoomFlowQueryWithoutDistinct": {
-          "description": "Detects callers of Room @Query DAO functions returning Flow\u003c...\u003e that omit a chained .distinctUntilChanged().",
+          "description": "Detects callers of Room @Query DAO functions returning Flow\u003c...\u003e that omit a chained .distinctUntilChanged(). [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -7516,7 +7516,7 @@
           }
         },
         "RoomMigrationUsesExecSqlWithInterpolation": {
-          "description": "Detects db.execSQL(...) calls inside a Room Migration that use Kotlin string interpolation in the SQL string.",
+          "description": "Detects db.execSQL(...) calls inside a Room Migration that use Kotlin string interpolation in the SQL string. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -7535,7 +7535,7 @@
           }
         },
         "RoomMultipleWritesMissingTransaction": {
-          "description": "Detects Room DAO functions that perform 2+ @Insert/@Update/@Delete calls without being annotated @Transaction.",
+          "description": "Detects Room DAO functions that perform 2+ @Insert/@Update/@Delete calls without being annotated @Transaction. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -7554,7 +7554,7 @@
           }
         },
         "RoomQueryMissingWhereForUpdate": {
-          "description": "Detects Room @Query(\"UPDATE ...\")/@Query(\"DELETE ...\") whose SQL text omits a WHERE clause.",
+          "description": "Detects Room @Query(\"UPDATE ...\")/@Query(\"DELETE ...\") whose SQL text omits a WHERE clause. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -7573,7 +7573,7 @@
           }
         },
         "RoomQueryWithLikeMissingEscape": {
-          "description": "Detects Room @Query SQL using LIKE with a bind parameter but no wildcard embedding or ESCAPE directive, suggesting an exact-match instead of a pattern search.",
+          "description": "Detects Room @Query SQL using LIKE with a bind parameter but no wildcard embedding or ESCAPE directive, suggesting an exact-match instead of a pattern search. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -7592,7 +7592,7 @@
           }
         },
         "RoomRelationWithoutIndex": {
-          "description": "Detects @Relation(entityColumn = ...) referencing a column that is not declared in the target @Entity's indices.",
+          "description": "Detects @Relation(entityColumn = ...) referencing a column that is not declared in the target @Entity's indices. [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -7611,7 +7611,7 @@
           }
         },
         "RoomSelectStarWithoutLimit": {
-          "description": "Detects Room @Query(\"SELECT * ...\") without a LIMIT clause on a non-Flow/non-PagingSource return type; risks unbounded loads.",
+          "description": "Detects Room @Query(\"SELECT * ...\") without a LIMIT clause on a non-Flow/non-PagingSource return type; risks unbounded loads. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -7630,7 +7630,7 @@
           }
         },
         "RoomSuspendQueryInTransaction": {
-          "description": "Detects suspend @Transaction DAO functions calling sibling suspend @Query methods; Room already wraps suspending queries and the double-wrap breaks cancellation.",
+          "description": "Detects suspend @Transaction DAO functions calling sibling suspend @Query methods; Room already wraps suspending queries and the double-wrap breaks cancellation. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -7649,7 +7649,7 @@
           }
         },
         "SqliteCursorWithoutClose": {
-          "description": "Detects SQLiteDatabase rawQuery/query cursors assigned to local properties without .use {} or .close() in the same scope.",
+          "description": "Detects SQLiteDatabase rawQuery/query cursors assigned to local properties without .use {} or .close() in the same scope. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -7680,7 +7680,7 @@
       "additionalProperties": false,
       "properties": {
         "DeadCode": {
-          "description": "Detects public or internal symbols that are never referenced from any other file.",
+          "description": "Detects public or internal symbols that are never referenced from any other file. [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -7699,7 +7699,7 @@
           }
         },
         "ModuleDeadCode": {
-          "description": "Detects dead code with module-boundary awareness, categorizing symbols as truly dead or could-be-internal.",
+          "description": "Detects dead code with module-boundary awareness, categorizing symbols as truly dead or could-be-internal. [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -7730,7 +7730,7 @@
       "additionalProperties": false,
       "properties": {
         "AnvilContributesBindingWithoutScope": {
-          "description": "Detects @ContributesBinding scope mismatches with the @ContributesTo scope on the bound interface.",
+          "description": "Detects @ContributesBinding scope mismatches with the @ContributesTo scope on the bound interface. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -7749,7 +7749,7 @@
           }
         },
         "AnvilMergeComponentEmptyScope": {
-          "description": "Detects @MergeComponent scopes with no matching @ContributesTo or @ContributesBinding declarations.",
+          "description": "Detects @MergeComponent scopes with no matching @ContributesTo or @ContributesBinding declarations. [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -7768,7 +7768,7 @@
           }
         },
         "BindsInsteadOfProvides": {
-          "description": "Detects @Provides functions that return their single parameter unchanged; @Binds is cheaper.",
+          "description": "Detects @Provides functions that return their single parameter unchanged; @Binds is cheaper. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -7787,7 +7787,7 @@
           }
         },
         "BindsMismatchedArity": {
-          "description": "Detects @Binds functions that do not declare exactly one parameter as required by Dagger.",
+          "description": "Detects @Binds functions that do not declare exactly one parameter as required by Dagger. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -7806,7 +7806,7 @@
           }
         },
         "BindsReturnTypeMatchesParam": {
-          "description": "Detects @Binds functions whose parameter type equals the return type; a no-op binding.",
+          "description": "Detects @Binds functions whose parameter type equals the return type; a no-op binding. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -7825,7 +7825,7 @@
           }
         },
         "ComponentMissingModule": {
-          "description": "Detects @Component(modules = [...]) declarations whose listed modules do not transitively cover every reachable binding.",
+          "description": "Detects @Component(modules = [...]) declarations whose listed modules do not transitively cover every reachable binding. [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -7844,7 +7844,7 @@
           }
         },
         "DeadBindings": {
-          "description": "Detects @Provides/@Binds functions whose return type is not requested by any @Inject site or component exposure in the project.",
+          "description": "Detects @Provides/@Binds functions whose return type is not requested by any @Inject site or component exposure in the project. [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -7863,7 +7863,7 @@
           }
         },
         "DiCycleDetection": {
-          "description": "Detects cycles in the constructor-injected DI binding graph.",
+          "description": "Detects cycles in the constructor-injected DI binding graph. [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -7882,7 +7882,7 @@
           }
         },
         "HiltEntryPointOnNonInterface": {
-          "description": "Detects Hilt @EntryPoint annotations on classes or objects instead of interfaces.",
+          "description": "Detects Hilt @EntryPoint annotations on classes or objects instead of interfaces. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -7901,7 +7901,7 @@
           }
         },
         "HiltInstallInMismatch": {
-          "description": "Detects Hilt @Module/@InstallIn classes whose @Provides scope does not match the installed component.",
+          "description": "Detects Hilt @Module/@InstallIn classes whose @Provides scope does not match the installed component. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -7920,7 +7920,7 @@
           }
         },
         "HiltSingletonWithActivityDep": {
-          "description": "Detects @Singleton classes whose constructor takes Activity-, Fragment-, View-, or LifecycleOwner-scoped types.",
+          "description": "Detects @Singleton classes whose constructor takes Activity-, Fragment-, View-, or LifecycleOwner-scoped types. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -7939,7 +7939,7 @@
           }
         },
         "InjectOnAbstractClass": {
-          "description": "Detects @Inject primary constructors on abstract classes; Dagger cannot instantiate an abstract class.",
+          "description": "Detects @Inject primary constructors on abstract classes; Dagger cannot instantiate an abstract class. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -7958,7 +7958,7 @@
           }
         },
         "IntoMapDuplicateKey": {
-          "description": "Detects @IntoMap providers that share the same key in the same module/component; duplicate map keys create conflicting contributions.",
+          "description": "Detects @IntoMap providers that share the same key in the same module/component; duplicate map keys create conflicting contributions. [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -7977,7 +7977,7 @@
           }
         },
         "IntoMapMissingKey": {
-          "description": "Detects @IntoMap @Provides/@Binds functions that lack a @*Key annotation.",
+          "description": "Detects @IntoMap @Provides/@Binds functions that lack a @*Key annotation. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -7996,7 +7996,7 @@
           }
         },
         "IntoSetDuplicateType": {
-          "description": "Detects @IntoSet providers that contribute the same concrete impl in the same module/component; the set dedupes, dropping contributions.",
+          "description": "Detects @IntoSet providers that contribute the same concrete impl in the same module/component; the set dedupes, dropping contributions. [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -8015,7 +8015,7 @@
           }
         },
         "IntoSetOnNonSetReturn": {
-          "description": "Detects @IntoSet @Provides functions whose return type is a collection wrapper, which silently drops the intended contribution.",
+          "description": "Detects @IntoSet @Provides functions whose return type is a collection wrapper, which silently drops the intended contribution. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -8034,7 +8034,7 @@
           }
         },
         "LazyInsteadOfDirect": {
-          "description": "Detects Lazy\u003cT\u003e constructor params whose .get() is called eagerly at class init; direct injection is cheaper.",
+          "description": "Detects Lazy\u003cT\u003e constructor params whose .get() is called eagerly at class init; direct injection is cheaper. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -8053,7 +8053,7 @@
           }
         },
         "MetroFactoryDeclarationShape": {
-          "description": "Detects Metro factory annotations on concrete or sealed declarations; Metro factories must be interfaces or non-sealed abstract classes.",
+          "description": "Detects Metro factory annotations on concrete or sealed declarations; Metro factories must be interfaces or non-sealed abstract classes. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -8072,7 +8072,7 @@
           }
         },
         "MissingJvmSuppressWildcards": {
-          "description": "Detects @Provides/@Binds returning Set\u003cT\u003e or Map\u003cK,V\u003e without @JvmSuppressWildcards on the value type.",
+          "description": "Detects @Provides/@Binds returning Set\u003cT\u003e or Map\u003cK,V\u003e without @JvmSuppressWildcards on the value type. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -8091,7 +8091,7 @@
           }
         },
         "ModuleWithNonStaticProvides": {
-          "description": "Detects @Module abstract classes mixing @Binds with top-level @Provides; @Provides should live in a companion object.",
+          "description": "Detects @Module abstract classes mixing @Binds with top-level @Provides; @Provides should live in a companion object. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -8110,7 +8110,7 @@
           }
         },
         "ProviderInsteadOfLazy": {
-          "description": "Detects Provider\u003cT\u003e constructor params whose .get() is called exactly once; Lazy\u003cT\u003e matches the intent and is cheaper.",
+          "description": "Detects Provider\u003cT\u003e constructor params whose .get() is called exactly once; Lazy\u003cT\u003e matches the intent and is cheaper. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -8129,7 +8129,7 @@
           }
         },
         "ScopeOnParameterizedClass": {
-          "description": "Detects DI scope annotations on generic classes; the type parameter is erased so the scope holds a single instance.",
+          "description": "Detects DI scope annotations on generic classes; the type parameter is erased so the scope holds a single instance. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -8148,7 +8148,7 @@
           }
         },
         "SingletonOnMutableClass": {
-          "description": "Detects @Singleton classes that hold unprotected mutable state (var properties or mutable collection val initializers).",
+          "description": "Detects @Singleton classes that hold unprotected mutable state (var properties or mutable collection val initializers). [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -8167,7 +8167,7 @@
           }
         },
         "SubcomponentNotInstalled": {
-          "description": "Detects @Subcomponent declarations not returned from any parent component method; the subcomponent is orphaned.",
+          "description": "Detects @Subcomponent declarations not returned from any parent component method; the subcomponent is orphaned. [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -8198,7 +8198,7 @@
       "additionalProperties": false,
       "properties": {
         "EmptyCatchBlock": {
-          "description": "Detects catch blocks with an empty body that silently swallow exceptions. [fixable: semantic]",
+          "description": "Detects catch blocks with an empty body that silently swallow exceptions. [fixable: semantic] [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -8223,7 +8223,7 @@
           }
         },
         "EmptyClassBlock": {
-          "description": "Detects class declarations with an empty body that can have their braces removed. [fixable: semantic]",
+          "description": "Detects class declarations with an empty body that can have their braces removed. [fixable: semantic] [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -8242,7 +8242,7 @@
           }
         },
         "EmptyDefaultConstructor": {
-          "description": "Detects explicit empty default constructors that are redundant and can be removed. [fixable: semantic]",
+          "description": "Detects explicit empty default constructors that are redundant and can be removed. [fixable: semantic] [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -8261,7 +8261,7 @@
           }
         },
         "EmptyDoWhileBlock": {
-          "description": "Detects do-while loops with an empty body.",
+          "description": "Detects do-while loops with an empty body. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -8280,7 +8280,7 @@
           }
         },
         "EmptyElseBlock": {
-          "description": "Detects else blocks with an empty body. [fixable: semantic]",
+          "description": "Detects else blocks with an empty body. [fixable: semantic] [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -8299,7 +8299,7 @@
           }
         },
         "EmptyFinallyBlock": {
-          "description": "Detects finally blocks with an empty body that serve no purpose.",
+          "description": "Detects finally blocks with an empty body that serve no purpose. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -8318,7 +8318,7 @@
           }
         },
         "EmptyForBlock": {
-          "description": "Detects for loops with an empty body.",
+          "description": "Detects for loops with an empty body. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -8337,7 +8337,7 @@
           }
         },
         "EmptyFunctionBlock": {
-          "description": "Detects function declarations with an empty body. [fixable: semantic]",
+          "description": "Detects function declarations with an empty body. [fixable: semantic] [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -8361,7 +8361,7 @@
           }
         },
         "EmptyIfBlock": {
-          "description": "Detects if blocks with an empty body.",
+          "description": "Detects if blocks with an empty body. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -8380,7 +8380,7 @@
           }
         },
         "EmptyInitBlock": {
-          "description": "Detects init blocks with an empty body that can be removed. [fixable: semantic]",
+          "description": "Detects init blocks with an empty body that can be removed. [fixable: semantic] [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -8399,7 +8399,7 @@
           }
         },
         "EmptyKotlinFile": {
-          "description": "Detects Kotlin files with no meaningful code beyond package and import declarations.",
+          "description": "Detects Kotlin files with no meaningful code beyond package and import declarations. [precision: heuristic/text-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -8418,7 +8418,7 @@
           }
         },
         "EmptySecondaryConstructor": {
-          "description": "Detects secondary constructors with an empty body. [fixable: semantic]",
+          "description": "Detects secondary constructors with an empty body. [fixable: semantic] [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -8437,7 +8437,7 @@
           }
         },
         "EmptyTryBlock": {
-          "description": "Detects try blocks with an empty body.",
+          "description": "Detects try blocks with an empty body. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -8456,7 +8456,7 @@
           }
         },
         "EmptyWhenBlock": {
-          "description": "Detects when expressions with no entries.",
+          "description": "Detects when expressions with no entries. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -8475,7 +8475,7 @@
           }
         },
         "EmptyWhileBlock": {
-          "description": "Detects while loops with an empty body.",
+          "description": "Detects while loops with an empty body. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -8506,7 +8506,7 @@
       "additionalProperties": false,
       "properties": {
         "ErrorUsageWithThrowable": {
-          "description": "Detects error() calls that pass a Throwable argument instead of using throw directly.",
+          "description": "Detects error() calls that pass a Throwable argument instead of using throw directly. [precision: type-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -8525,7 +8525,7 @@
           }
         },
         "ExceptionRaisedInUnexpectedLocation": {
-          "description": "Detects throw statements inside equals, hashCode, toString, or finalize methods.",
+          "description": "Detects throw statements inside equals, hashCode, toString, or finalize methods. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -8557,7 +8557,7 @@
           }
         },
         "InstanceOfCheckForException": {
-          "description": "Detects instanceof/is checks for exception types inside catch blocks instead of using specific catch clauses.",
+          "description": "Detects instanceof/is checks for exception types inside catch blocks instead of using specific catch clauses. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -8576,7 +8576,7 @@
           }
         },
         "NotImplementedDeclaration": {
-          "description": "Detects TODO() calls that throw NotImplementedError at runtime.",
+          "description": "Detects TODO() calls that throw NotImplementedError at runtime. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -8595,7 +8595,7 @@
           }
         },
         "ObjectExtendsThrowable": {
-          "description": "Detects Kotlin object declarations that extend Throwable, which are singletons that lose stack trace information.",
+          "description": "Detects Kotlin object declarations that extend Throwable, which are singletons that lose stack trace information. [precision: type-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -8614,7 +8614,7 @@
           }
         },
         "PrintStackTrace": {
-          "description": "Detects printStackTrace() calls that should use a logger instead. [fixable: idiomatic]",
+          "description": "Detects printStackTrace() calls that should use a logger instead. [fixable: idiomatic] [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -8633,7 +8633,7 @@
           }
         },
         "RethrowCaughtException": {
-          "description": "Detects catch blocks whose only statement is rethrowing the caught exception, making the catch block useless.",
+          "description": "Detects catch blocks whose only statement is rethrowing the caught exception, making the catch block useless. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -8652,7 +8652,7 @@
           }
         },
         "ReturnFromFinally": {
-          "description": "Detects return statements inside finally blocks that can swallow exceptions from the try/catch.",
+          "description": "Detects return statements inside finally blocks that can swallow exceptions from the try/catch. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -8676,7 +8676,7 @@
           }
         },
         "SwallowedException": {
-          "description": "Detects catch blocks that silently swallow the caught exception without logging, handling, or rethrowing. [fixable: idiomatic]",
+          "description": "Detects catch blocks that silently swallow the caught exception without logging, handling, or rethrowing. [fixable: idiomatic] [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -8713,7 +8713,7 @@
           }
         },
         "ThrowingExceptionFromFinally": {
-          "description": "Detects throw statements inside finally blocks that can mask exceptions from the try/catch.",
+          "description": "Detects throw statements inside finally blocks that can mask exceptions from the try/catch. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -8732,7 +8732,7 @@
           }
         },
         "ThrowingExceptionInMain": {
-          "description": "Detects throw statements inside the main() function instead of graceful error handling.",
+          "description": "Detects throw statements inside the main() function instead of graceful error handling. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -8751,7 +8751,7 @@
           }
         },
         "ThrowingExceptionsWithoutMessageOrCause": {
-          "description": "Detects common exception types thrown without a descriptive message or cause argument.",
+          "description": "Detects common exception types thrown without a descriptive message or cause argument. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -8777,7 +8777,7 @@
           }
         },
         "ThrowingNewInstanceOfSameException": {
-          "description": "Detects catch blocks that throw a new instance of the same exception type instead of rethrowing the original.",
+          "description": "Detects catch blocks that throw a new instance of the same exception type instead of rethrowing the original. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -8796,7 +8796,7 @@
           }
         },
         "TooGenericExceptionCaught": {
-          "description": "Detects catching overly generic exception types like Exception or Throwable.",
+          "description": "Detects catching overly generic exception types like Exception or Throwable. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -8828,7 +8828,7 @@
           }
         },
         "TooGenericExceptionThrown": {
-          "description": "Detects throwing overly generic exception types like Exception or Throwable.",
+          "description": "Detects throwing overly generic exception types like Exception or Throwable. [precision: type-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -8866,7 +8866,7 @@
       "additionalProperties": false,
       "properties": {
         "LocaleGetDefaultForFormatting": {
-          "description": "Detects Locale.getDefault() passed to a formatter used for persistence or network IO; use Locale.ROOT or Locale.US instead.",
+          "description": "Detects Locale.getDefault() passed to a formatter used for persistence or network IO; use Locale.ROOT or Locale.US instead. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -8885,7 +8885,7 @@
           }
         },
         "PluralsBuiltWithIfElse": {
-          "description": "Detects manual pluralization built with if/else over count == 1 instead of getQuantityString / pluralStringResource.",
+          "description": "Detects manual pluralization built with if/else over count == 1 instead of getQuantityString / pluralStringResource. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -8904,7 +8904,7 @@
           }
         },
         "PluralsMissingZero": {
-          "description": "\u003cplurals\u003e in a CLDR zero-form locale is missing the zero quantity",
+          "description": "\u003cplurals\u003e in a CLDR zero-form locale is missing the zero quantity [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -8923,7 +8923,7 @@
           }
         },
         "StringConcatForTranslation": {
-          "description": "Detects `+` concatenation between stringResource(...) and a non-literal, which forces English word order.",
+          "description": "Detects `+` concatenation between stringResource(...) and a non-literal, which forces English word order. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -8942,7 +8942,7 @@
           }
         },
         "StringContainsHtmlWithoutCDATA": {
-          "description": "\u003cstring\u003e value contains literal HTML markup not wrapped in \u003c![CDATA[...]]\u003e or entity-escaped.",
+          "description": "\u003cstring\u003e value contains literal HTML markup not wrapped in \u003c![CDATA[...]]\u003e or entity-escaped. [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -8961,7 +8961,7 @@
           }
         },
         "StringResourcePlaceholderOrder": {
-          "description": "Variant string drops positional format syntax used by the default value",
+          "description": "Variant string drops positional format syntax used by the default value [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -8980,7 +8980,7 @@
           }
         },
         "StringTemplateForTranslation": {
-          "description": "Detects string templates that embed stringResource(...) alongside another dynamic interpolation, which forces English word order.",
+          "description": "Detects string templates that embed stringResource(...) alongside another dynamic interpolation, which forces English word order. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -8999,7 +8999,7 @@
           }
         },
         "TextDirectionLiteralInString": {
-          "description": "Detects string literals that embed Unicode BIDI control characters instead of using a directional formatter.",
+          "description": "Detects string literals that embed Unicode BIDI control characters instead of using a directional formatter. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -9018,7 +9018,7 @@
           }
         },
         "TranslatableMarkupMismatch": {
-          "description": "\u003cstring\u003e markup style differs across locale variants (HTML vs Markdown vs plain text).",
+          "description": "\u003cstring\u003e markup style differs across locale variants (HTML vs Markdown vs plain text). [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -9037,7 +9037,7 @@
           }
         },
         "UnicodeNormalizationMissing": {
-          "description": "Detects contains() calls inside search/find functions that do not normalize operands; unicode-equivalent characters will not match.",
+          "description": "Detects contains() calls inside search/find functions that do not normalize operands; unicode-equivalent characters will not match. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -9056,7 +9056,7 @@
           }
         },
         "UpperLowerInvariantMisuse": {
-          "description": "Detects Kotlin 1.5+ uppercase()/lowercase() called without an explicit Locale argument.",
+          "description": "Detects Kotlin 1.5+ uppercase()/lowercase() called without an explicit Locale argument. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -9087,7 +9087,7 @@
       "additionalProperties": false,
       "properties": {
         "ForbiddenPublicDataClass": {
-          "description": "Detects public data classes in library code whose exposed properties make the API hard to evolve.",
+          "description": "Detects public data classes in library code whose exposed properties make the API hard to evolve. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -9106,7 +9106,7 @@
           }
         },
         "LibraryCodeMustSpecifyReturnType": {
-          "description": "Detects public functions and properties in library code without explicit return type annotations.",
+          "description": "Detects public functions and properties in library code without explicit return type annotations. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -9125,7 +9125,7 @@
           }
         },
         "LibraryEntitiesShouldNotBePublic": {
-          "description": "Detects public top-level declarations in library code that could be made internal.",
+          "description": "Detects public top-level declarations in library code that could be made internal. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -9156,7 +9156,7 @@
       "additionalProperties": false,
       "properties": {
         "CopyrightYearOutdated": {
-          "description": "Detects stale copyright years in file header comments. [fixable: cosmetic]",
+          "description": "Detects stale copyright years in file header comments. [fixable: cosmetic] [precision: heuristic/text-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -9175,7 +9175,7 @@
           }
         },
         "DependencyLicenseIncompatible": {
-          "description": "Detects external dependencies whose license is incompatible with the project's declared license.",
+          "description": "Detects external dependencies whose license is incompatible with the project's declared license. [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -9199,7 +9199,7 @@
           }
         },
         "DependencyLicenseUnknown": {
-          "description": "Detects external dependencies not present in the embedded license registry.",
+          "description": "Detects external dependencies not present in the embedded license registry. [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -9223,7 +9223,7 @@
           }
         },
         "LgplStaticLinkingInApk": {
-          "description": "Detects Android application modules that statically link known-LGPL dependencies into the APK.",
+          "description": "Detects Android application modules that statically link known-LGPL dependencies into the APK. [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -9242,7 +9242,7 @@
           }
         },
         "MissingSpdxIdentifier": {
-          "description": "Detects file header comments that are missing a SPDX license identifier.",
+          "description": "Detects file header comments that are missing a SPDX license identifier. [precision: heuristic/text-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -9261,7 +9261,7 @@
           }
         },
         "NoticeFileOutOfDate": {
-          "description": "Detects projects whose NOTICE file is missing required attribution for declared dependencies.",
+          "description": "Detects projects whose NOTICE file is missing required attribution for declared dependencies. [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -9287,7 +9287,7 @@
           }
         },
         "OptInMarkerExposedPublicly": {
-          "description": "Detects @OptIn annotations on public API declarations that propagate the opt-in requirement to callers.",
+          "description": "Detects @OptIn annotations on public API declarations that propagate the opt-in requirement to callers. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -9306,7 +9306,7 @@
           }
         },
         "OptInMarkerNotRecognised": {
-          "description": "Detects @OptIn marker classes not in the embedded well-known markers list.",
+          "description": "Detects @OptIn marker classes not in the embedded well-known markers list. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -9332,7 +9332,7 @@
           }
         },
         "OptInWithoutJustification": {
-          "description": "Detects @OptIn annotations whose declaration has no preceding KDoc explaining why opting in is safe.",
+          "description": "Detects @OptIn annotations whose declaration has no preceding KDoc explaining why opting in is safe. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -9351,7 +9351,7 @@
           }
         },
         "OssLicensesNotIncludedInAndroid": {
-          "description": "Detects Android app modules with implementation dependencies but no attribution surface (oss-licenses-plugin or LICENSE file).",
+          "description": "Detects Android app modules with implementation dependencies but no attribution surface (oss-licenses-plugin or LICENSE file). [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -9370,7 +9370,7 @@
           }
         },
         "RequiresOptInWithoutLevel": {
-          "description": "Detects custom @RequiresOptIn annotation classes that omit an explicit level = WARNING|ERROR argument.",
+          "description": "Detects custom @RequiresOptIn annotation classes that omit an explicit level = WARNING|ERROR argument. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -9389,7 +9389,7 @@
           }
         },
         "RequiresOptInWithoutMessage": {
-          "description": "Detects @RequiresOptIn annotations that omit a message argument explaining why callers must opt in.",
+          "description": "Detects @RequiresOptIn annotations that omit a message argument explaining why callers must opt in. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -9408,7 +9408,7 @@
           }
         },
         "SpdxIdentifierInvalid": {
-          "description": "Detects file header SPDX-License-Identifier values that are not recognised SPDX short IDs.",
+          "description": "Detects file header SPDX-License-Identifier values that are not recognised SPDX short IDs. [precision: heuristic/text-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -9434,7 +9434,7 @@
           }
         },
         "SpdxIdentifierMismatchWithProject": {
-          "description": "Detects file SPDX identifiers that disagree with the project's configured license.",
+          "description": "Detects file SPDX identifiers that disagree with the project's configured license. [precision: heuristic/text-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -9458,7 +9458,7 @@
           }
         },
         "SuppressedWarningWithoutJustification": {
-          "description": "Detects @Suppress annotations whose declaration has no preceding KDoc explaining why silencing the warning is safe.",
+          "description": "Detects @Suppress annotations whose declaration has no preceding KDoc explaining why silencing the warning is safe. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -9514,7 +9514,7 @@
       "additionalProperties": false,
       "properties": {
         "BooleanPropertyNaming": {
-          "description": "Detects Boolean properties that do not start with an allowed prefix like is, has, or are. [fixable: semantic]",
+          "description": "Detects Boolean properties that do not start with an allowed prefix like is, has, or are. [fixable: semantic] [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -9539,7 +9539,7 @@
           }
         },
         "ClassNaming": {
-          "description": "Detects class names that do not match the expected naming pattern.",
+          "description": "Detects class names that do not match the expected naming pattern. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -9564,7 +9564,7 @@
           }
         },
         "ConstructorParameterNaming": {
-          "description": "Detects constructor val/var parameter names that do not match the expected naming pattern.",
+          "description": "Detects constructor val/var parameter names that do not match the expected naming pattern. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -9601,7 +9601,7 @@
           }
         },
         "EnumNaming": {
-          "description": "Detects enum entry names that do not match the expected naming pattern.",
+          "description": "Detects enum entry names that do not match the expected naming pattern. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -9626,7 +9626,7 @@
           }
         },
         "ForbiddenClassName": {
-          "description": "Detects class names that match a configured list of disallowed names.",
+          "description": "Detects class names that match a configured list of disallowed names. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -9658,7 +9658,7 @@
           }
         },
         "FunctionNameMaxLength": {
-          "description": "Detects function names that exceed the configured maximum length.",
+          "description": "Detects function names that exceed the configured maximum length. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -9686,7 +9686,7 @@
           }
         },
         "FunctionNameMinLength": {
-          "description": "Detects function names that are shorter than the configured minimum length.",
+          "description": "Detects function names that are shorter than the configured minimum length. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -9714,7 +9714,7 @@
           }
         },
         "FunctionNaming": {
-          "description": "Detects function names that do not match the expected naming pattern.",
+          "description": "Detects function names that do not match the expected naming pattern. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -9764,7 +9764,7 @@
           }
         },
         "FunctionParameterNaming": {
-          "description": "Detects function parameter names that do not match the expected naming pattern.",
+          "description": "Detects function parameter names that do not match the expected naming pattern. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -9795,7 +9795,7 @@
           }
         },
         "InvalidPackageDeclaration": {
-          "description": "Detects package declarations that do not match the file directory structure.",
+          "description": "Detects package declarations that do not match the file directory structure. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -9824,7 +9824,7 @@
           }
         },
         "LambdaParameterNaming": {
-          "description": "Detects lambda parameter names that do not match the expected naming pattern.",
+          "description": "Detects lambda parameter names that do not match the expected naming pattern. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -9849,7 +9849,7 @@
           }
         },
         "MatchingDeclarationName": {
-          "description": "Detects files where the single top-level declaration name does not match the filename.",
+          "description": "Detects files where the single top-level declaration name does not match the filename. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -9892,7 +9892,7 @@
           }
         },
         "MemberNameEqualsClassName": {
-          "description": "Detects class members whose name is the same as the containing class name.",
+          "description": "Detects class members whose name is the same as the containing class name. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -9916,7 +9916,7 @@
           }
         },
         "NoNameShadowing": {
-          "description": "Detects inner declarations that shadow an outer declaration with the same name.",
+          "description": "Detects inner declarations that shadow an outer declaration with the same name. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -9935,7 +9935,7 @@
           }
         },
         "NonBooleanPropertyPrefixedWithIs": {
-          "description": "Detects non-Boolean properties whose name starts with the is prefix.",
+          "description": "Detects non-Boolean properties whose name starts with the is prefix. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -9954,7 +9954,7 @@
           }
         },
         "ObjectPropertyNaming": {
-          "description": "Detects property names inside object declarations that do not match the expected naming pattern.",
+          "description": "Detects property names inside object declarations that do not match the expected naming pattern. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -9991,7 +9991,7 @@
           }
         },
         "PackageNaming": {
-          "description": "Detects package names that do not match the expected naming pattern.",
+          "description": "Detects package names that do not match the expected naming pattern. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -10016,7 +10016,7 @@
           }
         },
         "TopLevelPropertyNaming": {
-          "description": "Detects top-level property names that do not match the expected naming pattern.",
+          "description": "Detects top-level property names that do not match the expected naming pattern. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -10053,7 +10053,7 @@
           }
         },
         "VariableMaxLength": {
-          "description": "Detects variable names that exceed the configured maximum length.",
+          "description": "Detects variable names that exceed the configured maximum length. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -10081,7 +10081,7 @@
           }
         },
         "VariableMinLength": {
-          "description": "Detects variable names that are shorter than the configured minimum length.",
+          "description": "Detects variable names that are shorter than the configured minimum length. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -10109,7 +10109,7 @@
           }
         },
         "VariableNaming": {
-          "description": "Detects local variable names that do not match the expected naming pattern.",
+          "description": "Detects local variable names that do not match the expected naming pattern. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -10158,7 +10158,7 @@
       "additionalProperties": false,
       "properties": {
         "LogLevelGuardMissing": {
-          "description": "Detects debug/trace log messages with interpolated calls not guarded by a log-level check.",
+          "description": "Detects debug/trace log messages with interpolated calls not guarded by a log-level check. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -10177,7 +10177,7 @@
           }
         },
         "LogWithoutCorrelationId": {
-          "description": "Detects logger calls inside coroutine builders whose context does not include MDCContext.",
+          "description": "Detects logger calls inside coroutine builders whose context does not include MDCContext. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -10196,7 +10196,7 @@
           }
         },
         "LoggerInterpolatedMessage": {
-          "description": "Detects SLF4J/Logback/log4j logger calls whose message uses Kotlin string interpolation instead of parameterized placeholders.",
+          "description": "Detects SLF4J/Logback/log4j logger calls whose message uses Kotlin string interpolation instead of parameterized placeholders. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -10215,7 +10215,7 @@
           }
         },
         "LoggerStringConcat": {
-          "description": "Detects SLF4J/Logback/log4j logger calls whose message uses `+` string concatenation instead of parameterized placeholders.",
+          "description": "Detects SLF4J/Logback/log4j logger calls whose message uses `+` string concatenation instead of parameterized placeholders. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -10234,7 +10234,7 @@
           }
         },
         "LoggerWithoutLoggerField": {
-          "description": "Detects LoggerFactory.getLogger() calls inside function bodies instead of a class-level logger field.",
+          "description": "Detects LoggerFactory.getLogger() calls inside function bodies instead of a class-level logger field. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -10253,7 +10253,7 @@
           }
         },
         "MdcAcrossCoroutineBoundary": {
-          "description": "Detects MDC.put(...) followed by a coroutine builder without MDCContext(); MDC values do not propagate across dispatchers.",
+          "description": "Detects MDC.put(...) followed by a coroutine builder without MDCContext(); MDC values do not propagate across dispatchers. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -10272,7 +10272,7 @@
           }
         },
         "MdcPutNoRemove": {
-          "description": "Detects MDC.put(...) inside a function with no matching MDC.remove(...), MDC.clear(), or MDCCloseable, which leaks values across reused threads.",
+          "description": "Detects MDC.put(...) inside a function with no matching MDC.remove(...), MDC.clear(), or MDCCloseable, which leaks values across reused threads. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -10291,7 +10291,7 @@
           }
         },
         "MetricCounterNotMonotonic": {
-          "description": "Detects counter increment calls with negative literal amounts.",
+          "description": "Detects counter increment calls with negative literal amounts. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -10310,7 +10310,7 @@
           }
         },
         "MetricNameMissingUnit": {
-          "description": "Detects metric names that do not include a recognized unit suffix.",
+          "description": "Detects metric names that do not include a recognized unit suffix. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -10342,7 +10342,7 @@
           }
         },
         "MetricTagHighCardinality": {
-          "description": "Detects metric tag keys that are likely high-cardinality.",
+          "description": "Detects metric tag keys that are likely high-cardinality. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -10373,7 +10373,7 @@
           }
         },
         "MetricTimerOutsideBlock": {
-          "description": "Detects timer record blocks that are empty or only read values instead of timing meaningful work.",
+          "description": "Detects timer record blocks that are empty or only read values instead of timing meaningful work. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -10392,7 +10392,7 @@
           }
         },
         "NullableStructuredField": {
-          "description": "Detects structured log fields whose nullable value lacks an Elvis fallback.",
+          "description": "Detects structured log fields whose nullable value lacks an Elvis fallback. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -10411,7 +10411,7 @@
           }
         },
         "SpanAttributeWithHighCardinality": {
-          "description": "Detects OpenTelemetry span attributes that use high-cardinality keys.",
+          "description": "Detects OpenTelemetry span attributes that use high-cardinality keys. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -10442,7 +10442,7 @@
           }
         },
         "SpanStartWithoutFinish": {
-          "description": "Detects spans started into a local variable without a matching end(), use, or makeCurrent().use lifecycle call.",
+          "description": "Detects spans started into a local variable without a matching end(), use, or makeCurrent().use lifecycle call. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -10461,7 +10461,7 @@
           }
         },
         "StructuredLogKeyMixedCase": {
-          "description": "Detects mixed snake_case and camelCase structured logging keys within one file.",
+          "description": "Detects mixed snake_case and camelCase structured logging keys within one file. [precision: heuristic/text-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -10490,7 +10490,7 @@
           }
         },
         "TraceIdLoggedAsPlainMessage": {
-          "description": "Detects trace, span, request, or correlation IDs embedded directly in log messages.",
+          "description": "Detects trace, span, request, or correlation IDs embedded directly in log messages. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -10526,7 +10526,7 @@
           }
         },
         "UnstructuredErrorLog": {
-          "description": "Detects logger error/warn calls that interpolate Throwable values instead of passing them as structured throwable arguments.",
+          "description": "Detects logger error/warn calls that interpolate Throwable values instead of passing them as structured throwable arguments. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -10557,7 +10557,7 @@
           }
         },
         "WithContextWithoutTracingContext": {
-          "description": "Detects coroutine dispatcher switches inside active spans without tracing context propagation.",
+          "description": "Detects coroutine dispatcher switches inside active spans without tracing context propagation. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -10595,7 +10595,7 @@
       "additionalProperties": false,
       "properties": {
         "ArrayPrimitive": {
-          "description": "Detects Array\u003cInt\u003e and similar boxed primitive arrays that should use IntArray, LongArray, etc. [fixable: idiomatic]",
+          "description": "Detects Array\u003cInt\u003e and similar boxed primitive arrays that should use IntArray, LongArray, etc. [fixable: idiomatic] [precision: heuristic/text-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -10614,7 +10614,7 @@
           }
         },
         "BitmapDecodeWithoutOptions": {
-          "description": "Detects BitmapFactory.decode* calls without BitmapFactory.Options, which may decode full-size bitmaps.",
+          "description": "Detects BitmapFactory.decode* calls without BitmapFactory.Options, which may decode full-size bitmaps. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -10633,7 +10633,7 @@
           }
         },
         "CouldBeSequence": {
-          "description": "Detects collection operation chains that could use sequences to avoid intermediate allocations.",
+          "description": "Detects collection operation chains that could use sequences to avoid intermediate allocations. [precision: heuristic/text-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -10661,7 +10661,7 @@
           }
         },
         "ForEachOnRange": {
-          "description": "Detects (range).forEach patterns that should use a simple for loop to avoid lambda overhead. [fixable: idiomatic]",
+          "description": "Detects (range).forEach patterns that should use a simple for loop to avoid lambda overhead. [fixable: idiomatic] [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -10680,7 +10680,7 @@
           }
         },
         "SpreadOperator": {
-          "description": "Detects the spread operator (*array) in function calls which creates an array copy.",
+          "description": "Detects the spread operator (*array) in function calls which creates an array copy. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -10699,7 +10699,7 @@
           }
         },
         "UnnecessaryInitOnArray": {
-          "description": "Detects IntArray(n) { 0 } and similar array initializations where the init value is already the default. [fixable: idiomatic]",
+          "description": "Detects IntArray(n) { 0 } and similar array initializations where the init value is already the default. [fixable: idiomatic] [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -10718,7 +10718,7 @@
           }
         },
         "UnnecessaryPartOfBinaryExpression": {
-          "description": "Detects redundant parts of binary expressions like x \u0026\u0026 true or x || false. [fixable: idiomatic]",
+          "description": "Detects redundant parts of binary expressions like x \u0026\u0026 true or x || false. [fixable: idiomatic] [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -10737,7 +10737,7 @@
           }
         },
         "UnnecessaryTemporaryInstantiation": {
-          "description": "Detects temporary wrapper instantiations like Integer.valueOf(x).toString() that can be simplified. [fixable: idiomatic]",
+          "description": "Detects temporary wrapper instantiations like Integer.valueOf(x).toString() that can be simplified. [fixable: idiomatic] [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -10756,7 +10756,7 @@
           }
         },
         "UnnecessaryTypeCasting": {
-          "description": "Detects safe casts immediately compared with null and redundant casts to an already-known type. [fixable: idiomatic]",
+          "description": "Detects safe casts immediately compared with null and redundant casts to an already-known type. [fixable: idiomatic] [precision: type-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -10787,7 +10787,7 @@
       "additionalProperties": false,
       "properties": {
         "AbstractMemberNotImplemented": {
-          "description": "Detects concrete classes that fail to implement abstract members declared on a supertype.",
+          "description": "Detects concrete classes that fail to implement abstract members declared on a supertype. [precision: type-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -10806,7 +10806,7 @@
           }
         },
         "AvoidReferentialEquality": {
-          "description": "Detects usage of referential equality operators === or !== which compare object identity instead of value. [fixable: idiomatic]",
+          "description": "Detects usage of referential equality operators === or !== which compare object identity instead of value. [fixable: idiomatic] [precision: type-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -10832,7 +10832,7 @@
           }
         },
         "CastNullableToNonNullableType": {
-          "description": "Detects casting a nullable expression to a non-nullable type using 'as Type'. [fixable: idiomatic]",
+          "description": "Detects casting a nullable expression to a non-nullable type using 'as Type'. [fixable: idiomatic] [precision: type-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -10851,7 +10851,7 @@
           }
         },
         "CastToNullableType": {
-          "description": "Detects casts to nullable types like 'as Type?' which always succeed and may hide bugs. [fixable: idiomatic]",
+          "description": "Detects casts to nullable types like 'as Type?' which always succeed and may hide bugs. [fixable: idiomatic] [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -10870,7 +10870,7 @@
           }
         },
         "CharArrayToStringCall": {
-          "description": "Detects charArray.toString() calls that return the array's address instead of its content. [fixable: idiomatic]",
+          "description": "Detects charArray.toString() calls that return the array's address instead of its content. [fixable: idiomatic] [precision: type-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -10889,7 +10889,7 @@
           }
         },
         "Deprecation": {
-          "description": "Detects usage of deprecated functions, classes, or properties.",
+          "description": "Detects usage of deprecated functions, classes, or properties. [precision: type-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -10913,7 +10913,7 @@
           }
         },
         "DontDowncastCollectionTypes": {
-          "description": "Detects downcasting read-only collection types to mutable variants like 'as MutableList'. [fixable: semantic]",
+          "description": "Detects downcasting read-only collection types to mutable variants like 'as MutableList'. [fixable: semantic] [precision: type-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -10932,7 +10932,7 @@
           }
         },
         "DoubleMutabilityForCollection": {
-          "description": "Detects var declarations with mutable collection types, creating double mutability. [fixable: idiomatic]",
+          "description": "Detects var declarations with mutable collection types, creating double mutability. [fixable: idiomatic] [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -10958,7 +10958,7 @@
           }
         },
         "ElseCaseInsteadOfExhaustiveWhen": {
-          "description": "Detects when expressions on sealed classes or enums that use an else branch instead of exhaustive matching. [fixable: idiomatic]",
+          "description": "Detects when expressions on sealed classes or enums that use an else branch instead of exhaustive matching. [fixable: idiomatic] [precision: type-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -10977,7 +10977,7 @@
           }
         },
         "EqualsAlwaysReturnsTrueOrFalse": {
-          "description": "Detects equals() implementations that always return true or always return false.",
+          "description": "Detects equals() implementations that always return true or always return false. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -10996,7 +10996,7 @@
           }
         },
         "EqualsWithHashCodeExist": {
-          "description": "Detects classes that override equals() without hashCode() or vice versa.",
+          "description": "Detects classes that override equals() without hashCode() or vice versa. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -11015,7 +11015,7 @@
           }
         },
         "ExitOutsideMain": {
-          "description": "Detects exitProcess() or System.exit() calls outside of the main function.",
+          "description": "Detects exitProcess() or System.exit() calls outside of the main function. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -11034,7 +11034,7 @@
           }
         },
         "ExplicitGarbageCollectionCall": {
-          "description": "Detects explicit calls to System.gc() or Runtime.getRuntime().gc() which rarely improve performance. [fixable: idiomatic]",
+          "description": "Detects explicit calls to System.gc() or Runtime.getRuntime().gc() which rarely improve performance. [fixable: idiomatic] [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -11053,7 +11053,7 @@
           }
         },
         "HardcodedDateFormat": {
-          "description": "Detects DateTimeFormatter.ofPattern constructed without an explicit Locale. [fixable: semantic]",
+          "description": "Detects DateTimeFormatter.ofPattern constructed without an explicit Locale. [fixable: semantic] [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -11072,7 +11072,7 @@
           }
         },
         "HardcodedNumberFormat": {
-          "description": "Detects DecimalFormat or NumberFormat.getInstance constructed without an explicit Locale. [fixable: semantic]",
+          "description": "Detects DecimalFormat or NumberFormat.getInstance constructed without an explicit Locale. [fixable: semantic] [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -11091,7 +11091,7 @@
           }
         },
         "HasPlatformType": {
-          "description": "Detects public functions with expression bodies that lack an explicit return type, risking platform type exposure from Java interop.",
+          "description": "Detects public functions with expression bodies that lack an explicit return type, risking platform type exposure from Java interop. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -11110,7 +11110,7 @@
           }
         },
         "IgnoredReturnValue": {
-          "description": "Detects discarded return values from functional operations or @CheckReturnValue-annotated functions.",
+          "description": "Detects discarded return values from functional operations or @CheckReturnValue-annotated functions. [precision: type-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -11162,7 +11162,7 @@
           }
         },
         "ImplicitDefaultLocale": {
-          "description": "Detects locale-sensitive string methods called without an explicit Locale argument. [fixable: semantic]",
+          "description": "Detects locale-sensitive string methods called without an explicit Locale argument. [fixable: semantic] [precision: type-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -11181,7 +11181,7 @@
           }
         },
         "ImplicitUnitReturnType": {
-          "description": "Detects block-body functions that implicitly return Unit without an explicit return type. [fixable: idiomatic]",
+          "description": "Detects block-body functions that implicitly return Unit without an explicit return type. [fixable: idiomatic] [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -11200,7 +11200,7 @@
           }
         },
         "InvalidRange": {
-          "description": "Detects backwards ranges like 10..1 that produce empty ranges instead of using downTo. [fixable: idiomatic]",
+          "description": "Detects backwards ranges like 10..1 that produce empty ranges instead of using downTo. [fixable: idiomatic] [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -11219,7 +11219,7 @@
           }
         },
         "IteratorHasNextCallsNextMethod": {
-          "description": "Detects hasNext() implementations that call next(), which modifies iterator state.",
+          "description": "Detects hasNext() implementations that call next(), which modifies iterator state. [precision: type-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -11238,7 +11238,7 @@
           }
         },
         "IteratorNotThrowingNoSuchElementException": {
-          "description": "Detects Iterator.next() implementations that do not throw NoSuchElementException when exhausted.",
+          "description": "Detects Iterator.next() implementations that do not throw NoSuchElementException when exhausted. [precision: type-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -11257,7 +11257,7 @@
           }
         },
         "LateinitUsage": {
-          "description": "Detects lateinit var usage and suggests lazy initialization or nullable types instead.",
+          "description": "Detects lateinit var usage and suggests lazy initialization or nullable types instead. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -11282,7 +11282,7 @@
           }
         },
         "LocaleDefaultForCurrency": {
-          "description": "Detects Currency.getInstance(Locale.getDefault()) in money-related classes where currency should come from business data.",
+          "description": "Detects Currency.getInstance(Locale.getDefault()) in money-related classes where currency should come from business data. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -11301,7 +11301,7 @@
           }
         },
         "MapGetWithNotNullAssertionOperator": {
-          "description": "Detects map[key]!! usage and suggests getValue() or safe alternatives. [fixable: idiomatic]",
+          "description": "Detects map[key]!! usage and suggests getValue() or safe alternatives. [fixable: idiomatic] [precision: type-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -11320,7 +11320,7 @@
           }
         },
         "MissingPackageDeclaration": {
-          "description": "Detects Kotlin or Java source files that are missing a package declaration. [fixable: cosmetic]",
+          "description": "Detects Kotlin or Java source files that are missing a package declaration. [fixable: cosmetic] [precision: heuristic/text-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -11339,7 +11339,7 @@
           }
         },
         "MissingReturn": {
-          "description": "Detects block-bodied functions with a non-Unit return type whose body does not terminate on every path.",
+          "description": "Detects block-bodied functions with a non-Unit return type whose body does not terminate on every path. [precision: type-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -11358,7 +11358,7 @@
           }
         },
         "MissingSuperCall": {
-          "description": "Detects override functions that do not call the corresponding super method. [fixable: idiomatic]",
+          "description": "Detects override functions that do not call the corresponding super method. [fixable: idiomatic] [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -11387,7 +11387,7 @@
           }
         },
         "MissingUseCall": {
-          "description": "Detects Closeable or AutoCloseable resources opened without a .use {} block.",
+          "description": "Detects Closeable or AutoCloseable resources opened without a .use {} block. [precision: type-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -11406,7 +11406,7 @@
           }
         },
         "NoElseInWhenSealed": {
-          "description": "Detects when expressions on sealed classes or enums that are missing variants and have no else branch.",
+          "description": "Detects when expressions on sealed classes or enums that are missing variants and have no else branch. [precision: type-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -11425,7 +11425,7 @@
           }
         },
         "NonExhaustiveWhen": {
-          "description": "Detects 'when' used as an expression on a sealed/enum/Boolean subject without an else branch and missing one or more variants.",
+          "description": "Detects 'when' used as an expression on a sealed/enum/Boolean subject without an else branch and missing one or more variants. [precision: type-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -11444,7 +11444,7 @@
           }
         },
         "NullCheckOnMutableProperty": {
-          "description": "Detects null checks on mutable var properties that may be changed by another thread between the check and use.",
+          "description": "Detects null checks on mutable var properties that may be changed by another thread between the check and use. [precision: type-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -11463,7 +11463,7 @@
           }
         },
         "NullableToStringCall": {
-          "description": "Detects .toString() calls on nullable receivers that may produce the string \"null\".",
+          "description": "Detects .toString() calls on nullable receivers that may produce the string \"null\". [precision: type-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -11482,7 +11482,7 @@
           }
         },
         "OverrideSignatureMismatch": {
-          "description": "Detects 'override' functions whose parameter count does not match any supertype member with the same name.",
+          "description": "Detects 'override' functions whose parameter count does not match any supertype member with the same name. [precision: type-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -11501,7 +11501,7 @@
           }
         },
         "PropertyUsedBeforeDeclaration": {
-          "description": "Detects class properties referenced in initializers or init blocks before they are declared.",
+          "description": "Detects class properties referenced in initializers or init blocks before they are declared. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -11520,7 +11520,7 @@
           }
         },
         "SmartCastInvalidated": {
-          "description": "Detects smart-cast variables that are reassigned and then used without re-checking, which the compiler reports as SMARTCAST_IMPOSSIBLE.",
+          "description": "Detects smart-cast variables that are reassigned and then used without re-checking, which the compiler reports as SMARTCAST_IMPOSSIBLE. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -11539,7 +11539,7 @@
           }
         },
         "UnconditionalJumpStatementInLoop": {
-          "description": "Detects loops containing an unconditional return, break, or throw that causes the loop to execute only once.",
+          "description": "Detects loops containing an unconditional return, break, or throw that causes the loop to execute only once. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -11558,7 +11558,7 @@
           }
         },
         "UnnamedParameterUse": {
-          "description": "Detects function calls with many unnamed parameters where named parameters would improve readability.",
+          "description": "Detects function calls with many unnamed parameters where named parameters would improve readability. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -11582,7 +11582,7 @@
           }
         },
         "UnnecessaryNotNullCheck": {
-          "description": "Detects unnecessary null checks on expressions that are already non-nullable. [fixable: idiomatic]",
+          "description": "Detects unnecessary null checks on expressions that are already non-nullable. [fixable: idiomatic] [precision: type-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -11601,7 +11601,7 @@
           }
         },
         "UnnecessaryNotNullOperator": {
-          "description": "Detects the !! operator applied to expressions that are already non-nullable. [fixable: idiomatic]",
+          "description": "Detects the !! operator applied to expressions that are already non-nullable. [fixable: idiomatic] [precision: type-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -11620,7 +11620,7 @@
           }
         },
         "UnnecessarySafeCall": {
-          "description": "Detects the ?. safe-call operator applied to expressions that are already non-nullable. [fixable: idiomatic]",
+          "description": "Detects the ?. safe-call operator applied to expressions that are already non-nullable. [fixable: idiomatic] [precision: type-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -11639,7 +11639,7 @@
           }
         },
         "UnreachableCatchBlock": {
-          "description": "Detects catch blocks that are unreachable because a more general exception type is caught above.",
+          "description": "Detects catch blocks that are unreachable because a more general exception type is caught above. [precision: type-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -11658,7 +11658,7 @@
           }
         },
         "UnsafeCallOnNullableType": {
-          "description": "Detects usage of the !! not-null assertion operator which may throw NullPointerException.",
+          "description": "Detects usage of the !! not-null assertion operator which may throw NullPointerException. [precision: heuristic/text-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -11689,7 +11689,7 @@
           }
         },
         "UnsafeCast": {
-          "description": "Detects casts that Kotlin reports can never succeed. [fixable: semantic]",
+          "description": "Detects casts that Kotlin reports can never succeed. [fixable: semantic] [precision: heuristic/text-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -11720,7 +11720,7 @@
           }
         },
         "UnusedUnaryOperator": {
-          "description": "Detects standalone unary +x or -x expressions whose result is never used. [fixable: semantic]",
+          "description": "Detects standalone unary +x or -x expressions whose result is never used. [fixable: semantic] [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -11739,7 +11739,7 @@
           }
         },
         "UselessElvisOnNonNull": {
-          "description": "Detects the ?: elvis operator applied to expressions that are already non-nullable, making the fallback dead code. [fixable: semantic]",
+          "description": "Detects the ?: elvis operator applied to expressions that are already non-nullable, making the fallback dead code. [fixable: semantic] [precision: type-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -11758,7 +11758,7 @@
           }
         },
         "UselessPostfixExpression": {
-          "description": "Detects postfix increment or decrement in return statements where the operation has no effect. [fixable: idiomatic]",
+          "description": "Detects postfix increment or decrement in return statements where the operation has no effect. [fixable: idiomatic] [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -11777,7 +11777,7 @@
           }
         },
         "WrongEqualsTypeParameter": {
-          "description": "Detects equals() with a parameter type other than Any?, which does not properly override the contract. [fixable: idiomatic]",
+          "description": "Detects equals() with a parameter type other than Any?, which does not properly override the contract. [fixable: idiomatic] [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -11808,7 +11808,7 @@
       "additionalProperties": false,
       "properties": {
         "DeprecatedSymbolUsedError": {
-          "description": "Detects references to symbols annotated with @Deprecated(level = DeprecationLevel.ERROR). Mirrors kotlinc's DEPRECATION_ERROR.",
+          "description": "Detects references to symbols annotated with @Deprecated(level = DeprecationLevel.ERROR). Mirrors kotlinc's DEPRECATION_ERROR. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -11827,7 +11827,7 @@
           }
         },
         "DuplicateDeclaration": {
-          "description": "Detects two top-level fun/class/val declarations in one file with the same name and (for functions) matching parameter type signature. Mirrors kotlinc's CONFLICTING_OVERLOADS / REDECLARATION for the file-local subset.",
+          "description": "Detects two top-level fun/class/val declarations in one file with the same name and (for functions) matching parameter type signature. Mirrors kotlinc's CONFLICTING_OVERLOADS / REDECLARATION for the file-local subset. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -11846,7 +11846,7 @@
           }
         },
         "DuplicateLabel": {
-          "description": "Detects repeated constant labels in a subject-bearing `when` expression. Mirrors kotlinc's DUPLICATE_LABEL_IN_WHEN.",
+          "description": "Detects repeated constant labels in a subject-bearing `when` expression. Mirrors kotlinc's DUPLICATE_LABEL_IN_WHEN. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -11865,7 +11865,7 @@
           }
         },
         "UnreachableCode": {
-          "description": "Detects statements that follow an unconditional jump (return, throw, break, continue) in the same block. Mirrors kotlinc's UNREACHABLE_CODE.",
+          "description": "Detects statements that follow an unconditional jump (return, throw, break, continue) in the same block. Mirrors kotlinc's UNREACHABLE_CODE. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -11896,7 +11896,7 @@
       "additionalProperties": false,
       "properties": {
         "AdMobInitializedBeforeConsent": {
-          "description": "Detects MobileAds.initialize() in Application.onCreate before any consent info update call.",
+          "description": "Detects MobileAds.initialize() in Application.onCreate before any consent info update call. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -11915,7 +11915,7 @@
           }
         },
         "AnalyticsCallWithoutConsentGate": {
-          "description": "Detects analytics event calls that are not guarded by a consent or GDPR check.",
+          "description": "Detects analytics event calls that are not guarded by a consent or GDPR check. [precision: type-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -11934,7 +11934,7 @@
           }
         },
         "AnalyticsEventWithPiiParamName": {
-          "description": "Detects analytics event parameters whose key names match PII patterns like email, phone, or SSN.",
+          "description": "Detects analytics event parameters whose key names match PII patterns like email, phone, or SSN. [precision: type-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -11953,7 +11953,7 @@
           }
         },
         "AnalyticsUserIdFromPii": {
-          "description": "Detects user-ID setter calls whose argument is a PII property like email or phoneNumber.",
+          "description": "Detects user-ID setter calls whose argument is a PII property like email or phoneNumber. [precision: type-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -11972,7 +11972,7 @@
           }
         },
         "BiometricAuthNotFallingBackToDeviceCredential": {
-          "description": "Detects BiometricPrompt.authenticate() calls whose PromptInfo lacks device credential fallback.",
+          "description": "Detects BiometricPrompt.authenticate() calls whose PromptInfo lacks device credential fallback. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -11991,7 +11991,7 @@
           }
         },
         "ClipboardOnSensitiveInputType": {
-          "description": "Detects clipboard writes from variables whose names suggest passwords or credentials.",
+          "description": "Detects clipboard writes from variables whose names suggest passwords or credentials. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -12010,7 +12010,7 @@
           }
         },
         "ContactsAccessWithoutPermissionUi": {
-          "description": "Detects contacts queries not gated behind a RequestPermission activity-result callback.",
+          "description": "Detects contacts queries not gated behind a RequestPermission activity-result callback. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -12029,7 +12029,7 @@
           }
         },
         "CrashlyticsCustomKeyWithPii": {
-          "description": "Detects Crashlytics setCustomKey calls where the key name matches PII patterns.",
+          "description": "Detects Crashlytics setCustomKey calls where the key name matches PII patterns. [precision: type-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -12048,7 +12048,7 @@
           }
         },
         "FirebaseRemoteConfigDefaultsWithPii": {
-          "description": "Detects Firebase Remote Config default map keys that match PII patterns.",
+          "description": "Detects Firebase Remote Config default map keys that match PII patterns. [precision: type-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -12067,7 +12067,7 @@
           }
         },
         "LocationBackgroundWithoutRationale": {
-          "description": "Detects ACCESS_BACKGROUND_LOCATION requests without a shouldShowRequestPermissionRationale call.",
+          "description": "Detects ACCESS_BACKGROUND_LOCATION requests without a shouldShowRequestPermissionRationale call. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -12086,7 +12086,7 @@
           }
         },
         "LogOfSharedPreferenceRead": {
-          "description": "Detects logger calls that directly pass SharedPreferences values with sensitive keys.",
+          "description": "Detects logger calls that directly pass SharedPreferences values with sensitive keys. [precision: type-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -12105,7 +12105,7 @@
           }
         },
         "PlainFileWriteOfSensitive": {
-          "description": "Detects plain-file writes to paths containing sensitive terms without using EncryptedFile.",
+          "description": "Detects plain-file writes to paths containing sensitive terms without using EncryptedFile. [precision: type-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -12124,7 +12124,7 @@
           }
         },
         "ScreenshotNotBlockedOnLoginScreen": {
-          "description": "Detects sensitive screens (login, payment, PIN) that do not set FLAG_SECURE to block screenshots.",
+          "description": "Detects sensitive screens (login, payment, PIN) that do not set FLAG_SECURE to block screenshots. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -12143,7 +12143,7 @@
           }
         },
         "SharedPreferencesForSensitiveKey": {
-          "description": "Detects SharedPreferences put calls with key names matching sensitive patterns like token, password, or secret.",
+          "description": "Detects SharedPreferences put calls with key names matching sensitive patterns like token, password, or secret. [precision: type-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -12174,7 +12174,7 @@
       "additionalProperties": false,
       "properties": {
         "AllProjectsBlock": {
-          "description": "Detects deprecated allprojects {} blocks in Gradle build scripts.",
+          "description": "Detects deprecated allprojects {} blocks in Gradle build scripts. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -12193,7 +12193,7 @@
           }
         },
         "BuildConfigDebugInLibrary": {
-          "description": "Detects BuildConfig.DEBUG references inside Android library modules where the value is always false in release.",
+          "description": "Detects BuildConfig.DEBUG references inside Android library modules where the value is always false in release. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -12212,7 +12212,7 @@
           }
         },
         "BuildConfigDebugInverted": {
-          "description": "Detects negated BuildConfig.DEBUG guards wrapping logging calls that likely invert a debug-only check.",
+          "description": "Detects negated BuildConfig.DEBUG guards wrapping logging calls that likely invert a debug-only check. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -12231,7 +12231,7 @@
           }
         },
         "CommentedOutCodeBlock": {
-          "description": "Detects consecutive lines of commented-out Kotlin code that should be deleted or restored. [fixable: idiomatic]",
+          "description": "Detects consecutive lines of commented-out Kotlin code that should be deleted or restored. [fixable: idiomatic] [precision: heuristic/text-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -12250,7 +12250,7 @@
           }
         },
         "CommentedOutImport": {
-          "description": "Detects commented-out import statements that are either dead code or incomplete refactors. [fixable: idiomatic]",
+          "description": "Detects commented-out import statements that are either dead code or incomplete refactors. [fixable: idiomatic] [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -12269,7 +12269,7 @@
           }
         },
         "ConventionPluginDeadCode": {
-          "description": "Detects convention plugins under build-logic or buildSrc that are never applied by any module.",
+          "description": "Detects convention plugins under build-logic or buildSrc that are never applied by any module. [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -12288,7 +12288,7 @@
           }
         },
         "DebugToastInProduction": {
-          "description": "Detects Toast.makeText calls whose message starts with debug-related prefixes in production code.",
+          "description": "Detects Toast.makeText calls whose message starts with debug-related prefixes in production code. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -12307,7 +12307,7 @@
           }
         },
         "GradleBuildContainsTodo": {
-          "description": "Detects TODO comments in build.gradle(.kts) files that may block release readiness.",
+          "description": "Detects TODO comments in build.gradle(.kts) files that may block release readiness. [precision: heuristic/text-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -12326,7 +12326,7 @@
           }
         },
         "HardcodedEnvironmentName": {
-          "description": "Detects hardcoded environment names like 'dev', 'staging', or 'prod' passed to config APIs.",
+          "description": "Detects hardcoded environment names like 'dev', 'staging', or 'prod' passed to config APIs. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -12345,7 +12345,7 @@
           }
         },
         "HardcodedLocalhostUrl": {
-          "description": "Detects hardcoded localhost or 10.0.2.2 URLs in non-test production source files.",
+          "description": "Detects hardcoded localhost or 10.0.2.2 URLs in non-test production source files. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -12364,7 +12364,7 @@
           }
         },
         "HardcodedLogTag": {
-          "description": "Detects Log tag string literals matching the enclosing class name instead of using a companion TAG constant.",
+          "description": "Detects Log tag string literals matching the enclosing class name instead of using a companion TAG constant. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -12383,7 +12383,7 @@
           }
         },
         "MergeConflictMarkerLeftover": {
-          "description": "Detects unresolved merge conflict markers (\u003c\u003c\u003c, ===, \u003e\u003e\u003e) left in source files.",
+          "description": "Detects unresolved merge conflict markers (\u003c\u003c\u003c, ===, \u003e\u003e\u003e) left in source files. [precision: heuristic/text-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -12402,7 +12402,7 @@
           }
         },
         "ModuleTemplateConformance": {
-          "description": "Detects feature modules that do not conform to the configured module template.",
+          "description": "Detects feature modules that do not conform to the configured module template. [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -12421,7 +12421,7 @@
           }
         },
         "NonAsciiIdentifier": {
-          "description": "Detects class, function, or property names containing non-ASCII characters.",
+          "description": "Detects class, function, or property names containing non-ASCII characters. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -12440,7 +12440,7 @@
           }
         },
         "OpenForTestingCallerInNonTest": {
-          "description": "Detects subclassing of @OpenForTesting types outside test source sets.",
+          "description": "Detects subclassing of @OpenForTesting types outside test source sets. [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -12459,7 +12459,7 @@
           }
         },
         "PrintStackTraceInProduction": {
-          "description": "Detects printStackTrace() calls in code that has a logging framework available.",
+          "description": "Detects printStackTrace() calls in code that has a logging framework available. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -12478,7 +12478,7 @@
           }
         },
         "PrintlnInProduction": {
-          "description": "Detects println or print calls in production code that should use a logging framework.",
+          "description": "Detects println or print calls in production code that should use a logging framework. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -12497,7 +12497,7 @@
           }
         },
         "TestFixtureAccessedFromProduction": {
-          "description": "Detects usage of types declared under src/testFixtures/ from production source files.",
+          "description": "Detects usage of types declared under src/testFixtures/ from production source files. [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -12516,7 +12516,7 @@
           }
         },
         "TestOnlyImportInProduction": {
-          "description": "Detects test framework imports (JUnit, Mockito, MockK, etc.) in non-test source files.",
+          "description": "Detects test framework imports (JUnit, Mockito, MockK, etc.) in non-test source files. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -12535,7 +12535,7 @@
           }
         },
         "TimberTreeNotPlanted": {
-          "description": "Detects Timber logging usage without any Timber.plant() call in the project.",
+          "description": "Detects Timber logging usage without any Timber.plant() call in the project. [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -12554,7 +12554,7 @@
           }
         },
         "VisibleForTestingCallerInNonTest": {
-          "description": "Detects calls to @VisibleForTesting-annotated functions from non-test source files.",
+          "description": "Detects calls to @VisibleForTesting-annotated functions from non-test source files. [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -12585,7 +12585,7 @@
       "additionalProperties": false,
       "properties": {
         "BufferedReadWithoutBuffer": {
-          "description": "Detects FileInputStream.read() without BufferedInputStream wrapping for efficient reads.",
+          "description": "Detects FileInputStream.read() without BufferedInputStream wrapping for efficient reads. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -12604,7 +12604,7 @@
           }
         },
         "ComposePainterResourceInLoop": {
-          "description": "Detects painterResource() calls inside list or loop lambdas that create a fresh painter per iteration.",
+          "description": "Detects painterResource() calls inside list or loop lambdas that create a fresh painter per iteration. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -12623,7 +12623,7 @@
           }
         },
         "ComposeRememberInList": {
-          "description": "Detects remember {} inside items {} without a key argument, causing recomputation on list reorder.",
+          "description": "Detects remember {} inside items {} without a key argument, causing recomputation on list reorder. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -12642,7 +12642,7 @@
           }
         },
         "CursorLoopWithColumnIndexInLoop": {
-          "description": "Detects getColumnIndex() calls inside cursor while-loops that should be hoisted before the loop.",
+          "description": "Detects getColumnIndex() calls inside cursor while-loops that should be hoisted before the loop. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -12661,7 +12661,7 @@
           }
         },
         "DatabaseInstanceRecreated": {
-          "description": "Detects Room.databaseBuilder calls inside regular functions that recreate the database on each invocation.",
+          "description": "Detects Room.databaseBuilder calls inside regular functions that recreate the database on each invocation. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -12680,7 +12680,7 @@
           }
         },
         "DatabaseQueryOnMainThread": {
-          "description": "Detects SQLiteDatabase query calls in code with positive main-thread evidence.",
+          "description": "Detects SQLiteDatabase query calls in code with positive main-thread evidence. [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -12699,7 +12699,7 @@
           }
         },
         "HttpClientNotReused": {
-          "description": "Detects Java HttpClient.newHttpClient() in function bodies without singleton reuse.",
+          "description": "Detects Java HttpClient.newHttpClient() in function bodies without singleton reuse. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -12718,7 +12718,7 @@
           }
         },
         "ImageLoadedAtFullSizeInList": {
-          "description": "Detects Glide or Coil image loading without size constraints in list item contexts.",
+          "description": "Detects Glide or Coil image loading without size constraints in list item contexts. [precision: type-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -12737,7 +12737,7 @@
           }
         },
         "ImageLoaderNoMemoryCache": {
-          "description": "Detects image loaders configured to skip the memory cache, causing repeated decoding and GC pressure.",
+          "description": "Detects image loaders configured to skip the memory cache, causing repeated decoding and GC pressure. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -12756,7 +12756,7 @@
           }
         },
         "LazyColumnInsideColumn": {
-          "description": "Detects LazyColumn or LazyRow nested inside a scrollable Column or Row causing measurement issues.",
+          "description": "Detects LazyColumn or LazyRow nested inside a scrollable Column or Row causing measurement issues. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -12775,7 +12775,7 @@
           }
         },
         "OkHttpCallExecuteSync": {
-          "description": "Detects synchronous OkHttp Call.execute() inside suspend functions that block the coroutine thread.",
+          "description": "Detects synchronous OkHttp Call.execute() inside suspend functions that block the coroutine thread. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -12794,7 +12794,7 @@
           }
         },
         "OkHttpClientCreatedPerCall": {
-          "description": "Detects OkHttpClient construction in function bodies instead of reusing a singleton instance.",
+          "description": "Detects OkHttpClient construction in function bodies instead of reusing a singleton instance. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -12813,7 +12813,7 @@
           }
         },
         "PeriodicWorkRequestLessThan15Min": {
-          "description": "Detects PeriodicWorkRequest intervals below the 15-minute minimum enforced by WorkManager.",
+          "description": "Detects PeriodicWorkRequest intervals below the 15-minute minimum enforced by WorkManager. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -12832,7 +12832,7 @@
           }
         },
         "RecyclerAdapterStableIdsDefault": {
-          "description": "Detects RecyclerView.Adapter subclasses that do not enable stable IDs for better animation.",
+          "description": "Detects RecyclerView.Adapter subclasses that do not enable stable IDs for better animation. [precision: type-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -12851,7 +12851,7 @@
           }
         },
         "RecyclerAdapterWithoutDiffUtil": {
-          "description": "Detects RecyclerView.Adapter subclasses using notifyDataSetChanged() without DiffUtil.",
+          "description": "Detects RecyclerView.Adapter subclasses using notifyDataSetChanged() without DiffUtil. [precision: type-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -12870,7 +12870,7 @@
           }
         },
         "RecyclerViewInLazyColumn": {
-          "description": "Detects AndroidView wrapping a RecyclerView inside a LazyColumn or LazyRow causing nested scrolling conflicts.",
+          "description": "Detects AndroidView wrapping a RecyclerView inside a LazyColumn or LazyRow causing nested scrolling conflicts. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -12889,7 +12889,7 @@
           }
         },
         "RetrofitCreateInHotPath": {
-          "description": "Detects Retrofit.Builder().build().create() in function bodies instead of a singleton or @Provides.",
+          "description": "Detects Retrofit.Builder().build().create() in function bodies instead of a singleton or @Provides. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -12908,7 +12908,7 @@
           }
         },
         "RoomLoadsAllWhereFirstUsed": {
-          "description": "Detects getAll().first() patterns that load an entire table for a single element instead of using LIMIT 1.",
+          "description": "Detects getAll().first() patterns that load an entire table for a single element instead of using LIMIT 1. [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -12927,7 +12927,7 @@
           }
         },
         "WorkManagerNoBackoff": {
-          "description": "Detects OneTimeWorkRequest chains without a setBackoffCriteria policy for retryable work.",
+          "description": "Detects OneTimeWorkRequest chains without a setBackoffCriteria policy for retryable work. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -12946,7 +12946,7 @@
           }
         },
         "WorkManagerUniquePolicyKeepButReplaceIntended": {
-          "description": "Detects enqueueUniqueWork with KEEP policy followed by cancel logic where REPLACE may be intended.",
+          "description": "Detects enqueueUniqueWork with KEEP policy followed by cancel logic where REPLACE may be intended. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -12977,7 +12977,7 @@
       "additionalProperties": false,
       "properties": {
         "AllowAllHostnameVerifier": {
-          "description": "HostnameVerifier accepts all hostnames",
+          "description": "HostnameVerifier accepts all hostnames [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -12996,7 +12996,7 @@
           }
         },
         "BroadcastReceiverExportedFlagMissing": {
-          "description": "Dynamic receiver registration missing exported flag",
+          "description": "Dynamic receiver registration missing exported flag [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -13015,7 +13015,7 @@
           }
         },
         "ContentProviderQueryWithSelectionInterpolation": {
-          "description": "Detects interpolated selection strings passed to ContentResolver.query() that may enable SQL injection.",
+          "description": "Detects interpolated selection strings passed to ContentResolver.query() that may enable SQL injection. [precision: type-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -13034,7 +13034,7 @@
           }
         },
         "DeepLinkMissingAutoVerify": {
-          "description": "Deep link intent filter missing autoVerify",
+          "description": "Deep link intent filter missing autoVerify [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -13053,7 +13053,7 @@
           }
         },
         "DisableCertificatePinning": {
-          "description": "CertificatePinner has no pins",
+          "description": "CertificatePinner has no pins [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -13072,7 +13072,7 @@
           }
         },
         "FileFromUntrustedPath": {
-          "description": "Detects File construction from untrusted input in extraction or download functions without path traversal guards.",
+          "description": "Detects File construction from untrusted input in extraction or download functions without path traversal guards. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -13091,7 +13091,7 @@
           }
         },
         "GoogleApiKeyInResources": {
-          "description": "Detects Google API keys embedded directly in XML resource files",
+          "description": "Detects Google API keys embedded directly in XML resource files [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -13110,7 +13110,7 @@
           }
         },
         "GsonPolymorphicFromJson": {
-          "description": "Detects Gson fromJson calls that deserialize into Object/Any.",
+          "description": "Detects Gson fromJson calls that deserialize into Object/Any. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -13129,7 +13129,7 @@
           }
         },
         "HardcodedAwsAccessKey": {
-          "description": "Detects string literals that look like an AWS access-key ID committed directly into source.",
+          "description": "Detects string literals that look like an AWS access-key ID committed directly into source. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -13148,7 +13148,7 @@
           }
         },
         "HardcodedBearerToken": {
-          "description": "Detects bearer authorization strings with hardcoded tokens embedded directly in source code.",
+          "description": "Detects bearer authorization strings with hardcoded tokens embedded directly in source code. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -13167,7 +13167,7 @@
           }
         },
         "HardcodedGcpServiceAccount": {
-          "description": "Detects embedded GCP service-account JSON or private keys committed into source files.",
+          "description": "Detects embedded GCP service-account JSON or private keys committed into source files. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -13186,7 +13186,7 @@
           }
         },
         "HardcodedHttpUrl": {
-          "description": "Hardcoded HTTP URL in network API",
+          "description": "Hardcoded HTTP URL in network API [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -13205,7 +13205,7 @@
           }
         },
         "HardcodedJwt": {
-          "description": "Detects string literals that look like a JSON Web Token committed directly into source.",
+          "description": "Detects string literals that look like a JSON Web Token committed directly into source. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -13224,7 +13224,7 @@
           }
         },
         "HardcodedSecretKey": {
-          "description": "SecretKeySpec uses literal key bytes",
+          "description": "SecretKeySpec uses literal key bytes [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -13243,7 +13243,7 @@
           }
         },
         "ImplicitPendingIntent": {
-          "description": "PendingIntent missing mutability flag",
+          "description": "PendingIntent missing mutability flag [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -13262,7 +13262,7 @@
           }
         },
         "InsecureTrustManager": {
-          "description": "Trust manager accepts all certificates",
+          "description": "Trust manager accepts all certificates [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -13281,7 +13281,7 @@
           }
         },
         "JacksonDefaultTyping": {
-          "description": "Detects Jackson default typing APIs that enable polymorphic deserialization.",
+          "description": "Detects Jackson default typing APIs that enable polymorphic deserialization. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -13300,7 +13300,7 @@
           }
         },
         "JavaObjectInputStream": {
-          "description": "Detects ObjectInputStream construction in production source.",
+          "description": "Detects ObjectInputStream construction in production source. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -13319,7 +13319,7 @@
           }
         },
         "JdbcStatementExecute": {
-          "description": "Detects java.sql.Statement execution calls with interpolated or computed SQL strings.",
+          "description": "Detects java.sql.Statement execution calls with interpolated or computed SQL strings. [precision: type-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -13338,7 +13338,7 @@
           }
         },
         "LogPii": {
-          "description": "Detects logger calls that include sensitive variable names in interpolated or concatenated messages.",
+          "description": "Detects logger calls that include sensitive variable names in interpolated or concatenated messages. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -13363,7 +13363,7 @@
           }
         },
         "NetworkSecurityConfigDebugOverrides": {
-          "description": "Debug overrides in release network security config",
+          "description": "Debug overrides in release network security config [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -13382,7 +13382,7 @@
           }
         },
         "OkHttpDisableSslValidation": {
-          "description": "OkHttp TLS validation disabled",
+          "description": "OkHttp TLS validation disabled [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -13401,7 +13401,7 @@
           }
         },
         "PrngFromSystemTime": {
-          "description": "Predictable Random seed from system time",
+          "description": "Predictable Random seed from system time [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -13420,7 +13420,7 @@
           }
         },
         "ProcessBuilderShellArg": {
-          "description": "Detects ProcessBuilder shell commands whose -c script argument is interpolated or computed.",
+          "description": "Detects ProcessBuilder shell commands whose -c script argument is interpolated or computed. [precision: type-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -13439,7 +13439,7 @@
           }
         },
         "RoomRawQueryStringConcat": {
-          "description": "Detects SimpleSQLiteQuery SQL strings built with interpolation or non-static concatenation without bind args.",
+          "description": "Detects SimpleSQLiteQuery SQL strings built with interpolation or non-static concatenation without bind args. [precision: type-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -13458,7 +13458,7 @@
           }
         },
         "RsaNoPadding": {
-          "description": "RSA cipher without padding",
+          "description": "RSA cipher without padding [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -13477,7 +13477,7 @@
           }
         },
         "RuntimeExecUnsafeShape": {
-          "description": "Detects Runtime.getRuntime().exec(String) commands built with interpolation or non-static concatenation.",
+          "description": "Detects Runtime.getRuntime().exec(String) commands built with interpolation or non-static concatenation. [precision: type-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -13496,7 +13496,7 @@
           }
         },
         "SqlInjectionRawQuery": {
-          "description": "Detects SQLiteDatabase SQL arguments built with interpolation or non-static concatenation.",
+          "description": "Detects SQLiteDatabase SQL arguments built with interpolation or non-static concatenation. [precision: type-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -13515,7 +13515,7 @@
           }
         },
         "StartActivityWithUntrustedIntent": {
-          "description": "Parsed Intent launched without package or component guard",
+          "description": "Parsed Intent launched without package or component guard [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -13534,7 +13534,7 @@
           }
         },
         "StaticIv": {
-          "description": "Static IV literal",
+          "description": "Static IV literal [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -13553,7 +13553,7 @@
           }
         },
         "TempFileWorldReadable": {
-          "description": "Detects setReadable/setWritable/setExecutable(true, false) on a File from createTempFile, exposing the temp file to all users.",
+          "description": "Detects setReadable/setWritable/setExecutable(true, false) on a File from createTempFile, exposing the temp file to all users. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -13572,7 +13572,7 @@
           }
         },
         "UnprotectedDynamicReceiver": {
-          "description": "Dynamic receiver registered without broadcast permission",
+          "description": "Dynamic receiver registered without broadcast permission [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -13591,7 +13591,7 @@
           }
         },
         "WeakKeySize": {
-          "description": "Weak crypto key size",
+          "description": "Weak crypto key size [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -13610,7 +13610,7 @@
           }
         },
         "WeakMacAlgorithm": {
-          "description": "Weak Mac algorithm",
+          "description": "Weak Mac algorithm [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -13629,7 +13629,7 @@
           }
         },
         "WeakMessageDigest": {
-          "description": "Weak MessageDigest algorithm",
+          "description": "Weak MessageDigest algorithm [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -13648,7 +13648,7 @@
           }
         },
         "XmlExternalEntity": {
-          "description": "Detects XML parser factories created without XXE-disabling hardening.",
+          "description": "Detects XML parser factories created without XXE-disabling hardening. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -13667,7 +13667,7 @@
           }
         },
         "ZipSlipUnchecked": {
-          "description": "Detects zip extraction loops that build a destination File from an entry name without a canonical-path containment check.",
+          "description": "Detects zip extraction loops that build a destination File from an entry name without a canonical-path containment check. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -13723,7 +13723,7 @@
       "additionalProperties": false,
       "properties": {
         "AbstractClassCanBeConcreteClass": {
-          "description": "Detects abstract classes that have no abstract members and could be made concrete.",
+          "description": "Detects abstract classes that have no abstract members and could be made concrete. [precision: type-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -13742,7 +13742,7 @@
           }
         },
         "AbstractClassCanBeInterface": {
-          "description": "Detects abstract classes with no state that could be converted to interfaces.",
+          "description": "Detects abstract classes with no state that could be converted to interfaces. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -13761,7 +13761,7 @@
           }
         },
         "AlsoCouldBeApply": {
-          "description": "Detects .also {} blocks with multiple it. references that could use .apply {} instead. [fixable: semantic]",
+          "description": "Detects .also {} blocks with multiple it. references that could use .apply {} instead. [fixable: semantic] [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -13780,7 +13780,7 @@
           }
         },
         "BracesOnIfStatements": {
-          "description": "Detects if/else statements that are missing braces around their bodies. [fixable: cosmetic]",
+          "description": "Detects if/else statements that are missing braces around their bodies. [fixable: cosmetic] [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -13809,7 +13809,7 @@
           }
         },
         "BracesOnWhenStatements": {
-          "description": "Detects when branches that are missing braces around their bodies. [fixable: cosmetic]",
+          "description": "Detects when branches that are missing braces around their bodies. [fixable: cosmetic] [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -13838,7 +13838,7 @@
           }
         },
         "CanBeNonNullable": {
-          "description": "Detects nullable types that are initialized with non-null values and never assigned null.",
+          "description": "Detects nullable types that are initialized with non-null values and never assigned null. [precision: type-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -13857,7 +13857,7 @@
           }
         },
         "CascadingCallWrapping": {
-          "description": "Detects chained calls that are not properly indented from the previous line.",
+          "description": "Detects chained calls that are not properly indented from the previous line. [precision: heuristic/text-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -13881,7 +13881,7 @@
           }
         },
         "ClassOrdering": {
-          "description": "Detects class members that are not in the conventional ordering of properties, init blocks, constructors, functions, and companion objects.",
+          "description": "Detects class members that are not in the conventional ordering of properties, init blocks, constructors, functions, and companion objects. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -13900,7 +13900,7 @@
           }
         },
         "CollapsibleIfStatements": {
-          "description": "Detects nested if statements without else that can be merged with a logical AND. [fixable: idiomatic]",
+          "description": "Detects nested if statements without else that can be merged with a logical AND. [fixable: idiomatic] [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -13919,7 +13919,7 @@
           }
         },
         "DataClassContainsFunctions": {
-          "description": "Detects data classes that contain function members. [fixable: semantic]",
+          "description": "Detects data classes that contain function members. [fixable: semantic] [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -13945,7 +13945,7 @@
           }
         },
         "DataClassShouldBeImmutable": {
-          "description": "Detects data class properties declared as var instead of val. [fixable: idiomatic]",
+          "description": "Detects data class properties declared as var instead of val. [fixable: idiomatic] [precision: type-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -13964,7 +13964,7 @@
           }
         },
         "DestructuringDeclarationWithTooManyEntries": {
-          "description": "Detects destructuring declarations with more entries than the configured maximum.",
+          "description": "Detects destructuring declarations with more entries than the configured maximum. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -13992,7 +13992,7 @@
           }
         },
         "DoubleNegativeExpression": {
-          "description": "Detects double negative expressions like !isNotEmpty() that should use the positive variant. [fixable: idiomatic]",
+          "description": "Detects double negative expressions like !isNotEmpty() that should use the positive variant. [fixable: idiomatic] [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -14011,7 +14011,7 @@
           }
         },
         "DoubleNegativeLambda": {
-          "description": "Detects double negative lambda patterns like filterNot { !predicate } that should use filter. [fixable: idiomatic]",
+          "description": "Detects double negative lambda patterns like filterNot { !predicate } that should use filter. [fixable: idiomatic] [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -14037,7 +14037,7 @@
           }
         },
         "EqualsNullCall": {
-          "description": "Detects .equals(null) calls that should use == null instead. [fixable: idiomatic]",
+          "description": "Detects .equals(null) calls that should use == null instead. [fixable: idiomatic] [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -14056,7 +14056,7 @@
           }
         },
         "EqualsOnSignatureLine": {
-          "description": "Detects expression body equals signs placed on a separate line from the function signature. [fixable: cosmetic]",
+          "description": "Detects expression body equals signs placed on a separate line from the function signature. [fixable: cosmetic] [precision: heuristic/text-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -14075,7 +14075,7 @@
           }
         },
         "ExplicitCollectionElementAccessMethod": {
-          "description": "Detects explicit .get() and .set() calls that should use index operator syntax. [fixable: idiomatic]",
+          "description": "Detects explicit .get() and .set() calls that should use index operator syntax. [fixable: idiomatic] [precision: type-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -14094,7 +14094,7 @@
           }
         },
         "ExplicitItLambdaMultipleParameters": {
-          "description": "Detects multi-parameter lambdas that use it as a parameter name.",
+          "description": "Detects multi-parameter lambdas that use it as a parameter name. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -14113,7 +14113,7 @@
           }
         },
         "ExplicitItLambdaParameter": {
-          "description": "Detects single-parameter lambdas that explicitly name their parameter it instead of using the implicit it. [fixable: cosmetic]",
+          "description": "Detects single-parameter lambdas that explicitly name their parameter it instead of using the implicit it. [fixable: cosmetic] [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -14132,7 +14132,7 @@
           }
         },
         "ExpressionBodySyntax": {
-          "description": "Detects single-expression functions that could use expression body syntax with the = operator. [fixable: idiomatic]",
+          "description": "Detects single-expression functions that could use expression body syntax with the = operator. [fixable: idiomatic] [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -14156,7 +14156,7 @@
           }
         },
         "ForbiddenAnnotation": {
-          "description": "Detects usage of annotations that are configured as forbidden. [fixable: idiomatic]",
+          "description": "Detects usage of annotations that are configured as forbidden. [fixable: idiomatic] [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -14185,7 +14185,7 @@
           }
         },
         "ForbiddenComment": {
-          "description": "Detects comments containing forbidden markers like TODO, FIXME, or STOPSHIP.",
+          "description": "Detects comments containing forbidden markers like TODO, FIXME, or STOPSHIP. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -14222,7 +14222,7 @@
           }
         },
         "ForbiddenImport": {
-          "description": "Detects import statements matching configured forbidden patterns. [fixable: idiomatic]",
+          "description": "Detects import statements matching configured forbidden patterns. [fixable: idiomatic] [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -14259,7 +14259,7 @@
           }
         },
         "ForbiddenMethodCall": {
-          "description": "Detects calls to methods that are configured as forbidden. [fixable: idiomatic]",
+          "description": "Detects calls to methods that are configured as forbidden. [fixable: idiomatic] [precision: type-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -14289,7 +14289,7 @@
           }
         },
         "ForbiddenNamedParam": {
-          "description": "Detects named arguments in function calls where they should not be used.",
+          "description": "Detects named arguments in function calls where they should not be used. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -14320,7 +14320,7 @@
           }
         },
         "ForbiddenOptIn": {
-          "description": "Detects @OptIn annotations that opt into experimental APIs. [fixable: semantic]",
+          "description": "Detects @OptIn annotations that opt into experimental APIs. [fixable: semantic] [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -14346,7 +14346,7 @@
           }
         },
         "ForbiddenSuppress": {
-          "description": "Detects @Suppress annotations that silence warnings instead of fixing the underlying issue. [fixable: semantic]",
+          "description": "Detects @Suppress annotations that silence warnings instead of fixing the underlying issue. [fixable: semantic] [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -14372,7 +14372,7 @@
           }
         },
         "ForbiddenVoid": {
-          "description": "Detects usage of the Java Void type that should be replaced with Kotlin Unit. [fixable: idiomatic]",
+          "description": "Detects usage of the Java Void type that should be replaced with Kotlin Unit. [fixable: idiomatic] [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -14401,7 +14401,7 @@
           }
         },
         "FunctionOnlyReturningConstant": {
-          "description": "Detects functions whose body only returns a constant value that could be a const val.",
+          "description": "Detects functions whose body only returns a constant value that could be a const val. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -14437,7 +14437,7 @@
           }
         },
         "LoopWithTooManyJumpStatements": {
-          "description": "Detects loops containing more break or continue statements than the configured maximum.",
+          "description": "Detects loops containing more break or continue statements than the configured maximum. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -14465,7 +14465,7 @@
           }
         },
         "MagicNumber": {
-          "description": "Detects magic number literals in code that should be extracted to named constants.",
+          "description": "Detects magic number literals in code that should be extracted to named constants. [precision: heuristic/text-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -14611,7 +14611,7 @@
           }
         },
         "MandatoryBracesLoops": {
-          "description": "Detects for, while, and do-while loops that are missing braces around their bodies. [fixable: cosmetic]",
+          "description": "Detects for, while, and do-while loops that are missing braces around their bodies. [fixable: cosmetic] [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -14630,7 +14630,7 @@
           }
         },
         "MaxChainedCallsOnSameLine": {
-          "description": "Detects lines with more chained method calls than the configured maximum.",
+          "description": "Detects lines with more chained method calls than the configured maximum. [precision: heuristic/text-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -14658,7 +14658,7 @@
           }
         },
         "MaxLineLength": {
-          "description": "Detects lines that exceed the configured maximum character length.",
+          "description": "Detects lines that exceed the configured maximum character length. [precision: heuristic/text-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -14706,7 +14706,7 @@
           }
         },
         "MayBeConstant": {
-          "description": "Detects top-level val properties with constant initializers that could be declared as const val. [fixable: idiomatic]",
+          "description": "Detects top-level val properties with constant initializers that could be declared as const val. [fixable: idiomatic] [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -14725,7 +14725,7 @@
           }
         },
         "ModifierOrder": {
-          "description": "Detects modifiers that are not in the recommended Kotlin ordering. [fixable: cosmetic]",
+          "description": "Detects modifiers that are not in the recommended Kotlin ordering. [fixable: cosmetic] [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -14744,7 +14744,7 @@
           }
         },
         "MultilineLambdaItParameter": {
-          "description": "Detects multiline lambdas that use the implicit it parameter instead of naming it explicitly.",
+          "description": "Detects multiline lambdas that use the implicit it parameter instead of naming it explicitly. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -14763,7 +14763,7 @@
           }
         },
         "MultilineRawStringIndentation": {
-          "description": "Detects multiline raw strings that are missing trimIndent() or trimMargin() calls.",
+          "description": "Detects multiline raw strings that are missing trimIndent() or trimMargin() calls. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -14794,7 +14794,7 @@
           }
         },
         "NestedClassesVisibility": {
-          "description": "Detects nested classes with explicit public modifier inside internal parent classes. [fixable: cosmetic]",
+          "description": "Detects nested classes with explicit public modifier inside internal parent classes. [fixable: cosmetic] [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -14813,7 +14813,7 @@
           }
         },
         "NewLineAtEndOfFile": {
-          "description": "Detects files that do not end with a newline character. [fixable: cosmetic]",
+          "description": "Detects files that do not end with a newline character. [fixable: cosmetic] [precision: heuristic/text-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -14832,7 +14832,7 @@
           }
         },
         "NoTabs": {
-          "description": "Detects tab characters used for indentation instead of spaces. [fixable: cosmetic]",
+          "description": "Detects tab characters used for indentation instead of spaces. [fixable: cosmetic] [precision: heuristic/text-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -14868,7 +14868,7 @@
           }
         },
         "NullableBooleanCheck": {
-          "description": "Detects equality comparisons against Boolean literals like x == true on nullable Booleans. [fixable: idiomatic]",
+          "description": "Detects equality comparisons against Boolean literals like x == true on nullable Booleans. [fixable: idiomatic] [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -14887,7 +14887,7 @@
           }
         },
         "ObjectLiteralToLambda": {
-          "description": "Detects object literals implementing a single method that could be converted to a lambda.",
+          "description": "Detects object literals implementing a single method that could be converted to a lambda. [precision: type-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -14906,7 +14906,7 @@
           }
         },
         "OptionalAbstractKeyword": {
-          "description": "Detects redundant abstract modifier on interface members where it is implied. [fixable: cosmetic]",
+          "description": "Detects redundant abstract modifier on interface members where it is implied. [fixable: cosmetic] [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -14925,7 +14925,7 @@
           }
         },
         "OptionalUnit": {
-          "description": "Detects explicit Unit return types and return Unit statements that are redundant. [fixable: cosmetic]",
+          "description": "Detects explicit Unit return types and return Unit statements that are redundant. [fixable: cosmetic] [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -14944,7 +14944,7 @@
           }
         },
         "ProtectedMemberInFinalClass": {
-          "description": "Detects protected members in final classes where they should be private. [fixable: idiomatic]",
+          "description": "Detects protected members in final classes where they should be private. [fixable: idiomatic] [precision: type-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -14963,7 +14963,7 @@
           }
         },
         "RangeUntilInsteadOfRangeTo": {
-          "description": "Detects usage of the until infix function that can be replaced with the ..\u003c range operator. [fixable: idiomatic]",
+          "description": "Detects usage of the until infix function that can be replaced with the ..\u003c range operator. [fixable: idiomatic] [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -14982,7 +14982,7 @@
           }
         },
         "RedundantConstructorKeyword": {
-          "description": "Detects unnecessary constructor keyword on primary constructors without annotations or visibility modifiers. [fixable: cosmetic]",
+          "description": "Detects unnecessary constructor keyword on primary constructors without annotations or visibility modifiers. [fixable: cosmetic] [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -15001,7 +15001,7 @@
           }
         },
         "RedundantExplicitType": {
-          "description": "Detects explicit type annotations that can be inferred from the initializer. [fixable: cosmetic]",
+          "description": "Detects explicit type annotations that can be inferred from the initializer. [fixable: cosmetic] [precision: type-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -15020,7 +15020,7 @@
           }
         },
         "RedundantHigherOrderMapUsage": {
-          "description": "Detects identity .map { it } calls that are no-ops and can be removed. [fixable: idiomatic]",
+          "description": "Detects identity .map { it } calls that are no-ops and can be removed. [fixable: idiomatic] [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -15039,7 +15039,7 @@
           }
         },
         "RedundantVisibilityModifier": {
-          "description": "Detects explicit public modifier which is redundant since public is the default visibility in Kotlin. [fixable: cosmetic]",
+          "description": "Detects explicit public modifier which is redundant since public is the default visibility in Kotlin. [fixable: cosmetic] [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -15058,7 +15058,7 @@
           }
         },
         "ReturnCount": {
-          "description": "Detects functions with more return statements than the configured maximum.",
+          "description": "Detects functions with more return statements than the configured maximum. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -15108,7 +15108,7 @@
           }
         },
         "SafeCast": {
-          "description": "Detects is-check followed by unsafe cast patterns that should use safe cast as? instead.",
+          "description": "Detects is-check followed by unsafe cast patterns that should use safe cast as? instead. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -15127,7 +15127,7 @@
           }
         },
         "SerialVersionUIDInSerializableClass": {
-          "description": "Detects Serializable classes that are missing a serialVersionUID field. [fixable: idiomatic]",
+          "description": "Detects Serializable classes that are missing a serialVersionUID field. [fixable: idiomatic] [precision: type-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -15146,7 +15146,7 @@
           }
         },
         "SpacingAfterPackageAndImports": {
-          "description": "Detects missing blank lines after package and import declarations. [fixable: cosmetic]",
+          "description": "Detects missing blank lines after package and import declarations. [fixable: cosmetic] [precision: heuristic/text-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -15165,7 +15165,7 @@
           }
         },
         "StringShouldBeRawString": {
-          "description": "Detects string literals with many escape characters that would be more readable as raw strings.",
+          "description": "Detects string literals with many escape characters that would be more readable as raw strings. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -15193,7 +15193,7 @@
           }
         },
         "ThrowsCount": {
-          "description": "Detects functions with more throw statements than the configured maximum.",
+          "description": "Detects functions with more throw statements than the configured maximum. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -15226,7 +15226,7 @@
           }
         },
         "TrailingWhitespace": {
-          "description": "Detects lines that end with trailing whitespace characters. [fixable: cosmetic]",
+          "description": "Detects lines that end with trailing whitespace characters. [fixable: cosmetic] [precision: heuristic/text-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -15245,7 +15245,7 @@
           }
         },
         "TrimMultilineRawString": {
-          "description": "Detects multiline raw strings that should use trimIndent() or trimMargin() for proper indentation. [fixable: cosmetic]",
+          "description": "Detects multiline raw strings that should use trimIndent() or trimMargin() for proper indentation. [fixable: cosmetic] [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -15271,7 +15271,7 @@
           }
         },
         "UnderscoresInNumericLiterals": {
-          "description": "Detects large numeric literals that should use underscore separators for readability. [fixable: cosmetic]",
+          "description": "Detects large numeric literals that should use underscore separators for readability. [fixable: cosmetic] [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -15300,7 +15300,7 @@
           }
         },
         "UnnecessaryAny": {
-          "description": "Detects .any { true } and .filter {}.any() patterns that can be simplified. [fixable: idiomatic]",
+          "description": "Detects .any { true } and .filter {}.any() patterns that can be simplified. [fixable: idiomatic] [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -15319,7 +15319,7 @@
           }
         },
         "UnnecessaryApply": {
-          "description": "Detects .apply {} blocks that are empty or do not reference the receiver. [fixable: idiomatic]",
+          "description": "Detects .apply {} blocks that are empty or do not reference the receiver. [fixable: idiomatic] [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -15338,7 +15338,7 @@
           }
         },
         "UnnecessaryBackticks": {
-          "description": "Detects backtick-quoted identifiers that do not require backticks. [fixable: cosmetic]",
+          "description": "Detects backtick-quoted identifiers that do not require backticks. [fixable: cosmetic] [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -15357,7 +15357,7 @@
           }
         },
         "UnnecessaryBracesAroundTrailingLambda": {
-          "description": "Detects empty parentheses before trailing lambdas that can be removed. [fixable: cosmetic]",
+          "description": "Detects empty parentheses before trailing lambdas that can be removed. [fixable: cosmetic] [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -15376,7 +15376,7 @@
           }
         },
         "UnnecessaryFilter": {
-          "description": "Detects .filter {}.first() chains that can be simplified to .first {} with the predicate. [fixable: idiomatic]",
+          "description": "Detects .filter {}.first() chains that can be simplified to .first {} with the predicate. [fixable: idiomatic] [precision: type-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -15395,7 +15395,7 @@
           }
         },
         "UnnecessaryFullyQualifiedName": {
-          "description": "Detects fully qualified names that are unnecessary because the type is already imported.",
+          "description": "Detects fully qualified names that are unnecessary because the type is already imported. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -15414,7 +15414,7 @@
           }
         },
         "UnnecessaryInheritance": {
-          "description": "Detects unnecessary explicit inheritance from Any which is implicit in Kotlin. [fixable: idiomatic]",
+          "description": "Detects unnecessary explicit inheritance from Any which is implicit in Kotlin. [fixable: idiomatic] [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -15433,7 +15433,7 @@
           }
         },
         "UnnecessaryInnerClass": {
-          "description": "Detects inner classes that do not reference the outer class and could remove the inner modifier. [fixable: idiomatic]",
+          "description": "Detects inner classes that do not reference the outer class and could remove the inner modifier. [fixable: idiomatic] [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -15452,7 +15452,7 @@
           }
         },
         "UnnecessaryLet": {
-          "description": "Detects .let {} calls that are identity transforms or single-call chains replaceable by direct invocation. [fixable: idiomatic]",
+          "description": "Detects .let {} calls that are identity transforms or single-call chains replaceable by direct invocation. [fixable: idiomatic] [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -15471,7 +15471,7 @@
           }
         },
         "UnnecessaryParentheses": {
-          "description": "Detects unnecessary parentheses around expressions that add no value. [fixable: cosmetic]",
+          "description": "Detects unnecessary parentheses around expressions that add no value. [fixable: cosmetic] [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -15495,7 +15495,7 @@
           }
         },
         "UnnecessaryReversed": {
-          "description": "Detects chained sort and reverse calls that can be replaced with a single sort operation. [fixable: idiomatic]",
+          "description": "Detects chained sort and reverse calls that can be replaced with a single sort operation. [fixable: idiomatic] [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -15514,7 +15514,7 @@
           }
         },
         "UnusedImport": {
-          "description": "Detects import statements where the imported name is not referenced in the file. [fixable: idiomatic]",
+          "description": "Detects import statements where the imported name is not referenced in the file. [fixable: idiomatic] [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -15533,7 +15533,7 @@
           }
         },
         "UnusedParameter": {
-          "description": "Detects function parameters that are never used in the function body.",
+          "description": "Detects function parameters that are never used in the function body. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -15558,7 +15558,7 @@
           }
         },
         "UnusedPrivateClass": {
-          "description": "Detects private classes that are never referenced in the file.",
+          "description": "Detects private classes that are never referenced in the file. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -15577,7 +15577,7 @@
           }
         },
         "UnusedPrivateFunction": {
-          "description": "Detects private functions that are never called in the file.",
+          "description": "Detects private functions that are never called in the file. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -15602,7 +15602,7 @@
           }
         },
         "UnusedPrivateMember": {
-          "description": "Detects private members (classes, functions, properties) that are never used.",
+          "description": "Detects private members (classes, functions, properties) that are never used. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -15634,7 +15634,7 @@
           }
         },
         "UnusedPrivateProperty": {
-          "description": "Detects private properties that are never referenced in the file.",
+          "description": "Detects private properties that are never referenced in the file. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -15659,7 +15659,7 @@
           }
         },
         "UnusedVariable": {
-          "description": "Detects local variables that are declared but never used.",
+          "description": "Detects local variables that are declared but never used. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -15684,7 +15684,7 @@
           }
         },
         "UseAnyOrNoneInsteadOfFind": {
-          "description": "Detects .find {} != null patterns that should use .any {} or .none {} instead. [fixable: idiomatic]",
+          "description": "Detects .find {} != null patterns that should use .any {} or .none {} instead. [fixable: idiomatic] [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -15703,7 +15703,7 @@
           }
         },
         "UseArrayLiteralsInAnnotations": {
-          "description": "Detects arrayOf() calls in annotations that should use array literal [] syntax. [fixable: idiomatic]",
+          "description": "Detects arrayOf() calls in annotations that should use array literal [] syntax. [fixable: idiomatic] [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -15722,7 +15722,7 @@
           }
         },
         "UseCheckNotNull": {
-          "description": "Detects check(x != null) calls that should use checkNotNull(x) instead. [fixable: idiomatic]",
+          "description": "Detects check(x != null) calls that should use checkNotNull(x) instead. [fixable: idiomatic] [precision: type-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -15741,7 +15741,7 @@
           }
         },
         "UseCheckOrError": {
-          "description": "Detects if (!cond) throw IllegalStateException patterns that should use check(). [fixable: idiomatic]",
+          "description": "Detects if (!cond) throw IllegalStateException patterns that should use check(). [fixable: idiomatic] [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -15760,7 +15760,7 @@
           }
         },
         "UseDataClass": {
-          "description": "Detects classes with only properties in the constructor that could be data classes.",
+          "description": "Detects classes with only properties in the constructor that could be data classes. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -15784,7 +15784,7 @@
           }
         },
         "UseEmptyCounterpart": {
-          "description": "Detects listOf(), setOf(), and similar calls with no arguments that should use emptyList(), emptySet(), etc. [fixable: idiomatic]",
+          "description": "Detects listOf(), setOf(), and similar calls with no arguments that should use emptyList(), emptySet(), etc. [fixable: idiomatic] [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -15803,7 +15803,7 @@
           }
         },
         "UseIfEmptyOrIfBlank": {
-          "description": "Detects manual isEmpty/isBlank checks that could use .ifEmpty {} or .ifBlank {} instead. [fixable: idiomatic]",
+          "description": "Detects manual isEmpty/isBlank checks that could use .ifEmpty {} or .ifBlank {} instead. [fixable: idiomatic] [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -15822,7 +15822,7 @@
           }
         },
         "UseIfInsteadOfWhen": {
-          "description": "Detects when expressions with two or fewer branches that could be replaced with if. [fixable: idiomatic]",
+          "description": "Detects when expressions with two or fewer branches that could be replaced with if. [fixable: idiomatic] [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -15846,7 +15846,7 @@
           }
         },
         "UseIsNullOrEmpty": {
-          "description": "Detects x == null || x.isEmpty() patterns that should use isNullOrEmpty(). [fixable: idiomatic]",
+          "description": "Detects x == null || x.isEmpty() patterns that should use isNullOrEmpty(). [fixable: idiomatic] [precision: type-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -15865,7 +15865,7 @@
           }
         },
         "UseLet": {
-          "description": "Detects null checks that could be replaced with ?.let {} scope function.",
+          "description": "Detects null checks that could be replaced with ?.let {} scope function. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -15884,7 +15884,7 @@
           }
         },
         "UseOrEmpty": {
-          "description": "Detects x ?: emptyList() patterns that should use .orEmpty() instead. [fixable: idiomatic]",
+          "description": "Detects x ?: emptyList() patterns that should use .orEmpty() instead. [fixable: idiomatic] [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -15903,7 +15903,7 @@
           }
         },
         "UseRequire": {
-          "description": "Detects if (!cond) throw IllegalArgumentException patterns that should use require(). [fixable: idiomatic]",
+          "description": "Detects if (!cond) throw IllegalArgumentException patterns that should use require(). [fixable: idiomatic] [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -15922,7 +15922,7 @@
           }
         },
         "UseRequireNotNull": {
-          "description": "Detects require(x != null) calls that should use requireNotNull(x) instead. [fixable: idiomatic]",
+          "description": "Detects require(x != null) calls that should use requireNotNull(x) instead. [fixable: idiomatic] [precision: type-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -15941,7 +15941,7 @@
           }
         },
         "UseSumOfInsteadOfFlatMapSize": {
-          "description": "Detects flatMap/map followed by size/count/sum chains that should use sumOf instead. [fixable: idiomatic]",
+          "description": "Detects flatMap/map followed by size/count/sum chains that should use sumOf instead. [fixable: idiomatic] [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -15960,7 +15960,7 @@
           }
         },
         "UselessCallOnNotNull": {
-          "description": "Detects calls like .orEmpty() or .isNullOrEmpty() on receivers that are already non-null. [fixable: idiomatic]",
+          "description": "Detects calls like .orEmpty() or .isNullOrEmpty() on receivers that are already non-null. [fixable: idiomatic] [precision: type-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -15979,7 +15979,7 @@
           }
         },
         "UtilityClassWithPublicConstructor": {
-          "description": "Detects utility classes that have a public constructor instead of a private one. [fixable: idiomatic]",
+          "description": "Detects utility classes that have a public constructor instead of a private one. [fixable: idiomatic] [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -15998,7 +15998,7 @@
           }
         },
         "VarCouldBeVal": {
-          "description": "Detects var properties that are never reassigned and could be declared as val. [fixable: idiomatic]",
+          "description": "Detects var properties that are never reassigned and could be declared as val. [fixable: idiomatic] [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -16022,7 +16022,7 @@
           }
         },
         "WildcardImport": {
-          "description": "Detects wildcard import statements that should be replaced with explicit imports.",
+          "description": "Detects wildcard import statements that should be replaced with explicit imports. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -16065,7 +16065,7 @@
       "additionalProperties": false,
       "properties": {
         "ApplyPluginTwice": {
-          "description": "Detects a Gradle plugin applied in both plugins { } and apply(plugin = ...) in the same build file. [fixable: idiomatic]",
+          "description": "Detects a Gradle plugin applied in both plugins { } and apply(plugin = ...) in the same build file. [fixable: idiomatic] [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -16084,7 +16084,7 @@
           }
         },
         "CompileSdkMismatchAcrossModules": {
-          "description": "Detects Android modules whose compileSdk is lower than the maximum compileSdk in the project.",
+          "description": "Detects Android modules whose compileSdk is lower than the maximum compileSdk in the project. [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -16103,7 +16103,7 @@
           }
         },
         "ConfigurationsAllSideEffect": {
-          "description": "Detects configurations.all blocks that mutate dependency resolution globally.",
+          "description": "Detects configurations.all blocks that mutate dependency resolution globally. [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -16127,7 +16127,7 @@
           }
         },
         "ConventionPluginAppliedToWrongTarget": {
-          "description": "Detects convention plugins applied to incompatible Gradle module targets.",
+          "description": "Detects convention plugins applied to incompatible Gradle module targets. [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -16153,7 +16153,7 @@
           }
         },
         "DependenciesInRootProject": {
-          "description": "Detects dependency declarations directly in the root Gradle project.",
+          "description": "Detects dependency declarations directly in the root Gradle project. [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -16183,7 +16183,7 @@
           }
         },
         "DependencyFromBintray": {
-          "description": "Detects Gradle repositories hosted on retired Bintray endpoints.",
+          "description": "Detects Gradle repositories hosted on retired Bintray endpoints. [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -16202,7 +16202,7 @@
           }
         },
         "DependencyFromHttp": {
-          "description": "Detects Gradle Maven/Ivy repositories fetched over plaintext HTTP.",
+          "description": "Detects Gradle Maven/Ivy repositories fetched over plaintext HTTP. [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -16240,7 +16240,7 @@
           }
         },
         "DependencyFromJcenter": {
-          "description": "Detects Gradle repositories that still use JCenter.",
+          "description": "Detects Gradle repositories that still use JCenter. [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -16259,7 +16259,7 @@
           }
         },
         "DependencySnapshotInRelease": {
-          "description": "Detects Gradle dependencies that use SNAPSHOT versions in release builds.",
+          "description": "Detects Gradle dependencies that use SNAPSHOT versions in release builds. [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -16290,7 +16290,7 @@
           }
         },
         "DependencyVerificationDisabled": {
-          "description": "Detects Gradle dependency verification disabled in gradle.properties.",
+          "description": "Detects Gradle dependency verification disabled in gradle.properties. [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -16314,7 +16314,7 @@
           }
         },
         "DependencyWithoutGroup": {
-          "description": "Detects legacy Gradle dependency coordinates that omit the group.",
+          "description": "Detects legacy Gradle dependency coordinates that omit the group. [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -16333,7 +16333,7 @@
           }
         },
         "GradleWrapperValidationAction": {
-          "description": "Detects GitHub Actions Gradle setup steps missing wrapper validation.",
+          "description": "Detects GitHub Actions Gradle setup steps missing wrapper validation. [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -16352,7 +16352,7 @@
           }
         },
         "JvmTargetMismatch": {
-          "description": "Detects Kotlin JVM target and Java compatibility settings that disagree.",
+          "description": "Detects Kotlin JVM target and Java compatibility settings that disagree. [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -16371,7 +16371,7 @@
           }
         },
         "KotlinVersionMismatchAcrossModules": {
-          "description": "Detects modules whose Kotlin JVM target or toolchain differs from the project majority.",
+          "description": "Detects modules whose Kotlin JVM target or toolchain differs from the project majority. [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -16390,7 +16390,7 @@
           }
         },
         "MissingGradleChecksums": {
-          "description": "Detects Gradle dependency locking declarations without a sibling gradle.lockfile.",
+          "description": "Detects Gradle dependency locking declarations without a sibling gradle.lockfile. [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -16409,7 +16409,7 @@
           }
         },
         "VersionCatalogBuildSrcMismatch": {
-          "description": "Detects buildSrc/build-logic dependency coordinates whose version disagrees with libs.versions.toml.",
+          "description": "Detects buildSrc/build-logic dependency coordinates whose version disagrees with libs.versions.toml. [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -16428,7 +16428,7 @@
           }
         },
         "VersionCatalogDuplicateVersion": {
-          "description": "Detects [versions] aliases in libs.versions.toml that share the same literal version string.",
+          "description": "Detects [versions] aliases in libs.versions.toml that share the same literal version string. [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -16447,7 +16447,7 @@
           }
         },
         "VersionCatalogRawVersionInBuild": {
-          "description": "Detects build.gradle(.kts) dependency literals whose group:name coordinate is already declared in libs.versions.toml.",
+          "description": "Detects build.gradle(.kts) dependency literals whose group:name coordinate is already declared in libs.versions.toml. [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -16466,7 +16466,7 @@
           }
         },
         "VersionCatalogUnused": {
-          "description": "Detects libs.versions.toml aliases not referenced by any build script or convention plugin.",
+          "description": "Detects libs.versions.toml aliases not referenced by any build script or convention plugin. [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -16523,7 +16523,7 @@
       "additionalProperties": false,
       "properties": {
         "AssertEqualsArgumentOrder": {
-          "description": "Detects assertEquals calls with reversed argument order (actual, expected) instead of (expected, actual).",
+          "description": "Detects assertEquals calls with reversed argument order (actual, expected) instead of (expected, actual). [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -16542,7 +16542,7 @@
           }
         },
         "AssertNullableWithNotNullAssertion": {
-          "description": "Detects non-null assertions (!!) inside assertion calls where assertNotNull should be used instead.",
+          "description": "Detects non-null assertions (!!) inside assertion calls where assertNotNull should be used instead. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -16561,7 +16561,7 @@
           }
         },
         "AssertTrueOnComparison": {
-          "description": "Detects assertTrue(a == b) calls that should use assertEquals for better failure messages.",
+          "description": "Detects assertTrue(a == b) calls that should use assertEquals for better failure messages. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -16580,7 +16580,7 @@
           }
         },
         "MixedAssertionLibraries": {
-          "description": "Detects files that import both JUnit Assert and Google Truth assertion APIs.",
+          "description": "Detects files that import both JUnit Assert and Google Truth assertion APIs. [precision: heuristic/text-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -16599,7 +16599,7 @@
           }
         },
         "MockWithoutVerify": {
-          "description": "Detects mock objects created in test functions that are never verified or stubbed.",
+          "description": "Detects mock objects created in test functions that are never verified or stubbed. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -16618,7 +16618,7 @@
           }
         },
         "RelaxedMockUsedForValueClass": {
-          "description": "Detects relaxed mocks of primitive or value types where literal values should be used instead.",
+          "description": "Detects relaxed mocks of primitive or value types where literal values should be used instead. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -16637,7 +16637,7 @@
           }
         },
         "RunBlockingInTest": {
-          "description": "Detects runBlocking usage in test functions where runTest provides better coroutine test support.",
+          "description": "Detects runBlocking usage in test functions where runTest provides better coroutine test support. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -16656,7 +16656,7 @@
           }
         },
         "RunTestWithDelay": {
-          "description": "Detects delay() calls inside runTest blocks where advanceTimeBy should be used instead.",
+          "description": "Detects delay() calls inside runTest blocks where advanceTimeBy should be used instead. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -16675,7 +16675,7 @@
           }
         },
         "RunTestWithThreadSleep": {
-          "description": "Detects Thread.sleep() calls inside runTest blocks where advanceTimeBy should be used instead.",
+          "description": "Detects Thread.sleep() calls inside runTest blocks where advanceTimeBy should be used instead. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -16694,7 +16694,7 @@
           }
         },
         "SharedMutableStateInObject": {
-          "description": "Detects mutable var properties in companion objects or object declarations shared across tests.",
+          "description": "Detects mutable var properties in companion objects or object declarations shared across tests. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -16713,7 +16713,7 @@
           }
         },
         "SpyOnDataClass": {
-          "description": "Detects spying on data class instances where value-based equality breaks spy semantics.",
+          "description": "Detects spying on data class instances where value-based equality breaks spy semantics. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -16732,7 +16732,7 @@
           }
         },
         "TestDispatcherNotInjected": {
-          "description": "Detects production dispatchers (Dispatchers.IO, Default, Main) used directly in test functions.",
+          "description": "Detects production dispatchers (Dispatchers.IO, Default, Main) used directly in test functions. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -16751,7 +16751,7 @@
           }
         },
         "TestFunctionReturnValue": {
-          "description": "Detects @Test functions that return a non-Unit type, since JUnit ignores return values.",
+          "description": "Detects @Test functions that return a non-Unit type, since JUnit ignores return values. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -16770,7 +16770,7 @@
           }
         },
         "TestInheritanceDepth": {
-          "description": "Detects test class inheritance hierarchies deeper than two levels that should be flattened.",
+          "description": "Detects test class inheritance hierarchies deeper than two levels that should be flattened. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -16789,7 +16789,7 @@
           }
         },
         "TestNameContainsUnderscore": {
-          "description": "Detects test function names using underscores where backtick-quoted names are preferred. [fixable: cosmetic]",
+          "description": "Detects test function names using underscores where backtick-quoted names are preferred. [fixable: cosmetic] [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -16808,7 +16808,7 @@
           }
         },
         "TestWithOnlyTodo": {
-          "description": "Detects @Test functions whose body is only a TODO() or fail() call without @Ignore.",
+          "description": "Detects @Test functions whose body is only a TODO() or fail() call without @Ignore. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -16827,7 +16827,7 @@
           }
         },
         "TestWithoutAssertion": {
-          "description": "Detects @Test functions that contain no assertion or verification calls.",
+          "description": "Detects @Test functions that contain no assertion or verification calls. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -16858,7 +16858,7 @@
           }
         },
         "UntestedPublicApi": {
-          "description": "Detects public Kotlin API declarations that are not referenced from test sources.",
+          "description": "Detects public Kotlin API declarations that are not referenced from test sources. [precision: project-structure-aware]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -16877,7 +16877,7 @@
           }
         },
         "VerifyWithoutMock": {
-          "description": "Detects verify or coVerify calls on objects that are not declared as mocks in the test.",
+          "description": "Detects verify or coVerify calls on objects that are not declared as mocks in the test. [precision: ast-backed]",
           "type": "object",
           "additionalProperties": false,
           "properties": {


### PR DESCRIPTION
## Summary
- Promote the precision classification previously hidden in `internal/rules/meta_lookup.go` to a queryable field on `api.Rule` / `api.RuleDescriptor`, so docs, dashboards, IDE pickers, and MCP clients can filter rules by evidence tier.
- Precision is a `uint8` enum ordered noisiest → cleanest (`PrecisionHeuristicTextBacked` < `PrecisionASTBacked` < `PrecisionProjectStructure` < `PrecisionTypeAware` < `PrecisionPolicy`), exposed through stable string labels for wire/UX surfaces.
- Closes #184.

## Wiring
- `internal/rules/api/precision.go` — new enum + `String()` + `ParsePrecision()` (canonical labels only) + `PrecisionProvider` interface for stubbing in tests.
- `Rule.Precision` and `RuleDescriptor.Precision` fields; `WithPrecision(p)` fake helper.
- `V2RulePrecision` resolution order: explicit `Rule.Precision` → `PrecisionProvider` on `Rule.Implementation` → derived from `Needs` / `NodeTypes` / override maps.
- `MetaForRule` always returns a non-`Unset` precision via a small `resolvePrecision` helper.
- `schema.RuleMeta.Precision` plus a `[precision: …]` tag appended to each per-rule schema description (`make schema` regen included).
- MCP `rules` tool: `precision` filter on `search`, precision returned by `explain` and `search` hits, and a registry-wide precision breakdown on `categories`.
- SARIF `properties` block gains a `precision` field per result.
- Fixes a latent bug in `internal/mcp/resources.go` that ran `string(uint8)` once the type flipped to `uint8`.

## Test plan
- [x] `go build -o krit ./cmd/krit/`
- [x] `go vet ./...`
- [x] `golangci-lint run ./internal/rules/... ./internal/schema/... ./internal/mcp/... ./internal/output/...`
- [x] `go test ./... -count=1`
- [x] `make integration` (11/11 PASS)
- [x] `make regression` (PASS, finding counts unchanged for webservice + android-app playgrounds)
- [x] `make schema` regenerated `schemas/krit-config.schema.json` (delta is `[precision: …]` appended to each rule description)
- [x] New tests: `TestPrecisionString`, `TestPrecisionOrdering`, `TestParsePrecision`, `TestV2RulePrecision_Override`, `TestV2RulePrecision_ProviderFallback`, `TestMetaForRule_PrecisionFallback`, `TestMetaForRule_PrecisionExplicit`, `TestMetaForRule_PrecisionAlwaysSet`