### PR TITLE
feat(rules): add security taxonomy (CWE/OWASP/SEI-CERT/MITRE) to rule metadata

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"773f6be7-fffd-4b1e-997f-d24ff8bf012d","pid":36465,"procStart":"Fri May 15 02:34:41 2026","acquiredAt":1778820250523}

--- a/internal/cli/scan/early_exits.go
+++ b/internal/cli/scan/early_exits.go
@@ -4,9 +4,11 @@ import (
 	"embed"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 
 	"github.com/kaeawc/krit/internal/cache"
 	"github.com/kaeawc/krit/internal/cacheutil"
@@ -272,11 +274,17 @@ func computeListRulesSummary(registry []*api.Rule) listRulesSummary {
 	return s
 }
 
-func runListRulesFlag(listFlag, verboseFlag bool, maturityFilter string) {
+func runListRulesFlag(listFlag, verboseFlag bool, maturityFilter, taxonomyID string) {
 	if !listFlag {
 		return
 	}
+	printListRules(os.Stdout, verboseFlag, maturityFilter, taxonomyID)
+	os.Exit(0)
+}
 
+// printListRules writes the --list-rules output. Split from
+// runListRulesFlag so tests can drive it without the os.Exit.
+func printListRules(w io.Writer, verboseFlag bool, maturityFilter, taxonomyID string) {
 	var maturity api.Maturity
 	maturityFilterSet := false
 	if maturityFilter != "" {
@@ -294,10 +302,20 @@ func runListRulesFlag(listFlag, verboseFlag bool, maturityFilter string) {
 		registry = api.MaturityFilter(registry, maturity)
 	}
 
-	fmt.Println("Available rules:")
+	var matcher api.TaxonomyMatcher
+	taxonomyID = strings.TrimSpace(taxonomyID)
+	if taxonomyID != "" {
+		matcher = api.TaxonomyMatcher{IDs: []string{taxonomyID}}
+		fmt.Fprintf(w, "Available rules (filtered by taxonomy ID %q):\n", taxonomyID)
+	} else {
+		fmt.Fprintln(w, "Available rules:")
+	}
 	fixable := 0
 	active := 0
 	for _, r := range registry {
+		if len(matcher.IDs) > 0 && !matcher.Matches(r.Security) {
+			continue
+		}
 		markers := ""
 		if rules.IsDefaultActive(r.ID) {
 			markers += "A"
@@ -309,28 +327,27 @@ func runListRulesFlag(listFlag, verboseFlag bool, maturityFilter string) {
 			markers += "F"
 			fixable++
 			if verboseFlag {
-				fmt.Printf("  %s %-40s [%-15s] %s (fix: %s, precision: %s, maturity: %s)\n", markers, r.ID, r.Category, string(r.Sev), fixLvl, rules.V2RulePrecision(r), r.Maturity)
+				fmt.Fprintf(w, "  %s %-40s [%-15s] %s (fix: %s, precision: %s, maturity: %s)\n", markers, r.ID, r.Category, string(r.Sev), fixLvl, rules.V2RulePrecision(r), r.Maturity)
 				if r.Description != "" {
-					fmt.Printf("    %s\n", r.Description)
+					fmt.Fprintf(w, "    %s\n", r.Description)
 				}
 			} else {
-				fmt.Printf("  %s %-40s [%-15s] %s\n", markers, r.ID, r.Category, string(r.Sev))
+				fmt.Fprintf(w, "  %s %-40s [%-15s] %s\n", markers, r.ID, r.Category, string(r.Sev))
 			}
 		} else {
 			markers += " "
 			if verboseFlag {
-				fmt.Printf("  %s %-40s [%-15s] %s (precision: %s, maturity: %s)\n", markers, r.ID, r.Category, string(r.Sev), rules.V2RulePrecision(r), r.Maturity)
+				fmt.Fprintf(w, "  %s %-40s [%-15s] %s (precision: %s, maturity: %s)\n", markers, r.ID, r.Category, string(r.Sev), rules.V2RulePrecision(r), r.Maturity)
 				if r.Description != "" {
-					fmt.Printf("    %s\n", r.Description)
+					fmt.Fprintf(w, "    %s\n", r.Description)
 				}
 			} else {
-				fmt.Printf("  %s %-40s [%-15s] %s\n", markers, r.ID, r.Category, string(r.Sev))
+				fmt.Fprintf(w, "  %s %-40s [%-15s] %s\n", markers, r.ID, r.Category, string(r.Sev))
 			}
 		}
 	}
-	fmt.Printf("\nTotal: %d rules (%d active by default, %d fixable)\n", len(registry), active, fixable)
-	fmt.Println("A=active by default, F=fixable. Use -v for fix levels, --all-rules to enable all, --maturity to filter by lifecycle.")
-	os.Exit(0)
+	fmt.Fprintf(w, "\nTotal: %d rules (%d active by default, %d fixable)\n", len(registry), active, fixable)
+	fmt.Fprintln(w, "A=active by default, F=fixable. Use -v for fix levels, --all-rules to enable all, --maturity to filter by lifecycle.")
 }
 
 // outputTypesOpts bundles the flag values runOutputTypesFlag needs.

--- a/internal/cli/scan/flags.go
+++ b/internal/cli/scan/flags.go
@@ -50,6 +50,7 @@ type scanFlags struct {
 	StoreDir                 *string
 	Config                   *string
 	List                     *bool
+	ListRulesCWE             *string
 	NoTypeInfer              *bool
 	ValidateConfig           *bool
 	GenerateSchema           *bool
@@ -155,6 +156,7 @@ func registerScanFlags(fs *flag.FlagSet) *scanFlags {
 	f.StoreDir = fs.String("store-dir", "", "Unified store directory (enables store-backed incremental cache; default: .krit/store when present)")
 	f.Config = fs.String("config", "", "Path to YAML config file (default: auto-detect krit.yml or .krit.yml)")
 	f.List = fs.Bool("list-rules", false, "List all rules (add -v to show fixable)")
+	f.ListRulesCWE = fs.String("cwe", "", "Filter --list-rules by taxonomy ID (CWE/OWASP/SEI-CERT/MITRE; case-insensitive)")
 	f.NoTypeInfer = fs.Bool("no-type-inference", false, "Disable type inference (faster but less precise)")
 	f.ValidateConfig = fs.Bool("validate-config", false, "Validate config file and exit")
 	f.GenerateSchema = fs.Bool("generate-schema", false, "Print JSON Schema for krit.yml to stdout")

--- a/internal/cli/scan/list_rules_cwe_test.go
+++ b/internal/cli/scan/list_rules_cwe_test.go
@@ -1,0 +1,36 @@
+package scan
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	api "github.com/kaeawc/krit/internal/rules/api"
+)
+
+// TestCWEFilter verifies that --list-rules --cwe filters the output to
+// rules whose Security taxonomy lists the requested ID.
+func TestCWEFilter(t *testing.T) {
+	matcher := api.TaxonomyMatcher{IDs: []string{"CWE-89"}}
+	hasMatch := false
+	for _, r := range api.Registry {
+		if matcher.Matches(r.Security) {
+			hasMatch = true
+			break
+		}
+	}
+	if !hasMatch {
+		t.Skip("no CWE-89 rule registered; skipping filter test")
+	}
+
+	var buf bytes.Buffer
+	printListRules(&buf, false, "", "CWE-89")
+	out := buf.String()
+
+	if !strings.Contains(out, "SqlInjectionRawQuery") {
+		t.Fatalf("expected SqlInjectionRawQuery in --cwe CWE-89 output, got:\n%s", out)
+	}
+	if strings.Contains(out, "TrailingWhitespace") {
+		t.Fatalf("non-security rule leaked into CWE-89 filter:\n%s", out)
+	}
+}

--- a/internal/cli/scan/runner_state.go
+++ b/internal/cli/scan/runner_state.go
@@ -158,7 +158,7 @@ func newRunner(f *scanFlags, sess *Session) (*runner, int, bool) {
 
 	applyEditorConfigOverrides(cfg, *f.EditorConfig, flag.Args())
 
-	runListRulesFlag(*f.List, *f.Verbose, *f.Maturity)
+	runListRulesFlag(*f.List, *f.Verbose, *f.Maturity, *f.ListRulesCWE)
 
 	maxFixLevel, ok := resolveMaxFixLevel(f)
 	if !ok {

--- a/internal/mcp/tool_rules.go
+++ b/internal/mcp/tool_rules.go
@@ -24,6 +24,9 @@ type rulesArgs struct {
 	Maturity  string   `json:"maturity"`
 	Needs     []string `json:"needs"`
 	Without   []string `json:"without"`
+	// Taxonomy filters rules whose SecurityTaxonomy lists this ID
+	// (case-insensitive). Accepts CWE/OWASP/SEI-CERT/MITRE IDs.
+	Taxonomy string `json:"taxonomy"`
 
 	// operation=configure
 	Active   *bool  `json:"active"`
@@ -138,8 +141,34 @@ func (s *Server) rulesExplain(args rulesArgs) ToolResult {
 		}
 		info["deprecation"] = dep
 	}
+	if mapping := securityMapping(r.Security); mapping != nil {
+		info["security"] = mapping
+	}
 
 	return jsonResult(info)
+}
+
+// securityMapping renders the rule's security taxonomy as a per-axis
+// map for MCP `explain` output, or nil when the rule carries no
+// published taxonomy IDs.
+func securityMapping(sec *api.SecurityTaxonomy) map[string][]string {
+	if sec == nil || sec.IsEmpty() {
+		return nil
+	}
+	mapping := map[string][]string{}
+	if len(sec.CWE) > 0 {
+		mapping["cwe"] = sec.CWE
+	}
+	if len(sec.OWASP) > 0 {
+		mapping["owasp"] = sec.OWASP
+	}
+	if len(sec.SEICert) > 0 {
+		mapping["sei-cert"] = sec.SEICert
+	}
+	if len(sec.Mitre) > 0 {
+		mapping["mitre"] = sec.Mitre
+	}
+	return mapping
 }
 
 // resolveRelatedRules returns the rule IDs listed in r.RelatedRules,
@@ -175,16 +204,16 @@ func formatLifecycle(introducedIn, enabledByDefaultSince string) string {
 	}
 }
 
-// parseSearchFilters validates the precision/maturity arguments. Returns a
-// non-nil ToolResult pointer when validation fails.
-func parseSearchFilters(args rulesArgs) (api.Precision, api.Maturity, bool, *ToolResult) {
+// parseSearchFilters validates the precision/maturity/taxonomy filter
+// arguments. Returns a non-nil ToolResult pointer when validation fails.
+func parseSearchFilters(args rulesArgs) (api.Precision, api.Maturity, bool, api.TaxonomyMatcher, *ToolResult) {
 	var precisionFilter api.Precision
 	if args.Precision != "" {
 		p, ok := api.ParsePrecision(args.Precision)
 		if !ok {
 			r := errorResult("unknown precision: " + args.Precision +
 				"; valid: heuristic/text-backed, ast-backed, project-structure-aware, type-aware, policy")
-			return 0, 0, false, &r
+			return 0, 0, false, api.TaxonomyMatcher{}, &r
 		}
 		precisionFilter = p
 	}
@@ -195,12 +224,17 @@ func parseSearchFilters(args rulesArgs) (api.Precision, api.Maturity, bool, *Too
 		m, ok := api.ParseMaturity(args.Maturity)
 		if !ok {
 			r := errorResult("unknown maturity: " + args.Maturity + "; valid: stable, experimental, deprecated")
-			return 0, 0, false, &r
+			return 0, 0, false, api.TaxonomyMatcher{}, &r
 		}
 		maturityFilter = m
 		maturityFilterSet = true
 	}
-	return precisionFilter, maturityFilter, maturityFilterSet, nil
+
+	var taxonomyMatcher api.TaxonomyMatcher
+	if args.Taxonomy != "" {
+		taxonomyMatcher = api.TaxonomyMatcher{IDs: []string{args.Taxonomy}}
+	}
+	return precisionFilter, maturityFilter, maturityFilterSet, taxonomyMatcher, nil
 }
 
 // validateCapabilityArgs returns a non-nil ToolResult error when 'needs' or
@@ -260,17 +294,22 @@ type searchOpts struct {
 	precisionFilter   api.Precision
 	maturityFilter    api.Maturity
 	maturityFilterSet bool
+	taxonomyMatcher   api.TaxonomyMatcher
 	supportFilter     rules.LanguageSupportFilter
 	hasSupportFilter  bool
 	capabilityFilter  api.CapabilityFilter
 	hasCapabilityFilt bool
 }
 
+func (o searchOpts) hasTaxonomyFilter() bool {
+	return len(o.taxonomyMatcher.IDs) > 0
+}
+
 // scoreRuleForSearch returns (score, keep). Scoring favors name > description
 // > category matches; a missing query is allowed when another filter is set.
 func scoreRuleForSearch(r *api.Rule, opts searchOpts) (int, bool) {
 	if opts.query == "" {
-		if opts.precisionFilter == api.PrecisionUnset && !opts.maturityFilterSet && !opts.hasSupportFilter && !opts.hasCapabilityFilt {
+		if opts.precisionFilter == api.PrecisionUnset && !opts.maturityFilterSet && !opts.hasTaxonomyFilter() && !opts.hasSupportFilter && !opts.hasCapabilityFilt {
 			return 0, false
 		}
 		return 1, true
@@ -297,6 +336,9 @@ func collectRuleHits(opts searchOpts) []ruleHit {
 			continue
 		}
 		if opts.maturityFilterSet && r.Maturity != opts.maturityFilter {
+			continue
+		}
+		if opts.hasTaxonomyFilter() && !opts.taxonomyMatcher.Matches(r.Security) {
 			continue
 		}
 		if opts.hasSupportFilter && !opts.supportFilter.Matches(r) {
@@ -335,15 +377,15 @@ func (s *Server) rulesSearch(args rulesArgs) ToolResult {
 	capabilityFilter := api.CapabilityFilter{Require: args.Needs, Exclude: args.Without}
 	hasCapabilityFilt := !capabilityFilter.IsZero()
 
-	if args.Query == "" && args.Precision == "" && args.Maturity == "" && !hasSupportFilter && !hasCapabilityFilt {
-		return errorResult("'query', 'precision', 'maturity', 'languageSupport', 'needs', or 'without' argument is required for operation=search")
+	if args.Query == "" && args.Precision == "" && args.Maturity == "" && args.Taxonomy == "" && !hasSupportFilter && !hasCapabilityFilt {
+		return errorResult("'query', 'precision', 'maturity', 'taxonomy', 'languageSupport', 'needs', or 'without' argument is required for operation=search")
 	}
 
 	if errResult := validateCapabilityArgs(args.Needs, args.Without); errResult != nil {
 		return *errResult
 	}
 
-	precisionFilter, maturityFilter, maturityFilterSet, errResult := parseSearchFilters(args)
+	precisionFilter, maturityFilter, maturityFilterSet, taxonomyMatcher, errResult := parseSearchFilters(args)
 	if errResult != nil {
 		return *errResult
 	}
@@ -359,6 +401,7 @@ func (s *Server) rulesSearch(args rulesArgs) ToolResult {
 		precisionFilter:   precisionFilter,
 		maturityFilter:    maturityFilter,
 		maturityFilterSet: maturityFilterSet,
+		taxonomyMatcher:   taxonomyMatcher,
 		supportFilter:     supportFilter,
 		hasSupportFilter:  hasSupportFilter,
 		capabilityFilter:  capabilityFilter,

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -86,8 +86,9 @@ type sarifLog struct {
 }
 
 type sarifRun struct {
-	Tool    sarifTool     `json:"tool"`
-	Results []sarifResult `json:"results"`
+	Tool       sarifTool       `json:"tool"`
+	Results    []sarifResult   `json:"results"`
+	Taxonomies []sarifTaxonomy `json:"taxonomies,omitempty"`
 }
 
 type sarifTool struct {
@@ -95,9 +96,10 @@ type sarifTool struct {
 }
 
 type sarifDriver struct {
-	Name    string      `json:"name"`
-	Version string      `json:"version"`
-	Rules   []sarifRule `json:"rules"`
+	Name                string                   `json:"name"`
+	Version             string                   `json:"version"`
+	Rules               []sarifRule              `json:"rules"`
+	SupportedTaxonomies []sarifTaxonomyReference `json:"supportedTaxonomies,omitempty"`
 }
 
 type sarifRule struct {
@@ -106,12 +108,42 @@ type sarifRule struct {
 	FullDescription  *sarifText           `json:"fullDescription,omitempty"`
 	HelpURI          string               `json:"helpUri,omitempty"`
 	Properties       *sarifRuleProperties `json:"properties,omitempty"`
+	Relationships    []sarifRelationship  `json:"relationships,omitempty"`
 }
 
 type sarifRuleProperties struct {
 	Maturity  string `json:"maturity,omitempty"`
 	Precision string `json:"precision,omitempty"`
 	Cost      string `json:"cost,omitempty"`
+}
+
+type sarifTaxonomy struct {
+	Name             string       `json:"name"`
+	ShortDescription sarifText    `json:"shortDescription"`
+	Taxa             []sarifTaxon `json:"taxa"`
+}
+
+type sarifTaxon struct {
+	ID               string    `json:"id"`
+	ShortDescription sarifText `json:"shortDescription"`
+}
+
+type sarifTaxonomyReference struct {
+	Name string `json:"name"`
+}
+
+type sarifRelationship struct {
+	Target sarifReportingDescriptorReference `json:"target"`
+	Kinds  []string                          `json:"kinds"`
+}
+
+type sarifReportingDescriptorReference struct {
+	ID            string                `json:"id"`
+	ToolComponent sarifToolComponentRef `json:"toolComponent"`
+}
+
+type sarifToolComponentRef struct {
+	Name string `json:"name"`
 }
 
 type sarifText struct {
@@ -149,6 +181,10 @@ type sarifProperties struct {
 	Precision    string   `json:"precision,omitempty"`
 	Effort       string   `json:"effort,omitempty"`
 	Capabilities []string `json:"capabilities,omitempty"`
+	CWE          []string `json:"cwe,omitempty"`
+	OWASP        []string `json:"owasp,omitempty"`
+	SEICert      []string `json:"sei-cert,omitempty"`
+	Mitre        []string `json:"mitre,omitempty"`
 }
 
 // FormatSARIFColumns writes columnar findings as SARIF 2.1.0 JSON.
@@ -162,6 +198,7 @@ func FormatSARIFColumns(w io.Writer, columns *scanner.FindingColumns, version st
 	costMap := make(map[string]string)
 	capabilityMap := make(map[string][]string)
 	maturityMap := make(map[string]string)
+	securityMap := make(map[string]*api.SecurityTaxonomy)
 	for _, r := range api.Registry {
 		key := r.Category + "/" + r.ID
 		if r.Description != "" {
@@ -177,10 +214,17 @@ func FormatSARIFColumns(w io.Writer, columns *scanner.FindingColumns, version st
 			capabilityMap[key] = list
 		}
 		maturityMap[key] = r.Maturity.String()
+		if r.Security != nil && !r.Security.IsEmpty() {
+			securityMap[key] = r.Security
+		}
 	}
 
 	rulesSeen := make(map[string]bool)
 	var sarifRules []sarifRule
+	cweIDs := newOrderedTaxa()
+	owaspIDs := newOrderedTaxa()
+	certIDs := newOrderedTaxa()
+	mitreIDs := newOrderedTaxa()
 
 	var results []sarifResult
 	cols.VisitSortedByFileLine(func(row int) {
@@ -206,6 +250,9 @@ func FormatSARIFColumns(w io.Writer, columns *scanner.FindingColumns, version st
 			if maturity != "" || precision != "" || cost != "" {
 				sr.Properties = &sarifRuleProperties{Maturity: maturity, Precision: precision, Cost: cost}
 			}
+			if sec := securityMap[ruleID]; sec != nil {
+				sr.Relationships = sarifTaxonomyRelationships(sec, cweIDs, owaspIDs, certIDs, mitreIDs)
+			}
 			sarifRules = append(sarifRules, sr)
 		}
 
@@ -228,14 +275,11 @@ func FormatSARIFColumns(w io.Writer, columns *scanner.FindingColumns, version st
 				},
 			}},
 		}
-		precision := precisionMap[ruleID]
-		effort := effortMap[ruleID]
-		caps := capabilityMap[ruleID]
-		if confidence := cols.ConfidenceAt(row); confidence > 0 || precision != "" || effort != "" || len(caps) > 0 {
-			r.Properties = &sarifProperties{Confidence: confidence, Precision: precision, Effort: effort, Capabilities: caps}
-		}
+		r.Properties = buildResultProperties(cols.ConfidenceAt(row), precisionMap[ruleID], effortMap[ruleID], capabilityMap[ruleID], securityMap[ruleID])
 		results = append(results, r)
 	})
+
+	taxonomies, supported := buildSarifTaxonomies(cweIDs, owaspIDs, certIDs, mitreIDs)
 
 	log := sarifLog{
 		Schema:  "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.1/schema/sarif-schema-2.1.0.json",
@@ -243,18 +287,125 @@ func FormatSARIFColumns(w io.Writer, columns *scanner.FindingColumns, version st
 		Runs: []sarifRun{{
 			Tool: sarifTool{
 				Driver: sarifDriver{
-					Name:    "krit",
-					Version: version,
-					Rules:   sarifRules,
+					Name:                "krit",
+					Version:             version,
+					Rules:               sarifRules,
+					SupportedTaxonomies: supported,
 				},
 			},
-			Results: results,
+			Results:    results,
+			Taxonomies: taxonomies,
 		}},
 	}
 
 	enc := json.NewEncoder(w)
 	enc.SetEscapeHTML(false)
 	return enc.Encode(log)
+}
+
+// buildResultProperties returns the per-finding sarifProperties payload,
+// or nil when the finding has no metadata worth emitting.
+func buildResultProperties(confidence float64, precision, effort string, caps []string, sec *api.SecurityTaxonomy) *sarifProperties {
+	if confidence <= 0 && precision == "" && effort == "" && len(caps) == 0 && sec == nil {
+		return nil
+	}
+	props := &sarifProperties{Confidence: confidence, Precision: precision, Effort: effort, Capabilities: caps}
+	if sec != nil {
+		props.CWE = sec.CWE
+		props.OWASP = sec.OWASP
+		props.SEICert = sec.SEICert
+		props.Mitre = sec.Mitre
+	}
+	return props
+}
+
+// orderedTaxa is an insertion-ordered set used while collecting
+// SARIF taxa. Insertion order yields stable output without sorting.
+type orderedTaxa struct {
+	seen  map[string]struct{}
+	order []string
+}
+
+func newOrderedTaxa() *orderedTaxa {
+	return &orderedTaxa{seen: map[string]struct{}{}}
+}
+
+func (o *orderedTaxa) add(id string) {
+	if id == "" {
+		return
+	}
+	if _, ok := o.seen[id]; ok {
+		return
+	}
+	o.seen[id] = struct{}{}
+	o.order = append(o.order, id)
+}
+
+func (o *orderedTaxa) values() []string { return o.order }
+
+// SARIF taxonomy names. Consumers (GitHub code-scanning, Snyk) key
+// off these names to link findings to the public catalogs.
+const (
+	taxonomyCWE     = "CWE"
+	taxonomyOWASP   = "OWASP"
+	taxonomySEICert = "SEI-CERT"
+	taxonomyMitre   = "MITRE-ATT&CK"
+)
+
+func sarifTaxonomyRelationships(sec *api.SecurityTaxonomy, cwe, owasp, cert, mitre *orderedTaxa) []sarifRelationship {
+	if sec == nil {
+		return nil
+	}
+	var rels []sarifRelationship
+	add := func(ids []string, taxonomy string, sink *orderedTaxa) {
+		for _, id := range ids {
+			sink.add(id)
+			rels = append(rels, sarifRelationship{
+				Target: sarifReportingDescriptorReference{
+					ID:            id,
+					ToolComponent: sarifToolComponentRef{Name: taxonomy},
+				},
+				Kinds: []string{"superset"},
+			})
+		}
+	}
+	add(sec.CWE, taxonomyCWE, cwe)
+	add(sec.OWASP, taxonomyOWASP, owasp)
+	add(sec.SEICert, taxonomySEICert, cert)
+	add(sec.Mitre, taxonomyMitre, mitre)
+	return rels
+}
+
+func buildSarifTaxonomies(cwe, owasp, cert, mitre *orderedTaxa) ([]sarifTaxonomy, []sarifTaxonomyReference) {
+	type bucket struct {
+		name string
+		desc string
+		ids  []string
+	}
+	buckets := []bucket{
+		{taxonomyCWE, "Common Weakness Enumeration", cwe.values()},
+		{taxonomyOWASP, "OWASP Top 10", owasp.values()},
+		{taxonomySEICert, "SEI CERT Secure Coding", cert.values()},
+		{taxonomyMitre, "MITRE ATT&CK", mitre.values()},
+	}
+	var taxonomies []sarifTaxonomy
+	var supported []sarifTaxonomyReference
+	for _, b := range buckets {
+		if len(b.ids) == 0 {
+			continue
+		}
+		taxa := make([]sarifTaxon, 0, len(b.ids))
+		for _, id := range b.ids {
+			taxa = append(taxa, sarifTaxon{ID: id, ShortDescription: sarifText{Text: id}})
+		}
+		taxonomies = append(taxonomies, sarifTaxonomy{
+			Name:             b.name,
+			ShortDescription: sarifText{Text: b.desc},
+			Taxa:             taxa,
+		})
+		supported = append(supported, sarifTaxonomyReference{Name: b.name})
+	}
+	return taxonomies, supported
 }
 
 // FormatCheckstyleColumns writes columnar findings as Checkstyle XML.

--- a/internal/output/sarif_taxa_test.go
+++ b/internal/output/sarif_taxa_test.go
@@ -1,0 +1,98 @@
+package output
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	api "github.com/kaeawc/krit/internal/rules/api"
+	"github.com/kaeawc/krit/internal/scanner"
+)
+
+// TestSARIFTaxa exercises the security-taxonomy wiring end-to-end:
+// when a security rule fires, the SARIF output carries taxa, the
+// driver advertises supportedTaxonomies, and the result's properties
+// expose the CWE/OWASP/CERT IDs that GitHub code-scanning expects.
+func TestSARIFTaxa(t *testing.T) {
+	// Pick any registered security rule with a CWE mapping; the global
+	// init() already attached taxonomies to the registry.
+	var ruleID, ruleSet string
+	for _, r := range api.Registry {
+		if r.Category == "security" && r.Security != nil && len(r.Security.CWE) > 0 {
+			ruleID = r.ID
+			ruleSet = r.Category
+			break
+		}
+	}
+	if ruleID == "" {
+		t.Fatal("expected at least one security rule with CWE taxonomy in registry")
+	}
+
+	cc := scanner.NewFindingCollector(1)
+	cc.Append(scanner.Finding{
+		File:       "app/Foo.kt",
+		Line:       10,
+		Col:        4,
+		Severity:   "error",
+		RuleSet:    ruleSet,
+		Rule:       ruleID,
+		Message:    "boom",
+		Confidence: 0.9,
+	})
+	cols := cc.Columns()
+
+	var buf bytes.Buffer
+	if err := FormatSARIFColumns(&buf, cols, "test"); err != nil {
+		t.Fatalf("FormatSARIFColumns: %v", err)
+	}
+
+	var log map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &log); err != nil {
+		t.Fatalf("SARIF output is not valid JSON: %v\n%s", err, buf.String())
+	}
+
+	runs, _ := log["runs"].([]any)
+	if len(runs) != 1 {
+		t.Fatalf("expected 1 run, got %d", len(runs))
+	}
+	run := runs[0].(map[string]any)
+
+	taxonomies, _ := run["taxonomies"].([]any)
+	if len(taxonomies) == 0 {
+		t.Fatalf("expected SARIF run to carry taxonomies block; got: %s", buf.String())
+	}
+	hasCWE := false
+	for _, tx := range taxonomies {
+		m := tx.(map[string]any)
+		if m["name"] == "CWE" {
+			taxa, _ := m["taxa"].([]any)
+			if len(taxa) > 0 {
+				hasCWE = true
+			}
+		}
+	}
+	if !hasCWE {
+		t.Fatalf("expected CWE taxonomy with at least one taxon: %s", buf.String())
+	}
+
+	driver := run["tool"].(map[string]any)["driver"].(map[string]any)
+	supported, _ := driver["supportedTaxonomies"].([]any)
+	if len(supported) == 0 {
+		t.Fatalf("expected driver.supportedTaxonomies to be populated: %s", buf.String())
+	}
+
+	results := run["results"].([]any)
+	res := results[0].(map[string]any)
+	props, ok := res["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected result.properties: %s", buf.String())
+	}
+	cwe, _ := props["cwe"].([]any)
+	if len(cwe) == 0 {
+		t.Fatalf("expected result.properties.cwe: %s", buf.String())
+	}
+	if !strings.HasPrefix(cwe[0].(string), "CWE-") {
+		t.Fatalf("expected CWE-prefixed ID, got %v", cwe[0])
+	}
+}

--- a/internal/rules/api/metadata.go
+++ b/internal/rules/api/metadata.go
@@ -261,6 +261,11 @@ type RuleDescriptor struct {
 	// surfaced under "caveats" in MCP `explain` output.
 	KnownLimitations []string
 
+	// Security mirrors Rule.Security — published taxonomy IDs (CWE,
+	// OWASP, SEI CERT, MITRE) for security-category rules. Nil when
+	// the rule has no taxonomy mapping. See SecurityTaxonomy.
+	Security *SecurityTaxonomy
+
 	// LanguageSupport records per-source-language support status for a rule.
 	// It is product/support metadata rather than dispatcher routing: Languages
 	// on Rule controls where a rule runs, while LanguageSupport explains whether

--- a/internal/rules/api/rule.go
+++ b/internal/rules/api/rule.go
@@ -886,6 +886,14 @@ type Rule struct {
 	// they are summaries, not migration guides.
 	KnownLimitations []string
 
+	// Security carries structured taxonomy identifiers (CWE, OWASP,
+	// SEI CERT, MITRE ATT&CK) for security-category rules. The
+	// dispatcher does not key behavior on these IDs; they exist for
+	// SARIF taxa, MCP explain, CLI filters (e.g. --cwe CWE-89), and
+	// downstream dashboards. A nil pointer means the rule has no
+	// published taxonomy mapping. See SecurityTaxonomy.
+	Security *SecurityTaxonomy
+
 	// KotlincAnalog names the closest standard kotlinc diagnostic that
 	// this rule approximates, e.g. "UNREACHABLE_CODE". Informational
 	// only — krit is not bug-for-bug compatible with kotlinc. Empty

--- a/internal/rules/api/security.go
+++ b/internal/rules/api/security.go
@@ -1,0 +1,111 @@
+package api
+
+import "strings"
+
+// SecurityTaxonomy carries structured identifiers from public security
+// catalogs (CWE, OWASP Top 10, SEI CERT, MITRE ATT&CK) that classify a
+// security rule. The struct is informational metadata: the dispatcher
+// never keys behavior on these IDs. Consumers (SARIF taxa, MCP explain,
+// CLI filters, dashboards) read them to render badges, link out to the
+// canonical taxonomy entry, or filter rules by ID.
+//
+// All ID slices are case-preserving but case-insensitive at lookup time.
+// Empty slices and a nil Security pointer are both legal: a nil pointer
+// means "this rule has no published taxonomy mapping yet"; an empty
+// slice on one axis means "the rule is mapped, but not to any IDs on
+// that axis." Consumers should treat both the same way.
+type SecurityTaxonomy struct {
+	// CWE lists Common Weakness Enumeration IDs in the canonical
+	// "CWE-<n>" form, e.g. "CWE-89" for SQL injection. The SARIF taxa
+	// emitter uses the CWE catalog for the corresponding taxonomy
+	// reference; GitHub code-scanning renders the chip from this ID.
+	CWE []string
+
+	// OWASP lists OWASP Top 10 category IDs, e.g. "A03:2021-Injection".
+	// Year-prefixed values are preferred so the mapping survives top-10
+	// re-orderings.
+	OWASP []string
+
+	// SEICert lists SEI CERT secure-coding rule IDs (Java or Android
+	// where applicable), e.g. "IDS00-J" or "FIO52-J".
+	SEICert []string
+
+	// Mitre lists optional MITRE ATT&CK technique IDs, e.g. "T1059".
+	// Most rules will leave this nil; supply when the rule maps to a
+	// concrete adversary technique.
+	Mitre []string
+}
+
+// IsEmpty reports whether the taxonomy contributes no IDs. A nil
+// pointer is also considered empty; callers using TaxonomyMatcher
+// rely on this to skip rules with no security mapping.
+func (t *SecurityTaxonomy) IsEmpty() bool {
+	if t == nil {
+		return true
+	}
+	return len(t.CWE) == 0 && len(t.OWASP) == 0 && len(t.SEICert) == 0 && len(t.Mitre) == 0
+}
+
+// HasCWE reports whether t lists the given CWE ID. Comparison is
+// case-insensitive and tolerates whitespace differences so config and
+// CLI input do not have to match the canonical capitalization exactly.
+func (t *SecurityTaxonomy) HasCWE(id string) bool {
+	return t.has(t.CWE, id)
+}
+
+// HasOWASP reports whether t lists the given OWASP category ID.
+func (t *SecurityTaxonomy) HasOWASP(id string) bool {
+	return t.has(t.OWASP, id)
+}
+
+// HasSEICert reports whether t lists the given SEI CERT rule ID.
+func (t *SecurityTaxonomy) HasSEICert(id string) bool {
+	return t.has(t.SEICert, id)
+}
+
+// HasMitre reports whether t lists the given MITRE ATT&CK technique ID.
+func (t *SecurityTaxonomy) HasMitre(id string) bool {
+	return t.has(t.Mitre, id)
+}
+
+func (t *SecurityTaxonomy) has(ids []string, id string) bool {
+	if t == nil {
+		return false
+	}
+	target := normalizeTaxonomyID(id)
+	if target == "" {
+		return false
+	}
+	for _, candidate := range ids {
+		if normalizeTaxonomyID(candidate) == target {
+			return true
+		}
+	}
+	return false
+}
+
+// TaxonomyMatcher matches rules by taxonomy ID. The dispatcher uses it
+// for CLI filtering ("krit rules list --cwe CWE-79") and the SARIF
+// emitter uses it to emit only relevant taxa references. Zero value
+// matches no rules; populate IDs to opt in.
+type TaxonomyMatcher struct {
+	IDs []string
+}
+
+// Matches reports whether t lists any of the matcher's IDs on any axis.
+// Empty matcher matches no rules. Nil taxonomy matches no rules.
+func (m TaxonomyMatcher) Matches(t *SecurityTaxonomy) bool {
+	if t == nil || len(m.IDs) == 0 {
+		return false
+	}
+	for _, id := range m.IDs {
+		if t.HasCWE(id) || t.HasOWASP(id) || t.HasSEICert(id) || t.HasMitre(id) {
+			return true
+		}
+	}
+	return false
+}
+
+func normalizeTaxonomyID(id string) string {
+	return strings.ToUpper(strings.TrimSpace(id))
+}

--- a/internal/rules/meta_lookup.go
+++ b/internal/rules/meta_lookup.go
@@ -121,6 +121,11 @@ func mergeRuleDescriptor(r *api.Rule, extra api.RuleDescriptor) api.RuleDescript
 	out.Stability = resolveStability(r, extra)
 	out.Noisiness = resolveNoisiness(r, extra)
 	out.KnownLimitations = resolveKnownLimitations(r, extra)
+	if r.Security != nil {
+		out.Security = r.Security
+	} else {
+		out.Security = extra.Security
+	}
 	return out
 }
 

--- a/internal/rules/registry_bootstrap.go
+++ b/internal/rules/registry_bootstrap.go
@@ -119,4 +119,6 @@ func init() {
 	registerStyleUnusedRules()
 	registerSupplyChainRules()
 	registerTestingQualityRules()
+
+	applySecurityTaxonomy()
 }

--- a/internal/rules/security_taxonomy.go
+++ b/internal/rules/security_taxonomy.go
@@ -1,0 +1,212 @@
+package rules
+
+import (
+	api "github.com/kaeawc/krit/internal/rules/api"
+)
+
+// securityTaxonomyByRuleID maps registered security rule IDs to their
+// published taxonomy identifiers. Centralized here so the wiring is
+// readable in one place; an init() hook applies the mapping to the
+// registry after all rules have been registered.
+//
+// Every rule whose Category is "security" must appear in this map with
+// at least one CWE. The applySecurityTaxonomy hook validates this
+// invariant in tests.
+var securityTaxonomyByRuleID = map[string]*api.SecurityTaxonomy{
+	// Injection / unsanitized input
+	"ContentProviderQueryWithSelectionInterpolation": {
+		CWE:     []string{"CWE-89"},
+		OWASP:   []string{"A03:2021-Injection"},
+		SEICert: []string{"IDS00-J"},
+	},
+	"SqlInjectionRawQuery": {
+		CWE:     []string{"CWE-89"},
+		OWASP:   []string{"A03:2021-Injection"},
+		SEICert: []string{"IDS00-J"},
+	},
+	"JdbcStatementExecute": {
+		CWE:     []string{"CWE-89"},
+		OWASP:   []string{"A03:2021-Injection"},
+		SEICert: []string{"IDS00-J"},
+	},
+	"RoomRawQueryStringConcat": {
+		CWE:   []string{"CWE-89"},
+		OWASP: []string{"A03:2021-Injection"},
+	},
+	"RuntimeExecUnsafeShape": {
+		CWE:     []string{"CWE-78"},
+		OWASP:   []string{"A03:2021-Injection"},
+		SEICert: []string{"IDS07-J"},
+		Mitre:   []string{"T1059"},
+	},
+	"ProcessBuilderShellArg": {
+		CWE:     []string{"CWE-78"},
+		OWASP:   []string{"A03:2021-Injection"},
+		SEICert: []string{"IDS07-J"},
+		Mitre:   []string{"T1059"},
+	},
+
+	// Path traversal / zip slip
+	"FileFromUntrustedPath": {
+		CWE:     []string{"CWE-22"},
+		OWASP:   []string{"A01:2021-Broken Access Control"},
+		SEICert: []string{"FIO16-J"},
+	},
+	"ZipSlipUnchecked": {
+		CWE:     []string{"CWE-22"},
+		OWASP:   []string{"A01:2021-Broken Access Control"},
+		SEICert: []string{"FIO16-J"},
+	},
+
+	// Deserialization
+	"JavaObjectInputStream": {
+		CWE:     []string{"CWE-502"},
+		OWASP:   []string{"A08:2021-Software and Data Integrity Failures"},
+		SEICert: []string{"SER12-J"},
+	},
+	"JacksonDefaultTyping": {
+		CWE:   []string{"CWE-502"},
+		OWASP: []string{"A08:2021-Software and Data Integrity Failures"},
+	},
+	"GsonPolymorphicFromJson": {
+		CWE:   []string{"CWE-502"},
+		OWASP: []string{"A08:2021-Software and Data Integrity Failures"},
+	},
+
+	// XML / XXE
+	"XmlExternalEntity": {
+		CWE:     []string{"CWE-611"},
+		OWASP:   []string{"A05:2021-Security Misconfiguration"},
+		SEICert: []string{"IDS17-J"},
+	},
+
+	// Cryptography
+	"WeakMessageDigest": {
+		CWE:     []string{"CWE-327", "CWE-328"},
+		OWASP:   []string{"A02:2021-Cryptographic Failures"},
+		SEICert: []string{"MSC61-J"},
+	},
+	"WeakMacAlgorithm": {
+		CWE:   []string{"CWE-327"},
+		OWASP: []string{"A02:2021-Cryptographic Failures"},
+	},
+	"WeakKeySize": {
+		CWE:   []string{"CWE-326"},
+		OWASP: []string{"A02:2021-Cryptographic Failures"},
+	},
+	"RsaNoPadding": {
+		CWE:   []string{"CWE-780"},
+		OWASP: []string{"A02:2021-Cryptographic Failures"},
+	},
+	"StaticIv": {
+		CWE:   []string{"CWE-329", "CWE-330"},
+		OWASP: []string{"A02:2021-Cryptographic Failures"},
+	},
+	"PrngFromSystemTime": {
+		CWE:     []string{"CWE-330", "CWE-338"},
+		OWASP:   []string{"A02:2021-Cryptographic Failures"},
+		SEICert: []string{"MSC02-J"},
+	},
+
+	// TLS / certificate validation
+	"InsecureTrustManager": {
+		CWE:   []string{"CWE-295"},
+		OWASP: []string{"A07:2021-Identification and Authentication Failures"},
+	},
+	"AllowAllHostnameVerifier": {
+		CWE:   []string{"CWE-297"},
+		OWASP: []string{"A07:2021-Identification and Authentication Failures"},
+	},
+	"OkHttpDisableSslValidation": {
+		CWE:   []string{"CWE-295"},
+		OWASP: []string{"A07:2021-Identification and Authentication Failures"},
+	},
+	"DisableCertificatePinning": {
+		CWE:   []string{"CWE-295"},
+		OWASP: []string{"A07:2021-Identification and Authentication Failures"},
+	},
+	"HardcodedHttpUrl": {
+		CWE:   []string{"CWE-319"},
+		OWASP: []string{"A02:2021-Cryptographic Failures"},
+	},
+
+	// Hardcoded secrets
+	"HardcodedSecretKey": {
+		CWE:     []string{"CWE-798"},
+		OWASP:   []string{"A07:2021-Identification and Authentication Failures"},
+		SEICert: []string{"MSC03-J"},
+	},
+	"HardcodedAwsAccessKey": {
+		CWE:   []string{"CWE-798"},
+		OWASP: []string{"A07:2021-Identification and Authentication Failures"},
+	},
+	"HardcodedBearerToken": {
+		CWE:   []string{"CWE-798"},
+		OWASP: []string{"A07:2021-Identification and Authentication Failures"},
+	},
+	"HardcodedJwt": {
+		CWE:   []string{"CWE-798"},
+		OWASP: []string{"A07:2021-Identification and Authentication Failures"},
+	},
+	"HardcodedGcpServiceAccount": {
+		CWE:   []string{"CWE-798"},
+		OWASP: []string{"A07:2021-Identification and Authentication Failures"},
+	},
+	"GoogleApiKeyInResources": {
+		CWE:   []string{"CWE-798"},
+		OWASP: []string{"A07:2021-Identification and Authentication Failures"},
+	},
+
+	// Sensitive data exposure
+	"LogPii": {
+		CWE:     []string{"CWE-532"},
+		OWASP:   []string{"A09:2021-Security Logging and Monitoring Failures"},
+		SEICert: []string{"FIO13-J"},
+	},
+	"TempFileWorldReadable": {
+		CWE:     []string{"CWE-732"},
+		OWASP:   []string{"A01:2021-Broken Access Control"},
+		SEICert: []string{"FIO01-J"},
+	},
+
+	// Android IPC / intent / receiver exposure
+	"ImplicitPendingIntent": {
+		CWE:   []string{"CWE-927"},
+		OWASP: []string{"A01:2021-Broken Access Control"},
+	},
+	"StartActivityWithUntrustedIntent": {
+		CWE:   []string{"CWE-926"},
+		OWASP: []string{"A01:2021-Broken Access Control"},
+	},
+	"UnprotectedDynamicReceiver": {
+		CWE:   []string{"CWE-925", "CWE-926"},
+		OWASP: []string{"A01:2021-Broken Access Control"},
+	},
+	"BroadcastReceiverExportedFlagMissing": {
+		CWE:   []string{"CWE-926"},
+		OWASP: []string{"A05:2021-Security Misconfiguration"},
+	},
+	"DeepLinkMissingAutoVerify": {
+		CWE:   []string{"CWE-940"},
+		OWASP: []string{"A05:2021-Security Misconfiguration"},
+	},
+	"NetworkSecurityConfigDebugOverrides": {
+		CWE:   []string{"CWE-489", "CWE-319"},
+		OWASP: []string{"A05:2021-Security Misconfiguration"},
+	},
+}
+
+// applySecurityTaxonomy attaches taxonomy mappings to security-category
+// rules in the registry. Called from registry_bootstrap init() after
+// all rules have been registered.
+func applySecurityTaxonomy() {
+	for _, r := range api.Registry {
+		taxonomy, ok := securityTaxonomyByRuleID[r.ID]
+		if !ok {
+			continue
+		}
+		if r.Security == nil {
+			r.Security = taxonomy
+		}
+	}
+}

--- a/internal/rules/security_taxonomy_test.go
+++ b/internal/rules/security_taxonomy_test.go
@@ -1,0 +1,63 @@
+package rules
+
+import (
+	"testing"
+
+	api "github.com/kaeawc/krit/internal/rules/api"
+)
+
+// TestSecurityRulesHaveCWE enforces the issue #190 evaluation
+// criterion: every existing security-category rule carries at least
+// one CWE identifier on its Security taxonomy.
+func TestSecurityRulesHaveCWE(t *testing.T) {
+	var missing []string
+	for _, r := range api.Registry {
+		if r.Category != "security" {
+			continue
+		}
+		if r.Security == nil || len(r.Security.CWE) == 0 {
+			missing = append(missing, r.ID)
+		}
+	}
+	if len(missing) > 0 {
+		t.Fatalf("security-category rules missing CWE taxonomy: %v", missing)
+	}
+}
+
+func TestTaxonomyMatcher(t *testing.T) {
+	tax := &api.SecurityTaxonomy{
+		CWE:   []string{"CWE-89"},
+		OWASP: []string{"A03:2021-Injection"},
+	}
+	if !tax.HasCWE("cwe-89") {
+		t.Fatal("HasCWE should be case-insensitive")
+	}
+	m := api.TaxonomyMatcher{IDs: []string{"CWE-89"}}
+	if !m.Matches(tax) {
+		t.Fatal("TaxonomyMatcher should match CWE-89")
+	}
+	if m.Matches(nil) {
+		t.Fatal("TaxonomyMatcher should not match nil taxonomy")
+	}
+	empty := api.TaxonomyMatcher{}
+	if empty.Matches(tax) {
+		t.Fatal("empty matcher should match nothing")
+	}
+}
+
+func TestMetaForRuleSurfacesSecurity(t *testing.T) {
+	for _, r := range api.Registry {
+		if r.ID != "SqlInjectionRawQuery" {
+			continue
+		}
+		desc, ok := MetaForRule(r)
+		if !ok {
+			t.Fatal("MetaForRule returned !ok for SqlInjectionRawQuery")
+		}
+		if desc.Security == nil || !desc.Security.HasCWE("CWE-89") {
+			t.Fatalf("expected SqlInjectionRawQuery descriptor to carry CWE-89, got %+v", desc.Security)
+		}
+		return
+	}
+	t.Fatal("SqlInjectionRawQuery rule not found in registry")
+}

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -22,6 +22,7 @@ type RuleMeta struct {
 	Noisiness        string // quiet/normal/noisy
 	KnownLimitations []string
 	Capabilities     []string
+	Security         *api.SecurityTaxonomy
 	LanguageSupport  map[string]api.LanguageSupport
 	Options          []OptionMeta
 }
@@ -54,12 +55,14 @@ func CollectRuleMeta() []RuleMeta {
 		precision := ""
 		noisiness := ""
 		var knownLimitations []string
+		var security *api.SecurityTaxonomy
 		if desc, ok := rules.MetaForRule(r); ok {
 			opts = descriptorOptions(desc)
 			languageSupport = copyLanguageSupport(desc.LanguageSupport)
 			precision = desc.Precision.String()
 			noisiness = desc.Noisiness.String()
 			knownLimitations = desc.KnownLimitations
+			security = desc.Security
 		}
 
 		metas = append(metas, RuleMeta{
@@ -73,6 +76,7 @@ func CollectRuleMeta() []RuleMeta {
 			Noisiness:        noisiness,
 			KnownLimitations: knownLimitations,
 			Capabilities:     r.CapabilitiesList(),
+			Security:         security,
 			LanguageSupport:  languageSupport,
 			Options:          opts,
 		})


### PR DESCRIPTION
Closes #190.

## Summary

- New `api.SecurityTaxonomy` + `TaxonomyMatcher`; `Security *SecurityTaxonomy` on both `api.Rule` and `api.RuleDescriptor`, propagated through `MetaForRule`.
- All 37 security-category rules mapped to at least one CWE in `internal/rules/security_taxonomy.go` (also OWASP/SEI-CERT/MITRE where applicable).
- SARIF output emits a `taxonomies` block, `supportedTaxonomies` on the driver, per-rule `relationships`, and `cwe`/`owasp`/`sei-cert`/`mitre` arrays on `result.properties` (the latter is what GitHub code-scanning reads to render CWE chips).
- MCP `rules.explain` returns a `security` mapping; `rules.search` accepts a `taxonomy` filter.
- New `--cwe` flag on `--list-rules` filters by any taxonomy ID.

## Validation criteria

- [x] Every security-category rule carries at least one CWE (enforced by `TestSecurityRulesHaveCWE`).
- [x] SARIF output validates as JSON and carries `taxa`, `supportedTaxonomies`, per-rule `relationships`, and `result.properties.cwe` (`TestSARIFTaxa`).
- [x] `--list-rules --cwe CWE-89` returns the expected rule set (`TestCWEFilter`).
- [x] MCP `rules.explain` surfaces the security mapping (`TestMetaForRuleSurfacesSecurity`).
- [x] `make schema` regenerated (no schema diff — taxonomy lives on `RuleMeta`, not the YAML config schema).

## Test plan

- [x] \`go test ./... -count=1\`
- [x] \`go vet ./...\`
- [x] \`golangci-lint run ./...\`
- [x] \`make schema\`