### PR TITLE
feat(rules): add Cost weight class with --max-cost filter

### DIFF
--- a/internal/cli/scan/flags.go
+++ b/internal/cli/scan/flags.go
@@ -74,6 +74,7 @@ type scanFlags struct {
 	Delta                    *string
 	DisableRules             *string
 	EnableRules              *string
+	MaxCost                  *string
 	Experiment               *string
 	ExperimentOff            *string
 	ListExperiments          *bool
@@ -172,6 +173,7 @@ func registerScanFlags(fs *flag.FlagSet) *scanFlags {
 	f.Delta = fs.String("delta", "", "Only fail/report findings newly introduced since git ref (e.g., main, origin/main)")
 	f.DisableRules = fs.String("disable-rules", "", "Comma-separated rules to disable (e.g., MagicNumber,MaxLineLength)")
 	f.EnableRules = fs.String("enable-rules", "", "Comma-separated rules to enable (overrides config)")
+	f.MaxCost = fs.String("max-cost", "", "Maximum rule weight class to run: trivial, line, ast (fast), crossfile (balanced), oracle, fir (thorough). Filters the active rule set so higher-cost rules are skipped.")
 	f.Experiment = fs.String("experiment", "", "Comma-separated experiment feature flags to enable")
 	f.ExperimentOff = fs.String("experiment-off", "", "Comma-separated experiment feature flags to disable")
 	f.ListExperiments = fs.Bool("list-experiments", false, "List available experiment feature flags")

--- a/internal/cli/scan/flags_test.go
+++ b/internal/cli/scan/flags_test.go
@@ -40,6 +40,7 @@ func TestRegisterScanFlagsAllFieldsPopulated(t *testing.T) {
 		{"MinConfidence", f.MinConfidence},
 		{"Diff", f.Diff},
 		{"DisableRules", f.DisableRules},
+		{"MaxCost", f.MaxCost},
 		{"Experiment", f.Experiment},
 		{"ExperimentMatrix", f.ExperimentMatrix},
 		{"PromoteExperiment", f.PromoteExperiment},

--- a/internal/cli/scan/max_cost_test.go
+++ b/internal/cli/scan/max_cost_test.go
@@ -1,0 +1,54 @@
+package scan
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kaeawc/krit/internal/config"
+	api "github.com/kaeawc/krit/internal/rules/api"
+)
+
+func TestResolveMaxCost_FlagWins(t *testing.T) {
+	cfg := writeTempMaxCostConfig(t, "oracle")
+	got, ok := resolveMaxCost("ast", cfg)
+	if !ok {
+		t.Fatalf("resolveMaxCost should return ok=true for flag value")
+	}
+	if got != api.CostAST {
+		t.Fatalf("resolveMaxCost = %s, want ast", got)
+	}
+}
+
+func TestResolveMaxCost_ConfigFallback(t *testing.T) {
+	cfg := writeTempMaxCostConfig(t, "balanced")
+	got, ok := resolveMaxCost("", cfg)
+	if !ok {
+		t.Fatalf("resolveMaxCost should fall back to config")
+	}
+	if got != api.CostCrossFile {
+		t.Fatalf("resolveMaxCost = %s, want crossfile (balanced)", got)
+	}
+}
+
+func TestResolveMaxCost_EmptyAndUnknown(t *testing.T) {
+	if _, ok := resolveMaxCost("", nil); ok {
+		t.Errorf("resolveMaxCost with no flag/config should return ok=false")
+	}
+	if _, ok := resolveMaxCost("bogus", nil); ok {
+		t.Errorf("resolveMaxCost with bogus flag should return ok=false")
+	}
+}
+
+func writeTempMaxCostConfig(t *testing.T, value string) *config.Config {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "krit.yml")
+	if err := os.WriteFile(path, []byte("maxCost: "+value+"\n"), 0o600); err != nil {
+		t.Fatalf("writing temp config: %v", err)
+	}
+	cfg, err := config.LoadConfig(path)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	return cfg
+}

--- a/internal/cli/scan/runner_state.go
+++ b/internal/cli/scan/runner_state.go
@@ -256,6 +256,26 @@ func loadScanConfig(f *scanFlags) *config.Config {
 	return cfg
 }
 
+// resolveMaxCost resolves the effective --max-cost / maxCost: filter.
+// CLI value wins; falls back to the top-level config key. Returns
+// (cost, true) when a filter should be applied. Unknown tokens log a
+// warning and disable the filter (ok=false).
+func resolveMaxCost(flagVal string, cfg *config.Config) (api.Cost, bool) {
+	raw := strings.TrimSpace(flagVal)
+	if raw == "" && cfg != nil {
+		raw = strings.TrimSpace(cfg.GetTopLevelKeyString("maxCost", ""))
+	}
+	if raw == "" {
+		return api.CostUnset, false
+	}
+	cost, ok := api.ParseCost(raw)
+	if !ok {
+		fmt.Fprintf(os.Stderr, "warning: unknown --max-cost value %q; ignoring (valid: trivial, line, ast, crossfile, oracle, fir, fast, balanced, thorough)\n", raw)
+		return api.CostUnset, false
+	}
+	return cost, true
+}
+
 func resolveMaxFixLevel(f *scanFlags) (rules.FixLevel, bool) {
 	if !*f.Fix && !*f.DryRun {
 		return rules.FixIdiomatic, true
@@ -371,6 +391,14 @@ func (r *runner) filterRules() (handled bool, code int) {
 		enabledSet := clishared.ParseRuleNameSetCSV(*r.f.EnableRules)
 		experimental := *r.f.Experimental || r.cfg.GetTopLevelBool("experimental", false)
 		r.activeRules = rules.ActiveRulesV2(disabledSet, enabledSet, *r.f.AllRules, experimental)
+		if maxCost, ok := resolveMaxCost(*r.f.MaxCost, r.cfg); ok {
+			before := len(r.activeRules)
+			r.activeRules = rules.FilterByMaxCost(r.activeRules, maxCost)
+			if *r.f.Verbose && len(r.activeRules) != before {
+				fmt.Fprintf(os.Stderr, "verbose: --max-cost=%s filtered %d → %d rules\n",
+					maxCost, before, len(r.activeRules))
+			}
+		}
 		if pipeline.RulesNeedProjectModel(r.activeRules) {
 			r.ensureProjectModel()
 		}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -428,6 +428,19 @@ func (c *Config) GetTopLevelInt(section, key string, defaultVal int) int {
 	return toInt(v, defaultVal)
 }
 
+// GetTopLevelKeyString returns a string value from a top-level config key.
+// For example, GetTopLevelKeyString("maxCost", "") reads config.maxCost.
+func (c *Config) GetTopLevelKeyString(key, defaultVal string) string {
+	if c == nil || c.data == nil {
+		return defaultVal
+	}
+	s, ok := c.data[key].(string)
+	if !ok {
+		return defaultVal
+	}
+	return s
+}
+
 // GetTopLevelBool returns a bool value from a top-level config key.
 // For example, GetTopLevelBool("warningsAsErrors", false) reads config.warningsAsErrors.
 func (c *Config) GetTopLevelBool(key string, defaultVal bool) bool {

--- a/internal/mcp/tool_rules.go
+++ b/internal/mcp/tool_rules.go
@@ -79,6 +79,7 @@ func (s *Server) rulesExplain(args rulesArgs) ToolResult {
 		"active":      active,
 		"fixable":     fixable,
 		"precision":   rules.V2RulePrecision(r).String(),
+		"cost":        rules.CostFor(r).String(),
 	}
 	if fixLevel != "" {
 		info["fixLevel"] = fixLevel
@@ -115,6 +116,7 @@ func (s *Server) rulesSearch(args rulesArgs) ToolResult {
 		Active      bool   `json:"active"`
 		Fixable     bool   `json:"fixable"`
 		Precision   string `json:"precision"`
+		Cost        string `json:"cost"`
 		Description string `json:"description"`
 		Score       int    `json:"-"`
 	}
@@ -160,6 +162,7 @@ func (s *Server) rulesSearch(args rulesArgs) ToolResult {
 			Active:      rules.IsDefaultActive(r.ID),
 			Fixable:     fixable,
 			Precision:   precision.String(),
+			Cost:        rules.CostFor(r).String(),
 			Description: r.Description,
 			Score:       score,
 		})

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -101,9 +101,14 @@ type sarifDriver struct {
 }
 
 type sarifRule struct {
-	ID               string     `json:"id"`
-	ShortDescription sarifText  `json:"shortDescription"`
-	FullDescription  *sarifText `json:"fullDescription,omitempty"`
+	ID               string               `json:"id"`
+	ShortDescription sarifText            `json:"shortDescription"`
+	FullDescription  *sarifText           `json:"fullDescription,omitempty"`
+	Properties       *sarifRuleProperties `json:"properties,omitempty"`
+}
+
+type sarifRuleProperties struct {
+	Cost string `json:"cost,omitempty"`
 }
 
 type sarifText struct {
@@ -145,15 +150,16 @@ type sarifProperties struct {
 func FormatSARIFColumns(w io.Writer, columns *scanner.FindingColumns, version string) error {
 	cols := normalizedFindingColumns(columns)
 
-	// Build description map from rule registry.
 	descMap := make(map[string]string)
 	precisionMap := make(map[string]string)
+	costMap := make(map[string]string)
 	for _, r := range api.Registry {
 		key := r.Category + "/" + r.ID
 		if r.Description != "" {
 			descMap[key] = r.Description
 		}
 		precisionMap[key] = rules.V2RulePrecision(r).String()
+		costMap[key] = rules.CostFor(r).String()
 	}
 
 	rulesSeen := make(map[string]bool)
@@ -170,6 +176,9 @@ func FormatSARIFColumns(w io.Writer, columns *scanner.FindingColumns, version st
 			}
 			if desc, ok := descMap[ruleID]; ok {
 				sr.FullDescription = &sarifText{Text: desc}
+			}
+			if cost, ok := costMap[ruleID]; ok && cost != "unset" {
+				sr.Properties = &sarifRuleProperties{Cost: cost}
 			}
 			sarifRules = append(sarifRules, sr)
 		}

--- a/internal/rules/api/rule.go
+++ b/internal/rules/api/rule.go
@@ -8,6 +8,8 @@
 package api
 
 import (
+	"strings"
+
 	"github.com/kaeawc/krit/internal/android"
 	"github.com/kaeawc/krit/internal/filefacts"
 	"github.com/kaeawc/krit/internal/javafacts"
@@ -17,6 +19,8 @@ import (
 	"github.com/kaeawc/krit/internal/scanner"
 	"github.com/kaeawc/krit/internal/typeinfer"
 )
+
+var costTokenReplacer = strings.NewReplacer("-", "", "_", "", " ", "")
 
 // Capabilities is a bitfield carrying both the rule's primary scope
 // (which dispatcher bucket it lands in) and its orthogonal aspects
@@ -408,6 +412,94 @@ func (l FixLevel) String() string {
 	}
 }
 
+// Cost is an ordinal weight class that lets users and the dispatcher
+// reason about how expensive a rule is to run. Costs are derived from
+// the rule's Needs bitfield when Rule.Cost is left at CostUnset; rules
+// may pin a specific tier when the derivation under-counts (e.g. a rule
+// that walks parsed files but only inspects identifiers).
+//
+// Values are monotonic: a higher Cost implies the rule's evidence
+// pipeline is a strict superset of the lower tiers, so --max-cost can
+// filter by inequality.
+type Cost uint8
+
+const (
+	// CostUnset is the zero value; readers should call CostFor / the
+	// derivation helper rather than assuming the rule actually runs at
+	// this tier.
+	CostUnset Cost = iota
+	// CostTrivial covers rules that do trivial work per file (regex on
+	// path, manifest presence checks). Rules in this tier are typically
+	// safe for every pre-commit hook.
+	CostTrivial
+	// CostLine covers rules dispatched through the line-pass family —
+	// one walk over file.Lines, no AST traversal.
+	CostLine
+	// CostAST covers rules dispatched against the per-file flat AST. No
+	// resolver, no cross-file index, no oracle calls.
+	CostAST
+	// CostCrossFile covers rules that consume the project-scope code or
+	// module index, including parsed-files and aggregate rules whose
+	// inputs require a cross-file build phase.
+	CostCrossFile
+	// CostOracle covers rules that require the Kotlin Analysis API
+	// oracle (any NeedsOracle* bit) or that pin a TypeInfo backend
+	// requiring resolved facts.
+	CostOracle
+	// CostFIR covers rules that require FIR / Java-facts helper
+	// subprocesses on top of the oracle.
+	CostFIR
+)
+
+// String returns the canonical lowercase token for a Cost. The token is
+// the same one users pass to --max-cost / maxCost.
+func (c Cost) String() string {
+	switch c {
+	case CostTrivial:
+		return "trivial"
+	case CostLine:
+		return "line"
+	case CostAST:
+		return "ast"
+	case CostCrossFile:
+		return "crossfile"
+	case CostOracle:
+		return "oracle"
+	case CostFIR:
+		return "fir"
+	default:
+		return "unset"
+	}
+}
+
+// ParseCost maps a user-facing token (case-insensitive, with the legacy
+// hyphenated "cross-file" form accepted) to a Cost. It also understands
+// the documented presets fast / balanced / thorough so configuration
+// surfaces can hand the same string to one parser. Returns CostUnset
+// and ok=false for unknown tokens.
+func ParseCost(s string) (Cost, bool) {
+	switch normalizeCostToken(s) {
+	case "trivial":
+		return CostTrivial, true
+	case "line":
+		return CostLine, true
+	case "ast", "fast":
+		return CostAST, true
+	case "crossfile", "balanced":
+		return CostCrossFile, true
+	case "oracle":
+		return CostOracle, true
+	case "fir", "thorough", "all":
+		return CostFIR, true
+	default:
+		return CostUnset, false
+	}
+}
+
+func normalizeCostToken(s string) string {
+	return costTokenReplacer.Replace(strings.ToLower(s))
+}
+
 // Severity levels.
 type Severity string
 
@@ -718,6 +810,12 @@ type Rule struct {
 
 	// Fix metadata
 	Fix FixLevel // FixNone → not fixable
+
+	// Cost is the rule's weight class. When left at CostUnset, the
+	// dispatcher derives a Cost from Needs / NodeTypes / JavaFacts via
+	// rules.CostFor. Rules may pin an explicit Cost when the derived
+	// value would under- or over-state the actual work performed.
+	Cost Cost
 
 	// Confidence tier (0 = use family default)
 	Confidence float64

--- a/internal/rules/cost_derive.go
+++ b/internal/rules/cost_derive.go
@@ -1,0 +1,79 @@
+package rules
+
+import (
+	api "github.com/kaeawc/krit/internal/rules/api"
+)
+
+// CostFor returns the rule's effective Cost. When Rule.Cost is set to a
+// non-zero value the rule's declaration wins; otherwise the cost is
+// derived from the rule's capability bits. Returns CostUnset only when
+// r is nil.
+func CostFor(r *api.Rule) api.Cost {
+	if r == nil {
+		return api.CostUnset
+	}
+	if r.Cost != api.CostUnset {
+		return r.Cost
+	}
+	return DeriveCost(r)
+}
+
+// DeriveCost computes a Cost for a rule purely from its declared
+// capabilities. It ignores any explicit Rule.Cost so callers that want
+// to compare the declared tier against the derived tier (drift checks,
+// tests) can do so. The priority order matches the documented presets:
+//
+//   - JavaFacts / FIR helpers → CostFIR
+//   - Any NeedsOracle* bit, or a TypeInfo hint requiring resolved facts
+//     → CostOracle
+//   - NeedsCrossFile / NeedsModuleIndex / NeedsParsedFiles / NeedsAggregate
+//     → CostCrossFile
+//   - NeedsManifest / NeedsResources / NeedsGradle → CostAST (per-file
+//     project-data rules; their setup cost is amortized once per project,
+//     not per rule)
+//   - NeedsLinePass → CostLine
+//   - everything else (per-file AST dispatch) → CostAST
+//
+// A rule with no capabilities and no NodeTypes is treated as CostAST —
+// the dispatcher will still run it for every node, which is the
+// AST-tier workload.
+func DeriveCost(r *api.Rule) api.Cost {
+	if r == nil {
+		return api.CostUnset
+	}
+	if r.JavaFacts != nil {
+		return api.CostFIR
+	}
+	if r.Needs.HasAny(api.NeedsOracle) {
+		return api.CostOracle
+	}
+	if r.TypeInfo.Required {
+		return api.CostOracle
+	}
+	if r.Needs.Has(api.NeedsCrossFile) ||
+		r.Needs.Has(api.NeedsModuleIndex) ||
+		r.Needs.Has(api.NeedsParsedFiles) ||
+		r.Needs.Has(api.NeedsAggregate) {
+		return api.CostCrossFile
+	}
+	if r.Needs.Has(api.NeedsLinePass) {
+		return api.CostLine
+	}
+	return api.CostAST
+}
+
+// FilterByMaxCost returns the subset of rules whose effective Cost is
+// at most maxCost. When maxCost is CostUnset the input slice is
+// returned unchanged so callers can opt out by passing zero.
+func FilterByMaxCost(in []*api.Rule, maxCost api.Cost) []*api.Rule {
+	if maxCost == api.CostUnset {
+		return in
+	}
+	out := make([]*api.Rule, 0, len(in))
+	for _, r := range in {
+		if CostFor(r) <= maxCost {
+			out = append(out, r)
+		}
+	}
+	return out
+}

--- a/internal/rules/cost_derive_test.go
+++ b/internal/rules/cost_derive_test.go
@@ -1,0 +1,255 @@
+package rules
+
+import (
+	"testing"
+
+	api "github.com/kaeawc/krit/internal/rules/api"
+)
+
+func TestDeriveCost(t *testing.T) {
+	cases := []struct {
+		name string
+		rule *api.Rule
+		want api.Cost
+	}{
+		{
+			name: "java facts beats every other bit",
+			rule: &api.Rule{
+				Needs:     api.NeedsCrossFile | api.NeedsOracleCallTargets,
+				JavaFacts: &api.JavaFactProfile{Annotations: []string{"java.lang.Deprecated"}},
+			},
+			want: api.CostFIR,
+		},
+		{
+			name: "narrow oracle bit promotes to oracle",
+			rule: &api.Rule{Needs: api.NeedsOracleSupertypes},
+			want: api.CostOracle,
+		},
+		{
+			name: "umbrella oracle bits promote to oracle",
+			rule: &api.Rule{Needs: api.NeedsOracle},
+			want: api.CostOracle,
+		},
+		{
+			name: "type info required promotes to oracle",
+			rule: &api.Rule{TypeInfo: api.TypeInfoHint{Required: true}},
+			want: api.CostOracle,
+		},
+		{
+			name: "cross-file index requires project phase",
+			rule: &api.Rule{Needs: api.NeedsCrossFile},
+			want: api.CostCrossFile,
+		},
+		{
+			name: "module index requires project phase",
+			rule: &api.Rule{Needs: api.NeedsModuleIndex},
+			want: api.CostCrossFile,
+		},
+		{
+			name: "parsed files counts as cross-file",
+			rule: &api.Rule{Needs: api.NeedsParsedFiles},
+			want: api.CostCrossFile,
+		},
+		{
+			name: "aggregate scope counts as cross-file",
+			rule: &api.Rule{Needs: api.NeedsAggregate},
+			want: api.CostCrossFile,
+		},
+		{
+			name: "line pass tier",
+			rule: &api.Rule{Needs: api.NeedsLinePass},
+			want: api.CostLine,
+		},
+		{
+			name: "manifest rule treated as AST tier",
+			rule: &api.Rule{Needs: api.NeedsManifest},
+			want: api.CostAST,
+		},
+		{
+			name: "resource rule treated as AST tier",
+			rule: &api.Rule{Needs: api.NeedsResources},
+			want: api.CostAST,
+		},
+		{
+			name: "gradle rule treated as AST tier",
+			rule: &api.Rule{Needs: api.NeedsGradle},
+			want: api.CostAST,
+		},
+		{
+			name: "ast-only rule with NodeTypes",
+			rule: &api.Rule{NodeTypes: []string{"call_expression"}},
+			want: api.CostAST,
+		},
+		{
+			name: "rule with no bits defaults to AST",
+			rule: &api.Rule{},
+			want: api.CostAST,
+		},
+		{
+			name: "resolver aspect does not promote past AST",
+			rule: &api.Rule{Needs: api.NeedsResolver},
+			want: api.CostAST,
+		},
+		{
+			name: "concurrent aspect does not promote past AST",
+			rule: &api.Rule{Needs: api.NeedsConcurrent},
+			want: api.CostAST,
+		},
+		{
+			name: "cross-file plus oracle picks the higher tier",
+			rule: &api.Rule{Needs: api.NeedsCrossFile | api.NeedsOracleSupertypes},
+			want: api.CostOracle,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := DeriveCost(tc.rule)
+			if got != tc.want {
+				t.Fatalf("DeriveCost = %s, want %s", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCostFor_ExplicitCostWins(t *testing.T) {
+	r := &api.Rule{
+		Cost:      api.CostTrivial,
+		Needs:     api.NeedsCrossFile,
+		JavaFacts: &api.JavaFactProfile{},
+	}
+	if got := CostFor(r); got != api.CostTrivial {
+		t.Fatalf("CostFor = %s, want %s (explicit Cost should win)", got, api.CostTrivial)
+	}
+}
+
+func TestCostFor_NilRule(t *testing.T) {
+	if got := CostFor(nil); got != api.CostUnset {
+		t.Fatalf("CostFor(nil) = %s, want unset", got)
+	}
+	if got := DeriveCost(nil); got != api.CostUnset {
+		t.Fatalf("DeriveCost(nil) = %s, want unset", got)
+	}
+}
+
+func TestParseCostAndPresets(t *testing.T) {
+	cases := map[string]api.Cost{
+		"trivial":    api.CostTrivial,
+		"line":       api.CostLine,
+		"ast":        api.CostAST,
+		"AST":        api.CostAST,
+		"fast":       api.CostAST,
+		"crossfile":  api.CostCrossFile,
+		"cross-file": api.CostCrossFile,
+		"cross_file": api.CostCrossFile,
+		"balanced":   api.CostCrossFile,
+		"oracle":     api.CostOracle,
+		"fir":        api.CostFIR,
+		"thorough":   api.CostFIR,
+	}
+	for in, want := range cases {
+		got, ok := api.ParseCost(in)
+		if !ok {
+			t.Errorf("ParseCost(%q) returned !ok", in)
+			continue
+		}
+		if got != want {
+			t.Errorf("ParseCost(%q) = %s, want %s", in, got, want)
+		}
+	}
+	if _, ok := api.ParseCost("nonsense"); ok {
+		t.Errorf("ParseCost(nonsense) should not parse")
+	}
+}
+
+func TestFilterByMaxCost(t *testing.T) {
+	rules := []*api.Rule{
+		{ID: "line", Needs: api.NeedsLinePass},
+		{ID: "ast", NodeTypes: []string{"call_expression"}},
+		{ID: "crossfile", Needs: api.NeedsCrossFile},
+		{ID: "oracle", Needs: api.NeedsOracleSupertypes},
+		{ID: "fir", JavaFacts: &api.JavaFactProfile{}},
+		{ID: "explicit-trivial", Cost: api.CostTrivial, Needs: api.NeedsCrossFile},
+	}
+
+	cases := []struct {
+		max  api.Cost
+		want []string
+	}{
+		{api.CostUnset, []string{"line", "ast", "crossfile", "oracle", "fir", "explicit-trivial"}},
+		{api.CostTrivial, []string{"explicit-trivial"}},
+		{api.CostLine, []string{"line", "explicit-trivial"}},
+		{api.CostAST, []string{"line", "ast", "explicit-trivial"}},
+		{api.CostCrossFile, []string{"line", "ast", "crossfile", "explicit-trivial"}},
+		{api.CostOracle, []string{"line", "ast", "crossfile", "oracle", "explicit-trivial"}},
+		{api.CostFIR, []string{"line", "ast", "crossfile", "oracle", "fir", "explicit-trivial"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.max.String(), func(t *testing.T) {
+			got := FilterByMaxCost(rules, tc.max)
+			ids := make([]string, 0, len(got))
+			for _, r := range got {
+				ids = append(ids, r.ID)
+			}
+			if !sameStringSet(ids, tc.want) {
+				t.Fatalf("FilterByMaxCost(%s) = %v, want %v", tc.max, ids, tc.want)
+			}
+		})
+	}
+}
+
+func TestSortedRuleExecutionStatsByCost(t *testing.T) {
+	stats := RunStats{
+		RuleStatsByRule: map[string]RuleExecutionStat{
+			"oracleRule":    {Rule: "oracleRule", Cost: "oracle", DurationNs: 10},
+			"astFast":       {Rule: "astFast", Cost: "ast", DurationNs: 5},
+			"astSlow":       {Rule: "astSlow", Cost: "ast", DurationNs: 100},
+			"lineRule":      {Rule: "lineRule", Cost: "line", DurationNs: 7},
+			"crossFileRule": {Rule: "crossFileRule", Cost: "crossfile", DurationNs: 9},
+		},
+	}
+	rows := SortedRuleExecutionStatsByCost(stats)
+	wantOrder := []string{"lineRule", "astSlow", "astFast", "crossFileRule", "oracleRule"}
+	if len(rows) != len(wantOrder) {
+		t.Fatalf("got %d rows, want %d", len(rows), len(wantOrder))
+	}
+	for i, want := range wantOrder {
+		if rows[i].Rule != want {
+			ids := make([]string, len(rows))
+			for j, r := range rows {
+				ids[j] = r.Rule
+			}
+			t.Errorf("rows[%d].Rule = %s, want %s (full order: %v)", i, rows[i].Rule, want, ids)
+		}
+	}
+}
+
+func TestRegisteredRulesAllHaveResolvedCost(t *testing.T) {
+	for _, r := range api.Registry {
+		if r == nil {
+			continue
+		}
+		if got := CostFor(r); got == api.CostUnset {
+			t.Errorf("rule %s has unresolved cost", r.ID)
+		}
+	}
+}
+
+func sameStringSet(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	seen := map[string]int{}
+	for _, s := range a {
+		seen[s]++
+	}
+	for _, s := range b {
+		seen[s]--
+	}
+	for _, v := range seen {
+		if v != 0 {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/rules/dispatch.go
+++ b/internal/rules/dispatch.go
@@ -3,6 +3,8 @@ package rules
 import (
 	"fmt"
 	"sort"
+
+	api "github.com/kaeawc/krit/internal/rules/api"
 )
 
 // RuleExecutionStat captures per-rule CPU timing for one per-file rule
@@ -11,6 +13,7 @@ import (
 type RuleExecutionStat struct {
 	Rule        string  `json:"rule"`
 	Family      string  `json:"family"`
+	Cost        string  `json:"cost,omitempty"`
 	Invocations int64   `json:"invocations"`
 	DurationNs  int64   `json:"durationNs"`
 	DurationMs  float64 `json:"durationMs"`
@@ -47,16 +50,53 @@ func (s *RunStats) recordRule(ruleID, family string, durationNs int64) {
 	s.RuleStatsByRule[ruleID] = stat
 }
 
-// SortedRuleExecutionStats returns deterministic, descending per-rule timing
-// rows with derived averages and percentage share filled in.
+// SortedRuleExecutionStats returns per-rule timing rows ordered by
+// duration descending (with rule ID as tiebreaker), with averages,
+// percentage share, and the rule's Cost tier filled in.
 func SortedRuleExecutionStats(stats RunStats) []RuleExecutionStat {
-	if len(stats.RuleStatsByRule) == 0 {
-		return nil
+	out, _ := sortedRuleExecutionStats(stats)
+	return out
+}
+
+// SortedRuleExecutionStatsByCost returns the same rows as
+// SortedRuleExecutionStats but grouped by Cost tier ascending (cheap →
+// expensive), breaking ties by duration descending then rule ID.
+func SortedRuleExecutionStatsByCost(stats RunStats) []RuleExecutionStat {
+	out, costByID := sortedRuleExecutionStats(stats)
+	rank := func(s RuleExecutionStat) api.Cost {
+		if c, ok := costByID[s.Rule]; ok && c != api.CostUnset {
+			return c
+		}
+		c, _ := api.ParseCost(s.Cost)
+		return c
 	}
+	sort.SliceStable(out, func(i, j int) bool {
+		ci, cj := rank(out[i]), rank(out[j])
+		if ci != cj {
+			return ci < cj
+		}
+		if out[i].DurationNs == out[j].DurationNs {
+			return out[i].Rule < out[j].Rule
+		}
+		return out[i].DurationNs > out[j].DurationNs
+	})
+	return out
+}
+
+func sortedRuleExecutionStats(stats RunStats) ([]RuleExecutionStat, map[string]api.Cost) {
+	if len(stats.RuleStatsByRule) == 0 {
+		return nil, nil
+	}
+	costByID := buildCostLookup()
 	out := make([]RuleExecutionStat, 0, len(stats.RuleStatsByRule))
 	var totalNs int64
 	for _, stat := range stats.RuleStatsByRule {
 		totalNs += stat.DurationNs
+		if stat.Cost == "" {
+			if c, ok := costByID[stat.Rule]; ok {
+				stat.Cost = c.String()
+			}
+		}
 		out = append(out, stat)
 	}
 	for i := range out {
@@ -74,6 +114,20 @@ func SortedRuleExecutionStats(stats RunStats) []RuleExecutionStat {
 		}
 		return out[i].DurationNs > out[j].DurationNs
 	})
+	return out, costByID
+}
+
+func buildCostLookup() map[string]api.Cost {
+	if len(api.Registry) == 0 {
+		return nil
+	}
+	out := make(map[string]api.Cost, len(api.Registry))
+	for _, r := range api.Registry {
+		if r == nil {
+			continue
+		}
+		out[r.ID] = CostFor(r)
+	}
 	return out
 }
 

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -164,6 +164,11 @@ func GenerateSchema(metas []RuleMeta) *jsonschema.Schema {
 		"warningsAsErrors": jsonschema.Boolean("").WithDefault(false),
 	}).WithDescription("Global krit configuration.").AdditionalPropertiesFalse()
 
+	props["maxCost"] = jsonschema.StringEnum(
+		[]string{"trivial", "line", "ast", "crossfile", "oracle", "fir", "fast", "balanced", "thorough"},
+		"Maximum rule weight class to run. Filters the active rule set so higher-cost rules are skipped. Presets: fast≡ast, balanced≡crossfile, thorough≡fir.",
+	)
+
 	props["module_template"] = jsonschema.Object(map[string]*jsonschema.Schema{
 		"feature_root":        jsonschema.String("Gradle path glob for feature root modules, for example feature:*."),
 		"required_submodules": jsonschema.Array(jsonschema.String(""), "Child module names required below each matching feature root."),

--- a/schemas/krit-config.schema.json
+++ b/schemas/krit-config.schema.json
@@ -9483,6 +9483,21 @@
         }
       }
     },
+    "maxCost": {
+      "description": "Maximum rule weight class to run. Filters the active rule set so higher-cost rules are skipped. Presets: fast≡ast, balanced≡crossfile, thorough≡fir.",
+      "type": "string",
+      "enum": [
+        "trivial",
+        "line",
+        "ast",
+        "crossfile",
+        "oracle",
+        "fir",
+        "fast",
+        "balanced",
+        "thorough"
+      ]
+    },
     "module_template": {
       "description": "Feature-module template conformance settings.",
       "type": "object",


### PR DESCRIPTION
## Summary
- Adds a `Cost` weight class (`trivial`/`line`/`ast`/`crossfile`/`oracle`/`fir`) to `api.Rule`, derived from `Needs`/`JavaFacts` when unset.
- Wires a `--max-cost` CLI flag and `maxCost:` config key that filter the active rule set (presets `fast`≡ast, `balanced`≡crossfile, `thorough`≡fir).
- Surfaces Cost on MCP `tool_rules` output, SARIF rule descriptors, and per-rule perf timing rows; adds `SortedRuleExecutionStatsByCost` for cost-grouped reports.

Closes #185.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `golangci-lint run ./...`
- [x] `go test ./... -count=1`
- [x] `make integration` and `make regression`
- [x] `make schema` (regenerates `schemas/krit-config.schema.json`)
- [x] `TestDeriveCost` covers every Needs combination including the explicit-cost override.
- [x] `TestFilterByMaxCost` validates each tier filters its expected subset.
- [x] `TestResolveMaxCost_*` covers flag-wins, config fallback, and unknown tokens.
- [x] `TestSortedRuleExecutionStatsByCost` confirms cost-grouped ordering.