### PR TITLE
feat(rules): add DocsURL for canonical rule docs links

### DIFF
--- a/internal/lsp/hover.go
+++ b/internal/lsp/hover.go
@@ -53,7 +53,7 @@ type hoverRuleMeta struct {
 // formatHoverColumns renders hover markdown for the rows in columns whose
 // indices are listed in rowIndices (typically all rows whose Line == the
 // hovered LSP line).
-func formatHoverColumns(columns *scanner.FindingColumns, rowIndices []int, cfg *config.Config, docsURI string) string {
+func formatHoverColumns(columns *scanner.FindingColumns, rowIndices []int, cfg *config.Config) string {
 	if columns == nil {
 		return ""
 	}
@@ -62,12 +62,12 @@ func formatHoverColumns(columns *scanner.FindingColumns, rowIndices []int, cfg *
 		if i > 0 {
 			sb.WriteString("\n\n---\n\n")
 		}
-		sb.WriteString(formatHoverRow(columns, row, cfg, docsURI))
+		sb.WriteString(formatHoverRow(columns, row, cfg))
 	}
 	return sb.String()
 }
 
-func formatHoverRow(columns *scanner.FindingColumns, row int, cfg *config.Config, docsURI string) string {
+func formatHoverRow(columns *scanner.FindingColumns, row int, cfg *config.Config) string {
 	rule := columns.RuleAt(row)
 	ruleSet := columns.RuleSetAt(row)
 	currentSeverity := currentRuleSeverity(cfg, ruleSet, rule, columns.SeverityAt(row))
@@ -87,8 +87,8 @@ func formatHoverRow(columns *scanner.FindingColumns, row int, cfg *config.Config
 			sb.WriteString(desc.Description)
 			sb.WriteString("\n\n")
 		}
-		if docsURI != "" {
-			fmt.Fprintf(&sb, "[Open rule docs](%s)\n\n", docsURI)
+		if desc.DocsURL != "" {
+			fmt.Fprintf(&sb, "[Open rule docs](%s)\n\n", desc.DocsURL)
 		}
 	}
 	if sb.Len() == 0 {

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -900,7 +900,7 @@ func (s *Server) handleHover(req *Request) {
 	var sections []string
 	matched := hoverFindingRows(&columns, doc.Content, params.Position)
 	if len(matched) > 0 {
-		sections = append(sections, formatHoverColumns(&columns, matched, s.cfg, s.ruleDocsURI()))
+		sections = append(sections, formatHoverColumns(&columns, matched, s.cfg))
 	}
 
 	if section := s.oracleHoverSection(uri, params.Position); section != "" {
@@ -962,17 +962,6 @@ func positionToByteOffset(content []byte, pos Position) int {
 		col++
 	}
 	return len(content)
-}
-
-func (s *Server) ruleDocsURI() string {
-	rootPath := uriToPath(s.rootURI)
-	if rootPath == "" {
-		rootPath, _ = os.Getwd()
-	}
-	if rootPath == "" {
-		return ""
-	}
-	return pathToURI(filepath.Join(rootPath, "docs", "rules.md"))
 }
 
 // handleDocumentSymbol returns the symbol outline for a Kotlin file using the flat tree.

--- a/internal/lsp/server_test.go
+++ b/internal/lsp/server_test.go
@@ -1566,8 +1566,8 @@ func TestHoverReturnsRuleInfo(t *testing.T) {
 	if !strings.Contains(hover.Contents.Value, "Detects magic number literals") {
 		t.Errorf("expected hover to contain rule description, got: %s", hover.Contents.Value)
 	}
-	if !strings.Contains(hover.Contents.Value, "[Open rule docs](file://") || !strings.Contains(hover.Contents.Value, "/docs/rules.md)") {
-		t.Errorf("expected hover to contain rule docs link, got: %s", hover.Contents.Value)
+	if !strings.Contains(hover.Contents.Value, "[Open rule docs](https://krit.dev/rules/MagicNumber)") {
+		t.Errorf("expected hover to contain canonical rule docs link, got: %s", hover.Contents.Value)
 	}
 	if !strings.Contains(hover.Contents.Value, "Severity: `warning`") {
 		t.Errorf("expected hover to contain severity, got: %s", hover.Contents.Value)

--- a/internal/mcp/tool_rules.go
+++ b/internal/mcp/tool_rules.go
@@ -88,6 +88,9 @@ func (s *Server) rulesExplain(args rulesArgs) ToolResult {
 		"owners":       desc.Owners,
 		"maintainedBy": "Maintained by " + strings.Join(desc.Owners, ", "),
 	}
+	if docs := api.RuleDocsURL(r); docs != "" {
+		info["docsURL"] = docs
+	}
 	if fixLevel != "" {
 		info["fixLevel"] = fixLevel
 	}

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -104,6 +104,7 @@ type sarifRule struct {
 	ID               string               `json:"id"`
 	ShortDescription sarifText            `json:"shortDescription"`
 	FullDescription  *sarifText           `json:"fullDescription,omitempty"`
+	HelpURI          string               `json:"helpUri,omitempty"`
 	Properties       *sarifRuleProperties `json:"properties,omitempty"`
 }
 
@@ -152,6 +153,7 @@ func FormatSARIFColumns(w io.Writer, columns *scanner.FindingColumns, version st
 	cols := normalizedFindingColumns(columns)
 
 	descMap := make(map[string]string)
+	helpURIMap := make(map[string]string)
 	precisionMap := make(map[string]string)
 	costMap := make(map[string]string)
 	capabilityMap := make(map[string][]string)
@@ -159,6 +161,9 @@ func FormatSARIFColumns(w io.Writer, columns *scanner.FindingColumns, version st
 		key := r.Category + "/" + r.ID
 		if r.Description != "" {
 			descMap[key] = r.Description
+		}
+		if uri := api.RuleDocsURL(r); uri != "" {
+			helpURIMap[key] = uri
 		}
 		precisionMap[key] = rules.V2RulePrecision(r).String()
 		costMap[key] = rules.CostFor(r).String()
@@ -181,6 +186,9 @@ func FormatSARIFColumns(w io.Writer, columns *scanner.FindingColumns, version st
 			}
 			if desc, ok := descMap[ruleID]; ok {
 				sr.FullDescription = &sarifText{Text: desc}
+			}
+			if uri, ok := helpURIMap[ruleID]; ok {
+				sr.HelpURI = uri
 			}
 			if cost, ok := costMap[ruleID]; ok && cost != "unset" {
 				sr.Properties = &sarifRuleProperties{Cost: cost}

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -921,6 +921,44 @@ func TestFormatSARIF_ConfidenceField(t *testing.T) {
 	}
 }
 
+func TestFormatSARIF_HelpURI(t *testing.T) {
+	findings := []scanner.Finding{
+		{File: "a.kt", Line: 1, Col: 1, Severity: "warning", RuleSet: "style", Rule: "MagicNumber",
+			Message: "magic"},
+	}
+	var buf bytes.Buffer
+	FormatSARIF(&buf, findings, "1.0.0")
+
+	var sarif sarifLog
+	if err := json.Unmarshal(buf.Bytes(), &sarif); err != nil {
+		t.Fatalf("invalid SARIF JSON: %v", err)
+	}
+	if len(sarif.Runs) == 0 {
+		t.Fatal("expected at least one run")
+	}
+	rulesOut := sarif.Runs[0].Tool.Driver.Rules
+	if len(rulesOut) == 0 {
+		t.Fatal("expected at least one rule in driver")
+	}
+	if rulesOut[0].HelpURI != "https://krit.dev/rules/MagicNumber" {
+		t.Errorf("expected helpUri https://krit.dev/rules/MagicNumber, got %q", rulesOut[0].HelpURI)
+	}
+}
+
+func TestFormatSARIF_HelpURI_OmittedForUnknownRule(t *testing.T) {
+	findings := []scanner.Finding{
+		{File: "a.kt", Line: 1, Col: 1, Severity: "warning", RuleSet: "synthetic", Rule: "DoesNotExist",
+			Message: "x"},
+	}
+	var buf bytes.Buffer
+	FormatSARIF(&buf, findings, "1.0.0")
+
+	// helpUri is omitempty: rules absent from the registry contribute no URI.
+	if strings.Contains(buf.String(), `"helpUri"`) {
+		t.Errorf("expected no helpUri for unknown rule, got:\n%s", buf.String())
+	}
+}
+
 func TestFormatCheckstyle_EmptyFindings(t *testing.T) {
 	var buf bytes.Buffer
 	FormatCheckstyle(&buf, nil)

--- a/internal/rules/api/docs.go
+++ b/internal/rules/api/docs.go
@@ -1,0 +1,64 @@
+package api
+
+import "sync/atomic"
+
+// DefaultDocsBaseURL is the canonical documentation host that
+// DefaultDocsResolver appends rule IDs to when a rule does not set
+// DocsURL explicitly. Must end with "/".
+const DefaultDocsBaseURL = "https://krit.dev/rules/"
+
+// DocsResolver derives the documentation URL for a rule.
+type DocsResolver interface {
+	DocsURL(r *Rule) string
+}
+
+// DefaultDocsResolver composes "<BaseURL><rule-id>" when Rule.DocsURL is
+// empty. A zero value uses DefaultDocsBaseURL; tests may set BaseURL to
+// redirect derivation. BaseURL must end with "/" when set.
+type DefaultDocsResolver struct {
+	BaseURL string
+}
+
+// DocsURL implements DocsResolver.
+func (d DefaultDocsResolver) DocsURL(r *Rule) string {
+	if r == nil {
+		return ""
+	}
+	if r.DocsURL != "" {
+		return r.DocsURL
+	}
+	if r.ID == "" {
+		return ""
+	}
+	base := d.BaseURL
+	if base == "" {
+		base = DefaultDocsBaseURL
+	}
+	return base + r.ID
+}
+
+var docsResolver atomic.Pointer[DocsResolver]
+
+func init() {
+	var d DocsResolver = DefaultDocsResolver{}
+	docsResolver.Store(&d)
+}
+
+// RuleDocsURL returns the canonical documentation URL for r.
+func RuleDocsURL(r *Rule) string {
+	return (*docsResolver.Load()).DocsURL(r)
+}
+
+// SetDocsResolver swaps the package-level resolver and returns the
+// prior value. Passing nil installs the zero-value DefaultDocsResolver.
+// Safe for concurrent use.
+func SetDocsResolver(d DocsResolver) DocsResolver {
+	if d == nil {
+		d = DefaultDocsResolver{}
+	}
+	prev := docsResolver.Swap(&d)
+	if prev == nil {
+		return DefaultDocsResolver{}
+	}
+	return *prev
+}

--- a/internal/rules/api/docs_test.go
+++ b/internal/rules/api/docs_test.go
@@ -1,0 +1,67 @@
+package api
+
+import "testing"
+
+func TestDocsURLDerivation(t *testing.T) {
+	tests := []struct {
+		name     string
+		resolver DocsResolver
+		rule     *Rule
+		want     string
+	}{
+		{
+			name:     "explicit DocsURL wins",
+			resolver: DefaultDocsResolver{},
+			rule:     &Rule{ID: "MagicNumber", DocsURL: "https://example.com/magic"},
+			want:     "https://example.com/magic",
+		},
+		{
+			name:     "derived from default base",
+			resolver: DefaultDocsResolver{},
+			rule:     &Rule{ID: "MagicNumber"},
+			want:     "https://krit.dev/rules/MagicNumber",
+		},
+		{
+			name:     "custom base URL",
+			resolver: DefaultDocsResolver{BaseURL: "https://docs.example.com/r/"},
+			rule:     &Rule{ID: "MagicNumber"},
+			want:     "https://docs.example.com/r/MagicNumber",
+		},
+		{
+			name:     "nil rule returns empty",
+			resolver: DefaultDocsResolver{},
+			rule:     nil,
+			want:     "",
+		},
+		{
+			name:     "rule without ID or DocsURL returns empty",
+			resolver: DefaultDocsResolver{},
+			rule:     &Rule{},
+			want:     "",
+		},
+		{
+			name:     "DocsURL still wins when ID is empty",
+			resolver: DefaultDocsResolver{},
+			rule:     &Rule{DocsURL: "https://example.com/x"},
+			want:     "https://example.com/x",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.resolver.DocsURL(tt.rule); got != tt.want {
+				t.Errorf("DocsURL() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRuleDocsURL_UsesPackageResolver(t *testing.T) {
+	prev := SetDocsResolver(DefaultDocsResolver{BaseURL: "https://fake.test/rules/"})
+	t.Cleanup(func() { SetDocsResolver(prev) })
+
+	got := RuleDocsURL(&Rule{ID: "R1"})
+	if want := "https://fake.test/rules/R1"; got != want {
+		t.Errorf("RuleDocsURL() = %q, want %q", got, want)
+	}
+}

--- a/internal/rules/api/metadata.go
+++ b/internal/rules/api/metadata.go
@@ -204,6 +204,10 @@ type RuleDescriptor struct {
 	// Description is the human-readable rule summary.
 	Description string
 
+	// DocsURL mirrors Rule.DocsURL — the canonical documentation URL.
+	// When empty, RuleDocsURL derives one from DefaultDocsBaseURL + ID.
+	DocsURL string
+
 	// DefaultActive reports whether the rule runs by default. Rules with
 	// DefaultActive == false are opt-in (must be enabled via config or
 	// --all-rules).

--- a/internal/rules/api/rule.go
+++ b/internal/rules/api/rule.go
@@ -707,6 +707,10 @@ type Rule struct {
 	Description string
 	Sev         Severity
 
+	// DocsURL is the canonical documentation URL for this rule. When
+	// empty, RuleDocsURL derives a URL from DefaultDocsBaseURL + rule ID.
+	DocsURL string
+
 	// Aliases are legacy or alternate IDs for this rule. They do NOT
 	// appear in the registry as separate rules; they only affect
 	// suppression: @Suppress("<alias>") (and inline `// krit:ignore[<alias>]`)

--- a/internal/rules/meta_lookup.go
+++ b/internal/rules/meta_lookup.go
@@ -101,6 +101,14 @@ func mergeRuleDescriptor(r *api.Rule, extra api.RuleDescriptor) api.RuleDescript
 		out.Tags = extra.Tags
 	}
 	out.Owners = resolveOwners(r, extra)
+	if r.DocsURL != "" {
+		out.DocsURL = r.DocsURL
+	} else {
+		out.DocsURL = extra.DocsURL
+	}
+	if out.DocsURL == "" {
+		out.DocsURL = api.RuleDocsURL(r)
+	}
 	out.Precision = resolvePrecision(r, extra)
 	return out
 }


### PR DESCRIPTION
## Summary

- Adds `DocsURL` to `api.Rule` and `api.RuleDescriptor`, plus a `DocsResolver` interface (`DefaultDocsResolver` derives `https://krit.dev/rules/<id>` when `DocsURL` is empty).
- Wires the URL into SARIF `reportingDescriptor.helpUri` and LSP `textDocument/hover` (replacing the generic `docs/rules.md` link), and exposes it via the MCP `rules.explain` tool.
- `MetaForRule` now populates the derived URL on the descriptor so consumers always see a canonical link without re-deriving.

Closes #198.

## Test plan

- [x] `go build`, `go vet`, `golangci-lint run`, `go test ./... -race` (on touched packages)
- [x] New `TestDocsURLDerivation` covers explicit URL, default base, custom base, nil rule, empty ID
- [x] New `TestFormatSARIF_HelpURI` asserts SARIF `helpUri` for a registered rule and `omitempty` for unknown rules
- [x] Updated `TestHoverReturnsRuleInfo` asserts the canonical `https://krit.dev/rules/MagicNumber` link