### PR TITLE
feat(cli): auto-detect krit daemon with binary-hash handshake (#204)

### DIFF
--- a/internal/cli/daemonclient/client.go
+++ b/internal/cli/daemonclient/client.go
@@ -14,6 +14,8 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/kaeawc/krit/internal/daemon"
@@ -46,6 +48,36 @@ func Discover(repoRoot string) (*Client, bool) {
 		return nil, false
 	}
 	return &Client{socketPath: socket}, true
+}
+
+// TryConnect is Discover with an explicit socket-path override. When
+// socketOverride is empty the behaviour matches Discover; otherwise
+// the override drives the dial directly so `--daemon-socket PATH`
+// can point at non-default locations (test fixtures, multi-root
+// setups). Never returns an error — the CLI's auto-detect contract
+// is that socket noise does not bubble up to the user.
+func TryConnect(repoRoot, socketOverride string) (*Client, bool) {
+	if socketOverride == "" {
+		return Discover(repoRoot)
+	}
+	if !daemon.Available(socketOverride) {
+		return nil, false
+	}
+	return &Client{socketPath: socketOverride}, true
+}
+
+// CurrentBinaryHash returns the SHA-256 hex digest of the running CLI's
+// binary. Empty when the executable can't be located or read; callers
+// treat empty as "skip the handshake" so out-of-tree builds and tests
+// stay usable.
+func CurrentBinaryHash() string { return currentBinaryHash() }
+
+// IsBinaryHashMismatch reports whether err is the daemon's
+// "binary hash mismatch" rejection. Used by the CLI to print a
+// one-line warning and fall back to in-process execution after a
+// `go install` left a stale daemon resident.
+func IsBinaryHashMismatch(err error) bool {
+	return err != nil && strings.Contains(err.Error(), daemon.ErrBinaryHashMismatchPrefix)
 }
 
 // EnsureCompatible discovers a running daemon, compares its
@@ -103,8 +135,20 @@ func waitForSocketGone(socket string, timeout time.Duration) {
 // currentBinaryHash returns the SHA-256 hex digest of the running
 // CLI's binary. Empty string disables the hash comparison so old
 // daemons (or unreadable executables) don't trigger spurious
-// restarts.
+// restarts. Cached after the first call — the executable path
+// doesn't change within a process lifetime, and the daemon-handshake
+// path would otherwise re-read + re-hash a 50MB binary on every
+// AnalyzeProject invocation.
 func currentBinaryHash() string {
+	if cached := binaryHashCache.Load(); cached != nil {
+		return *cached
+	}
+	hash := computeCurrentBinaryHash()
+	binaryHashCache.Store(&hash)
+	return hash
+}
+
+func computeCurrentBinaryHash() string {
 	exe, err := os.Executable()
 	if err != nil {
 		return ""
@@ -120,6 +164,8 @@ func currentBinaryHash() string {
 	}
 	return hex.EncodeToString(h.Sum(nil))
 }
+
+var binaryHashCache atomic.Pointer[string]
 
 // SpawnOptions controls EnsureRunning's behaviour.
 type SpawnOptions struct {
@@ -240,6 +286,25 @@ func (c *Client) AnalyzeBuffers(args daemon.AnalyzeBuffersArgs) (daemon.AnalyzeB
 	var result daemon.AnalyzeBuffersResult
 	if err := daemon.Call(c.socketPath, daemon.VerbAnalyzeBuffers, args, &result); err != nil {
 		return daemon.AnalyzeBuffersResult{}, err
+	}
+	return result, nil
+}
+
+// AnalyzeProject dispatches the analyze-project verb. The caller's
+// binary hash is injected automatically when args.ClientBinaryHash is
+// empty, so default callers always participate in the handshake. A
+// daemon-side hash mismatch surfaces as an error that
+// IsBinaryHashMismatch matches.
+func (c *Client) AnalyzeProject(args daemon.AnalyzeProjectArgs) (daemon.AnalyzeProjectResult, error) {
+	if c == nil {
+		return daemon.AnalyzeProjectResult{}, errors.New("daemonclient: nil client")
+	}
+	if args.ClientBinaryHash == "" {
+		args.ClientBinaryHash = currentBinaryHash()
+	}
+	var result daemon.AnalyzeProjectResult
+	if err := daemon.Call(c.socketPath, daemon.VerbAnalyzeProject, args, &result); err != nil {
+		return daemon.AnalyzeProjectResult{}, err
 	}
 	return result, nil
 }

--- a/internal/cli/daemonclient/tryconnect_test.go
+++ b/internal/cli/daemonclient/tryconnect_test.go
@@ -1,0 +1,181 @@
+package daemonclient
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/kaeawc/krit/internal/daemon"
+)
+
+// TestTryConnect_FindsRunningDaemon checks the happy path: a daemon
+// is listening at the conventional socket and TryConnect returns a
+// usable client.
+func TestTryConnect_FindsRunningDaemon(t *testing.T) {
+	socketDir, _ := startEchoDaemon(t)
+	root := newTempRoot(t)
+	expected := daemon.DefaultSocketPath(root)
+	if err := os.MkdirAll(filepath.Dir(expected), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.Symlink(filepath.Join(socketDir, "d.sock"), expected); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	c, ok := TryConnect(root, "")
+	if !ok {
+		t.Fatalf("TryConnect returned no client")
+	}
+	if c.SocketPath() != expected {
+		t.Errorf("socket path mismatch: got %q want %q", c.SocketPath(), expected)
+	}
+}
+
+// TestTryConnect_NoSocketFallsBack covers the auto-detect "nothing
+// running" branch — no socket at all, no error, ok=false. The CLI's
+// silent-fallback contract depends on this.
+func TestTryConnect_NoSocketFallsBack(t *testing.T) {
+	root := newTempRoot(t)
+	if c, ok := TryConnect(root, ""); ok {
+		t.Fatalf("expected ok=false when no daemon is running, got client=%q", c.SocketPath())
+	}
+}
+
+// TestTryConnect_StaleSocketFallsBack mirrors the issue's stale-socket
+// requirement: a socket file exists but no listener is bound. Dialing
+// fails fast; TryConnect treats this as "fall back silently".
+func TestTryConnect_StaleSocketFallsBack(t *testing.T) {
+	root := newTempRoot(t)
+	socket := daemon.DefaultSocketPath(root)
+	if err := os.MkdirAll(filepath.Dir(socket), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(socket, []byte{}, 0o600); err != nil {
+		t.Fatalf("create stale socket: %v", err)
+	}
+	if c, ok := TryConnect(root, ""); ok {
+		t.Fatalf("expected ok=false on stale socket, got client=%q", c.SocketPath())
+	}
+}
+
+// TestTryConnect_HonorsSocketOverride confirms --daemon-socket
+// semantics: an explicit path beats the default discovery rule.
+func TestTryConnect_HonorsSocketOverride(t *testing.T) {
+	socketDir, _ := startEchoDaemon(t)
+	override := filepath.Join(socketDir, "d.sock")
+	root := newTempRoot(t)
+	// Default discovery would fail (no symlink); override drives the
+	// dial directly.
+	c, ok := TryConnect(root, override)
+	if !ok {
+		t.Fatalf("expected ok=true with override; got false")
+	}
+	if c.SocketPath() != override {
+		t.Errorf("socket path mismatch: got %q want %q", c.SocketPath(), override)
+	}
+}
+
+// TestIsBinaryHashMismatch_MatchesDaemonError checks the wire
+// detection path: an error coming back from daemon.Call carrying the
+// ErrBinaryHashMismatchPrefix is classified as a mismatch.
+func TestIsBinaryHashMismatch_MatchesDaemonError(t *testing.T) {
+	err := errors.New("binary hash mismatch (daemon=aaaa client=bbbb)")
+	if !IsBinaryHashMismatch(err) {
+		t.Fatal("expected true")
+	}
+	if IsBinaryHashMismatch(nil) {
+		t.Fatal("nil should be false")
+	}
+	if IsBinaryHashMismatch(errors.New("unrelated")) {
+		t.Fatal("unrelated error should be false")
+	}
+}
+
+// TestAnalyzeProject_MismatchSurfacesError exercises the end-to-end
+// handshake: a daemon configured to enforce a different hash refuses
+// the AnalyzeProject call, and IsBinaryHashMismatch classifies the
+// error.
+func TestAnalyzeProject_MismatchSurfacesError(t *testing.T) {
+	socket := startAnalyzeProjectDaemon(t, "aaaa-daemon-hash")
+	c := &Client{socketPath: socket}
+	_, err := c.AnalyzeProject(daemon.AnalyzeProjectArgs{ClientBinaryHash: "bbbb-client-hash"})
+	if err == nil {
+		t.Fatal("expected mismatch error, got nil")
+	}
+	if !IsBinaryHashMismatch(err) {
+		t.Errorf("expected IsBinaryHashMismatch=true; got err=%v", err)
+	}
+}
+
+// TestAnalyzeProject_HashMatchReturnsResult covers the happy
+// handshake: matching hashes pass through and the daemon's payload is
+// returned unchanged.
+func TestAnalyzeProject_HashMatchReturnsResult(t *testing.T) {
+	socket := startAnalyzeProjectDaemon(t, "matching-hash")
+	c := &Client{socketPath: socket}
+	res, err := c.AnalyzeProject(daemon.AnalyzeProjectArgs{ClientBinaryHash: "matching-hash"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(res.Findings) != `{"rules":[],"line":[]}` {
+		t.Errorf("findings mismatch: %s", string(res.Findings))
+	}
+}
+
+// startAnalyzeProjectDaemon spins up a minimal server that registers
+// only the analyze-project verb with the same hash-rejection rule the
+// real server uses. Returns the socket path; the server is torn down
+// via t.Cleanup.
+func startAnalyzeProjectDaemon(t *testing.T, daemonHash string) string {
+	t.Helper()
+	socketDir, err := os.MkdirTemp("/tmp", "krit-cli-mismatch-")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(socketDir) })
+	socket := filepath.Join(socketDir, "d.sock")
+
+	srv := daemon.NewServer(socket)
+	srv.Register(daemon.VerbAnalyzeProject, func(_ context.Context, raw json.RawMessage) (any, error) {
+		var args daemon.AnalyzeProjectArgs
+		if len(raw) > 0 {
+			if err := json.Unmarshal(raw, &args); err != nil {
+				return nil, err
+			}
+		}
+		if args.ClientBinaryHash != "" && daemonHash != "" && args.ClientBinaryHash != daemonHash {
+			return nil, fmt.Errorf("%s (daemon=%s client=%s)", daemon.ErrBinaryHashMismatchPrefix, daemonHash, args.ClientBinaryHash)
+		}
+		return daemon.AnalyzeProjectResult{Findings: json.RawMessage(`{"rules":[],"line":[]}`)}, nil
+	})
+	if err := srv.Start(context.Background()); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	t.Cleanup(srv.Stop)
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if daemon.Available(socket) {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	return socket
+}
+
+// newTempRoot is a thin wrapper that builds a short-path temp
+// directory under /tmp so macOS's 104-byte socket path limit doesn't
+// bite long test names.
+func newTempRoot(t *testing.T) string {
+	t.Helper()
+	root, err := os.MkdirTemp("/tmp", "krit-tryconn-")
+	if err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(root) })
+	return root
+}

--- a/internal/cli/scan/daemon_delegate.go
+++ b/internal/cli/scan/daemon_delegate.go
@@ -1,0 +1,126 @@
+package scan
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"github.com/kaeawc/krit/internal/cli/daemonclient"
+	"github.com/kaeawc/krit/internal/daemon"
+)
+
+// tryDaemonDelegate attempts to dispatch the current scan through a
+// running krit daemon. handled=true means the daemon produced the
+// output and the caller should exit with the returned code;
+// handled=false means the caller falls back to the in-process path.
+// Fallback is silent except for the daemon-talked-but-failed case,
+// which logs a warning and continues.
+func tryDaemonDelegate(f *scanFlags, paths []string, repoDir string) (bool, int) {
+	if f == nil || *f.NoDaemon {
+		return false, 0
+	}
+	if !daemonCompatibleFlags(f) {
+		return false, 0
+	}
+	client, ok := daemonclient.TryConnect(repoDir, *f.DaemonSocket)
+	if !ok {
+		return false, 0
+	}
+
+	start := time.Now()
+	res, err := client.AnalyzeProject(buildDaemonAnalyzeArgs(f, paths))
+	if err != nil {
+		if daemonclient.IsBinaryHashMismatch(err) {
+			fmt.Fprintf(os.Stderr, "warning: krit daemon rejected request (%v); falling back to in-process. Restart it with: krit daemon restart\n", err)
+			return false, 0
+		}
+		fmt.Fprintf(os.Stderr, "warning: krit daemon call failed (%v); falling back to in-process\n", err)
+		return false, 0
+	}
+
+	fmt.Fprintln(os.Stderr, "info: using daemon")
+	w, closer, openErr := openDaemonOutputWriter(f)
+	if openErr != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", openErr)
+		return true, 2
+	}
+	if _, err := w.Write(res.Findings); err != nil {
+		_ = closer()
+		fmt.Fprintf(os.Stderr, "error: write findings: %v\n", err)
+		return true, 2
+	}
+	if err := closer(); err != nil {
+		fmt.Fprintf(os.Stderr, "error: close output: %v\n", err)
+		return true, 2
+	}
+	return true, finalScanExit(os.Stderr, res.Stats.FindingsCount, time.Since(start), *f.Quiet)
+}
+
+// daemonCompatibleFlags reports whether the requested flag set can be
+// served by the daemon's analyze-project verb. Modes that write files,
+// invoke profiling, or run meta commands stay on the in-process path.
+// Order kept as named groups so a future flag's owner can decide which
+// bucket their flag belongs in.
+func daemonCompatibleFlags(f *scanFlags) bool {
+	mutating := []bool{*f.Fix, *f.DryRun, *f.RemoveDeadCode, *f.FixBinary}
+	meta := []bool{*f.Init, *f.Doctor, *f.Version, *f.List, *f.ValidateConfig, *f.GenerateSchema,
+		*f.BaselineAudit, *f.RuleAudit, *f.OracleFilterFingerprint, *f.ListExperiments}
+	profiling := []bool{*f.Perf, *f.PerfRules, *f.ProfileDispatch}
+	cacheOps := []bool{*f.NoCache, *f.ClearCache, *f.ClearMatrixCache}
+	for _, group := range [][]bool{mutating, meta, profiling, cacheOps} {
+		for _, on := range group {
+			if on {
+				return false
+			}
+		}
+	}
+	strs := []string{*f.CreateBaseline, *f.CPUProfile, *f.MemProfile,
+		*f.Completions, *f.SampleRule, *f.InputTypes, *f.OutputTypes, *f.Delta,
+		*f.PromoteExperiment, *f.DeprecateExperiment, *f.NewExperiment, *f.ExperimentMatrix}
+	for _, s := range strs {
+		if s != "" {
+			return false
+		}
+	}
+	return true
+}
+
+// buildDaemonAnalyzeArgs translates the scan-flag set into the
+// daemon's wire args. Only flags daemonCompatibleFlags admits are
+// propagated; anything outside that set should have been filtered
+// upstream.
+func buildDaemonAnalyzeArgs(f *scanFlags, paths []string) daemon.AnalyzeProjectArgs {
+	format := *f.Format
+	if *f.Report != "" {
+		format = *f.Report
+	}
+	return daemon.AnalyzeProjectArgs{
+		Paths:            paths,
+		Format:           format,
+		BaselinePath:     *f.Baseline,
+		DiffRef:          *f.Diff,
+		MinConfidence:    *f.MinConfidence,
+		WarningsAsErrors: *f.WarningsAsErrors,
+		IncludeGenerated: *f.IncludeGenerated,
+		AllRules:         *f.AllRules,
+		Experimental:     *f.Experimental,
+		EnableRules:      *f.EnableRules,
+		DisableRules:     *f.DisableRules,
+		ClientBinaryHash: daemonclient.CurrentBinaryHash(),
+	}
+}
+
+// openDaemonOutputWriter mirrors runner.openOutputWriter for the
+// daemon path. Returns the writer, a closer (no-op for stdout), and
+// any creation error.
+func openDaemonOutputWriter(f *scanFlags) (io.Writer, func() error, error) {
+	if *f.Output != "" {
+		file, err := os.Create(*f.Output)
+		if err != nil {
+			return nil, func() error { return nil }, fmt.Errorf("create %s: %w", *f.Output, err)
+		}
+		return file, file.Close, nil
+	}
+	return os.Stdout, func() error { return nil }, nil
+}

--- a/internal/cli/scan/daemon_delegate_test.go
+++ b/internal/cli/scan/daemon_delegate_test.go
@@ -1,0 +1,238 @@
+package scan
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/kaeawc/krit/internal/daemon"
+)
+
+// TestTryDaemonDelegate_NoDaemonShortCircuits guards the
+// `--no-daemon` contract: even if a socket is reachable, the CLI must
+// not attempt the dial when the user has opted out.
+func TestTryDaemonDelegate_NoDaemonShortCircuits(t *testing.T) {
+	socketDir := startMockDaemon(t, mockBehavior{})
+	root := newRoot(t)
+	linkSock(t, root, filepath.Join(socketDir, "d.sock"))
+
+	f := freshScanFlags(t)
+	*f.NoDaemon = true
+
+	handled, code := tryDaemonDelegate(f, []string{root}, root)
+	if handled {
+		t.Fatalf("expected fall-through; got handled=true code=%d", code)
+	}
+}
+
+// TestTryDaemonDelegate_NoSocketFallsBack is the auto-detect path:
+// no daemon listening, no fallback flag, the CLI should simply hand
+// off to in-process by returning handled=false.
+func TestTryDaemonDelegate_NoSocketFallsBack(t *testing.T) {
+	root := newRoot(t)
+	f := freshScanFlags(t)
+
+	handled, _ := tryDaemonDelegate(f, []string{root}, root)
+	if handled {
+		t.Fatalf("expected fall-through when no daemon is reachable")
+	}
+}
+
+// TestTryDaemonDelegate_StaleSocketFallsBack pins the kill -9 case:
+// a leftover socket inode with no listener must not propagate as an
+// error — the CLI should silently drop into in-process mode.
+func TestTryDaemonDelegate_StaleSocketFallsBack(t *testing.T) {
+	root := newRoot(t)
+	socket := daemon.DefaultSocketPath(root)
+	if err := os.MkdirAll(filepath.Dir(socket), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(socket, []byte{}, 0o600); err != nil {
+		t.Fatalf("create stale: %v", err)
+	}
+	f := freshScanFlags(t)
+
+	handled, _ := tryDaemonDelegate(f, []string{root}, root)
+	if handled {
+		t.Fatalf("expected fall-through on stale socket; got handled=true")
+	}
+}
+
+// TestTryDaemonDelegate_HashMismatchFallsBack confirms the daemon's
+// rejection lands as a fallback rather than an error: the CLI prints
+// a warning (not asserted here) and continues in-process.
+func TestTryDaemonDelegate_HashMismatchFallsBack(t *testing.T) {
+	socketDir := startMockDaemon(t, mockBehavior{rejectHash: true})
+	root := newRoot(t)
+	linkSock(t, root, filepath.Join(socketDir, "d.sock"))
+
+	f := freshScanFlags(t)
+	handled, _ := tryDaemonDelegate(f, []string{root}, root)
+	if handled {
+		t.Fatalf("expected fall-through after mismatch; got handled=true")
+	}
+}
+
+// TestTryDaemonDelegate_FlagBlocksDelegation exercises the
+// compatibility filter: `--fix` (and friends) must not be silently
+// dispatched through the daemon since the daemon doesn't perform
+// file rewrites.
+func TestTryDaemonDelegate_FlagBlocksDelegation(t *testing.T) {
+	socketDir := startMockDaemon(t, mockBehavior{})
+	root := newRoot(t)
+	linkSock(t, root, filepath.Join(socketDir, "d.sock"))
+
+	f := freshScanFlags(t)
+	*f.Fix = true
+
+	handled, _ := tryDaemonDelegate(f, []string{root}, root)
+	if handled {
+		t.Fatalf("expected fall-through with --fix; got handled=true")
+	}
+}
+
+// TestTryDaemonDelegate_HappyPathReturnsExitFromFindings closes the
+// loop: on a clean delegation, the CLI surfaces FindingsCount via
+// the standard exit-code rule (0 = clean, 1 = any finding).
+func TestTryDaemonDelegate_HappyPathReturnsExitFromFindings(t *testing.T) {
+	socketDir := startMockDaemon(t, mockBehavior{
+		findings:      `{"rules":["X"],"line":[1]}`,
+		findingsCount: 1,
+	})
+	root := newRoot(t)
+	linkSock(t, root, filepath.Join(socketDir, "d.sock"))
+
+	out := redirectStdout(t)
+	f := freshScanFlags(t)
+	handled, code := tryDaemonDelegate(f, []string{root}, root)
+	if !handled {
+		t.Fatalf("expected handled=true on clean delegation")
+	}
+	if code != 1 {
+		t.Errorf("expected exit 1 with findings; got %d", code)
+	}
+	if want := `{"rules":["X"],"line":[1]}`; out() != want {
+		t.Errorf("findings byte mismatch:\n got %q\nwant %q", out(), want)
+	}
+}
+
+// freshScanFlags builds a default-valued scanFlags via a fresh
+// FlagSet so each test gets independent storage.
+func freshScanFlags(t *testing.T) *scanFlags {
+	t.Helper()
+	fs := flag.NewFlagSet("scan-test", flag.ContinueOnError)
+	return registerScanFlags(fs)
+}
+
+// linkSock places root/.krit/daemon.sock pointing at socket so the
+// default-discovery path inside TryConnect succeeds.
+func linkSock(t *testing.T, root, socket string) {
+	t.Helper()
+	target := daemon.DefaultSocketPath(root)
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.Symlink(socket, target); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+}
+
+// newRoot returns a short-path tempdir under /tmp so the
+// .krit/daemon.sock path stays under macOS's 104-byte cap.
+func newRoot(t *testing.T) string {
+	t.Helper()
+	r, err := os.MkdirTemp("/tmp", "krit-deleg-")
+	if err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(r) })
+	return r
+}
+
+// mockBehavior controls what startMockDaemon's analyze-project verb
+// returns. rejectHash forces the daemon to refuse any non-empty
+// client hash with the documented prefix; findings/findingsCount let
+// tests assert on byte-for-byte response shape and exit code logic.
+type mockBehavior struct {
+	rejectHash    bool
+	findings      string
+	findingsCount int
+}
+
+// startMockDaemon spins up a minimal server with status, shutdown,
+// and analyze-project verbs registered. The analyze-project handler
+// applies the configured behavior so each test can drive a different
+// reply shape without re-implementing the wire protocol.
+func startMockDaemon(t *testing.T, b mockBehavior) string {
+	t.Helper()
+	socketDir, err := os.MkdirTemp("/tmp", "krit-deleg-srv-")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(socketDir) })
+	socket := filepath.Join(socketDir, "d.sock")
+	srv := daemon.NewServer(socket)
+	srv.Register(daemon.VerbStatus, func(_ context.Context, _ json.RawMessage) (any, error) {
+		return daemon.StatusResult{Ready: true}, nil
+	})
+	srv.Register(daemon.VerbShutdown, func(_ context.Context, _ json.RawMessage) (any, error) {
+		return map[string]bool{"ok": true}, nil
+	})
+	srv.Register(daemon.VerbAnalyzeProject, func(_ context.Context, raw json.RawMessage) (any, error) {
+		var args daemon.AnalyzeProjectArgs
+		if len(raw) > 0 {
+			if err := json.Unmarshal(raw, &args); err != nil {
+				return nil, err
+			}
+		}
+		if b.rejectHash {
+			return nil, fmt.Errorf("%s (daemon=ZZZZ client=%s)", daemon.ErrBinaryHashMismatchPrefix, args.ClientBinaryHash)
+		}
+		findings := b.findings
+		if findings == "" {
+			findings = `{"rules":[],"line":[]}`
+		}
+		return daemon.AnalyzeProjectResult{
+			Findings: json.RawMessage(findings),
+			Stats:    daemon.AnalyzeProjectStats{FindingsCount: b.findingsCount},
+		}, nil
+	})
+	if err := srv.Start(context.Background()); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	t.Cleanup(srv.Stop)
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if daemon.Available(socket) {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	return socketDir
+}
+
+// redirectStdout swaps os.Stdout for a pipe and returns a thunk that
+// drains the captured bytes. Used to assert byte-identical findings
+// emission from the daemon path without spinning up an external
+// process.
+func redirectStdout(t *testing.T) func() string {
+	t.Helper()
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stdout = w
+	t.Cleanup(func() { os.Stdout = orig })
+	return func() string {
+		_ = w.Close()
+		buf, _ := io.ReadAll(r)
+		return string(buf)
+	}
+}

--- a/internal/cli/scan/flags.go
+++ b/internal/cli/scan/flags.go
@@ -101,6 +101,8 @@ type scanFlags struct {
 	RuleAuditCluster         *string
 	BaselineAudit            *bool
 	Depth                    *string
+	NoDaemon                 *bool
+	DaemonSocket             *string
 }
 
 // registerScanFlags declares every scan-verb flag against fs and returns a
@@ -200,5 +202,7 @@ func registerScanFlags(fs *flag.FlagSet) *scanFlags {
 	f.RuleAuditCluster = fs.String("rule-audit-cluster", "", "Filter --rule-audit to rules whose cluster label contains this substring (e.g. 'res/', 'manifest', 'kt')")
 	f.BaselineAudit = fs.Bool("baseline-audit", false, "Audit a baseline file for dead entries and removed rules, then exit")
 	f.Depth = fs.String("depth", "", "Analysis depth preset: fast (skip JVM oracle), balanced (default), thorough. Overrides krit.yml analysis.depth; individual --no-* flags still take precedence.")
+	f.NoDaemon = fs.Bool("no-daemon", false, "Force in-process execution; do not contact the krit daemon even if a socket is reachable.")
+	f.DaemonSocket = fs.String("daemon-socket", "", "Override the krit daemon socket path (default <repoRoot>/.krit/daemon.sock).")
 	return f
 }

--- a/internal/cli/scan/scan.go
+++ b/internal/cli/scan/scan.go
@@ -288,6 +288,9 @@ func Run() int {
 
 	ctx := context.Background()
 	repoDir := oracle.FindRepoDir(flag.Args())
+	if handled, code := tryDaemonDelegate(f, flag.Args(), repoDir); handled {
+		return code
+	}
 	sess, err := NewSession(ctx, repoDir, f)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)

--- a/internal/cli/serve/analyze_project.go
+++ b/internal/cli/serve/analyze_project.go
@@ -43,6 +43,10 @@ func handleAnalyzeProject(_ context.Context, state *daemonState, raw json.RawMes
 		}
 	}
 
+	if daemonHash := daemonBinaryHash(); args.ClientBinaryHash != "" && daemonHash != "" && args.ClientBinaryHash != daemonHash {
+		return nil, fmt.Errorf("%s (daemon=%s client=%s)", daemon.ErrBinaryHashMismatchPrefix, daemonHash, args.ClientBinaryHash)
+	}
+
 	state.analyzeMu.Lock()
 	cold := !state.coldDone.Load()
 	if args.RequireWarm && cold {

--- a/internal/cli/serve/analyze_project_hash_test.go
+++ b/internal/cli/serve/analyze_project_hash_test.go
@@ -1,0 +1,48 @@
+package serve
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/kaeawc/krit/internal/daemon"
+)
+
+// TestAnalyzeProject_BinaryHashMismatchRejected pins the daemon
+// handshake: a non-empty client hash that disagrees with the running
+// binary's hash makes the verb refuse the request with the documented
+// ErrBinaryHashMismatchPrefix prefix. The CLI side detects this prefix
+// to fall back to in-process without prompting after a stale-binary
+// `go install`.
+func TestAnalyzeProject_BinaryHashMismatchRejected(t *testing.T) {
+	socket, state := startServerForTest(t)
+	writeKotlinFile(t, state.root, "Foo.kt", "package demo\n\nclass Foo\n")
+
+	var got daemon.AnalyzeProjectResult
+	err := daemon.Call(socket, daemon.VerbAnalyzeProject,
+		daemon.AnalyzeProjectArgs{ClientBinaryHash: "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"},
+		&got)
+	if err == nil {
+		t.Fatalf("expected mismatch rejection, got result=%+v", got)
+	}
+	if !strings.Contains(err.Error(), daemon.ErrBinaryHashMismatchPrefix) {
+		t.Errorf("expected error containing %q; got %v", daemon.ErrBinaryHashMismatchPrefix, err)
+	}
+}
+
+// TestAnalyzeProject_EmptyClientHashSkipsHandshake confirms that
+// callers that haven't computed their binary hash (e.g. older tools)
+// still get a successful response — the handshake is opt-in via a
+// non-empty ClientBinaryHash.
+func TestAnalyzeProject_EmptyClientHashSkipsHandshake(t *testing.T) {
+	socket, state := startServerForTest(t)
+	writeKotlinFile(t, state.root, "Foo.kt", "package demo\n\nclass Foo\n")
+
+	var got daemon.AnalyzeProjectResult
+	if err := daemon.Call(socket, daemon.VerbAnalyzeProject,
+		daemon.AnalyzeProjectArgs{}, &got); err != nil {
+		t.Fatalf("call: %v", err)
+	}
+	if len(got.Findings) == 0 {
+		t.Errorf("expected non-empty Findings on empty-hash call")
+	}
+}

--- a/internal/daemon/protocol.go
+++ b/internal/daemon/protocol.go
@@ -35,6 +35,17 @@ const (
 	VerbAnalyzeProject = "analyze-project"
 )
 
+// ErrBinaryHashMismatchPrefix is the error.Error() prefix the daemon
+// emits when it rejects a request whose ClientBinaryHash does not
+// match its own. CLI callers detect this prefix to fall back to
+// in-process execution after printing a short "binary diverged"
+// warning. The full error reads
+// "binary hash mismatch (daemon=<x> client=<y>)" so logs carry both
+// hashes for diagnostics. Mirrors the JSON-RPC error code -32001 the
+// issue calls out, transported via the daemon's
+// `{ok:false,error:...}` envelope instead of a code field.
+const ErrBinaryHashMismatchPrefix = "binary hash mismatch"
+
 // AbiHashArgs is the argument shape for the abi-hash verb.
 type AbiHashArgs struct {
 	Target string `json:"target"`
@@ -160,6 +171,13 @@ type AnalyzeProjectArgs struct {
 	// hard SLA set this — useful for IDE workflows that can show a
 	// "warming up" indicator instead of blocking on the first call.
 	RequireWarm bool `json:"require_warm,omitempty"`
+	// ClientBinaryHash is the SHA-256 of the calling CLI's krit
+	// binary. When non-empty and the daemon's hash is non-empty, the
+	// daemon refuses the request when they differ — prevents a
+	// freshly-installed CLI from talking to a stale daemon. Empty
+	// disables the handshake (back-compat for clients that don't
+	// know their hash).
+	ClientBinaryHash string `json:"client_binary_hash,omitempty"`
 }
 
 // AnalyzeProjectResult is the response payload. Findings is the raw


### PR DESCRIPTION
## Summary
- Adds `daemonclient.TryConnect(repoDir, socketOverride)` for silent socket auto-detect plus the `--daemon-socket PATH` override (`(nil, false)` for every non-connectable case — missing/stale/refused).
- Adds the binary-hash handshake: `AnalyzeProjectArgs.ClientBinaryHash` is filled by the client and the daemon refuses divergent requests with the `daemon.ErrBinaryHashMismatchPrefix` envelope; the CLI logs a one-line warning suggesting `krit daemon restart` and falls back to in-process.
- Wires `tryDaemonDelegate` into the scan default verb: when a daemon is reachable and the flag set is compatible (no `--fix`, profiling, meta commands, etc.), the CLI prints `info: using daemon`, dispatches `analyze-project`, writes findings to stdout/`-o`, and reuses `finalScanExit` so the exit-code rule stays identical to the in-process path. `--no-daemon` short-circuits the dial.
- Caches `currentBinaryHash` via `atomic.Pointer[string]` so the SHA-256 of the krit binary isn't recomputed on every call (mirrors the existing daemon-side cache).

## Test plan
- [x] `go test ./internal/cli/daemonclient/ ./internal/cli/scan/ ./internal/cli/serve/ -count=1`
- [x] `go build ./... && go vet ./... && golangci-lint run ./...`
- [x] `make lint-rules`
- [x] `go test ./... -count=1` (full suite green)
- [x] Server-side rejection: `TestAnalyzeProject_BinaryHashMismatchRejected` in `internal/cli/serve/analyze_project_hash_test.go`.
- [x] Stale-socket / no-socket / override / mismatch / happy path: `TestTryConnect_*`, `TestTryDaemonDelegate_*`.

## Issue
Closes #204.