### PR TITLE
feat(rules): filter rules by Java LanguageSupport status

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,12 @@ vet:
 #   - concurrent-state: go/WaitGroup/MergeCollectors needs NeedsConcurrent
 #   - fix-drift: Fix != FixNone requires an f.Fix assignment in the Check body
 #   - opt-in-reason: DefaultActive: false requires an OptInReason classification
+#   - java-support-coverage: rules declaring NeedsTypeInfo/NeedsResolver must
+#     carry an explicit Java LanguageSupport entry (existing rules are
+#     grandfathered; new ones must classify)
 lint-rules:
 	go test ./internal/ruleslinter/ -run 'TestRulesPackageHasNoCapabilityDrift|TestRulesPackageHasNoNewAdHocCaches|TestRulesPackageHasOptInReasons' -count=1
+	go test ./internal/rules/ -run 'TestRulesWithTypeInfoDeclareExplicitJavaSupport' -count=1
 
 lint: build
 	./krit .

--- a/cmd/krit/verb_dispatch.go
+++ b/cmd/krit/verb_dispatch.go
@@ -21,6 +21,7 @@ import (
 	climprecommit "github.com/kaeawc/krit/internal/cli/precommit"
 	climrename "github.com/kaeawc/krit/internal/cli/rename"
 	climriskmap "github.com/kaeawc/krit/internal/cli/riskmap"
+	climrules "github.com/kaeawc/krit/internal/cli/rules"
 	climscore "github.com/kaeawc/krit/internal/cli/score"
 	climscorecard "github.com/kaeawc/krit/internal/cli/scorecard"
 	climselecttests "github.com/kaeawc/krit/internal/cli/selecttests"
@@ -67,6 +68,7 @@ const (
 	verbPrecommit
 	verbSnapshot
 	verbTriage
+	verbRules
 )
 
 var verbByName = map[string]subcommandVerb{
@@ -100,6 +102,7 @@ var verbByName = map[string]subcommandVerb{
 	"precommit":          verbPrecommit,
 	"snapshot":           verbSnapshot,
 	"triage":             verbTriage,
+	"rules":              verbRules,
 }
 
 func classifyVerb(arg string) subcommandVerb {
@@ -180,6 +183,8 @@ func runVerbAndExitB(verb subcommandVerb, rest []string) bool {
 		os.Exit(climsnapshot.Run(rest))
 	case verbTriage:
 		os.Exit(climtriage.Run(rest))
+	case verbRules:
+		os.Exit(climrules.Run(rest))
 	}
 	return false
 }

--- a/internal/cli/rules/rules.go
+++ b/internal/cli/rules/rules.go
@@ -1,0 +1,165 @@
+// Package rules implements the `krit rules` CLI verb. It exposes
+// list and coverage subcommands that query the rule registry by
+// language support classification.
+package rules
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strings"
+	"text/tabwriter"
+
+	rulespkg "github.com/kaeawc/krit/internal/rules"
+	api "github.com/kaeawc/krit/internal/rules/api"
+)
+
+// Run is the verb entrypoint wired from cmd/krit's verb dispatcher.
+func Run(args []string) int {
+	return run(args, os.Stdout, os.Stderr)
+}
+
+func run(args []string, stdout, stderr io.Writer) int {
+	if len(args) == 0 {
+		fmt.Fprintln(stderr, "rules: missing subcommand; expected 'list' or 'coverage'")
+		return 2
+	}
+	sub := args[0]
+	rest := args[1:]
+	switch sub {
+	case "list":
+		return runList(rest, stdout, stderr)
+	case "coverage":
+		return runCoverage(rest, stdout, stderr)
+	default:
+		fmt.Fprintf(stderr, "rules: unknown subcommand %q; expected 'list' or 'coverage'\n", sub)
+		return 2
+	}
+}
+
+func runList(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("rules list", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	language := fs.String("language", "", "Restrict to a language ('java'); when set, --status filters by LanguageSupport classification")
+	status := fs.String("status", "", "LanguageSupport status filter (comma-separated, e.g. 'partial,pending' or '!supported')")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	filter, err := buildFilter(*language, *status)
+	if err != nil {
+		fmt.Fprintf(stderr, "rules list: %v\n", err)
+		return 2
+	}
+	matches := rulespkg.FilterRegistry(api.Registry, filter)
+	sort.Slice(matches, func(i, j int) bool { return matches[i].ID < matches[j].ID })
+
+	tw := tabwriter.NewWriter(stdout, 0, 0, 2, ' ', 0)
+	if filter.Language != "" {
+		fmt.Fprintln(tw, "RULE\tCATEGORY\tSEVERITY\tSTATUS\tREASON/EVIDENCE")
+	} else {
+		fmt.Fprintln(tw, "RULE\tCATEGORY\tSEVERITY")
+	}
+	for _, r := range matches {
+		if filter.Language == "" {
+			fmt.Fprintf(tw, "%s\t%s\t%s\n", r.ID, r.Category, string(r.Sev))
+			continue
+		}
+		statusStr, note := supportCell(r, filter.Language)
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\n", r.ID, r.Category, string(r.Sev), statusStr, note)
+	}
+	if err := tw.Flush(); err != nil {
+		fmt.Fprintf(stderr, "rules list: %v\n", err)
+		return 1
+	}
+	fmt.Fprintf(stdout, "\n%d rule(s)\n", len(matches))
+	return 0
+}
+
+func runCoverage(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("rules coverage", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	language := fs.String("language", "java", "Language to report coverage for (currently only 'java' is wired)")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if *language == "" {
+		fmt.Fprintln(stderr, "rules coverage: --language is required")
+		return 2
+	}
+	matches := append([]*api.Rule(nil), api.Registry...)
+	sort.Slice(matches, func(i, j int) bool {
+		if matches[i] == nil || matches[j] == nil {
+			return matches[i] != nil
+		}
+		return matches[i].ID < matches[j].ID
+	})
+
+	totals := map[api.LanguageSupportStatus]int{}
+	unclassified := 0
+
+	tw := tabwriter.NewWriter(stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintf(tw, "RULE\tCATEGORY\t%s STATUS\tREASON/EVIDENCE\n", strings.ToUpper(*language))
+	for _, r := range matches {
+		if r == nil {
+			continue
+		}
+		statusStr, note := supportCell(r, *language)
+		if support, ok := rulespkg.LanguageSupportForRule(r, *language); ok {
+			totals[support.Status]++
+		} else {
+			unclassified++
+		}
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n", r.ID, r.Category, statusStr, note)
+	}
+	if err := tw.Flush(); err != nil {
+		fmt.Fprintf(stderr, "rules coverage: %v\n", err)
+		return 1
+	}
+
+	fmt.Fprintln(stdout)
+	fmt.Fprintf(stdout, "Total: %d rule(s)\n", len(matches))
+	for _, status := range []api.LanguageSupportStatus{
+		api.LanguageSupportSupported,
+		api.LanguageSupportPartial,
+		api.LanguageSupportPending,
+		api.LanguageSupportNeedsDesign,
+		api.LanguageSupportNotApplicable,
+	} {
+		fmt.Fprintf(stdout, "  %s: %d\n", status, totals[status])
+	}
+	if unclassified > 0 {
+		fmt.Fprintf(stdout, "  (unclassified): %d\n", unclassified)
+	}
+	return 0
+}
+
+// supportCell returns the (status, note) pair to render for a rule in the
+// LanguageSupport column. Unclassified rules return a sentinel placeholder.
+func supportCell(r *api.Rule, language string) (string, string) {
+	support, ok := rulespkg.LanguageSupportForRule(r, language)
+	if !ok {
+		return "(unclassified)", ""
+	}
+	return string(support.Status), support.Summary()
+}
+
+func buildFilter(language, statusExpr string) (rulespkg.LanguageSupportFilter, error) {
+	statuses, negate, err := rulespkg.ParseStatusFilter(statusExpr)
+	if err != nil {
+		return rulespkg.LanguageSupportFilter{}, err
+	}
+	if language == "" && (len(statuses) > 0 || negate) {
+		return rulespkg.LanguageSupportFilter{}, fmt.Errorf("--status requires --language")
+	}
+	filter := rulespkg.LanguageSupportFilter{
+		Language: language,
+		Status:   statuses,
+		Negate:   negate,
+	}
+	if err := filter.Validate(); err != nil {
+		return rulespkg.LanguageSupportFilter{}, err
+	}
+	return filter, nil
+}

--- a/internal/cli/rules/rules_test.go
+++ b/internal/cli/rules/rules_test.go
@@ -1,0 +1,165 @@
+package rules
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRunRulesListByLanguageAndStatus(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"list", "--language", "java", "--status", "supported"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit code = %d, stderr=%q", code, stderr.String())
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "AddJavascriptInterface") {
+		t.Fatalf("expected supported rule AddJavascriptInterface in output:\n%s", out)
+	}
+	if strings.Contains(out, "LongMethod") {
+		t.Fatalf("LongMethod is pending; should not be in supported-only listing:\n%s", out)
+	}
+	if !strings.Contains(out, "rule(s)") {
+		t.Fatalf("expected summary in output:\n%s", out)
+	}
+}
+
+func TestRunRulesListNegatedStatus(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"list", "--language", "java", "--status", "!supported"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit code = %d, stderr=%q", code, stderr.String())
+	}
+	out := stdout.String()
+	if strings.Contains(out, "AddJavascriptInterface\t") {
+		// AddJavascriptInterface explicitly supported, must be excluded.
+		t.Fatalf("supported rule leaked into !supported listing:\n%s", out)
+	}
+}
+
+func TestRunRulesListUnknownStatusErrors(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"list", "--language", "java", "--status", "bogus"}, &stdout, &stderr)
+	if code == 0 {
+		t.Fatalf("expected error exit, got 0; stdout=%q", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "bogus") {
+		t.Fatalf("expected error mentioning 'bogus' in stderr, got %q", stderr.String())
+	}
+}
+
+func TestRunRulesListStatusRequiresLanguage(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"list", "--status", "partial"}, &stdout, &stderr)
+	if code == 0 {
+		t.Fatalf("expected error exit when --status is given without --language")
+	}
+	if !strings.Contains(stderr.String(), "language") {
+		t.Fatalf("expected error to mention language requirement, got %q", stderr.String())
+	}
+}
+
+func TestRunRulesCoverageJavaContainsHeaderAndTotals(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"coverage", "--language", "java"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit code = %d, stderr=%q", code, stderr.String())
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "JAVA STATUS") {
+		t.Fatalf("expected JAVA STATUS header in coverage output:\n%s", out)
+	}
+	if !strings.Contains(out, "Total:") {
+		t.Fatalf("expected Total: summary in coverage output:\n%s", out)
+	}
+	// Every Kotlin-supported (= default-active) rule must appear in the table.
+	if !strings.Contains(out, "AddJavascriptInterface") {
+		t.Fatalf("coverage output missing AddJavascriptInterface:\n%s", out)
+	}
+	if !strings.Contains(out, "LongMethod") {
+		t.Fatalf("coverage output missing LongMethod (ruleset-default classified):\n%s", out)
+	}
+}
+
+func TestRunRulesUnknownSubcommand(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"frobnicate"}, &stdout, &stderr)
+	if code == 0 {
+		t.Fatalf("expected non-zero exit for unknown subcommand")
+	}
+	if !strings.Contains(stderr.String(), "frobnicate") {
+		t.Fatalf("expected unknown subcommand name in stderr, got %q", stderr.String())
+	}
+}
+
+// TestRunRulesCoverageJavaGolden snapshots the coverage table head so a
+// regression in registry ordering or status classification shows up loudly.
+// The snapshot only locks the first few rows + summary so adding new
+// classified rules doesn't churn the golden — only changes near the
+// alphabetic prefix matter. Set KRIT_UPDATE_GOLDEN=1 to refresh.
+func TestRunRulesCoverageJavaGolden(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"coverage", "--language", "java"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit code = %d, stderr=%q", code, stderr.String())
+	}
+	got := normalizeCoverageGolden(stdout.String())
+
+	goldenPath := filepath.Join("testdata", "coverage_java.golden")
+	if os.Getenv("KRIT_UPDATE_GOLDEN") == "1" {
+		if err := os.MkdirAll(filepath.Dir(goldenPath), 0o755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		if err := os.WriteFile(goldenPath, []byte(got), 0o644); err != nil {
+			t.Fatalf("write golden: %v", err)
+		}
+		t.Skip("golden updated")
+	}
+	want, err := os.ReadFile(goldenPath)
+	if err != nil {
+		t.Fatalf("reading golden (set KRIT_UPDATE_GOLDEN=1 to regenerate): %v", err)
+	}
+	if string(want) != got {
+		t.Fatalf("coverage golden mismatch.\nDIFF:\n--- want\n%s\n--- got\n%s", string(want), got)
+	}
+}
+
+// normalizeCoverageGolden strips the per-rule rows that follow the header
+// and just keeps the header, the first three rows, and the summary block.
+// The first three rows are stable (sorted by ID) and the totals are
+// classification-driven, so the snapshot stays meaningful without
+// turning into a giant churn magnet.
+func normalizeCoverageGolden(s string) string {
+	lines := strings.Split(s, "\n")
+	if len(lines) == 0 {
+		return s
+	}
+	var kept []string
+	// Header.
+	kept = append(kept, lines[0])
+	// First three data rows (or fewer).
+	dataCount := 0
+	idx := 1
+	for ; idx < len(lines) && dataCount < 3; idx++ {
+		if lines[idx] == "" {
+			continue
+		}
+		kept = append(kept, lines[idx])
+		dataCount++
+	}
+	// Walk forward to the blank line that separates rows from the summary.
+	for ; idx < len(lines); idx++ {
+		if strings.TrimSpace(lines[idx]) == "" {
+			kept = append(kept, "...")
+			kept = append(kept, lines[idx])
+			break
+		}
+	}
+	// Summary tail.
+	for idx++; idx < len(lines); idx++ {
+		kept = append(kept, lines[idx])
+	}
+	return strings.Join(kept, "\n")
+}

--- a/internal/cli/rules/testdata/coverage_java.golden
+++ b/internal/cli/rules/testdata/coverage_java.golden
@@ -1,0 +1,13 @@
+RULE                                            CATEGORY             JAVA STATUS     REASON/EVIDENCE
+AbsentOrWrongFileLicense                        comments             pending         Source comment and documentation rules need Java-specific syntax review.
+AbstractClassCanBeConcreteClass                 style                partial         Java comment/import style rules, line-based formatting checks, and decimal numeric literal readability are supported; most remaining style rules encode Kotlin syntax and require explicit per-rule review.
+AbstractClassCanBeInterface                     style                partial         Java comment/import style rules, line-based formatting checks, and decimal numeric literal readability are supported; most remaining style rules encode Kotlin syntax and require explicit per-rule review.
+...
+
+Total: 784 rule(s)
+  supported: 119
+  partial: 455
+  pending: 140
+  needs-design: 0
+  not-applicable: 49
+  (unclassified): 21

--- a/internal/mcp/tool_rules.go
+++ b/internal/mcp/tool_rules.go
@@ -28,6 +28,18 @@ type rulesArgs struct {
 	// operation=configure
 	Active   *bool  `json:"active"`
 	Severity string `json:"severity"`
+
+	// operation=search: optional LanguageSupport filter. Empty Language
+	// disables the filter; an empty Status list with a non-empty Language
+	// keeps every rule with a classification for that language.
+	LanguageSupport *languageSupportArg `json:"languageSupport,omitempty"`
+}
+
+// languageSupportArg mirrors rules.LanguageSupportFilter on the wire.
+type languageSupportArg struct {
+	Language string   `json:"language"`
+	Status   []string `json:"status,omitempty"`
+	Negate   bool     `json:"negate,omitempty"`
 }
 
 func (s *Server) toolRules(arguments json.RawMessage) ToolResult {
@@ -145,8 +157,7 @@ func resolveRelatedRules(r *api.Rule) []string {
 }
 
 // formatLifecycle renders a human-readable summary of when a rule first
-// shipped and (optionally) when it became default-active, e.g.
-// "Introduced in 0.2.0; default since 0.4.0".
+// shipped and (optionally) when it became default-active.
 func formatLifecycle(introducedIn, enabledByDefaultSince string) string {
 	switch {
 	case introducedIn == "" && enabledByDefaultSince == "":
@@ -160,8 +171,8 @@ func formatLifecycle(introducedIn, enabledByDefaultSince string) string {
 	}
 }
 
-// parseSearchFilters validates the precision/maturity filter arguments.
-// Returns a non-nil ToolResult pointer when validation fails.
+// parseSearchFilters validates the precision/maturity arguments. Returns a
+// non-nil ToolResult pointer when validation fails.
 func parseSearchFilters(args rulesArgs) (api.Precision, api.Maturity, bool, *ToolResult) {
 	var precisionFilter api.Precision
 	if args.Precision != "" {
@@ -202,83 +213,100 @@ func validateCapabilityArgs(needs, without []string) *ToolResult {
 	return nil
 }
 
-// rulesSearch performs a case-insensitive substring match over rule name,
-// description, and category. Results are ranked by where the match landed
-// (name > description > category) then alphabetical.
-func (s *Server) rulesSearch(args rulesArgs) ToolResult {
-	capabilityFilter := api.CapabilityFilter{Require: args.Needs, Exclude: args.Without}
-	if args.Query == "" && args.Precision == "" && args.Maturity == "" && capabilityFilter.IsZero() {
-		return errorResult("'query', 'precision', 'maturity', 'needs', or 'without' argument is required for operation=search")
+// buildSupportFilter converts a rulesArgs.LanguageSupport payload into a
+// validated rules.LanguageSupportFilter. Returns a non-nil ToolResult only
+// when validation fails.
+func buildSupportFilter(args rulesArgs) (rules.LanguageSupportFilter, *ToolResult) {
+	if args.LanguageSupport == nil || args.LanguageSupport.Language == "" {
+		return rules.LanguageSupportFilter{}, nil
 	}
-
-	if errResult := validateCapabilityArgs(args.Needs, args.Without); errResult != nil {
-		return *errResult
+	statuses := make([]api.LanguageSupportStatus, 0, len(args.LanguageSupport.Status))
+	for _, s := range args.LanguageSupport.Status {
+		statuses = append(statuses, api.LanguageSupportStatus(s))
 	}
-
-	q := strings.ToLower(args.Query)
-	categoryFilter := strings.ToLower(args.Category)
-
-	precisionFilter, maturityFilter, maturityFilterSet, errResult := parseSearchFilters(args)
-	if errResult != nil {
-		return *errResult
+	f := rules.LanguageSupportFilter{
+		Language: args.LanguageSupport.Language,
+		Status:   statuses,
+		Negate:   args.LanguageSupport.Negate,
 	}
-
-	type hit struct {
-		Name         string   `json:"name"`
-		Category     string   `json:"ruleSet"`
-		Severity     string   `json:"severity"`
-		Active       bool     `json:"active"`
-		Fixable      bool     `json:"fixable"`
-		Precision    string   `json:"precision"`
-		Maturity     string   `json:"maturity"`
-		Cost         string   `json:"cost"`
-		Capabilities []string `json:"capabilities"`
-		Description  string   `json:"description"`
-		Score        int      `json:"-"`
+	if err := f.Validate(); err != nil {
+		errRes := errorResult(err.Error())
+		return rules.LanguageSupportFilter{}, &errRes
 	}
+	return f, nil
+}
 
-	hits := make([]hit, 0, 32)
+type ruleHit struct {
+	Name         string   `json:"name"`
+	Category     string   `json:"ruleSet"`
+	Severity     string   `json:"severity"`
+	Active       bool     `json:"active"`
+	Fixable      bool     `json:"fixable"`
+	Precision    string   `json:"precision"`
+	Maturity     string   `json:"maturity"`
+	Cost         string   `json:"cost"`
+	Capabilities []string `json:"capabilities"`
+	Description  string   `json:"description"`
+	Score        int      `json:"-"`
+}
+
+type searchOpts struct {
+	query             string
+	category          string
+	precisionFilter   api.Precision
+	maturityFilter    api.Maturity
+	maturityFilterSet bool
+	supportFilter     rules.LanguageSupportFilter
+	hasSupportFilter  bool
+	capabilityFilter  api.CapabilityFilter
+	hasCapabilityFilt bool
+}
+
+// scoreRuleForSearch returns (score, keep). Scoring favors name > description
+// > category matches; a missing query is allowed when another filter is set.
+func scoreRuleForSearch(r *api.Rule, opts searchOpts) (int, bool) {
+	if opts.query == "" {
+		if opts.precisionFilter == api.PrecisionUnset && !opts.maturityFilterSet && !opts.hasSupportFilter && !opts.hasCapabilityFilt {
+			return 0, false
+		}
+		return 1, true
+	}
+	switch {
+	case strings.Contains(strings.ToLower(r.ID), opts.query):
+		return 3, true
+	case strings.Contains(strings.ToLower(r.Description), opts.query):
+		return 2, true
+	case strings.Contains(strings.ToLower(r.Category), opts.query):
+		return 1, true
+	}
+	return 0, false
+}
+
+func collectRuleHits(opts searchOpts) []ruleHit {
+	hits := make([]ruleHit, 0, 32)
 	for _, r := range api.Registry {
-		if categoryFilter != "" && !strings.EqualFold(r.Category, args.Category) {
+		if opts.category != "" && !strings.EqualFold(r.Category, opts.category) {
 			continue
 		}
-
 		precision := rules.V2RulePrecision(r)
-		if precisionFilter != api.PrecisionUnset && precision != precisionFilter {
+		if opts.precisionFilter != api.PrecisionUnset && precision != opts.precisionFilter {
 			continue
 		}
-
-		if maturityFilterSet && r.Maturity != maturityFilter {
+		if opts.maturityFilterSet && r.Maturity != opts.maturityFilter {
 			continue
 		}
-
-		if !capabilityFilter.MatchRule(r) {
+		if opts.hasSupportFilter && !opts.supportFilter.Matches(r) {
 			continue
 		}
-
-		score := 0
-		nameMatch := strings.Contains(strings.ToLower(r.ID), q)
-		descMatch := strings.Contains(strings.ToLower(r.Description), q)
-		catMatch := strings.Contains(strings.ToLower(r.Category), q)
-
-		switch {
-		case q == "":
-			// No query text: any of precision / maturity / needs / without acts
-			// as the filter. We've already applied those above, so anything that
-			// reaches here matches.
-			score = 1
-		case nameMatch:
-			score = 3
-		case descMatch:
-			score = 2
-		case catMatch:
-			score = 1
-		default:
+		if !opts.capabilityFilter.MatchRule(r) {
 			continue
 		}
-
+		score, keep := scoreRuleForSearch(r, opts)
+		if !keep {
+			continue
+		}
 		_, fixable := rules.GetV2FixLevel(r)
-		hits = append(hits, hit{
+		hits = append(hits, ruleHit{
 			Name:         r.ID,
 			Category:     r.Category,
 			Severity:     string(r.Sev),
@@ -292,6 +320,46 @@ func (s *Server) rulesSearch(args rulesArgs) ToolResult {
 			Score:        score,
 		})
 	}
+	return hits
+}
+
+// rulesSearch performs a case-insensitive substring match over rule name,
+// description, and category. Results are ranked by where the match landed
+// (name > description > category) then alphabetical.
+func (s *Server) rulesSearch(args rulesArgs) ToolResult {
+	hasSupportFilter := args.LanguageSupport != nil && args.LanguageSupport.Language != ""
+	capabilityFilter := api.CapabilityFilter{Require: args.Needs, Exclude: args.Without}
+	hasCapabilityFilt := !capabilityFilter.IsZero()
+
+	if args.Query == "" && args.Precision == "" && args.Maturity == "" && !hasSupportFilter && !hasCapabilityFilt {
+		return errorResult("'query', 'precision', 'maturity', 'languageSupport', 'needs', or 'without' argument is required for operation=search")
+	}
+
+	if errResult := validateCapabilityArgs(args.Needs, args.Without); errResult != nil {
+		return *errResult
+	}
+
+	precisionFilter, maturityFilter, maturityFilterSet, errResult := parseSearchFilters(args)
+	if errResult != nil {
+		return *errResult
+	}
+
+	supportFilter, errResult := buildSupportFilter(args)
+	if errResult != nil {
+		return *errResult
+	}
+
+	hits := collectRuleHits(searchOpts{
+		query:             strings.ToLower(args.Query),
+		category:          args.Category,
+		precisionFilter:   precisionFilter,
+		maturityFilter:    maturityFilter,
+		maturityFilterSet: maturityFilterSet,
+		supportFilter:     supportFilter,
+		hasSupportFilter:  hasSupportFilter,
+		capabilityFilter:  capabilityFilter,
+		hasCapabilityFilt: hasCapabilityFilt,
+	})
 
 	sort.SliceStable(hits, func(i, j int) bool {
 		if hits[i].Score != hits[j].Score {
@@ -301,9 +369,9 @@ func (s *Server) rulesSearch(args rulesArgs) ToolResult {
 	})
 
 	type searchResult struct {
-		Query string `json:"query"`
-		Total int    `json:"total"`
-		Hits  []hit  `json:"hits"`
+		Query string    `json:"query"`
+		Total int       `json:"total"`
+		Hits  []ruleHit `json:"hits"`
 	}
 
 	return jsonResult(searchResult{

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -122,8 +122,16 @@ func rulesToolDef() ToolDefinition {
 			"maturity":  jsonschema.StringEnum([]string{"stable", "experimental", "deprecated"}, "Filter by lifecycle stage (operation=search)"),
 			"needs":     jsonschema.Array(jsonschema.String(""), "Require these capability labels — every label must be present (operation=search). Use 'oracle' as a shorthand for any oracle:* bit."),
 			"without":   jsonschema.Array(jsonschema.String(""), "Exclude rules that declare any of these capability labels (operation=search). 'without: [oracle]' filters out every NeedsOracle* rule."),
-			"active":    jsonschema.Boolean("Override active flag (operation=configure)"),
-			"severity":  jsonschema.StringEnum([]string{"error", "warning", "info"}, "Override severity (operation=configure)"),
+			"languageSupport": jsonschema.Object(map[string]*jsonschema.Schema{
+				"language": jsonschema.String("Language key (currently 'java')"),
+				"status": jsonschema.Array(
+					jsonschema.StringEnum([]string{"supported", "partial", "pending", "not-applicable", "needs-design"}, "LanguageSupport status"),
+					"Status set; empty means any classified rule for that language",
+				),
+				"negate": jsonschema.Boolean("Invert the membership test (e.g. status=['supported'], negate=true means 'not yet fully supported')"),
+			}).WithDescription("Filter by LanguageSupport classification (operation=search)"),
+			"active":   jsonschema.Boolean("Override active flag (operation=configure)"),
+			"severity": jsonschema.StringEnum([]string{"error", "warning", "info"}, "Override severity (operation=configure)"),
 		}),
 	}
 }

--- a/internal/mcp/tools_new_ops_test.go
+++ b/internal/mcp/tools_new_ops_test.go
@@ -31,6 +31,69 @@ func TestRulesSearch(t *testing.T) {
 	}
 }
 
+// TestRulesSearchLanguageSupportFilter verifies search filters by
+// LanguageSupport classification.
+func TestRulesSearchLanguageSupportFilter(t *testing.T) {
+	args, _ := json.Marshal(rulesArgs{
+		Operation: "search",
+		LanguageSupport: &languageSupportArg{
+			Language: "java",
+			Status:   []string{"supported"},
+		},
+	})
+	responses := runServer(t, Request{
+		JSONRPC: "2.0",
+		ID:      float64(1),
+		Method:  "tools/call",
+		Params:  mustJSON(t, ToolCallParams{Name: "rules", Arguments: args}),
+	})
+	data, _ := json.Marshal(responses[0].Result)
+	var result ToolResult
+	if err := json.Unmarshal(data, &result); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("tool returned error: %s", result.Content[0].Text)
+	}
+	text := result.Content[0].Text
+	if !strings.Contains(text, "AddJavascriptInterface") {
+		t.Errorf("expected AddJavascriptInterface in java=supported hits, got: %s", text)
+	}
+}
+
+// TestRulesSearchLanguageSupportNegated verifies the negate flag flips
+// LanguageSupport membership.
+func TestRulesSearchLanguageSupportNegated(t *testing.T) {
+	args, _ := json.Marshal(rulesArgs{
+		Operation: "search",
+		LanguageSupport: &languageSupportArg{
+			Language: "java",
+			Status:   []string{"supported"},
+			Negate:   true,
+		},
+	})
+	responses := runServer(t, Request{
+		JSONRPC: "2.0",
+		ID:      float64(1),
+		Method:  "tools/call",
+		Params:  mustJSON(t, ToolCallParams{Name: "rules", Arguments: args}),
+	})
+	data, _ := json.Marshal(responses[0].Result)
+	var result ToolResult
+	if err := json.Unmarshal(data, &result); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("tool returned error: %s", result.Content[0].Text)
+	}
+	text := result.Content[0].Text
+	// AddJavascriptInterface is explicitly java=supported and must be excluded
+	// from the negated set.
+	if strings.Contains(text, "\"name\":\"AddJavascriptInterface\"") {
+		t.Errorf("expected AddJavascriptInterface excluded by negate; got: %s", text)
+	}
+}
+
 // TestRulesSearchMissingQuery verifies search requires a query.
 func TestRulesSearchMissingQuery(t *testing.T) {
 	args, _ := json.Marshal(rulesArgs{Operation: "search"})

--- a/internal/rules/api/metadata.go
+++ b/internal/rules/api/metadata.go
@@ -340,6 +340,22 @@ type LanguageSupport struct {
 	Fixtures []string              `json:"fixtures,omitempty" yaml:"fixtures,omitempty"`
 }
 
+// Summary returns a one-line human-readable justification for the
+// classification, preferring Reason, then evidence, then fixtures.
+// Empty string when none are populated.
+func (s LanguageSupport) Summary() string {
+	if s.Reason != "" {
+		return s.Reason
+	}
+	if len(s.Evidence) > 0 {
+		return "evidence: " + strings.Join(s.Evidence, ", ")
+	}
+	if len(s.Fixtures) > 0 {
+		return "fixtures: " + strings.Join(s.Fixtures, ", ")
+	}
+	return ""
+}
+
 // ConfigOption describes a single configurable field on a rule.
 //
 // Apply closures downcast the target interface to the concrete rule struct and

--- a/internal/rules/language_support_filter.go
+++ b/internal/rules/language_support_filter.go
@@ -1,0 +1,132 @@
+package rules
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	api "github.com/kaeawc/krit/internal/rules/api"
+)
+
+// LanguageSupportFilter narrows a registry by per-language LanguageSupport
+// status. An empty Status list matches any status (so a filter is meaningful
+// as long as Language is set). Negate flips the membership check.
+type LanguageSupportFilter struct {
+	Language string
+	Status   []api.LanguageSupportStatus
+	Negate   bool
+}
+
+// IsZero reports whether the filter would not narrow the registry.
+func (f LanguageSupportFilter) IsZero() bool {
+	return f.Language == "" && len(f.Status) == 0 && !f.Negate
+}
+
+// Validate normalizes f and reports any unknown status values. An empty
+// Language is allowed only when Status is also empty (a no-op filter).
+func (f LanguageSupportFilter) Validate() error {
+	if f.Language == "" && (len(f.Status) > 0 || f.Negate) {
+		return fmt.Errorf("language support filter: language is required when status or negate is set")
+	}
+	for _, s := range f.Status {
+		if !s.Valid() {
+			return fmt.Errorf("language support filter: unknown status %q", s)
+		}
+	}
+	return nil
+}
+
+// Matches reports whether the rule's resolved support for f.Language passes
+// the filter. A nil rule never matches.
+func (f LanguageSupportFilter) Matches(r *api.Rule) bool {
+	if r == nil {
+		return false
+	}
+	if f.IsZero() {
+		return true
+	}
+	support, ok := LanguageSupportForRule(r, f.Language)
+	if !ok {
+		return f.Negate
+	}
+	if len(f.Status) == 0 {
+		return !f.Negate
+	}
+	for _, s := range f.Status {
+		if s == support.Status {
+			return !f.Negate
+		}
+	}
+	return f.Negate
+}
+
+// LanguageSupportForRule returns the per-language support entry for the
+// given language key, falling back to ruleset defaults when no per-rule
+// override exists. Currently only "java" is wired to a source-of-truth
+// matrix; other languages return (zero, false).
+func LanguageSupportForRule(r *api.Rule, language string) (api.LanguageSupport, bool) {
+	if r == nil || language == "" {
+		return api.LanguageSupport{}, false
+	}
+	switch language {
+	case JavaLanguageSupportKey:
+		return JavaSupportForRule(r)
+	default:
+		return api.LanguageSupport{}, false
+	}
+}
+
+// FilterRegistry returns rules from the registry that match f, in registry
+// order. Returns a fresh slice; the registry itself is not modified.
+func FilterRegistry(registry []*api.Rule, f LanguageSupportFilter) []*api.Rule {
+	if f.IsZero() {
+		out := make([]*api.Rule, 0, len(registry))
+		for _, r := range registry {
+			if r != nil {
+				out = append(out, r)
+			}
+		}
+		return out
+	}
+	out := make([]*api.Rule, 0, len(registry))
+	for _, r := range registry {
+		if f.Matches(r) {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+// ParseStatusFilter parses a status filter expression of the form
+// "supported", "partial,pending", or "!supported". The leading "!"
+// applies to the whole expression. Spaces around commas are tolerated.
+// Empty input returns (nil, false, nil).
+func ParseStatusFilter(expr string) ([]api.LanguageSupportStatus, bool, error) {
+	expr = strings.TrimSpace(expr)
+	if expr == "" {
+		return nil, false, nil
+	}
+	negate := false
+	if strings.HasPrefix(expr, "!") {
+		negate = true
+		expr = strings.TrimSpace(strings.TrimPrefix(expr, "!"))
+	}
+	if expr == "" {
+		return nil, negate, fmt.Errorf("status filter: expected at least one status after '!'")
+	}
+	raw := strings.Split(expr, ",")
+	statuses := make([]api.LanguageSupportStatus, 0, len(raw))
+	for _, s := range raw {
+		s = strings.TrimSpace(s)
+		if s == "" {
+			continue
+		}
+		status := api.LanguageSupportStatus(s)
+		if !status.Valid() {
+			return nil, negate, fmt.Errorf("status filter: unknown status %q", s)
+		}
+		statuses = append(statuses, status)
+	}
+	sort.Slice(statuses, func(i, j int) bool { return statuses[i] < statuses[j] })
+	return statuses, negate, nil
+}

--- a/internal/rules/language_support_filter_test.go
+++ b/internal/rules/language_support_filter_test.go
@@ -1,0 +1,174 @@
+package rules
+
+import (
+	"reflect"
+	"testing"
+
+	api "github.com/kaeawc/krit/internal/rules/api"
+)
+
+func TestLanguageSupportFilterMatches(t *testing.T) {
+	supported := mustV2RuleByID(t, "AddJavascriptInterface") // explicit supported
+	longMethod := mustV2RuleByID(t, "LongMethod")            // ruleset default = pending
+	composeRule := findRuleForCategory(t, "compose")         // ruleset default = not-applicable
+
+	cases := []struct {
+		name   string
+		filter LanguageSupportFilter
+		rule   *api.Rule
+		want   bool
+	}{
+		{
+			name:   "zero filter matches every rule",
+			filter: LanguageSupportFilter{},
+			rule:   supported,
+			want:   true,
+		},
+		{
+			name:   "language only matches when classification exists",
+			filter: LanguageSupportFilter{Language: "java"},
+			rule:   supported,
+			want:   true,
+		},
+		{
+			name:   "matching status passes",
+			filter: LanguageSupportFilter{Language: "java", Status: []api.LanguageSupportStatus{api.LanguageSupportSupported}},
+			rule:   supported,
+			want:   true,
+		},
+		{
+			name:   "non-matching status drops",
+			filter: LanguageSupportFilter{Language: "java", Status: []api.LanguageSupportStatus{api.LanguageSupportPartial}},
+			rule:   supported,
+			want:   false,
+		},
+		{
+			name:   "ruleset default classifies pending rules",
+			filter: LanguageSupportFilter{Language: "java", Status: []api.LanguageSupportStatus{api.LanguageSupportPending}},
+			rule:   longMethod,
+			want:   true,
+		},
+		{
+			name:   "negation flips match",
+			filter: LanguageSupportFilter{Language: "java", Status: []api.LanguageSupportStatus{api.LanguageSupportSupported}, Negate: true},
+			rule:   supported,
+			want:   false,
+		},
+		{
+			name:   "negation passes when status doesn't match",
+			filter: LanguageSupportFilter{Language: "java", Status: []api.LanguageSupportStatus{api.LanguageSupportSupported}, Negate: true},
+			rule:   longMethod,
+			want:   true,
+		},
+		{
+			name:   "not-applicable status reachable via ruleset default",
+			filter: LanguageSupportFilter{Language: "java", Status: []api.LanguageSupportStatus{api.LanguageSupportNotApplicable}},
+			rule:   composeRule,
+			want:   true,
+		},
+		{
+			name:   "unknown language returns false unless negated",
+			filter: LanguageSupportFilter{Language: "scala"},
+			rule:   supported,
+			want:   false,
+		},
+		{
+			name:   "unknown language with negate passes through",
+			filter: LanguageSupportFilter{Language: "scala", Negate: true},
+			rule:   supported,
+			want:   true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.filter.Matches(tc.rule)
+			if got != tc.want {
+				t.Fatalf("Matches() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestLanguageSupportFilterValidate(t *testing.T) {
+	if err := (LanguageSupportFilter{}).Validate(); err != nil {
+		t.Fatalf("zero filter should validate, got %v", err)
+	}
+	if err := (LanguageSupportFilter{Status: []api.LanguageSupportStatus{api.LanguageSupportSupported}}).Validate(); err == nil {
+		t.Fatal("status without language should error")
+	}
+	if err := (LanguageSupportFilter{Language: "java", Status: []api.LanguageSupportStatus{"bogus"}}).Validate(); err == nil {
+		t.Fatal("unknown status should error")
+	}
+	if err := (LanguageSupportFilter{Language: "java", Status: []api.LanguageSupportStatus{api.LanguageSupportSupported, api.LanguageSupportPartial}}).Validate(); err != nil {
+		t.Fatalf("valid filter should pass, got %v", err)
+	}
+}
+
+func TestParseStatusFilter(t *testing.T) {
+	cases := []struct {
+		in         string
+		want       []api.LanguageSupportStatus
+		wantNegate bool
+		wantErr    bool
+	}{
+		{in: "", want: nil},
+		{in: "supported", want: []api.LanguageSupportStatus{api.LanguageSupportSupported}},
+		{in: "supported,partial", want: []api.LanguageSupportStatus{api.LanguageSupportPartial, api.LanguageSupportSupported}},
+		{in: "!supported", want: []api.LanguageSupportStatus{api.LanguageSupportSupported}, wantNegate: true},
+		{in: " ! supported , partial ", want: []api.LanguageSupportStatus{api.LanguageSupportPartial, api.LanguageSupportSupported}, wantNegate: true},
+		{in: "!", wantErr: true},
+		{in: "bogus", wantErr: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			got, neg, err := ParseStatusFilter(tc.in)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if neg != tc.wantNegate {
+				t.Fatalf("negate = %v, want %v", neg, tc.wantNegate)
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("statuses = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFilterRegistry(t *testing.T) {
+	all := FilterRegistry(api.Registry, LanguageSupportFilter{})
+	if len(all) == 0 {
+		t.Fatal("zero filter should return the full registry")
+	}
+	supported := FilterRegistry(api.Registry, LanguageSupportFilter{
+		Language: "java",
+		Status:   []api.LanguageSupportStatus{api.LanguageSupportSupported},
+	})
+	if len(supported) == 0 {
+		t.Fatal("expected at least one rule with java=supported")
+	}
+	for _, r := range supported {
+		s, _ := JavaSupportForRule(r)
+		if s.Status != api.LanguageSupportSupported {
+			t.Fatalf("rule %s leaked through java=supported filter (status=%s)", r.ID, s.Status)
+		}
+	}
+}
+
+func findRuleForCategory(t *testing.T, category string) *api.Rule {
+	t.Helper()
+	for _, r := range api.Registry {
+		if r != nil && r.Category == category {
+			return r
+		}
+	}
+	t.Fatalf("no rule found in category %s", category)
+	return nil
+}

--- a/internal/rules/language_support_lint_test.go
+++ b/internal/rules/language_support_lint_test.go
@@ -1,0 +1,167 @@
+package rules
+
+import (
+	"sort"
+	"strings"
+	"testing"
+
+	api "github.com/kaeawc/krit/internal/rules/api"
+)
+
+// TestRulesWithTypeInfoDeclareExplicitJavaSupport is the lint gate
+// referenced by issue #194: every rule that declares NeedsTypeInfo
+// (i.e. NeedsResolver) must carry an explicit Java LanguageSupport
+// entry. Type-aware rules are exactly the ones where Java parity is
+// most likely to silently drift, so we force the author to record
+// whether Java is supported / partial / pending / not-applicable /
+// needs-design rather than silently inheriting a ruleset default.
+func TestRulesWithTypeInfoDeclareExplicitJavaSupport(t *testing.T) {
+	matrix := JavaSupportReadiness()
+	var missing []string
+	for _, r := range api.Registry {
+		if r == nil {
+			continue
+		}
+		if !r.Needs.Has(api.NeedsResolver) {
+			continue
+		}
+		if _, ok := matrix.Rules[r.ID]; ok {
+			continue
+		}
+		// Per-rule LanguageSupport on the Rule literal also counts as
+		// an explicit declaration.
+		if _, ok := r.LanguageSupport[JavaLanguageSupportKey]; ok {
+			continue
+		}
+		if grandfatheredTypeInfoRulesWithoutExplicitJavaSupport[r.ID] {
+			continue
+		}
+		missing = append(missing, r.ID+" (ruleset "+r.Category+")")
+	}
+	sort.Strings(missing)
+	if len(missing) > 0 {
+		t.Fatalf("rules with NeedsTypeInfo/NeedsResolver must declare an explicit Java LanguageSupport entry in JavaSupportReadiness.Rules or Rule.LanguageSupport:\n  %s",
+			strings.Join(missing, "\n  "))
+	}
+
+	// Guard against staleness: a grandfathered rule that loses NeedsResolver
+	// or gains an explicit entry no longer belongs on the allowlist.
+	var stale []string
+	for id := range grandfatheredTypeInfoRulesWithoutExplicitJavaSupport {
+		r := findRegistryRule(id)
+		if r == nil {
+			stale = append(stale, id+" (no longer registered)")
+			continue
+		}
+		if !r.Needs.Has(api.NeedsResolver) {
+			stale = append(stale, id+" (no longer needs resolver)")
+			continue
+		}
+		if _, ok := matrix.Rules[id]; ok {
+			stale = append(stale, id+" (now classified in JavaSupportReadiness)")
+			continue
+		}
+		if _, ok := r.LanguageSupport[JavaLanguageSupportKey]; ok {
+			stale = append(stale, id+" (now has explicit LanguageSupport)")
+		}
+	}
+	sort.Strings(stale)
+	if len(stale) > 0 {
+		t.Fatalf("grandfathered list is stale; remove these from grandfatheredTypeInfoRulesWithoutExplicitJavaSupport:\n  %s",
+			strings.Join(stale, "\n  "))
+	}
+}
+
+func findRegistryRule(id string) *api.Rule {
+	for _, r := range api.Registry {
+		if r != nil && r.ID == id {
+			return r
+		}
+	}
+	return nil
+}
+
+// grandfatheredTypeInfoRulesWithoutExplicitJavaSupport lists pre-existing
+// type-aware rules that have not yet been classified per-rule for Java
+// support. The lint gate above forbids adding *new* NeedsTypeInfo rules
+// without an explicit entry; this set should only shrink as rules either
+// gain entries in JavaSupportReadiness.Rules or have their type-info
+// requirement dropped.
+var grandfatheredTypeInfoRulesWithoutExplicitJavaSupport = map[string]bool{
+	"AbstractClassCanBeConcreteClass":                true,
+	"AbstractMemberNotImplemented":                   true,
+	"AnalyticsCallWithoutConsentGate":                true,
+	"AnalyticsEventWithPiiParamName":                 true,
+	"AnalyticsUserIdFromPii":                         true,
+	"AnimatorDurationIgnoresScale":                   true,
+	"ArrayPrimitive":                                 true,
+	"AvoidReferentialEquality":                       true,
+	"CanBeNonNullable":                               true,
+	"CastNullableToNonNullableType":                  true,
+	"CharArrayToStringCall":                          true,
+	"ContentProviderQueryWithSelectionInterpolation": true,
+	"CouldBeSequence":                                true,
+	"CrashlyticsCustomKeyWithPii":                    true,
+	"DataClassShouldBeImmutable":                     true,
+	"Deprecation":                                    true,
+	"DontDowncastCollectionTypes":                    true,
+	"ElseCaseInsteadOfExhaustiveWhen":                true,
+	"ErrorUsageWithThrowable":                        true,
+	"ExplicitCollectionElementAccessMethod":          true,
+	"FirebaseRemoteConfigDefaultsWithPii":            true,
+	"ForbiddenMethodCall":                            true,
+	"IgnoredReturnValue":                             true,
+	"ImageLoadedAtFullSizeInList":                    true,
+	"ImplicitDefaultLocale":                          true,
+	"InlinedApi":                                     true,
+	"IteratorHasNextCallsNextMethod":                 true,
+	"IteratorNotThrowingNoSuchElementException":      true,
+	"LogConditional":                                 true,
+	"LogOfSharedPreferenceRead":                      true,
+	"MainDispatcherInLibraryCode":                    true,
+	"MapGetWithNotNullAssertionOperator":             true,
+	"MissingPermission":                              true,
+	"MissingReturn":                                  true,
+	"MissingUseCall":                                 true,
+	"NewApi":                                         true,
+	"NoElseInWhenSealed":                             true,
+	"NonExhaustiveWhen":                              true,
+	"NullCheckOnMutableProperty":                     true,
+	"NullableToStringCall":                           true,
+	"ObjectAnimatorBinding":                          true,
+	"ObjectExtendsThrowable":                         true,
+	"ObjectLiteralToLambda":                          true,
+	"ObsoleteLayoutParam":                            true,
+	"OverrideSignatureMismatch":                      true,
+	"PlainFileWriteOfSensitive":                      true,
+	"ProtectedMemberInFinalClass":                    true,
+	"Range":                                          true,
+	"RedundantExplicitType":                          true,
+	"RedundantSuspendModifier":                       true,
+	"Registered":                                     true,
+	"RequiresApiViolation":                           true,
+	"RoomRawQueryStringConcat":                       true,
+	"SerialVersionUIDInSerializableClass":            true,
+	"SharedPreferencesForSensitiveKey":               true,
+	"SuspendFunSwallowedCancellation":                true,
+	"TestFixtureAccessedFromProduction":              true,
+	"TimberTreeNotPlanted":                           true,
+	"TooGenericExceptionThrown":                      true,
+	"UnnecessaryFilter":                              true,
+	"UnnecessaryNotNullCheck":                        true,
+	"UnnecessaryNotNullOperator":                     true,
+	"UnnecessarySafeCall":                            true,
+	"UnnecessaryTypeCasting":                         true,
+	"UnreachableCatchBlock":                          true,
+	"UnsafeCast":                                     true,
+	"UseCheckNotNull":                                true,
+	"UseIsNullOrEmpty":                               true,
+	"UseRequireNotNull":                              true,
+	"UselessCallOnNotNull":                           true,
+	"UselessElvisOnNonNull":                          true,
+	"ViewHolder":                                     true,
+	"ViewTag":                                        true,
+	"Wakelock":                                       true,
+	"WithContextInSuspendFunctionNoop":               true,
+	"WrongConstant":                                  true,
+}


### PR DESCRIPTION
## Summary
- New `LanguageSupportFilter` (`internal/rules/language_support_filter.go`) narrows the registry by per-language LanguageSupport status with optional negation; statuses are typed `api.LanguageSupportStatus`.
- New `krit rules` CLI verb with `list --language java --status partial` (and `!supported`) plus `coverage --language java` for a full Java parity table.
- MCP `rules` tool's `search` operation now accepts `languageSupport: {language, status, negate}`.
- `make lint-rules` now requires new `NeedsTypeInfo`/`NeedsResolver` rules to declare an explicit Java LanguageSupport entry (existing rules are grandfathered).

Closes #194.

## Test plan
- [x] `go test ./internal/rules/ -run 'LanguageSupport|ParseStatusFilter|FilterRegistry|TypeInfoDeclareExplicit' -count=1`
- [x] `go test ./internal/cli/rules/ -count=1` (includes coverage golden snapshot)
- [x] `go test ./internal/mcp/ -run TestRulesSearch -count=1`
- [x] `make lint-rules`
- [x] `golangci-lint run ./...`
- [x] `go vet ./...`
- [x] `go test ./... -count=1`
- [x] Smoke: `./krit rules list --language java --status partial`, `./krit rules coverage --language java`