### PR TITLE
feat(daemon): krit-daemon owns resident oracle JVM (#207)

### DIFF
--- a/internal/sessdaemon/analyze.go
+++ b/internal/sessdaemon/analyze.go
@@ -87,6 +87,12 @@ func (s *Server) buildProjectInput(paths []string) (pipeline.ProjectInput, error
 		host.AnalysisCache = sess.AnalysisCache
 		host.PrebuiltLibraryFacts = sess.LibraryFacts
 	}
+	// Lazy-start (or recover) the resident krit-types JVM. ensureOracle
+	// returns nil when the JAR is missing or after a crash-retry has
+	// exhausted its budget — analyze proceeds without oracle in that
+	// case so the client always gets a response.
+	oracleDaemon := s.ensureOracle(paths)
+	host.OracleDaemon = oracleDaemon
 	// scan.NewSession leaves ParseCache nil — lazily attach one and
 	// stash it on the session so subsequent analyze calls are warm.
 	// Safe because analyze is serialised through s.mu.
@@ -103,11 +109,12 @@ func (s *Server) buildProjectInput(paths []string) (pipeline.ProjectInput, error
 
 	return pipeline.ProjectInput{
 		Args: pipeline.ProjectArgs{
-			Config:      cfg,
-			Paths:       paths,
-			ActiveRules: activeRules,
-			Format:      "json",
-			Version:     "daemon",
+			Config:        cfg,
+			Paths:         paths,
+			ActiveRules:   activeRules,
+			Format:        "json",
+			Version:       "daemon",
+			OracleEnabled: oracleDaemon != nil,
 		},
 		Host: host,
 	}, nil

--- a/internal/sessdaemon/oracle_daemon.go
+++ b/internal/sessdaemon/oracle_daemon.go
@@ -1,0 +1,75 @@
+package sessdaemon
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/kaeawc/krit/internal/oracle"
+)
+
+// oracleStarter abstracts JVM-subprocess construction so tests can
+// substitute a fake without spinning up a real krit-types daemon. A
+// nil daemon with nil error means "not configured in this environment"
+// (e.g. krit-types.jar missing); the caller leaves oracle disabled
+// without latching for-the-process so a deferred install can recover.
+type oracleStarter interface {
+	Start(scanPaths []string) (*oracle.Daemon, error)
+}
+
+type defaultOracleStarter struct{}
+
+func (defaultOracleStarter) Start(scanPaths []string) (*oracle.Daemon, error) {
+	if oracle.FindJar(scanPaths) == "" {
+		return nil, nil
+	}
+	return oracle.InvokeDaemon(scanPaths, false)
+}
+
+// oracleDaemonState tracks the resident *oracle.Daemon's recovery
+// semantics. The Daemon handle itself lives on session.OracleDaemon
+// (issue #207) so Session.Close stops the JVM during daemon shutdown.
+type oracleDaemonState struct {
+	disabled bool
+	starter  oracleStarter
+}
+
+// ensureOracle returns the resident *oracle.Daemon, lazy-starting it
+// on first request and recovering after a mid-life crash. Returns nil
+// when the JVM is not configured in this environment, when a previous
+// failure has latched disabled, or when both attempts of the
+// retry-once budget fail.
+//
+// Called from handleAnalyze, which holds s.mu for the duration of the
+// request — no additional synchronisation here.
+func (s *Server) ensureOracle(scanPaths []string) *oracle.Daemon {
+	if s.oracle.disabled {
+		return nil
+	}
+
+	if d := s.session.OracleDaemon; d != nil {
+		if err := d.Ping(); err == nil {
+			return d
+		}
+		_ = d.Close()
+		s.session.OracleDaemon = nil
+	}
+
+	var lastErr error
+	for attempt := 0; attempt < 2; attempt++ {
+		d, err := s.oracle.starter.Start(scanPaths)
+		if err == nil {
+			if d == nil {
+				// Starter reported "not configured" — no retry, no latch.
+				return nil
+			}
+			s.session.OracleDaemon = d
+			return d
+		}
+		// Cold-start failures often clear on a second attempt (JDK
+		// file lock, transient port conflict on the krit-types socket).
+		lastErr = err
+	}
+	s.oracle.disabled = true
+	fmt.Fprintf(os.Stderr, "krit-daemon: oracle daemon: start failed twice (%v); disabling for this daemon lifetime\n", lastErr)
+	return nil
+}

--- a/internal/sessdaemon/oracle_daemon_test.go
+++ b/internal/sessdaemon/oracle_daemon_test.go
@@ -1,0 +1,150 @@
+package sessdaemon
+
+import (
+	"errors"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+
+	"github.com/kaeawc/krit/internal/oracle"
+)
+
+// fakeOracleStarter records every Start call and returns a pre-canned
+// daemon (or error) so tests exercise the lifecycle without spinning
+// up a real JVM. A nil daemon + nil err entry encodes the "JVM not
+// configured" signal.
+type fakeOracleStarter struct {
+	calls   atomic.Int32
+	returns []*oracle.Daemon
+	errs    []error
+}
+
+func (f *fakeOracleStarter) Start(scanPaths []string) (*oracle.Daemon, error) {
+	idx := int(f.calls.Add(1)) - 1
+	if idx < len(f.errs) && f.errs[idx] != nil {
+		return nil, f.errs[idx]
+	}
+	if idx < len(f.returns) {
+		return f.returns[idx], nil
+	}
+	return nil, nil
+}
+
+func newTestServer(t *testing.T) *Server {
+	t.Helper()
+	srv, err := NewServer(t.Context(), Options{
+		RepoDir:    t.TempDir(),
+		SocketPath: filepath.Join(t.TempDir(), "d.sock"),
+	})
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	t.Cleanup(func() { _ = srv.session.Close() })
+	return srv
+}
+
+// TestEnsureOracle_NotConfiguredDoesNotLatch verifies that the
+// starter's nil-daemon-nil-err "not configured" signal returns nil
+// without latching disabled — a deferred jar install must be able to
+// recover on a later request without restarting the daemon.
+func TestEnsureOracle_NotConfiguredDoesNotLatch(t *testing.T) {
+	srv := newTestServer(t)
+	fake := &fakeOracleStarter{}
+	srv.oracle.starter = fake
+
+	if d := srv.ensureOracle([]string{srv.repoDir}); d != nil {
+		t.Errorf("ensureOracle returned %v; want nil when starter reports not configured", d)
+	}
+	if got := fake.calls.Load(); got != 1 {
+		t.Errorf("starter called %d times; want 1", got)
+	}
+	if srv.oracle.disabled {
+		t.Errorf("'not configured' should not latch disabled")
+	}
+}
+
+// TestEnsureOracle_DisabledShortCircuits verifies that once disabled,
+// the path stays disabled — no Start call, no Ping call.
+func TestEnsureOracle_DisabledShortCircuits(t *testing.T) {
+	srv := newTestServer(t)
+	fake := &fakeOracleStarter{}
+	srv.oracle.starter = fake
+	srv.oracle.disabled = true
+
+	if d := srv.ensureOracle([]string{srv.repoDir}); d != nil {
+		t.Errorf("ensureOracle returned %v; want nil when disabled", d)
+	}
+	if got := fake.calls.Load(); got != 0 {
+		t.Errorf("starter called %d times; want 0 when disabled", got)
+	}
+}
+
+// TestEnsureOracle_StartErrorRetriesOnceThenDisables verifies the
+// retry-once-then-fall-back contract from issue #207: two consecutive
+// failures latch disabled, and subsequent requests skip the JVM
+// without re-calling the starter.
+func TestEnsureOracle_StartErrorRetriesOnceThenDisables(t *testing.T) {
+	srv := newTestServer(t)
+	fake := &fakeOracleStarter{errs: []error{errors.New("jvm boom"), errors.New("still boom")}}
+	srv.oracle.starter = fake
+
+	if d := srv.ensureOracle([]string{srv.repoDir}); d != nil {
+		t.Errorf("ensureOracle returned %v; want nil after retry exhaustion", d)
+	}
+	if got := fake.calls.Load(); got != 2 {
+		t.Errorf("starter called %d times; want 2 (initial + 1 retry)", got)
+	}
+	if !srv.oracle.disabled {
+		t.Errorf("oracle.disabled = false; want true after both attempts failed")
+	}
+
+	prev := fake.calls.Load()
+	if d := srv.ensureOracle([]string{srv.repoDir}); d != nil {
+		t.Errorf("ensureOracle returned %v on subsequent call; want nil", d)
+	}
+	if got := fake.calls.Load(); got != prev {
+		t.Errorf("starter called %d times after disabled latch; want %d", got, prev)
+	}
+}
+
+// TestEnsureOracle_FirstAttemptSucceedsAfterRetry exercises the
+// transient-failure path: first Start errors, second succeeds. No
+// disable latch; the handle is stored on session.OracleDaemon.
+func TestEnsureOracle_FirstAttemptSucceedsAfterRetry(t *testing.T) {
+	srv := newTestServer(t)
+	stub := &oracle.Daemon{}
+	fake := &fakeOracleStarter{
+		returns: []*oracle.Daemon{nil, stub},
+		errs:    []error{errors.New("transient"), nil},
+	}
+	srv.oracle.starter = fake
+
+	got := srv.ensureOracle([]string{srv.repoDir})
+	if got != stub {
+		t.Errorf("ensureOracle returned %v; want %v after transient failure recovery", got, stub)
+	}
+	if srv.oracle.disabled {
+		t.Errorf("oracle.disabled latched after a recoverable failure")
+	}
+	if fake.calls.Load() != 2 {
+		t.Errorf("starter called %d times; want 2", fake.calls.Load())
+	}
+}
+
+// TestEnsureOracle_StoresOnSession verifies that once started the
+// Daemon is stored on session.OracleDaemon so Session.Close stops the
+// JVM during daemon shutdown.
+func TestEnsureOracle_StoresOnSession(t *testing.T) {
+	srv := newTestServer(t)
+	stub := &oracle.Daemon{}
+	fake := &fakeOracleStarter{returns: []*oracle.Daemon{stub}}
+	srv.oracle.starter = fake
+
+	got := srv.ensureOracle([]string{srv.repoDir})
+	if got != stub {
+		t.Errorf("ensureOracle returned %v; want %v", got, stub)
+	}
+	if srv.session.OracleDaemon != stub {
+		t.Errorf("session.OracleDaemon = %v; want %v (so Session.Close shuts it down)", srv.session.OracleDaemon, stub)
+	}
+}

--- a/internal/sessdaemon/server.go
+++ b/internal/sessdaemon/server.go
@@ -41,6 +41,12 @@ type Server struct {
 
 	session *scan.Session
 
+	// oracle owns lazy construction + crash recovery of the resident
+	// krit-types JVM. The Daemon handle itself lives on session.OracleDaemon
+	// (see #207) so Session.Close cleans it up on shutdown without an
+	// extra hook here.
+	oracle oracleDaemonState
+
 	listener net.Listener
 	startAt  time.Time
 
@@ -82,6 +88,7 @@ func NewServer(ctx context.Context, opts Options) (*Server, error) {
 		binaryHash: opts.BinaryHash,
 		pid:        os.Getpid(),
 		session:    sess,
+		oracle:     oracleDaemonState{starter: defaultOracleStarter{}},
 		stopped:    make(chan struct{}),
 	}, nil
 }


### PR DESCRIPTION
## Summary
- `ensureOracle` lazy-starts the krit-types JVM on the first analyze request and reuses it across the daemon's lifetime, eliminating ~150–400 ms JVM cold start on every warm invocation.
- The handle lives on `session.OracleDaemon` so `Session.Close` stops the JVM during daemon shutdown — no orphan child after `krit daemon stop`.
- JVM crash recovery: a failed `Ping` closes the dead handle, then up to two `InvokeDaemon` attempts run. Two consecutive failures latch `oracle.disabled` for the daemon lifetime, and subsequent requests fall back to source-only analysis with a one-line warning. Recovery requires `krit daemon restart`.

Closes #207.

## Validation
- `oracle.disabled` latch + retry budget covered by `TestEnsureOracle_StartErrorRetriesOnceThenDisables` and `TestEnsureOracle_FirstAttemptSucceedsAfterRetry`.
- Cleanup contract covered by `TestEnsureOracle_StoresOnSession` (daemon is stored on `session.OracleDaemon`, so the existing `Session.Close` → `OracleDaemon.Close` path in `internal/cli/scan/session.go` reaps the JVM on `daemon stop` from #205).
- Graceful disable when JAR is missing covered by `TestEnsureOracle_NotConfiguredDoesNotLatch` — a deferred install recovers without restart.

## Test plan
- [x] `go build -o krit ./cmd/krit/`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...`
- [x] `go test ./... -count=1`