### PR TITLE
feat(rules): add RelatedRules cross-links between rules

### DIFF
--- a/internal/cli/scan/flags.go
+++ b/internal/cli/scan/flags.go
@@ -73,6 +73,7 @@ type scanFlags struct {
 	Diff                     *string
 	Delta                    *string
 	DisableRules             *string
+	DisableRelated           *bool
 	EnableRules              *string
 	Experiment               *string
 	ExperimentOff            *string
@@ -171,6 +172,7 @@ func registerScanFlags(fs *flag.FlagSet) *scanFlags {
 	f.Diff = fs.String("diff", "", "Only report findings in files changed since git ref (e.g., HEAD~1, main, origin/main)")
 	f.Delta = fs.String("delta", "", "Only fail/report findings newly introduced since git ref (e.g., main, origin/main)")
 	f.DisableRules = fs.String("disable-rules", "", "Comma-separated rules to disable (e.g., MagicNumber,MaxLineLength)")
+	f.DisableRelated = fs.Bool("disable-related", false, "Also disable every rule listed in the RelatedRules metadata of each --disable-rules entry (non-transitive: only one hop is followed).")
 	f.EnableRules = fs.String("enable-rules", "", "Comma-separated rules to enable (overrides config)")
 	f.Experiment = fs.String("experiment", "", "Comma-separated experiment feature flags to enable")
 	f.ExperimentOff = fs.String("experiment-off", "", "Comma-separated experiment feature flags to disable")

--- a/internal/cli/scan/runner_state.go
+++ b/internal/cli/scan/runner_state.go
@@ -369,6 +369,9 @@ func (r *runner) filterRules() (handled bool, code int) {
 	r.tracker.TrackVoid("filterRules", func() {
 		disabledSet := clishared.ParseRuleNameSetCSV(*r.f.DisableRules)
 		enabledSet := clishared.ParseRuleNameSetCSV(*r.f.EnableRules)
+		if *r.f.DisableRelated {
+			rules.ExpandWithRelated(disabledSet, api.Registry)
+		}
 		experimental := *r.f.Experimental || r.cfg.GetTopLevelBool("experimental", false)
 		r.activeRules = rules.ActiveRulesV2(disabledSet, enabledSet, *r.f.AllRules, experimental)
 		if pipeline.RulesNeedProjectModel(r.activeRules) {

--- a/internal/mcp/tool_rules.go
+++ b/internal/mcp/tool_rules.go
@@ -83,8 +83,29 @@ func (s *Server) rulesExplain(args rulesArgs) ToolResult {
 	if fixLevel != "" {
 		info["fixLevel"] = fixLevel
 	}
+	if related := resolveRelatedRules(r); len(related) > 0 {
+		info["relatedRules"] = related
+	}
 
 	return jsonResult(info)
+}
+
+// resolveRelatedRules returns the rule IDs listed in r.RelatedRules,
+// filtered to those that still resolve in the registry. ValidateRelations
+// already rejects dangling references at NewDispatcher time; this filter
+// is a defensive guard for callers that introspect the registry without
+// having constructed a dispatcher.
+func resolveRelatedRules(r *api.Rule) []string {
+	if r == nil || len(r.RelatedRules) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(r.RelatedRules))
+	for _, id := range r.RelatedRules {
+		if findRule(id) != nil {
+			out = append(out, id)
+		}
+	}
+	return out
 }
 
 // rulesSearch performs a case-insensitive substring match over rule name,

--- a/internal/mcp/tool_rules_related_test.go
+++ b/internal/mcp/tool_rules_related_test.go
@@ -1,0 +1,36 @@
+package mcp
+
+import (
+	"testing"
+
+	api "github.com/kaeawc/krit/internal/rules/api"
+)
+
+func TestResolveRelatedRules_NilRule(t *testing.T) {
+	if got := resolveRelatedRules(nil); got != nil {
+		t.Fatalf("resolveRelatedRules(nil) = %v; want nil", got)
+	}
+}
+
+func TestResolveRelatedRules_EmptyList(t *testing.T) {
+	r := &api.Rule{ID: "Solo"}
+	if got := resolveRelatedRules(r); got != nil {
+		t.Fatalf("resolveRelatedRules with empty RelatedRules = %v; want nil", got)
+	}
+}
+
+func TestResolveRelatedRules_ResolvesAgainstRegistry(t *testing.T) {
+	// Pick two real registered rules so findRule can return them.
+	if len(api.Registry) < 2 {
+		t.Skip("registry has fewer than 2 rules; cannot exercise resolveRelatedRules cross-link")
+	}
+	first := api.Registry[0].ID
+	second := api.Registry[1].ID
+
+	r := &api.Rule{ID: "synthetic", RelatedRules: []string{first, "Ghost-Rule-Should-Not-Exist", second}}
+	got := resolveRelatedRules(r)
+	want := []string{first, second}
+	if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Fatalf("resolveRelatedRules = %v; want %v (unknown IDs filtered)", got, want)
+	}
+}

--- a/internal/rules/api/metadata.go
+++ b/internal/rules/api/metadata.go
@@ -176,6 +176,11 @@ type RuleDescriptor struct {
 	// guidance via ReplacedBy / Reason.
 	Deprecated *Deprecation
 
+	// RelatedRules mirrors Rule.RelatedRules — advisory cross-links to
+	// other rule IDs covering overlapping concerns. See Rule.RelatedRules
+	// for the full contract.
+	RelatedRules []string
+
 	// RuleSet is the configuration group this rule belongs to
 	// (e.g. "complexity", "naming", "performance").
 	RuleSet string

--- a/internal/rules/api/related_rules_test.go
+++ b/internal/rules/api/related_rules_test.go
@@ -1,0 +1,66 @@
+package api
+
+import (
+	"errors"
+	"testing"
+)
+
+// rule constructs a minimal *Rule fixture for relation-validation tests.
+// It bypasses Register so the global Registry stays untouched.
+func relatedRule(id string, related ...string) *Rule {
+	return &Rule{
+		ID:           id,
+		Description:  id + " description",
+		Sev:          SeverityInfo,
+		RelatedRules: related,
+	}
+}
+
+func TestValidateRelations_TriangleIsAsymmetric(t *testing.T) {
+	// Asymmetric chain: A → B, B → C, C → (nothing). The issue calls out
+	// that relations are directional advisory hints — symmetry is not
+	// required.
+	a := relatedRule("A", "B")
+	b := relatedRule("B", "C")
+	c := relatedRule("C")
+	if err := ValidateRelations([]*Rule{a, b, c}); err != nil {
+		t.Fatalf("ValidateRelations on asymmetric chain returned %v; want nil", err)
+	}
+}
+
+func TestValidateRelations_UnknownIDIsRejected(t *testing.T) {
+	a := relatedRule("A", "Ghost")
+	err := ValidateRelations([]*Rule{a})
+	if err == nil {
+		t.Fatalf("ValidateRelations on dangling reference returned nil; want error")
+	}
+	var rel *RelationError
+	if !errors.As(err, &rel) {
+		t.Fatalf("ValidateRelations returned %T; want *RelationError", err)
+	}
+	if rel.Rule != "A" || rel.Reference != "Ghost" {
+		t.Fatalf("RelationError = %+v; want rule=A reference=Ghost", rel)
+	}
+}
+
+func TestValidateRelations_SelfReferenceIsRejected(t *testing.T) {
+	a := relatedRule("A", "A")
+	err := ValidateRelations([]*Rule{a})
+	if err == nil {
+		t.Fatalf("ValidateRelations on self-reference returned nil; want error")
+	}
+}
+
+func TestValidateRelations_EmptyRegistryIsOK(t *testing.T) {
+	if err := ValidateRelations(nil); err != nil {
+		t.Fatalf("ValidateRelations(nil) = %v; want nil", err)
+	}
+}
+
+func TestValidateRelations_NilRulesAreSkipped(t *testing.T) {
+	a := relatedRule("A", "B")
+	b := relatedRule("B")
+	if err := ValidateRelations([]*Rule{nil, a, nil, b}); err != nil {
+		t.Fatalf("ValidateRelations with nil entries returned %v; want nil", err)
+	}
+}

--- a/internal/rules/api/rule.go
+++ b/internal/rules/api/rule.go
@@ -647,6 +647,19 @@ type Rule struct {
 	// user migrates.
 	Deprecated *Deprecation
 
+	// RelatedRules names other rule IDs that cover overlapping concerns —
+	// near-duplicates, narrower/broader variants, or alternative styles for
+	// the same defect class. Unlike Deprecated.ReplacedBy (which only
+	// applies to deprecated rules) this field is a general advisory link
+	// usable by all rules. Relations are directional hints and need not be
+	// symmetric. Consumers:
+	//   - MCP `explain` renders a "Related rules" cross-link section.
+	//   - `--disable-related` extends the disabled set with the related
+	//     IDs of every explicitly disabled rule (non-transitive).
+	// ValidateRelations enforces that every referenced ID exists in the
+	// registry at NewDispatcher time.
+	RelatedRules []string
+
 	// Dispatch routing.
 	//
 	// Scope, when set, declares the rule's primary dispatcher bucket
@@ -1008,6 +1021,51 @@ func NeedsJavaFacts(rules []*Rule) bool {
 		}
 	}
 	return false
+}
+
+// ValidateRelations checks that every ID listed in any rule's
+// RelatedRules exists in the supplied rule set. Relations are
+// directional advisory hints — symmetry is NOT required. Returns nil
+// when every reference resolves; otherwise an error naming the first
+// offending (rule, referenced ID) pair found in stable iteration order.
+//
+// Callers are expected to invoke this from NewDispatcher (or another
+// registry-construction boundary) so dangling references surface at
+// startup rather than via silent dead links in MCP output.
+func ValidateRelations(rules []*Rule) error {
+	ids := make(map[string]bool, len(rules))
+	for _, r := range rules {
+		if r == nil {
+			continue
+		}
+		ids[r.ID] = true
+	}
+	for _, r := range rules {
+		if r == nil {
+			continue
+		}
+		for _, ref := range r.RelatedRules {
+			if ref == r.ID {
+				return &RelationError{Rule: r.ID, Reference: ref, Reason: "rule cannot relate to itself"}
+			}
+			if !ids[ref] {
+				return &RelationError{Rule: r.ID, Reference: ref, Reason: "unknown rule ID"}
+			}
+		}
+	}
+	return nil
+}
+
+// RelationError describes an invalid RelatedRules entry surfaced by
+// ValidateRelations.
+type RelationError struct {
+	Rule      string
+	Reference string
+	Reason    string
+}
+
+func (e *RelationError) Error() string {
+	return "rule " + e.Rule + " RelatedRules entry " + e.Reference + ": " + e.Reason
 }
 
 // Registry holds all registered v2 rules.

--- a/internal/rules/defaults.go
+++ b/internal/rules/defaults.go
@@ -141,6 +141,35 @@ func IsDeprecated(name string) bool {
 	return deprecatedRules[name]
 }
 
+// ExpandWithRelated mutates disabledSet in place, adding every rule ID
+// that appears in the RelatedRules metadata of any rule already in the
+// set. The expansion is non-transitive: only one hop is followed. A
+// related ID that is not present in registry is silently skipped — that
+// case is already rejected by ValidateRelations at dispatcher
+// construction, so a stale entry here means the user passed an unknown
+// rule ID via --disable-rules (which is its own diagnostic surface) or
+// the registry was filtered after validation.
+func ExpandWithRelated(disabledSet map[string]bool, registry []*api.Rule) {
+	if len(disabledSet) == 0 {
+		return
+	}
+	// Snapshot the initial set so the one-hop guarantee survives the
+	// in-place mutation below — iterating against the live map would
+	// promote second-hop relations as new entries are added.
+	seed := make(map[string]bool, len(disabledSet))
+	for id := range disabledSet {
+		seed[id] = true
+	}
+	for _, r := range registry {
+		if r == nil || !seed[r.ID] {
+			continue
+		}
+		for _, related := range r.RelatedRules {
+			disabledSet[related] = true
+		}
+	}
+}
+
 // ActiveRulesV2 filters api.Registry using config-driven activation.
 //
 // A rule is included when it is not in disabledSet AND either:

--- a/internal/rules/dispatcher.go
+++ b/internal/rules/dispatcher.go
@@ -125,6 +125,15 @@ func NewDispatcher(rules []*api.Rule, resolver ...typeinfer.TypeResolver) *Dispa
 		d.typeResolver = resolver[0]
 	}
 
+	// Validate RelatedRules references against the full registry so
+	// dangling cross-links panic at startup rather than producing dead
+	// links in MCP output or surprising --disable-related behavior. The
+	// full registry is used (not just the active subset) so a project
+	// disabling some rules does not mask a typo in another's metadata.
+	if err := api.ValidateRelations(api.Registry); err != nil {
+		panic("rules: invalid RelatedRules registration: " + err.Error())
+	}
+
 	// Apply RunAfter ordering so any rule that declares a dependency
 	// runs after the rule(s) it depends on across every per-file scope
 	// bucket. Rules without RunAfter keep their original relative order.

--- a/internal/rules/meta_lookup.go
+++ b/internal/rules/meta_lookup.go
@@ -90,6 +90,11 @@ func mergeRuleDescriptor(r *api.Rule, extra api.RuleDescriptor) api.RuleDescript
 	} else {
 		out.Deprecated = extra.Deprecated
 	}
+	if len(r.RelatedRules) > 0 {
+		out.RelatedRules = r.RelatedRules
+	} else {
+		out.RelatedRules = extra.RelatedRules
+	}
 	if len(r.Tags) > 0 {
 		out.Tags = r.Tags
 	} else {

--- a/internal/rules/related_rules_test.go
+++ b/internal/rules/related_rules_test.go
@@ -1,0 +1,71 @@
+package rules
+
+import (
+	"testing"
+
+	api "github.com/kaeawc/krit/internal/rules/api"
+)
+
+func relatedFakeRule(id string, related ...string) *api.Rule {
+	r := fakeRule(id, api.MaturityStable)
+	r.RelatedRules = related
+	return r
+}
+
+func TestExpandWithRelated_AddsOneHop(t *testing.T) {
+	registry := []*api.Rule{
+		relatedFakeRule("A", "B", "C"),
+		relatedFakeRule("B", "D"), // not followed: only one hop
+		relatedFakeRule("C"),
+		relatedFakeRule("D"),
+	}
+
+	disabled := map[string]bool{"A": true}
+	ExpandWithRelated(disabled, registry)
+
+	for _, id := range []string{"A", "B", "C"} {
+		if !disabled[id] {
+			t.Errorf("expected %s to be disabled after expansion; set = %v", id, disabled)
+		}
+	}
+	if disabled["D"] {
+		t.Errorf("expansion should be non-transitive; D was reachable only through B and must not be disabled. set = %v", disabled)
+	}
+}
+
+func TestExpandWithRelated_EmptySetIsNoop(t *testing.T) {
+	registry := []*api.Rule{relatedFakeRule("A", "B"), relatedFakeRule("B")}
+	disabled := map[string]bool{}
+	ExpandWithRelated(disabled, registry)
+	if len(disabled) != 0 {
+		t.Fatalf("ExpandWithRelated on empty set should be a no-op; got %v", disabled)
+	}
+}
+
+func TestExpandWithRelated_NoOpWhenNoneDisabledMatch(t *testing.T) {
+	registry := []*api.Rule{relatedFakeRule("A", "B"), relatedFakeRule("B")}
+	disabled := map[string]bool{"X": true}
+	ExpandWithRelated(disabled, registry)
+	if disabled["A"] || disabled["B"] {
+		t.Fatalf("rules unrelated to disabled set must not be touched; got %v", disabled)
+	}
+}
+
+func TestActiveRulesV2_RespectsExpandedDisabledSet(t *testing.T) {
+	registry := []*api.Rule{
+		relatedFakeRule("A", "B"),
+		relatedFakeRule("B"),
+		relatedFakeRule("C"),
+	}
+	disabled := map[string]bool{"A": true}
+	ExpandWithRelated(disabled, registry)
+
+	got := selectActiveRules(registry, disabled, nil, false, false, nil, nil, nil)
+	ids := ruleIDs(got)
+	if containsID(ids, "A") || containsID(ids, "B") {
+		t.Fatalf("A and its related rule B should be filtered out; got %v", ids)
+	}
+	if !containsID(ids, "C") {
+		t.Fatalf("unrelated rule C should remain active; got %v", ids)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `Rule.RelatedRules []string` (mirrored on `RuleDescriptor`) so any rule can advisory-link to near-duplicates and overlapping-concern variants — previously only `Deprecation.ReplacedBy` could do this, and only for deprecated rules.
- `api.ValidateRelations(registry)` rejects unknown IDs and self-loops; invoked from `NewDispatcher` so dangling references panic at startup instead of producing dead links in MCP output.
- MCP `rules.explain` emits a `relatedRules` array (filtered to IDs that resolve in the registry).
- New `--disable-related` flag pairs with `--disable-rules` to extend the disabled set with one hop of related IDs. The expansion is **non-transitive**: only relations of the seed IDs are added (implemented via a seed snapshot so the in-place mutation doesn't promote second-hop links).

Closes #192.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...` (0 issues)
- [x] `go test ./... -count=1`
- New unit tests:
  - `TestValidateRelations_*` (asymmetric triangle, unknown ID, self-reference, nil entries)
  - `TestExpandWithRelated_*` (one-hop, empty/no-match no-ops, integration with `selectActiveRules`)
  - `TestResolveRelatedRules_*` (filters unknown IDs in MCP explain output)