### PR TITLE
feat(rules): add output Stability field with baseline-audit warning

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,6 +75,27 @@ tools/krit-types/  JVM/KAA helper for compiler-backed type facts
 tools/krit-fir/    JVM/FIR helper for compiler checks
 ```
 
+## Rule Output Stability
+
+Each rule carries a `Stability` field (`api.Stability`) that describes
+its *output-shape* commitment — separate from `Maturity` (lifecycle).
+Consumers of krit JSON, SARIF, baseline files, and CI gates read this
+to decide whether the rule is safe to pin against:
+
+- `StabilityFrozen` — message text, finding location, and fix range
+  will not change.
+- `StabilityStable` — bug-fix changes only.
+- `StabilityEvolving` — shape may change between minor versions.
+
+The default for unannotated rules is `StabilityStable` (experimental
+rules default to `StabilityEvolving`). Promotions (Evolving → Stable →
+Frozen) are always allowed. **Downgrading a rule from `StabilityFrozen`
+to `StabilityEvolving` requires a major-version bump** — the field
+exists precisely so external baselines and dashboards can rely on it.
+
+`baseline-audit` warns when a baselined finding belongs to a rule whose
+effective stability is `StabilityEvolving`.
+
 ## PR Conventions
 
 - Keep PRs focused on a single change.

--- a/internal/cli/scan/baseline_audit.go
+++ b/internal/cli/scan/baseline_audit.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/kaeawc/krit/internal/rules"
 	api "github.com/kaeawc/krit/internal/rules/api"
 	"github.com/kaeawc/krit/internal/scanner"
 )
@@ -17,10 +18,17 @@ type baselineAuditIssue struct {
 	Reason string                `json:"reason"`
 }
 
+type baselineAuditWarning struct {
+	Entry     scanner.BaselineEntry `json:"entry"`
+	Stability string                `json:"stability"`
+	Message   string                `json:"message"`
+}
+
 type baselineAuditReport struct {
-	BaselinePath string               `json:"baselinePath"`
-	ScanPaths    []string             `json:"scanPaths"`
-	StaleEntries []baselineAuditIssue `json:"staleEntries"`
+	BaselinePath string                 `json:"baselinePath"`
+	ScanPaths    []string               `json:"scanPaths"`
+	StaleEntries []baselineAuditIssue   `json:"staleEntries"`
+	Warnings     []baselineAuditWarning `json:"warnings,omitempty"`
 }
 
 func RunBaselineAuditColumns(columns *scanner.FindingColumns, baseline *scanner.Baseline, baselinePath, basePath string, scanPaths []string, format string) int {
@@ -37,29 +45,21 @@ func RunBaselineAuditColumns(columns *scanner.FindingColumns, baseline *scanner.
 	}
 
 	knownRules := make(map[string]bool, len(api.Registry))
+	ruleByID := make(map[string]*api.Rule, len(api.Registry))
 	for _, rule := range api.Registry {
 		knownRules[rule.ID] = true
+		ruleByID[rule.ID] = rule
 	}
 
 	knownFiles := collectBaselineAuditFiles(scanPaths)
-	stale := make([]baselineAuditIssue, 0)
-	for _, entry := range baseline.Entries() {
-		if liveIDs[entry.ID] {
-			continue
-		}
+	stale, warnings := classifyBaselineEntries(baseline.Entries(), liveIDs, knownRules, ruleByID, baselinePath, basePath, knownFiles)
 
-		reason := "finding no longer exists"
-		switch {
-		case entry.Rule == "" || !knownRules[entry.Rule]:
-			reason = "rule deleted"
-		case !baselineEntryFileExists(entry, baselinePath, basePath, knownFiles):
-			reason = "file no longer exists"
+	sort.Slice(warnings, func(i, j int) bool {
+		if warnings[i].Entry.Rule != warnings[j].Entry.Rule {
+			return warnings[i].Entry.Rule < warnings[j].Entry.Rule
 		}
-		stale = append(stale, baselineAuditIssue{
-			Entry:  entry,
-			Reason: reason,
-		})
-	}
+		return warnings[i].Entry.ID < warnings[j].Entry.ID
+	})
 
 	sort.Slice(stale, func(i, j int) bool {
 		if stale[i].Reason != stale[j].Reason {
@@ -81,6 +81,7 @@ func RunBaselineAuditColumns(columns *scanner.FindingColumns, baseline *scanner.
 			BaselinePath: baselinePath,
 			ScanPaths:    append([]string(nil), scanPaths...),
 			StaleEntries: stale,
+			Warnings:     warnings,
 		}); err != nil {
 			fmt.Fprintf(os.Stderr, "error: encode baseline-audit JSON: %v\n", err)
 			return 2
@@ -89,20 +90,83 @@ func RunBaselineAuditColumns(columns *scanner.FindingColumns, baseline *scanner.
 	}
 
 	fmt.Printf("Baseline audit - %s\n", baselinePath)
-	if len(stale) == 0 {
+	if len(stale) == 0 && len(warnings) == 0 {
 		fmt.Println("No stale baseline entries found.")
 		return 0
 	}
 
-	fmt.Printf("Dead baseline entries: %d\n", len(stale))
-	for _, issue := range stale {
-		path := issue.Entry.Path
-		if path == "" {
-			path = "(unknown path)"
+	if len(stale) > 0 {
+		fmt.Printf("Dead baseline entries: %d\n", len(stale))
+		for _, issue := range stale {
+			path := issue.Entry.Path
+			if path == "" {
+				path = "(unknown path)"
+			}
+			fmt.Printf("  %s :: %s (%s)\n", path, issue.Entry.Rule, issue.Reason)
 		}
-		fmt.Printf("  %s :: %s (%s)\n", path, issue.Entry.Rule, issue.Reason)
+	}
+
+	if len(warnings) > 0 {
+		fmt.Printf("Stability warnings: %d (rules whose output may change between minor versions)\n", len(warnings))
+		for _, w := range warnings {
+			path := w.Entry.Path
+			if path == "" {
+				path = "(unknown path)"
+			}
+			fmt.Printf("  %s :: %s [stability=%s]\n", path, w.Entry.Rule, w.Stability)
+		}
 	}
 	return 0
+}
+
+// classifyBaselineEntries splits baseline entries into (stale, warnings).
+// Stale entries are baseline IDs no longer produced by the scan; warnings
+// flag live findings whose owning rule has StabilityEvolving so consumers
+// know the pin may break on a minor-version bump.
+func classifyBaselineEntries(
+	entries []scanner.BaselineEntry,
+	liveIDs, knownRules map[string]bool,
+	ruleByID map[string]*api.Rule,
+	baselinePath, basePath string,
+	knownFiles map[string]bool,
+) ([]baselineAuditIssue, []baselineAuditWarning) {
+	stale := make([]baselineAuditIssue, 0)
+	warnings := make([]baselineAuditWarning, 0)
+	seenWarning := make(map[string]bool)
+	for _, entry := range entries {
+		if liveIDs[entry.ID] {
+			if w, ok := stabilityWarning(entry, ruleByID); ok && !seenWarning[entry.ID] {
+				seenWarning[entry.ID] = true
+				warnings = append(warnings, w)
+			}
+			continue
+		}
+		reason := "finding no longer exists"
+		switch {
+		case entry.Rule == "" || !knownRules[entry.Rule]:
+			reason = "rule deleted"
+		case !baselineEntryFileExists(entry, baselinePath, basePath, knownFiles):
+			reason = "file no longer exists"
+		}
+		stale = append(stale, baselineAuditIssue{Entry: entry, Reason: reason})
+	}
+	return stale, warnings
+}
+
+func stabilityWarning(entry scanner.BaselineEntry, ruleByID map[string]*api.Rule) (baselineAuditWarning, bool) {
+	r := ruleByID[entry.Rule]
+	if r == nil {
+		return baselineAuditWarning{}, false
+	}
+	s := rules.V2RuleStability(r)
+	if s != api.StabilityEvolving {
+		return baselineAuditWarning{}, false
+	}
+	return baselineAuditWarning{
+		Entry:     entry,
+		Stability: s.String(),
+		Message:   "rule output may change between minor versions; baseline pin is fragile",
+	}, true
 }
 
 func ResolveBaselineAuditPath(explicit string, scanPaths []string) (string, error) {

--- a/internal/cli/scan/baseline_audit_stability_test.go
+++ b/internal/cli/scan/baseline_audit_stability_test.go
@@ -1,0 +1,128 @@
+package scan
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	api "github.com/kaeawc/krit/internal/rules/api"
+	"github.com/kaeawc/krit/internal/scanner"
+)
+
+// captureStdout swaps os.Stdout for the duration of fn and returns what was
+// written. Mirrors the helper used by other scan tests but kept local so this
+// file does not depend on test-only exports from elsewhere.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stdout = w
+	done := make(chan struct{})
+	var buf bytes.Buffer
+	go func() {
+		_, _ = io.Copy(&buf, r)
+		close(done)
+	}()
+	fn()
+	_ = w.Close()
+	<-done
+	os.Stdout = orig
+	return buf.String()
+}
+
+// registerEvolvingRule registers a rule with StabilityEvolving so the audit
+// report can flag baselined findings that hit it. The registry is global so we
+// restore it after the test.
+func registerEvolvingRule(t *testing.T, id string) {
+	t.Helper()
+	saved := api.Registry
+	t.Cleanup(func() { api.Registry = saved })
+	api.Register(&api.Rule{
+		ID:          id,
+		Category:    "test",
+		Description: "evolving rule for baseline audit test",
+		Sev:         api.SeverityInfo,
+		Stability:   api.StabilityEvolving,
+		Check:       func(*api.Context) {},
+	})
+}
+
+func TestBaselineWarnsEvolving(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "Foo.kt")
+	if err := os.WriteFile(file, []byte("fun demo() = 1\n"), 0o644); err != nil {
+		t.Fatalf("write sample file: %v", err)
+	}
+
+	registerEvolvingRule(t, "TestEvolvingRule")
+
+	findings := []scanner.Finding{{File: file, Rule: "TestEvolvingRule", Message: "evolving finding"}}
+	columns := scanner.CollectFindings(findings)
+	baseline := &scanner.Baseline{
+		CurrentIssues: map[string]bool{
+			scanner.BaselineID(findings[0], "", dir): true,
+		},
+		ManuallySuppressed: map[string]bool{},
+	}
+	baselinePath := filepath.Join(dir, "baseline.xml")
+
+	out := captureStdout(t, func() {
+		_ = RunBaselineAuditColumns(&columns, baseline, baselinePath, dir, []string{dir}, "plain")
+	})
+
+	if !strings.Contains(out, "Stability warnings:") {
+		t.Fatalf("expected stability warnings header in output, got:\n%s", out)
+	}
+	if !strings.Contains(out, "TestEvolvingRule") || !strings.Contains(out, "stability=evolving") {
+		t.Fatalf("expected evolving rule annotation in output, got:\n%s", out)
+	}
+}
+
+func TestBaselineWarnsEvolving_JSONIncludesWarnings(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "Foo.kt")
+	if err := os.WriteFile(file, []byte("fun demo() = 1\n"), 0o644); err != nil {
+		t.Fatalf("write sample file: %v", err)
+	}
+
+	registerEvolvingRule(t, "TestEvolvingRuleJSON")
+
+	findings := []scanner.Finding{{File: file, Rule: "TestEvolvingRuleJSON", Message: "evolving finding"}}
+	columns := scanner.CollectFindings(findings)
+	baseline := &scanner.Baseline{
+		CurrentIssues: map[string]bool{
+			scanner.BaselineID(findings[0], "", dir): true,
+		},
+		ManuallySuppressed: map[string]bool{},
+	}
+	baselinePath := filepath.Join(dir, "baseline.xml")
+
+	out := captureStdout(t, func() {
+		_ = RunBaselineAuditColumns(&columns, baseline, baselinePath, dir, []string{dir}, "json")
+	})
+
+	var report struct {
+		Warnings []struct {
+			Stability string `json:"stability"`
+			Entry     struct {
+				Rule string `json:"Rule"`
+			} `json:"entry"`
+		} `json:"warnings"`
+	}
+	if err := json.Unmarshal([]byte(out), &report); err != nil {
+		t.Fatalf("decode JSON: %v\nraw:\n%s", err, out)
+	}
+	if len(report.Warnings) != 1 {
+		t.Fatalf("want 1 warning, got %d (raw: %s)", len(report.Warnings), out)
+	}
+	if report.Warnings[0].Stability != "evolving" || report.Warnings[0].Entry.Rule != "TestEvolvingRuleJSON" {
+		t.Fatalf("unexpected warning entry: %+v", report.Warnings[0])
+	}
+}

--- a/internal/mcp/tool_rules.go
+++ b/internal/mcp/tool_rules.go
@@ -83,6 +83,7 @@ func (s *Server) rulesExplain(args rulesArgs) ToolResult {
 		"active":       active,
 		"fixable":      fixable,
 		"precision":    rules.V2RulePrecision(r).String(),
+		"stability":    rules.V2RuleStability(r).String(),
 		"cost":         rules.CostFor(r).String(),
 		"capabilities": r.CapabilitiesList(),
 		"owners":       desc.Owners,

--- a/internal/rules/api/fake.go
+++ b/internal/rules/api/fake.go
@@ -83,6 +83,11 @@ func WithPrecision(p Precision) FakeOption {
 	return func(r *Rule) { r.Precision = p }
 }
 
+// WithStability sets the rule's output-shape stability commitment.
+func WithStability(s Stability) FakeOption {
+	return func(r *Rule) { r.Stability = s }
+}
+
 // FakeContext creates a minimal context for testing with the given file.
 // A FindingCollector is pre-allocated; use ContextFindings(ctx) to read results.
 func FakeContext(file *scanner.File) *Context {

--- a/internal/rules/api/metadata.go
+++ b/internal/rules/api/metadata.go
@@ -228,6 +228,12 @@ type RuleDescriptor struct {
 	// from rule shape; otherwise this value is authoritative.
 	Precision Precision
 
+	// Stability mirrors Rule.Stability — the rule's output-shape
+	// commitment (evolving / stable / frozen). StabilityUnset means
+	// the rule has not declared a tier; consumers should treat that
+	// conservatively. See Rule.Stability for the contract.
+	Stability Stability
+
 	// LanguageSupport records per-source-language support status for a rule.
 	// It is product/support metadata rather than dispatcher routing: Languages
 	// on Rule controls where a rule runs, while LanguageSupport explains whether

--- a/internal/rules/api/rule.go
+++ b/internal/rules/api/rule.go
@@ -808,6 +808,16 @@ type Rule struct {
 	// it is filterable metadata for CLI, MCP, SARIF, and IDE consumers.
 	Precision Precision
 
+	// Stability declares the rule's *output-shape* commitment — whether
+	// message text, finding location, or fix range may change between
+	// versions. Distinct from Maturity (which describes the rule's
+	// lifecycle). Consumers that pin findings (baseline files, CI gates,
+	// dashboards) read this to decide whether the rule is safe to depend
+	// on. The dispatcher does not key behavior on this field. Zero value
+	// (StabilityUnset) means the rule has not declared a tier and
+	// consumers should treat it conservatively.
+	Stability Stability
+
 	// KotlincAnalog names the closest standard kotlinc diagnostic that
 	// this rule approximates, e.g. "UNREACHABLE_CODE". Informational
 	// only — krit is not bug-for-bug compatible with kotlinc. Empty

--- a/internal/rules/api/stability.go
+++ b/internal/rules/api/stability.go
@@ -1,0 +1,74 @@
+package api
+
+// Stability is a rule's *output-shape* commitment, distinct from Maturity
+// (lifecycle). It tells consumers of krit JSON, SARIF, baseline files,
+// dashboards, and CI gates whether the rule's message text, finding
+// location, or fix range is safe to pin against between releases.
+//
+// Values are ordered from least committed (Evolving) to most committed
+// (Frozen) so callers can filter with comparisons, e.g.
+// "warn for any baselined finding from a rule with Stability < StabilityStable".
+// The zero value (StabilityUnset) means the rule has not declared a
+// stability tier.
+//
+// Downgrades from StabilityFrozen → StabilityEvolving require a major
+// version bump. Promotions are always allowed.
+type Stability uint8
+
+const (
+	// StabilityUnset is the zero value. The rule has not declared a
+	// stability commitment; consumers should treat this conservatively
+	// (assume Evolving).
+	StabilityUnset Stability = iota
+	// StabilityEvolving means the rule's message text, finding location,
+	// or fix range may change between minor versions. Consumers pinning
+	// findings (baseline files, CI gates) should expect churn.
+	StabilityEvolving
+	// StabilityStable means the rule accepts only bug-fix changes to its
+	// output shape. Message wording or fix-range tweaks land only when
+	// they correct a real defect.
+	StabilityStable
+	// StabilityFrozen means the rule's message text, finding location,
+	// and fix range will not change. Suitable for long-lived baselines
+	// and external CI gates.
+	StabilityFrozen
+)
+
+// String returns the stable kebab-case label for the stability tier.
+// The labels appear in MCP responses, baseline-audit output, and SARIF
+// properties; treat them as a wire format.
+func (s Stability) String() string {
+	switch s {
+	case StabilityEvolving:
+		return "evolving"
+	case StabilityStable:
+		return "stable"
+	case StabilityFrozen:
+		return "frozen"
+	default:
+		return "unset"
+	}
+}
+
+// ParseStability returns the Stability matching the given label. The
+// labels accepted are exactly the canonical strings emitted by String().
+// Unknown labels (and the empty string) return StabilityUnset, false.
+func ParseStability(s string) (Stability, bool) {
+	switch s {
+	case "evolving":
+		return StabilityEvolving, true
+	case "stable":
+		return StabilityStable, true
+	case "frozen":
+		return StabilityFrozen, true
+	default:
+		return StabilityUnset, false
+	}
+}
+
+// StabilityProvider lets tests stub a stability value without
+// constructing a full Rule. MetaForRule checks for this interface on
+// Rule.Implementation before falling back to the rule's declared field.
+type StabilityProvider interface {
+	Stability() Stability
+}

--- a/internal/rules/api/stability_test.go
+++ b/internal/rules/api/stability_test.go
@@ -1,0 +1,57 @@
+package api
+
+import "testing"
+
+func TestStabilityString(t *testing.T) {
+	cases := []struct {
+		in   Stability
+		want string
+	}{
+		{StabilityUnset, "unset"},
+		{StabilityEvolving, "evolving"},
+		{StabilityStable, "stable"},
+		{StabilityFrozen, "frozen"},
+	}
+	for _, c := range cases {
+		if got := c.in.String(); got != c.want {
+			t.Errorf("Stability(%d).String() = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestStabilityOrdering(t *testing.T) {
+	// Values must be ordered least-committed -> most-committed so
+	// callers can filter with comparisons (e.g. < StabilityStable).
+	ordered := []Stability{
+		StabilityUnset,
+		StabilityEvolving,
+		StabilityStable,
+		StabilityFrozen,
+	}
+	for i := 1; i < len(ordered); i++ {
+		if ordered[i-1] >= ordered[i] {
+			t.Fatalf("ordering broken at index %d: %v not before %v", i, ordered[i-1], ordered[i])
+		}
+	}
+}
+
+func TestParseStability(t *testing.T) {
+	cases := []struct {
+		in   string
+		want Stability
+		ok   bool
+	}{
+		{"evolving", StabilityEvolving, true},
+		{"stable", StabilityStable, true},
+		{"frozen", StabilityFrozen, true},
+		{"", StabilityUnset, false},
+		{"unset", StabilityUnset, false},
+		{"bogus", StabilityUnset, false},
+	}
+	for _, c := range cases {
+		got, ok := ParseStability(c.in)
+		if ok != c.ok || got != c.want {
+			t.Errorf("ParseStability(%q) = (%v, %v), want (%v, %v)", c.in, got, ok, c.want, c.ok)
+		}
+	}
+}

--- a/internal/rules/meta_lookup.go
+++ b/internal/rules/meta_lookup.go
@@ -102,6 +102,7 @@ func mergeRuleDescriptor(r *api.Rule, extra api.RuleDescriptor) api.RuleDescript
 	}
 	out.Owners = resolveOwners(r, extra)
 	out.Precision = resolvePrecision(r, extra)
+	out.Stability = resolveStability(r, extra)
 	return out
 }
 
@@ -131,6 +132,49 @@ func resolvePrecision(r *api.Rule, extra api.RuleDescriptor) api.Precision {
 		return extra.Precision
 	}
 	return V2RulePrecision(r)
+}
+
+// resolveStability picks the tier returned in a descriptor. A
+// MetaProvider-supplied extra.Stability only wins when the rule itself
+// declared no explicit override; otherwise V2RuleStability is the
+// single source of truth (it already honors Rule.Stability and
+// StabilityProvider). V2RuleStability never returns StabilityUnset, so
+// MetaForRule always emits a populated tier.
+func resolveStability(r *api.Rule, extra api.RuleDescriptor) api.Stability {
+	if r.Stability == api.StabilityUnset && extra.Stability != api.StabilityUnset {
+		return extra.Stability
+	}
+	return V2RuleStability(r)
+}
+
+// V2RuleStability returns the rule's effective output-shape stability.
+//
+// Resolution order:
+//  1. Rule.Stability when set (non-zero) — the rule declared a tier.
+//  2. Rule.Implementation when it implements api.StabilityProvider —
+//     lets tests stub a tier without touching the Rule literal.
+//  3. Derived default: experimental rules are StabilityEvolving (their
+//     output is expected to change as they soak), every other rule
+//     defaults to StabilityStable. Rules that need the strongest
+//     "frozen" commitment must opt in explicitly.
+func V2RuleStability(r *api.Rule) api.Stability {
+	if r == nil {
+		return api.StabilityEvolving
+	}
+	if r.Stability != api.StabilityUnset {
+		return r.Stability
+	}
+	if r.Implementation != nil {
+		if sp, ok := r.Implementation.(api.StabilityProvider); ok {
+			if s := sp.Stability(); s != api.StabilityUnset {
+				return s
+			}
+		}
+	}
+	if r.Maturity == api.MaturityExperimental {
+		return api.StabilityEvolving
+	}
+	return api.StabilityStable
 }
 
 func withRuleLanguageSupport(r *api.Rule, m api.RuleDescriptor) api.RuleDescriptor {

--- a/internal/rules/stability.go
+++ b/internal/rules/stability.go
@@ -1,0 +1,15 @@
+package rules
+
+import api "github.com/kaeawc/krit/internal/rules/api"
+
+// Stability is re-exported from the api package so existing callers
+// (`rules.Stability`, `rules.StabilityFrozen`, …) keep compiling.
+// New code should reference api.Stability directly.
+type Stability = api.Stability
+
+const (
+	StabilityUnset    = api.StabilityUnset
+	StabilityEvolving = api.StabilityEvolving
+	StabilityStable   = api.StabilityStable
+	StabilityFrozen   = api.StabilityFrozen
+)

--- a/internal/rules/stability_test.go
+++ b/internal/rules/stability_test.go
@@ -1,0 +1,65 @@
+package rules
+
+import (
+	"testing"
+
+	api "github.com/kaeawc/krit/internal/rules/api"
+)
+
+// TestEveryDefaultActiveRuleHasStability is the contract gate from #196:
+// every default-active rule must resolve to a non-Unset Stability so
+// downstream consumers (baseline tooling, CI gates) can rely on the
+// commitment without per-rule special cases. The default derivation lives
+// in V2RuleStability, so this test covers both rules that declared
+// Stability explicitly and rules that fall through to the default.
+func TestEveryDefaultActiveRuleHasStability(t *testing.T) {
+	missing := 0
+	for _, r := range api.Registry {
+		if !IsDefaultActive(r.ID) {
+			continue
+		}
+		if V2RuleStability(r) == api.StabilityUnset {
+			t.Errorf("default-active rule %s has no Stability tier", r.ID)
+			missing++
+		}
+	}
+	if missing > 0 {
+		t.Fatalf("%d default-active rules missing Stability", missing)
+	}
+}
+
+func TestV2RuleStabilityDefaults(t *testing.T) {
+	cases := []struct {
+		name string
+		rule *api.Rule
+		want api.Stability
+	}{
+		{
+			name: "explicit override wins",
+			rule: &api.Rule{ID: "X", Stability: api.StabilityFrozen},
+			want: api.StabilityFrozen,
+		},
+		{
+			name: "experimental defaults to evolving",
+			rule: &api.Rule{ID: "X", Maturity: api.MaturityExperimental},
+			want: api.StabilityEvolving,
+		},
+		{
+			name: "stable rule defaults to stable",
+			rule: &api.Rule{ID: "X"},
+			want: api.StabilityStable,
+		},
+		{
+			name: "nil rule treated as evolving",
+			rule: nil,
+			want: api.StabilityEvolving,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := V2RuleStability(c.rule); got != c.want {
+				t.Fatalf("V2RuleStability = %v, want %v", got, c.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #196

## Summary

- Adds `api.Stability` (Frozen / Stable / Evolving) — distinct from `Maturity` — so consumers pinning krit findings (CI gates, baseline files, dashboards) can tell whether a rule's output shape is safe to depend on.
- `V2RuleStability` derives a tier when `Rule.Stability` is unset (experimental → Evolving, otherwise Stable), so every default-active rule resolves to a populated tier without per-rule edits.
- `baseline-audit` warns when a baselined finding belongs to a `StabilityEvolving` rule (plain + JSON output).
- MCP \`rules.explain\` surfaces the tier alongside precision.
- CONTRIBUTING gains a Rule Output Stability section noting Frozen → Evolving downgrades require a major-version bump.

## Test plan

- [x] \`TestEveryDefaultActiveRuleHasStability\` — every default-active rule resolves to a non-Unset tier.
- [x] \`TestBaselineWarnsEvolving\` (plain + JSON variants) — baseline-audit annotates evolving-rule pins.
- [x] \`TestStabilityString\` / \`TestStabilityOrdering\` / \`TestParseStability\` / \`TestV2RuleStabilityDefaults\`.
- [x] \`go build ./... && go vet ./... && golangci-lint run ./... && go test ./... -count=1\` all pass.