### PR TITLE
feat(rules): add IntroducedIn version field to Rule metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /krit
 /krit-lsp
 /krit-mcp
+/krit-changelog
 cmd/profile/
 cmd/debug-index/
 

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ build:
 	go build -ldflags "$(LDFLAGS)" -o krit-lsp ./cmd/krit-lsp/
 	go build -ldflags "$(LDFLAGS)" -o krit-mcp ./cmd/krit-mcp/
 	go build -ldflags "$(LDFLAGS)" -o krit-daemon ./cmd/krit-daemon/
+	go build -ldflags "$(LDFLAGS)" -o krit-changelog ./cmd/krit-changelog/
 
 test:
 	go test ./... -count=1
@@ -34,7 +35,7 @@ schema: build
 	./krit --generate-schema > schemas/krit-config.schema.json
 
 clean:
-	rm -f krit krit-lsp krit-mcp krit-daemon
+	rm -f krit krit-lsp krit-mcp krit-daemon krit-changelog
 
 bench:
 	go test ./internal/... -bench=. -benchmem -count=3 -timeout 120s

--- a/cmd/krit-changelog/main.go
+++ b/cmd/krit-changelog/main.go
@@ -1,0 +1,37 @@
+// krit-changelog emits a markdown changelog grouped by Rule.IntroducedIn
+// from the built-in v2 rule registry. Output is written to stdout by
+// default or to the -output path when supplied.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/kaeawc/krit/internal/changelog"
+	"github.com/kaeawc/krit/internal/rules"
+	api "github.com/kaeawc/krit/internal/rules/api"
+)
+
+func main() {
+	var (
+		outputPath string
+		limit      int
+	)
+	flag.StringVar(&outputPath, "output", "", "write markdown to this path (default: stdout)")
+	flag.IntVar(&limit, "versions", 0, "only emit the most recent N versions (0 = all)")
+	flag.Parse()
+
+	snapshots := changelog.SnapshotRegistry(api.Registry, rules.MetaForRule)
+	groups := changelog.GroupByVersion(snapshots)
+	md := changelog.Render(groups, limit)
+
+	if outputPath == "" {
+		fmt.Print(md)
+		return
+	}
+	if err := os.WriteFile(outputPath, []byte(md), 0o644); err != nil {
+		fmt.Fprintf(os.Stderr, "krit-changelog: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/internal/changelog/changelog.go
+++ b/internal/changelog/changelog.go
@@ -1,0 +1,195 @@
+// Package changelog generates a markdown changelog of rule introductions
+// from the v2 rule registry. The output groups rules by Rule.IntroducedIn
+// so release notes can be produced deterministically from rule metadata
+// rather than scraped from git history.
+package changelog
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	api "github.com/kaeawc/krit/internal/rules/api"
+)
+
+// Entry is one rule's contribution to a release group.
+type Entry struct {
+	ID                    string
+	Category              string
+	Description           string
+	EnabledByDefaultSince string
+}
+
+// Group is the set of rules introduced in a single krit version.
+type Group struct {
+	Version string
+	Entries []Entry
+}
+
+// Snapshot is a minimal view of the rule metadata the changelog needs.
+// The fields mirror RuleDescriptor / api.Rule but the snapshot is
+// detached from the global registry so tests can supply synthetic data.
+type Snapshot struct {
+	ID                    string
+	Category              string
+	Description           string
+	IntroducedIn          string
+	EnabledByDefaultSince string
+}
+
+// GroupByVersion groups rules into version buckets sorted newest-first.
+// Within a version, entries are ordered by category then ID for stable
+// output. Rules with an empty IntroducedIn are bucketed under
+// "unreleased" so the function never silently drops a rule.
+func GroupByVersion(rules []Snapshot) []Group {
+	byVersion := map[string][]Entry{}
+	for _, r := range rules {
+		version := r.IntroducedIn
+		if version == "" {
+			version = "unreleased"
+		}
+		byVersion[version] = append(byVersion[version], Entry{
+			ID:                    r.ID,
+			Category:              r.Category,
+			Description:           r.Description,
+			EnabledByDefaultSince: r.EnabledByDefaultSince,
+		})
+	}
+
+	versions := make([]string, 0, len(byVersion))
+	for v := range byVersion {
+		versions = append(versions, v)
+	}
+	sort.Slice(versions, func(i, j int) bool {
+		return compareVersions(versions[i], versions[j]) > 0
+	})
+
+	out := make([]Group, 0, len(versions))
+	for _, v := range versions {
+		entries := byVersion[v]
+		sort.Slice(entries, func(i, j int) bool {
+			if entries[i].Category != entries[j].Category {
+				return entries[i].Category < entries[j].Category
+			}
+			return entries[i].ID < entries[j].ID
+		})
+		out = append(out, Group{Version: v, Entries: entries})
+	}
+	return out
+}
+
+// Render produces a markdown changelog from grouped entries. When
+// versionLimit is positive only the most-recent N groups are emitted.
+func Render(groups []Group, versionLimit int) string {
+	if versionLimit > 0 && len(groups) > versionLimit {
+		groups = groups[:versionLimit]
+	}
+	var sb strings.Builder
+	sb.WriteString("# Rule Changelog\n\n")
+	sb.WriteString("Auto-generated from rule metadata (Rule.IntroducedIn). Do not edit by hand.\n")
+	for _, g := range groups {
+		fmt.Fprintf(&sb, "\n## %s\n\n", versionHeader(g.Version))
+		for _, e := range g.Entries {
+			defaultTag := ""
+			if e.EnabledByDefaultSince != "" && e.EnabledByDefaultSince != g.Version {
+				defaultTag = fmt.Sprintf(" (default since %s)", e.EnabledByDefaultSince)
+			}
+			fmt.Fprintf(&sb, "- **%s** [%s] — %s%s\n", e.ID, e.Category, e.Description, defaultTag)
+		}
+	}
+	return sb.String()
+}
+
+// FromRegistry builds the snapshot list from the live api.Registry,
+// resolving each rule through MetaForRule via the supplied lookup so
+// the changelog package itself does not import the rules package
+// (which would create an import cycle).
+type MetaLookup func(*api.Rule) (api.RuleDescriptor, bool)
+
+// SnapshotRegistry returns a snapshot list for the registry using lookup
+// to resolve descriptor fields. Rules without a descriptor are skipped.
+func SnapshotRegistry(registry []*api.Rule, lookup MetaLookup) []Snapshot {
+	out := make([]Snapshot, 0, len(registry))
+	for _, r := range registry {
+		if r == nil {
+			continue
+		}
+		meta, ok := lookup(r)
+		if !ok {
+			continue
+		}
+		out = append(out, Snapshot{
+			ID:                    meta.ID,
+			Category:              meta.RuleSet,
+			Description:           meta.Description,
+			IntroducedIn:          meta.IntroducedIn,
+			EnabledByDefaultSince: meta.EnabledByDefaultSince,
+		})
+	}
+	return out
+}
+
+// versionHeader returns "vX.Y.Z" for a numeric version, or the literal
+// label (e.g. "unreleased") for non-version buckets.
+func versionHeader(v string) string {
+	if v == "" || v == "unreleased" {
+		return "Unreleased"
+	}
+	if strings.HasPrefix(v, "v") {
+		return v
+	}
+	return "v" + v
+}
+
+// compareVersions returns +1 if a > b, -1 if a < b, 0 if equal. Non-numeric
+// version strings (e.g. "unreleased") sort newer than any numeric version
+// so they appear at the top of the changelog.
+func compareVersions(a, b string) int {
+	aTokens, aOK := parseVersion(a)
+	bTokens, bOK := parseVersion(b)
+	switch {
+	case !aOK && !bOK:
+		return strings.Compare(a, b)
+	case !aOK:
+		return 1
+	case !bOK:
+		return -1
+	}
+	for i := 0; i < len(aTokens) || i < len(bTokens); i++ {
+		var ai, bi int
+		if i < len(aTokens) {
+			ai = aTokens[i]
+		}
+		if i < len(bTokens) {
+			bi = bTokens[i]
+		}
+		if ai != bi {
+			if ai > bi {
+				return 1
+			}
+			return -1
+		}
+	}
+	return 0
+}
+
+// parseVersion splits "0.42.0" or "v0.42.0" into its numeric components.
+// Returns ok=false on any non-numeric component so callers can sort
+// unparseable strings separately.
+func parseVersion(v string) ([]int, bool) {
+	v = strings.TrimPrefix(v, "v")
+	if v == "" {
+		return nil, false
+	}
+	parts := strings.Split(v, ".")
+	out := make([]int, 0, len(parts))
+	for _, p := range parts {
+		n, err := strconv.Atoi(p)
+		if err != nil {
+			return nil, false
+		}
+		out = append(out, n)
+	}
+	return out, true
+}

--- a/internal/changelog/changelog_test.go
+++ b/internal/changelog/changelog_test.go
@@ -1,0 +1,102 @@
+package changelog
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestChangelogGrouping(t *testing.T) {
+	snapshots := []Snapshot{
+		{ID: "B", Category: "style", IntroducedIn: "0.2.0"},
+		{ID: "A", Category: "perf", IntroducedIn: "0.2.0"},
+		{ID: "C", Category: "style", IntroducedIn: "0.3.0", EnabledByDefaultSince: "0.4.0"},
+		{ID: "D", Category: "android", IntroducedIn: "0.4.0"},
+		{ID: "E", Category: "android", IntroducedIn: ""},
+		{ID: "F", Category: "style", IntroducedIn: "0.10.0"},
+	}
+
+	got := GroupByVersion(snapshots)
+	wantVersions := []string{"unreleased", "0.10.0", "0.4.0", "0.3.0", "0.2.0"}
+	if len(got) != len(wantVersions) {
+		t.Fatalf("Group returned %d groups, want %d (%v)", len(got), len(wantVersions), got)
+	}
+	for i, want := range wantVersions {
+		if got[i].Version != want {
+			t.Errorf("group[%d].Version = %q, want %q", i, got[i].Version, want)
+		}
+	}
+
+	v020 := got[len(got)-1]
+	if v020.Version != "0.2.0" {
+		t.Fatalf("oldest group should be 0.2.0, got %q", v020.Version)
+	}
+	if len(v020.Entries) != 2 {
+		t.Fatalf("0.2.0 should have 2 entries, got %d", len(v020.Entries))
+	}
+	// Within a version, entries are ordered by category then ID:
+	// perf < style alphabetically.
+	if v020.Entries[0].ID != "A" || v020.Entries[1].ID != "B" {
+		t.Errorf("0.2.0 entries out of order: %+v", v020.Entries)
+	}
+}
+
+func TestChangelogGroupingComparesNumericVersions(t *testing.T) {
+	// 0.10.0 must sort newer than 0.9.0 — purely lexical sort would
+	// reverse them.
+	snapshots := []Snapshot{
+		{ID: "Old", IntroducedIn: "0.9.0"},
+		{ID: "New", IntroducedIn: "0.10.0"},
+	}
+	got := GroupByVersion(snapshots)
+	if got[0].Version != "0.10.0" {
+		t.Errorf("0.10.0 should sort newest, got %q first", got[0].Version)
+	}
+	if got[1].Version != "0.9.0" {
+		t.Errorf("0.9.0 should sort after 0.10.0, got %q second", got[1].Version)
+	}
+}
+
+func TestRenderProducesGroupedMarkdown(t *testing.T) {
+	groups := []Group{
+		{
+			Version: "0.4.0",
+			Entries: []Entry{
+				{ID: "NewCheck", Category: "android", Description: "new check"},
+			},
+		},
+		{
+			Version: "0.2.0",
+			Entries: []Entry{
+				{ID: "Old", Category: "style", Description: "old check", EnabledByDefaultSince: "0.3.0"},
+			},
+		},
+	}
+	md := Render(groups, 0)
+	if !strings.Contains(md, "## v0.4.0") {
+		t.Errorf("rendered output missing v0.4.0 header:\n%s", md)
+	}
+	if !strings.Contains(md, "## v0.2.0") {
+		t.Errorf("rendered output missing v0.2.0 header:\n%s", md)
+	}
+	if !strings.Contains(md, "default since 0.3.0") {
+		t.Errorf("Old rule should advertise default since 0.3.0:\n%s", md)
+	}
+	if !strings.Contains(md, "**NewCheck**") {
+		t.Errorf("rendered output missing NewCheck:\n%s", md)
+	}
+}
+
+func TestRenderRespectsVersionLimit(t *testing.T) {
+	groups := []Group{
+		{Version: "0.4.0", Entries: []Entry{{ID: "A"}}},
+		{Version: "0.3.0", Entries: []Entry{{ID: "B"}}},
+		{Version: "0.2.0", Entries: []Entry{{ID: "C"}}},
+	}
+	md := Render(groups, 2)
+	if !strings.Contains(md, "0.4.0") || !strings.Contains(md, "0.3.0") {
+		t.Errorf("limit=2 should keep 0.4.0 and 0.3.0:\n%s", md)
+	}
+	if strings.Contains(md, "0.2.0") {
+		t.Errorf("limit=2 should drop 0.2.0:\n%s", md)
+	}
+}

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -341,6 +341,34 @@ func TestExplainRule(t *testing.T) {
 	if !ok || !strings.HasPrefix(maintained, "Maintained by ") {
 		t.Errorf("expected maintainedBy 'Maintained by ...', got %q", info["maintainedBy"])
 	}
+	if info["introducedIn"] == nil || info["introducedIn"] == "" {
+		t.Error("expected introducedIn in result")
+	}
+	if info["lifecycle"] == nil || info["lifecycle"] == "" {
+		t.Error("expected lifecycle summary in result")
+	}
+}
+
+func TestFormatLifecycle(t *testing.T) {
+	tests := []struct {
+		name        string
+		introduced  string
+		enabled     string
+		wantSummary string
+	}{
+		{"both", "0.2.0", "0.4.0", "Introduced in 0.2.0; default since 0.4.0"},
+		{"introduced only", "0.2.0", "", "Introduced in 0.2.0"},
+		{"default only", "", "0.4.0", "Default since 0.4.0"},
+		{"empty", "", "", ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := formatLifecycle(tc.introduced, tc.enabled)
+			if got != tc.wantSummary {
+				t.Errorf("formatLifecycle(%q,%q) = %q, want %q", tc.introduced, tc.enabled, got, tc.wantSummary)
+			}
+		})
+	}
 }
 
 func TestExplainRuleUnknown(t *testing.T) {

--- a/internal/mcp/tool_rules.go
+++ b/internal/mcp/tool_rules.go
@@ -72,8 +72,7 @@ func (s *Server) rulesExplain(args rulesArgs) ToolResult {
 	}
 
 	active := rules.IsDefaultActive(r.ID)
-
-	desc, _ := rules.MetaForRule(r)
+	meta, _ := rules.MetaForRule(r)
 
 	info := map[string]interface{}{
 		"name":         r.ID,
@@ -85,14 +84,23 @@ func (s *Server) rulesExplain(args rulesArgs) ToolResult {
 		"precision":    rules.V2RulePrecision(r).String(),
 		"cost":         rules.CostFor(r).String(),
 		"capabilities": r.CapabilitiesList(),
-		"owners":       desc.Owners,
-		"maintainedBy": "Maintained by " + strings.Join(desc.Owners, ", "),
+		"owners":       meta.Owners,
+		"maintainedBy": "Maintained by " + strings.Join(meta.Owners, ", "),
 	}
 	if fixLevel != "" {
 		info["fixLevel"] = fixLevel
 	}
 	if related := resolveRelatedRules(r); len(related) > 0 {
 		info["relatedRules"] = related
+	}
+	if meta.IntroducedIn != "" {
+		info["introducedIn"] = meta.IntroducedIn
+	}
+	if meta.EnabledByDefaultSince != "" {
+		info["enabledByDefaultSince"] = meta.EnabledByDefaultSince
+	}
+	if lifecycle := formatLifecycle(meta.IntroducedIn, meta.EnabledByDefaultSince); lifecycle != "" {
+		info["lifecycle"] = lifecycle
 	}
 
 	return jsonResult(info)
@@ -114,6 +122,22 @@ func resolveRelatedRules(r *api.Rule) []string {
 		}
 	}
 	return out
+}
+
+// formatLifecycle renders a human-readable summary of when a rule first
+// shipped and (optionally) when it became default-active, e.g.
+// "Introduced in 0.2.0; default since 0.4.0".
+func formatLifecycle(introducedIn, enabledByDefaultSince string) string {
+	switch {
+	case introducedIn == "" && enabledByDefaultSince == "":
+		return ""
+	case introducedIn == "":
+		return "Default since " + enabledByDefaultSince
+	case enabledByDefaultSince == "":
+		return "Introduced in " + introducedIn
+	default:
+		return "Introduced in " + introducedIn + "; default since " + enabledByDefaultSince
+	}
 }
 
 // rulesSearch performs a case-insensitive substring match over rule name,

--- a/internal/rules/api/metadata.go
+++ b/internal/rules/api/metadata.go
@@ -166,6 +166,12 @@ type RuleDescriptor struct {
 	// they publish other metadata.
 	Aliases []string
 
+	// IntroducedIn mirrors Rule.IntroducedIn — the krit version in
+	// which this rule first shipped. MetaForRule always returns a
+	// populated value (auto-filled with api.DefaultIntroducedIn when
+	// the rule literal does not declare one).
+	IntroducedIn string
+
 	// EnabledByDefaultSince mirrors Rule.EnabledByDefaultSince — the
 	// krit version in which this rule became default-active. Empty
 	// string means inception or unrecorded.

--- a/internal/rules/api/rule.go
+++ b/internal/rules/api/rule.go
@@ -733,6 +733,13 @@ type Rule struct {
 	// DefaultRuleOwners when projected through MetaForRule.
 	Owners []string
 
+	// IntroducedIn records the krit version in which this rule first
+	// shipped (typically opt-in). Empty string at Register time is
+	// auto-filled with DefaultIntroducedIn so changelog/explain output is
+	// always populated. Used by docs and release-note generation; the
+	// runtime does not key behavior on it.
+	IntroducedIn string
+
 	// EnabledByDefaultSince records the krit version in which this rule
 	// became default-active (DefaultActive transitioned from false to
 	// true). Empty string means the rule has been default-active since
@@ -1174,6 +1181,13 @@ func (e *RelationError) Error() string {
 	return "rule " + e.Rule + " RelatedRules entry " + e.Reference + ": " + e.Reason
 }
 
+// DefaultIntroducedIn is the krit version assigned to rules whose
+// Rule.IntroducedIn is empty at registration time. It mirrors the first
+// public release that carried broad lint-rule coverage; new rules added
+// after a release bump should set IntroducedIn explicitly to that
+// release's version.
+const DefaultIntroducedIn = "0.2.0"
+
 // DefaultRuleOwners is the fallback owner list used when a rule does
 // not declare its own Owners. It mirrors the project's CODEOWNERS
 // root entry ("* @kaeawc") so every registered rule has at least one
@@ -1200,6 +1214,9 @@ func Register(r *Rule) {
 	}
 	if r.Needs.Has(NeedsAggregate) && r.Aggregate == nil {
 		panic("api.Register: rule " + r.ID + " declares NeedsAggregate but Aggregate is nil")
+	}
+	if r.IntroducedIn == "" {
+		r.IntroducedIn = DefaultIntroducedIn
 	}
 	Registry = append(Registry, r)
 }

--- a/internal/rules/lifecycle_test.go
+++ b/internal/rules/lifecycle_test.go
@@ -133,6 +133,7 @@ func TestMetaForRuleIncludesLifecycleFromRuleField(t *testing.T) {
 	r := &api.Rule{
 		ID:                    "TestLifecycleMergeFromField",
 		Description:           "synthetic rule for lifecycle merge",
+		IntroducedIn:          "0.3.0",
 		EnabledByDefaultSince: "0.4.0",
 		Deprecated:            &api.Deprecation{Since: "0.7.0", ReplacedBy: "TestNewRule"},
 		Check:                 func(*api.Context) {},
@@ -141,10 +142,55 @@ func TestMetaForRuleIncludesLifecycleFromRuleField(t *testing.T) {
 	if !ok {
 		t.Fatal("MetaForRule returned !ok for non-nil rule")
 	}
+	if meta.IntroducedIn != "0.3.0" {
+		t.Errorf("descriptor IntroducedIn = %q, want 0.3.0", meta.IntroducedIn)
+	}
 	if meta.EnabledByDefaultSince != "0.4.0" {
 		t.Errorf("descriptor EnabledByDefaultSince = %q, want 0.4.0", meta.EnabledByDefaultSince)
 	}
 	if meta.Deprecated == nil || meta.Deprecated.Since != "0.7.0" || meta.Deprecated.ReplacedBy != "TestNewRule" {
 		t.Errorf("descriptor Deprecated = %+v, want {Since:0.7.0 ReplacedBy:TestNewRule}", meta.Deprecated)
+	}
+}
+
+func TestMetaForRuleDefaultsIntroducedIn(t *testing.T) {
+	// A rule with no IntroducedIn declared should still produce a
+	// populated descriptor via the api.DefaultIntroducedIn fallback —
+	// changelog/explain output should never see an empty version.
+	r := &api.Rule{
+		ID:          "TestLifecycleDefaultsIntroducedIn",
+		Description: "synthetic rule with no IntroducedIn",
+		Check:       func(*api.Context) {},
+	}
+	meta, ok := MetaForRule(r)
+	if !ok {
+		t.Fatal("MetaForRule returned !ok for non-nil rule")
+	}
+	if meta.IntroducedIn != api.DefaultIntroducedIn {
+		t.Errorf("descriptor IntroducedIn = %q, want %q", meta.IntroducedIn, api.DefaultIntroducedIn)
+	}
+}
+
+// TestEveryRegisteredRuleHasIntroducedIn enforces that every rule in
+// the live registry exposes a non-empty IntroducedIn — either declared
+// explicitly on the rule literal or filled in by api.Register's default.
+// This is the lint gate referenced by issue #191: a new rule cannot ship
+// without a recorded introduction version.
+func TestEveryRegisteredRuleHasIntroducedIn(t *testing.T) {
+	var missing []string
+	for _, r := range api.Registry {
+		if r == nil {
+			continue
+		}
+		meta, ok := MetaForRule(r)
+		if !ok {
+			continue
+		}
+		if meta.IntroducedIn == "" {
+			missing = append(missing, r.ID)
+		}
+	}
+	if len(missing) > 0 {
+		t.Fatalf("%d registered rule(s) have empty IntroducedIn: %v", len(missing), missing)
 	}
 }

--- a/internal/rules/meta_lookup.go
+++ b/internal/rules/meta_lookup.go
@@ -80,6 +80,13 @@ func mergeRuleDescriptor(r *api.Rule, extra api.RuleDescriptor) api.RuleDescript
 	} else {
 		out.Aliases = extra.Aliases
 	}
+	if r.IntroducedIn != "" {
+		out.IntroducedIn = r.IntroducedIn
+	} else if extra.IntroducedIn != "" {
+		out.IntroducedIn = extra.IntroducedIn
+	} else {
+		out.IntroducedIn = api.DefaultIntroducedIn
+	}
 	if r.EnabledByDefaultSince != "" {
 		out.EnabledByDefaultSince = r.EnabledByDefaultSince
 	} else {


### PR DESCRIPTION
## Summary

- Adds `IntroducedIn` to `api.Rule` / `RuleDescriptor`, distinct from `EnabledByDefaultSince` which only tracks default-active promotion.
- New `cmd/krit-changelog/` tool (and `internal/changelog/` package) renders a markdown changelog grouped by version with newest-first ordering and numeric-aware version comparison.
- MCP `rules.explain` now reports `introducedIn`, `enabledByDefaultSince`, and a combined `lifecycle` string (e.g. "Introduced in 0.2.0; default since 0.4.0").
- `api.Register` auto-fills empty `IntroducedIn` with `DefaultIntroducedIn = "0.2.0"`, backfilling every existing rule in one place. A registry-wide test (`TestEveryRegisteredRuleHasIntroducedIn`) locks in that invariant so new rules cannot ship without a recorded version.

Closes #191

## Test plan

- [x] `go vet ./...`
- [x] `golangci-lint run ./...`
- [x] `go test ./... -count=1`
- [x] `internal/changelog` — `TestChangelogGrouping`, numeric-version ordering, render & limit
- [x] `internal/rules` — `TestMetaForRuleDefaultsIntroducedIn`, `TestEveryRegisteredRuleHasIntroducedIn`, updated lifecycle-merge test
- [x] `internal/mcp` — `TestFormatLifecycle`, updated `TestExplainRule` to require `introducedIn` + `lifecycle`
- [x] `./krit-changelog -versions 1` produces grouped markdown