### PR TITLE
feat(rules): add Effort tier for manual-fix difficulty

### DIFF
--- a/cmd/krit/verb_dispatch.go
+++ b/cmd/krit/verb_dispatch.go
@@ -29,6 +29,7 @@ import (
 	climsuggestreviewers "github.com/kaeawc/krit/internal/cli/suggestreviewers"
 	climtestcoverage "github.com/kaeawc/krit/internal/cli/testcoverage"
 	climtransform "github.com/kaeawc/krit/internal/cli/transform"
+	climtriage "github.com/kaeawc/krit/internal/cli/triage"
 	climusedsymbols "github.com/kaeawc/krit/internal/cli/usedsymbols"
 )
 
@@ -65,6 +66,7 @@ const (
 	verbGraph
 	verbPrecommit
 	verbSnapshot
+	verbTriage
 )
 
 var verbByName = map[string]subcommandVerb{
@@ -97,6 +99,7 @@ var verbByName = map[string]subcommandVerb{
 	"graph":              verbGraph,
 	"precommit":          verbPrecommit,
 	"snapshot":           verbSnapshot,
+	"triage":             verbTriage,
 }
 
 func classifyVerb(arg string) subcommandVerb {
@@ -175,6 +178,8 @@ func runVerbAndExitB(verb subcommandVerb, rest []string) bool {
 	case verbSnapshot:
 		climsnapshot.Version = version
 		os.Exit(climsnapshot.Run(rest))
+	case verbTriage:
+		os.Exit(climtriage.Run(rest))
 	}
 	return false
 }

--- a/internal/cli/triage/triage.go
+++ b/internal/cli/triage/triage.go
@@ -1,0 +1,133 @@
+// Package triage implements `krit triage`, a post-processing filter
+// over a JSON findings report that drops findings whose rule exceeds a
+// requested manual-fix effort budget.
+//
+// Workflow: `krit --format=json . > findings.json && krit triage
+// --max-effort=local findings.json`. Reading the same JSON report krit
+// emits keeps the command independent of the scan pipeline; teams can
+// run triage on archived reports without re-scanning.
+package triage
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/kaeawc/krit/internal/output"
+	"github.com/kaeawc/krit/internal/rules"
+	api "github.com/kaeawc/krit/internal/rules/api"
+)
+
+// Run is the CLI entry point invoked from cmd/krit.
+func Run(args []string) int { return run(args, os.Stdin, os.Stdout, os.Stderr) }
+
+func run(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("triage", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	maxEffort := fs.String("max-effort", "local",
+		"Drop findings whose rule exceeds this effort tier. One of: trivial, local, refactor, architectural.")
+	if err := fs.Parse(args); err != nil {
+		return 1
+	}
+
+	budget, ok := api.ParseEffort(*maxEffort)
+	if !ok {
+		fmt.Fprintf(stderr, "triage: invalid --max-effort %q; valid: trivial, local, refactor, architectural\n", *maxEffort)
+		return 1
+	}
+
+	src, err := openSource(fs.Args(), stdin)
+	if err != nil {
+		fmt.Fprintf(stderr, "triage: %v\n", err)
+		return 1
+	}
+	defer src.Close()
+
+	var report output.JSONReport
+	if err := json.NewDecoder(src).Decode(&report); err != nil {
+		fmt.Fprintf(stderr, "triage: decoding findings: %v\n", err)
+		return 1
+	}
+
+	classifier := registryClassifier()
+	report.Findings = FilterFindings(report.Findings, budget, classifier)
+	rebuildSummary(&report)
+
+	enc := json.NewEncoder(stdout)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(&report); err != nil {
+		fmt.Fprintf(stderr, "triage: encoding findings: %v\n", err)
+		return 1
+	}
+	return 0
+}
+
+// FilterFindings returns findings whose effort is <= budget. The
+// effort per finding is read from finding.Effort when populated;
+// otherwise it is looked up via classify(ruleID). Findings whose rule
+// is unknown to the classifier are kept (a missing rule means we can't
+// make a triage decision, so the conservative choice is to surface it).
+func FilterFindings(in []output.JSONFinding, budget api.Effort, classify func(rule string) api.Effort) []output.JSONFinding {
+	out := make([]output.JSONFinding, 0, len(in))
+	for _, f := range in {
+		eff := api.EffortUnset
+		if f.Effort != "" {
+			if parsed, ok := api.ParseEffort(f.Effort); ok {
+				eff = parsed
+			}
+		}
+		if eff == api.EffortUnset && classify != nil {
+			eff = classify(f.Rule)
+		}
+		if eff != api.EffortUnset && eff > budget {
+			continue
+		}
+		out = append(out, f)
+	}
+	return out
+}
+
+func registryClassifier() func(string) api.Effort {
+	cache := make(map[string]api.Effort, len(api.Registry))
+	for _, r := range api.Registry {
+		cache[r.ID] = rules.V2RuleEffort(r)
+	}
+	return func(id string) api.Effort {
+		if e, ok := cache[id]; ok {
+			return e
+		}
+		return api.EffortUnset
+	}
+}
+
+func openSource(args []string, stdin io.Reader) (io.ReadCloser, error) {
+	if len(args) == 0 || args[0] == "-" {
+		return io.NopCloser(stdin), nil
+	}
+	f, err := os.Open(args[0])
+	if err != nil {
+		return nil, fmt.Errorf("opening %s: %w", args[0], err)
+	}
+	return f, nil
+}
+
+func rebuildSummary(report *output.JSONReport) {
+	byRuleSet := make(map[string]int)
+	byRule := make(map[string]int)
+	fixable := 0
+	for _, f := range report.Findings {
+		byRuleSet[f.RuleSet]++
+		byRule[f.Rule]++
+		if f.Fixable {
+			fixable++
+		}
+	}
+	report.Summary = output.JSONSummary{
+		Total:     len(report.Findings),
+		ByRuleSet: byRuleSet,
+		ByRule:    byRule,
+		Fixable:   fixable,
+	}
+}

--- a/internal/cli/triage/triage_test.go
+++ b/internal/cli/triage/triage_test.go
@@ -1,0 +1,124 @@
+package triage
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/kaeawc/krit/internal/output"
+	api "github.com/kaeawc/krit/internal/rules/api"
+)
+
+func TestTriageMaxEffort_filtersByEffort(t *testing.T) {
+	classify := func(rule string) api.Effort {
+		switch rule {
+		case "Trivial":
+			return api.EffortTrivial
+		case "Local":
+			return api.EffortLocal
+		case "Refactor":
+			return api.EffortRefactor
+		case "Architectural":
+			return api.EffortArchitectural
+		}
+		return api.EffortUnset
+	}
+	in := []output.JSONFinding{
+		{Rule: "Trivial", RuleSet: "a"},
+		{Rule: "Local", RuleSet: "a"},
+		{Rule: "Refactor", RuleSet: "b"},
+		{Rule: "Architectural", RuleSet: "b"},
+	}
+
+	cases := []struct {
+		cap  api.Effort
+		want []string
+	}{
+		{api.EffortTrivial, []string{"Trivial"}},
+		{api.EffortLocal, []string{"Trivial", "Local"}},
+		{api.EffortRefactor, []string{"Trivial", "Local", "Refactor"}},
+		{api.EffortArchitectural, []string{"Trivial", "Local", "Refactor", "Architectural"}},
+	}
+	for _, c := range cases {
+		got := FilterFindings(in, c.cap, classify)
+		names := make([]string, len(got))
+		for i, f := range got {
+			names[i] = f.Rule
+		}
+		if !equal(names, c.want) {
+			t.Errorf("cap=%v: got %v, want %v", c.cap, names, c.want)
+		}
+	}
+}
+
+// Findings carrying an explicit Effort field should be honored without
+// consulting the classifier — this is how the field flows through from
+// the JSON producer when teams archive reports for later triage.
+func TestTriageMaxEffort_honorsExplicitEffort(t *testing.T) {
+	classify := func(string) api.Effort { return api.EffortUnset }
+	in := []output.JSONFinding{
+		{Rule: "A", Effort: "trivial"},
+		{Rule: "B", Effort: "refactor"},
+		{Rule: "C"}, // no effort, unknown rule -> kept (conservative)
+	}
+	got := FilterFindings(in, api.EffortLocal, classify)
+	if len(got) != 2 || got[0].Rule != "A" || got[1].Rule != "C" {
+		t.Errorf("got %+v", got)
+	}
+}
+
+// Smoke-test Run end-to-end via stdin/stdout to confirm the command
+// rebuilds the summary after filtering.
+func TestRun_filtersAndRebuildsSummary(t *testing.T) {
+	report := output.JSONReport{
+		Success: true, Version: "test",
+		Findings: []output.JSONFinding{
+			{Rule: "A", RuleSet: "x", Effort: "trivial", Fixable: true},
+			{Rule: "B", RuleSet: "x", Effort: "refactor"},
+		},
+	}
+	body, err := json.Marshal(report)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"--max-effort=local"}, bytes.NewReader(body), &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit=%d stderr=%s", code, stderr.String())
+	}
+
+	var out output.JSONReport
+	if err := json.Unmarshal(stdout.Bytes(), &out); err != nil {
+		t.Fatalf("decode: %v\nstdout=%s", err, stdout.String())
+	}
+	if len(out.Findings) != 1 || out.Findings[0].Rule != "A" {
+		t.Fatalf("findings = %+v", out.Findings)
+	}
+	if out.Summary.Total != 1 || out.Summary.Fixable != 1 {
+		t.Errorf("summary = %+v", out.Summary)
+	}
+}
+
+func TestRun_rejectsUnknownEffort(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"--max-effort=bogus"}, strings.NewReader("{}"), &stdout, &stderr)
+	if code == 0 {
+		t.Fatal("expected non-zero exit for bogus effort")
+	}
+	if !strings.Contains(stderr.String(), "invalid --max-effort") {
+		t.Errorf("stderr lacked diagnostic: %q", stderr.String())
+	}
+}
+
+func equal(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/mcp/resources.go
+++ b/internal/mcp/resources.go
@@ -45,6 +45,7 @@ type ruleInfo struct {
 	RuleSet     string `json:"ruleSet"`
 	Severity    string `json:"severity"`
 	Precision   string `json:"precision"`
+	Effort      string `json:"effort"`
 	Active      bool   `json:"active"`
 	Fixable     bool   `json:"fixable"`
 	FixLevel    string `json:"fixLevel,omitempty"`
@@ -66,6 +67,7 @@ func rulesResource() (string, string, error) {
 			RuleSet:     r.Category,
 			Severity:    string(r.Sev),
 			Precision:   rules.V2RulePrecision(r).String(),
+			Effort:      rules.V2RuleEffort(r).String(),
 			Active:      rules.IsDefaultActive(r.ID),
 			Fixable:     fixable,
 			FixLevel:    fixLevel,

--- a/internal/mcp/tool_rules.go
+++ b/internal/mcp/tool_rules.go
@@ -79,6 +79,7 @@ func (s *Server) rulesExplain(args rulesArgs) ToolResult {
 		"active":      active,
 		"fixable":     fixable,
 		"precision":   rules.V2RulePrecision(r).String(),
+		"effort":      rules.V2RuleEffort(r).String(),
 	}
 	if fixLevel != "" {
 		info["fixLevel"] = fixLevel

--- a/internal/output/json.go
+++ b/internal/output/json.go
@@ -46,6 +46,7 @@ type JSONFinding struct {
 	Fixable    bool    `json:"fixable"`
 	FixLevel   string  `json:"fixLevel,omitempty"`
 	Confidence float64 `json:"confidence,omitempty"`
+	Effort     string  `json:"effort,omitempty"`
 }
 
 // JSONSummary summarizes findings.
@@ -101,8 +102,9 @@ func formatJSONColumnsImpl(w io.Writer, columns *scanner.FindingColumns, version
 
 	cols := normalizedFindingColumns(columns)
 
-	// Build fix-level lookup
+	// Build fix-level and effort lookups
 	fixLevels := make(map[string]string)
+	efforts := make(map[string]string)
 	for _, r := range activeRules {
 		if r == nil {
 			continue
@@ -110,12 +112,15 @@ func formatJSONColumnsImpl(w io.Writer, columns *scanner.FindingColumns, version
 		if lvl, ok := rules.GetV2FixLevel(r); ok {
 			fixLevels[r.ID] = lvl.String()
 		}
+		if e := rules.V2RuleEffort(r); e != api.EffortUnset {
+			efforts[r.ID] = e.String()
+		}
 	}
 
 	byRuleSet := make(map[string]int)
 	byRule := make(map[string]int)
 	fixableCount := 0
-	findingsJSON, err := buildJSONFindings(columns, fixLevels, byRuleSet, byRule, &fixableCount, indent)
+	findingsJSON, err := buildJSONFindings(columns, fixLevels, efforts, byRuleSet, byRule, &fixableCount, indent)
 	if err != nil {
 		return fmt.Errorf("marshal findings: %w", err)
 	}
@@ -164,7 +169,7 @@ func formatJSONColumnsImpl(w io.Writer, columns *scanner.FindingColumns, version
 	return enc.Encode(report)
 }
 
-func buildJSONFindings(columns *scanner.FindingColumns, fixLevels map[string]string, byRuleSet, byRule map[string]int, fixableCount *int, indent bool) (json.RawMessage, error) {
+func buildJSONFindings(columns *scanner.FindingColumns, fixLevels, efforts map[string]string, byRuleSet, byRule map[string]int, fixableCount *int, indent bool) (json.RawMessage, error) {
 	cols := normalizedFindingColumns(columns)
 	if cols.Len() == 0 {
 		return json.RawMessage("[]"), nil
@@ -215,6 +220,7 @@ func buildJSONFindings(columns *scanner.FindingColumns, fixLevels map[string]str
 			finding.FixLevel = fixLevels[rule]
 			*fixableCount = *fixableCount + 1
 		}
+		finding.Effort = efforts[rule]
 		byRuleSet[ruleSet]++
 		byRule[rule]++
 

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -139,6 +139,7 @@ type sarifRegion struct {
 type sarifProperties struct {
 	Confidence float64 `json:"confidence,omitempty"`
 	Precision  string  `json:"precision,omitempty"`
+	Effort     string  `json:"effort,omitempty"`
 }
 
 // FormatSARIFColumns writes columnar findings as SARIF 2.1.0 JSON.
@@ -148,12 +149,14 @@ func FormatSARIFColumns(w io.Writer, columns *scanner.FindingColumns, version st
 	// Build description map from rule registry.
 	descMap := make(map[string]string)
 	precisionMap := make(map[string]string)
+	effortMap := make(map[string]string)
 	for _, r := range api.Registry {
 		key := r.Category + "/" + r.ID
 		if r.Description != "" {
 			descMap[key] = r.Description
 		}
 		precisionMap[key] = rules.V2RulePrecision(r).String()
+		effortMap[key] = rules.V2RuleEffort(r).String()
 	}
 
 	rulesSeen := make(map[string]bool)
@@ -194,8 +197,9 @@ func FormatSARIFColumns(w io.Writer, columns *scanner.FindingColumns, version st
 			}},
 		}
 		precision := precisionMap[ruleID]
-		if confidence := cols.ConfidenceAt(row); confidence > 0 || precision != "" {
-			r.Properties = &sarifProperties{Confidence: confidence, Precision: precision}
+		effort := effortMap[ruleID]
+		if confidence := cols.ConfidenceAt(row); confidence > 0 || precision != "" || effort != "" {
+			r.Properties = &sarifProperties{Confidence: confidence, Precision: precision, Effort: effort}
 		}
 		results = append(results, r)
 	})

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -698,6 +698,43 @@ func TestFormatJSON_SortsByFileLineAndLexicalTieBreakers(t *testing.T) {
 	}
 }
 
+// TestFormatSARIF_Effort verifies the SARIF effort property is wired
+// through from V2RuleEffort. The test registers a temporary rule so the
+// formatter's registry lookup picks up the effort tier, then restores
+// the registry to its prior state.
+func TestFormatSARIF_Effort(t *testing.T) {
+	savedRegistry := api.Registry
+	t.Cleanup(func() { api.Registry = savedRegistry })
+
+	r := &api.Rule{
+		ID: "EffortFixture", Category: "triage",
+		Description: "fixture", Sev: api.SeverityWarning,
+		NodeTypes: []string{"call_expression"},
+		Effort:    api.EffortArchitectural,
+		Check:     func(*api.Context) {},
+	}
+	api.Registry = append(append([]*api.Rule{}, savedRegistry...), r)
+
+	findings := []scanner.Finding{
+		{File: "a.kt", Line: 1, Col: 1, Severity: "warning",
+			RuleSet: "triage", Rule: "EffortFixture", Message: "m"},
+	}
+	var buf bytes.Buffer
+	FormatSARIF(&buf, findings, "1.0.0")
+	var sarif map[string]interface{}
+	if err := json.Unmarshal(buf.Bytes(), &sarif); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	results := sarif["runs"].([]interface{})[0].(map[string]interface{})["results"].([]interface{})
+	props, ok := results[0].(map[string]interface{})["properties"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("missing properties; result=%v", results[0])
+	}
+	if got := props["effort"]; got != "architectural" {
+		t.Errorf("effort = %v, want architectural", got)
+	}
+}
+
 func TestFormatSARIF_MultipleRules(t *testing.T) {
 	findings := []scanner.Finding{
 		{File: "a.kt", Line: 1, Col: 1, Severity: "warning", RuleSet: "style", Rule: "R1", Message: "m1"},

--- a/internal/rules/api/effort.go
+++ b/internal/rules/api/effort.go
@@ -1,0 +1,84 @@
+package api
+
+// Effort estimates the manual-fix difficulty of findings emitted by a
+// rule. It is orthogonal to FixLevel — FixLevel describes auto-fix safety
+// (whether krit can rewrite the source itself and how confident the
+// rewrite is), while Effort describes how much human work the fix takes
+// once a developer sits down with the report.
+//
+// Values are ordered from least to most work so callers can filter with
+// comparisons (e.g. `triage --max-effort local` keeps EffortTrivial and
+// EffortLocal, drops EffortRefactor and above). Zero (EffortUnset) means
+// the rule has not declared an explicit value and consumers should fall
+// back to the derived tier via V2RuleEffort.
+type Effort uint8
+
+const (
+	// EffortUnset is the zero value. Consumers should derive a tier via
+	// V2RuleEffort (rules package) when they see this value.
+	EffortUnset Effort = iota
+	// EffortTrivial: a single-line edit. Renames, missing modifier,
+	// stray import, swapping a deprecated call for its replacement.
+	EffortTrivial
+	// EffortLocal: changes confined to one file. Reordering a few
+	// statements, extracting a small helper, adjusting a local API.
+	EffortLocal
+	// EffortRefactor: the fix touches multiple files. Renaming a public
+	// symbol, restructuring a layer boundary, splitting a module.
+	EffortRefactor
+	// EffortArchitectural: requires design discussion before the fix can
+	// even be scoped. Architectural rules, layering violations, deep
+	// coupling, policy decisions.
+	EffortArchitectural
+)
+
+// String returns the stable, kebab-cased label for the effort tier.
+// Used by CLI flags, MCP responses, SARIF properties, and config docs.
+func (e Effort) String() string {
+	switch e {
+	case EffortTrivial:
+		return "trivial"
+	case EffortLocal:
+		return "local"
+	case EffortRefactor:
+		return "refactor"
+	case EffortArchitectural:
+		return "architectural"
+	default:
+		return "unset"
+	}
+}
+
+// ParseEffort returns the Effort matching the given label. The labels
+// accepted are exactly the canonical strings emitted by String(), keeping
+// CLI flags and the parser in lockstep. Unknown labels (and the empty
+// string) return EffortUnset, false.
+func ParseEffort(s string) (Effort, bool) {
+	switch s {
+	case "trivial":
+		return EffortTrivial, true
+	case "local":
+		return EffortLocal, true
+	case "refactor":
+		return EffortRefactor, true
+	case "architectural":
+		return EffortArchitectural, true
+	default:
+		return EffortUnset, false
+	}
+}
+
+// EffortProvider lets tests stub an Effort value without constructing a
+// full Rule. MetaForRule checks for this interface on Rule.Implementation
+// before falling back to the derived value, mirroring PrecisionProvider.
+type EffortProvider interface {
+	Effort() Effort
+}
+
+// EffortClassifier produces an Effort for a Rule. The production
+// implementation lives in package rules (V2RuleEffort); tests can pass a
+// fake to exercise filtering and reporting without depending on the
+// derivation heuristics.
+type EffortClassifier interface {
+	Classify(r *Rule) Effort
+}

--- a/internal/rules/api/effort_test.go
+++ b/internal/rules/api/effort_test.go
@@ -1,0 +1,60 @@
+package api
+
+import "testing"
+
+func TestEffortString(t *testing.T) {
+	cases := []struct {
+		in   Effort
+		want string
+	}{
+		{EffortUnset, "unset"},
+		{EffortTrivial, "trivial"},
+		{EffortLocal, "local"},
+		{EffortRefactor, "refactor"},
+		{EffortArchitectural, "architectural"},
+	}
+	for _, c := range cases {
+		if got := c.in.String(); got != c.want {
+			t.Errorf("Effort(%d).String() = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestEffortOrdering(t *testing.T) {
+	// Values must be ordered easiest -> hardest so `triage --max-effort`
+	// can filter with >= comparisons.
+	ordered := []Effort{
+		EffortUnset,
+		EffortTrivial,
+		EffortLocal,
+		EffortRefactor,
+		EffortArchitectural,
+	}
+	for i := 1; i < len(ordered); i++ {
+		if ordered[i-1] >= ordered[i] {
+			t.Fatalf("ordering broken at %d: %v not before %v", i, ordered[i-1], ordered[i])
+		}
+	}
+}
+
+func TestParseEffort(t *testing.T) {
+	cases := []struct {
+		in   string
+		want Effort
+		ok   bool
+	}{
+		{"trivial", EffortTrivial, true},
+		{"local", EffortLocal, true},
+		{"refactor", EffortRefactor, true},
+		{"architectural", EffortArchitectural, true},
+		{"", EffortUnset, false},
+		{"unset", EffortUnset, false},
+		{"bogus", EffortUnset, false},
+	}
+	for _, c := range cases {
+		got, ok := ParseEffort(c.in)
+		if ok != c.ok || got != c.want {
+			t.Errorf("ParseEffort(%q) = (%v,%v), want (%v,%v)", c.in, got, ok, c.want, c.ok)
+		}
+	}
+}

--- a/internal/rules/api/metadata.go
+++ b/internal/rules/api/metadata.go
@@ -217,6 +217,13 @@ type RuleDescriptor struct {
 	// from rule shape; otherwise this value is authoritative.
 	Precision Precision
 
+	// Effort mirrors Rule.Effort — manual-fix difficulty
+	// (trivial / local / refactor / architectural). EffortUnset means
+	// MetaForRule should derive the tier from rule shape via
+	// V2RuleEffort; otherwise this value is authoritative. Orthogonal
+	// to FixLevel (auto-fix safety).
+	Effort Effort
+
 	// LanguageSupport records per-source-language support status for a rule.
 	// It is product/support metadata rather than dispatcher routing: Languages
 	// on Rule controls where a rule runs, while LanguageSupport explains whether

--- a/internal/rules/api/rule.go
+++ b/internal/rules/api/rule.go
@@ -695,6 +695,15 @@ type Rule struct {
 	// it is filterable metadata for CLI, MCP, SARIF, and IDE consumers.
 	Precision Precision
 
+	// Effort estimates manual-fix difficulty for findings emitted by
+	// this rule. Orthogonal to Fix (auto-fix safety): a rule can be
+	// auto-fixable (FixCosmetic) and still EffortRefactor — the
+	// autofix runs across many files. When EffortUnset (the zero
+	// value), MetaForRule derives a tier from rule shape using
+	// V2RuleEffort. Filterable metadata for CLI (`triage --max-effort`),
+	// MCP `explain`, and SARIF triage dashboards.
+	Effort Effort
+
 	// KotlincAnalog names the closest standard kotlinc diagnostic that
 	// this rule approximates, e.g. "UNREACHABLE_CODE". Informational
 	// only — krit is not bug-for-bug compatible with kotlinc. Empty

--- a/internal/rules/effort.go
+++ b/internal/rules/effort.go
@@ -1,0 +1,70 @@
+package rules
+
+import (
+	api "github.com/kaeawc/krit/internal/rules/api"
+)
+
+// V2RuleEffort returns the manual-fix difficulty tier for a rule.
+//
+// Resolution order mirrors V2RulePrecision:
+//  1. Rule.Effort when set (non-zero) — author override.
+//  2. Rule.Implementation when it implements api.EffortProvider — lets
+//     tests stub a tier without touching the Rule literal.
+//  3. Derived from rule shape (Needs / NodeTypes / known override maps).
+//
+// V2RuleEffort never returns EffortUnset, so callers can use the result
+// directly for filtering and dashboards.
+func V2RuleEffort(r *api.Rule) api.Effort {
+	if r == nil {
+		return api.EffortLocal
+	}
+	if r.Effort != api.EffortUnset {
+		return r.Effort
+	}
+	if r.Implementation != nil {
+		if ep, ok := r.Implementation.(api.EffortProvider); ok {
+			if e := ep.Effort(); e != api.EffortUnset {
+				return e
+			}
+		}
+	}
+
+	// Rules that emit policy / architectural opinions are not fixable
+	// by a developer without a design discussion. The same is true for
+	// rules driven by Gradle / manifest config — those typically require
+	// coordinating with build owners or release captains.
+	if V2RulePrecision(r) == api.PrecisionPolicy {
+		return api.EffortArchitectural
+	}
+
+	// Project-scope rules report defects whose fix can ripple through
+	// many files: dead-code symbols, cross-file references, layer or
+	// module-graph violations, Gradle config drift.
+	if r.Needs.HasAny(api.NeedsCrossFile |
+		api.NeedsModuleIndex |
+		api.NeedsParsedFiles |
+		api.NeedsGradle |
+		api.NeedsManifest |
+		api.NeedsResources) {
+		return api.EffortRefactor
+	}
+
+	// Auto-fixable cosmetic rules are by definition one-line edits even
+	// when the user fixes them manually.
+	if r.Fix == api.FixCosmetic {
+		return api.EffortTrivial
+	}
+
+	// Line-pass and aggregate rules are file-local by construction:
+	// they collect signal during a single-file walk and finalize per
+	// file. Default per-file AST rules also stay file-local.
+	return api.EffortLocal
+}
+
+// ClassifyEffort is the package-level EffortClassifier implementation
+// backed by V2RuleEffort. Useful as a default classifier for callers
+// that accept the api.EffortClassifier interface.
+type ClassifyEffort struct{}
+
+// Classify implements api.EffortClassifier.
+func (ClassifyEffort) Classify(r *api.Rule) api.Effort { return V2RuleEffort(r) }

--- a/internal/rules/effort_test.go
+++ b/internal/rules/effort_test.go
@@ -1,0 +1,128 @@
+package rules
+
+import (
+	"testing"
+
+	api "github.com/kaeawc/krit/internal/rules/api"
+)
+
+// stubEffortProvider exercises the EffortProvider fallback path.
+type stubEffortProvider struct{ e api.Effort }
+
+func (s stubEffortProvider) Effort() api.Effort { return s.e }
+
+func TestEffortDerivation(t *testing.T) {
+	cases := []struct {
+		name string
+		rule *api.Rule
+		want api.Effort
+	}{
+		{
+			name: "explicit override wins",
+			rule: &api.Rule{
+				ID: "X", Category: "c", Description: "d", Sev: api.SeverityWarning,
+				Needs: api.NeedsCrossFile, Effort: api.EffortTrivial,
+				Check: func(*api.Context) {},
+			},
+			want: api.EffortTrivial,
+		},
+		{
+			name: "provider fallback",
+			rule: &api.Rule{
+				ID: "X", Category: "c", Description: "d", Sev: api.SeverityWarning,
+				NodeTypes:      []string{"call_expression"},
+				Implementation: stubEffortProvider{e: api.EffortArchitectural},
+				Check:          func(*api.Context) {},
+			},
+			want: api.EffortArchitectural,
+		},
+		{
+			name: "cross-file rule derives refactor",
+			rule: &api.Rule{
+				ID: "X", Category: "c", Description: "d", Sev: api.SeverityWarning,
+				Needs: api.NeedsCrossFile, Check: func(*api.Context) {},
+			},
+			want: api.EffortRefactor,
+		},
+		{
+			name: "manifest rule derives refactor",
+			rule: &api.Rule{
+				ID: "X", Category: "c", Description: "d", Sev: api.SeverityWarning,
+				Needs: api.NeedsManifest, Check: func(*api.Context) {},
+			},
+			want: api.EffortRefactor,
+		},
+		{
+			name: "policy precision derives architectural",
+			rule: &api.Rule{
+				ID: "X", Category: "c", Description: "d", Sev: api.SeverityWarning,
+				NodeTypes: []string{"call_expression"},
+				Precision: api.PrecisionPolicy,
+				Check:     func(*api.Context) {},
+			},
+			want: api.EffortArchitectural,
+		},
+		{
+			name: "cosmetic-fix rule derives trivial",
+			rule: &api.Rule{
+				ID: "X", Category: "c", Description: "d", Sev: api.SeverityWarning,
+				NodeTypes: []string{"call_expression"},
+				Fix:       api.FixCosmetic,
+				Check:     func(*api.Context) {},
+			},
+			want: api.EffortTrivial,
+		},
+		{
+			name: "default per-file rule is local",
+			rule: &api.Rule{
+				ID: "X", Category: "c", Description: "d", Sev: api.SeverityWarning,
+				NodeTypes: []string{"call_expression"}, Check: func(*api.Context) {},
+			},
+			want: api.EffortLocal,
+		},
+		{
+			name: "nil rule returns local",
+			rule: nil,
+			want: api.EffortLocal,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := V2RuleEffort(c.rule); got != c.want {
+				t.Errorf("V2RuleEffort = %v, want %v", got, c.want)
+			}
+		})
+	}
+}
+
+// TestMetaForRule_EffortAlwaysSet verifies the no-zero-leakage invariant
+// from the issue's evaluation criteria: every default-active (and every
+// registered) rule reports a non-zero Effort via MetaForRule.
+func TestMetaForRule_EffortAlwaysSet(t *testing.T) {
+	for _, r := range api.Registry {
+		desc, ok := MetaForRule(r)
+		if !ok {
+			t.Fatalf("MetaForRule(%s) returned ok=false", r.ID)
+		}
+		if desc.Effort == api.EffortUnset {
+			t.Fatalf("rule %s: descriptor effort is EffortUnset", r.ID)
+		}
+	}
+}
+
+// TestMetaForRule_EffortExplicit verifies that an explicit Rule.Effort
+// is mirrored on the descriptor without re-deriving.
+func TestMetaForRule_EffortExplicit(t *testing.T) {
+	r := &api.Rule{
+		ID: "ExplicitEffortRule", Category: "test", Description: "explicit",
+		Sev: api.SeverityWarning, NodeTypes: []string{"call_expression"},
+		Effort: api.EffortArchitectural, Check: func(*api.Context) {},
+	}
+	desc, ok := MetaForRule(r)
+	if !ok {
+		t.Fatal("MetaForRule returned ok=false")
+	}
+	if desc.Effort != api.EffortArchitectural {
+		t.Fatalf("effort = %v, want EffortArchitectural", desc.Effort)
+	}
+}

--- a/internal/rules/meta_lookup.go
+++ b/internal/rules/meta_lookup.go
@@ -96,6 +96,7 @@ func mergeRuleDescriptor(r *api.Rule, extra api.RuleDescriptor) api.RuleDescript
 		out.Tags = extra.Tags
 	}
 	out.Precision = resolvePrecision(r, extra)
+	out.Effort = resolveEffort(r, extra)
 	return out
 }
 
@@ -110,6 +111,18 @@ func resolvePrecision(r *api.Rule, extra api.RuleDescriptor) api.Precision {
 		return extra.Precision
 	}
 	return V2RulePrecision(r)
+}
+
+// resolveEffort mirrors resolvePrecision for the Effort tier: an explicit
+// extra.Effort wins only when the Rule itself didn't declare a value;
+// otherwise V2RuleEffort (which honors Rule.Effort and EffortProvider)
+// owns the answer. V2RuleEffort never returns EffortUnset so MetaForRule
+// always emits a populated tier.
+func resolveEffort(r *api.Rule, extra api.RuleDescriptor) api.Effort {
+	if r.Effort == api.EffortUnset && extra.Effort != api.EffortUnset {
+		return extra.Effort
+	}
+	return V2RuleEffort(r)
 }
 
 func withRuleLanguageSupport(r *api.Rule, m api.RuleDescriptor) api.RuleDescriptor {


### PR DESCRIPTION
## Summary

Closes #195.

- Adds `api.Effort` (`trivial` / `local` / `refactor` / `architectural`) on `api.Rule` and `RuleDescriptor`, orthogonal to `FixLevel` — `FixLevel` describes autofixer safety, `Effort` describes how much human work the manual fix takes.
- `V2RuleEffort` derives a tier from rule shape when the rule didn't declare one: policy-precision → architectural, cross-file / manifest / gradle / resources / module-index / parsed-files → refactor, cosmetic-fix → trivial, otherwise local. `EffortProvider` and `EffortClassifier` mirror the precision plumbing for tests.
- Wires the tier into MCP `rules` `explain` / `search` / rules resource, SARIF `properties.effort`, JSON `JSONFinding.effort`, and a new `krit triage --max-effort=<tier>` subcommand that filters a JSON findings report by effort budget.

## Test plan

- [x] `TestEffortDerivation`, `TestMetaForRule_EffortAlwaysSet`, `TestMetaForRule_EffortExplicit` — derivation and registry-wide no-zero-leakage invariant.
- [x] `TestTriageMaxEffort_*` — filtering by budget, honoring explicit per-finding effort, end-to-end stdin/stdout `Run`.
- [x] `TestFormatSARIF_Effort` — SARIF properties carry the derived tier.
- [x] `make ci` (build, vet, lint, full unit tests, integration suite).