### PR TITLE
feat(daemon): divergence harness for resident-cache correctness

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test vet lint lint-rules fix schema clean bench integration playground ci regression all install install-completions watch
+.PHONY: build test vet lint lint-rules fix schema clean bench integration playground ci regression daemon-verify all install install-completions watch
 
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
 LDFLAGS = -s -w -X main.version=$(VERSION)
@@ -48,7 +48,14 @@ playground: build
 regression: build
 	bash scripts/regression-check.sh
 
-ci: build vet test integration regression
+# daemon-verify runs the divergence harness unit suite, which is the
+# correctness oracle for the daemon's resident-cache path. When daemon
+# strict-verify mode lands it will also drive the harness across the
+# fixture tree and any opt-in corpus pointed at by KRIT_CORPUS_DIR.
+daemon-verify:
+	go test ./internal/daemon/ -run 'TestCompare|TestDiff' -count=1
+
+ci: build vet test integration regression daemon-verify
 
 DESTDIR ?=
 

--- a/internal/daemon/divergence.go
+++ b/internal/daemon/divergence.go
@@ -1,0 +1,198 @@
+package daemon
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/kaeawc/krit/internal/scanner"
+)
+
+const (
+	sideDaemon   = "daemon"
+	sideBaseline = "baseline"
+)
+
+// Diff describes how a daemon analyze result differs from a freshly-computed
+// in-process baseline. AddedByDaemon are rows the daemon emitted that the
+// baseline did not; DroppedByDaemon are rows the baseline emitted that the
+// daemon did not. PathsTouched lists the distinct files implicated by either
+// side, sorted for stable logs.
+//
+// Equality is a multiset comparison on a structural key (file, line, col,
+// rule set, rule, severity, message). Two findings sharing that key are
+// considered the same row even if their byte offsets, confidence, or fix
+// payloads differ — those are downstream rendering concerns and would
+// otherwise cause noisy divergence reports across cosmetic refactors.
+type Diff struct {
+	AddedByDaemon   []scanner.Finding
+	DroppedByDaemon []scanner.Finding
+	PathsTouched    []string
+}
+
+// IsClean reports whether the daemon and baseline produced the same multiset
+// of findings.
+func (d Diff) IsClean() bool {
+	return len(d.AddedByDaemon) == 0 && len(d.DroppedByDaemon) == 0
+}
+
+// Compare returns the multiset difference of daemonCols and baselineCols.
+// Nil columns are treated as empty.
+//
+// The algorithm builds a single signed-count map (daemon contributes +1,
+// baseline -1), then walks each side in sorted-by-file order, materializing
+// a Finding only for rows where the running imbalance proves they are
+// excess on that side. The common clean-run case allocates no Finding rows
+// at all.
+func Compare(daemonCols, baselineCols *scanner.FindingColumns) Diff {
+	dN, bN := lenOf(daemonCols), lenOf(baselineCols)
+	if dN == 0 && bN == 0 {
+		return Diff{}
+	}
+
+	counts := make(map[findingKey]int, dN+bN)
+	for row := 0; row < dN; row++ {
+		counts[keyFromCols(daemonCols, row)]++
+	}
+	for row := 0; row < bN; row++ {
+		counts[keyFromCols(baselineCols, row)]--
+	}
+
+	added := collectExcess(daemonCols, counts, +1)
+	dropped := collectExcess(baselineCols, counts, -1)
+
+	return Diff{
+		AddedByDaemon:   added,
+		DroppedByDaemon: dropped,
+		PathsTouched:    pathsTouched(added, dropped),
+	}
+}
+
+// WriteLog renders the diff as newline-delimited JSON: one object per row,
+// daemon-added rows first, then baseline-dropped rows. Within each side rows
+// are already in file/line order from Compare. The destination directory is
+// created on demand. An empty diff produces a zero-byte file so presence-or
+// -absence checks stay simple for CI.
+func (d Diff) WriteLog(path string) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("divergence: prepare log dir: %w", err)
+	}
+	f, err := os.Create(path)
+	if err != nil {
+		return fmt.Errorf("divergence: create log: %w", err)
+	}
+	defer f.Close()
+	enc := json.NewEncoder(f)
+	for _, row := range d.AddedByDaemon {
+		if err := enc.Encode(divergenceRow(sideDaemon, row)); err != nil {
+			return fmt.Errorf("divergence: write row: %w", err)
+		}
+	}
+	for _, row := range d.DroppedByDaemon {
+		if err := enc.Encode(divergenceRow(sideBaseline, row)); err != nil {
+			return fmt.Errorf("divergence: write row: %w", err)
+		}
+	}
+	return nil
+}
+
+type findingKey struct {
+	File     string
+	Line     int
+	Col      int
+	RuleSet  string
+	Rule     string
+	Severity string
+	Message  string
+}
+
+func keyFromCols(cols *scanner.FindingColumns, row int) findingKey {
+	return findingKey{
+		File:     cols.FileAt(row),
+		Line:     cols.LineAt(row),
+		Col:      cols.ColumnAt(row),
+		RuleSet:  cols.RuleSetAt(row),
+		Rule:     cols.RuleAt(row),
+		Severity: cols.SeverityAt(row),
+		Message:  cols.MessageAt(row),
+	}
+}
+
+func lenOf(cols *scanner.FindingColumns) int {
+	if cols == nil {
+		return 0
+	}
+	return cols.N
+}
+
+// collectExcess walks cols in sorted order and materializes a Finding for
+// each row whose key has remaining imbalance in the direction given by sign
+// (+1 means cols is the daemon side, -1 means cols is the baseline side).
+// The map is mutated as rows are consumed so duplicate keys yield the right
+// number of rows.
+func collectExcess(cols *scanner.FindingColumns, counts map[findingKey]int, sign int) []scanner.Finding {
+	if cols == nil || cols.N == 0 {
+		return nil
+	}
+	var out []scanner.Finding
+	cols.VisitSortedByFileLine(func(row int) {
+		k := keyFromCols(cols, row)
+		if sign > 0 && counts[k] > 0 {
+			out = append(out, cols.Finding(row))
+			counts[k]--
+		} else if sign < 0 && counts[k] < 0 {
+			out = append(out, cols.Finding(row))
+			counts[k]++
+		}
+	})
+	return out
+}
+
+func pathsTouched(added, dropped []scanner.Finding) []string {
+	if len(added) == 0 && len(dropped) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(added)+len(dropped))
+	for _, f := range added {
+		seen[f.File] = struct{}{}
+	}
+	for _, f := range dropped {
+		seen[f.File] = struct{}{}
+	}
+	paths := make([]string, 0, len(seen))
+	for p := range seen {
+		paths = append(paths, p)
+	}
+	sort.Strings(paths)
+	return paths
+}
+
+// divergenceLogRow is the on-disk shape of a divergence log entry. Field
+// names are short and stable so the log stays grep-friendly.
+type divergenceLogRow struct {
+	Side     string  `json:"side"`
+	RuleSet  string  `json:"ruleSet"`
+	Rule     string  `json:"rule"`
+	File     string  `json:"file"`
+	Line     int     `json:"line"`
+	Col      int     `json:"col"`
+	Severity string  `json:"severity"`
+	Message  string  `json:"message"`
+	Conf     float64 `json:"confidence,omitempty"`
+}
+
+func divergenceRow(side string, f scanner.Finding) divergenceLogRow {
+	return divergenceLogRow{
+		Side:     side,
+		RuleSet:  f.RuleSet,
+		Rule:     f.Rule,
+		File:     f.File,
+		Line:     f.Line,
+		Col:      f.Col,
+		Severity: f.Severity,
+		Message:  f.Message,
+		Conf:     f.Confidence,
+	}
+}

--- a/internal/daemon/divergence_test.go
+++ b/internal/daemon/divergence_test.go
@@ -1,0 +1,209 @@
+package daemon
+
+import (
+	"bufio"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/kaeawc/krit/internal/scanner"
+)
+
+func TestCompareIsCleanForIdenticalInputs(t *testing.T) {
+	rows := []scanner.Finding{
+		{File: "a.kt", Line: 10, Col: 4, RuleSet: "perf", Rule: "Foo", Severity: "warning", Message: "boom"},
+		{File: "b.kt", Line: 3, Col: 1, RuleSet: "style", Rule: "Bar", Severity: "info", Message: "tidy"},
+	}
+	daemon := scanner.CollectFindings(rows)
+	baseline := scanner.CollectFindings(rows)
+	diff := Compare(&daemon, &baseline)
+	if !diff.IsClean() {
+		t.Fatalf("expected clean diff, got added=%+v dropped=%+v", diff.AddedByDaemon, diff.DroppedByDaemon)
+	}
+	if diff.PathsTouched != nil {
+		t.Fatalf("expected empty PathsTouched, got %v", diff.PathsTouched)
+	}
+}
+
+func TestCompareDetectsAddedAndDropped(t *testing.T) {
+	common := scanner.Finding{File: "a.kt", Line: 10, Col: 4, RuleSet: "perf", Rule: "Foo", Severity: "warning", Message: "boom"}
+	onlyDaemon := scanner.Finding{File: "a.kt", Line: 20, Col: 1, RuleSet: "perf", Rule: "Foo", Severity: "warning", Message: "second"}
+	onlyBaseline := scanner.Finding{File: "b.kt", Line: 5, Col: 2, RuleSet: "style", Rule: "Bar", Severity: "info", Message: "third"}
+
+	daemon := scanner.CollectFindings([]scanner.Finding{common, onlyDaemon})
+	baseline := scanner.CollectFindings([]scanner.Finding{common, onlyBaseline})
+
+	diff := Compare(&daemon, &baseline)
+	if diff.IsClean() {
+		t.Fatalf("expected non-clean diff")
+	}
+	if len(diff.AddedByDaemon) != 1 || diff.AddedByDaemon[0].Line != 20 {
+		t.Fatalf("unexpected AddedByDaemon: %+v", diff.AddedByDaemon)
+	}
+	if len(diff.DroppedByDaemon) != 1 || diff.DroppedByDaemon[0].File != "b.kt" {
+		t.Fatalf("unexpected DroppedByDaemon: %+v", diff.DroppedByDaemon)
+	}
+	wantPaths := []string{"a.kt", "b.kt"}
+	if !reflect.DeepEqual(diff.PathsTouched, wantPaths) {
+		t.Fatalf("PathsTouched = %v, want %v", diff.PathsTouched, wantPaths)
+	}
+}
+
+func TestCompareIsMultisetAware(t *testing.T) {
+	dup := scanner.Finding{File: "a.kt", Line: 1, Col: 1, RuleSet: "perf", Rule: "Foo", Severity: "warning", Message: "dup"}
+	daemon := scanner.CollectFindings([]scanner.Finding{dup, dup, dup})
+	baseline := scanner.CollectFindings([]scanner.Finding{dup})
+
+	diff := Compare(&daemon, &baseline)
+	if len(diff.AddedByDaemon) != 2 {
+		t.Fatalf("expected 2 added rows from duplicate, got %d", len(diff.AddedByDaemon))
+	}
+	if len(diff.DroppedByDaemon) != 0 {
+		t.Fatalf("expected 0 dropped rows, got %d", len(diff.DroppedByDaemon))
+	}
+}
+
+func TestCompareIgnoresRowOrdering(t *testing.T) {
+	a := scanner.Finding{File: "a.kt", Line: 1, RuleSet: "perf", Rule: "Foo", Severity: "warning", Message: "x"}
+	b := scanner.Finding{File: "b.kt", Line: 2, RuleSet: "perf", Rule: "Foo", Severity: "warning", Message: "y"}
+
+	daemon := scanner.CollectFindings([]scanner.Finding{a, b})
+	baseline := scanner.CollectFindings([]scanner.Finding{b, a})
+
+	diff := Compare(&daemon, &baseline)
+	if !diff.IsClean() {
+		t.Fatalf("expected reordered inputs to compare equal, got added=%+v dropped=%+v", diff.AddedByDaemon, diff.DroppedByDaemon)
+	}
+}
+
+func TestCompareHandlesNilColumns(t *testing.T) {
+	row := scanner.Finding{File: "a.kt", Line: 1, RuleSet: "perf", Rule: "Foo", Severity: "warning", Message: "x"}
+	daemon := scanner.CollectFindings([]scanner.Finding{row})
+
+	diff := Compare(&daemon, nil)
+	if len(diff.AddedByDaemon) != 1 || len(diff.DroppedByDaemon) != 0 {
+		t.Fatalf("nil baseline: added=%d dropped=%d", len(diff.AddedByDaemon), len(diff.DroppedByDaemon))
+	}
+
+	diff = Compare(nil, &daemon)
+	if len(diff.AddedByDaemon) != 0 || len(diff.DroppedByDaemon) != 1 {
+		t.Fatalf("nil daemon: added=%d dropped=%d", len(diff.AddedByDaemon), len(diff.DroppedByDaemon))
+	}
+
+	diff = Compare(nil, nil)
+	if !diff.IsClean() {
+		t.Fatalf("expected nil/nil compare to be clean")
+	}
+}
+
+func TestCompareWithInjectedWorkspaceMutation(t *testing.T) {
+	staleRow := scanner.Finding{
+		File: "src/Auth.kt", Line: 12, Col: 8,
+		RuleSet: "security", Rule: "InsecureCrypto",
+		Severity: "error", Message: "MD5 detected",
+	}
+	freshRow := scanner.Finding{
+		File: "src/Auth.kt", Line: 14, Col: 8,
+		RuleSet: "security", Rule: "InsecureCrypto",
+		Severity: "error", Message: "MD5 detected",
+	}
+
+	daemonCols := scanner.CollectFindings([]scanner.Finding{staleRow})
+	baselineCols := scanner.CollectFindings([]scanner.Finding{freshRow})
+
+	diff := Compare(&daemonCols, &baselineCols)
+	if diff.IsClean() {
+		t.Fatalf("expected mutation to surface divergence")
+	}
+	if len(diff.AddedByDaemon) != 1 || diff.AddedByDaemon[0].Line != 12 {
+		t.Fatalf("AddedByDaemon = %+v, want stale row at line 12", diff.AddedByDaemon)
+	}
+	if len(diff.DroppedByDaemon) != 1 || diff.DroppedByDaemon[0].Line != 14 {
+		t.Fatalf("DroppedByDaemon = %+v, want fresh row at line 14", diff.DroppedByDaemon)
+	}
+}
+
+func TestDiffWriteLogIsHumanGreppable(t *testing.T) {
+	added := scanner.Finding{File: "a.kt", Line: 1, Col: 1, RuleSet: "perf", Rule: "Foo", Severity: "warning", Message: "added"}
+	dropped := scanner.Finding{File: "b.kt", Line: 2, Col: 1, RuleSet: "style", Rule: "Bar", Severity: "info", Message: "dropped"}
+	diff := Diff{
+		AddedByDaemon:   []scanner.Finding{added},
+		DroppedByDaemon: []scanner.Finding{dropped},
+		PathsTouched:    []string{"a.kt", "b.kt"},
+	}
+
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "nested", "diff.log")
+	if err := diff.WriteLog(logPath); err != nil {
+		t.Fatalf("WriteLog: %v", err)
+	}
+
+	f, err := os.Open(logPath)
+	if err != nil {
+		t.Fatalf("open log: %v", err)
+	}
+	defer f.Close()
+
+	var rows []divergenceLogRow
+	scanr := bufio.NewScanner(f)
+	for scanr.Scan() {
+		var row divergenceLogRow
+		if err := json.Unmarshal(scanr.Bytes(), &row); err != nil {
+			t.Fatalf("each line must be valid JSON: %v\nline=%q", err, scanr.Text())
+		}
+		rows = append(rows, row)
+	}
+	if err := scanr.Err(); err != nil {
+		t.Fatalf("scan log: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("expected 2 rows, got %d", len(rows))
+	}
+	if rows[0].Side != "daemon" || rows[0].File != "a.kt" {
+		t.Fatalf("first row = %+v, want daemon-side a.kt", rows[0])
+	}
+	if rows[1].Side != "baseline" || rows[1].File != "b.kt" {
+		t.Fatalf("second row = %+v, want baseline-side b.kt", rows[1])
+	}
+}
+
+func TestDiffWriteLogCleanProducesEmptyFile(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "diff.log")
+	if err := (Diff{}).WriteLog(logPath); err != nil {
+		t.Fatalf("WriteLog: %v", err)
+	}
+	info, err := os.Stat(logPath)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if info.Size() != 0 {
+		t.Fatalf("expected empty log for clean diff, got %d bytes", info.Size())
+	}
+}
+
+func TestCompareDeterministicOrdering(t *testing.T) {
+	rows := []scanner.Finding{
+		{File: "z.kt", Line: 1, RuleSet: "perf", Rule: "Foo", Severity: "warning", Message: "z"},
+		{File: "a.kt", Line: 2, RuleSet: "perf", Rule: "Foo", Severity: "warning", Message: "a"},
+		{File: "m.kt", Line: 5, RuleSet: "perf", Rule: "Foo", Severity: "warning", Message: "m"},
+	}
+	daemon := scanner.CollectFindings(rows)
+	baseline := scanner.CollectFindings(nil)
+	diff := Compare(&daemon, &baseline)
+
+	want := []string{"a.kt", "m.kt", "z.kt"}
+	got := make([]string, len(diff.AddedByDaemon))
+	for i, f := range diff.AddedByDaemon {
+		got[i] = f.File
+	}
+	if !sort.StringsAreSorted(got) {
+		t.Fatalf("AddedByDaemon not sorted by file: %v", got)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("AddedByDaemon order = %v, want %v", got, want)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds the `Compare(daemonCols, baselineCols *scanner.FindingColumns) Diff` correctness oracle from #202: multiset diff of daemon vs in-process baseline findings, keyed by (file, line, col, ruleset, rule, severity, message).
- `Diff.WriteLog` emits newline-delimited JSON (one row per finding, daemon-side first, then baseline-side) so divergence logs stay grep-friendly.
- Common clean-run path allocates no `Finding` rows: single signed-count map (+1 for daemon rows, -1 for baseline), then `Finding{}` materialization only for surviving imbalances, ordered via `FindingColumns.VisitSortedByFileLine`.
- New `make daemon-verify` target runs the harness unit suite and is wired into `make ci`; broader strict-verify daemon integration will plug into the same surface.

Refs #202.

## Test plan

- [x] `go test ./internal/daemon/ -count=1` (9 new tests covering clean diff, added/dropped, multiset duplicates, order-insensitivity, nil columns, injected workspace mutation, log shape, empty-log invariant, deterministic ordering)
- [x] `go vet ./...`
- [x] `golangci-lint run ./...`
- [x] `make daemon-verify`