### PR TITLE
feat(rules): add Noisiness tier and KnownLimitations metadata

### DIFF
--- a/internal/cli/scan/flags.go
+++ b/internal/cli/scan/flags.go
@@ -33,6 +33,7 @@ type scanFlags struct {
 	AllRules                 *bool
 	Experimental             *bool
 	Maturity                 *string
+	Strict                   *bool
 	Baseline                 *string
 	CreateBaseline           *string
 	BasePath                 *string
@@ -137,6 +138,7 @@ func registerScanFlags(fs *flag.FlagSet) *scanFlags {
 	f.Experimental = fs.Bool("experimental", false, "Enable rules whose Maturity is experimental (does not enable deprecated rules)")
 	fs.BoolVar(f.Experimental, "enable-experimental", false, "Alias for --experimental")
 	f.Maturity = fs.String("maturity", "", "With --list-rules: filter to rules whose Maturity matches (stable, experimental, or deprecated)")
+	f.Strict = fs.Bool("strict", false, "Strict preset: exclude rules declared NoisinessNoisy. Combine with config strict: true.")
 	f.Baseline = fs.String("baseline", "", "Baseline file to suppress known issues (XML or JSON)")
 	f.CreateBaseline = fs.String("create-baseline", "", "Create a baseline file from current findings")
 	f.BasePath = fs.String("base-path", "", "Base path for relative file paths in baselines and reports (default: first scan path)")

--- a/internal/cli/scan/runner_state.go
+++ b/internal/cli/scan/runner_state.go
@@ -393,7 +393,8 @@ func (r *runner) filterRules() (handled bool, code int) {
 			rules.ExpandWithRelated(disabledSet, api.Registry)
 		}
 		experimental := *r.f.Experimental || r.cfg.GetTopLevelBool("experimental", false)
-		r.activeRules = rules.ActiveRulesV2(disabledSet, enabledSet, *r.f.AllRules, experimental)
+		strict := *r.f.Strict || r.cfg.GetTopLevelBool("strict", false)
+		r.activeRules = rules.ActiveRulesV2(disabledSet, enabledSet, *r.f.AllRules, experimental, strict)
 		if maxCost, ok := resolveMaxCost(*r.f.MaxCost, r.cfg); ok {
 			before := len(r.activeRules)
 			r.activeRules = rules.FilterByMaxCost(r.activeRules, maxCost)

--- a/internal/cli/scan/scan_contract_test.go
+++ b/internal/cli/scan/scan_contract_test.go
@@ -131,7 +131,7 @@ func runRunProjectDirect(t *testing.T, root string) []byte {
 
 	cfg := config.NewConfig()
 	rules.ApplyConfig(cfg)
-	activeRules := rules.ActiveRulesV2(map[string]bool{}, map[string]bool{}, false, false)
+	activeRules := rules.ActiveRulesV2(map[string]bool{}, map[string]bool{}, false, false, false)
 
 	repoDir := oracle.FindRepoDir([]string{root})
 	if repoDir == "" {

--- a/internal/cli/scorecard/scorecard.go
+++ b/internal/cli/scorecard/scorecard.go
@@ -85,7 +85,7 @@ func Build(paths []string, configPath string) ([]Row, error) {
 		cfg = config.NewConfig()
 	}
 	rules.ApplyConfig(cfg)
-	active := rules.ActiveRulesV2(nil, nil, false, false)
+	active := rules.ActiveRulesV2(nil, nil, false, false, false)
 	findings := runRules(files, active)
 
 	pmi := module.BuildPerModuleIndex(graph, files, runtime.NumCPU())

--- a/internal/cli/serve/analyze_project.go
+++ b/internal/cli/serve/analyze_project.go
@@ -213,7 +213,8 @@ func (s *daemonState) buildProjectInput(args daemon.AnalyzeProjectArgs) (pipelin
 	disabledSet := clishared.ParseRuleNameSetCSV(args.DisableRules)
 	enabledSet := clishared.ParseRuleNameSetCSV(args.EnableRules)
 	experimental := args.Experimental || cfg.GetTopLevelBool("experimental", false)
-	activeRules := rules.ActiveRulesV2(disabledSet, enabledSet, args.AllRules, experimental)
+	strict := args.Strict || cfg.GetTopLevelBool("strict", false)
+	activeRules := rules.ActiveRulesV2(disabledSet, enabledSet, args.AllRules, experimental, strict)
 
 	paths := args.Paths
 	if len(paths) == 0 {

--- a/internal/cli/serve/analyze_project_equivalence_test.go
+++ b/internal/cli/serve/analyze_project_equivalence_test.go
@@ -48,7 +48,7 @@ func TestAnalyzeProject_OutputMatchesDirectRunProject(t *testing.T) {
 	// --- Direct path -----------------------------------------------
 	cfg := config.NewConfig()
 	rules.ApplyConfig(cfg)
-	activeRules := rules.ActiveRulesV2(map[string]bool{}, map[string]bool{}, false, false)
+	activeRules := rules.ActiveRulesV2(map[string]bool{}, map[string]bool{}, false, false, false)
 	repoDir := oracle.FindRepoDir([]string{state.root})
 	if repoDir == "" {
 		repoDir = state.root

--- a/internal/daemon/protocol.go
+++ b/internal/daemon/protocol.go
@@ -163,6 +163,10 @@ type AnalyzeProjectArgs struct {
 	// Experimental enables experimental flags whose default-off behavior
 	// the daemon would otherwise suppress.
 	Experimental bool `json:"experimental,omitempty"`
+	// Strict enables the strict preset: rules whose effective Noisiness
+	// is NoisinessNoisy are excluded unless explicitly named in
+	// EnableRules.
+	Strict bool `json:"strict,omitempty"`
 	// EnableRules / DisableRules are comma-separated rule-id lists.
 	EnableRules  string `json:"enable_rules,omitempty"`
 	DisableRules string `json:"disable_rules,omitempty"`

--- a/internal/mcp/tool_rules.go
+++ b/internal/mcp/tool_rules.go
@@ -86,6 +86,7 @@ func (s *Server) rulesExplain(args rulesArgs) ToolResult {
 		"effort":       rules.V2RuleEffort(r).String(),
 		"stability":    rules.V2RuleStability(r).String(),
 		"maturity":     r.Maturity.String(),
+		"noisiness":    rules.V2RuleNoisiness(r).String(),
 		"cost":         rules.CostFor(r).String(),
 		"capabilities": r.CapabilitiesList(),
 		"owners":       meta.Owners,
@@ -96,6 +97,9 @@ func (s *Server) rulesExplain(args rulesArgs) ToolResult {
 	}
 	if fixLevel != "" {
 		info["fixLevel"] = fixLevel
+	}
+	if len(meta.KnownLimitations) > 0 {
+		info["caveats"] = meta.KnownLimitations
 	}
 	if related := resolveRelatedRules(r); len(related) > 0 {
 		info["relatedRules"] = related

--- a/internal/mcp/tool_rules_test.go
+++ b/internal/mcp/tool_rules_test.go
@@ -1,0 +1,68 @@
+package mcp
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// assertCaveat asserts that the MCP rules.explain payload for ruleID
+// includes a caveat bullet matching substr. Used by tests covering the
+// KnownLimitations -> caveats wire-up.
+func assertCaveat(t *testing.T, ruleID, substr string) {
+	t.Helper()
+	s := &Server{}
+	res := s.rulesExplain(rulesArgs{Rule: ruleID})
+	if res.IsError {
+		t.Fatalf("rulesExplain(%s) returned error: %s", ruleID, res.Content[0].Text)
+	}
+	if len(res.Content) == 0 {
+		t.Fatalf("rulesExplain(%s) returned no content", ruleID)
+	}
+	var payload map[string]interface{}
+	if err := json.Unmarshal([]byte(res.Content[0].Text), &payload); err != nil {
+		t.Fatalf("unmarshal explain payload: %v", err)
+	}
+	raw, ok := payload["caveats"]
+	if !ok {
+		t.Fatalf("rule %s explain payload missing 'caveats' key: %v", ruleID, payload)
+	}
+	bullets, ok := raw.([]interface{})
+	if !ok {
+		t.Fatalf("rule %s 'caveats' is not a list: %T", ruleID, raw)
+	}
+	for _, b := range bullets {
+		if s, ok := b.(string); ok && strings.Contains(s, substr) {
+			return
+		}
+	}
+	t.Fatalf("rule %s caveats %v missing bullet containing %q", ruleID, bullets, substr)
+}
+
+// TestRulesExplain_SurfacesCaveats verifies that MCP rules.explain
+// renders KnownLimitations under a top-level "caveats" key and that the
+// noisiness tier is included.
+func TestRulesExplain_SurfacesCaveats(t *testing.T) {
+	assertCaveat(t, "MagicNumber", "Heuristic literal scan")
+}
+
+// TestRulesExplain_NoisinessAlwaysPresent verifies the explain payload
+// always carries a 'noisiness' tier (never empty / unset).
+func TestRulesExplain_NoisinessAlwaysPresent(t *testing.T) {
+	s := &Server{}
+	res := s.rulesExplain(rulesArgs{Rule: "MagicNumber"})
+	if res.IsError {
+		t.Fatalf("rulesExplain returned error: %s", res.Content[0].Text)
+	}
+	var payload map[string]interface{}
+	if err := json.Unmarshal([]byte(res.Content[0].Text), &payload); err != nil {
+		t.Fatalf("unmarshal explain payload: %v", err)
+	}
+	n, ok := payload["noisiness"].(string)
+	if !ok {
+		t.Fatalf("explain payload missing string 'noisiness': %v", payload)
+	}
+	if n == "" || n == "unset" {
+		t.Fatalf("noisiness tier should be populated, got %q", n)
+	}
+}

--- a/internal/rules/api/metadata.go
+++ b/internal/rules/api/metadata.go
@@ -251,6 +251,16 @@ type RuleDescriptor struct {
 	// conservatively. See Rule.Stability for the contract.
 	Stability Stability
 
+	// Noisiness mirrors Rule.Noisiness — the rule's declared
+	// false-positive tendency (quiet / normal / noisy). NoisinessUnset
+	// means MetaForRule should derive the tier from Precision via
+	// V2RuleNoisiness; otherwise this value is authoritative.
+	Noisiness Noisiness
+
+	// KnownLimitations mirrors Rule.KnownLimitations — short caveats
+	// surfaced under "caveats" in MCP `explain` output.
+	KnownLimitations []string
+
 	// LanguageSupport records per-source-language support status for a rule.
 	// It is product/support metadata rather than dispatcher routing: Languages
 	// on Rule controls where a rule runs, while LanguageSupport explains whether

--- a/internal/rules/api/noisiness.go
+++ b/internal/rules/api/noisiness.go
@@ -1,0 +1,70 @@
+package api
+
+// Noisiness is a rule's declared false-positive tendency: a coarse
+// signal-to-noise label users can filter on without inspecting the
+// underlying evidence tier. Most rules are NoisinessNormal — declared
+// only when an author has direct evidence the rule reliably (or
+// noisily) fires on real code.
+//
+// Values are ordered cleanest to noisiest so callers can filter with
+// comparisons: "strict" gating runs rules with Noisiness <= NoisinessNormal
+// and excludes NoisinessNoisy entries. PrecisionUnset (zero) means the
+// rule has not declared a tier and consumers should derive one — the
+// V2RuleNoisiness helper does this from Precision (heuristic/text-backed
+// rules default to NoisinessNoisy; every other tier defaults to
+// NoisinessNormal).
+type Noisiness uint8
+
+const (
+	// NoisinessUnset is the zero value. Resolve via V2RuleNoisiness.
+	NoisinessUnset Noisiness = iota
+	// NoisinessQuiet marks rules with near-zero observed false-positive
+	// rate (e.g. compiler-mirror rules, FQN-resolved type-aware checks).
+	NoisinessQuiet
+	// NoisinessNormal is the default tier — typical real-world signal.
+	NoisinessNormal
+	// NoisinessNoisy marks rules known to produce false positives on
+	// real code. Excluded by the "strict" preset; users who keep them on
+	// should expect to review findings or pair the rule with a baseline.
+	NoisinessNoisy
+)
+
+// String returns the stable, lowercase label for the noisiness tier.
+// Used by CLI output, MCP responses, SARIF properties, and config docs.
+func (n Noisiness) String() string {
+	switch n {
+	case NoisinessQuiet:
+		return "quiet"
+	case NoisinessNormal:
+		return "normal"
+	case NoisinessNoisy:
+		return "noisy"
+	default:
+		return "unset"
+	}
+}
+
+// ParseNoisiness returns the Noisiness matching the given label. Labels
+// accepted are exactly the canonical strings emitted by String(), so the
+// MCP schema enum and the parser stay in lockstep. Unknown labels (and
+// the empty string) return NoisinessUnset, false.
+func ParseNoisiness(s string) (Noisiness, bool) {
+	switch s {
+	case "quiet":
+		return NoisinessQuiet, true
+	case "normal":
+		return NoisinessNormal, true
+	case "noisy":
+		return NoisinessNoisy, true
+	default:
+		return NoisinessUnset, false
+	}
+}
+
+// NoisinessProvider lets tests stub a noisiness value without
+// constructing a full Rule. The dispatcher and MetaForRule check for
+// this interface on Rule.Implementation before falling back to the
+// derived value.
+type NoisinessProvider interface {
+	Noisiness() Noisiness
+}

--- a/internal/rules/api/noisiness_test.go
+++ b/internal/rules/api/noisiness_test.go
@@ -1,0 +1,51 @@
+package api
+
+import "testing"
+
+func TestNoisinessString(t *testing.T) {
+	cases := []struct {
+		in   Noisiness
+		want string
+	}{
+		{NoisinessUnset, "unset"},
+		{NoisinessQuiet, "quiet"},
+		{NoisinessNormal, "normal"},
+		{NoisinessNoisy, "noisy"},
+	}
+	for _, c := range cases {
+		if got := c.in.String(); got != c.want {
+			t.Errorf("Noisiness(%d).String() = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestNoisinessOrdering(t *testing.T) {
+	// Values must be ordered cleanest -> noisiest so callers can filter
+	// with comparisons (e.g. <= NoisinessNormal excludes NoisinessNoisy).
+	ordered := []Noisiness{NoisinessUnset, NoisinessQuiet, NoisinessNormal, NoisinessNoisy}
+	for i := 1; i < len(ordered); i++ {
+		if ordered[i-1] >= ordered[i] {
+			t.Fatalf("ordering broken at index %d: %v not before %v", i, ordered[i-1], ordered[i])
+		}
+	}
+}
+
+func TestParseNoisiness(t *testing.T) {
+	cases := []struct {
+		in   string
+		want Noisiness
+		ok   bool
+	}{
+		{"quiet", NoisinessQuiet, true},
+		{"normal", NoisinessNormal, true},
+		{"noisy", NoisinessNoisy, true},
+		{"", NoisinessUnset, false},
+		{"bogus", NoisinessUnset, false},
+	}
+	for _, c := range cases {
+		got, ok := ParseNoisiness(c.in)
+		if ok != c.ok || got != c.want {
+			t.Errorf("ParseNoisiness(%q) = (%v, %v), want (%v, %v)", c.in, got, ok, c.want, c.ok)
+		}
+	}
+}

--- a/internal/rules/api/rule.go
+++ b/internal/rules/api/rule.go
@@ -869,6 +869,23 @@ type Rule struct {
 	// consumers should treat it conservatively.
 	Stability Stability
 
+	// Noisiness declares the rule's false-positive tendency. When
+	// NoisinessUnset (the zero value), MetaForRule derives the tier
+	// from Precision via V2RuleNoisiness (heuristic/text-backed →
+	// NoisinessNoisy; everything else → NoisinessNormal). Rules may
+	// override when the author has direct evidence (e.g. a type-aware
+	// rule that still produces FPs due to incomplete library facts).
+	// The "strict" preset excludes NoisinessNoisy rules; the dispatcher
+	// does not otherwise key behavior on this field.
+	Noisiness Noisiness
+
+	// KnownLimitations are short bullet-style caveats describing cases
+	// the rule is known to miss or fire on incorrectly. MCP `explain`
+	// surfaces these under a "caveats" key so users can decide whether
+	// a finding is worth chasing. Keep each bullet under one line —
+	// they are summaries, not migration guides.
+	KnownLimitations []string
+
 	// KotlincAnalog names the closest standard kotlinc diagnostic that
 	// this rule approximates, e.g. "UNREACHABLE_CODE". Informational
 	// only — krit is not bug-for-bug compatible with kotlinc. Empty

--- a/internal/rules/defaults.go
+++ b/internal/rules/defaults.go
@@ -33,6 +33,12 @@ var experimentalRules = map[string]bool{}
 // must name them explicitly via --enable-rules to run them.
 var deprecatedRules = map[string]bool{}
 
+// noisyRules lists rules whose effective Noisiness (Rule.Noisiness or
+// the value derived from Precision) is NoisinessNoisy. Used by the
+// "strict" preset to filter out high-FP rules without disturbing the
+// experimental / deprecated lifecycle filters.
+var noisyRules = map[string]bool{}
+
 var defaultInactiveOnce sync.Once
 
 // ensureDefaultInactive populates DefaultInactive from every registered
@@ -58,6 +64,9 @@ func ensureDefaultInactive() {
 			case api.MaturityDeprecated:
 				deprecatedRules[r.ID] = true
 				DefaultInactive[r.ID] = true
+			}
+			if V2RuleNoisiness(r) == NoisinessNoisy {
+				noisyRules[r.ID] = true
 			}
 			desc, ok := MetaForRule(r)
 			if !ok {
@@ -170,6 +179,15 @@ func ExpandWithRelated(disabledSet map[string]bool, registry []*api.Rule) {
 	}
 }
 
+// IsNoisy reports whether a rule's effective Noisiness is NoisinessNoisy
+// (declared on Rule or derived from Precision). Used by the "strict"
+// preset to skip noisy rules; returns false for rules outside the
+// registry.
+func IsNoisy(name string) bool {
+	ensureDefaultInactive()
+	return noisyRules[name]
+}
+
 // ActiveRulesV2 filters api.Registry using config-driven activation.
 //
 // A rule is included when it is not in disabledSet AND either:
@@ -182,9 +200,15 @@ func ExpandWithRelated(disabledSet map[string]bool, registry []*api.Rule) {
 // only path that re-enables a deprecated rule is naming it explicitly in
 // enabledSet. This keeps deprecated rules from coming back to life when
 // users flip broad opt-in flags.
-func ActiveRulesV2(disabledSet, enabledSet map[string]bool, allRules, experimental bool) []*api.Rule {
+//
+// When strict=true, rules whose effective Noisiness is NoisinessNoisy
+// are excluded UNLESS the user named them explicitly in enabledSet
+// (explicit opt-in always wins). Strict is independent of experimental
+// and allRules: --strict --all-rules still drops noisy rules so the
+// preset's contract holds.
+func ActiveRulesV2(disabledSet, enabledSet map[string]bool, allRules, experimental, strict bool) []*api.Rule {
 	ensureDefaultInactive()
-	return selectActiveRules(api.Registry, disabledSet, enabledSet, allRules, experimental, experimentalRules, deprecatedRules, DefaultInactive)
+	return selectActiveRules(api.Registry, disabledSet, enabledSet, allRules, experimental, strict, experimentalRules, deprecatedRules, noisyRules, DefaultInactive)
 }
 
 // selectActiveRules is the registry-agnostic core of ActiveRulesV2,
@@ -192,12 +216,15 @@ func ActiveRulesV2(disabledSet, enabledSet map[string]bool, allRules, experiment
 // without mutating the global api.Registry.
 //
 // defaultInactive carries the same semantics as the package-level
-// DefaultInactive map: presence means the rule is opt-in.
+// DefaultInactive map: presence means the rule is opt-in. noisySet
+// holds rules whose effective Noisiness is NoisinessNoisy; when
+// strict=true these are excluded unless the user named them in
+// enabledSet.
 func selectActiveRules(
 	reg []*api.Rule,
 	disabledSet, enabledSet map[string]bool,
-	allRules, experimental bool,
-	experimentalSet, deprecatedSet, defaultInactive map[string]bool,
+	allRules, experimental, strict bool,
+	experimentalSet, deprecatedSet, noisySet, defaultInactive map[string]bool,
 ) []*api.Rule {
 	var out []*api.Rule
 	for _, r := range reg {
@@ -209,6 +236,9 @@ func selectActiveRules(
 			continue
 		}
 		if deprecatedSet[r.ID] {
+			continue
+		}
+		if strict && noisySet[r.ID] {
 			continue
 		}
 		if allRules {

--- a/internal/rules/defaults_test.go
+++ b/internal/rules/defaults_test.go
@@ -39,7 +39,7 @@ func containsID(ss []string, s string) bool {
 // defaultInactive runs by default.
 func TestSelectActiveRules_StableDefault(t *testing.T) {
 	reg := []*api.Rule{fakeRule("Stable", api.MaturityStable)}
-	got := selectActiveRules(reg, nil, nil, false, false, nil, nil, nil)
+	got := selectActiveRules(reg, nil, nil, false, false, false, nil, nil, nil, nil)
 	if !containsID(ruleIDs(got), "Stable") {
 		t.Fatalf("stable rule should be active by default; got %v", ruleIDs(got))
 	}
@@ -52,12 +52,12 @@ func TestSelectActiveRules_ExperimentalOffByDefault(t *testing.T) {
 	exp := map[string]bool{"Exp": true}
 	inactive := map[string]bool{"Exp": true}
 
-	got := selectActiveRules(reg, nil, nil, false, false, exp, nil, inactive)
+	got := selectActiveRules(reg, nil, nil, false, false, false, exp, nil, nil, inactive)
 	if containsID(ruleIDs(got), "Exp") {
 		t.Fatalf("experimental rule should be off by default; got %v", ruleIDs(got))
 	}
 
-	got = selectActiveRules(reg, nil, nil, false, true, exp, nil, inactive)
+	got = selectActiveRules(reg, nil, nil, false, true, false, exp, nil, nil, inactive)
 	if !containsID(ruleIDs(got), "Exp") {
 		t.Fatalf("--experimental should re-enable experimental rules; got %v", ruleIDs(got))
 	}
@@ -82,7 +82,7 @@ func TestSelectActiveRules_DeprecatedNeverImplicitlyOn(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			got := selectActiveRules(reg, nil, nil, c.allRules, c.expFlg, nil, dep, inactive)
+			got := selectActiveRules(reg, nil, nil, c.allRules, c.expFlg, false, nil, dep, nil, inactive)
 			if containsID(ruleIDs(got), "Old") {
 				t.Errorf("deprecated rule must not be implicitly enabled by %s; got %v", c.name, ruleIDs(got))
 			}
@@ -90,7 +90,7 @@ func TestSelectActiveRules_DeprecatedNeverImplicitlyOn(t *testing.T) {
 	}
 
 	en := map[string]bool{"Old": true}
-	got := selectActiveRules(reg, nil, en, false, false, nil, dep, inactive)
+	got := selectActiveRules(reg, nil, en, false, false, false, nil, dep, nil, inactive)
 	if !containsID(ruleIDs(got), "Old") {
 		t.Fatalf("explicit enable should run a deprecated rule; got %v", ruleIDs(got))
 	}
@@ -103,7 +103,7 @@ func TestSelectActiveRules_DisabledAlwaysWins(t *testing.T) {
 	dis := map[string]bool{"X": true}
 	en := map[string]bool{"X": true}
 
-	got := selectActiveRules(reg, dis, en, true, true, nil, nil, nil)
+	got := selectActiveRules(reg, dis, en, true, true, false, nil, nil, nil, nil)
 	if containsID(ruleIDs(got), "X") {
 		t.Fatalf("disabledSet must override every other path; got %v", ruleIDs(got))
 	}
@@ -121,7 +121,7 @@ func TestSelectActiveRules_AllRulesIncludesExperimental(t *testing.T) {
 	dep := map[string]bool{"Old": true}
 	inactive := map[string]bool{"Exp": true, "Old": true}
 
-	got := ruleIDs(selectActiveRules(reg, nil, nil, true, false, exp, dep, inactive))
+	got := ruleIDs(selectActiveRules(reg, nil, nil, true, false, false, exp, dep, nil, inactive))
 	if !containsID(got, "Stable") || !containsID(got, "Exp") {
 		t.Errorf("--all-rules should include stable and experimental; got %v", got)
 	}
@@ -138,7 +138,7 @@ func TestSelectActiveRules_OptInStillRunsViaEnableSet(t *testing.T) {
 	inactive := map[string]bool{"OptIn": true}
 	en := map[string]bool{"OptIn": true}
 
-	got := selectActiveRules(reg, nil, en, false, false, nil, nil, inactive)
+	got := selectActiveRules(reg, nil, en, false, false, false, nil, nil, nil, inactive)
 	if !containsID(ruleIDs(got), "OptIn") {
 		t.Fatalf("explicit enable should run an opt-in rule; got %v", ruleIDs(got))
 	}

--- a/internal/rules/meta_lookup.go
+++ b/internal/rules/meta_lookup.go
@@ -119,6 +119,8 @@ func mergeRuleDescriptor(r *api.Rule, extra api.RuleDescriptor) api.RuleDescript
 	out.Precision = resolvePrecision(r, extra)
 	out.Effort = resolveEffort(r, extra)
 	out.Stability = resolveStability(r, extra)
+	out.Noisiness = resolveNoisiness(r, extra)
+	out.KnownLimitations = resolveKnownLimitations(r, extra)
 	return out
 }
 
@@ -203,6 +205,28 @@ func V2RuleStability(r *api.Rule) api.Stability {
 		return api.StabilityEvolving
 	}
 	return api.StabilityStable
+}
+
+// resolveNoisiness mirrors resolvePrecision for the Noisiness tier.
+// V2RuleNoisiness consults Rule.Noisiness and NoisinessProvider before
+// deriving from Precision, so a MetaProvider-supplied extra.Noisiness
+// only wins when the rule itself declared no explicit override.
+// V2RuleNoisiness never returns NoisinessUnset.
+func resolveNoisiness(r *api.Rule, extra api.RuleDescriptor) api.Noisiness {
+	if r.Noisiness == api.NoisinessUnset && extra.Noisiness != api.NoisinessUnset {
+		return extra.Noisiness
+	}
+	return V2RuleNoisiness(r)
+}
+
+// resolveKnownLimitations prefers the rule's inline KnownLimitations
+// when present and falls back to the MetaProvider value otherwise. The
+// returned slice is the underlying slice — callers must not mutate it.
+func resolveKnownLimitations(r *api.Rule, extra api.RuleDescriptor) []string {
+	if len(r.KnownLimitations) > 0 {
+		return r.KnownLimitations
+	}
+	return extra.KnownLimitations
 }
 
 func withRuleLanguageSupport(r *api.Rule, m api.RuleDescriptor) api.RuleDescriptor {

--- a/internal/rules/meta_performance.go
+++ b/internal/rules/meta_performance.go
@@ -10,6 +10,10 @@ func (r *ArrayPrimitiveRule) Meta() api.RuleDescriptor {
 		RuleSet:       "performance",
 		DefaultActive: true,
 		FixLevel:      "idiomatic",
+		KnownLimitations: []string{
+			"Lexical type-token match: aliased types via typealias to Array<Int> are not detected.",
+			"Identifies the declared type only; runtime allocation patterns (e.g. Array(n) { it.toInt() }) are out of scope.",
+		},
 	}
 }
 
@@ -27,6 +31,10 @@ func (r *CouldBeSequenceRule) Meta() api.RuleDescriptor {
 		RuleSet:       "performance",
 		DefaultActive: false,
 		OptInReason:   api.OptInReasonOpinionated,
+		KnownLimitations: []string{
+			"Counts chained calls by lexical name without confirming the receiver is a Collection: receivers exposing similarly named extensions on non-Iterable types may be flagged.",
+			"Threshold tuning is project-dependent; small chains on large collections may still benefit from .asSequence().",
+		},
 		Options: []api.ConfigOption{
 			api.IntOption(api.IntOptionSpec[CouldBeSequenceRule]{
 				Name:        "allowedOperations",

--- a/internal/rules/meta_style_forbidden.go
+++ b/internal/rules/meta_style_forbidden.go
@@ -148,6 +148,10 @@ func (r *MagicNumberRule) Meta() api.RuleDescriptor {
 		ID:            "MagicNumber",
 		RuleSet:       "style",
 		DefaultActive: true,
+		KnownLimitations: []string{
+			"Heuristic literal scan: numeric arguments threaded through helper functions or builders may still be flagged at the call site.",
+			"Preview / Compose scaffolding annotations are excluded via ignoreAnnotated; custom annotation conventions may need additional configuration.",
+		},
 		Options: []api.ConfigOption{
 			api.StringListOption(api.StringListOptionSpec[MagicNumberRule]{
 				Name:        "ignoreAnnotated",

--- a/internal/rules/noisiness.go
+++ b/internal/rules/noisiness.go
@@ -1,0 +1,54 @@
+package rules
+
+import api "github.com/kaeawc/krit/internal/rules/api"
+
+// Noisiness is re-exported from the api package so existing callers
+// (`rules.Noisiness`, `rules.NoisinessNoisy`, …) keep compiling.
+// New code should reference api.Noisiness directly.
+type Noisiness = api.Noisiness
+
+const (
+	NoisinessUnset  = api.NoisinessUnset
+	NoisinessQuiet  = api.NoisinessQuiet
+	NoisinessNormal = api.NoisinessNormal
+	NoisinessNoisy  = api.NoisinessNoisy
+)
+
+// V2RuleNoisiness returns the declared false-positive tendency for a
+// rule.
+//
+// Resolution order:
+//  1. Rule.Noisiness when set (non-zero) — the rule has overridden the
+//     derived tier.
+//  2. Rule.Implementation when it implements api.NoisinessProvider —
+//     lets tests stub a tier without touching the Rule literal.
+//  3. Derived from Precision: PrecisionHeuristicTextBacked maps to
+//     NoisinessNoisy; every other precision tier maps to
+//     NoisinessNormal. V2RuleNoisiness never returns NoisinessUnset.
+func V2RuleNoisiness(r *api.Rule) Noisiness {
+	if r == nil {
+		return NoisinessNormal
+	}
+	if r.Noisiness != NoisinessUnset {
+		return r.Noisiness
+	}
+	if r.Implementation != nil {
+		if np, ok := r.Implementation.(api.NoisinessProvider); ok {
+			if n := np.Noisiness(); n != NoisinessUnset {
+				return n
+			}
+		}
+	}
+	return NoisinessFromPrecision(V2RulePrecision(r))
+}
+
+// NoisinessFromPrecision returns the default noisiness derived from a
+// precision tier. PrecisionHeuristicTextBacked maps to NoisinessNoisy;
+// every other tier (including PrecisionUnset, which V2RulePrecision
+// never produces) maps to NoisinessNormal.
+func NoisinessFromPrecision(p api.Precision) Noisiness {
+	if p == api.PrecisionHeuristicTextBacked {
+		return NoisinessNoisy
+	}
+	return NoisinessNormal
+}

--- a/internal/rules/noisiness_test.go
+++ b/internal/rules/noisiness_test.go
@@ -1,0 +1,134 @@
+package rules
+
+import (
+	"testing"
+
+	api "github.com/kaeawc/krit/internal/rules/api"
+)
+
+// TestNoisinessFromPrecision verifies the derivation table from Precision
+// to default Noisiness: heuristic/text-backed maps to Noisy, every other
+// tier maps to Normal.
+func TestNoisinessFromPrecision(t *testing.T) {
+	cases := []struct {
+		precision api.Precision
+		want      api.Noisiness
+	}{
+		{api.PrecisionHeuristicTextBacked, api.NoisinessNoisy},
+		{api.PrecisionASTBacked, api.NoisinessNormal},
+		{api.PrecisionProjectStructure, api.NoisinessNormal},
+		{api.PrecisionTypeAware, api.NoisinessNormal},
+		{api.PrecisionPolicy, api.NoisinessNormal},
+		{api.PrecisionUnset, api.NoisinessNormal},
+	}
+	for _, c := range cases {
+		if got := NoisinessFromPrecision(c.precision); got != c.want {
+			t.Errorf("NoisinessFromPrecision(%q) = %q, want %q",
+				c.precision, got, c.want)
+		}
+	}
+}
+
+// TestV2RuleNoisiness_Override verifies explicit Rule.Noisiness wins
+// over the derived value.
+func TestV2RuleNoisiness_Override(t *testing.T) {
+	r := &api.Rule{
+		ID:          "Override",
+		Category:    "test",
+		Description: "override",
+		Sev:         api.SeverityWarning,
+		NodeTypes:   []string{"call_expression"}, // derives PrecisionASTBacked -> NoisinessNormal
+		Check:       func(*api.Context) {},
+		Noisiness:   api.NoisinessQuiet,
+	}
+	if got := V2RuleNoisiness(r); got != api.NoisinessQuiet {
+		t.Fatalf("explicit Noisiness override ignored: got %q", got)
+	}
+}
+
+// TestV2RuleNoisiness_DerivedFromHeuristic verifies that a rule without
+// an explicit Noisiness inherits NoisinessNoisy when its derived
+// Precision is heuristic/text-backed.
+func TestV2RuleNoisiness_DerivedFromHeuristic(t *testing.T) {
+	// MagicNumber is in heuristicRuleNames so V2RulePrecision returns
+	// PrecisionHeuristicTextBacked; we expect NoisinessNoisy to derive.
+	r := &api.Rule{
+		ID:          "MagicNumber",
+		Category:    "style",
+		Description: "magic",
+		Sev:         api.SeverityWarning,
+		NodeTypes:   []string{"integer_literal"},
+		Check:       func(*api.Context) {},
+	}
+	if got := V2RuleNoisiness(r); got != api.NoisinessNoisy {
+		t.Fatalf("heuristic rule should derive NoisinessNoisy; got %q", got)
+	}
+}
+
+// TestStrictPresetExcludesNoisy verifies the strict flag drops rules
+// whose effective Noisiness is NoisinessNoisy unless they are named
+// explicitly in enabledSet.
+func TestStrictPresetExcludesNoisy(t *testing.T) {
+	reg := []*api.Rule{
+		fakeRule("Quiet", api.MaturityStable),
+		fakeRule("Loud", api.MaturityStable),
+	}
+	noisy := map[string]bool{"Loud": true}
+
+	got := ruleIDs(selectActiveRules(reg, nil, nil, false, false, true, nil, nil, noisy, nil))
+	if containsID(got, "Loud") {
+		t.Fatalf("strict should exclude noisy rule; got %v", got)
+	}
+	if !containsID(got, "Quiet") {
+		t.Fatalf("strict should keep non-noisy rule; got %v", got)
+	}
+
+	// Explicit enable wins over strict.
+	en := map[string]bool{"Loud": true}
+	got = ruleIDs(selectActiveRules(reg, nil, en, false, false, true, nil, nil, noisy, nil))
+	if !containsID(got, "Loud") {
+		t.Fatalf("explicit enable should override strict; got %v", got)
+	}
+
+	// Without strict, noisy rules run normally.
+	got = ruleIDs(selectActiveRules(reg, nil, nil, false, false, false, nil, nil, noisy, nil))
+	if !containsID(got, "Loud") {
+		t.Fatalf("noisy rule should run when strict=false; got %v", got)
+	}
+}
+
+// TestMetaForRule_NoisinessAlwaysSet verifies every registered rule has
+// a non-zero Noisiness after MetaForRule resolves it.
+func TestMetaForRule_NoisinessAlwaysSet(t *testing.T) {
+	for _, r := range api.Registry {
+		desc, ok := MetaForRule(r)
+		if !ok {
+			t.Fatalf("MetaForRule(%s) returned ok=false", r.ID)
+		}
+		if desc.Noisiness == api.NoisinessUnset {
+			t.Fatalf("rule %s: descriptor noisiness is NoisinessUnset", r.ID)
+		}
+	}
+}
+
+// TestMetaForRule_KnownLimitationsSurfaced verifies that KnownLimitations
+// declared on the rule's Meta() descriptor flow through MetaForRule.
+func TestMetaForRule_KnownLimitationsSurfaced(t *testing.T) {
+	var found *api.Rule
+	for _, r := range api.Registry {
+		if r.ID == "MagicNumber" {
+			found = r
+			break
+		}
+	}
+	if found == nil {
+		t.Skip("MagicNumber rule not registered in this build")
+	}
+	desc, ok := MetaForRule(found)
+	if !ok {
+		t.Fatal("MetaForRule(MagicNumber) returned ok=false")
+	}
+	if len(desc.KnownLimitations) == 0 {
+		t.Fatalf("MagicNumber should publish KnownLimitations bullets")
+	}
+}

--- a/internal/rules/related_rules_test.go
+++ b/internal/rules/related_rules_test.go
@@ -60,7 +60,7 @@ func TestActiveRulesV2_RespectsExpandedDisabledSet(t *testing.T) {
 	disabled := map[string]bool{"A": true}
 	ExpandWithRelated(disabled, registry)
 
-	got := selectActiveRules(registry, disabled, nil, false, false, nil, nil, nil)
+	got := selectActiveRules(registry, disabled, nil, false, false, false, nil, nil, nil, nil)
 	ids := ruleIDs(got)
 	if containsID(ids, "A") || containsID(ids, "B") {
 		t.Fatalf("A and its related rule B should be filtered out; got %v", ids)

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -12,16 +12,18 @@ import (
 
 // RuleMeta describes a rule's configurable options for schema generation.
 type RuleMeta struct {
-	Name            string
-	Description     string
-	RuleSet         string
-	Active          bool // default active state
-	Fixable         bool
-	FixLevel        string // cosmetic/idiomatic/semantic or ""
-	Precision       string // heuristic/ast-backed/project-structure/type-aware/policy
-	Capabilities    []string
-	LanguageSupport map[string]api.LanguageSupport
-	Options         []OptionMeta
+	Name             string
+	Description      string
+	RuleSet          string
+	Active           bool // default active state
+	Fixable          bool
+	FixLevel         string // cosmetic/idiomatic/semantic or ""
+	Precision        string // heuristic/ast-backed/project-structure/type-aware/policy
+	Noisiness        string // quiet/normal/noisy
+	KnownLimitations []string
+	Capabilities     []string
+	LanguageSupport  map[string]api.LanguageSupport
+	Options          []OptionMeta
 }
 
 // OptionMeta describes one configurable option of a rule.
@@ -50,23 +52,29 @@ func CollectRuleMeta() []RuleMeta {
 		var opts []OptionMeta
 		var languageSupport map[string]api.LanguageSupport
 		precision := ""
+		noisiness := ""
+		var knownLimitations []string
 		if desc, ok := rules.MetaForRule(r); ok {
 			opts = descriptorOptions(desc)
 			languageSupport = copyLanguageSupport(desc.LanguageSupport)
 			precision = desc.Precision.String()
+			noisiness = desc.Noisiness.String()
+			knownLimitations = desc.KnownLimitations
 		}
 
 		metas = append(metas, RuleMeta{
-			Name:            r.ID,
-			Description:     r.Description,
-			RuleSet:         r.Category,
-			Active:          active,
-			Fixable:         fixable,
-			FixLevel:        fixLevel,
-			Precision:       precision,
-			Capabilities:    r.CapabilitiesList(),
-			LanguageSupport: languageSupport,
-			Options:         opts,
+			Name:             r.ID,
+			Description:      r.Description,
+			RuleSet:          r.Category,
+			Active:           active,
+			Fixable:          fixable,
+			FixLevel:         fixLevel,
+			Precision:        precision,
+			Noisiness:        noisiness,
+			KnownLimitations: knownLimitations,
+			Capabilities:     r.CapabilitiesList(),
+			LanguageSupport:  languageSupport,
+			Options:          opts,
 		})
 	}
 	return metas
@@ -245,8 +253,14 @@ func ruleSchema(m RuleMeta) *jsonschema.Schema {
 	if m.Precision != "" && m.Precision != "unset" {
 		desc += fmt.Sprintf(" [precision: %s]", m.Precision)
 	}
+	if m.Noisiness != "" && m.Noisiness != "unset" {
+		desc += fmt.Sprintf(" [noisiness: %s]", m.Noisiness)
+	}
 	if len(m.Capabilities) > 0 {
 		desc += fmt.Sprintf(" [capabilities: %s]", strings.Join(m.Capabilities, ", "))
+	}
+	for _, caveat := range m.KnownLimitations {
+		desc += "\nCaveat: " + caveat
 	}
 
 	return jsonschema.Object(ruleProps).

--- a/internal/sessdaemon/analyze.go
+++ b/internal/sessdaemon/analyze.go
@@ -79,7 +79,7 @@ func (s *Server) handleAnalyze(ctx context.Context, w *bufio.Writer, req Request
 func (s *Server) buildProjectInput(paths []string) (pipeline.ProjectInput, error) {
 	cfg := config.NewConfig()
 	rules.ApplyConfig(cfg)
-	activeRules := rules.ActiveRulesV2(nil, nil, false, false)
+	activeRules := rules.ActiveRulesV2(nil, nil, false, false, false)
 
 	host := pipeline.ProjectHostState{}
 	if sess := s.session; sess != nil {

--- a/internal/sessdaemon/server_test.go
+++ b/internal/sessdaemon/server_test.go
@@ -43,7 +43,7 @@ func TestAnalyzeMatchesInProcessRunProject(t *testing.T) {
 
 	cfg := config.NewConfig()
 	rules.ApplyConfig(cfg)
-	active := rules.ActiveRulesV2(nil, nil, false, false)
+	active := rules.ActiveRulesV2(nil, nil, false, false, false)
 	directRes, err := pipeline.RunProjectAnalysis(context.Background(), pipeline.ProjectInput{
 		Args: pipeline.ProjectArgs{
 			Config:      cfg,

--- a/internal/snapshot/findings.go
+++ b/internal/snapshot/findings.go
@@ -129,7 +129,7 @@ func RunFindings(ctx context.Context, repoRoot, commitSHA string, opts FindingsR
 	}
 	activeRules := opts.ActiveRules
 	if len(activeRules) == 0 {
-		activeRules = rules.ActiveRulesV2(nil, nil, false, false)
+		activeRules = rules.ActiveRulesV2(nil, nil, false, false, false)
 	}
 
 	res, err := pipeline.RunProject(ctx, pipeline.ProjectInput{

--- a/schemas/krit-config.schema.json
+++ b/schemas/krit-config.schema.json
@@ -12,7 +12,7 @@
       "additionalProperties": false,
       "properties": {
         "AnimatorDurationIgnoresScale": {
-          "description": "Detects animator durations that ignore the system ANIMATOR_DURATION_SCALE accessibility setting. [precision: type-aware] [capabilities: oracle:call-targets, resolver]",
+          "description": "Detects animator durations that ignore the system ANIMATOR_DURATION_SCALE accessibility setting. [precision: type-aware] [noisiness: normal] [capabilities: oracle:call-targets, resolver]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -31,7 +31,7 @@
           }
         },
         "ComposeClickableWithoutMinTouchTarget": {
-          "description": "Detects clickable Compose modifiers with explicit touch target dimensions below the 48dp minimum. [precision: ast-backed]",
+          "description": "Detects clickable Compose modifiers with explicit touch target dimensions below the 48dp minimum. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -50,7 +50,7 @@
           }
         },
         "ComposeDecorativeImageContentDescription": {
-          "description": "Detects decorative images with null contentDescription that are not hidden from TalkBack. [precision: ast-backed]",
+          "description": "Detects decorative images with null contentDescription that are not hidden from TalkBack. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -69,7 +69,7 @@
           }
         },
         "ComposeIconButtonMissingContentDescription": {
-          "description": "Detects Icon or IconButton composables missing a contentDescription for screen readers. [precision: ast-backed]",
+          "description": "Detects Icon or IconButton composables missing a contentDescription for screen readers. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -88,7 +88,7 @@
           }
         },
         "ComposeRawTextLiteral": {
-          "description": "Detects Compose Text() calls using hardcoded string literals instead of stringResource() for i18n. [precision: ast-backed]",
+          "description": "Detects Compose Text() calls using hardcoded string literals instead of stringResource() for i18n. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -119,7 +119,7 @@
           }
         },
         "ComposeSemanticsMissingRole": {
-          "description": "Detects interactive Compose modifiers (clickable, toggleable, selectable) without an explicit accessibility role. [precision: ast-backed]",
+          "description": "Detects interactive Compose modifiers (clickable, toggleable, selectable) without an explicit accessibility role. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -150,7 +150,7 @@
           }
         },
         "ComposeTextFieldMissingLabel": {
-          "description": "Detects TextField or OutlinedTextField composables missing a label parameter for accessibility. [precision: ast-backed]",
+          "description": "Detects TextField or OutlinedTextField composables missing a label parameter for accessibility. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -169,7 +169,7 @@
           }
         },
         "ToastForAccessibilityAnnouncement": {
-          "description": "Detects Toast.makeText used in accessibility-related functions instead of announceForAccessibility. [precision: ast-backed]",
+          "description": "Detects Toast.makeText used in accessibility-related functions instead of announceForAccessibility. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -200,7 +200,7 @@
       "additionalProperties": false,
       "properties": {
         "AccidentalOctal": {
-          "description": "Accidental octal interpretation [precision: ast-backed]",
+          "description": "Accidental octal interpretation [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -219,7 +219,7 @@
           }
         },
         "AdapterViewChildrenResource": {
-          "description": "AdapterView cannot have children in XML [precision: project-structure-aware] [capabilities: resources]",
+          "description": "AdapterView cannot have children in XML [precision: project-structure-aware] [noisiness: normal] [capabilities: resources]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -238,7 +238,7 @@
           }
         },
         "AddJavascriptInterface": {
-          "description": "addJavascriptInterface called [precision: type-aware] [capabilities: oracle:call-targets, oracle:supertypes, resolver]",
+          "description": "addJavascriptInterface called [precision: type-aware] [noisiness: normal] [capabilities: oracle:call-targets, oracle:supertypes, resolver]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -257,7 +257,7 @@
           }
         },
         "AllowBackupManifest": {
-          "description": "Missing or true allowBackup attribute [precision: project-structure-aware] [capabilities: manifest]",
+          "description": "Missing or true allowBackup attribute [precision: project-structure-aware] [noisiness: normal] [capabilities: manifest]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -276,7 +276,7 @@
           }
         },
         "AlwaysShowActionResource": {
-          "description": "showAsAction=always can crowd the action bar [precision: project-structure-aware] [capabilities: resources]",
+          "description": "showAsAction=always can crowd the action bar [precision: project-structure-aware] [noisiness: normal] [capabilities: resources]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -295,7 +295,7 @@
           }
         },
         "AndroidGradlePluginVersion": {
-          "description": "AGP version too old [precision: project-structure-aware] [capabilities: gradle]",
+          "description": "AGP version too old [precision: project-structure-aware] [noisiness: normal] [capabilities: gradle]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -314,7 +314,7 @@
           }
         },
         "AppCompatMethod": {
-          "description": "Using Wrong AppCompat Method [precision: ast-backed]",
+          "description": "Using Wrong AppCompat Method [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -333,7 +333,7 @@
           }
         },
         "AppCompatResource": {
-          "description": "Using android:showAsAction instead of app:showAsAction [precision: project-structure-aware] [capabilities: resources]",
+          "description": "Using android:showAsAction instead of app:showAsAction [precision: project-structure-aware] [noisiness: normal] [capabilities: resources]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -352,7 +352,7 @@
           }
         },
         "AppIndexingErrorManifest": {
-          "description": "VIEW intent filter missing http/https data scheme [precision: project-structure-aware] [capabilities: manifest]",
+          "description": "VIEW intent filter missing http/https data scheme [precision: project-structure-aware] [noisiness: normal] [capabilities: manifest]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -371,7 +371,7 @@
           }
         },
         "AppIndexingWarningManifest": {
-          "description": "Browsable intent filter missing VIEW action [precision: project-structure-aware] [capabilities: manifest]",
+          "description": "Browsable intent filter missing VIEW action [precision: project-structure-aware] [noisiness: normal] [capabilities: manifest]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -390,7 +390,7 @@
           }
         },
         "Assert": {
-          "description": "Assertions are unreliable on Android [precision: ast-backed]",
+          "description": "Assertions are unreliable on Android [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -409,7 +409,7 @@
           }
         },
         "BackButtonResource": {
-          "description": "Explicit back button in layout [precision: project-structure-aware] [capabilities: resources]",
+          "description": "Explicit back button in layout [precision: project-structure-aware] [noisiness: normal] [capabilities: resources]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -428,7 +428,7 @@
           }
         },
         "BackupRules": {
-          "description": "Missing backup configuration [precision: project-structure-aware] [capabilities: manifest]",
+          "description": "Missing backup configuration [precision: project-structure-aware] [noisiness: normal] [capabilities: manifest]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -447,7 +447,7 @@
           }
         },
         "ButtonCaseResource": {
-          "description": "OK/Cancel button with wrong capitalization [precision: project-structure-aware] [capabilities: resources]",
+          "description": "OK/Cancel button with wrong capitalization [precision: project-structure-aware] [noisiness: normal] [capabilities: resources]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -466,7 +466,7 @@
           }
         },
         "ButtonOrderResource": {
-          "description": "Cancel button should appear before OK button [precision: project-structure-aware] [capabilities: resources]",
+          "description": "Cancel button should appear before OK button [precision: project-structure-aware] [noisiness: normal] [capabilities: resources]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -485,7 +485,7 @@
           }
         },
         "ButtonStyleResource": {
-          "description": "Dialog button without borderless style [precision: project-structure-aware] [capabilities: resources]",
+          "description": "Dialog button without borderless style [precision: project-structure-aware] [noisiness: normal] [capabilities: resources]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -504,7 +504,7 @@
           }
         },
         "ByteOrderMark": {
-          "description": "Byte order mark (BOM) found in file [precision: heuristic/text-backed] [capabilities: line-pass]",
+          "description": "Byte order mark (BOM) found in file [precision: heuristic/text-backed] [noisiness: noisy] [capabilities: line-pass]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -523,7 +523,7 @@
           }
         },
         "CheckResult": {
-          "description": "Ignoring results [precision: ast-backed]",
+          "description": "Ignoring results [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -542,7 +542,7 @@
           }
         },
         "CleartextTraffic": {
-          "description": "usesCleartextTraffic enabled [precision: project-structure-aware] [capabilities: manifest]",
+          "description": "usesCleartextTraffic enabled [precision: project-structure-aware] [noisiness: normal] [capabilities: manifest]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -561,7 +561,7 @@
           }
         },
         "ClickableViewAccessibilityResource": {
-          "description": "Clickable view missing contentDescription [precision: project-structure-aware] [capabilities: resources]",
+          "description": "Clickable view missing contentDescription [precision: project-structure-aware] [noisiness: normal] [capabilities: resources]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -580,7 +580,7 @@
           }
         },
         "CommitPrefEdits": {
-          "description": "Missing commit() on SharedPreferences editor [precision: ast-backed]",
+          "description": "Missing commit() on SharedPreferences editor [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -599,7 +599,7 @@
           }
         },
         "CommitTransaction": {
-          "description": "Missing commit() on FragmentTransaction [precision: ast-backed]",
+          "description": "Missing commit() on FragmentTransaction [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -618,7 +618,7 @@
           }
         },
         "ContentDescription": {
-          "description": "Image without contentDescription [precision: ast-backed]",
+          "description": "Image without contentDescription [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -637,7 +637,7 @@
           }
         },
         "ConvertToWebp": {
-          "description": "Large PNG could be smaller as WebP [precision: heuristic/text-backed]",
+          "description": "Large PNG could be smaller as WebP [precision: heuristic/text-backed] [noisiness: noisy]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -656,7 +656,7 @@
           }
         },
         "CustomViewStyleable": {
-          "description": "Mismatched Styleable/Custom View Name [precision: ast-backed]",
+          "description": "Mismatched Styleable/Custom View Name [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -675,7 +675,7 @@
           }
         },
         "CutPasteIdResource": {
-          "description": "Likely cut \u0026 paste mistakes [precision: project-structure-aware] [capabilities: resources]",
+          "description": "Likely cut \u0026 paste mistakes [precision: project-structure-aware] [noisiness: normal] [capabilities: resources]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -694,7 +694,7 @@
           }
         },
         "DebuggableManifest": {
-          "description": "Hardcoded value of android:debuggable in manifest [precision: project-structure-aware] [capabilities: manifest]",
+          "description": "Hardcoded value of android:debuggable in manifest [precision: project-structure-aware] [noisiness: normal] [capabilities: manifest]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -713,7 +713,7 @@
           }
         },
         "DefaultLocale": {
-          "description": "Implied default locale in case conversion [precision: ast-backed]",
+          "description": "Implied default locale in case conversion [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -732,7 +732,7 @@
           }
         },
         "Deprecated": {
-          "description": "Using deprecated API [precision: ast-backed]",
+          "description": "Using deprecated API [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -751,7 +751,7 @@
           }
         },
         "DeprecatedDependency": {
-          "description": "Deprecated library dependency [precision: project-structure-aware] [capabilities: gradle]",
+          "description": "Deprecated library dependency [precision: project-structure-aware] [noisiness: normal] [capabilities: gradle]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -770,7 +770,7 @@
           }
         },
         "DeviceAdminManifest": {
-          "description": "Malformed Device Admin [precision: project-structure-aware] [capabilities: manifest]",
+          "description": "Malformed Device Admin [precision: project-structure-aware] [noisiness: normal] [capabilities: manifest]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -789,7 +789,7 @@
           }
         },
         "DisableBaselineAlignmentResource": {
-          "description": "Missing baselineAligned=false on weighted LinearLayout [precision: project-structure-aware] [capabilities: resources]",
+          "description": "Missing baselineAligned=false on weighted LinearLayout [precision: project-structure-aware] [noisiness: normal] [capabilities: resources]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -808,7 +808,7 @@
           }
         },
         "DrawAllocation": {
-          "description": "Memory allocations within drawing code [precision: ast-backed]",
+          "description": "Memory allocations within drawing code [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -827,7 +827,7 @@
           }
         },
         "DuplicateActivityManifest": {
-          "description": "Activity registered more than once [precision: project-structure-aware] [capabilities: manifest]",
+          "description": "Activity registered more than once [precision: project-structure-aware] [noisiness: normal] [capabilities: manifest]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -846,7 +846,7 @@
           }
         },
         "DuplicateIdsResource": {
-          "description": "Duplicate android:id in layout [precision: project-structure-aware] [capabilities: resources]",
+          "description": "Duplicate android:id in layout [precision: project-structure-aware] [noisiness: normal] [capabilities: resources]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -865,7 +865,7 @@
           }
         },
         "DuplicateIncludedIdsResource": {
-          "description": "Duplicate ids across included layouts [precision: project-structure-aware] [capabilities: resources]",
+          "description": "Duplicate ids across included layouts [precision: project-structure-aware] [noisiness: normal] [capabilities: resources]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -884,7 +884,7 @@
           }
         },
         "DuplicateUsesFeatureManifest": {
-          "description": "Duplicate \u003cuses-feature\u003e declaration [precision: project-structure-aware] [capabilities: manifest]",
+          "description": "Duplicate \u003cuses-feature\u003e declaration [precision: project-structure-aware] [noisiness: normal] [capabilities: manifest]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -903,7 +903,7 @@
           }
         },
         "DynamicVersion": {
-          "description": "Dynamic dependency version with partial wildcard [precision: project-structure-aware] [capabilities: gradle]",
+          "description": "Dynamic dependency version with partial wildcard [precision: project-structure-aware] [noisiness: normal] [capabilities: gradle]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -922,7 +922,7 @@
           }
         },
         "EasterEgg": {
-          "description": "Code contains easter egg references [precision: heuristic/text-backed] [capabilities: line-pass]",
+          "description": "Code contains easter egg references [precision: heuristic/text-backed] [noisiness: noisy] [capabilities: line-pass]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -941,7 +941,7 @@
           }
         },
         "ExportedContentProvider": {
-          "description": "Exported content provider does not require permission [precision: ast-backed]",
+          "description": "Exported content provider does not require permission [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -960,7 +960,7 @@
           }
         },
         "ExportedPreferenceActivityManifest": {
-          "description": "Exported PreferenceActivity is vulnerable to fragment injection [precision: project-structure-aware] [capabilities: manifest]",
+          "description": "Exported PreferenceActivity is vulnerable to fragment injection [precision: project-structure-aware] [noisiness: normal] [capabilities: manifest]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -979,7 +979,7 @@
           }
         },
         "ExportedReceiver": {
-          "description": "Exported receiver does not require permission [precision: ast-backed]",
+          "description": "Exported receiver does not require permission [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -998,7 +998,7 @@
           }
         },
         "ExportedService": {
-          "description": "Exported service does not require permission [precision: ast-backed]",
+          "description": "Exported service does not require permission [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -1017,7 +1017,7 @@
           }
         },
         "ExportedServiceManifest": {
-          "description": "Exported service without required permission [precision: project-structure-aware] [capabilities: manifest]",
+          "description": "Exported service without required permission [precision: project-structure-aware] [noisiness: normal] [capabilities: manifest]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -1036,7 +1036,7 @@
           }
         },
         "ExportedWithoutPermission": {
-          "description": "Exported component without required permission [precision: project-structure-aware] [capabilities: manifest]",
+          "description": "Exported component without required permission [precision: project-structure-aware] [noisiness: normal] [capabilities: manifest]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -1055,7 +1055,7 @@
           }
         },
         "ExtraTextResource": {
-          "description": "Extraneous text in resource files [precision: project-structure-aware] [capabilities: resources]",
+          "description": "Extraneous text in resource files [precision: project-structure-aware] [noisiness: normal] [capabilities: resources]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -1074,7 +1074,7 @@
           }
         },
         "FieldGetter": {
-          "description": "Using getter instead of field access [precision: ast-backed]",
+          "description": "Using getter instead of field access [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -1093,7 +1093,7 @@
           }
         },
         "FloatMath": {
-          "description": "Using FloatMath instead of Math [precision: ast-backed]",
+          "description": "Using FloatMath instead of Math [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -1112,7 +1112,7 @@
           }
         },
         "FragmentConstructor": {
-          "description": "Fragment not instantiatable [precision: ast-backed]",
+          "description": "Fragment not instantiatable [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -1131,7 +1131,7 @@
           }
         },
         "FullBackupContentManifest": {
-          "description": "Invalid fullBackupContent or dataExtractionRules [precision: project-structure-aware] [capabilities: manifest]",
+          "description": "Invalid fullBackupContent or dataExtractionRules [precision: project-structure-aware] [noisiness: normal] [capabilities: manifest]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -1150,7 +1150,7 @@
           }
         },
         "GetInstance": {
-          "description": "Cipher.getInstance with insecure algorithm [precision: ast-backed]",
+          "description": "Cipher.getInstance with insecure algorithm [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -1169,7 +1169,7 @@
           }
         },
         "GetSignatures": {
-          "description": "Using deprecated GET_SIGNATURES [precision: ast-backed]",
+          "description": "Using deprecated GET_SIGNATURES [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -1188,7 +1188,7 @@
           }
         },
         "GifUsage": {
-          "description": "GIF file in resources [precision: heuristic/text-backed]",
+          "description": "GIF file in resources [precision: heuristic/text-backed] [noisiness: noisy]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -1207,7 +1207,7 @@
           }
         },
         "GoogleAppIndexingDeepLinkErrorManifest": {
-          "description": "Deep link data element with scheme but no host [precision: project-structure-aware] [capabilities: manifest]",
+          "description": "Deep link data element with scheme but no host [precision: project-structure-aware] [noisiness: normal] [capabilities: manifest]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -1226,7 +1226,7 @@
           }
         },
         "GoogleAppIndexingWarningManifest": {
-          "description": "No activity with deep link support [precision: heuristic/text-backed] [capabilities: manifest]",
+          "description": "No activity with deep link support [precision: heuristic/text-backed] [noisiness: noisy] [capabilities: manifest]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -1245,7 +1245,7 @@
           }
         },
         "GradleCompatible": {
-          "description": "Incompatible Gradle versions [precision: project-structure-aware] [capabilities: gradle]",
+          "description": "Incompatible Gradle versions [precision: project-structure-aware] [noisiness: normal] [capabilities: gradle]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -1264,7 +1264,7 @@
           }
         },
         "GradleDependency": {
-          "description": "Obsolete Gradle dependency [precision: project-structure-aware] [capabilities: gradle]",
+          "description": "Obsolete Gradle dependency [precision: project-structure-aware] [noisiness: normal] [capabilities: gradle]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -1289,7 +1289,7 @@
           }
         },
         "GradleDeprecated": {
-          "description": "Deprecated Gradle construct [precision: project-structure-aware] [capabilities: gradle]",
+          "description": "Deprecated Gradle construct [precision: project-structure-aware] [noisiness: normal] [capabilities: gradle]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -1308,7 +1308,7 @@
           }
         },
         "GradleDynamicVersion": {
-          "description": "Gradle dynamic version [precision: project-structure-aware] [capabilities: gradle]",
+          "description": "Gradle dynamic version [precision: project-structure-aware] [noisiness: normal] [capabilities: gradle]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -1327,7 +1327,7 @@
           }
         },
         "GradleGetter": {
-          "description": "Gradle implicit getter call [precision: project-structure-aware] [capabilities: gradle]",
+          "description": "Gradle implicit getter call [precision: project-structure-aware] [noisiness: normal] [capabilities: gradle]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -1346,7 +1346,7 @@
           }
         },
         "GradleIdeError": {
-          "description": "Gradle IDE Support Issues [precision: project-structure-aware] [capabilities: gradle]",
+          "description": "Gradle IDE Support Issues [precision: project-structure-aware] [noisiness: normal] [capabilities: gradle]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -1365,7 +1365,7 @@
           }
         },
         "GradleOverrides": {
-          "description": "Value overridden by Gradle build script [precision: project-structure-aware] [capabilities: gradle]",
+          "description": "Value overridden by Gradle build script [precision: project-structure-aware] [noisiness: normal] [capabilities: gradle]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -1384,7 +1384,7 @@
           }
         },
         "GradleOverridesManifest": {
-          "description": "SDK version in manifest overridden by Gradle [precision: project-structure-aware] [capabilities: manifest]",
+          "description": "SDK version in manifest overridden by Gradle [precision: project-structure-aware] [noisiness: normal] [capabilities: manifest]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -1403,7 +1403,7 @@
           }
         },
         "GradlePath": {
-          "description": "Gradle path issues [precision: project-structure-aware] [capabilities: gradle]",
+          "description": "Gradle path issues [precision: project-structure-aware] [noisiness: normal] [capabilities: gradle]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -1422,7 +1422,7 @@
           }
         },
         "GradlePluginCompatibility": {
-          "description": "AGP version incompatible with Gradle version [precision: project-structure-aware] [capabilities: gradle]",
+          "description": "AGP version incompatible with Gradle version [precision: project-structure-aware] [noisiness: normal] [capabilities: gradle]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -1441,7 +1441,7 @@
           }
         },
         "GrantAllUris": {
-          "description": "Overly broad URI permissions [precision: type-aware] [capabilities: oracle:supertypes, resolver]",
+          "description": "Overly broad URI permissions [precision: type-aware] [noisiness: normal] [capabilities: oracle:supertypes, resolver]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -1460,7 +1460,7 @@
           }
         },
         "GridLayout": {
-          "description": "GridLayout without columnCount [precision: ast-backed]",
+          "description": "GridLayout without columnCount [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -1479,7 +1479,7 @@
           }
         },
         "HandlerLeak": {
-          "description": "Handler reference leaks [precision: type-aware] [capabilities: resolver]",
+          "description": "Handler reference leaks [precision: type-aware] [noisiness: normal] [capabilities: resolver]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -1498,7 +1498,7 @@
           }
         },
         "HardcodedText": {
-          "description": "Hardcoded text [precision: ast-backed]",
+          "description": "Hardcoded text [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -1517,7 +1517,7 @@
           }
         },
         "HardcodedValuesResource": {
-          "description": "Hardcoded text in layout XML [precision: project-structure-aware] [capabilities: resources]",
+          "description": "Hardcoded text in layout XML [precision: project-structure-aware] [noisiness: normal] [capabilities: resources]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -1536,7 +1536,7 @@
           }
         },
         "IconColors": {
-          "description": "Icon colors do not follow the recommended visual style [precision: heuristic/text-backed]",
+          "description": "Icon colors do not follow the recommended visual style [precision: heuristic/text-backed] [noisiness: noisy]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -1555,7 +1555,7 @@
           }
         },
         "IconDensities": {
-          "description": "Missing density variants for icon [precision: heuristic/text-backed]",
+          "description": "Missing density variants for icon [precision: heuristic/text-backed] [noisiness: noisy]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -1574,7 +1574,7 @@
           }
         },
         "IconDipSize": {
-          "description": "Icon dimensions don't match expected DPI ratios [precision: heuristic/text-backed]",
+          "description": "Icon dimensions don't match expected DPI ratios [precision: heuristic/text-backed] [noisiness: noisy]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -1593,7 +1593,7 @@
           }
         },
         "IconDuplicates": {
-          "description": "Same image across densities without scaling [precision: heuristic/text-backed]",
+          "description": "Same image across densities without scaling [precision: heuristic/text-backed] [noisiness: noisy]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -1612,7 +1612,7 @@
           }
         },
         "IconDuplicatesConfig": {
-          "description": "Identical icons across configuration folders [precision: heuristic/text-backed]",
+          "description": "Identical icons across configuration folders [precision: heuristic/text-backed] [noisiness: noisy]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -1631,7 +1631,7 @@
           }
         },
         "IconExpectedSize": {
-          "description": "Launcher icon not at expected size [precision: heuristic/text-backed]",
+          "description": "Launcher icon not at expected size [precision: heuristic/text-backed] [noisiness: noisy]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -1650,7 +1650,7 @@
           }
         },
         "IconExtension": {
-          "description": "Icon format does not match the file extension [precision: heuristic/text-backed]",
+          "description": "Icon format does not match the file extension [precision: heuristic/text-backed] [noisiness: noisy]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -1669,7 +1669,7 @@
           }
         },
         "IconLauncherShape": {
-          "description": "Launcher icon has transparent corners [precision: heuristic/text-backed]",
+          "description": "Launcher icon has transparent corners [precision: heuristic/text-backed] [noisiness: noisy]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -1688,7 +1688,7 @@
           }
         },
         "IconLocation": {
-          "description": "Image defined in density-independent drawable folder [precision: heuristic/text-backed]",
+          "description": "Image defined in density-independent drawable folder [precision: heuristic/text-backed] [noisiness: noisy]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -1707,7 +1707,7 @@
           }
         },
         "IconMissingDensityFolder": {
-          "description": "Missing density folder [precision: heuristic/text-backed]",
+          "description": "Missing density folder [precision: heuristic/text-backed] [noisiness: noisy]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -1726,7 +1726,7 @@
           }
         },
         "IconMixedNinePatch": {
-          "description": "Clashing PNG and 9-PNG files [precision: heuristic/text-backed]",
+          "description": "Clashing PNG and 9-PNG files [precision: heuristic/text-backed] [noisiness: noisy]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -1745,7 +1745,7 @@
           }
         },
         "IconNoDpi": {
-          "description": "Icon in both nodpi and density-specific folder [precision: heuristic/text-backed]",
+          "description": "Icon in both nodpi and density-specific folder [precision: heuristic/text-backed] [noisiness: noisy]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -1764,7 +1764,7 @@
           }
         },
         "IconXmlAndPng": {
-          "description": "Icon is specified both as .xml file and as a bitmap [precision: heuristic/text-backed]",
+          "description": "Icon is specified both as .xml file and as a bitmap [precision: heuristic/text-backed] [noisiness: noisy]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -1783,7 +1783,7 @@
           }
         },
         "IllegalResourceRefResource": {
-          "description": "Name is not a valid resource reference format [precision: project-structure-aware] [capabilities: resources]",
+          "description": "Name is not a valid resource reference format [precision: project-structure-aware] [noisiness: normal] [capabilities: resources]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -1802,7 +1802,7 @@
           }
         },
         "ImpliedQuantityResource": {
-          "description": "Plural 'one' without %d placeholder [precision: project-structure-aware] [capabilities: resources]",
+          "description": "Plural 'one' without %d placeholder [precision: project-structure-aware] [noisiness: normal] [capabilities: resources]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -1821,7 +1821,7 @@
           }
         },
         "InOrMmUsageResource": {
-          "description": "Using in or mm dimension units [precision: project-structure-aware] [capabilities: resources]",
+          "description": "Using in or mm dimension units [precision: project-structure-aware] [noisiness: normal] [capabilities: resources]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -1840,7 +1840,7 @@
           }
         },
         "IncludeLayoutParamResource": {
-          "description": "\u003cinclude\u003e with layout_width/height is ignored [precision: project-structure-aware] [capabilities: resources]",
+          "description": "\u003cinclude\u003e with layout_width/height is ignored [precision: project-structure-aware] [noisiness: normal] [capabilities: resources]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -1859,7 +1859,7 @@
           }
         },
         "InconsistentArraysResource": {
-          "description": "Inconsistencies in array element counts [precision: project-structure-aware] [capabilities: resources]",
+          "description": "Inconsistencies in array element counts [precision: project-structure-aware] [noisiness: normal] [capabilities: resources]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -1878,7 +1878,7 @@
           }
         },
         "InconsistentLayout": {
-          "description": "Inconsistent layouts in different configurations [precision: project-structure-aware] [capabilities: resources]",
+          "description": "Inconsistent layouts in different configurations [precision: project-structure-aware] [noisiness: normal] [capabilities: resources]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -1897,7 +1897,7 @@
           }
         },
         "InefficientWeightResource": {
-          "description": "LinearLayout with weights missing orientation [precision: project-structure-aware] [capabilities: resources]",
+          "description": "LinearLayout with weights missing orientation [precision: project-structure-aware] [noisiness: normal] [capabilities: resources]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -1916,7 +1916,7 @@
           }
         },
         "InlinedApi": {
-          "description": "Using inlined constants from newer API [precision: type-aware] [capabilities: resolver]",
+          "description": "Using inlined constants from newer API [precision: type-aware] [noisiness: normal] [capabilities: resolver]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -1935,7 +1935,7 @@
           }
         },
         "InnerclassSeparator": {
-          "description": "Inner classes should use '$' not '/' [precision: ast-backed]",
+          "description": "Inner classes should use '$' not '/' [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -1954,7 +1954,7 @@
           }
         },
         "InsecureBaseConfigurationManifest": {
-          "description": "Missing networkSecurityConfig on API 28+ [precision: project-structure-aware] [capabilities: manifest]",
+          "description": "Missing networkSecurityConfig on API 28+ [precision: project-structure-aware] [noisiness: normal] [capabilities: manifest]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -1973,7 +1973,7 @@
           }
         },
         "Instantiatable": {
-          "description": "Registered class not instantiatable [precision: ast-backed]",
+          "description": "Registered class not instantiatable [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -1992,7 +1992,7 @@
           }
         },
         "IntentFilterExportRequired": {
-          "description": "Component with intent-filter missing android:exported (API 31+) [precision: project-structure-aware] [capabilities: manifest]",
+          "description": "Component with intent-filter missing android:exported (API 31+) [precision: project-structure-aware] [noisiness: normal] [capabilities: manifest]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -2011,7 +2011,7 @@
           }
         },
         "InvalidIdResource": {
-          "description": "Malformed android:id value [precision: project-structure-aware] [capabilities: resources]",
+          "description": "Malformed android:id value [precision: project-structure-aware] [noisiness: normal] [capabilities: resources]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -2030,7 +2030,7 @@
           }
         },
         "InvalidResourceFolderResource": {
-          "description": "Invalid resource folder name [precision: project-structure-aware] [capabilities: resources]",
+          "description": "Invalid resource folder name [precision: project-structure-aware] [noisiness: normal] [capabilities: resources]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -2049,7 +2049,7 @@
           }
         },
         "InvalidUsesTagAttributeManifest": {
-          "description": "Invalid android:required value on \u003cuses-feature\u003e [precision: project-structure-aware] [capabilities: manifest]",
+          "description": "Invalid android:required value on \u003cuses-feature\u003e [precision: project-structure-aware] [noisiness: normal] [capabilities: manifest]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -2068,7 +2068,7 @@
           }
         },
         "LabelForResource": {
-          "description": "EditText without a corresponding labelFor [precision: project-structure-aware] [capabilities: resources]",
+          "description": "EditText without a corresponding labelFor [precision: project-structure-aware] [noisiness: normal] [capabilities: resources]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -2087,7 +2087,7 @@
           }
         },
         "LayoutAutofillHintMismatch": {
-          "description": "inputType without matching autofillHints [precision: project-structure-aware] [capabilities: resources]",
+          "description": "inputType without matching autofillHints [precision: project-structure-aware] [noisiness: normal] [capabilities: resources]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -2106,7 +2106,7 @@
           }
         },
         "LayoutClickableWithoutMinSize": {
-          "description": "Clickable view below 48dp [precision: project-structure-aware] [capabilities: resources]",
+          "description": "Clickable view below 48dp [precision: project-structure-aware] [noisiness: normal] [capabilities: resources]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -2125,7 +2125,7 @@
           }
         },
         "LayoutEditTextMissingImportance": {
-          "description": "EditText missing importantForAutofill [precision: project-structure-aware] [capabilities: resources]",
+          "description": "EditText missing importantForAutofill [precision: project-structure-aware] [noisiness: normal] [capabilities: resources]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -2144,7 +2144,7 @@
           }
         },
         "LayoutImportantForAccessibilityNo": {
-          "description": "Interactive view hidden from accessibility [precision: project-structure-aware] [capabilities: resources]",
+          "description": "Interactive view hidden from accessibility [precision: project-structure-aware] [noisiness: normal] [capabilities: resources]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -2163,7 +2163,7 @@
           }
         },
         "LayoutInflation": {
-          "description": "Layout inflation without parent [precision: project-structure-aware] [capabilities: resources]",
+          "description": "Layout inflation without parent [precision: project-structure-aware] [noisiness: normal] [capabilities: resources]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -2182,7 +2182,7 @@
           }
         },
         "LayoutMinTouchTargetInButtonRow": {
-          "description": "Button in row without 48dp min height [precision: project-structure-aware] [capabilities: resources]",
+          "description": "Button in row without 48dp min height [precision: project-structure-aware] [noisiness: normal] [capabilities: resources]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -2201,7 +2201,7 @@
           }
         },
         "LibraryCustomView": {
-          "description": "Custom view using hardcoded namespace [precision: ast-backed]",
+          "description": "Custom view using hardcoded namespace [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -2220,7 +2220,7 @@
           }
         },
         "LocalSuppress": {
-          "description": "@SuppressLint misuse [precision: ast-backed]",
+          "description": "@SuppressLint misuse [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -2239,7 +2239,7 @@
           }
         },
         "LocaleConfigMissing": {
-          "description": "android:localeConfig points at a missing XML resource [precision: project-structure-aware] [capabilities: manifest]",
+          "description": "android:localeConfig points at a missing XML resource [precision: project-structure-aware] [noisiness: normal] [capabilities: manifest]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -2258,7 +2258,7 @@
           }
         },
         "LocaleConfigStale": {
-          "description": "locales_config.xml is out of sync with locale-specific values folders [precision: project-structure-aware] [capabilities: resources]",
+          "description": "locales_config.xml is out of sync with locale-specific values folders [precision: project-structure-aware] [noisiness: normal] [capabilities: resources]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -2277,7 +2277,7 @@
           }
         },
         "LocaleFolder": {
-          "description": "Wrong locale folder naming [precision: heuristic/text-backed] [capabilities: line-pass]",
+          "description": "Wrong locale folder naming [precision: heuristic/text-backed] [noisiness: noisy] [capabilities: line-pass]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -2296,7 +2296,7 @@
           }
         },
         "LogConditional": {
-          "description": "Unconditional logging calls [precision: type-aware] [capabilities: oracle:call-targets, resolver]",
+          "description": "Unconditional logging calls [precision: type-aware] [noisiness: normal] [capabilities: oracle:call-targets, resolver]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -2315,7 +2315,7 @@
           }
         },
         "LogTagMismatch": {
-          "description": "Mismatched Log tag [precision: ast-backed]",
+          "description": "Mismatched Log tag [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -2334,7 +2334,7 @@
           }
         },
         "LongLogTag": {
-          "description": "Log tag exceeds 23 characters [precision: ast-backed]",
+          "description": "Log tag exceeds 23 characters [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -2353,7 +2353,7 @@
           }
         },
         "MangledCRLF": {
-          "description": "Mixed line endings in file [precision: heuristic/text-backed] [capabilities: line-pass]",
+          "description": "Mixed line endings in file [precision: heuristic/text-backed] [noisiness: noisy] [capabilities: line-pass]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -2372,7 +2372,7 @@
           }
         },
         "ManifestOrderManifest": {
-          "description": "\u003capplication\u003e appears before \u003cuses-permission\u003e or \u003cuses-sdk\u003e [precision: project-structure-aware] [capabilities: manifest]",
+          "description": "\u003capplication\u003e appears before \u003cuses-permission\u003e or \u003cuses-sdk\u003e [precision: project-structure-aware] [noisiness: normal] [capabilities: manifest]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -2391,7 +2391,7 @@
           }
         },
         "ManifestTypoManifest": {
-          "description": "Typos in manifest element tags [precision: project-structure-aware] [capabilities: manifest]",
+          "description": "Typos in manifest element tags [precision: project-structure-aware] [noisiness: normal] [capabilities: manifest]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -2410,7 +2410,7 @@
           }
         },
         "MavenLocal": {
-          "description": "mavenLocal() causes unreproducible builds [precision: project-structure-aware] [capabilities: gradle]",
+          "description": "mavenLocal() causes unreproducible builds [precision: project-structure-aware] [noisiness: normal] [capabilities: gradle]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -2429,7 +2429,7 @@
           }
         },
         "MergeRootFrameResource": {
-          "description": "Root FrameLayout replaceable with merge tag [precision: project-structure-aware] [capabilities: resources]",
+          "description": "Root FrameLayout replaceable with merge tag [precision: project-structure-aware] [noisiness: normal] [capabilities: resources]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -2448,7 +2448,7 @@
           }
         },
         "MinSdkTooLow": {
-          "description": "minSdkVersion below recommended minimum [precision: policy] [capabilities: gradle]",
+          "description": "minSdkVersion below recommended minimum [precision: policy] [noisiness: normal] [capabilities: gradle]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -2471,7 +2471,7 @@
           }
         },
         "MipmapLauncher": {
-          "description": "Launcher icon should use @mipmap/ not @drawable/ [precision: project-structure-aware] [capabilities: manifest]",
+          "description": "Launcher icon should use @mipmap/ not @drawable/ [precision: project-structure-aware] [noisiness: normal] [capabilities: manifest]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -2490,7 +2490,7 @@
           }
         },
         "MissingApplicationIconManifest": {
-          "description": "Missing android:icon on \u003capplication\u003e [precision: project-structure-aware] [capabilities: manifest]",
+          "description": "Missing android:icon on \u003capplication\u003e [precision: project-structure-aware] [noisiness: normal] [capabilities: manifest]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -2509,7 +2509,7 @@
           }
         },
         "MissingContentDescriptionResource": {
-          "description": "Image without contentDescription [precision: project-structure-aware] [capabilities: resources]",
+          "description": "Image without contentDescription [precision: project-structure-aware] [noisiness: normal] [capabilities: resources]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -2528,7 +2528,7 @@
           }
         },
         "MissingExportedFlag": {
-          "description": "Component with intent-filter missing android:exported (API 31+) [precision: project-structure-aware] [capabilities: manifest]",
+          "description": "Component with intent-filter missing android:exported (API 31+) [precision: project-structure-aware] [noisiness: normal] [capabilities: manifest]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -2547,7 +2547,7 @@
           }
         },
         "MissingIdResource": {
-          "description": "Fragments should specify an id or tag [precision: project-structure-aware] [capabilities: resources]",
+          "description": "Fragments should specify an id or tag [precision: project-structure-aware] [noisiness: normal] [capabilities: resources]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -2566,7 +2566,7 @@
           }
         },
         "MissingLeanbackLauncherManifest": {
-          "description": "Leanback feature without LEANBACK_LAUNCHER activity [precision: project-structure-aware] [capabilities: manifest]",
+          "description": "Leanback feature without LEANBACK_LAUNCHER activity [precision: project-structure-aware] [noisiness: normal] [capabilities: manifest]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -2585,7 +2585,7 @@
           }
         },
         "MissingLeanbackSupportManifest": {
-          "description": "Leanback feature without touchscreen opt-out [precision: project-structure-aware] [capabilities: manifest]",
+          "description": "Leanback feature without touchscreen opt-out [precision: project-structure-aware] [noisiness: normal] [capabilities: manifest]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -2604,7 +2604,7 @@
           }
         },
         "MissingPermission": {
-          "description": "Missing permission check before API call [precision: type-aware] [capabilities: oracle:call-targets, resolver]",
+          "description": "Missing permission check before API call [precision: type-aware] [noisiness: normal] [capabilities: oracle:call-targets, resolver]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -2623,7 +2623,7 @@
           }
         },
         "MissingPrefixResource": {
-          "description": "Attribute missing android: namespace prefix [precision: project-structure-aware] [capabilities: resources]",
+          "description": "Attribute missing android: namespace prefix [precision: project-structure-aware] [noisiness: normal] [capabilities: resources]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -2642,7 +2642,7 @@
           }
         },
         "MissingQuantityResource": {
-          "description": "Plural missing required quantity [precision: project-structure-aware] [capabilities: resources]",
+          "description": "Plural missing required quantity [precision: project-structure-aware] [noisiness: normal] [capabilities: resources]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -2661,7 +2661,7 @@
           }
         },
         "MissingRegisteredManifest": {
-          "description": "Missing registered class [precision: project-structure-aware] [capabilities: manifest]",
+          "description": "Missing registered class [precision: project-structure-aware] [noisiness: normal] [capabilities: manifest]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -2680,7 +2680,7 @@
           }
         },
         "MissingVersionManifest": {
-          "description": "Missing versionCode or versionName on \u003cmanifest\u003e [precision: project-structure-aware] [capabilities: manifest]",
+          "description": "Missing versionCode or versionName on \u003cmanifest\u003e [precision: project-structure-aware] [noisiness: normal] [capabilities: manifest]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -2699,7 +2699,7 @@
           }
         },
         "MockLocationManifest": {
-          "description": "ACCESS_MOCK_LOCATION in non-debug manifest [precision: project-structure-aware] [capabilities: manifest]",
+          "description": "ACCESS_MOCK_LOCATION in non-debug manifest [precision: project-structure-aware] [noisiness: normal] [capabilities: manifest]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -2718,7 +2718,7 @@
           }
         },
         "MultipleUsesSdkManifest": {
-          "description": "More than one \u003cuses-sdk\u003e element [precision: project-structure-aware] [capabilities: manifest]",
+          "description": "More than one \u003cuses-sdk\u003e element [precision: project-structure-aware] [noisiness: normal] [capabilities: manifest]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -2737,7 +2737,7 @@
           }
         },
         "NamespaceTypoResource": {
-          "description": "Misspelled namespace URI [precision: project-structure-aware] [capabilities: resources]",
+          "description": "Misspelled namespace URI [precision: project-structure-aware] [noisiness: normal] [capabilities: resources]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -2756,7 +2756,7 @@
           }
         },
         "NegativeMarginResource": {
-          "description": "Negative margin value [precision: project-structure-aware] [capabilities: resources]",
+          "description": "Negative margin value [precision: project-structure-aware] [noisiness: normal] [capabilities: resources]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -2782,7 +2782,7 @@
           }
         },
         "NestedScrolling": {
-          "description": "Nested scrolling widgets [precision: ast-backed]",
+          "description": "Nested scrolling widgets [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -2801,7 +2801,7 @@
           }
         },
         "NestedScrollingResource": {
-          "description": "ScrollView inside ScrollView [precision: project-structure-aware] [capabilities: resources]",
+          "description": "ScrollView inside ScrollView [precision: project-structure-aware] [noisiness: normal] [capabilities: resources]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -2820,7 +2820,7 @@
           }
         },
         "NestedWeightsResource": {
-          "description": "Nested layout_weight causes exponential measure passes [precision: project-structure-aware] [capabilities: resources]",
+          "description": "Nested layout_weight causes exponential measure passes [precision: project-structure-aware] [noisiness: normal] [capabilities: resources]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -2839,7 +2839,7 @@
           }
         },
         "NewApi": {
-          "description": "Calling new APIs on older versions [precision: type-aware] [capabilities: oracle:call-targets, resolver]",
+          "description": "Calling new APIs on older versions [precision: type-aware] [noisiness: normal] [capabilities: oracle:call-targets, resolver]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -2858,7 +2858,7 @@
           }
         },
         "NewerVersionAvailable": {
-          "description": "Newer library version available [precision: policy] [capabilities: gradle]",
+          "description": "Newer library version available [precision: policy] [noisiness: normal] [capabilities: gradle]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -2883,7 +2883,7 @@
           }
         },
         "NfcTechWhitespace": {
-          "description": "Whitespace in NFC tech-list [precision: ast-backed]",
+          "description": "Whitespace in NFC tech-list [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -2902,7 +2902,7 @@
           }
         },
         "NonInternationalizedSms": {
-          "description": "SMS with non-i18n considerations [precision: ast-backed]",
+          "description": "SMS with non-i18n considerations [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -2921,7 +2921,7 @@
           }
         },
         "NotSiblingResource": {
-          "description": "RelativeLayout Invalid Constraints [precision: project-structure-aware] [capabilities: resources]",
+          "description": "RelativeLayout Invalid Constraints [precision: project-structure-aware] [noisiness: normal] [capabilities: resources]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -2940,7 +2940,7 @@
           }
         },
         "ObjectAnimatorBinding": {
-          "description": "Incorrect ObjectAnimator Property [precision: type-aware] [capabilities: oracle:call-targets, oracle:members, oracle:supertypes, resolver]",
+          "description": "Incorrect ObjectAnimator Property [precision: type-aware] [noisiness: normal] [capabilities: oracle:call-targets, oracle:members, oracle:supertypes, resolver]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -2959,7 +2959,7 @@
           }
         },
         "ObsoleteLayoutParam": {
-          "description": "Obsolete layout params [precision: type-aware] [capabilities: oracle:call-targets, resolver]",
+          "description": "Obsolete layout params [precision: type-aware] [noisiness: normal] [capabilities: oracle:call-targets, resolver]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -2978,7 +2978,7 @@
           }
         },
         "ObsoleteLayoutParamsResource": {
-          "description": "layout_weight on non-LinearLayout child [precision: project-structure-aware] [capabilities: resources]",
+          "description": "layout_weight on non-LinearLayout child [precision: project-structure-aware] [noisiness: normal] [capabilities: resources]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -2997,7 +2997,7 @@
           }
         },
         "OldTargetApi": {
-          "description": "targetSdkVersion below recommended minimum [precision: policy] [capabilities: gradle]",
+          "description": "targetSdkVersion below recommended minimum [precision: policy] [noisiness: normal] [capabilities: gradle]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -3020,7 +3020,7 @@
           }
         },
         "OnClick": {
-          "description": "android:onClick handler missing or has wrong signature [precision: project-structure-aware] [capabilities: parsed-files, resources]",
+          "description": "android:onClick handler missing or has wrong signature [precision: project-structure-aware] [noisiness: normal] [capabilities: parsed-files, resources]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -3039,7 +3039,7 @@
           }
         },
         "OnClickResource": {
-          "description": "android:onClick in layout XML is discouraged [precision: project-structure-aware] [capabilities: resources]",
+          "description": "android:onClick in layout XML is discouraged [precision: project-structure-aware] [noisiness: normal] [capabilities: resources]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -3058,7 +3058,7 @@
           }
         },
         "OrientationResource": {
-          "description": "LinearLayout missing explicit orientation [precision: project-structure-aware] [capabilities: resources]",
+          "description": "LinearLayout missing explicit orientation [precision: project-structure-aware] [noisiness: normal] [capabilities: resources]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -3077,7 +3077,7 @@
           }
         },
         "OverdrawResource": {
-          "description": "Root and child layout both have background (overdraw) [precision: project-structure-aware] [capabilities: resources]",
+          "description": "Root and child layout both have background (overdraw) [precision: project-structure-aware] [noisiness: normal] [capabilities: resources]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -3096,7 +3096,7 @@
           }
         },
         "Override": {
-          "description": "Method override errors [precision: ast-backed]",
+          "description": "Method override errors [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -3115,7 +3115,7 @@
           }
         },
         "OverrideAbstract": {
-          "description": "Missing abstract method overrides [precision: ast-backed]",
+          "description": "Missing abstract method overrides [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -3134,7 +3134,7 @@
           }
         },
         "PackagedPrivateKey": {
-          "description": "Packaged private key [precision: heuristic/text-backed] [capabilities: line-pass]",
+          "description": "Packaged private key [precision: heuristic/text-backed] [noisiness: noisy] [capabilities: line-pass]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -3153,7 +3153,7 @@
           }
         },
         "ParcelCreator": {
-          "description": "Missing Parcelable CREATOR field [precision: ast-backed]",
+          "description": "Missing Parcelable CREATOR field [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -3172,7 +3172,7 @@
           }
         },
         "PermissionImpliesUnsupportedHardwareManifest": {
-          "description": "Permission implies hardware feature not declared optional [precision: project-structure-aware] [capabilities: manifest]",
+          "description": "Permission implies hardware feature not declared optional [precision: project-structure-aware] [noisiness: normal] [capabilities: manifest]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -3191,7 +3191,7 @@
           }
         },
         "PluralsCandidate": {
-          "description": "Potential plurals [precision: ast-backed]",
+          "description": "Potential plurals [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -3210,7 +3210,7 @@
           }
         },
         "Proguard": {
-          "description": "Obsolete proguard.cfg reference [precision: ast-backed]",
+          "description": "Obsolete proguard.cfg reference [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -3229,7 +3229,7 @@
           }
         },
         "ProguardSplit": {
-          "description": "Proguard config should be split [precision: heuristic/text-backed] [capabilities: line-pass]",
+          "description": "Proguard config should be split [precision: heuristic/text-backed] [noisiness: noisy] [capabilities: line-pass]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -3248,7 +3248,7 @@
           }
         },
         "PropertyEscape": {
-          "description": "Invalid property file escapes [precision: ast-backed]",
+          "description": "Invalid property file escapes [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -3267,7 +3267,7 @@
           }
         },
         "ProtectedPermissionsManifest": {
-          "description": "Using system app permission [precision: project-structure-aware] [capabilities: manifest]",
+          "description": "Using system app permission [precision: project-structure-aware] [noisiness: normal] [capabilities: manifest]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -3286,7 +3286,7 @@
           }
         },
         "PxUsageResource": {
-          "description": "Using px instead of dp in dimensions [precision: project-structure-aware] [capabilities: resources]",
+          "description": "Using px instead of dp in dimensions [precision: project-structure-aware] [noisiness: normal] [capabilities: resources]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -3305,7 +3305,7 @@
           }
         },
         "Range": {
-          "description": "Outside allowed range [precision: type-aware] [capabilities: oracle:call-targets, resolver]",
+          "description": "Outside allowed range [precision: type-aware] [noisiness: normal] [capabilities: oracle:call-targets, resolver]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -3324,7 +3324,7 @@
           }
         },
         "Recycle": {
-          "description": "Missing recycle() calls [precision: ast-backed]",
+          "description": "Missing recycle() calls [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -3343,7 +3343,7 @@
           }
         },
         "Registered": {
-          "description": "Class is not registered in the manifest [precision: type-aware] [capabilities: resolver]",
+          "description": "Class is not registered in the manifest [precision: type-aware] [noisiness: normal] [capabilities: resolver]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -3362,7 +3362,7 @@
           }
         },
         "RelativeOverlapResource": {
-          "description": "Views in RelativeLayout may overlap [precision: project-structure-aware] [capabilities: resources]",
+          "description": "Views in RelativeLayout may overlap [precision: project-structure-aware] [noisiness: normal] [capabilities: resources]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -3381,7 +3381,7 @@
           }
         },
         "RemoteVersion": {
-          "description": "Non-deterministic dependency version (+ or latest) [precision: project-structure-aware] [capabilities: gradle]",
+          "description": "Non-deterministic dependency version (+ or latest) [precision: project-structure-aware] [noisiness: normal] [capabilities: gradle]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -3400,7 +3400,7 @@
           }
         },
         "RequiredSizeResource": {
-          "description": "View missing layout_width or layout_height [precision: project-structure-aware] [capabilities: resources]",
+          "description": "View missing layout_width or layout_height [precision: project-structure-aware] [noisiness: normal] [capabilities: resources]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -3419,7 +3419,7 @@
           }
         },
         "RequiresApiViolation": {
-          "description": "Calling an API above the module's minSdk [precision: type-aware] [capabilities: oracle:call-targets, resolver]",
+          "description": "Calling an API above the module's minSdk [precision: type-aware] [noisiness: normal] [capabilities: oracle:call-targets, resolver]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -3438,7 +3438,7 @@
           }
         },
         "ResAutoResource": {
-          "description": "Namespace used in resource files should be res-auto [precision: project-structure-aware] [capabilities: resources]",
+          "description": "Namespace used in resource files should be res-auto [precision: project-structure-aware] [noisiness: normal] [capabilities: resources]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -3457,7 +3457,7 @@
           }
         },
         "ResourceAsColor": {
-          "description": "Should pass resolved color instead of resource id [precision: ast-backed]",
+          "description": "Should pass resolved color instead of resource id [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -3476,7 +3476,7 @@
           }
         },
         "ResourceName": {
-          "description": "Resource name not in snake_case [precision: ast-backed]",
+          "description": "Resource name not in snake_case [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -3495,7 +3495,7 @@
           }
         },
         "ResourceType": {
-          "description": "Wrong resource type [precision: ast-backed]",
+          "description": "Wrong resource type [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -3514,7 +3514,7 @@
           }
         },
         "RtlAware": {
-          "description": "Using non-RTL-aware View methods [precision: ast-backed]",
+          "description": "Using non-RTL-aware View methods [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -3533,7 +3533,7 @@
           }
         },
         "RtlCompatManifest": {
-          "description": "Missing supportsRtl with targetSdkVersion \u003e= 17 [precision: project-structure-aware] [capabilities: manifest]",
+          "description": "Missing supportsRtl with targetSdkVersion \u003e= 17 [precision: project-structure-aware] [noisiness: normal] [capabilities: manifest]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -3552,7 +3552,7 @@
           }
         },
         "RtlEnabledManifest": {
-          "description": "Missing supportsRtl=true on \u003capplication\u003e [precision: project-structure-aware] [capabilities: manifest]",
+          "description": "Missing supportsRtl=true on \u003capplication\u003e [precision: project-structure-aware] [noisiness: normal] [capabilities: manifest]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -3571,7 +3571,7 @@
           }
         },
         "RtlFieldAccess": {
-          "description": "Direct field access of non-RTL-aware View fields [precision: ast-backed]",
+          "description": "Direct field access of non-RTL-aware View fields [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -3590,7 +3590,7 @@
           }
         },
         "RtlHardcodedResource": {
-          "description": "Using left/right instead of start/end for RTL [precision: project-structure-aware] [capabilities: resources]",
+          "description": "Using left/right instead of start/end for RTL [precision: project-structure-aware] [noisiness: normal] [capabilities: resources]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -3609,7 +3609,7 @@
           }
         },
         "RtlSuperscriptResource": {
-          "description": "Superscript/subscript may break in RTL [precision: project-structure-aware] [capabilities: resources]",
+          "description": "Superscript/subscript may break in RTL [precision: project-structure-aware] [noisiness: normal] [capabilities: resources]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -3628,7 +3628,7 @@
           }
         },
         "RtlSymmetryResource": {
-          "description": "Asymmetric padding or margin (Left without Right or vice versa) [precision: project-structure-aware] [capabilities: resources]",
+          "description": "Asymmetric padding or margin (Left without Right or vice versa) [precision: project-structure-aware] [noisiness: normal] [capabilities: resources]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -3647,7 +3647,7 @@
           }
         },
         "SQLiteString": {
-          "description": "Using STRING instead of TEXT in SQLite [precision: ast-backed]",
+          "description": "Using STRING instead of TEXT in SQLite [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -3666,7 +3666,7 @@
           }
         },
         "ScrollViewCount": {
-          "description": "ScrollViews can have only one child [precision: ast-backed]",
+          "description": "ScrollViews can have only one child [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -3685,7 +3685,7 @@
           }
         },
         "ScrollViewCountResource": {
-          "description": "ScrollView with more than one child [precision: project-structure-aware] [capabilities: resources]",
+          "description": "ScrollView with more than one child [precision: project-structure-aware] [noisiness: normal] [capabilities: resources]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -3704,7 +3704,7 @@
           }
         },
         "ScrollViewSizeResource": {
-          "description": "ScrollView size validation [precision: project-structure-aware] [capabilities: resources]",
+          "description": "ScrollView size validation [precision: project-structure-aware] [noisiness: normal] [capabilities: resources]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -3723,7 +3723,7 @@
           }
         },
         "SdCardPath": {
-          "description": "Hardcoded reference to /sdcard [precision: ast-backed]",
+          "description": "Hardcoded reference to /sdcard [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -3742,7 +3742,7 @@
           }
         },
         "SecureRandom": {
-          "description": "Insecure random source or deterministic SecureRandom seed [precision: ast-backed]",
+          "description": "Insecure random source or deterministic SecureRandom seed [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -3761,7 +3761,7 @@
           }
         },
         "ServiceCast": {
-          "description": "Wrong system service cast [precision: ast-backed]",
+          "description": "Wrong system service cast [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -3780,7 +3780,7 @@
           }
         },
         "ServiceExportedManifest": {
-          "description": "Exported service does not require permission [precision: project-structure-aware] [capabilities: manifest]",
+          "description": "Exported service does not require permission [precision: project-structure-aware] [noisiness: normal] [capabilities: manifest]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -3799,7 +3799,7 @@
           }
         },
         "SetJavaScriptEnabled": {
-          "description": "Using setJavaScriptEnabled [precision: type-aware] [capabilities: oracle:call-targets, resolver]",
+          "description": "Using setJavaScriptEnabled [precision: type-aware] [noisiness: normal] [capabilities: oracle:call-targets, resolver]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -3818,7 +3818,7 @@
           }
         },
         "SetTextI18n": {
-          "description": "TextView with internationalization issues [precision: ast-backed]",
+          "description": "TextView with internationalization issues [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -3837,7 +3837,7 @@
           }
         },
         "ShiftFlags": {
-          "description": "Suspicious flag constant declarations [precision: ast-backed]",
+          "description": "Suspicious flag constant declarations [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -3856,7 +3856,7 @@
           }
         },
         "ShortAlarm": {
-          "description": "Short or frequent alarm [precision: ast-backed]",
+          "description": "Short or frequent alarm [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -3875,7 +3875,7 @@
           }
         },
         "ShowToast": {
-          "description": "Toast created but not shown [precision: ast-backed]",
+          "description": "Toast created but not shown [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -3894,7 +3894,7 @@
           }
         },
         "SimpleDateFormat": {
-          "description": "Using SimpleDateFormat directly without Locale [precision: ast-backed]",
+          "description": "Using SimpleDateFormat directly without Locale [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -3913,7 +3913,7 @@
           }
         },
         "SmallSpResource": {
-          "description": "Text size below 12sp [precision: project-structure-aware] [capabilities: resources]",
+          "description": "Text size below 12sp [precision: project-structure-aware] [noisiness: normal] [capabilities: resources]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -3932,7 +3932,7 @@
           }
         },
         "SpUsageResource": {
-          "description": "Using dp instead of sp for textSize [precision: project-structure-aware] [capabilities: resources]",
+          "description": "Using dp instead of sp for textSize [precision: project-structure-aware] [noisiness: normal] [capabilities: resources]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -3951,7 +3951,7 @@
           }
         },
         "StateListReachableResource": {
-          "description": "Unreachable item in selector drawable [precision: project-structure-aware] [capabilities: resources]",
+          "description": "Unreachable item in selector drawable [precision: project-structure-aware] [noisiness: normal] [capabilities: resources]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -3970,7 +3970,7 @@
           }
         },
         "StopShip": {
-          "description": "STOPSHIP comment found [precision: heuristic/text-backed] [capabilities: line-pass]",
+          "description": "STOPSHIP comment found [precision: heuristic/text-backed] [noisiness: noisy] [capabilities: line-pass]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -3989,7 +3989,7 @@
           }
         },
         "StringFormatCountResource": {
-          "description": "Formatting argument types incomplete or inconsistent [precision: project-structure-aware] [capabilities: resources]",
+          "description": "Formatting argument types incomplete or inconsistent [precision: project-structure-aware] [noisiness: normal] [capabilities: resources]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -4008,7 +4008,7 @@
           }
         },
         "StringFormatInvalidResource": {
-          "description": "Invalid format string [precision: project-structure-aware] [capabilities: resources]",
+          "description": "Invalid format string [precision: project-structure-aware] [noisiness: normal] [capabilities: resources]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -4027,7 +4027,7 @@
           }
         },
         "StringFormatMatchesResource": {
-          "description": "String.format string doesn't match the XML format string [precision: project-structure-aware] [capabilities: resources]",
+          "description": "String.format string doesn't match the XML format string [precision: project-structure-aware] [noisiness: normal] [capabilities: resources]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -4046,7 +4046,7 @@
           }
         },
         "StringFormatTrivialResource": {
-          "description": "Placeholder-only string format [precision: project-structure-aware] [capabilities: resources]",
+          "description": "Placeholder-only string format [precision: project-structure-aware] [noisiness: normal] [capabilities: resources]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -4065,7 +4065,7 @@
           }
         },
         "StringInteger": {
-          "description": "String value where integer expected in Gradle DSL [precision: project-structure-aware] [capabilities: gradle]",
+          "description": "String value where integer expected in Gradle DSL [precision: project-structure-aware] [noisiness: normal] [capabilities: gradle]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -4084,7 +4084,7 @@
           }
         },
         "StringNotLocalizableResource": {
-          "description": "String resource should not be localized [precision: project-structure-aware] [capabilities: resources]",
+          "description": "String resource should not be localized [precision: project-structure-aware] [noisiness: normal] [capabilities: resources]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -4103,7 +4103,7 @@
           }
         },
         "StringNotSelectable": {
-          "description": "Non-selectable text with URLs or phone numbers [precision: project-structure-aware] [capabilities: resources]",
+          "description": "Non-selectable text with URLs or phone numbers [precision: project-structure-aware] [noisiness: normal] [capabilities: resources]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -4122,7 +4122,7 @@
           }
         },
         "StringRepeatedInContentDescription": {
-          "description": "contentDescription duplicates visible text [precision: project-structure-aware] [capabilities: resources]",
+          "description": "contentDescription duplicates visible text [precision: project-structure-aware] [noisiness: normal] [capabilities: resources]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -4141,7 +4141,7 @@
           }
         },
         "StringResourceMissingPositional": {
-          "description": "String resource has multiple non-positional format specifiers [precision: project-structure-aware] [capabilities: resources]",
+          "description": "String resource has multiple non-positional format specifiers [precision: project-structure-aware] [noisiness: normal] [capabilities: resources]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -4160,7 +4160,7 @@
           }
         },
         "StringShouldBeInt": {
-          "description": "String value where integer expected in Gradle DSL [precision: project-structure-aware] [capabilities: gradle]",
+          "description": "String value where integer expected in Gradle DSL [precision: project-structure-aware] [noisiness: normal] [capabilities: gradle]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -4179,7 +4179,7 @@
           }
         },
         "StringSpanInContentDescription": {
-          "description": "String with HTML used in contentDescription [precision: project-structure-aware] [capabilities: resources]",
+          "description": "String with HTML used in contentDescription [precision: project-structure-aware] [noisiness: normal] [capabilities: resources]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -4198,7 +4198,7 @@
           }
         },
         "StringTrailingWhitespace": {
-          "description": "String resource has trailing whitespace [precision: project-structure-aware] [capabilities: resources]",
+          "description": "String resource has trailing whitespace [precision: project-structure-aware] [noisiness: normal] [capabilities: resources]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -4217,7 +4217,7 @@
           }
         },
         "SupportAnnotationUsage": {
-          "description": "Incorrect support annotation usage [precision: ast-backed]",
+          "description": "Incorrect support annotation usage [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -4236,7 +4236,7 @@
           }
         },
         "Suspicious0dpResource": {
-          "description": "0dp dimension on wrong axis in LinearLayout [precision: project-structure-aware] [capabilities: resources]",
+          "description": "0dp dimension on wrong axis in LinearLayout [precision: project-structure-aware] [noisiness: normal] [capabilities: resources]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -4255,7 +4255,7 @@
           }
         },
         "SwitchIntDef": {
-          "description": "Missing @IntDef constants in switch [precision: ast-backed]",
+          "description": "Missing @IntDef constants in switch [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -4274,7 +4274,7 @@
           }
         },
         "SystemPermission": {
-          "description": "Requesting dangerous system permission [precision: project-structure-aware] [capabilities: manifest]",
+          "description": "Requesting dangerous system permission [precision: project-structure-aware] [noisiness: normal] [capabilities: manifest]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -4293,7 +4293,7 @@
           }
         },
         "TargetNewer": {
-          "description": "Target SDK version is too old [precision: project-structure-aware] [capabilities: manifest]",
+          "description": "Target SDK version is too old [precision: project-structure-aware] [noisiness: normal] [capabilities: manifest]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -4312,7 +4312,7 @@
           }
         },
         "TextFieldsResource": {
-          "description": "EditText missing inputType or hint [precision: project-structure-aware] [capabilities: resources]",
+          "description": "EditText missing inputType or hint [precision: project-structure-aware] [noisiness: normal] [capabilities: resources]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -4331,7 +4331,7 @@
           }
         },
         "TextViewEdits": {
-          "description": "Calling setText on an EditText [precision: ast-backed]",
+          "description": "Calling setText on an EditText [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -4350,7 +4350,7 @@
           }
         },
         "TooDeepLayoutResource": {
-          "description": "Layout nesting too deep [precision: project-structure-aware] [capabilities: resources]",
+          "description": "Layout nesting too deep [precision: project-structure-aware] [noisiness: normal] [capabilities: resources]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -4369,7 +4369,7 @@
           }
         },
         "TooManyViewsResource": {
-          "description": "Layout has too many views [precision: project-structure-aware] [capabilities: resources]",
+          "description": "Layout has too many views [precision: project-structure-aware] [noisiness: normal] [capabilities: resources]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -4388,7 +4388,7 @@
           }
         },
         "TrulyRandom": {
-          "description": "Hardcoded seed defeats SecureRandom [precision: heuristic/text-backed] [capabilities: line-pass]",
+          "description": "Hardcoded seed defeats SecureRandom [precision: heuristic/text-backed] [noisiness: noisy] [capabilities: line-pass]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -4407,7 +4407,7 @@
           }
         },
         "TrustedServer": {
-          "description": "Trusting all certificates [precision: ast-backed]",
+          "description": "Trusting all certificates [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -4426,7 +4426,7 @@
           }
         },
         "UniqueConstants": {
-          "description": "Overlapping enumeration constants [precision: ast-backed]",
+          "description": "Overlapping enumeration constants [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -4445,7 +4445,7 @@
           }
         },
         "UniquePermission": {
-          "description": "Custom permission collides with system permission [precision: project-structure-aware] [capabilities: manifest]",
+          "description": "Custom permission collides with system permission [precision: project-structure-aware] [noisiness: normal] [capabilities: manifest]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -4464,7 +4464,7 @@
           }
         },
         "UnknownIdInLayout": {
-          "description": "Reference to unknown @id in layout [precision: ast-backed]",
+          "description": "Reference to unknown @id in layout [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -4483,7 +4483,7 @@
           }
         },
         "UnpackedNativeCodeManifest": {
-          "description": "Missing extractNativeLibs=false with native libraries [precision: project-structure-aware] [capabilities: manifest]",
+          "description": "Missing extractNativeLibs=false with native libraries [precision: project-structure-aware] [noisiness: normal] [capabilities: manifest]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -4502,7 +4502,7 @@
           }
         },
         "UnprotectedSMSBroadcastReceiverManifest": {
-          "description": "SMS receiver without permission protection [precision: project-structure-aware] [capabilities: manifest]",
+          "description": "SMS receiver without permission protection [precision: project-structure-aware] [noisiness: normal] [capabilities: manifest]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -4521,7 +4521,7 @@
           }
         },
         "UnsafeProtectedBroadcastReceiverManifest": {
-          "description": "Exported receiver for protected broadcast without permission [precision: project-structure-aware] [capabilities: manifest]",
+          "description": "Exported receiver for protected broadcast without permission [precision: project-structure-aware] [noisiness: normal] [capabilities: manifest]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -4540,7 +4540,7 @@
           }
         },
         "UnsupportedChromeOsHardwareManifest": {
-          "description": "Hardware feature unsupported on Chrome OS not marked optional [precision: project-structure-aware] [capabilities: manifest]",
+          "description": "Hardware feature unsupported on Chrome OS not marked optional [precision: project-structure-aware] [noisiness: normal] [capabilities: manifest]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -4559,7 +4559,7 @@
           }
         },
         "UnusedAttributeResource": {
-          "description": "Attribute unused on older platforms [precision: project-structure-aware] [capabilities: resources]",
+          "description": "Attribute unused on older platforms [precision: project-structure-aware] [noisiness: normal] [capabilities: resources]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -4578,7 +4578,7 @@
           }
         },
         "UnusedNamespaceResource": {
-          "description": "Unused namespace [precision: project-structure-aware] [capabilities: resources]",
+          "description": "Unused namespace [precision: project-structure-aware] [noisiness: normal] [capabilities: resources]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -4597,7 +4597,7 @@
           }
         },
         "UnusedQuantityResource": {
-          "description": "Plural defines quantity unused for language [precision: project-structure-aware] [capabilities: resources]",
+          "description": "Plural defines quantity unused for language [precision: project-structure-aware] [noisiness: normal] [capabilities: resources]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -4616,7 +4616,7 @@
           }
         },
         "UnusedResources": {
-          "description": "Unused resources [precision: ast-backed]",
+          "description": "Unused resources [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -4635,7 +4635,7 @@
           }
         },
         "UseAlpha2": {
-          "description": "3-letter ISO code in locale folder [precision: heuristic/text-backed] [capabilities: line-pass]",
+          "description": "3-letter ISO code in locale folder [precision: heuristic/text-backed] [noisiness: noisy] [capabilities: line-pass]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -4654,7 +4654,7 @@
           }
         },
         "UseCheckPermissionManifest": {
-          "description": "Exported service with sensitive action but no permission [precision: project-structure-aware] [capabilities: manifest]",
+          "description": "Exported service with sensitive action but no permission [precision: project-structure-aware] [noisiness: normal] [capabilities: manifest]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -4673,7 +4673,7 @@
           }
         },
         "UseCompoundDrawablesResource": {
-          "description": "Node can be replaced by a TextView with compound drawables [precision: project-structure-aware] [capabilities: resources]",
+          "description": "Node can be replaced by a TextView with compound drawables [precision: project-structure-aware] [noisiness: normal] [capabilities: resources]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -4692,7 +4692,7 @@
           }
         },
         "UseSparseArrays": {
-          "description": "HashMap can be replaced with SparseArray [precision: ast-backed]",
+          "description": "HashMap can be replaced with SparseArray [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -4711,7 +4711,7 @@
           }
         },
         "UseValueOf": {
-          "description": "Should use valueOf instead of constructor [fixable: idiomatic] [precision: ast-backed]",
+          "description": "Should use valueOf instead of constructor [fixable: idiomatic] [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -4730,7 +4730,7 @@
           }
         },
         "UselessLeafResource": {
-          "description": "Empty ViewGroup with no background or id [precision: project-structure-aware] [capabilities: resources]",
+          "description": "Empty ViewGroup with no background or id [precision: project-structure-aware] [noisiness: normal] [capabilities: resources]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -4749,7 +4749,7 @@
           }
         },
         "UselessParentResource": {
-          "description": "Useless parent layout with single child [precision: project-structure-aware] [capabilities: resources]",
+          "description": "Useless parent layout with single child [precision: project-structure-aware] [noisiness: normal] [capabilities: resources]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -4768,7 +4768,7 @@
           }
         },
         "UsesSdkManifest": {
-          "description": "Missing \u003cuses-sdk\u003e element in manifest [precision: project-structure-aware] [capabilities: manifest]",
+          "description": "Missing \u003cuses-sdk\u003e element in manifest [precision: project-structure-aware] [noisiness: normal] [capabilities: manifest]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -4787,7 +4787,7 @@
           }
         },
         "ViewConstructor": {
-          "description": "Missing View constructors [precision: ast-backed]",
+          "description": "Missing View constructors [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -4806,7 +4806,7 @@
           }
         },
         "ViewHolder": {
-          "description": "View holder candidates [precision: type-aware] [capabilities: resolver]",
+          "description": "View holder candidates [precision: type-aware] [noisiness: normal] [capabilities: resolver]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -4825,7 +4825,7 @@
           }
         },
         "ViewTag": {
-          "description": "Tagged object may leak [precision: heuristic/text-backed] [capabilities: oracle:call-targets, oracle:supertypes, resolver]",
+          "description": "Tagged object may leak [precision: heuristic/text-backed] [noisiness: noisy] [capabilities: oracle:call-targets, oracle:supertypes, resolver]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -4844,7 +4844,7 @@
           }
         },
         "Wakelock": {
-          "description": "Incorrect WakeLock usage [precision: heuristic/text-backed] [capabilities: oracle:call-targets, resolver]",
+          "description": "Incorrect WakeLock usage [precision: heuristic/text-backed] [noisiness: noisy] [capabilities: oracle:call-targets, resolver]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -4863,7 +4863,7 @@
           }
         },
         "WebViewAllowContentAccess": {
-          "description": "WebSettings.allowContentAccess explicitly enabled [precision: ast-backed]",
+          "description": "WebSettings.allowContentAccess explicitly enabled [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -4882,7 +4882,7 @@
           }
         },
         "WebViewAllowFileAccess": {
-          "description": "WebSettings.allowFileAccess explicitly enabled [precision: ast-backed]",
+          "description": "WebSettings.allowFileAccess explicitly enabled [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -4901,7 +4901,7 @@
           }
         },
         "WebViewDebuggingEnabled": {
-          "description": "WebView remote debugging explicitly enabled [precision: ast-backed]",
+          "description": "WebView remote debugging explicitly enabled [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -4920,7 +4920,7 @@
           }
         },
         "WebViewFileAccessFromFileUrls": {
-          "description": "WebSettings.allowFileAccessFromFileURLs explicitly enabled [precision: ast-backed]",
+          "description": "WebSettings.allowFileAccessFromFileURLs explicitly enabled [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -4939,7 +4939,7 @@
           }
         },
         "WebViewInScrollViewResource": {
-          "description": "WebView inside ScrollView [precision: project-structure-aware] [capabilities: resources]",
+          "description": "WebView inside ScrollView [precision: project-structure-aware] [noisiness: normal] [capabilities: resources]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -4958,7 +4958,7 @@
           }
         },
         "WebViewMixedContentAllowAll": {
-          "description": "WebSettings.mixedContentMode set to MIXED_CONTENT_ALWAYS_ALLOW [precision: ast-backed]",
+          "description": "WebSettings.mixedContentMode set to MIXED_CONTENT_ALWAYS_ALLOW [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -4977,7 +4977,7 @@
           }
         },
         "WebViewUniversalAccessFromFileUrls": {
-          "description": "WebSettings.allowUniversalAccessFromFileURLs explicitly enabled [precision: ast-backed]",
+          "description": "WebSettings.allowUniversalAccessFromFileURLs explicitly enabled [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -4996,7 +4996,7 @@
           }
         },
         "WorldReadableFiles": {
-          "description": "Using MODE_WORLD_READABLE [precision: ast-backed]",
+          "description": "Using MODE_WORLD_READABLE [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -5015,7 +5015,7 @@
           }
         },
         "WorldWriteableFiles": {
-          "description": "Using MODE_WORLD_WRITEABLE [precision: ast-backed]",
+          "description": "Using MODE_WORLD_WRITEABLE [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -5034,7 +5034,7 @@
           }
         },
         "WrongCall": {
-          "description": "Using wrong draw/layout method [precision: ast-backed]",
+          "description": "Using wrong draw/layout method [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -5053,7 +5053,7 @@
           }
         },
         "WrongCaseResource": {
-          "description": "Wrong case in view tag [precision: project-structure-aware] [capabilities: resources]",
+          "description": "Wrong case in view tag [precision: project-structure-aware] [noisiness: normal] [capabilities: resources]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -5072,7 +5072,7 @@
           }
         },
         "WrongConstant": {
-          "description": "Wrong constant passed to API [precision: type-aware] [capabilities: oracle:call-targets, resolver]",
+          "description": "Wrong constant passed to API [precision: type-aware] [noisiness: normal] [capabilities: oracle:call-targets, resolver]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -5091,7 +5091,7 @@
           }
         },
         "WrongFolderResource": {
-          "description": "Resource file in the wrong res folder [precision: project-structure-aware] [capabilities: resources]",
+          "description": "Resource file in the wrong res folder [precision: project-structure-aware] [noisiness: normal] [capabilities: resources]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -5110,7 +5110,7 @@
           }
         },
         "WrongImport": {
-          "description": "Importing android.R instead of app R [fixable: idiomatic] [precision: ast-backed]",
+          "description": "Importing android.R instead of app R [fixable: idiomatic] [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -5129,7 +5129,7 @@
           }
         },
         "WrongManifestParentManifest": {
-          "description": "Element declared under wrong parent in manifest [precision: project-structure-aware] [capabilities: manifest]",
+          "description": "Element declared under wrong parent in manifest [precision: project-structure-aware] [noisiness: normal] [capabilities: manifest]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -5148,7 +5148,7 @@
           }
         },
         "WrongRegionResource": {
-          "description": "Suspicious Language/Region Combination [precision: project-structure-aware] [capabilities: resources]",
+          "description": "Suspicious Language/Region Combination [precision: project-structure-aware] [noisiness: normal] [capabilities: resources]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -5167,7 +5167,7 @@
           }
         },
         "WrongThread": {
-          "description": "Wrong thread [precision: ast-backed]",
+          "description": "Wrong thread [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -5186,7 +5186,7 @@
           }
         },
         "WrongViewCast": {
-          "description": "Mismatched view type [precision: type-aware] [capabilities: oracle:call-targets, oracle:supertypes, resolver]",
+          "description": "Mismatched view type [precision: type-aware] [noisiness: normal] [capabilities: oracle:call-targets, oracle:supertypes, resolver]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -5217,7 +5217,7 @@
       "additionalProperties": false,
       "properties": {
         "FanInFanOutHotspot": {
-          "description": "Detects class-like declarations with unusually high fan-in across the project. [precision: project-structure-aware] [capabilities: cross-file]",
+          "description": "Detects class-like declarations with unusually high fan-in across the project. [precision: project-structure-aware] [noisiness: normal] [capabilities: cross-file]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -5250,7 +5250,7 @@
           }
         },
         "GodClassOrModule": {
-          "description": "Detects source files that import from an unusually broad set of packages, suggesting too many responsibilities. [precision: heuristic/text-backed] [capabilities: line-pass]",
+          "description": "Detects source files that import from an unusually broad set of packages, suggesting too many responsibilities. [precision: heuristic/text-backed] [noisiness: noisy] [capabilities: line-pass]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -5269,7 +5269,7 @@
           }
         },
         "LayerDependencyViolation": {
-          "description": "Flags Gradle module dependencies that cross architectural layer boundaries not permitted by the configured layer matrix. [precision: project-structure-aware] [capabilities: module-index]",
+          "description": "Flags Gradle module dependencies that cross architectural layer boundaries not permitted by the configured layer matrix. [precision: project-structure-aware] [noisiness: normal] [capabilities: module-index]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -5288,7 +5288,7 @@
           }
         },
         "ModuleDependencyCycle": {
-          "description": "Detects cycles in the Gradle module dependency graph (e.g. :a → :b → :c → :a). [precision: project-structure-aware] [capabilities: module-index]",
+          "description": "Detects cycles in the Gradle module dependency graph (e.g. :a → :b → :c → :a). [precision: project-structure-aware] [noisiness: normal] [capabilities: module-index]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -5307,7 +5307,7 @@
           }
         },
         "PackageDependencyCycle": {
-          "description": "Detects cycles in the package-level import graph within a single Gradle module. [precision: project-structure-aware] [capabilities: module-index]",
+          "description": "Detects cycles in the package-level import graph within a single Gradle module. [precision: project-structure-aware] [noisiness: normal] [capabilities: module-index]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -5326,7 +5326,7 @@
           }
         },
         "PackageNamingConventionDrift": {
-          "description": "Detects Kotlin source files whose package declaration does not match the directory path under src/main/kotlin. [precision: ast-backed]",
+          "description": "Detects Kotlin source files whose package declaration does not match the directory path under src/main/kotlin. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -5345,7 +5345,7 @@
           }
         },
         "PublicToInternalLeakyAbstraction": {
-          "description": "Flags public classes that are thin wrappers delegating to a single private or internal field, which leak internal abstractions through a nominally public API. [precision: heuristic/text-backed] [capabilities: line-pass]",
+          "description": "Flags public classes that are thin wrappers delegating to a single private or internal field, which leak internal abstractions through a nominally public API. [precision: heuristic/text-backed] [noisiness: noisy] [capabilities: line-pass]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -5380,7 +5380,7 @@
       "additionalProperties": false,
       "properties": {
         "AbsentOrWrongFileLicense": {
-          "description": "Detects files that are missing a valid license header comment. [fixable: cosmetic] [precision: heuristic/text-backed] [capabilities: line-pass]",
+          "description": "Detects files that are missing a valid license header comment. [fixable: cosmetic] [precision: heuristic/text-backed] [noisiness: noisy] [capabilities: line-pass]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -5409,7 +5409,7 @@
           }
         },
         "DeprecatedBlockTag": {
-          "description": "Detects @deprecated KDoc tags that should use the @Deprecated annotation instead. [fixable: idiomatic] [precision: ast-backed]",
+          "description": "Detects @deprecated KDoc tags that should use the @Deprecated annotation instead. [fixable: idiomatic] [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -5428,7 +5428,7 @@
           }
         },
         "DocumentationOverPrivateFunction": {
-          "description": "Detects KDoc documentation on private functions where it is unnecessary. [fixable: idiomatic] [precision: ast-backed]",
+          "description": "Detects KDoc documentation on private functions where it is unnecessary. [fixable: idiomatic] [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -5447,7 +5447,7 @@
           }
         },
         "DocumentationOverPrivateProperty": {
-          "description": "Detects KDoc documentation on private properties where it is unnecessary. [fixable: idiomatic] [precision: ast-backed]",
+          "description": "Detects KDoc documentation on private properties where it is unnecessary. [fixable: idiomatic] [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -5466,7 +5466,7 @@
           }
         },
         "EndOfSentenceFormat": {
-          "description": "Detects KDoc first sentences that do not end with proper punctuation. [fixable: cosmetic] [precision: ast-backed]",
+          "description": "Detects KDoc first sentences that do not end with proper punctuation. [fixable: cosmetic] [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -5491,7 +5491,7 @@
           }
         },
         "KDocReferencesNonPublicProperty": {
-          "description": "Detects KDoc bracket references that point to non-public properties. [precision: ast-backed]",
+          "description": "Detects KDoc bracket references that point to non-public properties. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -5510,7 +5510,7 @@
           }
         },
         "KdocLinkValidation": {
-          "description": "Detects KDoc bracket links that do not resolve to source symbols. [precision: project-structure-aware] [capabilities: cross-file, parsed-files]",
+          "description": "Detects KDoc bracket links that do not resolve to source symbols. [precision: project-structure-aware] [noisiness: normal] [capabilities: cross-file, parsed-files]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -5529,7 +5529,7 @@
           }
         },
         "OutdatedDocumentation": {
-          "description": "Detects @param tags in KDoc that do not match the actual function parameters. [fixable: cosmetic] [precision: ast-backed]",
+          "description": "Detects @param tags in KDoc that do not match the actual function parameters. [fixable: cosmetic] [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -5558,7 +5558,7 @@
           }
         },
         "SampleAnnotationFreshness": {
-          "description": "Detects KDoc @sample tags whose fully-qualified target function is not present in analysed sources. [precision: project-structure-aware] [capabilities: cross-file, parsed-files]",
+          "description": "Detects KDoc @sample tags whose fully-qualified target function is not present in analysed sources. [precision: project-structure-aware] [noisiness: normal] [capabilities: cross-file, parsed-files]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -5577,7 +5577,7 @@
           }
         },
         "UndocumentedPublicClass": {
-          "description": "Detects public classes that are missing KDoc documentation. [precision: ast-backed]",
+          "description": "Detects public classes that are missing KDoc documentation. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -5616,7 +5616,7 @@
           }
         },
         "UndocumentedPublicFunction": {
-          "description": "Detects public functions that are missing KDoc documentation. [precision: ast-backed]",
+          "description": "Detects public functions that are missing KDoc documentation. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -5635,7 +5635,7 @@
           }
         },
         "UndocumentedPublicProperty": {
-          "description": "Detects public properties that are missing KDoc documentation. [precision: ast-backed]",
+          "description": "Detects public properties that are missing KDoc documentation. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -5666,7 +5666,7 @@
       "additionalProperties": false,
       "properties": {
         "CognitiveComplexMethod": {
-          "description": "Detects functions whose cognitive complexity exceeds a configurable threshold, weighting nesting depth. [precision: ast-backed]",
+          "description": "Detects functions whose cognitive complexity exceeds a configurable threshold, weighting nesting depth. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -5694,7 +5694,7 @@
           }
         },
         "ComplexCondition": {
-          "description": "Detects conditions with too many mixed logical operators. [precision: ast-backed]",
+          "description": "Detects conditions with too many mixed logical operators. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -5722,7 +5722,7 @@
           }
         },
         "ComplexInterface": {
-          "description": "Detects interfaces with too many member declarations. [precision: ast-backed]",
+          "description": "Detects interfaces with too many member declarations. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -5760,7 +5760,7 @@
           }
         },
         "CyclomaticComplexMethod": {
-          "description": "Counts independent paths through a function (branches, loops, catches). High cyclomatic complexity predicts defect density and makes code harder to test exhaustively. [precision: ast-backed]",
+          "description": "Counts independent paths through a function (branches, loops, catches). High cyclomatic complexity predicts defect density and makes code harder to test exhaustively. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -5815,7 +5815,7 @@
           }
         },
         "LabeledExpression": {
-          "description": "Detects labeled expressions such as return@label, break@label, and continue@label. [precision: ast-backed]",
+          "description": "Detects labeled expressions such as return@label, break@label, and continue@label. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -5841,7 +5841,7 @@
           }
         },
         "LargeClass": {
-          "description": "Detects classes that exceed a configurable line count threshold. [precision: ast-backed]",
+          "description": "Detects classes that exceed a configurable line count threshold. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -5869,7 +5869,7 @@
           }
         },
         "LongMethod": {
-          "description": "Flags functions that exceed the configured line limit. Long functions are harder to test and understand — consider extracting logical sub-steps into named helpers. [precision: heuristic/text-backed]",
+          "description": "Flags functions that exceed the configured line limit. Long functions are harder to test and understand — consider extracting logical sub-steps into named helpers. [precision: heuristic/text-backed] [noisiness: noisy]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -5897,7 +5897,7 @@
           }
         },
         "LongParameterList": {
-          "description": "Detects functions or constructors with too many parameters. [precision: ast-backed]",
+          "description": "Detects functions or constructors with too many parameters. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -5947,7 +5947,7 @@
           }
         },
         "MethodOverloading": {
-          "description": "Detects methods with too many overloads of the same name in a scope. [precision: ast-backed]",
+          "description": "Detects methods with too many overloads of the same name in a scope. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -5975,7 +5975,7 @@
           }
         },
         "NamedArguments": {
-          "description": "Detects function calls with too many unnamed positional arguments. [precision: ast-backed]",
+          "description": "Detects function calls with too many unnamed positional arguments. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -6003,7 +6003,7 @@
           }
         },
         "NestedBlockDepth": {
-          "description": "Detects functions with excessive nesting depth of control flow blocks. [precision: ast-backed]",
+          "description": "Detects functions with excessive nesting depth of control flow blocks. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -6031,7 +6031,7 @@
           }
         },
         "NestedScopeFunctions": {
-          "description": "Detects excessively nested Kotlin scope functions like apply, also, let, run, and with. [precision: ast-backed]",
+          "description": "Detects excessively nested Kotlin scope functions like apply, also, let, run, and with. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -6066,7 +6066,7 @@
           }
         },
         "ReplaceSafeCallChainWithRun": {
-          "description": "Detects chains of three or more safe calls (?.) that could be simplified with ?.run { }. [precision: ast-backed]",
+          "description": "Detects chains of three or more safe calls (?.) that could be simplified with ?.run { }. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -6085,7 +6085,7 @@
           }
         },
         "StringLiteralDuplication": {
-          "description": "Detects string literals that appear more than a configurable number of times in a file. [precision: ast-backed]",
+          "description": "Detects string literals that appear more than a configurable number of times in a file. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -6128,7 +6128,7 @@
           }
         },
         "TooManyFunctions": {
-          "description": "Detects files or classes that declare too many functions. [precision: ast-backed]",
+          "description": "Detects files or classes that declare too many functions. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -6208,7 +6208,7 @@
       "additionalProperties": false,
       "properties": {
         "ComposeColumnRowInScrollable": {
-          "description": "Detects nested same-axis scroll containers such as Column with verticalScroll containing LazyColumn. [precision: ast-backed]",
+          "description": "Detects nested same-axis scroll containers such as Column with verticalScroll containing LazyColumn. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -6227,7 +6227,7 @@
           }
         },
         "ComposeDerivedStateMisuse": {
-          "description": "Detects unnecessary derivedStateOf wrapping a direct boolean comparison of Compose state reads. [precision: ast-backed]",
+          "description": "Detects unnecessary derivedStateOf wrapping a direct boolean comparison of Compose state reads. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -6246,7 +6246,7 @@
           }
         },
         "ComposeDisposableEffectMissingDispose": {
-          "description": "Detects DisposableEffect blocks whose body does not end with onDispose, causing resource leaks. [precision: ast-backed]",
+          "description": "Detects DisposableEffect blocks whose body does not end with onDispose, causing resource leaks. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -6265,7 +6265,7 @@
           }
         },
         "ComposeLambdaCapturesUnstableState": {
-          "description": "Detects inline onClick lambdas in lazy item builders that capture the current item without hoisting through remember. [precision: ast-backed]",
+          "description": "Detects inline onClick lambdas in lazy item builders that capture the current item without hoisting through remember. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -6284,7 +6284,7 @@
           }
         },
         "ComposeLaunchedEffectWithoutKeys": {
-          "description": "Detects LaunchedEffect blocks keyed only on constants whose body reads enclosing parameters that change. [precision: ast-backed]",
+          "description": "Detects LaunchedEffect blocks keyed only on constants whose body reads enclosing parameters that change. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -6303,7 +6303,7 @@
           }
         },
         "ComposeModifierBackgroundAfterClip": {
-          "description": "Detects Modifier chains where background() is applied before clip(), painting outside the clip shape. [precision: ast-backed]",
+          "description": "Detects Modifier chains where background() is applied before clip(), painting outside the clip shape. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -6322,7 +6322,7 @@
           }
         },
         "ComposeModifierClickableBeforePadding": {
-          "description": "Detects Modifier chains where clickable is applied before padding, excluding the padding region from the click area. [precision: ast-backed]",
+          "description": "Detects Modifier chains where clickable is applied before padding, excluding the padding region from the click area. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -6341,7 +6341,7 @@
           }
         },
         "ComposeModifierFillAfterSize": {
-          "description": "Detects Modifier chains where fillMaxWidth/Height/Size follows size(), overriding the explicit size. [precision: ast-backed]",
+          "description": "Detects Modifier chains where fillMaxWidth/Height/Size follows size(), overriding the explicit size. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -6360,7 +6360,7 @@
           }
         },
         "ComposeModifierPassedThenChained": {
-          "description": "Detects @Composable functions that declare a modifier parameter but never use it, starting fresh Modifier chains instead. [precision: ast-backed]",
+          "description": "Detects @Composable functions that declare a modifier parameter but never use it, starting fresh Modifier chains instead. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -6379,7 +6379,7 @@
           }
         },
         "ComposeMutableDefaultArgument": {
-          "description": "Detects @Composable parameters with mutable collection defaults that re-evaluate on each recomposition. [precision: ast-backed]",
+          "description": "Detects @Composable parameters with mutable collection defaults that re-evaluate on each recomposition. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -6398,7 +6398,7 @@
           }
         },
         "ComposeMutableStateInComposition": {
-          "description": "Detects mutableStateOf() used as a plain local without remember, causing state loss on every recomposition. [precision: ast-backed]",
+          "description": "Detects mutableStateOf() used as a plain local without remember, causing state loss on every recomposition. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -6417,7 +6417,7 @@
           }
         },
         "ComposePreviewAnnotationMissing": {
-          "description": "Detects @Composable functions whose name ends in Preview but lack the @Preview annotation. [precision: ast-backed]",
+          "description": "Detects @Composable functions whose name ends in Preview but lack the @Preview annotation. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -6436,7 +6436,7 @@
           }
         },
         "ComposePreviewWithBackingState": {
-          "description": "Detects @Preview functions that call runtime state holders like hiltViewModel() or collectAsState() which fail in the preview renderer. [precision: ast-backed]",
+          "description": "Detects @Preview functions that call runtime state holders like hiltViewModel() or collectAsState() which fail in the preview renderer. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -6455,7 +6455,7 @@
           }
         },
         "ComposeRememberSaveableNonParcelable": {
-          "description": "Detects rememberSaveable blocks constructing non-primitive types without an explicit saver argument. [precision: ast-backed]",
+          "description": "Detects rememberSaveable blocks constructing non-primitive types without an explicit saver argument. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -6474,7 +6474,7 @@
           }
         },
         "ComposeRememberWithoutKey": {
-          "description": "Detects remember blocks that reference enclosing parameters but have no keys, causing stale cached values. [precision: ast-backed]",
+          "description": "Detects remember blocks that reference enclosing parameters but have no keys, causing stale cached values. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -6493,7 +6493,7 @@
           }
         },
         "ComposeSideEffectInComposition": {
-          "description": "Detects direct assignments inside @Composable function bodies that are not wrapped in a recognized effect scope. [precision: ast-backed]",
+          "description": "Detects direct assignments inside @Composable function bodies that are not wrapped in a recognized effect scope. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -6524,7 +6524,7 @@
           }
         },
         "ComposeStatefulDefaultParameter": {
-          "description": "Detects @Composable parameters with constructor-call defaults that allocate fresh instances every recomposition. [precision: ast-backed]",
+          "description": "Detects @Composable parameters with constructor-call defaults that allocate fresh instances every recomposition. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -6543,7 +6543,7 @@
           }
         },
         "ComposeStringResourceInsideLambda": {
-          "description": "Detects stringResource() calls inside callback lambdas where the composition-only API will crash at runtime. [precision: ast-backed]",
+          "description": "Detects stringResource() calls inside callback lambdas where the composition-only API will crash at runtime. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -6562,7 +6562,7 @@
           }
         },
         "ComposeUnstableParameter": {
-          "description": "Detects @Composable function parameters using mutable collection types that prevent recomposition skipping. [precision: ast-backed]",
+          "description": "Detects @Composable function parameters using mutable collection types that prevent recomposition skipping. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -6608,7 +6608,7 @@
       "additionalProperties": false,
       "properties": {
         "ChannelReceiveWithoutClose": {
-          "description": "Detects Channel properties in a class that are never closed, leaking the receiver coroutine. [precision: ast-backed]",
+          "description": "Detects Channel properties in a class that are never closed, leaking the receiver coroutine. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -6627,7 +6627,7 @@
           }
         },
         "CollectInOnCreateWithoutLifecycle": {
-          "description": "Detects Flow.collect calls in lifecycle callbacks that are not wrapped by repeatOnLifecycle. [precision: ast-backed]",
+          "description": "Detects Flow.collect calls in lifecycle callbacks that are not wrapped by repeatOnLifecycle. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -6646,7 +6646,7 @@
           }
         },
         "CollectionsSynchronizedListIteration": {
-          "description": "Detects iteration over Collections.synchronized* wrappers without external synchronization. [precision: ast-backed]",
+          "description": "Detects iteration over Collections.synchronized* wrappers without external synchronization. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -6665,7 +6665,7 @@
           }
         },
         "ConcurrentModificationIteration": {
-          "description": "Detects collection mutation inside for loops that causes ConcurrentModificationException. [precision: ast-backed]",
+          "description": "Detects collection mutation inside for loops that causes ConcurrentModificationException. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -6684,7 +6684,7 @@
           }
         },
         "CoroutineLaunchedInTestWithoutRunTest": {
-          "description": "Detects launch/async calls in @Test functions that are not wrapped in runTest. [precision: ast-backed]",
+          "description": "Detects launch/async calls in @Test functions that are not wrapped in runTest. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -6703,7 +6703,7 @@
           }
         },
         "CoroutineScopeCreatedButNeverCancelled": {
-          "description": "Detects CoroutineScope properties in a class that are never cancelled, leaking coroutines. [precision: ast-backed]",
+          "description": "Detects CoroutineScope properties in a class that are never cancelled, leaking coroutines. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -6722,7 +6722,7 @@
           }
         },
         "DeferredAwaitInFinally": {
-          "description": "Detects Deferred.await() calls inside finally blocks that can throw and mask the original exception. [precision: ast-backed]",
+          "description": "Detects Deferred.await() calls inside finally blocks that can throw and mask the original exception. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -6741,7 +6741,7 @@
           }
         },
         "FlowWithoutFlowOn": {
-          "description": "Detects flow chains with a terminal operator but no flowOn, risking execution on the wrong dispatcher. [precision: ast-backed]",
+          "description": "Detects flow chains with a terminal operator but no flowOn, risking execution on the wrong dispatcher. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -6760,7 +6760,7 @@
           }
         },
         "GlobalCoroutineUsage": {
-          "description": "Flags use of GlobalScope for launching coroutines. Coroutines in GlobalScope are not tied to any lifecycle and can leak if not cancelled. Prefer a structured CoroutineScope. [fixable: idiomatic] [precision: ast-backed]",
+          "description": "Flags use of GlobalScope for launching coroutines. Coroutines in GlobalScope are not tied to any lifecycle and can leak if not cancelled. Prefer a structured CoroutineScope. [fixable: idiomatic] [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -6779,7 +6779,7 @@
           }
         },
         "GlobalScopeLaunchInViewModel": {
-          "description": "Detects GlobalScope.launch/async inside ViewModel or Presenter classes instead of viewModelScope. [precision: ast-backed]",
+          "description": "Detects GlobalScope.launch/async inside ViewModel or Presenter classes instead of viewModelScope. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -6798,7 +6798,7 @@
           }
         },
         "InjectDispatcher": {
-          "description": "Detects hardcoded Dispatchers.IO/Default/Unconfined passed as arguments instead of injected dispatchers. [precision: ast-backed]",
+          "description": "Detects hardcoded Dispatchers.IO/Default/Unconfined passed as arguments instead of injected dispatchers. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -6830,7 +6830,7 @@
           }
         },
         "LaunchWithoutCoroutineExceptionHandler": {
-          "description": "Detects launch blocks containing throw statements but no CoroutineExceptionHandler to catch uncaught exceptions. [precision: ast-backed]",
+          "description": "Detects launch blocks containing throw statements but no CoroutineExceptionHandler to catch uncaught exceptions. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -6849,7 +6849,7 @@
           }
         },
         "MainDispatcherInLibraryCode": {
-          "description": "Detects Dispatchers.Main usage in library modules that lack the kotlinx-coroutines-android dependency. [precision: project-structure-aware] [capabilities: module-index, oracle:call-targets, resolver]",
+          "description": "Detects Dispatchers.Main usage in library modules that lack the kotlinx-coroutines-android dependency. [precision: project-structure-aware] [noisiness: normal] [capabilities: module-index, oracle:call-targets, resolver]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -6868,7 +6868,7 @@
           }
         },
         "MutableStateInObject": {
-          "description": "Detects mutable var properties inside object declarations that are shared mutable state without synchronization. [precision: ast-backed]",
+          "description": "Detects mutable var properties inside object declarations that are shared mutable state without synchronization. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -6887,7 +6887,7 @@
           }
         },
         "RedundantSuspendModifier": {
-          "description": "Detects suspend functions that contain no suspend calls in their body. [fixable: idiomatic] [precision: type-aware] [capabilities: oracle:call-targets, oracle:suspend-markers, resolver]",
+          "description": "Detects suspend functions that contain no suspend calls in their body. [fixable: idiomatic] [precision: type-aware] [noisiness: normal] [capabilities: oracle:call-targets, oracle:suspend-markers, resolver]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -6906,7 +6906,7 @@
           }
         },
         "SharedFlowWithoutReplay": {
-          "description": "Detects MutableSharedFlow() created with default configuration that has no replay or buffer capacity. [precision: ast-backed]",
+          "description": "Detects MutableSharedFlow() created with default configuration that has no replay or buffer capacity. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -6925,7 +6925,7 @@
           }
         },
         "SleepInsteadOfDelay": {
-          "description": "Detects Thread.sleep() usage inside suspend functions or coroutine builder lambdas instead of delay(). [fixable: idiomatic] [precision: ast-backed]",
+          "description": "Detects Thread.sleep() usage inside suspend functions or coroutine builder lambdas instead of delay(). [fixable: idiomatic] [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -6944,7 +6944,7 @@
           }
         },
         "StateFlowCompareByReference": {
-          "description": "Detects redundant .distinctUntilChanged() after .map{} on StateFlow, which already deduplicates by equality. [precision: ast-backed]",
+          "description": "Detects redundant .distinctUntilChanged() after .map{} on StateFlow, which already deduplicates by equality. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -6963,7 +6963,7 @@
           }
         },
         "StateFlowMutableLeak": {
-          "description": "Detects publicly exposed MutableStateFlow properties that should be private with a read-only StateFlow accessor. [precision: ast-backed]",
+          "description": "Detects publicly exposed MutableStateFlow properties that should be private with a read-only StateFlow accessor. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -6982,7 +6982,7 @@
           }
         },
         "SupervisorScopeInEventHandler": {
-          "description": "Detects supervisorScope with a single child operation where supervisor semantics provide no benefit. [precision: ast-backed]",
+          "description": "Detects supervisorScope with a single child operation where supervisor semantics provide no benefit. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -7001,7 +7001,7 @@
           }
         },
         "SuspendFunInFinallySection": {
-          "description": "Detects suspend function calls inside finally blocks that may not execute if the coroutine is cancelled. [precision: ast-backed]",
+          "description": "Detects suspend function calls inside finally blocks that may not execute if the coroutine is cancelled. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -7020,7 +7020,7 @@
           }
         },
         "SuspendFunSwallowedCancellation": {
-          "description": "Detects catch blocks that catch CancellationException without rethrowing, breaking structured concurrency. [fixable: idiomatic] [precision: type-aware] [capabilities: oracle:call-targets, oracle:suspend-markers, resolver]",
+          "description": "Detects catch blocks that catch CancellationException without rethrowing, breaking structured concurrency. [fixable: idiomatic] [precision: type-aware] [noisiness: normal] [capabilities: oracle:call-targets, oracle:suspend-markers, resolver]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -7039,7 +7039,7 @@
           }
         },
         "SuspendFunWithCoroutineScopeReceiver": {
-          "description": "Detects functions that are both suspend and extension on CoroutineScope, which should be one or the other. [fixable: idiomatic] [precision: ast-backed]",
+          "description": "Detects functions that are both suspend and extension on CoroutineScope, which should be one or the other. [fixable: idiomatic] [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -7058,7 +7058,7 @@
           }
         },
         "SuspendFunWithFlowReturnType": {
-          "description": "Detects suspend functions that return a Flow type, since Flow builders are cold and do not require suspend. [fixable: idiomatic] [precision: ast-backed]",
+          "description": "Detects suspend functions that return a Flow type, since Flow builders are cold and do not require suspend. [fixable: idiomatic] [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -7077,7 +7077,7 @@
           }
         },
         "SynchronizedOnBoxedPrimitive": {
-          "description": "Detects synchronized() blocks using a boxed primitive value as the lock monitor. [precision: ast-backed]",
+          "description": "Detects synchronized() blocks using a boxed primitive value as the lock monitor. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -7096,7 +7096,7 @@
           }
         },
         "SynchronizedOnNonFinal": {
-          "description": "Detects synchronized() blocks using a var property as the lock, which can change the monitor object. [precision: ast-backed]",
+          "description": "Detects synchronized() blocks using a var property as the lock, which can change the monitor object. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -7115,7 +7115,7 @@
           }
         },
         "SynchronizedOnString": {
-          "description": "Detects synchronized() blocks using a string literal as the lock monitor. [precision: ast-backed]",
+          "description": "Detects synchronized() blocks using a string literal as the lock monitor. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -7134,7 +7134,7 @@
           }
         },
         "VolatileMissingOnDcl": {
-          "description": "Detects double-checked locking patterns on a var property without @Volatile annotation. [precision: ast-backed]",
+          "description": "Detects double-checked locking patterns on a var property without @Volatile annotation. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -7153,7 +7153,7 @@
           }
         },
         "WithContextInSuspendFunctionNoop": {
-          "description": "Detects nested withContext calls using the same dispatcher as the parent, which is redundant. [precision: type-aware] [capabilities: oracle:call-targets, resolver]",
+          "description": "Detects nested withContext calls using the same dispatcher as the parent, which is redundant. [precision: type-aware] [noisiness: normal] [capabilities: oracle:call-targets, resolver]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -7269,7 +7269,7 @@
       "additionalProperties": false,
       "properties": {
         "DaoNotInterface": {
-          "description": "Detects Room DAOs declared as abstract classes instead of interfaces. [precision: ast-backed]",
+          "description": "Detects Room DAOs declared as abstract classes instead of interfaces. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -7288,7 +7288,7 @@
           }
         },
         "DaoWithoutAnnotations": {
-          "description": "Detects Room DAO member functions missing required annotations like @Query, @Insert, @Update, or @Delete. [precision: ast-backed]",
+          "description": "Detects Room DAO member functions missing required annotations like @Query, @Insert, @Update, or @Delete. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -7307,7 +7307,7 @@
           }
         },
         "EntityMutableColumn": {
-          "description": "Detects Room @Entity class primary-constructor parameters declared as var, which prevents straightforward copy-on-write. [precision: ast-backed]",
+          "description": "Detects Room @Entity class primary-constructor parameters declared as var, which prevents straightforward copy-on-write. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -7326,7 +7326,7 @@
           }
         },
         "EntityPrimaryKeyNotStable": {
-          "description": "Detects @Entity @PrimaryKey declared as var without autoGenerate = true; mutable primary keys break equals/hashCode. [precision: ast-backed]",
+          "description": "Detects @Entity @PrimaryKey declared as var without autoGenerate = true; mutable primary keys break equals/hashCode. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -7345,7 +7345,7 @@
           }
         },
         "ForeignKeyWithoutOnDelete": {
-          "description": "Detects Room @ForeignKey(...) without an onDelete argument; the default NO_ACTION usually leaves stale rows. [precision: ast-backed]",
+          "description": "Detects Room @ForeignKey(...) without an onDelete argument; the default NO_ACTION usually leaves stale rows. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -7364,7 +7364,7 @@
           }
         },
         "JdbcPreparedStatementNotClosed": {
-          "description": "Detects JDBC prepared statements assigned to local properties without .use {} or .close() in the same scope. [precision: ast-backed]",
+          "description": "Detects JDBC prepared statements assigned to local properties without .use {} or .close() in the same scope. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -7383,7 +7383,7 @@
           }
         },
         "JdbcResultSetLeakedFromFunction": {
-          "description": "Detects functions whose declared return type is java.sql.ResultSet; callers almost always forget to close the ResultSet. [precision: ast-backed]",
+          "description": "Detects functions whose declared return type is java.sql.ResultSet; callers almost always forget to close the ResultSet. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -7402,7 +7402,7 @@
           }
         },
         "RoomConflictStrategyReplaceOnFk": {
-          "description": "Detects @Insert(onConflict = REPLACE) on a Room entity that declares foreign keys; REPLACE deletes and re-inserts, cascading FK deletes. [precision: project-structure-aware] [capabilities: cross-file]",
+          "description": "Detects @Insert(onConflict = REPLACE) on a Room entity that declares foreign keys; REPLACE deletes and re-inserts, cascading FK deletes. [precision: project-structure-aware] [noisiness: normal] [capabilities: cross-file]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -7421,7 +7421,7 @@
           }
         },
         "RoomDatabaseVersionNotBumped": {
-          "description": "Detects @Database whose version is unchanged while @Entity sources have changed since HEAD. CI-only: skipped unless KRIT_CI_MODE=1. [precision: project-structure-aware] [capabilities: parsed-files]",
+          "description": "Detects @Database whose version is unchanged while @Entity sources have changed since HEAD. CI-only: skipped unless KRIT_CI_MODE=1. [precision: project-structure-aware] [noisiness: normal] [capabilities: parsed-files]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -7440,7 +7440,7 @@
           }
         },
         "RoomEntityChangedMigrationMissing": {
-          "description": "Detects @Entity columns whose names do not appear in any Room Migration(M, N) declaration in the project. [precision: project-structure-aware] [capabilities: cross-file]",
+          "description": "Detects @Entity columns whose names do not appear in any Room Migration(M, N) declaration in the project. [precision: project-structure-aware] [noisiness: normal] [capabilities: cross-file]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -7459,7 +7459,7 @@
           }
         },
         "RoomExportSchemaDisabled": {
-          "description": "Detects Room @Database(exportSchema = false); disabling schema export loses migration history. [precision: ast-backed]",
+          "description": "Detects Room @Database(exportSchema = false); disabling schema export loses migration history. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -7478,7 +7478,7 @@
           }
         },
         "RoomFallbackToDestructiveMigration": {
-          "description": "Detects Room database builders calling fallbackToDestructiveMigration outside debug source sets; silent data loss on schema version bump. [precision: ast-backed]",
+          "description": "Detects Room database builders calling fallbackToDestructiveMigration outside debug source sets; silent data loss on schema version bump. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -7497,7 +7497,7 @@
           }
         },
         "RoomFlowQueryWithoutDistinct": {
-          "description": "Detects callers of Room @Query DAO functions returning Flow\u003c...\u003e that omit a chained .distinctUntilChanged(). [precision: project-structure-aware] [capabilities: parsed-files]",
+          "description": "Detects callers of Room @Query DAO functions returning Flow\u003c...\u003e that omit a chained .distinctUntilChanged(). [precision: project-structure-aware] [noisiness: normal] [capabilities: parsed-files]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -7516,7 +7516,7 @@
           }
         },
         "RoomMigrationUsesExecSqlWithInterpolation": {
-          "description": "Detects db.execSQL(...) calls inside a Room Migration that use Kotlin string interpolation in the SQL string. [precision: ast-backed]",
+          "description": "Detects db.execSQL(...) calls inside a Room Migration that use Kotlin string interpolation in the SQL string. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -7535,7 +7535,7 @@
           }
         },
         "RoomMultipleWritesMissingTransaction": {
-          "description": "Detects Room DAO functions that perform 2+ @Insert/@Update/@Delete calls without being annotated @Transaction. [precision: ast-backed]",
+          "description": "Detects Room DAO functions that perform 2+ @Insert/@Update/@Delete calls without being annotated @Transaction. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -7554,7 +7554,7 @@
           }
         },
         "RoomQueryMissingWhereForUpdate": {
-          "description": "Detects Room @Query(\"UPDATE ...\")/@Query(\"DELETE ...\") whose SQL text omits a WHERE clause. [precision: ast-backed]",
+          "description": "Detects Room @Query(\"UPDATE ...\")/@Query(\"DELETE ...\") whose SQL text omits a WHERE clause. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -7573,7 +7573,7 @@
           }
         },
         "RoomQueryWithLikeMissingEscape": {
-          "description": "Detects Room @Query SQL using LIKE with a bind parameter but no wildcard embedding or ESCAPE directive, suggesting an exact-match instead of a pattern search. [precision: ast-backed]",
+          "description": "Detects Room @Query SQL using LIKE with a bind parameter but no wildcard embedding or ESCAPE directive, suggesting an exact-match instead of a pattern search. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -7592,7 +7592,7 @@
           }
         },
         "RoomRelationWithoutIndex": {
-          "description": "Detects @Relation(entityColumn = ...) referencing a column that is not declared in the target @Entity's indices. [precision: project-structure-aware] [capabilities: cross-file]",
+          "description": "Detects @Relation(entityColumn = ...) referencing a column that is not declared in the target @Entity's indices. [precision: project-structure-aware] [noisiness: normal] [capabilities: cross-file]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -7611,7 +7611,7 @@
           }
         },
         "RoomSelectStarWithoutLimit": {
-          "description": "Detects Room @Query(\"SELECT * ...\") without a LIMIT clause on a non-Flow/non-PagingSource return type; risks unbounded loads. [precision: ast-backed]",
+          "description": "Detects Room @Query(\"SELECT * ...\") without a LIMIT clause on a non-Flow/non-PagingSource return type; risks unbounded loads. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -7630,7 +7630,7 @@
           }
         },
         "RoomSuspendQueryInTransaction": {
-          "description": "Detects suspend @Transaction DAO functions calling sibling suspend @Query methods; Room already wraps suspending queries and the double-wrap breaks cancellation. [precision: ast-backed]",
+          "description": "Detects suspend @Transaction DAO functions calling sibling suspend @Query methods; Room already wraps suspending queries and the double-wrap breaks cancellation. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -7649,7 +7649,7 @@
           }
         },
         "SqliteCursorWithoutClose": {
-          "description": "Detects SQLiteDatabase rawQuery/query cursors assigned to local properties without .use {} or .close() in the same scope. [precision: ast-backed]",
+          "description": "Detects SQLiteDatabase rawQuery/query cursors assigned to local properties without .use {} or .close() in the same scope. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -7680,7 +7680,7 @@
       "additionalProperties": false,
       "properties": {
         "DeadCode": {
-          "description": "Detects public or internal symbols that are never referenced from any other file. [precision: project-structure-aware] [capabilities: cross-file]",
+          "description": "Detects public or internal symbols that are never referenced from any other file. [precision: project-structure-aware] [noisiness: normal] [capabilities: cross-file]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -7699,7 +7699,7 @@
           }
         },
         "ModuleDeadCode": {
-          "description": "Detects dead code with module-boundary awareness, categorizing symbols as truly dead or could-be-internal. [precision: project-structure-aware] [capabilities: module-index]",
+          "description": "Detects dead code with module-boundary awareness, categorizing symbols as truly dead or could-be-internal. [precision: project-structure-aware] [noisiness: normal] [capabilities: module-index]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -7730,7 +7730,7 @@
       "additionalProperties": false,
       "properties": {
         "AnvilContributesBindingWithoutScope": {
-          "description": "Detects @ContributesBinding scope mismatches with the @ContributesTo scope on the bound interface. [precision: ast-backed]",
+          "description": "Detects @ContributesBinding scope mismatches with the @ContributesTo scope on the bound interface. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -7749,7 +7749,7 @@
           }
         },
         "AnvilMergeComponentEmptyScope": {
-          "description": "Detects @MergeComponent scopes with no matching @ContributesTo or @ContributesBinding declarations. [precision: project-structure-aware] [capabilities: cross-file]",
+          "description": "Detects @MergeComponent scopes with no matching @ContributesTo or @ContributesBinding declarations. [precision: project-structure-aware] [noisiness: normal] [capabilities: cross-file]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -7768,7 +7768,7 @@
           }
         },
         "BindsInsteadOfProvides": {
-          "description": "Detects @Provides functions that return their single parameter unchanged; @Binds is cheaper. [precision: ast-backed]",
+          "description": "Detects @Provides functions that return their single parameter unchanged; @Binds is cheaper. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -7787,7 +7787,7 @@
           }
         },
         "BindsMismatchedArity": {
-          "description": "Detects @Binds functions that do not declare exactly one parameter as required by Dagger. [precision: ast-backed]",
+          "description": "Detects @Binds functions that do not declare exactly one parameter as required by Dagger. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -7806,7 +7806,7 @@
           }
         },
         "BindsReturnTypeMatchesParam": {
-          "description": "Detects @Binds functions whose parameter type equals the return type; a no-op binding. [precision: ast-backed]",
+          "description": "Detects @Binds functions whose parameter type equals the return type; a no-op binding. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -7825,7 +7825,7 @@
           }
         },
         "ComponentMissingModule": {
-          "description": "Detects @Component(modules = [...]) declarations whose listed modules do not transitively cover every reachable binding. [precision: project-structure-aware] [capabilities: cross-file]",
+          "description": "Detects @Component(modules = [...]) declarations whose listed modules do not transitively cover every reachable binding. [precision: project-structure-aware] [noisiness: normal] [capabilities: cross-file]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -7844,7 +7844,7 @@
           }
         },
         "DeadBindings": {
-          "description": "Detects @Provides/@Binds functions whose return type is not requested by any @Inject site or component exposure in the project. [precision: project-structure-aware] [capabilities: cross-file]",
+          "description": "Detects @Provides/@Binds functions whose return type is not requested by any @Inject site or component exposure in the project. [precision: project-structure-aware] [noisiness: normal] [capabilities: cross-file]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -7863,7 +7863,7 @@
           }
         },
         "DiCycleDetection": {
-          "description": "Detects cycles in the constructor-injected DI binding graph. [precision: project-structure-aware] [capabilities: parsed-files]",
+          "description": "Detects cycles in the constructor-injected DI binding graph. [precision: project-structure-aware] [noisiness: normal] [capabilities: parsed-files]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -7882,7 +7882,7 @@
           }
         },
         "HiltEntryPointOnNonInterface": {
-          "description": "Detects Hilt @EntryPoint annotations on classes or objects instead of interfaces. [precision: ast-backed]",
+          "description": "Detects Hilt @EntryPoint annotations on classes or objects instead of interfaces. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -7901,7 +7901,7 @@
           }
         },
         "HiltInstallInMismatch": {
-          "description": "Detects Hilt @Module/@InstallIn classes whose @Provides scope does not match the installed component. [precision: ast-backed]",
+          "description": "Detects Hilt @Module/@InstallIn classes whose @Provides scope does not match the installed component. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -7920,7 +7920,7 @@
           }
         },
         "HiltSingletonWithActivityDep": {
-          "description": "Detects @Singleton classes whose constructor takes Activity-, Fragment-, View-, or LifecycleOwner-scoped types. [precision: ast-backed]",
+          "description": "Detects @Singleton classes whose constructor takes Activity-, Fragment-, View-, or LifecycleOwner-scoped types. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -7939,7 +7939,7 @@
           }
         },
         "InjectOnAbstractClass": {
-          "description": "Detects @Inject primary constructors on abstract classes; Dagger cannot instantiate an abstract class. [precision: ast-backed]",
+          "description": "Detects @Inject primary constructors on abstract classes; Dagger cannot instantiate an abstract class. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -7958,7 +7958,7 @@
           }
         },
         "IntoMapDuplicateKey": {
-          "description": "Detects @IntoMap providers that share the same key in the same module/component; duplicate map keys create conflicting contributions. [precision: project-structure-aware] [capabilities: cross-file]",
+          "description": "Detects @IntoMap providers that share the same key in the same module/component; duplicate map keys create conflicting contributions. [precision: project-structure-aware] [noisiness: normal] [capabilities: cross-file]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -7977,7 +7977,7 @@
           }
         },
         "IntoMapMissingKey": {
-          "description": "Detects @IntoMap @Provides/@Binds functions that lack a @*Key annotation. [precision: ast-backed]",
+          "description": "Detects @IntoMap @Provides/@Binds functions that lack a @*Key annotation. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -7996,7 +7996,7 @@
           }
         },
         "IntoSetDuplicateType": {
-          "description": "Detects @IntoSet providers that contribute the same concrete impl in the same module/component; the set dedupes, dropping contributions. [precision: project-structure-aware] [capabilities: cross-file]",
+          "description": "Detects @IntoSet providers that contribute the same concrete impl in the same module/component; the set dedupes, dropping contributions. [precision: project-structure-aware] [noisiness: normal] [capabilities: cross-file]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -8015,7 +8015,7 @@
           }
         },
         "IntoSetOnNonSetReturn": {
-          "description": "Detects @IntoSet @Provides functions whose return type is a collection wrapper, which silently drops the intended contribution. [precision: ast-backed]",
+          "description": "Detects @IntoSet @Provides functions whose return type is a collection wrapper, which silently drops the intended contribution. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -8034,7 +8034,7 @@
           }
         },
         "LazyInsteadOfDirect": {
-          "description": "Detects Lazy\u003cT\u003e constructor params whose .get() is called eagerly at class init; direct injection is cheaper. [precision: ast-backed]",
+          "description": "Detects Lazy\u003cT\u003e constructor params whose .get() is called eagerly at class init; direct injection is cheaper. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -8053,7 +8053,7 @@
           }
         },
         "MetroFactoryDeclarationShape": {
-          "description": "Detects Metro factory annotations on concrete or sealed declarations; Metro factories must be interfaces or non-sealed abstract classes. [precision: ast-backed]",
+          "description": "Detects Metro factory annotations on concrete or sealed declarations; Metro factories must be interfaces or non-sealed abstract classes. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -8072,7 +8072,7 @@
           }
         },
         "MissingJvmSuppressWildcards": {
-          "description": "Detects @Provides/@Binds returning Set\u003cT\u003e or Map\u003cK,V\u003e without @JvmSuppressWildcards on the value type. [precision: ast-backed]",
+          "description": "Detects @Provides/@Binds returning Set\u003cT\u003e or Map\u003cK,V\u003e without @JvmSuppressWildcards on the value type. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -8091,7 +8091,7 @@
           }
         },
         "ModuleWithNonStaticProvides": {
-          "description": "Detects @Module abstract classes mixing @Binds with top-level @Provides; @Provides should live in a companion object. [precision: ast-backed]",
+          "description": "Detects @Module abstract classes mixing @Binds with top-level @Provides; @Provides should live in a companion object. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -8110,7 +8110,7 @@
           }
         },
         "ProviderInsteadOfLazy": {
-          "description": "Detects Provider\u003cT\u003e constructor params whose .get() is called exactly once; Lazy\u003cT\u003e matches the intent and is cheaper. [precision: ast-backed]",
+          "description": "Detects Provider\u003cT\u003e constructor params whose .get() is called exactly once; Lazy\u003cT\u003e matches the intent and is cheaper. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -8129,7 +8129,7 @@
           }
         },
         "ScopeOnParameterizedClass": {
-          "description": "Detects DI scope annotations on generic classes; the type parameter is erased so the scope holds a single instance. [precision: ast-backed]",
+          "description": "Detects DI scope annotations on generic classes; the type parameter is erased so the scope holds a single instance. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -8148,7 +8148,7 @@
           }
         },
         "SingletonOnMutableClass": {
-          "description": "Detects @Singleton classes that hold unprotected mutable state (var properties or mutable collection val initializers). [precision: ast-backed]",
+          "description": "Detects @Singleton classes that hold unprotected mutable state (var properties or mutable collection val initializers). [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -8167,7 +8167,7 @@
           }
         },
         "SubcomponentNotInstalled": {
-          "description": "Detects @Subcomponent declarations not returned from any parent component method; the subcomponent is orphaned. [precision: project-structure-aware] [capabilities: cross-file]",
+          "description": "Detects @Subcomponent declarations not returned from any parent component method; the subcomponent is orphaned. [precision: project-structure-aware] [noisiness: normal] [capabilities: cross-file]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -8198,7 +8198,7 @@
       "additionalProperties": false,
       "properties": {
         "EmptyCatchBlock": {
-          "description": "Detects catch blocks with an empty body that silently swallow exceptions. [fixable: semantic] [precision: ast-backed]",
+          "description": "Detects catch blocks with an empty body that silently swallow exceptions. [fixable: semantic] [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -8223,7 +8223,7 @@
           }
         },
         "EmptyClassBlock": {
-          "description": "Detects class declarations with an empty body that can have their braces removed. [fixable: semantic] [precision: ast-backed]",
+          "description": "Detects class declarations with an empty body that can have their braces removed. [fixable: semantic] [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -8242,7 +8242,7 @@
           }
         },
         "EmptyDefaultConstructor": {
-          "description": "Detects explicit empty default constructors that are redundant and can be removed. [fixable: semantic] [precision: ast-backed]",
+          "description": "Detects explicit empty default constructors that are redundant and can be removed. [fixable: semantic] [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -8261,7 +8261,7 @@
           }
         },
         "EmptyDoWhileBlock": {
-          "description": "Detects do-while loops with an empty body. [precision: ast-backed]",
+          "description": "Detects do-while loops with an empty body. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -8280,7 +8280,7 @@
           }
         },
         "EmptyElseBlock": {
-          "description": "Detects else blocks with an empty body. [fixable: semantic] [precision: ast-backed]",
+          "description": "Detects else blocks with an empty body. [fixable: semantic] [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -8299,7 +8299,7 @@
           }
         },
         "EmptyFinallyBlock": {
-          "description": "Detects finally blocks with an empty body that serve no purpose. [precision: ast-backed]",
+          "description": "Detects finally blocks with an empty body that serve no purpose. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -8318,7 +8318,7 @@
           }
         },
         "EmptyForBlock": {
-          "description": "Detects for loops with an empty body. [precision: ast-backed]",
+          "description": "Detects for loops with an empty body. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -8337,7 +8337,7 @@
           }
         },
         "EmptyFunctionBlock": {
-          "description": "Detects function declarations with an empty body. [fixable: semantic] [precision: ast-backed]",
+          "description": "Detects function declarations with an empty body. [fixable: semantic] [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -8361,7 +8361,7 @@
           }
         },
         "EmptyIfBlock": {
-          "description": "Detects if blocks with an empty body. [precision: ast-backed]",
+          "description": "Detects if blocks with an empty body. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -8380,7 +8380,7 @@
           }
         },
         "EmptyInitBlock": {
-          "description": "Detects init blocks with an empty body that can be removed. [fixable: semantic] [precision: ast-backed]",
+          "description": "Detects init blocks with an empty body that can be removed. [fixable: semantic] [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -8399,7 +8399,7 @@
           }
         },
         "EmptyKotlinFile": {
-          "description": "Detects Kotlin files with no meaningful code beyond package and import declarations. [precision: heuristic/text-backed] [capabilities: line-pass]",
+          "description": "Detects Kotlin files with no meaningful code beyond package and import declarations. [precision: heuristic/text-backed] [noisiness: noisy] [capabilities: line-pass]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -8418,7 +8418,7 @@
           }
         },
         "EmptySecondaryConstructor": {
-          "description": "Detects secondary constructors with an empty body. [fixable: semantic] [precision: ast-backed]",
+          "description": "Detects secondary constructors with an empty body. [fixable: semantic] [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -8437,7 +8437,7 @@
           }
         },
         "EmptyTryBlock": {
-          "description": "Detects try blocks with an empty body. [precision: ast-backed]",
+          "description": "Detects try blocks with an empty body. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -8456,7 +8456,7 @@
           }
         },
         "EmptyWhenBlock": {
-          "description": "Detects when expressions with no entries. [precision: ast-backed]",
+          "description": "Detects when expressions with no entries. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -8475,7 +8475,7 @@
           }
         },
         "EmptyWhileBlock": {
-          "description": "Detects while loops with an empty body. [precision: ast-backed]",
+          "description": "Detects while loops with an empty body. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -8506,7 +8506,7 @@
       "additionalProperties": false,
       "properties": {
         "ErrorUsageWithThrowable": {
-          "description": "Detects error() calls that pass a Throwable argument instead of using throw directly. [precision: type-aware] [capabilities: resolver]",
+          "description": "Detects error() calls that pass a Throwable argument instead of using throw directly. [precision: type-aware] [noisiness: normal] [capabilities: resolver]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -8525,7 +8525,7 @@
           }
         },
         "ExceptionRaisedInUnexpectedLocation": {
-          "description": "Detects throw statements inside equals, hashCode, toString, or finalize methods. [precision: ast-backed]",
+          "description": "Detects throw statements inside equals, hashCode, toString, or finalize methods. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -8557,7 +8557,7 @@
           }
         },
         "InstanceOfCheckForException": {
-          "description": "Detects instanceof/is checks for exception types inside catch blocks instead of using specific catch clauses. [precision: ast-backed]",
+          "description": "Detects instanceof/is checks for exception types inside catch blocks instead of using specific catch clauses. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -8576,7 +8576,7 @@
           }
         },
         "NotImplementedDeclaration": {
-          "description": "Detects TODO() calls that throw NotImplementedError at runtime. [precision: ast-backed]",
+          "description": "Detects TODO() calls that throw NotImplementedError at runtime. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -8595,7 +8595,7 @@
           }
         },
         "ObjectExtendsThrowable": {
-          "description": "Detects Kotlin object declarations that extend Throwable, which are singletons that lose stack trace information. [precision: type-aware] [capabilities: resolver]",
+          "description": "Detects Kotlin object declarations that extend Throwable, which are singletons that lose stack trace information. [precision: type-aware] [noisiness: normal] [capabilities: resolver]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -8614,7 +8614,7 @@
           }
         },
         "PrintStackTrace": {
-          "description": "Detects printStackTrace() calls that should use a logger instead. [fixable: idiomatic] [precision: ast-backed]",
+          "description": "Detects printStackTrace() calls that should use a logger instead. [fixable: idiomatic] [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -8633,7 +8633,7 @@
           }
         },
         "RethrowCaughtException": {
-          "description": "Detects catch blocks whose only statement is rethrowing the caught exception, making the catch block useless. [precision: ast-backed]",
+          "description": "Detects catch blocks whose only statement is rethrowing the caught exception, making the catch block useless. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -8652,7 +8652,7 @@
           }
         },
         "ReturnFromFinally": {
-          "description": "Detects return statements inside finally blocks that can swallow exceptions from the try/catch. [precision: ast-backed]",
+          "description": "Detects return statements inside finally blocks that can swallow exceptions from the try/catch. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -8676,7 +8676,7 @@
           }
         },
         "SwallowedException": {
-          "description": "Detects catch blocks that silently swallow the caught exception without logging, handling, or rethrowing. [fixable: idiomatic] [precision: ast-backed]",
+          "description": "Detects catch blocks that silently swallow the caught exception without logging, handling, or rethrowing. [fixable: idiomatic] [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -8713,7 +8713,7 @@
           }
         },
         "ThrowingExceptionFromFinally": {
-          "description": "Detects throw statements inside finally blocks that can mask exceptions from the try/catch. [precision: ast-backed]",
+          "description": "Detects throw statements inside finally blocks that can mask exceptions from the try/catch. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -8732,7 +8732,7 @@
           }
         },
         "ThrowingExceptionInMain": {
-          "description": "Detects throw statements inside the main() function instead of graceful error handling. [precision: ast-backed]",
+          "description": "Detects throw statements inside the main() function instead of graceful error handling. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -8751,7 +8751,7 @@
           }
         },
         "ThrowingExceptionsWithoutMessageOrCause": {
-          "description": "Detects common exception types thrown without a descriptive message or cause argument. [precision: ast-backed]",
+          "description": "Detects common exception types thrown without a descriptive message or cause argument. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -8777,7 +8777,7 @@
           }
         },
         "ThrowingNewInstanceOfSameException": {
-          "description": "Detects catch blocks that throw a new instance of the same exception type instead of rethrowing the original. [precision: ast-backed]",
+          "description": "Detects catch blocks that throw a new instance of the same exception type instead of rethrowing the original. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -8796,7 +8796,7 @@
           }
         },
         "TooGenericExceptionCaught": {
-          "description": "Detects catching overly generic exception types like Exception or Throwable. [precision: ast-backed]",
+          "description": "Detects catching overly generic exception types like Exception or Throwable. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -8828,7 +8828,7 @@
           }
         },
         "TooGenericExceptionThrown": {
-          "description": "Detects throwing overly generic exception types like Exception or Throwable. [precision: type-aware] [capabilities: resolver]",
+          "description": "Detects throwing overly generic exception types like Exception or Throwable. [precision: type-aware] [noisiness: normal] [capabilities: resolver]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -8866,7 +8866,7 @@
       "additionalProperties": false,
       "properties": {
         "LocaleGetDefaultForFormatting": {
-          "description": "Detects Locale.getDefault() passed to a formatter used for persistence or network IO; use Locale.ROOT or Locale.US instead. [precision: ast-backed]",
+          "description": "Detects Locale.getDefault() passed to a formatter used for persistence or network IO; use Locale.ROOT or Locale.US instead. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -8885,7 +8885,7 @@
           }
         },
         "PluralsBuiltWithIfElse": {
-          "description": "Detects manual pluralization built with if/else over count == 1 instead of getQuantityString / pluralStringResource. [precision: ast-backed]",
+          "description": "Detects manual pluralization built with if/else over count == 1 instead of getQuantityString / pluralStringResource. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -8904,7 +8904,7 @@
           }
         },
         "PluralsMissingZero": {
-          "description": "\u003cplurals\u003e in a CLDR zero-form locale is missing the zero quantity [precision: project-structure-aware] [capabilities: resources]",
+          "description": "\u003cplurals\u003e in a CLDR zero-form locale is missing the zero quantity [precision: project-structure-aware] [noisiness: normal] [capabilities: resources]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -8923,7 +8923,7 @@
           }
         },
         "StringConcatForTranslation": {
-          "description": "Detects `+` concatenation between stringResource(...) and a non-literal, which forces English word order. [precision: ast-backed]",
+          "description": "Detects `+` concatenation between stringResource(...) and a non-literal, which forces English word order. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -8942,7 +8942,7 @@
           }
         },
         "StringContainsHtmlWithoutCDATA": {
-          "description": "\u003cstring\u003e value contains literal HTML markup not wrapped in \u003c![CDATA[...]]\u003e or entity-escaped. [precision: project-structure-aware] [capabilities: resources]",
+          "description": "\u003cstring\u003e value contains literal HTML markup not wrapped in \u003c![CDATA[...]]\u003e or entity-escaped. [precision: project-structure-aware] [noisiness: normal] [capabilities: resources]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -8961,7 +8961,7 @@
           }
         },
         "StringResourcePlaceholderOrder": {
-          "description": "Variant string drops positional format syntax used by the default value [precision: project-structure-aware] [capabilities: resources]",
+          "description": "Variant string drops positional format syntax used by the default value [precision: project-structure-aware] [noisiness: normal] [capabilities: resources]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -8980,7 +8980,7 @@
           }
         },
         "StringTemplateForTranslation": {
-          "description": "Detects string templates that embed stringResource(...) alongside another dynamic interpolation, which forces English word order. [precision: ast-backed]",
+          "description": "Detects string templates that embed stringResource(...) alongside another dynamic interpolation, which forces English word order. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -8999,7 +8999,7 @@
           }
         },
         "TextDirectionLiteralInString": {
-          "description": "Detects string literals that embed Unicode BIDI control characters instead of using a directional formatter. [precision: ast-backed]",
+          "description": "Detects string literals that embed Unicode BIDI control characters instead of using a directional formatter. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -9018,7 +9018,7 @@
           }
         },
         "TranslatableMarkupMismatch": {
-          "description": "\u003cstring\u003e markup style differs across locale variants (HTML vs Markdown vs plain text). [precision: project-structure-aware] [capabilities: resources]",
+          "description": "\u003cstring\u003e markup style differs across locale variants (HTML vs Markdown vs plain text). [precision: project-structure-aware] [noisiness: normal] [capabilities: resources]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -9037,7 +9037,7 @@
           }
         },
         "UnicodeNormalizationMissing": {
-          "description": "Detects contains() calls inside search/find functions that do not normalize operands; unicode-equivalent characters will not match. [precision: ast-backed]",
+          "description": "Detects contains() calls inside search/find functions that do not normalize operands; unicode-equivalent characters will not match. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -9056,7 +9056,7 @@
           }
         },
         "UpperLowerInvariantMisuse": {
-          "description": "Detects Kotlin 1.5+ uppercase()/lowercase() called without an explicit Locale argument. [precision: ast-backed]",
+          "description": "Detects Kotlin 1.5+ uppercase()/lowercase() called without an explicit Locale argument. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -9087,7 +9087,7 @@
       "additionalProperties": false,
       "properties": {
         "ForbiddenPublicDataClass": {
-          "description": "Detects public data classes in library code whose exposed properties make the API hard to evolve. [precision: ast-backed]",
+          "description": "Detects public data classes in library code whose exposed properties make the API hard to evolve. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -9106,7 +9106,7 @@
           }
         },
         "LibraryCodeMustSpecifyReturnType": {
-          "description": "Detects public functions and properties in library code without explicit return type annotations. [precision: ast-backed]",
+          "description": "Detects public functions and properties in library code without explicit return type annotations. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -9125,7 +9125,7 @@
           }
         },
         "LibraryEntitiesShouldNotBePublic": {
-          "description": "Detects public top-level declarations in library code that could be made internal. [precision: ast-backed]",
+          "description": "Detects public top-level declarations in library code that could be made internal. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -9156,7 +9156,7 @@
       "additionalProperties": false,
       "properties": {
         "CopyrightYearOutdated": {
-          "description": "Detects stale copyright years in file header comments. [fixable: cosmetic] [precision: heuristic/text-backed] [capabilities: line-pass]",
+          "description": "Detects stale copyright years in file header comments. [fixable: cosmetic] [precision: heuristic/text-backed] [noisiness: noisy] [capabilities: line-pass]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -9175,7 +9175,7 @@
           }
         },
         "DependencyLicenseIncompatible": {
-          "description": "Detects external dependencies whose license is incompatible with the project's declared license. [precision: project-structure-aware] [capabilities: gradle]",
+          "description": "Detects external dependencies whose license is incompatible with the project's declared license. [precision: project-structure-aware] [noisiness: normal] [capabilities: gradle]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -9199,7 +9199,7 @@
           }
         },
         "DependencyLicenseUnknown": {
-          "description": "Detects external dependencies not present in the embedded license registry. [precision: project-structure-aware] [capabilities: gradle]",
+          "description": "Detects external dependencies not present in the embedded license registry. [precision: project-structure-aware] [noisiness: normal] [capabilities: gradle]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -9223,7 +9223,7 @@
           }
         },
         "LgplStaticLinkingInApk": {
-          "description": "Detects Android application modules that statically link known-LGPL dependencies into the APK. [precision: project-structure-aware] [capabilities: gradle]",
+          "description": "Detects Android application modules that statically link known-LGPL dependencies into the APK. [precision: project-structure-aware] [noisiness: normal] [capabilities: gradle]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -9242,7 +9242,7 @@
           }
         },
         "MissingSpdxIdentifier": {
-          "description": "Detects file header comments that are missing a SPDX license identifier. [precision: heuristic/text-backed] [capabilities: line-pass]",
+          "description": "Detects file header comments that are missing a SPDX license identifier. [precision: heuristic/text-backed] [noisiness: noisy] [capabilities: line-pass]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -9261,7 +9261,7 @@
           }
         },
         "NoticeFileOutOfDate": {
-          "description": "Detects projects whose NOTICE file is missing required attribution for declared dependencies. [precision: project-structure-aware] [capabilities: gradle]",
+          "description": "Detects projects whose NOTICE file is missing required attribution for declared dependencies. [precision: project-structure-aware] [noisiness: normal] [capabilities: gradle]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -9287,7 +9287,7 @@
           }
         },
         "OptInMarkerExposedPublicly": {
-          "description": "Detects @OptIn annotations on public API declarations that propagate the opt-in requirement to callers. [precision: ast-backed]",
+          "description": "Detects @OptIn annotations on public API declarations that propagate the opt-in requirement to callers. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -9306,7 +9306,7 @@
           }
         },
         "OptInMarkerNotRecognised": {
-          "description": "Detects @OptIn marker classes not in the embedded well-known markers list. [precision: ast-backed]",
+          "description": "Detects @OptIn marker classes not in the embedded well-known markers list. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -9332,7 +9332,7 @@
           }
         },
         "OptInWithoutJustification": {
-          "description": "Detects @OptIn annotations whose declaration has no preceding KDoc explaining why opting in is safe. [precision: ast-backed]",
+          "description": "Detects @OptIn annotations whose declaration has no preceding KDoc explaining why opting in is safe. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -9351,7 +9351,7 @@
           }
         },
         "OssLicensesNotIncludedInAndroid": {
-          "description": "Detects Android app modules with implementation dependencies but no attribution surface (oss-licenses-plugin or LICENSE file). [precision: project-structure-aware] [capabilities: gradle]",
+          "description": "Detects Android app modules with implementation dependencies but no attribution surface (oss-licenses-plugin or LICENSE file). [precision: project-structure-aware] [noisiness: normal] [capabilities: gradle]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -9370,7 +9370,7 @@
           }
         },
         "RequiresOptInWithoutLevel": {
-          "description": "Detects custom @RequiresOptIn annotation classes that omit an explicit level = WARNING|ERROR argument. [precision: ast-backed]",
+          "description": "Detects custom @RequiresOptIn annotation classes that omit an explicit level = WARNING|ERROR argument. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -9389,7 +9389,7 @@
           }
         },
         "RequiresOptInWithoutMessage": {
-          "description": "Detects @RequiresOptIn annotations that omit a message argument explaining why callers must opt in. [precision: ast-backed]",
+          "description": "Detects @RequiresOptIn annotations that omit a message argument explaining why callers must opt in. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -9408,7 +9408,7 @@
           }
         },
         "SpdxIdentifierInvalid": {
-          "description": "Detects file header SPDX-License-Identifier values that are not recognised SPDX short IDs. [precision: heuristic/text-backed] [capabilities: line-pass]",
+          "description": "Detects file header SPDX-License-Identifier values that are not recognised SPDX short IDs. [precision: heuristic/text-backed] [noisiness: noisy] [capabilities: line-pass]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -9434,7 +9434,7 @@
           }
         },
         "SpdxIdentifierMismatchWithProject": {
-          "description": "Detects file SPDX identifiers that disagree with the project's configured license. [precision: heuristic/text-backed] [capabilities: line-pass]",
+          "description": "Detects file SPDX identifiers that disagree with the project's configured license. [precision: heuristic/text-backed] [noisiness: noisy] [capabilities: line-pass]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -9458,7 +9458,7 @@
           }
         },
         "SuppressedWarningWithoutJustification": {
-          "description": "Detects @Suppress annotations whose declaration has no preceding KDoc explaining why silencing the warning is safe. [precision: ast-backed]",
+          "description": "Detects @Suppress annotations whose declaration has no preceding KDoc explaining why silencing the warning is safe. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -9529,7 +9529,7 @@
       "additionalProperties": false,
       "properties": {
         "BooleanPropertyNaming": {
-          "description": "Detects Boolean properties that do not start with an allowed prefix like is, has, or are. [fixable: semantic] [precision: ast-backed]",
+          "description": "Detects Boolean properties that do not start with an allowed prefix like is, has, or are. [fixable: semantic] [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -9554,7 +9554,7 @@
           }
         },
         "ClassNaming": {
-          "description": "Detects class names that do not match the expected naming pattern. [precision: ast-backed]",
+          "description": "Detects class names that do not match the expected naming pattern. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -9579,7 +9579,7 @@
           }
         },
         "ConstructorParameterNaming": {
-          "description": "Detects constructor val/var parameter names that do not match the expected naming pattern. [precision: ast-backed]",
+          "description": "Detects constructor val/var parameter names that do not match the expected naming pattern. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -9616,7 +9616,7 @@
           }
         },
         "EnumNaming": {
-          "description": "Detects enum entry names that do not match the expected naming pattern. [precision: ast-backed]",
+          "description": "Detects enum entry names that do not match the expected naming pattern. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -9641,7 +9641,7 @@
           }
         },
         "ForbiddenClassName": {
-          "description": "Detects class names that match a configured list of disallowed names. [precision: ast-backed]",
+          "description": "Detects class names that match a configured list of disallowed names. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -9673,7 +9673,7 @@
           }
         },
         "FunctionNameMaxLength": {
-          "description": "Detects function names that exceed the configured maximum length. [precision: ast-backed]",
+          "description": "Detects function names that exceed the configured maximum length. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -9701,7 +9701,7 @@
           }
         },
         "FunctionNameMinLength": {
-          "description": "Detects function names that are shorter than the configured minimum length. [precision: ast-backed]",
+          "description": "Detects function names that are shorter than the configured minimum length. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -9729,7 +9729,7 @@
           }
         },
         "FunctionNaming": {
-          "description": "Detects function names that do not match the expected naming pattern. [precision: ast-backed]",
+          "description": "Detects function names that do not match the expected naming pattern. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -9779,7 +9779,7 @@
           }
         },
         "FunctionParameterNaming": {
-          "description": "Detects function parameter names that do not match the expected naming pattern. [precision: ast-backed]",
+          "description": "Detects function parameter names that do not match the expected naming pattern. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -9810,7 +9810,7 @@
           }
         },
         "InvalidPackageDeclaration": {
-          "description": "Detects package declarations that do not match the file directory structure. [precision: ast-backed]",
+          "description": "Detects package declarations that do not match the file directory structure. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -9839,7 +9839,7 @@
           }
         },
         "LambdaParameterNaming": {
-          "description": "Detects lambda parameter names that do not match the expected naming pattern. [precision: ast-backed]",
+          "description": "Detects lambda parameter names that do not match the expected naming pattern. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -9864,7 +9864,7 @@
           }
         },
         "MatchingDeclarationName": {
-          "description": "Detects files where the single top-level declaration name does not match the filename. [precision: ast-backed]",
+          "description": "Detects files where the single top-level declaration name does not match the filename. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -9907,7 +9907,7 @@
           }
         },
         "MemberNameEqualsClassName": {
-          "description": "Detects class members whose name is the same as the containing class name. [precision: ast-backed]",
+          "description": "Detects class members whose name is the same as the containing class name. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -9931,7 +9931,7 @@
           }
         },
         "NoNameShadowing": {
-          "description": "Detects inner declarations that shadow an outer declaration with the same name. [precision: ast-backed]",
+          "description": "Detects inner declarations that shadow an outer declaration with the same name. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -9950,7 +9950,7 @@
           }
         },
         "NonBooleanPropertyPrefixedWithIs": {
-          "description": "Detects non-Boolean properties whose name starts with the is prefix. [precision: ast-backed]",
+          "description": "Detects non-Boolean properties whose name starts with the is prefix. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -9969,7 +9969,7 @@
           }
         },
         "ObjectPropertyNaming": {
-          "description": "Detects property names inside object declarations that do not match the expected naming pattern. [precision: ast-backed]",
+          "description": "Detects property names inside object declarations that do not match the expected naming pattern. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -10006,7 +10006,7 @@
           }
         },
         "PackageNaming": {
-          "description": "Detects package names that do not match the expected naming pattern. [precision: ast-backed]",
+          "description": "Detects package names that do not match the expected naming pattern. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -10031,7 +10031,7 @@
           }
         },
         "TopLevelPropertyNaming": {
-          "description": "Detects top-level property names that do not match the expected naming pattern. [precision: ast-backed]",
+          "description": "Detects top-level property names that do not match the expected naming pattern. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -10068,7 +10068,7 @@
           }
         },
         "VariableMaxLength": {
-          "description": "Detects variable names that exceed the configured maximum length. [precision: ast-backed]",
+          "description": "Detects variable names that exceed the configured maximum length. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -10096,7 +10096,7 @@
           }
         },
         "VariableMinLength": {
-          "description": "Detects variable names that are shorter than the configured minimum length. [precision: ast-backed]",
+          "description": "Detects variable names that are shorter than the configured minimum length. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -10124,7 +10124,7 @@
           }
         },
         "VariableNaming": {
-          "description": "Detects local variable names that do not match the expected naming pattern. [precision: ast-backed]",
+          "description": "Detects local variable names that do not match the expected naming pattern. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -10173,7 +10173,7 @@
       "additionalProperties": false,
       "properties": {
         "LogLevelGuardMissing": {
-          "description": "Detects debug/trace log messages with interpolated calls not guarded by a log-level check. [precision: ast-backed]",
+          "description": "Detects debug/trace log messages with interpolated calls not guarded by a log-level check. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -10192,7 +10192,7 @@
           }
         },
         "LogWithoutCorrelationId": {
-          "description": "Detects logger calls inside coroutine builders whose context does not include MDCContext. [precision: ast-backed]",
+          "description": "Detects logger calls inside coroutine builders whose context does not include MDCContext. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -10211,7 +10211,7 @@
           }
         },
         "LoggerInterpolatedMessage": {
-          "description": "Detects SLF4J/Logback/log4j logger calls whose message uses Kotlin string interpolation instead of parameterized placeholders. [precision: ast-backed]",
+          "description": "Detects SLF4J/Logback/log4j logger calls whose message uses Kotlin string interpolation instead of parameterized placeholders. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -10230,7 +10230,7 @@
           }
         },
         "LoggerStringConcat": {
-          "description": "Detects SLF4J/Logback/log4j logger calls whose message uses `+` string concatenation instead of parameterized placeholders. [precision: ast-backed]",
+          "description": "Detects SLF4J/Logback/log4j logger calls whose message uses `+` string concatenation instead of parameterized placeholders. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -10249,7 +10249,7 @@
           }
         },
         "LoggerWithoutLoggerField": {
-          "description": "Detects LoggerFactory.getLogger() calls inside function bodies instead of a class-level logger field. [precision: ast-backed]",
+          "description": "Detects LoggerFactory.getLogger() calls inside function bodies instead of a class-level logger field. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -10268,7 +10268,7 @@
           }
         },
         "MdcAcrossCoroutineBoundary": {
-          "description": "Detects MDC.put(...) followed by a coroutine builder without MDCContext(); MDC values do not propagate across dispatchers. [precision: ast-backed]",
+          "description": "Detects MDC.put(...) followed by a coroutine builder without MDCContext(); MDC values do not propagate across dispatchers. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -10287,7 +10287,7 @@
           }
         },
         "MdcPutNoRemove": {
-          "description": "Detects MDC.put(...) inside a function with no matching MDC.remove(...), MDC.clear(), or MDCCloseable, which leaks values across reused threads. [precision: ast-backed]",
+          "description": "Detects MDC.put(...) inside a function with no matching MDC.remove(...), MDC.clear(), or MDCCloseable, which leaks values across reused threads. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -10306,7 +10306,7 @@
           }
         },
         "MetricCounterNotMonotonic": {
-          "description": "Detects counter increment calls with negative literal amounts. [precision: ast-backed]",
+          "description": "Detects counter increment calls with negative literal amounts. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -10325,7 +10325,7 @@
           }
         },
         "MetricNameMissingUnit": {
-          "description": "Detects metric names that do not include a recognized unit suffix. [precision: ast-backed]",
+          "description": "Detects metric names that do not include a recognized unit suffix. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -10357,7 +10357,7 @@
           }
         },
         "MetricTagHighCardinality": {
-          "description": "Detects metric tag keys that are likely high-cardinality. [precision: ast-backed]",
+          "description": "Detects metric tag keys that are likely high-cardinality. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -10388,7 +10388,7 @@
           }
         },
         "MetricTimerOutsideBlock": {
-          "description": "Detects timer record blocks that are empty or only read values instead of timing meaningful work. [precision: ast-backed]",
+          "description": "Detects timer record blocks that are empty or only read values instead of timing meaningful work. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -10407,7 +10407,7 @@
           }
         },
         "NullableStructuredField": {
-          "description": "Detects structured log fields whose nullable value lacks an Elvis fallback. [precision: ast-backed]",
+          "description": "Detects structured log fields whose nullable value lacks an Elvis fallback. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -10426,7 +10426,7 @@
           }
         },
         "SpanAttributeWithHighCardinality": {
-          "description": "Detects OpenTelemetry span attributes that use high-cardinality keys. [precision: ast-backed]",
+          "description": "Detects OpenTelemetry span attributes that use high-cardinality keys. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -10457,7 +10457,7 @@
           }
         },
         "SpanStartWithoutFinish": {
-          "description": "Detects spans started into a local variable without a matching end(), use, or makeCurrent().use lifecycle call. [precision: ast-backed]",
+          "description": "Detects spans started into a local variable without a matching end(), use, or makeCurrent().use lifecycle call. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -10476,7 +10476,7 @@
           }
         },
         "StructuredLogKeyMixedCase": {
-          "description": "Detects mixed snake_case and camelCase structured logging keys within one file. [precision: heuristic/text-backed] [capabilities: line-pass]",
+          "description": "Detects mixed snake_case and camelCase structured logging keys within one file. [precision: heuristic/text-backed] [noisiness: noisy] [capabilities: line-pass]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -10505,7 +10505,7 @@
           }
         },
         "TraceIdLoggedAsPlainMessage": {
-          "description": "Detects trace, span, request, or correlation IDs embedded directly in log messages. [precision: ast-backed]",
+          "description": "Detects trace, span, request, or correlation IDs embedded directly in log messages. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -10541,7 +10541,7 @@
           }
         },
         "UnstructuredErrorLog": {
-          "description": "Detects logger error/warn calls that interpolate Throwable values instead of passing them as structured throwable arguments. [precision: ast-backed]",
+          "description": "Detects logger error/warn calls that interpolate Throwable values instead of passing them as structured throwable arguments. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -10572,7 +10572,7 @@
           }
         },
         "WithContextWithoutTracingContext": {
-          "description": "Detects coroutine dispatcher switches inside active spans without tracing context propagation. [precision: ast-backed]",
+          "description": "Detects coroutine dispatcher switches inside active spans without tracing context propagation. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -10610,7 +10610,7 @@
       "additionalProperties": false,
       "properties": {
         "ArrayPrimitive": {
-          "description": "Detects Array\u003cInt\u003e and similar boxed primitive arrays that should use IntArray, LongArray, etc. [fixable: idiomatic] [precision: heuristic/text-backed] [capabilities: resolver]",
+          "description": "Detects Array\u003cInt\u003e and similar boxed primitive arrays that should use IntArray, LongArray, etc. [fixable: idiomatic] [precision: heuristic/text-backed] [noisiness: noisy] [capabilities: resolver]\nCaveat: Lexical type-token match: aliased types via typealias to Array\u003cInt\u003e are not detected.\nCaveat: Identifies the declared type only; runtime allocation patterns (e.g. Array(n) { it.toInt() }) are out of scope.",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -10629,7 +10629,7 @@
           }
         },
         "BitmapDecodeWithoutOptions": {
-          "description": "Detects BitmapFactory.decode* calls without BitmapFactory.Options, which may decode full-size bitmaps. [precision: ast-backed]",
+          "description": "Detects BitmapFactory.decode* calls without BitmapFactory.Options, which may decode full-size bitmaps. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -10648,7 +10648,7 @@
           }
         },
         "CouldBeSequence": {
-          "description": "Detects collection operation chains that could use sequences to avoid intermediate allocations. [precision: heuristic/text-backed] [capabilities: oracle:call-targets, resolver]",
+          "description": "Detects collection operation chains that could use sequences to avoid intermediate allocations. [precision: heuristic/text-backed] [noisiness: noisy] [capabilities: oracle:call-targets, resolver]\nCaveat: Counts chained calls by lexical name without confirming the receiver is a Collection: receivers exposing similarly named extensions on non-Iterable types may be flagged.\nCaveat: Threshold tuning is project-dependent; small chains on large collections may still benefit from .asSequence().",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -10676,7 +10676,7 @@
           }
         },
         "ForEachOnRange": {
-          "description": "Detects (range).forEach patterns that should use a simple for loop to avoid lambda overhead. [fixable: idiomatic] [precision: ast-backed]",
+          "description": "Detects (range).forEach patterns that should use a simple for loop to avoid lambda overhead. [fixable: idiomatic] [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -10695,7 +10695,7 @@
           }
         },
         "SpreadOperator": {
-          "description": "Detects the spread operator (*array) in function calls which creates an array copy. [precision: ast-backed]",
+          "description": "Detects the spread operator (*array) in function calls which creates an array copy. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -10714,7 +10714,7 @@
           }
         },
         "UnnecessaryInitOnArray": {
-          "description": "Detects IntArray(n) { 0 } and similar array initializations where the init value is already the default. [fixable: idiomatic] [precision: ast-backed]",
+          "description": "Detects IntArray(n) { 0 } and similar array initializations where the init value is already the default. [fixable: idiomatic] [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -10733,7 +10733,7 @@
           }
         },
         "UnnecessaryPartOfBinaryExpression": {
-          "description": "Detects redundant parts of binary expressions like x \u0026\u0026 true or x || false. [fixable: idiomatic] [precision: ast-backed]",
+          "description": "Detects redundant parts of binary expressions like x \u0026\u0026 true or x || false. [fixable: idiomatic] [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -10752,7 +10752,7 @@
           }
         },
         "UnnecessaryTemporaryInstantiation": {
-          "description": "Detects temporary wrapper instantiations like Integer.valueOf(x).toString() that can be simplified. [fixable: idiomatic] [precision: ast-backed]",
+          "description": "Detects temporary wrapper instantiations like Integer.valueOf(x).toString() that can be simplified. [fixable: idiomatic] [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -10771,7 +10771,7 @@
           }
         },
         "UnnecessaryTypeCasting": {
-          "description": "Detects safe casts immediately compared with null and redundant casts to an already-known type. [fixable: idiomatic] [precision: type-aware] [capabilities: resolver]",
+          "description": "Detects safe casts immediately compared with null and redundant casts to an already-known type. [fixable: idiomatic] [precision: type-aware] [noisiness: normal] [capabilities: resolver]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -10802,7 +10802,7 @@
       "additionalProperties": false,
       "properties": {
         "AbstractMemberNotImplemented": {
-          "description": "Detects concrete classes that fail to implement abstract members declared on a supertype. [precision: type-aware] [capabilities: resolver]",
+          "description": "Detects concrete classes that fail to implement abstract members declared on a supertype. [precision: type-aware] [noisiness: normal] [capabilities: resolver]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -10821,7 +10821,7 @@
           }
         },
         "AvoidReferentialEquality": {
-          "description": "Detects usage of referential equality operators === or !== which compare object identity instead of value. [fixable: idiomatic] [precision: type-aware] [capabilities: resolver]",
+          "description": "Detects usage of referential equality operators === or !== which compare object identity instead of value. [fixable: idiomatic] [precision: type-aware] [noisiness: normal] [capabilities: resolver]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -10847,7 +10847,7 @@
           }
         },
         "CastNullableToNonNullableType": {
-          "description": "Detects casting a nullable expression to a non-nullable type using 'as Type'. [fixable: idiomatic] [precision: type-aware] [capabilities: resolver]",
+          "description": "Detects casting a nullable expression to a non-nullable type using 'as Type'. [fixable: idiomatic] [precision: type-aware] [noisiness: normal] [capabilities: resolver]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -10866,7 +10866,7 @@
           }
         },
         "CastToNullableType": {
-          "description": "Detects casts to nullable types like 'as Type?' which always succeed and may hide bugs. [fixable: idiomatic] [precision: ast-backed]",
+          "description": "Detects casts to nullable types like 'as Type?' which always succeed and may hide bugs. [fixable: idiomatic] [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -10885,7 +10885,7 @@
           }
         },
         "CharArrayToStringCall": {
-          "description": "Detects charArray.toString() calls that return the array's address instead of its content. [fixable: idiomatic] [precision: type-aware] [capabilities: resolver]",
+          "description": "Detects charArray.toString() calls that return the array's address instead of its content. [fixable: idiomatic] [precision: type-aware] [noisiness: normal] [capabilities: resolver]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -10904,7 +10904,7 @@
           }
         },
         "Deprecation": {
-          "description": "Detects usage of deprecated functions, classes, or properties. [precision: type-aware] [capabilities: oracle:call-targets, resolver]",
+          "description": "Detects usage of deprecated functions, classes, or properties. [precision: type-aware] [noisiness: normal] [capabilities: oracle:call-targets, resolver]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -10928,7 +10928,7 @@
           }
         },
         "DontDowncastCollectionTypes": {
-          "description": "Detects downcasting read-only collection types to mutable variants like 'as MutableList'. [fixable: semantic] [precision: type-aware] [capabilities: resolver]",
+          "description": "Detects downcasting read-only collection types to mutable variants like 'as MutableList'. [fixable: semantic] [precision: type-aware] [noisiness: normal] [capabilities: resolver]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -10947,7 +10947,7 @@
           }
         },
         "DoubleMutabilityForCollection": {
-          "description": "Detects var declarations with mutable collection types, creating double mutability. [fixable: idiomatic] [precision: ast-backed]",
+          "description": "Detects var declarations with mutable collection types, creating double mutability. [fixable: idiomatic] [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -10973,7 +10973,7 @@
           }
         },
         "ElseCaseInsteadOfExhaustiveWhen": {
-          "description": "Detects when expressions on sealed classes or enums that use an else branch instead of exhaustive matching. [fixable: idiomatic] [precision: type-aware] [capabilities: resolver]",
+          "description": "Detects when expressions on sealed classes or enums that use an else branch instead of exhaustive matching. [fixable: idiomatic] [precision: type-aware] [noisiness: normal] [capabilities: resolver]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -10992,7 +10992,7 @@
           }
         },
         "EqualsAlwaysReturnsTrueOrFalse": {
-          "description": "Detects equals() implementations that always return true or always return false. [precision: ast-backed]",
+          "description": "Detects equals() implementations that always return true or always return false. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -11011,7 +11011,7 @@
           }
         },
         "EqualsWithHashCodeExist": {
-          "description": "Detects classes that override equals() without hashCode() or vice versa. [precision: ast-backed]",
+          "description": "Detects classes that override equals() without hashCode() or vice versa. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -11030,7 +11030,7 @@
           }
         },
         "ExitOutsideMain": {
-          "description": "Detects exitProcess() or System.exit() calls outside of the main function. [precision: ast-backed]",
+          "description": "Detects exitProcess() or System.exit() calls outside of the main function. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -11049,7 +11049,7 @@
           }
         },
         "ExplicitGarbageCollectionCall": {
-          "description": "Detects explicit calls to System.gc() or Runtime.getRuntime().gc() which rarely improve performance. [fixable: idiomatic] [precision: ast-backed]",
+          "description": "Detects explicit calls to System.gc() or Runtime.getRuntime().gc() which rarely improve performance. [fixable: idiomatic] [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -11068,7 +11068,7 @@
           }
         },
         "HardcodedDateFormat": {
-          "description": "Detects DateTimeFormatter.ofPattern constructed without an explicit Locale. [fixable: semantic] [precision: ast-backed]",
+          "description": "Detects DateTimeFormatter.ofPattern constructed without an explicit Locale. [fixable: semantic] [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -11087,7 +11087,7 @@
           }
         },
         "HardcodedNumberFormat": {
-          "description": "Detects DecimalFormat or NumberFormat.getInstance constructed without an explicit Locale. [fixable: semantic] [precision: ast-backed]",
+          "description": "Detects DecimalFormat or NumberFormat.getInstance constructed without an explicit Locale. [fixable: semantic] [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -11106,7 +11106,7 @@
           }
         },
         "HasPlatformType": {
-          "description": "Detects public functions with expression bodies that lack an explicit return type, risking platform type exposure from Java interop. [precision: ast-backed]",
+          "description": "Detects public functions with expression bodies that lack an explicit return type, risking platform type exposure from Java interop. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -11125,7 +11125,7 @@
           }
         },
         "IgnoredReturnValue": {
-          "description": "Detects discarded return values from functional operations or @CheckReturnValue-annotated functions. [precision: type-aware] [capabilities: oracle:call-targets, resolver]",
+          "description": "Detects discarded return values from functional operations or @CheckReturnValue-annotated functions. [precision: type-aware] [noisiness: normal] [capabilities: oracle:call-targets, resolver]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -11177,7 +11177,7 @@
           }
         },
         "ImplicitDefaultLocale": {
-          "description": "Detects locale-sensitive string methods called without an explicit Locale argument. [fixable: semantic] [precision: type-aware] [capabilities: resolver]",
+          "description": "Detects locale-sensitive string methods called without an explicit Locale argument. [fixable: semantic] [precision: type-aware] [noisiness: normal] [capabilities: resolver]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -11196,7 +11196,7 @@
           }
         },
         "ImplicitUnitReturnType": {
-          "description": "Detects block-body functions that implicitly return Unit without an explicit return type. [fixable: idiomatic] [precision: ast-backed]",
+          "description": "Detects block-body functions that implicitly return Unit without an explicit return type. [fixable: idiomatic] [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -11215,7 +11215,7 @@
           }
         },
         "InvalidRange": {
-          "description": "Detects backwards ranges like 10..1 that produce empty ranges instead of using downTo. [fixable: idiomatic] [precision: ast-backed]",
+          "description": "Detects backwards ranges like 10..1 that produce empty ranges instead of using downTo. [fixable: idiomatic] [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -11234,7 +11234,7 @@
           }
         },
         "IteratorHasNextCallsNextMethod": {
-          "description": "Detects hasNext() implementations that call next(), which modifies iterator state. [precision: type-aware] [capabilities: resolver]",
+          "description": "Detects hasNext() implementations that call next(), which modifies iterator state. [precision: type-aware] [noisiness: normal] [capabilities: resolver]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -11253,7 +11253,7 @@
           }
         },
         "IteratorNotThrowingNoSuchElementException": {
-          "description": "Detects Iterator.next() implementations that do not throw NoSuchElementException when exhausted. [precision: type-aware] [capabilities: resolver]",
+          "description": "Detects Iterator.next() implementations that do not throw NoSuchElementException when exhausted. [precision: type-aware] [noisiness: normal] [capabilities: resolver]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -11272,7 +11272,7 @@
           }
         },
         "LateinitUsage": {
-          "description": "Detects lateinit var usage and suggests lazy initialization or nullable types instead. [precision: ast-backed]",
+          "description": "Detects lateinit var usage and suggests lazy initialization or nullable types instead. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -11297,7 +11297,7 @@
           }
         },
         "LocaleDefaultForCurrency": {
-          "description": "Detects Currency.getInstance(Locale.getDefault()) in money-related classes where currency should come from business data. [precision: ast-backed]",
+          "description": "Detects Currency.getInstance(Locale.getDefault()) in money-related classes where currency should come from business data. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -11316,7 +11316,7 @@
           }
         },
         "MapGetWithNotNullAssertionOperator": {
-          "description": "Detects map[key]!! usage and suggests getValue() or safe alternatives. [fixable: idiomatic] [precision: type-aware] [capabilities: oracle:call-targets, oracle:members, oracle:supertypes, resolver]",
+          "description": "Detects map[key]!! usage and suggests getValue() or safe alternatives. [fixable: idiomatic] [precision: type-aware] [noisiness: normal] [capabilities: oracle:call-targets, oracle:members, oracle:supertypes, resolver]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -11335,7 +11335,7 @@
           }
         },
         "MissingPackageDeclaration": {
-          "description": "Detects Kotlin or Java source files that are missing a package declaration. [fixable: cosmetic] [precision: heuristic/text-backed] [capabilities: line-pass]",
+          "description": "Detects Kotlin or Java source files that are missing a package declaration. [fixable: cosmetic] [precision: heuristic/text-backed] [noisiness: noisy] [capabilities: line-pass]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -11354,7 +11354,7 @@
           }
         },
         "MissingReturn": {
-          "description": "Detects block-bodied functions with a non-Unit return type whose body does not terminate on every path. [precision: type-aware] [capabilities: resolver]",
+          "description": "Detects block-bodied functions with a non-Unit return type whose body does not terminate on every path. [precision: type-aware] [noisiness: normal] [capabilities: resolver]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -11373,7 +11373,7 @@
           }
         },
         "MissingSuperCall": {
-          "description": "Detects override functions that do not call the corresponding super method. [fixable: idiomatic] [precision: ast-backed]",
+          "description": "Detects override functions that do not call the corresponding super method. [fixable: idiomatic] [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -11402,7 +11402,7 @@
           }
         },
         "MissingUseCall": {
-          "description": "Detects Closeable or AutoCloseable resources opened without a .use {} block. [precision: type-aware] [capabilities: oracle:call-targets, resolver]",
+          "description": "Detects Closeable or AutoCloseable resources opened without a .use {} block. [precision: type-aware] [noisiness: normal] [capabilities: oracle:call-targets, resolver]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -11421,7 +11421,7 @@
           }
         },
         "NoElseInWhenSealed": {
-          "description": "Detects when expressions on sealed classes or enums that are missing variants and have no else branch. [precision: type-aware] [capabilities: resolver]",
+          "description": "Detects when expressions on sealed classes or enums that are missing variants and have no else branch. [precision: type-aware] [noisiness: normal] [capabilities: resolver]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -11440,7 +11440,7 @@
           }
         },
         "NonExhaustiveWhen": {
-          "description": "Detects 'when' used as an expression on a sealed/enum/Boolean subject without an else branch and missing one or more variants. [precision: type-aware] [capabilities: resolver]",
+          "description": "Detects 'when' used as an expression on a sealed/enum/Boolean subject without an else branch and missing one or more variants. [precision: type-aware] [noisiness: normal] [capabilities: resolver]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -11459,7 +11459,7 @@
           }
         },
         "NullCheckOnMutableProperty": {
-          "description": "Detects null checks on mutable var properties that may be changed by another thread between the check and use. [precision: type-aware] [capabilities: resolver]",
+          "description": "Detects null checks on mutable var properties that may be changed by another thread between the check and use. [precision: type-aware] [noisiness: normal] [capabilities: resolver]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -11478,7 +11478,7 @@
           }
         },
         "NullableToStringCall": {
-          "description": "Detects .toString() calls on nullable receivers that may produce the string \"null\". [precision: type-aware] [capabilities: oracle:call-targets, resolver]",
+          "description": "Detects .toString() calls on nullable receivers that may produce the string \"null\". [precision: type-aware] [noisiness: normal] [capabilities: oracle:call-targets, resolver]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -11497,7 +11497,7 @@
           }
         },
         "OverrideSignatureMismatch": {
-          "description": "Detects 'override' functions whose parameter count does not match any supertype member with the same name. [precision: type-aware] [capabilities: resolver]",
+          "description": "Detects 'override' functions whose parameter count does not match any supertype member with the same name. [precision: type-aware] [noisiness: normal] [capabilities: resolver]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -11516,7 +11516,7 @@
           }
         },
         "PropertyUsedBeforeDeclaration": {
-          "description": "Detects class properties referenced in initializers or init blocks before they are declared. [precision: ast-backed]",
+          "description": "Detects class properties referenced in initializers or init blocks before they are declared. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -11535,7 +11535,7 @@
           }
         },
         "SmartCastInvalidated": {
-          "description": "Detects smart-cast variables that are reassigned and then used without re-checking, which the compiler reports as SMARTCAST_IMPOSSIBLE. [precision: ast-backed]",
+          "description": "Detects smart-cast variables that are reassigned and then used without re-checking, which the compiler reports as SMARTCAST_IMPOSSIBLE. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -11554,7 +11554,7 @@
           }
         },
         "UnconditionalJumpStatementInLoop": {
-          "description": "Detects loops containing an unconditional return, break, or throw that causes the loop to execute only once. [precision: ast-backed]",
+          "description": "Detects loops containing an unconditional return, break, or throw that causes the loop to execute only once. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -11573,7 +11573,7 @@
           }
         },
         "UnnamedParameterUse": {
-          "description": "Detects function calls with many unnamed parameters where named parameters would improve readability. [precision: ast-backed]",
+          "description": "Detects function calls with many unnamed parameters where named parameters would improve readability. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -11597,7 +11597,7 @@
           }
         },
         "UnnecessaryNotNullCheck": {
-          "description": "Detects unnecessary null checks on expressions that are already non-nullable. [fixable: idiomatic] [precision: type-aware] [capabilities: resolver]",
+          "description": "Detects unnecessary null checks on expressions that are already non-nullable. [fixable: idiomatic] [precision: type-aware] [noisiness: normal] [capabilities: resolver]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -11616,7 +11616,7 @@
           }
         },
         "UnnecessaryNotNullOperator": {
-          "description": "Detects the !! operator applied to expressions that are already non-nullable. [fixable: idiomatic] [precision: type-aware] [capabilities: resolver]",
+          "description": "Detects the !! operator applied to expressions that are already non-nullable. [fixable: idiomatic] [precision: type-aware] [noisiness: normal] [capabilities: resolver]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -11635,7 +11635,7 @@
           }
         },
         "UnnecessarySafeCall": {
-          "description": "Detects the ?. safe-call operator applied to expressions that are already non-nullable. [fixable: idiomatic] [precision: type-aware] [capabilities: resolver]",
+          "description": "Detects the ?. safe-call operator applied to expressions that are already non-nullable. [fixable: idiomatic] [precision: type-aware] [noisiness: normal] [capabilities: resolver]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -11654,7 +11654,7 @@
           }
         },
         "UnreachableCatchBlock": {
-          "description": "Detects catch blocks that are unreachable because a more general exception type is caught above. [precision: type-aware] [capabilities: resolver]",
+          "description": "Detects catch blocks that are unreachable because a more general exception type is caught above. [precision: type-aware] [noisiness: normal] [capabilities: resolver]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -11673,7 +11673,7 @@
           }
         },
         "UnsafeCallOnNullableType": {
-          "description": "Detects usage of the !! not-null assertion operator which may throw NullPointerException. [precision: heuristic/text-backed]",
+          "description": "Detects usage of the !! not-null assertion operator which may throw NullPointerException. [precision: heuristic/text-backed] [noisiness: noisy]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -11704,7 +11704,7 @@
           }
         },
         "UnsafeCast": {
-          "description": "Detects casts that Kotlin reports can never succeed. [fixable: semantic] [precision: heuristic/text-backed] [capabilities: oracle:call-targets, oracle:diagnostics, resolver]",
+          "description": "Detects casts that Kotlin reports can never succeed. [fixable: semantic] [precision: heuristic/text-backed] [noisiness: noisy] [capabilities: oracle:call-targets, oracle:diagnostics, resolver]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -11735,7 +11735,7 @@
           }
         },
         "UnusedUnaryOperator": {
-          "description": "Detects standalone unary +x or -x expressions whose result is never used. [fixable: semantic] [precision: ast-backed]",
+          "description": "Detects standalone unary +x or -x expressions whose result is never used. [fixable: semantic] [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -11754,7 +11754,7 @@
           }
         },
         "UselessElvisOnNonNull": {
-          "description": "Detects the ?: elvis operator applied to expressions that are already non-nullable, making the fallback dead code. [fixable: semantic] [precision: type-aware] [capabilities: oracle:expr-type, resolver]",
+          "description": "Detects the ?: elvis operator applied to expressions that are already non-nullable, making the fallback dead code. [fixable: semantic] [precision: type-aware] [noisiness: normal] [capabilities: oracle:expr-type, resolver]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -11773,7 +11773,7 @@
           }
         },
         "UselessPostfixExpression": {
-          "description": "Detects postfix increment or decrement in return statements where the operation has no effect. [fixable: idiomatic] [precision: ast-backed]",
+          "description": "Detects postfix increment or decrement in return statements where the operation has no effect. [fixable: idiomatic] [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -11792,7 +11792,7 @@
           }
         },
         "WrongEqualsTypeParameter": {
-          "description": "Detects equals() with a parameter type other than Any?, which does not properly override the contract. [fixable: idiomatic] [precision: ast-backed]",
+          "description": "Detects equals() with a parameter type other than Any?, which does not properly override the contract. [fixable: idiomatic] [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -11823,7 +11823,7 @@
       "additionalProperties": false,
       "properties": {
         "DeprecatedSymbolUsedError": {
-          "description": "Detects references to symbols annotated with @Deprecated(level = DeprecationLevel.ERROR). Mirrors kotlinc's DEPRECATION_ERROR. [precision: ast-backed] [capabilities: oracle:member-annotations, oracle:members]",
+          "description": "Detects references to symbols annotated with @Deprecated(level = DeprecationLevel.ERROR). Mirrors kotlinc's DEPRECATION_ERROR. [precision: ast-backed] [noisiness: normal] [capabilities: oracle:member-annotations, oracle:members]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -11842,7 +11842,7 @@
           }
         },
         "DuplicateDeclaration": {
-          "description": "Detects two top-level fun/class/val declarations in one file with the same name and (for functions) matching parameter type signature. Mirrors kotlinc's CONFLICTING_OVERLOADS / REDECLARATION for the file-local subset. [precision: ast-backed]",
+          "description": "Detects two top-level fun/class/val declarations in one file with the same name and (for functions) matching parameter type signature. Mirrors kotlinc's CONFLICTING_OVERLOADS / REDECLARATION for the file-local subset. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -11861,7 +11861,7 @@
           }
         },
         "DuplicateLabel": {
-          "description": "Detects repeated constant labels in a subject-bearing `when` expression. Mirrors kotlinc's DUPLICATE_LABEL_IN_WHEN. [precision: ast-backed]",
+          "description": "Detects repeated constant labels in a subject-bearing `when` expression. Mirrors kotlinc's DUPLICATE_LABEL_IN_WHEN. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -11880,7 +11880,7 @@
           }
         },
         "UnreachableCode": {
-          "description": "Detects statements that follow an unconditional jump (return, throw, break, continue) in the same block. Mirrors kotlinc's UNREACHABLE_CODE. [precision: ast-backed]",
+          "description": "Detects statements that follow an unconditional jump (return, throw, break, continue) in the same block. Mirrors kotlinc's UNREACHABLE_CODE. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -11911,7 +11911,7 @@
       "additionalProperties": false,
       "properties": {
         "AdMobInitializedBeforeConsent": {
-          "description": "Detects MobileAds.initialize() in Application.onCreate before any consent info update call. [precision: ast-backed]",
+          "description": "Detects MobileAds.initialize() in Application.onCreate before any consent info update call. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -11930,7 +11930,7 @@
           }
         },
         "AnalyticsCallWithoutConsentGate": {
-          "description": "Detects analytics event calls that are not guarded by a consent or GDPR check. [precision: type-aware] [capabilities: resolver]",
+          "description": "Detects analytics event calls that are not guarded by a consent or GDPR check. [precision: type-aware] [noisiness: normal] [capabilities: resolver]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -11949,7 +11949,7 @@
           }
         },
         "AnalyticsEventWithPiiParamName": {
-          "description": "Detects analytics event parameters whose key names match PII patterns like email, phone, or SSN. [precision: type-aware] [capabilities: resolver]",
+          "description": "Detects analytics event parameters whose key names match PII patterns like email, phone, or SSN. [precision: type-aware] [noisiness: normal] [capabilities: resolver]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -11968,7 +11968,7 @@
           }
         },
         "AnalyticsUserIdFromPii": {
-          "description": "Detects user-ID setter calls whose argument is a PII property like email or phoneNumber. [precision: type-aware] [capabilities: resolver]",
+          "description": "Detects user-ID setter calls whose argument is a PII property like email or phoneNumber. [precision: type-aware] [noisiness: normal] [capabilities: resolver]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -11987,7 +11987,7 @@
           }
         },
         "BiometricAuthNotFallingBackToDeviceCredential": {
-          "description": "Detects BiometricPrompt.authenticate() calls whose PromptInfo lacks device credential fallback. [precision: ast-backed]",
+          "description": "Detects BiometricPrompt.authenticate() calls whose PromptInfo lacks device credential fallback. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -12006,7 +12006,7 @@
           }
         },
         "ClipboardOnSensitiveInputType": {
-          "description": "Detects clipboard writes from variables whose names suggest passwords or credentials. [precision: ast-backed]",
+          "description": "Detects clipboard writes from variables whose names suggest passwords or credentials. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -12025,7 +12025,7 @@
           }
         },
         "ContactsAccessWithoutPermissionUi": {
-          "description": "Detects contacts queries not gated behind a RequestPermission activity-result callback. [precision: ast-backed]",
+          "description": "Detects contacts queries not gated behind a RequestPermission activity-result callback. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -12044,7 +12044,7 @@
           }
         },
         "CrashlyticsCustomKeyWithPii": {
-          "description": "Detects Crashlytics setCustomKey calls where the key name matches PII patterns. [precision: type-aware] [capabilities: resolver]",
+          "description": "Detects Crashlytics setCustomKey calls where the key name matches PII patterns. [precision: type-aware] [noisiness: normal] [capabilities: resolver]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -12063,7 +12063,7 @@
           }
         },
         "FirebaseRemoteConfigDefaultsWithPii": {
-          "description": "Detects Firebase Remote Config default map keys that match PII patterns. [precision: type-aware] [capabilities: resolver]",
+          "description": "Detects Firebase Remote Config default map keys that match PII patterns. [precision: type-aware] [noisiness: normal] [capabilities: resolver]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -12082,7 +12082,7 @@
           }
         },
         "LocationBackgroundWithoutRationale": {
-          "description": "Detects ACCESS_BACKGROUND_LOCATION requests without a shouldShowRequestPermissionRationale call. [precision: ast-backed]",
+          "description": "Detects ACCESS_BACKGROUND_LOCATION requests without a shouldShowRequestPermissionRationale call. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -12101,7 +12101,7 @@
           }
         },
         "LogOfSharedPreferenceRead": {
-          "description": "Detects logger calls that directly pass SharedPreferences values with sensitive keys. [precision: type-aware] [capabilities: resolver]",
+          "description": "Detects logger calls that directly pass SharedPreferences values with sensitive keys. [precision: type-aware] [noisiness: normal] [capabilities: resolver]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -12120,7 +12120,7 @@
           }
         },
         "PlainFileWriteOfSensitive": {
-          "description": "Detects plain-file writes to paths containing sensitive terms without using EncryptedFile. [precision: type-aware] [capabilities: resolver]",
+          "description": "Detects plain-file writes to paths containing sensitive terms without using EncryptedFile. [precision: type-aware] [noisiness: normal] [capabilities: resolver]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -12139,7 +12139,7 @@
           }
         },
         "ScreenshotNotBlockedOnLoginScreen": {
-          "description": "Detects sensitive screens (login, payment, PIN) that do not set FLAG_SECURE to block screenshots. [precision: ast-backed]",
+          "description": "Detects sensitive screens (login, payment, PIN) that do not set FLAG_SECURE to block screenshots. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -12158,7 +12158,7 @@
           }
         },
         "SharedPreferencesForSensitiveKey": {
-          "description": "Detects SharedPreferences put calls with key names matching sensitive patterns like token, password, or secret. [precision: type-aware] [capabilities: resolver]",
+          "description": "Detects SharedPreferences put calls with key names matching sensitive patterns like token, password, or secret. [precision: type-aware] [noisiness: normal] [capabilities: resolver]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -12189,7 +12189,7 @@
       "additionalProperties": false,
       "properties": {
         "AllProjectsBlock": {
-          "description": "Detects deprecated allprojects {} blocks in Gradle build scripts. [precision: ast-backed]",
+          "description": "Detects deprecated allprojects {} blocks in Gradle build scripts. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -12208,7 +12208,7 @@
           }
         },
         "BuildConfigDebugInLibrary": {
-          "description": "Detects BuildConfig.DEBUG references inside Android library modules where the value is always false in release. [precision: ast-backed]",
+          "description": "Detects BuildConfig.DEBUG references inside Android library modules where the value is always false in release. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -12227,7 +12227,7 @@
           }
         },
         "BuildConfigDebugInverted": {
-          "description": "Detects negated BuildConfig.DEBUG guards wrapping logging calls that likely invert a debug-only check. [precision: ast-backed]",
+          "description": "Detects negated BuildConfig.DEBUG guards wrapping logging calls that likely invert a debug-only check. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -12246,7 +12246,7 @@
           }
         },
         "CommentedOutCodeBlock": {
-          "description": "Detects consecutive lines of commented-out Kotlin code that should be deleted or restored. [fixable: idiomatic] [precision: heuristic/text-backed] [capabilities: line-pass]",
+          "description": "Detects consecutive lines of commented-out Kotlin code that should be deleted or restored. [fixable: idiomatic] [precision: heuristic/text-backed] [noisiness: noisy] [capabilities: line-pass]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -12265,7 +12265,7 @@
           }
         },
         "CommentedOutImport": {
-          "description": "Detects commented-out import statements that are either dead code or incomplete refactors. [fixable: idiomatic] [precision: ast-backed]",
+          "description": "Detects commented-out import statements that are either dead code or incomplete refactors. [fixable: idiomatic] [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -12284,7 +12284,7 @@
           }
         },
         "ConventionPluginDeadCode": {
-          "description": "Detects convention plugins under build-logic or buildSrc that are never applied by any module. [precision: project-structure-aware] [capabilities: module-index]",
+          "description": "Detects convention plugins under build-logic or buildSrc that are never applied by any module. [precision: project-structure-aware] [noisiness: normal] [capabilities: module-index]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -12303,7 +12303,7 @@
           }
         },
         "DebugToastInProduction": {
-          "description": "Detects Toast.makeText calls whose message starts with debug-related prefixes in production code. [precision: ast-backed]",
+          "description": "Detects Toast.makeText calls whose message starts with debug-related prefixes in production code. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -12322,7 +12322,7 @@
           }
         },
         "GradleBuildContainsTodo": {
-          "description": "Detects TODO comments in build.gradle(.kts) files that may block release readiness. [precision: heuristic/text-backed] [capabilities: line-pass]",
+          "description": "Detects TODO comments in build.gradle(.kts) files that may block release readiness. [precision: heuristic/text-backed] [noisiness: noisy] [capabilities: line-pass]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -12341,7 +12341,7 @@
           }
         },
         "HardcodedEnvironmentName": {
-          "description": "Detects hardcoded environment names like 'dev', 'staging', or 'prod' passed to config APIs. [precision: ast-backed]",
+          "description": "Detects hardcoded environment names like 'dev', 'staging', or 'prod' passed to config APIs. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -12360,7 +12360,7 @@
           }
         },
         "HardcodedLocalhostUrl": {
-          "description": "Detects hardcoded localhost or 10.0.2.2 URLs in non-test production source files. [precision: ast-backed]",
+          "description": "Detects hardcoded localhost or 10.0.2.2 URLs in non-test production source files. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -12379,7 +12379,7 @@
           }
         },
         "HardcodedLogTag": {
-          "description": "Detects Log tag string literals matching the enclosing class name instead of using a companion TAG constant. [precision: ast-backed]",
+          "description": "Detects Log tag string literals matching the enclosing class name instead of using a companion TAG constant. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -12398,7 +12398,7 @@
           }
         },
         "MergeConflictMarkerLeftover": {
-          "description": "Detects unresolved merge conflict markers (\u003c\u003c\u003c, ===, \u003e\u003e\u003e) left in source files. [precision: heuristic/text-backed] [capabilities: line-pass]",
+          "description": "Detects unresolved merge conflict markers (\u003c\u003c\u003c, ===, \u003e\u003e\u003e) left in source files. [precision: heuristic/text-backed] [noisiness: noisy] [capabilities: line-pass]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -12417,7 +12417,7 @@
           }
         },
         "ModuleTemplateConformance": {
-          "description": "Detects feature modules that do not conform to the configured module template. [precision: project-structure-aware] [capabilities: module-index]",
+          "description": "Detects feature modules that do not conform to the configured module template. [precision: project-structure-aware] [noisiness: normal] [capabilities: module-index]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -12436,7 +12436,7 @@
           }
         },
         "NonAsciiIdentifier": {
-          "description": "Detects class, function, or property names containing non-ASCII characters. [precision: ast-backed]",
+          "description": "Detects class, function, or property names containing non-ASCII characters. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -12455,7 +12455,7 @@
           }
         },
         "OpenForTestingCallerInNonTest": {
-          "description": "Detects subclassing of @OpenForTesting types outside test source sets. [precision: project-structure-aware] [capabilities: cross-file]",
+          "description": "Detects subclassing of @OpenForTesting types outside test source sets. [precision: project-structure-aware] [noisiness: normal] [capabilities: cross-file]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -12474,7 +12474,7 @@
           }
         },
         "PrintStackTraceInProduction": {
-          "description": "Detects printStackTrace() calls in code that has a logging framework available. [precision: ast-backed]",
+          "description": "Detects printStackTrace() calls in code that has a logging framework available. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -12493,7 +12493,7 @@
           }
         },
         "PrintlnInProduction": {
-          "description": "Detects println or print calls in production code that should use a logging framework. [precision: ast-backed]",
+          "description": "Detects println or print calls in production code that should use a logging framework. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -12512,7 +12512,7 @@
           }
         },
         "TestFixtureAccessedFromProduction": {
-          "description": "Detects usage of types declared under src/testFixtures/ from production source files. [precision: project-structure-aware] [capabilities: cross-file, parsed-files, resolver]",
+          "description": "Detects usage of types declared under src/testFixtures/ from production source files. [precision: project-structure-aware] [noisiness: normal] [capabilities: cross-file, parsed-files, resolver]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -12531,7 +12531,7 @@
           }
         },
         "TestOnlyImportInProduction": {
-          "description": "Detects test framework imports (JUnit, Mockito, MockK, etc.) in non-test source files. [precision: ast-backed]",
+          "description": "Detects test framework imports (JUnit, Mockito, MockK, etc.) in non-test source files. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -12550,7 +12550,7 @@
           }
         },
         "TimberTreeNotPlanted": {
-          "description": "Detects Timber logging usage without any Timber.plant() call in the project. [precision: project-structure-aware] [capabilities: cross-file, oracle:call-targets, resolver]",
+          "description": "Detects Timber logging usage without any Timber.plant() call in the project. [precision: project-structure-aware] [noisiness: normal] [capabilities: cross-file, oracle:call-targets, resolver]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -12569,7 +12569,7 @@
           }
         },
         "VisibleForTestingCallerInNonTest": {
-          "description": "Detects calls to @VisibleForTesting-annotated functions from non-test source files. [precision: project-structure-aware] [capabilities: cross-file]",
+          "description": "Detects calls to @VisibleForTesting-annotated functions from non-test source files. [precision: project-structure-aware] [noisiness: normal] [capabilities: cross-file]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -12600,7 +12600,7 @@
       "additionalProperties": false,
       "properties": {
         "BufferedReadWithoutBuffer": {
-          "description": "Detects FileInputStream.read() without BufferedInputStream wrapping for efficient reads. [precision: ast-backed]",
+          "description": "Detects FileInputStream.read() without BufferedInputStream wrapping for efficient reads. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -12619,7 +12619,7 @@
           }
         },
         "ComposePainterResourceInLoop": {
-          "description": "Detects painterResource() calls inside list or loop lambdas that create a fresh painter per iteration. [precision: ast-backed]",
+          "description": "Detects painterResource() calls inside list or loop lambdas that create a fresh painter per iteration. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -12638,7 +12638,7 @@
           }
         },
         "ComposeRememberInList": {
-          "description": "Detects remember {} inside items {} without a key argument, causing recomputation on list reorder. [precision: ast-backed]",
+          "description": "Detects remember {} inside items {} without a key argument, causing recomputation on list reorder. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -12657,7 +12657,7 @@
           }
         },
         "CursorLoopWithColumnIndexInLoop": {
-          "description": "Detects getColumnIndex() calls inside cursor while-loops that should be hoisted before the loop. [precision: ast-backed]",
+          "description": "Detects getColumnIndex() calls inside cursor while-loops that should be hoisted before the loop. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -12676,7 +12676,7 @@
           }
         },
         "DatabaseInstanceRecreated": {
-          "description": "Detects Room.databaseBuilder calls inside regular functions that recreate the database on each invocation. [precision: ast-backed]",
+          "description": "Detects Room.databaseBuilder calls inside regular functions that recreate the database on each invocation. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -12695,7 +12695,7 @@
           }
         },
         "DatabaseQueryOnMainThread": {
-          "description": "Detects SQLiteDatabase query calls in code with positive main-thread evidence. [precision: project-structure-aware] [capabilities: parsed-files]",
+          "description": "Detects SQLiteDatabase query calls in code with positive main-thread evidence. [precision: project-structure-aware] [noisiness: normal] [capabilities: parsed-files]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -12714,7 +12714,7 @@
           }
         },
         "HttpClientNotReused": {
-          "description": "Detects Java HttpClient.newHttpClient() in function bodies without singleton reuse. [precision: ast-backed]",
+          "description": "Detects Java HttpClient.newHttpClient() in function bodies without singleton reuse. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -12733,7 +12733,7 @@
           }
         },
         "ImageLoadedAtFullSizeInList": {
-          "description": "Detects Glide or Coil image loading without size constraints in list item contexts. [precision: type-aware] [capabilities: oracle:supertypes, resolver]",
+          "description": "Detects Glide or Coil image loading without size constraints in list item contexts. [precision: type-aware] [noisiness: normal] [capabilities: oracle:supertypes, resolver]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -12752,7 +12752,7 @@
           }
         },
         "ImageLoaderNoMemoryCache": {
-          "description": "Detects image loaders configured to skip the memory cache, causing repeated decoding and GC pressure. [precision: ast-backed]",
+          "description": "Detects image loaders configured to skip the memory cache, causing repeated decoding and GC pressure. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -12771,7 +12771,7 @@
           }
         },
         "LazyColumnInsideColumn": {
-          "description": "Detects LazyColumn or LazyRow nested inside a scrollable Column or Row causing measurement issues. [precision: ast-backed]",
+          "description": "Detects LazyColumn or LazyRow nested inside a scrollable Column or Row causing measurement issues. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -12790,7 +12790,7 @@
           }
         },
         "OkHttpCallExecuteSync": {
-          "description": "Detects synchronous OkHttp Call.execute() inside suspend functions that block the coroutine thread. [precision: ast-backed]",
+          "description": "Detects synchronous OkHttp Call.execute() inside suspend functions that block the coroutine thread. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -12809,7 +12809,7 @@
           }
         },
         "OkHttpClientCreatedPerCall": {
-          "description": "Detects OkHttpClient construction in function bodies instead of reusing a singleton instance. [precision: ast-backed]",
+          "description": "Detects OkHttpClient construction in function bodies instead of reusing a singleton instance. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -12828,7 +12828,7 @@
           }
         },
         "PeriodicWorkRequestLessThan15Min": {
-          "description": "Detects PeriodicWorkRequest intervals below the 15-minute minimum enforced by WorkManager. [precision: ast-backed]",
+          "description": "Detects PeriodicWorkRequest intervals below the 15-minute minimum enforced by WorkManager. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -12847,7 +12847,7 @@
           }
         },
         "RecyclerAdapterStableIdsDefault": {
-          "description": "Detects RecyclerView.Adapter subclasses that do not enable stable IDs for better animation. [precision: type-aware] [capabilities: oracle:supertypes, resolver]",
+          "description": "Detects RecyclerView.Adapter subclasses that do not enable stable IDs for better animation. [precision: type-aware] [noisiness: normal] [capabilities: oracle:supertypes, resolver]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -12866,7 +12866,7 @@
           }
         },
         "RecyclerAdapterWithoutDiffUtil": {
-          "description": "Detects RecyclerView.Adapter subclasses using notifyDataSetChanged() without DiffUtil. [precision: type-aware] [capabilities: oracle:supertypes, resolver]",
+          "description": "Detects RecyclerView.Adapter subclasses using notifyDataSetChanged() without DiffUtil. [precision: type-aware] [noisiness: normal] [capabilities: oracle:supertypes, resolver]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -12885,7 +12885,7 @@
           }
         },
         "RecyclerViewInLazyColumn": {
-          "description": "Detects AndroidView wrapping a RecyclerView inside a LazyColumn or LazyRow causing nested scrolling conflicts. [precision: ast-backed]",
+          "description": "Detects AndroidView wrapping a RecyclerView inside a LazyColumn or LazyRow causing nested scrolling conflicts. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -12904,7 +12904,7 @@
           }
         },
         "RetrofitCreateInHotPath": {
-          "description": "Detects Retrofit.Builder().build().create() in function bodies instead of a singleton or @Provides. [precision: ast-backed]",
+          "description": "Detects Retrofit.Builder().build().create() in function bodies instead of a singleton or @Provides. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -12923,7 +12923,7 @@
           }
         },
         "RoomLoadsAllWhereFirstUsed": {
-          "description": "Detects getAll().first() patterns that load an entire table for a single element instead of using LIMIT 1. [precision: project-structure-aware] [capabilities: parsed-files]",
+          "description": "Detects getAll().first() patterns that load an entire table for a single element instead of using LIMIT 1. [precision: project-structure-aware] [noisiness: normal] [capabilities: parsed-files]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -12942,7 +12942,7 @@
           }
         },
         "WorkManagerNoBackoff": {
-          "description": "Detects OneTimeWorkRequest chains without a setBackoffCriteria policy for retryable work. [precision: ast-backed]",
+          "description": "Detects OneTimeWorkRequest chains without a setBackoffCriteria policy for retryable work. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -12961,7 +12961,7 @@
           }
         },
         "WorkManagerUniquePolicyKeepButReplaceIntended": {
-          "description": "Detects enqueueUniqueWork with KEEP policy followed by cancel logic where REPLACE may be intended. [precision: ast-backed]",
+          "description": "Detects enqueueUniqueWork with KEEP policy followed by cancel logic where REPLACE may be intended. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -12992,7 +12992,7 @@
       "additionalProperties": false,
       "properties": {
         "AllowAllHostnameVerifier": {
-          "description": "HostnameVerifier accepts all hostnames [precision: ast-backed]",
+          "description": "HostnameVerifier accepts all hostnames [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -13011,7 +13011,7 @@
           }
         },
         "BroadcastReceiverExportedFlagMissing": {
-          "description": "Dynamic receiver registration missing exported flag [precision: ast-backed]",
+          "description": "Dynamic receiver registration missing exported flag [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -13030,7 +13030,7 @@
           }
         },
         "ContentProviderQueryWithSelectionInterpolation": {
-          "description": "Detects interpolated selection strings passed to ContentResolver.query() that may enable SQL injection. [precision: type-aware] [capabilities: resolver]",
+          "description": "Detects interpolated selection strings passed to ContentResolver.query() that may enable SQL injection. [precision: type-aware] [noisiness: normal] [capabilities: resolver]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -13049,7 +13049,7 @@
           }
         },
         "DeepLinkMissingAutoVerify": {
-          "description": "Deep link intent filter missing autoVerify [precision: project-structure-aware] [capabilities: manifest]",
+          "description": "Deep link intent filter missing autoVerify [precision: project-structure-aware] [noisiness: normal] [capabilities: manifest]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -13068,7 +13068,7 @@
           }
         },
         "DisableCertificatePinning": {
-          "description": "CertificatePinner has no pins [precision: ast-backed]",
+          "description": "CertificatePinner has no pins [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -13087,7 +13087,7 @@
           }
         },
         "FileFromUntrustedPath": {
-          "description": "Detects File construction from untrusted input in extraction or download functions without path traversal guards. [precision: ast-backed]",
+          "description": "Detects File construction from untrusted input in extraction or download functions without path traversal guards. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -13106,7 +13106,7 @@
           }
         },
         "GoogleApiKeyInResources": {
-          "description": "Detects Google API keys embedded directly in XML resource files [precision: project-structure-aware] [capabilities: resources]",
+          "description": "Detects Google API keys embedded directly in XML resource files [precision: project-structure-aware] [noisiness: normal] [capabilities: resources]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -13125,7 +13125,7 @@
           }
         },
         "GsonPolymorphicFromJson": {
-          "description": "Detects Gson fromJson calls that deserialize into Object/Any. [precision: ast-backed]",
+          "description": "Detects Gson fromJson calls that deserialize into Object/Any. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -13144,7 +13144,7 @@
           }
         },
         "HardcodedAwsAccessKey": {
-          "description": "Detects string literals that look like an AWS access-key ID committed directly into source. [precision: ast-backed]",
+          "description": "Detects string literals that look like an AWS access-key ID committed directly into source. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -13163,7 +13163,7 @@
           }
         },
         "HardcodedBearerToken": {
-          "description": "Detects bearer authorization strings with hardcoded tokens embedded directly in source code. [precision: ast-backed]",
+          "description": "Detects bearer authorization strings with hardcoded tokens embedded directly in source code. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -13182,7 +13182,7 @@
           }
         },
         "HardcodedGcpServiceAccount": {
-          "description": "Detects embedded GCP service-account JSON or private keys committed into source files. [precision: ast-backed]",
+          "description": "Detects embedded GCP service-account JSON or private keys committed into source files. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -13201,7 +13201,7 @@
           }
         },
         "HardcodedHttpUrl": {
-          "description": "Hardcoded HTTP URL in network API [precision: ast-backed]",
+          "description": "Hardcoded HTTP URL in network API [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -13220,7 +13220,7 @@
           }
         },
         "HardcodedJwt": {
-          "description": "Detects string literals that look like a JSON Web Token committed directly into source. [precision: ast-backed]",
+          "description": "Detects string literals that look like a JSON Web Token committed directly into source. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -13239,7 +13239,7 @@
           }
         },
         "HardcodedSecretKey": {
-          "description": "SecretKeySpec uses literal key bytes [precision: ast-backed]",
+          "description": "SecretKeySpec uses literal key bytes [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -13258,7 +13258,7 @@
           }
         },
         "ImplicitPendingIntent": {
-          "description": "PendingIntent missing mutability flag [precision: ast-backed]",
+          "description": "PendingIntent missing mutability flag [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -13277,7 +13277,7 @@
           }
         },
         "InsecureTrustManager": {
-          "description": "Trust manager accepts all certificates [precision: ast-backed]",
+          "description": "Trust manager accepts all certificates [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -13296,7 +13296,7 @@
           }
         },
         "JacksonDefaultTyping": {
-          "description": "Detects Jackson default typing APIs that enable polymorphic deserialization. [precision: ast-backed]",
+          "description": "Detects Jackson default typing APIs that enable polymorphic deserialization. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -13315,7 +13315,7 @@
           }
         },
         "JavaObjectInputStream": {
-          "description": "Detects ObjectInputStream construction in production source. [precision: ast-backed]",
+          "description": "Detects ObjectInputStream construction in production source. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -13334,7 +13334,7 @@
           }
         },
         "JdbcStatementExecute": {
-          "description": "Detects java.sql.Statement execution calls with interpolated or computed SQL strings. [precision: type-aware] [capabilities: resolver]",
+          "description": "Detects java.sql.Statement execution calls with interpolated or computed SQL strings. [precision: type-aware] [noisiness: normal] [capabilities: resolver]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -13353,7 +13353,7 @@
           }
         },
         "LogPii": {
-          "description": "Detects logger calls that include sensitive variable names in interpolated or concatenated messages. [precision: ast-backed]",
+          "description": "Detects logger calls that include sensitive variable names in interpolated or concatenated messages. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -13378,7 +13378,7 @@
           }
         },
         "NetworkSecurityConfigDebugOverrides": {
-          "description": "Debug overrides in release network security config [precision: project-structure-aware] [capabilities: manifest]",
+          "description": "Debug overrides in release network security config [precision: project-structure-aware] [noisiness: normal] [capabilities: manifest]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -13397,7 +13397,7 @@
           }
         },
         "OkHttpDisableSslValidation": {
-          "description": "OkHttp TLS validation disabled [precision: ast-backed]",
+          "description": "OkHttp TLS validation disabled [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -13416,7 +13416,7 @@
           }
         },
         "PrngFromSystemTime": {
-          "description": "Predictable Random seed from system time [precision: ast-backed]",
+          "description": "Predictable Random seed from system time [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -13435,7 +13435,7 @@
           }
         },
         "ProcessBuilderShellArg": {
-          "description": "Detects ProcessBuilder shell commands whose -c script argument is interpolated or computed. [precision: type-aware] [capabilities: resolver]",
+          "description": "Detects ProcessBuilder shell commands whose -c script argument is interpolated or computed. [precision: type-aware] [noisiness: normal] [capabilities: resolver]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -13454,7 +13454,7 @@
           }
         },
         "RoomRawQueryStringConcat": {
-          "description": "Detects SimpleSQLiteQuery SQL strings built with interpolation or non-static concatenation without bind args. [precision: type-aware] [capabilities: resolver]",
+          "description": "Detects SimpleSQLiteQuery SQL strings built with interpolation or non-static concatenation without bind args. [precision: type-aware] [noisiness: normal] [capabilities: resolver]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -13473,7 +13473,7 @@
           }
         },
         "RsaNoPadding": {
-          "description": "RSA cipher without padding [precision: ast-backed]",
+          "description": "RSA cipher without padding [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -13492,7 +13492,7 @@
           }
         },
         "RuntimeExecUnsafeShape": {
-          "description": "Detects Runtime.getRuntime().exec(String) commands built with interpolation or non-static concatenation. [precision: type-aware] [capabilities: resolver]",
+          "description": "Detects Runtime.getRuntime().exec(String) commands built with interpolation or non-static concatenation. [precision: type-aware] [noisiness: normal] [capabilities: resolver]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -13511,7 +13511,7 @@
           }
         },
         "SqlInjectionRawQuery": {
-          "description": "Detects SQLiteDatabase SQL arguments built with interpolation or non-static concatenation. [precision: type-aware] [capabilities: resolver]",
+          "description": "Detects SQLiteDatabase SQL arguments built with interpolation or non-static concatenation. [precision: type-aware] [noisiness: normal] [capabilities: resolver]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -13530,7 +13530,7 @@
           }
         },
         "StartActivityWithUntrustedIntent": {
-          "description": "Parsed Intent launched without package or component guard [precision: ast-backed]",
+          "description": "Parsed Intent launched without package or component guard [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -13549,7 +13549,7 @@
           }
         },
         "StaticIv": {
-          "description": "Static IV literal [precision: ast-backed]",
+          "description": "Static IV literal [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -13568,7 +13568,7 @@
           }
         },
         "TempFileWorldReadable": {
-          "description": "Detects setReadable/setWritable/setExecutable(true, false) on a File from createTempFile, exposing the temp file to all users. [precision: ast-backed]",
+          "description": "Detects setReadable/setWritable/setExecutable(true, false) on a File from createTempFile, exposing the temp file to all users. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -13587,7 +13587,7 @@
           }
         },
         "UnprotectedDynamicReceiver": {
-          "description": "Dynamic receiver registered without broadcast permission [precision: ast-backed]",
+          "description": "Dynamic receiver registered without broadcast permission [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -13606,7 +13606,7 @@
           }
         },
         "WeakKeySize": {
-          "description": "Weak crypto key size [precision: ast-backed]",
+          "description": "Weak crypto key size [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -13625,7 +13625,7 @@
           }
         },
         "WeakMacAlgorithm": {
-          "description": "Weak Mac algorithm [precision: ast-backed]",
+          "description": "Weak Mac algorithm [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -13644,7 +13644,7 @@
           }
         },
         "WeakMessageDigest": {
-          "description": "Weak MessageDigest algorithm [precision: ast-backed]",
+          "description": "Weak MessageDigest algorithm [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -13663,7 +13663,7 @@
           }
         },
         "XmlExternalEntity": {
-          "description": "Detects XML parser factories created without XXE-disabling hardening. [precision: ast-backed]",
+          "description": "Detects XML parser factories created without XXE-disabling hardening. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -13682,7 +13682,7 @@
           }
         },
         "ZipSlipUnchecked": {
-          "description": "Detects zip extraction loops that build a destination File from an entry name without a canonical-path containment check. [precision: ast-backed]",
+          "description": "Detects zip extraction loops that build a destination File from an entry name without a canonical-path containment check. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -13738,7 +13738,7 @@
       "additionalProperties": false,
       "properties": {
         "AbstractClassCanBeConcreteClass": {
-          "description": "Detects abstract classes that have no abstract members and could be made concrete. [precision: type-aware] [capabilities: resolver]",
+          "description": "Detects abstract classes that have no abstract members and could be made concrete. [precision: type-aware] [noisiness: normal] [capabilities: resolver]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -13757,7 +13757,7 @@
           }
         },
         "AbstractClassCanBeInterface": {
-          "description": "Detects abstract classes with no state that could be converted to interfaces. [precision: ast-backed]",
+          "description": "Detects abstract classes with no state that could be converted to interfaces. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -13776,7 +13776,7 @@
           }
         },
         "AlsoCouldBeApply": {
-          "description": "Detects .also {} blocks with multiple it. references that could use .apply {} instead. [fixable: semantic] [precision: ast-backed]",
+          "description": "Detects .also {} blocks with multiple it. references that could use .apply {} instead. [fixable: semantic] [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -13795,7 +13795,7 @@
           }
         },
         "BracesOnIfStatements": {
-          "description": "Detects if/else statements that are missing braces around their bodies. [fixable: cosmetic] [precision: ast-backed]",
+          "description": "Detects if/else statements that are missing braces around their bodies. [fixable: cosmetic] [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -13824,7 +13824,7 @@
           }
         },
         "BracesOnWhenStatements": {
-          "description": "Detects when branches that are missing braces around their bodies. [fixable: cosmetic] [precision: ast-backed]",
+          "description": "Detects when branches that are missing braces around their bodies. [fixable: cosmetic] [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -13853,7 +13853,7 @@
           }
         },
         "CanBeNonNullable": {
-          "description": "Detects nullable types that are initialized with non-null values and never assigned null. [precision: type-aware] [capabilities: resolver]",
+          "description": "Detects nullable types that are initialized with non-null values and never assigned null. [precision: type-aware] [noisiness: normal] [capabilities: resolver]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -13872,7 +13872,7 @@
           }
         },
         "CascadingCallWrapping": {
-          "description": "Detects chained calls that are not properly indented from the previous line. [precision: heuristic/text-backed] [capabilities: line-pass]",
+          "description": "Detects chained calls that are not properly indented from the previous line. [precision: heuristic/text-backed] [noisiness: noisy] [capabilities: line-pass]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -13896,7 +13896,7 @@
           }
         },
         "ClassOrdering": {
-          "description": "Detects class members that are not in the conventional ordering of properties, init blocks, constructors, functions, and companion objects. [precision: ast-backed]",
+          "description": "Detects class members that are not in the conventional ordering of properties, init blocks, constructors, functions, and companion objects. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -13915,7 +13915,7 @@
           }
         },
         "CollapsibleIfStatements": {
-          "description": "Detects nested if statements without else that can be merged with a logical AND. [fixable: idiomatic] [precision: ast-backed]",
+          "description": "Detects nested if statements without else that can be merged with a logical AND. [fixable: idiomatic] [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -13934,7 +13934,7 @@
           }
         },
         "DataClassContainsFunctions": {
-          "description": "Detects data classes that contain function members. [fixable: semantic] [precision: ast-backed]",
+          "description": "Detects data classes that contain function members. [fixable: semantic] [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -13960,7 +13960,7 @@
           }
         },
         "DataClassShouldBeImmutable": {
-          "description": "Detects data class properties declared as var instead of val. [fixable: idiomatic] [precision: type-aware] [capabilities: resolver]",
+          "description": "Detects data class properties declared as var instead of val. [fixable: idiomatic] [precision: type-aware] [noisiness: normal] [capabilities: resolver]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -13979,7 +13979,7 @@
           }
         },
         "DestructuringDeclarationWithTooManyEntries": {
-          "description": "Detects destructuring declarations with more entries than the configured maximum. [precision: ast-backed]",
+          "description": "Detects destructuring declarations with more entries than the configured maximum. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -14007,7 +14007,7 @@
           }
         },
         "DoubleNegativeExpression": {
-          "description": "Detects double negative expressions like !isNotEmpty() that should use the positive variant. [fixable: idiomatic] [precision: ast-backed]",
+          "description": "Detects double negative expressions like !isNotEmpty() that should use the positive variant. [fixable: idiomatic] [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -14026,7 +14026,7 @@
           }
         },
         "DoubleNegativeLambda": {
-          "description": "Detects double negative lambda patterns like filterNot { !predicate } that should use filter. [fixable: idiomatic] [precision: ast-backed]",
+          "description": "Detects double negative lambda patterns like filterNot { !predicate } that should use filter. [fixable: idiomatic] [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -14052,7 +14052,7 @@
           }
         },
         "EqualsNullCall": {
-          "description": "Detects .equals(null) calls that should use == null instead. [fixable: idiomatic] [precision: ast-backed]",
+          "description": "Detects .equals(null) calls that should use == null instead. [fixable: idiomatic] [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -14071,7 +14071,7 @@
           }
         },
         "EqualsOnSignatureLine": {
-          "description": "Detects expression body equals signs placed on a separate line from the function signature. [fixable: cosmetic] [precision: heuristic/text-backed] [capabilities: line-pass]",
+          "description": "Detects expression body equals signs placed on a separate line from the function signature. [fixable: cosmetic] [precision: heuristic/text-backed] [noisiness: noisy] [capabilities: line-pass]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -14090,7 +14090,7 @@
           }
         },
         "ExplicitCollectionElementAccessMethod": {
-          "description": "Detects explicit .get() and .set() calls that should use index operator syntax. [fixable: idiomatic] [precision: type-aware] [capabilities: resolver]",
+          "description": "Detects explicit .get() and .set() calls that should use index operator syntax. [fixable: idiomatic] [precision: type-aware] [noisiness: normal] [capabilities: resolver]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -14109,7 +14109,7 @@
           }
         },
         "ExplicitItLambdaMultipleParameters": {
-          "description": "Detects multi-parameter lambdas that use it as a parameter name. [precision: ast-backed]",
+          "description": "Detects multi-parameter lambdas that use it as a parameter name. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -14128,7 +14128,7 @@
           }
         },
         "ExplicitItLambdaParameter": {
-          "description": "Detects single-parameter lambdas that explicitly name their parameter it instead of using the implicit it. [fixable: cosmetic] [precision: ast-backed]",
+          "description": "Detects single-parameter lambdas that explicitly name their parameter it instead of using the implicit it. [fixable: cosmetic] [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -14147,7 +14147,7 @@
           }
         },
         "ExpressionBodySyntax": {
-          "description": "Detects single-expression functions that could use expression body syntax with the = operator. [fixable: idiomatic] [precision: ast-backed]",
+          "description": "Detects single-expression functions that could use expression body syntax with the = operator. [fixable: idiomatic] [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -14171,7 +14171,7 @@
           }
         },
         "ForbiddenAnnotation": {
-          "description": "Detects usage of annotations that are configured as forbidden. [fixable: idiomatic] [precision: ast-backed]",
+          "description": "Detects usage of annotations that are configured as forbidden. [fixable: idiomatic] [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -14200,7 +14200,7 @@
           }
         },
         "ForbiddenComment": {
-          "description": "Detects comments containing forbidden markers like TODO, FIXME, or STOPSHIP. [precision: ast-backed]",
+          "description": "Detects comments containing forbidden markers like TODO, FIXME, or STOPSHIP. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -14237,7 +14237,7 @@
           }
         },
         "ForbiddenImport": {
-          "description": "Detects import statements matching configured forbidden patterns. [fixable: idiomatic] [precision: ast-backed]",
+          "description": "Detects import statements matching configured forbidden patterns. [fixable: idiomatic] [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -14274,7 +14274,7 @@
           }
         },
         "ForbiddenMethodCall": {
-          "description": "Detects calls to methods that are configured as forbidden. [fixable: idiomatic] [precision: type-aware] [capabilities: oracle:call-targets, resolver]",
+          "description": "Detects calls to methods that are configured as forbidden. [fixable: idiomatic] [precision: type-aware] [noisiness: normal] [capabilities: oracle:call-targets, resolver]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -14304,7 +14304,7 @@
           }
         },
         "ForbiddenNamedParam": {
-          "description": "Detects named arguments in function calls where they should not be used. [precision: ast-backed]",
+          "description": "Detects named arguments in function calls where they should not be used. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -14335,7 +14335,7 @@
           }
         },
         "ForbiddenOptIn": {
-          "description": "Detects @OptIn annotations that opt into experimental APIs. [fixable: semantic] [precision: ast-backed]",
+          "description": "Detects @OptIn annotations that opt into experimental APIs. [fixable: semantic] [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -14361,7 +14361,7 @@
           }
         },
         "ForbiddenSuppress": {
-          "description": "Detects @Suppress annotations that silence warnings instead of fixing the underlying issue. [fixable: semantic] [precision: ast-backed]",
+          "description": "Detects @Suppress annotations that silence warnings instead of fixing the underlying issue. [fixable: semantic] [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -14387,7 +14387,7 @@
           }
         },
         "ForbiddenVoid": {
-          "description": "Detects usage of the Java Void type that should be replaced with Kotlin Unit. [fixable: idiomatic] [precision: ast-backed]",
+          "description": "Detects usage of the Java Void type that should be replaced with Kotlin Unit. [fixable: idiomatic] [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -14416,7 +14416,7 @@
           }
         },
         "FunctionOnlyReturningConstant": {
-          "description": "Detects functions whose body only returns a constant value that could be a const val. [precision: ast-backed]",
+          "description": "Detects functions whose body only returns a constant value that could be a const val. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -14452,7 +14452,7 @@
           }
         },
         "LoopWithTooManyJumpStatements": {
-          "description": "Detects loops containing more break or continue statements than the configured maximum. [precision: ast-backed]",
+          "description": "Detects loops containing more break or continue statements than the configured maximum. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -14480,7 +14480,7 @@
           }
         },
         "MagicNumber": {
-          "description": "Detects magic number literals in code that should be extracted to named constants. [precision: heuristic/text-backed]",
+          "description": "Detects magic number literals in code that should be extracted to named constants. [precision: heuristic/text-backed] [noisiness: noisy]\nCaveat: Heuristic literal scan: numeric arguments threaded through helper functions or builders may still be flagged at the call site.\nCaveat: Preview / Compose scaffolding annotations are excluded via ignoreAnnotated; custom annotation conventions may need additional configuration.",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -14626,7 +14626,7 @@
           }
         },
         "MandatoryBracesLoops": {
-          "description": "Detects for, while, and do-while loops that are missing braces around their bodies. [fixable: cosmetic] [precision: ast-backed]",
+          "description": "Detects for, while, and do-while loops that are missing braces around their bodies. [fixable: cosmetic] [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -14645,7 +14645,7 @@
           }
         },
         "MaxChainedCallsOnSameLine": {
-          "description": "Detects lines with more chained method calls than the configured maximum. [precision: heuristic/text-backed] [capabilities: line-pass]",
+          "description": "Detects lines with more chained method calls than the configured maximum. [precision: heuristic/text-backed] [noisiness: noisy] [capabilities: line-pass]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -14673,7 +14673,7 @@
           }
         },
         "MaxLineLength": {
-          "description": "Detects lines that exceed the configured maximum character length. [precision: heuristic/text-backed] [capabilities: line-pass]",
+          "description": "Detects lines that exceed the configured maximum character length. [precision: heuristic/text-backed] [noisiness: noisy] [capabilities: line-pass]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -14721,7 +14721,7 @@
           }
         },
         "MayBeConstant": {
-          "description": "Detects top-level val properties with constant initializers that could be declared as const val. [fixable: idiomatic] [precision: ast-backed]",
+          "description": "Detects top-level val properties with constant initializers that could be declared as const val. [fixable: idiomatic] [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -14740,7 +14740,7 @@
           }
         },
         "ModifierOrder": {
-          "description": "Detects modifiers that are not in the recommended Kotlin ordering. [fixable: cosmetic] [precision: ast-backed]",
+          "description": "Detects modifiers that are not in the recommended Kotlin ordering. [fixable: cosmetic] [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -14759,7 +14759,7 @@
           }
         },
         "MultilineLambdaItParameter": {
-          "description": "Detects multiline lambdas that use the implicit it parameter instead of naming it explicitly. [precision: ast-backed]",
+          "description": "Detects multiline lambdas that use the implicit it parameter instead of naming it explicitly. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -14778,7 +14778,7 @@
           }
         },
         "MultilineRawStringIndentation": {
-          "description": "Detects multiline raw strings that are missing trimIndent() or trimMargin() calls. [precision: ast-backed]",
+          "description": "Detects multiline raw strings that are missing trimIndent() or trimMargin() calls. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -14809,7 +14809,7 @@
           }
         },
         "NestedClassesVisibility": {
-          "description": "Detects nested classes with explicit public modifier inside internal parent classes. [fixable: cosmetic] [precision: ast-backed]",
+          "description": "Detects nested classes with explicit public modifier inside internal parent classes. [fixable: cosmetic] [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -14828,7 +14828,7 @@
           }
         },
         "NewLineAtEndOfFile": {
-          "description": "Detects files that do not end with a newline character. [fixable: cosmetic] [precision: heuristic/text-backed] [capabilities: line-pass]",
+          "description": "Detects files that do not end with a newline character. [fixable: cosmetic] [precision: heuristic/text-backed] [noisiness: noisy] [capabilities: line-pass]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -14847,7 +14847,7 @@
           }
         },
         "NoTabs": {
-          "description": "Detects tab characters used for indentation instead of spaces. [fixable: cosmetic] [precision: heuristic/text-backed] [capabilities: line-pass]",
+          "description": "Detects tab characters used for indentation instead of spaces. [fixable: cosmetic] [precision: heuristic/text-backed] [noisiness: noisy] [capabilities: line-pass]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -14883,7 +14883,7 @@
           }
         },
         "NullableBooleanCheck": {
-          "description": "Detects equality comparisons against Boolean literals like x == true on nullable Booleans. [fixable: idiomatic] [precision: ast-backed]",
+          "description": "Detects equality comparisons against Boolean literals like x == true on nullable Booleans. [fixable: idiomatic] [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -14902,7 +14902,7 @@
           }
         },
         "ObjectLiteralToLambda": {
-          "description": "Detects object literals implementing a single method that could be converted to a lambda. [precision: type-aware] [capabilities: resolver]",
+          "description": "Detects object literals implementing a single method that could be converted to a lambda. [precision: type-aware] [noisiness: normal] [capabilities: resolver]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -14921,7 +14921,7 @@
           }
         },
         "OptionalAbstractKeyword": {
-          "description": "Detects redundant abstract modifier on interface members where it is implied. [fixable: cosmetic] [precision: ast-backed]",
+          "description": "Detects redundant abstract modifier on interface members where it is implied. [fixable: cosmetic] [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -14940,7 +14940,7 @@
           }
         },
         "OptionalUnit": {
-          "description": "Detects explicit Unit return types and return Unit statements that are redundant. [fixable: cosmetic] [precision: ast-backed]",
+          "description": "Detects explicit Unit return types and return Unit statements that are redundant. [fixable: cosmetic] [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -14959,7 +14959,7 @@
           }
         },
         "ProtectedMemberInFinalClass": {
-          "description": "Detects protected members in final classes where they should be private. [fixable: idiomatic] [precision: type-aware] [capabilities: resolver]",
+          "description": "Detects protected members in final classes where they should be private. [fixable: idiomatic] [precision: type-aware] [noisiness: normal] [capabilities: resolver]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -14978,7 +14978,7 @@
           }
         },
         "RangeUntilInsteadOfRangeTo": {
-          "description": "Detects usage of the until infix function that can be replaced with the ..\u003c range operator. [fixable: idiomatic] [precision: ast-backed]",
+          "description": "Detects usage of the until infix function that can be replaced with the ..\u003c range operator. [fixable: idiomatic] [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -14997,7 +14997,7 @@
           }
         },
         "RedundantConstructorKeyword": {
-          "description": "Detects unnecessary constructor keyword on primary constructors without annotations or visibility modifiers. [fixable: cosmetic] [precision: ast-backed]",
+          "description": "Detects unnecessary constructor keyword on primary constructors without annotations or visibility modifiers. [fixable: cosmetic] [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -15016,7 +15016,7 @@
           }
         },
         "RedundantExplicitType": {
-          "description": "Detects explicit type annotations that can be inferred from the initializer. [fixable: cosmetic] [precision: type-aware] [capabilities: resolver]",
+          "description": "Detects explicit type annotations that can be inferred from the initializer. [fixable: cosmetic] [precision: type-aware] [noisiness: normal] [capabilities: resolver]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -15035,7 +15035,7 @@
           }
         },
         "RedundantHigherOrderMapUsage": {
-          "description": "Detects identity .map { it } calls that are no-ops and can be removed. [fixable: idiomatic] [precision: ast-backed]",
+          "description": "Detects identity .map { it } calls that are no-ops and can be removed. [fixable: idiomatic] [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -15054,7 +15054,7 @@
           }
         },
         "RedundantVisibilityModifier": {
-          "description": "Detects explicit public modifier which is redundant since public is the default visibility in Kotlin. [fixable: cosmetic] [precision: ast-backed]",
+          "description": "Detects explicit public modifier which is redundant since public is the default visibility in Kotlin. [fixable: cosmetic] [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -15073,7 +15073,7 @@
           }
         },
         "ReturnCount": {
-          "description": "Detects functions with more return statements than the configured maximum. [precision: ast-backed]",
+          "description": "Detects functions with more return statements than the configured maximum. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -15123,7 +15123,7 @@
           }
         },
         "SafeCast": {
-          "description": "Detects is-check followed by unsafe cast patterns that should use safe cast as? instead. [precision: ast-backed]",
+          "description": "Detects is-check followed by unsafe cast patterns that should use safe cast as? instead. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -15142,7 +15142,7 @@
           }
         },
         "SerialVersionUIDInSerializableClass": {
-          "description": "Detects Serializable classes that are missing a serialVersionUID field. [fixable: idiomatic] [precision: type-aware] [capabilities: resolver]",
+          "description": "Detects Serializable classes that are missing a serialVersionUID field. [fixable: idiomatic] [precision: type-aware] [noisiness: normal] [capabilities: resolver]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -15161,7 +15161,7 @@
           }
         },
         "SpacingAfterPackageAndImports": {
-          "description": "Detects missing blank lines after package and import declarations. [fixable: cosmetic] [precision: heuristic/text-backed] [capabilities: line-pass]",
+          "description": "Detects missing blank lines after package and import declarations. [fixable: cosmetic] [precision: heuristic/text-backed] [noisiness: noisy] [capabilities: line-pass]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -15180,7 +15180,7 @@
           }
         },
         "StringShouldBeRawString": {
-          "description": "Detects string literals with many escape characters that would be more readable as raw strings. [precision: ast-backed]",
+          "description": "Detects string literals with many escape characters that would be more readable as raw strings. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -15208,7 +15208,7 @@
           }
         },
         "ThrowsCount": {
-          "description": "Detects functions with more throw statements than the configured maximum. [precision: ast-backed]",
+          "description": "Detects functions with more throw statements than the configured maximum. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -15241,7 +15241,7 @@
           }
         },
         "TrailingWhitespace": {
-          "description": "Detects lines that end with trailing whitespace characters. [fixable: cosmetic] [precision: heuristic/text-backed] [capabilities: line-pass]",
+          "description": "Detects lines that end with trailing whitespace characters. [fixable: cosmetic] [precision: heuristic/text-backed] [noisiness: noisy] [capabilities: line-pass]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -15260,7 +15260,7 @@
           }
         },
         "TrimMultilineRawString": {
-          "description": "Detects multiline raw strings that should use trimIndent() or trimMargin() for proper indentation. [fixable: cosmetic] [precision: ast-backed]",
+          "description": "Detects multiline raw strings that should use trimIndent() or trimMargin() for proper indentation. [fixable: cosmetic] [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -15286,7 +15286,7 @@
           }
         },
         "UnderscoresInNumericLiterals": {
-          "description": "Detects large numeric literals that should use underscore separators for readability. [fixable: cosmetic] [precision: ast-backed]",
+          "description": "Detects large numeric literals that should use underscore separators for readability. [fixable: cosmetic] [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -15315,7 +15315,7 @@
           }
         },
         "UnnecessaryAny": {
-          "description": "Detects .any { true } and .filter {}.any() patterns that can be simplified. [fixable: idiomatic] [precision: ast-backed]",
+          "description": "Detects .any { true } and .filter {}.any() patterns that can be simplified. [fixable: idiomatic] [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -15334,7 +15334,7 @@
           }
         },
         "UnnecessaryApply": {
-          "description": "Detects .apply {} blocks that are empty or do not reference the receiver. [fixable: idiomatic] [precision: ast-backed]",
+          "description": "Detects .apply {} blocks that are empty or do not reference the receiver. [fixable: idiomatic] [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -15353,7 +15353,7 @@
           }
         },
         "UnnecessaryBackticks": {
-          "description": "Detects backtick-quoted identifiers that do not require backticks. [fixable: cosmetic] [precision: ast-backed]",
+          "description": "Detects backtick-quoted identifiers that do not require backticks. [fixable: cosmetic] [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -15372,7 +15372,7 @@
           }
         },
         "UnnecessaryBracesAroundTrailingLambda": {
-          "description": "Detects empty parentheses before trailing lambdas that can be removed. [fixable: cosmetic] [precision: ast-backed]",
+          "description": "Detects empty parentheses before trailing lambdas that can be removed. [fixable: cosmetic] [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -15391,7 +15391,7 @@
           }
         },
         "UnnecessaryFilter": {
-          "description": "Detects .filter {}.first() chains that can be simplified to .first {} with the predicate. [fixable: idiomatic] [precision: type-aware] [capabilities: resolver]",
+          "description": "Detects .filter {}.first() chains that can be simplified to .first {} with the predicate. [fixable: idiomatic] [precision: type-aware] [noisiness: normal] [capabilities: resolver]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -15410,7 +15410,7 @@
           }
         },
         "UnnecessaryFullyQualifiedName": {
-          "description": "Detects fully qualified names that are unnecessary because the type is already imported. [precision: ast-backed]",
+          "description": "Detects fully qualified names that are unnecessary because the type is already imported. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -15429,7 +15429,7 @@
           }
         },
         "UnnecessaryInheritance": {
-          "description": "Detects unnecessary explicit inheritance from Any which is implicit in Kotlin. [fixable: idiomatic] [precision: ast-backed]",
+          "description": "Detects unnecessary explicit inheritance from Any which is implicit in Kotlin. [fixable: idiomatic] [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -15448,7 +15448,7 @@
           }
         },
         "UnnecessaryInnerClass": {
-          "description": "Detects inner classes that do not reference the outer class and could remove the inner modifier. [fixable: idiomatic] [precision: ast-backed]",
+          "description": "Detects inner classes that do not reference the outer class and could remove the inner modifier. [fixable: idiomatic] [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -15467,7 +15467,7 @@
           }
         },
         "UnnecessaryLet": {
-          "description": "Detects .let {} calls that are identity transforms or single-call chains replaceable by direct invocation. [fixable: idiomatic] [precision: ast-backed]",
+          "description": "Detects .let {} calls that are identity transforms or single-call chains replaceable by direct invocation. [fixable: idiomatic] [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -15486,7 +15486,7 @@
           }
         },
         "UnnecessaryParentheses": {
-          "description": "Detects unnecessary parentheses around expressions that add no value. [fixable: cosmetic] [precision: ast-backed]",
+          "description": "Detects unnecessary parentheses around expressions that add no value. [fixable: cosmetic] [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -15510,7 +15510,7 @@
           }
         },
         "UnnecessaryReversed": {
-          "description": "Detects chained sort and reverse calls that can be replaced with a single sort operation. [fixable: idiomatic] [precision: ast-backed]",
+          "description": "Detects chained sort and reverse calls that can be replaced with a single sort operation. [fixable: idiomatic] [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -15529,7 +15529,7 @@
           }
         },
         "UnusedImport": {
-          "description": "Detects import statements where the imported name is not referenced in the file. [fixable: idiomatic] [precision: ast-backed]",
+          "description": "Detects import statements where the imported name is not referenced in the file. [fixable: idiomatic] [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -15548,7 +15548,7 @@
           }
         },
         "UnusedParameter": {
-          "description": "Detects function parameters that are never used in the function body. [precision: ast-backed]",
+          "description": "Detects function parameters that are never used in the function body. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -15573,7 +15573,7 @@
           }
         },
         "UnusedPrivateClass": {
-          "description": "Detects private classes that are never referenced in the file. [precision: ast-backed]",
+          "description": "Detects private classes that are never referenced in the file. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -15592,7 +15592,7 @@
           }
         },
         "UnusedPrivateFunction": {
-          "description": "Detects private functions that are never called in the file. [precision: ast-backed]",
+          "description": "Detects private functions that are never called in the file. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -15617,7 +15617,7 @@
           }
         },
         "UnusedPrivateMember": {
-          "description": "Detects private members (classes, functions, properties) that are never used. [precision: ast-backed]",
+          "description": "Detects private members (classes, functions, properties) that are never used. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -15649,7 +15649,7 @@
           }
         },
         "UnusedPrivateProperty": {
-          "description": "Detects private properties that are never referenced in the file. [precision: ast-backed]",
+          "description": "Detects private properties that are never referenced in the file. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -15674,7 +15674,7 @@
           }
         },
         "UnusedVariable": {
-          "description": "Detects local variables that are declared but never used. [precision: ast-backed]",
+          "description": "Detects local variables that are declared but never used. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -15699,7 +15699,7 @@
           }
         },
         "UseAnyOrNoneInsteadOfFind": {
-          "description": "Detects .find {} != null patterns that should use .any {} or .none {} instead. [fixable: idiomatic] [precision: ast-backed]",
+          "description": "Detects .find {} != null patterns that should use .any {} or .none {} instead. [fixable: idiomatic] [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -15718,7 +15718,7 @@
           }
         },
         "UseArrayLiteralsInAnnotations": {
-          "description": "Detects arrayOf() calls in annotations that should use array literal [] syntax. [fixable: idiomatic] [precision: ast-backed]",
+          "description": "Detects arrayOf() calls in annotations that should use array literal [] syntax. [fixable: idiomatic] [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -15737,7 +15737,7 @@
           }
         },
         "UseCheckNotNull": {
-          "description": "Detects check(x != null) calls that should use checkNotNull(x) instead. [fixable: idiomatic] [precision: type-aware] [capabilities: resolver]",
+          "description": "Detects check(x != null) calls that should use checkNotNull(x) instead. [fixable: idiomatic] [precision: type-aware] [noisiness: normal] [capabilities: resolver]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -15756,7 +15756,7 @@
           }
         },
         "UseCheckOrError": {
-          "description": "Detects if (!cond) throw IllegalStateException patterns that should use check(). [fixable: idiomatic] [precision: ast-backed]",
+          "description": "Detects if (!cond) throw IllegalStateException patterns that should use check(). [fixable: idiomatic] [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -15775,7 +15775,7 @@
           }
         },
         "UseDataClass": {
-          "description": "Detects classes with only properties in the constructor that could be data classes. [precision: ast-backed]",
+          "description": "Detects classes with only properties in the constructor that could be data classes. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -15799,7 +15799,7 @@
           }
         },
         "UseEmptyCounterpart": {
-          "description": "Detects listOf(), setOf(), and similar calls with no arguments that should use emptyList(), emptySet(), etc. [fixable: idiomatic] [precision: ast-backed]",
+          "description": "Detects listOf(), setOf(), and similar calls with no arguments that should use emptyList(), emptySet(), etc. [fixable: idiomatic] [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -15818,7 +15818,7 @@
           }
         },
         "UseIfEmptyOrIfBlank": {
-          "description": "Detects manual isEmpty/isBlank checks that could use .ifEmpty {} or .ifBlank {} instead. [fixable: idiomatic] [precision: ast-backed]",
+          "description": "Detects manual isEmpty/isBlank checks that could use .ifEmpty {} or .ifBlank {} instead. [fixable: idiomatic] [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -15837,7 +15837,7 @@
           }
         },
         "UseIfInsteadOfWhen": {
-          "description": "Detects when expressions with two or fewer branches that could be replaced with if. [fixable: idiomatic] [precision: ast-backed]",
+          "description": "Detects when expressions with two or fewer branches that could be replaced with if. [fixable: idiomatic] [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -15861,7 +15861,7 @@
           }
         },
         "UseIsNullOrEmpty": {
-          "description": "Detects x == null || x.isEmpty() patterns that should use isNullOrEmpty(). [fixable: idiomatic] [precision: type-aware] [capabilities: oracle:call-targets, resolver]",
+          "description": "Detects x == null || x.isEmpty() patterns that should use isNullOrEmpty(). [fixable: idiomatic] [precision: type-aware] [noisiness: normal] [capabilities: oracle:call-targets, resolver]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -15880,7 +15880,7 @@
           }
         },
         "UseLet": {
-          "description": "Detects null checks that could be replaced with ?.let {} scope function. [precision: ast-backed]",
+          "description": "Detects null checks that could be replaced with ?.let {} scope function. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -15899,7 +15899,7 @@
           }
         },
         "UseOrEmpty": {
-          "description": "Detects x ?: emptyList() patterns that should use .orEmpty() instead. [fixable: idiomatic] [precision: ast-backed]",
+          "description": "Detects x ?: emptyList() patterns that should use .orEmpty() instead. [fixable: idiomatic] [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -15918,7 +15918,7 @@
           }
         },
         "UseRequire": {
-          "description": "Detects if (!cond) throw IllegalArgumentException patterns that should use require(). [fixable: idiomatic] [precision: ast-backed]",
+          "description": "Detects if (!cond) throw IllegalArgumentException patterns that should use require(). [fixable: idiomatic] [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -15937,7 +15937,7 @@
           }
         },
         "UseRequireNotNull": {
-          "description": "Detects require(x != null) calls that should use requireNotNull(x) instead. [fixable: idiomatic] [precision: type-aware] [capabilities: resolver]",
+          "description": "Detects require(x != null) calls that should use requireNotNull(x) instead. [fixable: idiomatic] [precision: type-aware] [noisiness: normal] [capabilities: resolver]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -15956,7 +15956,7 @@
           }
         },
         "UseSumOfInsteadOfFlatMapSize": {
-          "description": "Detects flatMap/map followed by size/count/sum chains that should use sumOf instead. [fixable: idiomatic] [precision: ast-backed]",
+          "description": "Detects flatMap/map followed by size/count/sum chains that should use sumOf instead. [fixable: idiomatic] [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -15975,7 +15975,7 @@
           }
         },
         "UselessCallOnNotNull": {
-          "description": "Detects calls like .orEmpty() or .isNullOrEmpty() on receivers that are already non-null. [fixable: idiomatic] [precision: type-aware] [capabilities: resolver]",
+          "description": "Detects calls like .orEmpty() or .isNullOrEmpty() on receivers that are already non-null. [fixable: idiomatic] [precision: type-aware] [noisiness: normal] [capabilities: resolver]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -15994,7 +15994,7 @@
           }
         },
         "UtilityClassWithPublicConstructor": {
-          "description": "Detects utility classes that have a public constructor instead of a private one. [fixable: idiomatic] [precision: ast-backed]",
+          "description": "Detects utility classes that have a public constructor instead of a private one. [fixable: idiomatic] [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -16013,7 +16013,7 @@
           }
         },
         "VarCouldBeVal": {
-          "description": "Detects var properties that are never reassigned and could be declared as val. [fixable: idiomatic] [precision: ast-backed]",
+          "description": "Detects var properties that are never reassigned and could be declared as val. [fixable: idiomatic] [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -16037,7 +16037,7 @@
           }
         },
         "WildcardImport": {
-          "description": "Detects wildcard import statements that should be replaced with explicit imports. [precision: ast-backed]",
+          "description": "Detects wildcard import statements that should be replaced with explicit imports. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -16080,7 +16080,7 @@
       "additionalProperties": false,
       "properties": {
         "ApplyPluginTwice": {
-          "description": "Detects a Gradle plugin applied in both plugins { } and apply(plugin = ...) in the same build file. [fixable: idiomatic] [precision: project-structure-aware] [capabilities: gradle]",
+          "description": "Detects a Gradle plugin applied in both plugins { } and apply(plugin = ...) in the same build file. [fixable: idiomatic] [precision: project-structure-aware] [noisiness: normal] [capabilities: gradle]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -16099,7 +16099,7 @@
           }
         },
         "CompileSdkMismatchAcrossModules": {
-          "description": "Detects Android modules whose compileSdk is lower than the maximum compileSdk in the project. [precision: project-structure-aware] [capabilities: module-index]",
+          "description": "Detects Android modules whose compileSdk is lower than the maximum compileSdk in the project. [precision: project-structure-aware] [noisiness: normal] [capabilities: module-index]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -16118,7 +16118,7 @@
           }
         },
         "ConfigurationsAllSideEffect": {
-          "description": "Detects configurations.all blocks that mutate dependency resolution globally. [precision: project-structure-aware] [capabilities: gradle]",
+          "description": "Detects configurations.all blocks that mutate dependency resolution globally. [precision: project-structure-aware] [noisiness: normal] [capabilities: gradle]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -16142,7 +16142,7 @@
           }
         },
         "ConventionPluginAppliedToWrongTarget": {
-          "description": "Detects convention plugins applied to incompatible Gradle module targets. [precision: project-structure-aware] [capabilities: module-index]",
+          "description": "Detects convention plugins applied to incompatible Gradle module targets. [precision: project-structure-aware] [noisiness: normal] [capabilities: module-index]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -16168,7 +16168,7 @@
           }
         },
         "DependenciesInRootProject": {
-          "description": "Detects dependency declarations directly in the root Gradle project. [precision: project-structure-aware] [capabilities: gradle]",
+          "description": "Detects dependency declarations directly in the root Gradle project. [precision: project-structure-aware] [noisiness: normal] [capabilities: gradle]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -16198,7 +16198,7 @@
           }
         },
         "DependencyFromBintray": {
-          "description": "Detects Gradle repositories hosted on retired Bintray endpoints. [precision: project-structure-aware] [capabilities: gradle]",
+          "description": "Detects Gradle repositories hosted on retired Bintray endpoints. [precision: project-structure-aware] [noisiness: normal] [capabilities: gradle]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -16217,7 +16217,7 @@
           }
         },
         "DependencyFromHttp": {
-          "description": "Detects Gradle Maven/Ivy repositories fetched over plaintext HTTP. [precision: project-structure-aware] [capabilities: gradle]",
+          "description": "Detects Gradle Maven/Ivy repositories fetched over plaintext HTTP. [precision: project-structure-aware] [noisiness: normal] [capabilities: gradle]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -16255,7 +16255,7 @@
           }
         },
         "DependencyFromJcenter": {
-          "description": "Detects Gradle repositories that still use JCenter. [precision: project-structure-aware] [capabilities: gradle]",
+          "description": "Detects Gradle repositories that still use JCenter. [precision: project-structure-aware] [noisiness: normal] [capabilities: gradle]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -16274,7 +16274,7 @@
           }
         },
         "DependencySnapshotInRelease": {
-          "description": "Detects Gradle dependencies that use SNAPSHOT versions in release builds. [precision: project-structure-aware] [capabilities: gradle]",
+          "description": "Detects Gradle dependencies that use SNAPSHOT versions in release builds. [precision: project-structure-aware] [noisiness: normal] [capabilities: gradle]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -16305,7 +16305,7 @@
           }
         },
         "DependencyVerificationDisabled": {
-          "description": "Detects Gradle dependency verification disabled in gradle.properties. [precision: project-structure-aware] [capabilities: module-index]",
+          "description": "Detects Gradle dependency verification disabled in gradle.properties. [precision: project-structure-aware] [noisiness: normal] [capabilities: module-index]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -16329,7 +16329,7 @@
           }
         },
         "DependencyWithoutGroup": {
-          "description": "Detects legacy Gradle dependency coordinates that omit the group. [precision: project-structure-aware] [capabilities: gradle]",
+          "description": "Detects legacy Gradle dependency coordinates that omit the group. [precision: project-structure-aware] [noisiness: normal] [capabilities: gradle]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -16348,7 +16348,7 @@
           }
         },
         "GradleWrapperValidationAction": {
-          "description": "Detects GitHub Actions Gradle setup steps missing wrapper validation. [precision: project-structure-aware] [capabilities: module-index]",
+          "description": "Detects GitHub Actions Gradle setup steps missing wrapper validation. [precision: project-structure-aware] [noisiness: normal] [capabilities: module-index]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -16367,7 +16367,7 @@
           }
         },
         "JvmTargetMismatch": {
-          "description": "Detects Kotlin JVM target and Java compatibility settings that disagree. [precision: project-structure-aware] [capabilities: gradle]",
+          "description": "Detects Kotlin JVM target and Java compatibility settings that disagree. [precision: project-structure-aware] [noisiness: normal] [capabilities: gradle]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -16386,7 +16386,7 @@
           }
         },
         "KotlinVersionMismatchAcrossModules": {
-          "description": "Detects modules whose Kotlin JVM target or toolchain differs from the project majority. [precision: project-structure-aware] [capabilities: module-index]",
+          "description": "Detects modules whose Kotlin JVM target or toolchain differs from the project majority. [precision: project-structure-aware] [noisiness: normal] [capabilities: module-index]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -16405,7 +16405,7 @@
           }
         },
         "MissingGradleChecksums": {
-          "description": "Detects Gradle dependency locking declarations without a sibling gradle.lockfile. [precision: project-structure-aware] [capabilities: module-index]",
+          "description": "Detects Gradle dependency locking declarations without a sibling gradle.lockfile. [precision: project-structure-aware] [noisiness: normal] [capabilities: module-index]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -16424,7 +16424,7 @@
           }
         },
         "VersionCatalogBuildSrcMismatch": {
-          "description": "Detects buildSrc/build-logic dependency coordinates whose version disagrees with libs.versions.toml. [precision: project-structure-aware] [capabilities: module-index]",
+          "description": "Detects buildSrc/build-logic dependency coordinates whose version disagrees with libs.versions.toml. [precision: project-structure-aware] [noisiness: normal] [capabilities: module-index]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -16443,7 +16443,7 @@
           }
         },
         "VersionCatalogDuplicateVersion": {
-          "description": "Detects [versions] aliases in libs.versions.toml that share the same literal version string. [precision: project-structure-aware] [capabilities: module-index]",
+          "description": "Detects [versions] aliases in libs.versions.toml that share the same literal version string. [precision: project-structure-aware] [noisiness: normal] [capabilities: module-index]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -16462,7 +16462,7 @@
           }
         },
         "VersionCatalogRawVersionInBuild": {
-          "description": "Detects build.gradle(.kts) dependency literals whose group:name coordinate is already declared in libs.versions.toml. [precision: project-structure-aware] [capabilities: module-index]",
+          "description": "Detects build.gradle(.kts) dependency literals whose group:name coordinate is already declared in libs.versions.toml. [precision: project-structure-aware] [noisiness: normal] [capabilities: module-index]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -16481,7 +16481,7 @@
           }
         },
         "VersionCatalogUnused": {
-          "description": "Detects libs.versions.toml aliases not referenced by any build script or convention plugin. [precision: project-structure-aware] [capabilities: module-index]",
+          "description": "Detects libs.versions.toml aliases not referenced by any build script or convention plugin. [precision: project-structure-aware] [noisiness: normal] [capabilities: module-index]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -16538,7 +16538,7 @@
       "additionalProperties": false,
       "properties": {
         "AssertEqualsArgumentOrder": {
-          "description": "Detects assertEquals calls with reversed argument order (actual, expected) instead of (expected, actual). [precision: ast-backed]",
+          "description": "Detects assertEquals calls with reversed argument order (actual, expected) instead of (expected, actual). [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -16557,7 +16557,7 @@
           }
         },
         "AssertNullableWithNotNullAssertion": {
-          "description": "Detects non-null assertions (!!) inside assertion calls where assertNotNull should be used instead. [precision: ast-backed]",
+          "description": "Detects non-null assertions (!!) inside assertion calls where assertNotNull should be used instead. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -16576,7 +16576,7 @@
           }
         },
         "AssertTrueOnComparison": {
-          "description": "Detects assertTrue(a == b) calls that should use assertEquals for better failure messages. [precision: ast-backed]",
+          "description": "Detects assertTrue(a == b) calls that should use assertEquals for better failure messages. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -16595,7 +16595,7 @@
           }
         },
         "MixedAssertionLibraries": {
-          "description": "Detects files that import both JUnit Assert and Google Truth assertion APIs. [precision: heuristic/text-backed] [capabilities: line-pass]",
+          "description": "Detects files that import both JUnit Assert and Google Truth assertion APIs. [precision: heuristic/text-backed] [noisiness: noisy] [capabilities: line-pass]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -16614,7 +16614,7 @@
           }
         },
         "MockWithoutVerify": {
-          "description": "Detects mock objects created in test functions that are never verified or stubbed. [precision: ast-backed]",
+          "description": "Detects mock objects created in test functions that are never verified or stubbed. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -16633,7 +16633,7 @@
           }
         },
         "RelaxedMockUsedForValueClass": {
-          "description": "Detects relaxed mocks of primitive or value types where literal values should be used instead. [precision: ast-backed]",
+          "description": "Detects relaxed mocks of primitive or value types where literal values should be used instead. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -16652,7 +16652,7 @@
           }
         },
         "RunBlockingInTest": {
-          "description": "Detects runBlocking usage in test functions where runTest provides better coroutine test support. [precision: ast-backed]",
+          "description": "Detects runBlocking usage in test functions where runTest provides better coroutine test support. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -16671,7 +16671,7 @@
           }
         },
         "RunTestWithDelay": {
-          "description": "Detects delay() calls inside runTest blocks where advanceTimeBy should be used instead. [precision: ast-backed]",
+          "description": "Detects delay() calls inside runTest blocks where advanceTimeBy should be used instead. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -16690,7 +16690,7 @@
           }
         },
         "RunTestWithThreadSleep": {
-          "description": "Detects Thread.sleep() calls inside runTest blocks where advanceTimeBy should be used instead. [precision: ast-backed]",
+          "description": "Detects Thread.sleep() calls inside runTest blocks where advanceTimeBy should be used instead. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -16709,7 +16709,7 @@
           }
         },
         "SharedMutableStateInObject": {
-          "description": "Detects mutable var properties in companion objects or object declarations shared across tests. [precision: ast-backed]",
+          "description": "Detects mutable var properties in companion objects or object declarations shared across tests. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -16728,7 +16728,7 @@
           }
         },
         "SpyOnDataClass": {
-          "description": "Detects spying on data class instances where value-based equality breaks spy semantics. [precision: ast-backed]",
+          "description": "Detects spying on data class instances where value-based equality breaks spy semantics. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -16747,7 +16747,7 @@
           }
         },
         "TestDispatcherNotInjected": {
-          "description": "Detects production dispatchers (Dispatchers.IO, Default, Main) used directly in test functions. [precision: ast-backed]",
+          "description": "Detects production dispatchers (Dispatchers.IO, Default, Main) used directly in test functions. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -16766,7 +16766,7 @@
           }
         },
         "TestFunctionReturnValue": {
-          "description": "Detects @Test functions that return a non-Unit type, since JUnit ignores return values. [precision: ast-backed]",
+          "description": "Detects @Test functions that return a non-Unit type, since JUnit ignores return values. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -16785,7 +16785,7 @@
           }
         },
         "TestInheritanceDepth": {
-          "description": "Detects test class inheritance hierarchies deeper than two levels that should be flattened. [precision: ast-backed]",
+          "description": "Detects test class inheritance hierarchies deeper than two levels that should be flattened. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -16804,7 +16804,7 @@
           }
         },
         "TestNameContainsUnderscore": {
-          "description": "Detects test function names using underscores where backtick-quoted names are preferred. [fixable: cosmetic] [precision: ast-backed]",
+          "description": "Detects test function names using underscores where backtick-quoted names are preferred. [fixable: cosmetic] [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -16823,7 +16823,7 @@
           }
         },
         "TestWithOnlyTodo": {
-          "description": "Detects @Test functions whose body is only a TODO() or fail() call without @Ignore. [precision: ast-backed]",
+          "description": "Detects @Test functions whose body is only a TODO() or fail() call without @Ignore. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -16842,7 +16842,7 @@
           }
         },
         "TestWithoutAssertion": {
-          "description": "Detects @Test functions that contain no assertion or verification calls. [precision: ast-backed]",
+          "description": "Detects @Test functions that contain no assertion or verification calls. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -16873,7 +16873,7 @@
           }
         },
         "UntestedPublicApi": {
-          "description": "Detects public Kotlin API declarations that are not referenced from test sources. [precision: project-structure-aware] [capabilities: cross-file, parsed-files]",
+          "description": "Detects public Kotlin API declarations that are not referenced from test sources. [precision: project-structure-aware] [noisiness: normal] [capabilities: cross-file, parsed-files]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -16892,7 +16892,7 @@
           }
         },
         "VerifyWithoutMock": {
-          "description": "Detects verify or coVerify calls on objects that are not declared as mocks in the test. [precision: ast-backed]",
+          "description": "Detects verify or coVerify calls on objects that are not declared as mocks in the test. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {


### PR DESCRIPTION
Closes #188.

## Summary
- Adds `api.Noisiness` (quiet/normal/noisy) with `String`/`Parse` and a `NoisinessProvider` hook mirroring the Precision tier scaffolding.
- Adds `Rule.KnownLimitations` / `RuleDescriptor.KnownLimitations` — short caveat bullets surfaced under `caveats` in MCP `rules.explain`.
- `V2RuleNoisiness` derives the default tier from Precision (heuristic/text-backed → noisy, else normal); explicit `Rule.Noisiness` or a `NoisinessProvider` on the implementation wins.
- New `--strict` flag and config `strict: true` exclude `NoisinessNoisy` rules from the active set unless they are explicitly named in `--enable-rules`. Strict is independent of `--all-rules` and `--experimental`.
- Schema descriptions now include `[noisiness: …]` and `Caveat: …` lines; MCP `rules.explain` returns a populated `noisiness` tier and a `caveats` array when present.
- `MagicNumber`, `ArrayPrimitive`, and `CouldBeSequence` ship initial KnownLimitations bullets as documented heuristic examples.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...` (0 issues)
- [x] `go test ./... -count=1`
- [x] `make schema` (committed regenerated schema)
- [x] `make integration` (11 passed)
- [x] `make regression` (within expected finding counts)
- [x] New unit tests: `TestNoisinessFromPrecision`, `TestV2RuleNoisiness_*`, `TestStrictPresetExcludesNoisy`, `TestMetaForRule_NoisinessAlwaysSet`, `TestMetaForRule_KnownLimitationsSurfaced`, `TestRulesExplain_SurfacesCaveats`, `TestRulesExplain_NoisinessAlwaysPresent`.