### PR TITLE
feat(rules): make Maturity queryable across MCP, CLI, and SARIF

### DIFF
--- a/internal/cli/scan/early_exits.go
+++ b/internal/cli/scan/early_exits.go
@@ -272,14 +272,32 @@ func computeListRulesSummary(registry []*api.Rule) listRulesSummary {
 	return s
 }
 
-func runListRulesFlag(listFlag, verboseFlag bool) {
+func runListRulesFlag(listFlag, verboseFlag bool, maturityFilter string) {
 	if !listFlag {
 		return
 	}
+
+	var maturity api.Maturity
+	maturityFilterSet := false
+	if maturityFilter != "" {
+		m, ok := api.ParseMaturity(maturityFilter)
+		if !ok {
+			fmt.Fprintf(os.Stderr, "error: unknown --maturity value %q; valid: stable, experimental, deprecated\n", maturityFilter)
+			os.Exit(2)
+		}
+		maturity = m
+		maturityFilterSet = true
+	}
+
+	registry := api.Registry
+	if maturityFilterSet {
+		registry = api.MaturityFilter(registry, maturity)
+	}
+
 	fmt.Println("Available rules:")
 	fixable := 0
 	active := 0
-	for _, r := range api.Registry {
+	for _, r := range registry {
 		markers := ""
 		if rules.IsDefaultActive(r.ID) {
 			markers += "A"
@@ -291,7 +309,7 @@ func runListRulesFlag(listFlag, verboseFlag bool) {
 			markers += "F"
 			fixable++
 			if verboseFlag {
-				fmt.Printf("  %s %-40s [%-15s] %s (fix: %s, precision: %s)\n", markers, r.ID, r.Category, string(r.Sev), fixLvl, rules.V2RulePrecision(r))
+				fmt.Printf("  %s %-40s [%-15s] %s (fix: %s, precision: %s, maturity: %s)\n", markers, r.ID, r.Category, string(r.Sev), fixLvl, rules.V2RulePrecision(r), r.Maturity)
 				if r.Description != "" {
 					fmt.Printf("    %s\n", r.Description)
 				}
@@ -301,7 +319,7 @@ func runListRulesFlag(listFlag, verboseFlag bool) {
 		} else {
 			markers += " "
 			if verboseFlag {
-				fmt.Printf("  %s %-40s [%-15s] %s (precision: %s)\n", markers, r.ID, r.Category, string(r.Sev), rules.V2RulePrecision(r))
+				fmt.Printf("  %s %-40s [%-15s] %s (precision: %s, maturity: %s)\n", markers, r.ID, r.Category, string(r.Sev), rules.V2RulePrecision(r), r.Maturity)
 				if r.Description != "" {
 					fmt.Printf("    %s\n", r.Description)
 				}
@@ -310,8 +328,8 @@ func runListRulesFlag(listFlag, verboseFlag bool) {
 			}
 		}
 	}
-	fmt.Printf("\nTotal: %d rules (%d active by default, %d fixable)\n", len(api.Registry), active, fixable)
-	fmt.Println("A=active by default, F=fixable. Use -v for fix levels, --all-rules to enable all.")
+	fmt.Printf("\nTotal: %d rules (%d active by default, %d fixable)\n", len(registry), active, fixable)
+	fmt.Println("A=active by default, F=fixable. Use -v for fix levels, --all-rules to enable all, --maturity to filter by lifecycle.")
 	os.Exit(0)
 }
 

--- a/internal/cli/scan/flags.go
+++ b/internal/cli/scan/flags.go
@@ -32,6 +32,7 @@ type scanFlags struct {
 	DryRun                   *bool
 	AllRules                 *bool
 	Experimental             *bool
+	Maturity                 *string
 	Baseline                 *string
 	CreateBaseline           *string
 	BasePath                 *string
@@ -134,6 +135,8 @@ func registerScanFlags(fs *flag.FlagSet) *scanFlags {
 	f.DryRun = fs.Bool("dry-run", false, "Show what --fix would change without modifying files")
 	f.AllRules = fs.Bool("all-rules", false, "Enable all rules including opt-in")
 	f.Experimental = fs.Bool("experimental", false, "Enable rules whose Maturity is experimental (does not enable deprecated rules)")
+	fs.BoolVar(f.Experimental, "enable-experimental", false, "Alias for --experimental")
+	f.Maturity = fs.String("maturity", "", "With --list-rules: filter to rules whose Maturity matches (stable, experimental, or deprecated)")
 	f.Baseline = fs.String("baseline", "", "Baseline file to suppress known issues (XML or JSON)")
 	f.CreateBaseline = fs.String("create-baseline", "", "Create a baseline file from current findings")
 	f.BasePath = fs.String("base-path", "", "Base path for relative file paths in baselines and reports (default: first scan path)")

--- a/internal/cli/scan/runner_state.go
+++ b/internal/cli/scan/runner_state.go
@@ -158,7 +158,7 @@ func newRunner(f *scanFlags, sess *Session) (*runner, int, bool) {
 
 	applyEditorConfigOverrides(cfg, *f.EditorConfig, flag.Args())
 
-	runListRulesFlag(*f.List, *f.Verbose)
+	runListRulesFlag(*f.List, *f.Verbose, *f.Maturity)
 
 	maxFixLevel, ok := resolveMaxFixLevel(f)
 	if !ok {

--- a/internal/mcp/tool_rules.go
+++ b/internal/mcp/tool_rules.go
@@ -21,6 +21,7 @@ type rulesArgs struct {
 	Query     string   `json:"query"`
 	Category  string   `json:"category"`
 	Precision string   `json:"precision"`
+	Maturity  string   `json:"maturity"`
 	Needs     []string `json:"needs"`
 	Without   []string `json:"without"`
 
@@ -84,6 +85,7 @@ func (s *Server) rulesExplain(args rulesArgs) ToolResult {
 		"precision":    rules.V2RulePrecision(r).String(),
 		"effort":       rules.V2RuleEffort(r).String(),
 		"stability":    rules.V2RuleStability(r).String(),
+		"maturity":     r.Maturity.String(),
 		"cost":         rules.CostFor(r).String(),
 		"capabilities": r.CapabilitiesList(),
 		"owners":       meta.Owners,
@@ -106,6 +108,19 @@ func (s *Server) rulesExplain(args rulesArgs) ToolResult {
 	}
 	if lifecycle := formatLifecycle(meta.IntroducedIn, meta.EnabledByDefaultSince); lifecycle != "" {
 		info["lifecycle"] = lifecycle
+	}
+	if r.Deprecated != nil {
+		dep := map[string]interface{}{}
+		if r.Deprecated.Since != "" {
+			dep["since"] = r.Deprecated.Since
+		}
+		if r.Deprecated.ReplacedBy != "" {
+			dep["replacedBy"] = r.Deprecated.ReplacedBy
+		}
+		if r.Deprecated.Reason != "" {
+			dep["reason"] = r.Deprecated.Reason
+		}
+		info["deprecation"] = dep
 	}
 
 	return jsonResult(info)
@@ -145,33 +160,67 @@ func formatLifecycle(introducedIn, enabledByDefaultSince string) string {
 	}
 }
 
+// parseSearchFilters validates the precision/maturity filter arguments.
+// Returns a non-nil ToolResult pointer when validation fails.
+func parseSearchFilters(args rulesArgs) (api.Precision, api.Maturity, bool, *ToolResult) {
+	var precisionFilter api.Precision
+	if args.Precision != "" {
+		p, ok := api.ParsePrecision(args.Precision)
+		if !ok {
+			r := errorResult("unknown precision: " + args.Precision +
+				"; valid: heuristic/text-backed, ast-backed, project-structure-aware, type-aware, policy")
+			return 0, 0, false, &r
+		}
+		precisionFilter = p
+	}
+
+	var maturityFilter api.Maturity
+	maturityFilterSet := false
+	if args.Maturity != "" {
+		m, ok := api.ParseMaturity(args.Maturity)
+		if !ok {
+			r := errorResult("unknown maturity: " + args.Maturity + "; valid: stable, experimental, deprecated")
+			return 0, 0, false, &r
+		}
+		maturityFilter = m
+		maturityFilterSet = true
+	}
+	return precisionFilter, maturityFilter, maturityFilterSet, nil
+}
+
+// validateCapabilityArgs returns a non-nil ToolResult error when 'needs' or
+// 'without' contains an unknown capability label.
+func validateCapabilityArgs(needs, without []string) *ToolResult {
+	if _, unknown := api.ParseCapabilities(needs); len(unknown) > 0 {
+		r := errorResult("unknown capability label(s) in 'needs': " + strings.Join(unknown, ", "))
+		return &r
+	}
+	if _, unknown := api.ParseCapabilities(without); len(unknown) > 0 {
+		r := errorResult("unknown capability label(s) in 'without': " + strings.Join(unknown, ", "))
+		return &r
+	}
+	return nil
+}
+
 // rulesSearch performs a case-insensitive substring match over rule name,
 // description, and category. Results are ranked by where the match landed
 // (name > description > category) then alphabetical.
 func (s *Server) rulesSearch(args rulesArgs) ToolResult {
 	capabilityFilter := api.CapabilityFilter{Require: args.Needs, Exclude: args.Without}
-	if args.Query == "" && args.Precision == "" && capabilityFilter.IsZero() {
-		return errorResult("'query', 'precision', 'needs', or 'without' argument is required for operation=search")
+	if args.Query == "" && args.Precision == "" && args.Maturity == "" && capabilityFilter.IsZero() {
+		return errorResult("'query', 'precision', 'maturity', 'needs', or 'without' argument is required for operation=search")
 	}
 
-	if _, unknown := api.ParseCapabilities(args.Needs); len(unknown) > 0 {
-		return errorResult("unknown capability label(s) in 'needs': " + strings.Join(unknown, ", "))
-	}
-	if _, unknown := api.ParseCapabilities(args.Without); len(unknown) > 0 {
-		return errorResult("unknown capability label(s) in 'without': " + strings.Join(unknown, ", "))
+	if errResult := validateCapabilityArgs(args.Needs, args.Without); errResult != nil {
+		return *errResult
 	}
 
 	q := strings.ToLower(args.Query)
 	categoryFilter := strings.ToLower(args.Category)
 
-	var precisionFilter api.Precision
-	if args.Precision != "" {
-		p, ok := api.ParsePrecision(args.Precision)
-		if !ok {
-			return errorResult("unknown precision: " + args.Precision +
-				"; valid: heuristic/text-backed, ast-backed, project-structure-aware, type-aware, policy")
-		}
-		precisionFilter = p
+	precisionFilter, maturityFilter, maturityFilterSet, errResult := parseSearchFilters(args)
+	if errResult != nil {
+		return *errResult
 	}
 
 	type hit struct {
@@ -181,6 +230,7 @@ func (s *Server) rulesSearch(args rulesArgs) ToolResult {
 		Active       bool     `json:"active"`
 		Fixable      bool     `json:"fixable"`
 		Precision    string   `json:"precision"`
+		Maturity     string   `json:"maturity"`
 		Cost         string   `json:"cost"`
 		Capabilities []string `json:"capabilities"`
 		Description  string   `json:"description"`
@@ -198,6 +248,10 @@ func (s *Server) rulesSearch(args rulesArgs) ToolResult {
 			continue
 		}
 
+		if maturityFilterSet && r.Maturity != maturityFilter {
+			continue
+		}
+
 		if !capabilityFilter.MatchRule(r) {
 			continue
 		}
@@ -209,8 +263,8 @@ func (s *Server) rulesSearch(args rulesArgs) ToolResult {
 
 		switch {
 		case q == "":
-			// No query text: any of precision / needs / without acts as the
-			// filter. We've already applied those above, so anything that
+			// No query text: any of precision / maturity / needs / without acts
+			// as the filter. We've already applied those above, so anything that
 			// reaches here matches.
 			score = 1
 		case nameMatch:
@@ -231,6 +285,7 @@ func (s *Server) rulesSearch(args rulesArgs) ToolResult {
 			Active:       rules.IsDefaultActive(r.ID),
 			Fixable:      fixable,
 			Precision:    precision.String(),
+			Maturity:     r.Maturity.String(),
 			Cost:         rules.CostFor(r).String(),
 			Capabilities: r.CapabilitiesList(),
 			Description:  r.Description,
@@ -271,6 +326,8 @@ func (s *Server) rulesCategories(_ rulesArgs) ToolResult {
 	active := map[string]int{}
 	precCounts := map[api.Precision]int{}
 	precActive := map[api.Precision]int{}
+	matCounts := map[api.Maturity]int{}
+	matActive := map[api.Maturity]int{}
 	for _, r := range api.Registry {
 		counts[r.Category]++
 		isActive := rules.IsDefaultActive(r.ID)
@@ -281,6 +338,10 @@ func (s *Server) rulesCategories(_ rulesArgs) ToolResult {
 		precCounts[p]++
 		if isActive {
 			precActive[p]++
+		}
+		matCounts[r.Maturity]++
+		if isActive {
+			matActive[r.Maturity]++
 		}
 	}
 
@@ -318,16 +379,28 @@ func (s *Server) rulesCategories(_ rulesArgs) ToolResult {
 		})
 	}
 
+	maturityOrder := []api.Maturity{api.MaturityStable, api.MaturityExperimental, api.MaturityDeprecated}
+	maturities := make([]bucketRow, 0, len(maturityOrder))
+	for _, m := range maturityOrder {
+		maturities = append(maturities, bucketRow{
+			Name:      m.String(),
+			RuleCount: matCounts[m],
+			Active:    matActive[m],
+		})
+	}
+
 	type categoriesResult struct {
 		Total      int         `json:"total"`
 		Categories []bucketRow `json:"categories"`
 		Precisions []bucketRow `json:"precisions"`
+		Maturities []bucketRow `json:"maturities"`
 	}
 
 	return jsonResult(categoriesResult{
 		Total:      len(rows),
 		Categories: rows,
 		Precisions: precisions,
+		Maturities: maturities,
 	})
 }
 

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -119,6 +119,7 @@ func rulesToolDef() ToolDefinition {
 			"query":     jsonschema.String("Free-text search query (operation=search)"),
 			"category":  jsonschema.String("Filter to one category (operation=search)"),
 			"precision": jsonschema.StringEnum([]string{"heuristic/text-backed", "ast-backed", "project-structure-aware", "type-aware", "policy"}, "Filter by precision tier (operation=search)"),
+			"maturity":  jsonschema.StringEnum([]string{"stable", "experimental", "deprecated"}, "Filter by lifecycle stage (operation=search)"),
 			"needs":     jsonschema.Array(jsonschema.String(""), "Require these capability labels — every label must be present (operation=search). Use 'oracle' as a shorthand for any oracle:* bit."),
 			"without":   jsonschema.Array(jsonschema.String(""), "Exclude rules that declare any of these capability labels (operation=search). 'without: [oracle]' filters out every NeedsOracle* rule."),
 			"active":    jsonschema.Boolean("Override active flag (operation=configure)"),

--- a/internal/mcp/tools_new_ops_test.go
+++ b/internal/mcp/tools_new_ops_test.go
@@ -429,3 +429,75 @@ func TestAnalyzeUnknownMode(t *testing.T) {
 		t.Error("expected error for unknown mode")
 	}
 }
+
+// TestRuleListFilter_Maturity verifies search returns only rules whose
+// Maturity matches the filter.
+func TestRuleListFilter_Maturity(t *testing.T) {
+	args, _ := json.Marshal(rulesArgs{Operation: "search", Maturity: "experimental"})
+	responses := runServer(t, Request{
+		JSONRPC: "2.0",
+		ID:      float64(1),
+		Method:  "tools/call",
+		Params:  mustJSON(t, ToolCallParams{Name: "rules", Arguments: args}),
+	})
+	data, _ := json.Marshal(responses[0].Result)
+	var result ToolResult
+	if err := json.Unmarshal(data, &result); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("tool returned error: %s", result.Content[0].Text)
+	}
+	var parsed struct {
+		Hits []struct {
+			Name     string `json:"name"`
+			Maturity string `json:"maturity"`
+		} `json:"hits"`
+	}
+	if err := json.Unmarshal([]byte(result.Content[0].Text), &parsed); err != nil {
+		t.Fatalf("unmarshal hits: %v", err)
+	}
+	for _, h := range parsed.Hits {
+		if h.Maturity != "experimental" {
+			t.Errorf("hit %q has maturity %q, want experimental", h.Name, h.Maturity)
+		}
+	}
+}
+
+// TestRulesCategoriesMaturityBuckets verifies the categories result exposes
+// the three maturity buckets with non-negative counts.
+func TestRulesCategoriesMaturityBuckets(t *testing.T) {
+	args, _ := json.Marshal(rulesArgs{Operation: "categories"})
+	responses := runServer(t, Request{
+		JSONRPC: "2.0",
+		ID:      float64(1),
+		Method:  "tools/call",
+		Params:  mustJSON(t, ToolCallParams{Name: "rules", Arguments: args}),
+	})
+	data, _ := json.Marshal(responses[0].Result)
+	var result ToolResult
+	if err := json.Unmarshal(data, &result); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("tool returned error: %s", result.Content[0].Text)
+	}
+	var parsed struct {
+		Maturities []struct {
+			Name      string `json:"name"`
+			RuleCount int    `json:"ruleCount"`
+		} `json:"maturities"`
+	}
+	if err := json.Unmarshal([]byte(result.Content[0].Text), &parsed); err != nil {
+		t.Fatalf("unmarshal maturities: %v", err)
+	}
+	if len(parsed.Maturities) != 3 {
+		t.Fatalf("expected 3 maturity buckets, got %d", len(parsed.Maturities))
+	}
+	want := map[string]bool{"stable": true, "experimental": true, "deprecated": true}
+	for _, b := range parsed.Maturities {
+		if !want[b.Name] {
+			t.Errorf("unexpected maturity bucket %q", b.Name)
+		}
+	}
+}

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -109,7 +109,9 @@ type sarifRule struct {
 }
 
 type sarifRuleProperties struct {
-	Cost string `json:"cost,omitempty"`
+	Maturity  string `json:"maturity,omitempty"`
+	Precision string `json:"precision,omitempty"`
+	Cost      string `json:"cost,omitempty"`
 }
 
 type sarifText struct {
@@ -159,6 +161,7 @@ func FormatSARIFColumns(w io.Writer, columns *scanner.FindingColumns, version st
 	effortMap := make(map[string]string)
 	costMap := make(map[string]string)
 	capabilityMap := make(map[string][]string)
+	maturityMap := make(map[string]string)
 	for _, r := range api.Registry {
 		key := r.Category + "/" + r.ID
 		if r.Description != "" {
@@ -173,6 +176,7 @@ func FormatSARIFColumns(w io.Writer, columns *scanner.FindingColumns, version st
 		if list := r.CapabilitiesList(); len(list) > 0 {
 			capabilityMap[key] = list
 		}
+		maturityMap[key] = r.Maturity.String()
 	}
 
 	rulesSeen := make(map[string]bool)
@@ -193,8 +197,14 @@ func FormatSARIFColumns(w io.Writer, columns *scanner.FindingColumns, version st
 			if uri, ok := helpURIMap[ruleID]; ok {
 				sr.HelpURI = uri
 			}
-			if cost, ok := costMap[ruleID]; ok && cost != "unset" {
-				sr.Properties = &sarifRuleProperties{Cost: cost}
+			maturity := maturityMap[ruleID]
+			precision := precisionMap[ruleID]
+			cost := costMap[ruleID]
+			if cost == "unset" {
+				cost = ""
+			}
+			if maturity != "" || precision != "" || cost != "" {
+				sr.Properties = &sarifRuleProperties{Maturity: maturity, Precision: precision, Cost: cost}
 			}
 			sarifRules = append(sarifRules, sr)
 		}

--- a/internal/rules/api/rule.go
+++ b/internal/rules/api/rule.go
@@ -549,6 +549,37 @@ func (m Maturity) String() string {
 	}
 }
 
+// ParseMaturity returns the Maturity matching the given label. Labels
+// accepted are exactly the canonical strings emitted by String() — keeping
+// the MCP schema enum, CLI flag parser, and downstream consumers in
+// lockstep. Unknown labels (and the empty string) return MaturityStable,
+// false.
+func ParseMaturity(s string) (Maturity, bool) {
+	switch s {
+	case "stable":
+		return MaturityStable, true
+	case "experimental":
+		return MaturityExperimental, true
+	case "deprecated":
+		return MaturityDeprecated, true
+	default:
+		return MaturityStable, false
+	}
+}
+
+// MaturityFilter returns rules whose Maturity matches the provided value.
+// Useful from production code (MCP/CLI filters) and tests alike. The
+// returned slice preserves input order and is always non-nil.
+func MaturityFilter(rules []*Rule, m Maturity) []*Rule {
+	out := make([]*Rule, 0, len(rules))
+	for _, r := range rules {
+		if r != nil && r.Maturity == m {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
 // OptInReason classifies *why* a default-inactive rule ships off by default.
 // It is required when DefaultActive == false and must remain unset
 // (OptInReasonUnspecified) when DefaultActive == true. The ruleslinter gate

--- a/internal/rules/api/rule_test.go
+++ b/internal/rules/api/rule_test.go
@@ -95,6 +95,65 @@ func TestFakeRule_WithMaturity(t *testing.T) {
 	}
 }
 
+func TestParseMaturity(t *testing.T) {
+	tests := []struct {
+		in     string
+		want   Maturity
+		wantOk bool
+	}{
+		{"stable", MaturityStable, true},
+		{"experimental", MaturityExperimental, true},
+		{"deprecated", MaturityDeprecated, true},
+		{"", MaturityStable, false},
+		{"Stable", MaturityStable, false},
+		{"unknown", MaturityStable, false},
+	}
+	for _, tt := range tests {
+		got, ok := ParseMaturity(tt.in)
+		if got != tt.want || ok != tt.wantOk {
+			t.Errorf("ParseMaturity(%q) = (%v, %v), want (%v, %v)", tt.in, got, ok, tt.want, tt.wantOk)
+		}
+	}
+}
+
+func TestMaturityFilter(t *testing.T) {
+	rules := []*Rule{
+		FakeRule("a", WithMaturity(MaturityStable)),
+		FakeRule("b", WithMaturity(MaturityExperimental)),
+		FakeRule("c", WithMaturity(MaturityDeprecated)),
+		FakeRule("d", WithMaturity(MaturityExperimental)),
+		FakeRule("e"), // zero value = stable
+	}
+
+	exp := MaturityFilter(rules, MaturityExperimental)
+	if len(exp) != 2 || exp[0].ID != "b" || exp[1].ID != "d" {
+		t.Fatalf("MaturityFilter(experimental) = %v, want [b d]", ruleIDsForTest(exp))
+	}
+
+	stable := MaturityFilter(rules, MaturityStable)
+	if len(stable) != 2 || stable[0].ID != "a" || stable[1].ID != "e" {
+		t.Fatalf("MaturityFilter(stable) = %v, want [a e]", ruleIDsForTest(stable))
+	}
+
+	dep := MaturityFilter(rules, MaturityDeprecated)
+	if len(dep) != 1 || dep[0].ID != "c" {
+		t.Fatalf("MaturityFilter(deprecated) = %v, want [c]", ruleIDsForTest(dep))
+	}
+
+	none := MaturityFilter(nil, MaturityStable)
+	if none == nil || len(none) != 0 {
+		t.Fatalf("MaturityFilter(nil) = %v, want non-nil empty slice", none)
+	}
+}
+
+func ruleIDsForTest(rs []*Rule) []string {
+	out := make([]string, len(rs))
+	for i, r := range rs {
+		out[i] = r.ID
+	}
+	return out
+}
+
 func TestFixLevel_String(t *testing.T) {
 	tests := []struct {
 		level FixLevel


### PR DESCRIPTION
## Summary
- Adds `api.ParseMaturity` and `api.MaturityFilter` helpers so MCP, CLI, and tests share one parser.
- MCP `rules.search` accepts a `maturity` filter; hits and `explain` include the rule's maturity, and `explain` surfaces a `deprecation` block when the rule has `api.Deprecation` metadata.
- MCP `rules.categories` adds per-maturity bucket counts (stable / experimental / deprecated).
- CLI: `--list-rules --maturity <stage>` filters output; `--enable-experimental` is wired as an alias for the existing `--experimental` flag; `-v` rows show the maturity tag.
- SARIF: per-rule `properties.maturity` (and `precision`) so dashboards can group findings by lifecycle stage.

Closes #186.

## Test plan
- [x] `go test ./... -count=1`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...`
- [x] New unit tests: `TestParseMaturity`, `TestMaturityFilter`, `TestRuleListFilter_Maturity`, `TestRulesCategoriesMaturityBuckets`.