### PR TITLE
feat(daemon): resident analysis cache + dirty-only cacheCheck + periodic flush

### DIFF
--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync/atomic"
 
 	"github.com/kaeawc/krit/internal/config"
 	"github.com/kaeawc/krit/internal/fsutil"
@@ -93,6 +94,11 @@ type Cache struct {
 	// a no-op.  Set via AttachStore after loading.
 	backingStore     *store.FileStore
 	storeRuleSetHash [16]byte
+
+	// mutated flags any UpdateEntryColumns since the last MarkFlushed.
+	// The daemon's periodic-flush goroutine reads this via
+	// MutatedSinceFlush to skip Save on idle ticks.
+	mutated atomic.Bool
 }
 
 // Result holds the outcome of checking files against the cache.
@@ -390,6 +396,89 @@ func (c *Cache) CheckFiles(filePaths []string, ruleHash string, scanPaths ...str
 	return result
 }
 
+// CheckFilesIncremental is CheckFiles but stats only the paths in the
+// dirty set; non-dirty paths skip the os.Stat/hash check and are
+// reported as cache hits whenever they have a cache entry. Returns the
+// same shape as CheckFiles.
+//
+// Callers MUST be holding a WorkspaceState whose watcher has been
+// running continuously since the last invocation — otherwise the dirty
+// set is incomplete and findings drift silently.
+//
+// The backing-store path is unaffected (entries there are content-hash
+// keyed and the lookup already amortizes to O(1) per file).
+func (c *Cache) CheckFilesIncremental(
+	filePaths []string,
+	dirty []string,
+	ruleHash string,
+	scanPaths ...string,
+) *Result {
+	result := &Result{
+		CachedPaths:  make(map[string]bool),
+		CachedHashes: make(map[string]string),
+		TotalFiles:   len(filePaths),
+	}
+	collector := scanner.NewFindingCollector(0)
+
+	if c.backingStore != nil {
+		return c.checkFilesFromStore(filePaths, result, collector)
+	}
+
+	if c.RuleHash != ruleHash {
+		return result
+	}
+	if len(scanPaths) > 0 && len(c.ScanPaths) > 0 {
+		if !scanPathsMatch(c.ScanPaths, scanPaths) {
+			return result
+		}
+	}
+
+	dirtySet := make(map[string]struct{}, len(dirty))
+	for _, p := range dirty {
+		dirtySet[absPath(p)] = struct{}{}
+	}
+
+	for _, path := range filePaths {
+		abs := absPath(path)
+		entry, ok := c.Files[abs]
+		if !ok {
+			continue
+		}
+		if _, isDirty := dirtySet[abs]; !isDirty {
+			result.CachedPaths[path] = true
+			result.CachedHashes[path] = entry.Hash
+			collector.AppendColumns(&entry.Columns)
+			result.TotalCached++
+			continue
+		}
+		if !NeedsReanalysis(path, entry) {
+			result.CachedPaths[path] = true
+			result.CachedHashes[path] = entry.Hash
+			collector.AppendColumns(&entry.Columns)
+			result.TotalCached++
+		}
+	}
+	result.CachedColumns = *collector.Columns()
+	return result
+}
+
+// MutatedSinceFlush reports whether UpdateEntryColumns has been called
+// since the last MarkFlushed.
+func (c *Cache) MutatedSinceFlush() bool {
+	if c == nil {
+		return false
+	}
+	return c.mutated.Load()
+}
+
+// MarkFlushed clears the mutation flag. Call after a successful Save.
+func (c *Cache) MarkFlushed() {
+	if c == nil {
+		return
+	}
+	c.mutated.Store(false)
+}
+
 // ShouldSkipFullSaveForSmallDelta reports whether a JSON-backed cache run
 // should avoid rewriting the full cache file after a tiny dirty worktree
 // delta. Dirty files are still reanalyzed on the next run unless their entry
@@ -458,6 +547,21 @@ func addDirtyRelPaths(dirty map[string]bool, top, out string) {
 			dirty[abs] = true
 		}
 	}
+}
+
+// absPath returns filepath.Abs(path) but short-circuits when path is
+// already absolute. CheckFilesIncremental iterates tens of thousands
+// of paths per call on warm daemons; skipping the Getwd+Clean for the
+// already-canonical case is measurable.
+func absPath(path string) string {
+	if filepath.IsAbs(path) {
+		return path
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return path
+	}
+	return abs
 }
 
 func normalizeAbsPath(path string) string {
@@ -560,6 +664,7 @@ func (c *Cache) updateEntry(path string, columns scanner.FindingColumns) {
 			Kind:        store.KindIncremental,
 		}
 		_ = c.backingStore.Put(key, data)
+		c.mutated.Store(true)
 		return
 	}
 	abs, _ := filepath.Abs(path)
@@ -573,6 +678,7 @@ func (c *Cache) updateEntry(path string, columns scanner.FindingColumns) {
 		Size:    info.Size(),
 		Columns: columns,
 	}
+	c.mutated.Store(true)
 }
 
 // Prune removes entries for files that no longer exist.

--- a/internal/cache/incremental_test.go
+++ b/internal/cache/incremental_test.go
@@ -1,0 +1,147 @@
+package cache
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kaeawc/krit/internal/scanner"
+)
+
+// TestCheckFilesIncremental_NonDirtyPathsHitWithoutStat verifies the
+// "skip stat for clean paths" behavior. fileA has a cache entry but is
+// not in the dirty set, so the cache returns it as a hit even though
+// we mutate the file on disk to differ from the cached metadata. A
+// CheckFiles call would stat it and miss; CheckFilesIncremental must
+// trust the watcher and return the cached row.
+func TestCheckFilesIncremental_NonDirtyPathsHitWithoutStat(t *testing.T) {
+	dir := t.TempDir()
+	fileA := filepath.Join(dir, "a.kt")
+	if err := os.WriteFile(fileA, []byte("fun a() {}"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	absA, _ := filepath.Abs(fileA)
+
+	c := &Cache{
+		RuleHash: "h",
+		Files: map[string]FileEntry{
+			absA: {
+				Hash:    "stale", // intentionally wrong hash
+				ModTime: 1,       // intentionally wrong mtime
+				Size:    1,       // intentionally wrong size
+				Columns: testFindingColumns([]scanner.Finding{
+					{File: fileA, Rule: "X", Message: "cached"},
+				}),
+			},
+		},
+	}
+
+	// Dirty set is empty: the watcher has not reported any change.
+	res := c.CheckFilesIncremental([]string{fileA}, nil, "h")
+	if res.TotalCached != 1 {
+		t.Fatalf("expected 1 cached hit, got %d", res.TotalCached)
+	}
+	if !res.CachedPaths[fileA] {
+		t.Fatal("fileA should be a hit (not in dirty set)")
+	}
+	if res.CachedColumns.Len() != 1 {
+		t.Fatalf("expected 1 cached finding, got %d", res.CachedColumns.Len())
+	}
+}
+
+// TestCheckFilesIncremental_DirtyPathRechecksAndMisses verifies that a
+// path in the dirty set goes through NeedsReanalysis. The cache entry
+// has stale metadata so the recheck misses and the path is reported
+// as a miss.
+func TestCheckFilesIncremental_DirtyPathRechecksAndMisses(t *testing.T) {
+	dir := t.TempDir()
+	fileA := filepath.Join(dir, "a.kt")
+	if err := os.WriteFile(fileA, []byte("fun a() {}"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	absA, _ := filepath.Abs(fileA)
+
+	c := &Cache{
+		RuleHash: "h",
+		Files: map[string]FileEntry{
+			absA: {Hash: "stale", ModTime: 1, Size: 1},
+		},
+	}
+
+	res := c.CheckFilesIncremental([]string{fileA}, []string{fileA}, "h")
+	if res.TotalCached != 0 {
+		t.Fatalf("expected dirty path to miss, got %d hits", res.TotalCached)
+	}
+	if res.CachedPaths[fileA] {
+		t.Fatal("dirty fileA should NOT be a cache hit")
+	}
+}
+
+// TestCheckFilesIncremental_DirtyPathStillHitsWhenMetadataMatches
+// verifies the "dirty but unchanged" case: the watcher noticed an
+// event (maybe a chmod or touch) but the content hasn't changed —
+// NeedsReanalysis returns false and the entry is still served.
+func TestCheckFilesIncremental_DirtyPathStillHitsWhenMetadataMatches(t *testing.T) {
+	dir := t.TempDir()
+	fileA := filepath.Join(dir, "a.kt")
+	if err := os.WriteFile(fileA, []byte("fun a() {}"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	absA, _ := filepath.Abs(fileA)
+	info, _ := os.Stat(fileA)
+
+	c := &Cache{
+		RuleHash: "h",
+		Files: map[string]FileEntry{
+			absA: {
+				Hash:    ComputeFileHash(fileA),
+				ModTime: info.ModTime().UnixMilli(),
+				Size:    info.Size(),
+			},
+		},
+	}
+
+	res := c.CheckFilesIncremental([]string{fileA}, []string{fileA}, "h")
+	if res.TotalCached != 1 {
+		t.Fatalf("expected dirty-but-unchanged path to hit, got %d", res.TotalCached)
+	}
+}
+
+// TestCheckFilesIncremental_RuleHashMismatchInvalidates verifies the
+// rule-hash-drift safety check still applies. A drift forces all
+// paths to misses regardless of dirty-set state.
+func TestCheckFilesIncremental_RuleHashMismatchInvalidates(t *testing.T) {
+	c := &Cache{
+		RuleHash: "old",
+		Files:    map[string]FileEntry{"/x.kt": {Hash: "h"}},
+	}
+	res := c.CheckFilesIncremental([]string{"/x.kt"}, nil, "new")
+	if res.TotalCached != 0 {
+		t.Fatalf("rule-hash drift should miss; got %d hits", res.TotalCached)
+	}
+}
+
+// TestMutatedSinceFlush tracks UpdateEntryColumns calls between
+// MarkFlushed boundaries. The daemon's periodic flush goroutine uses
+// MutatedSinceFlush to short-circuit Save when nothing changed.
+func TestMutatedSinceFlush(t *testing.T) {
+	dir := t.TempDir()
+	fileA := filepath.Join(dir, "a.kt")
+	if err := os.WriteFile(fileA, []byte("fun a() {}"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	c := &Cache{Files: map[string]FileEntry{}}
+	if c.MutatedSinceFlush() {
+		t.Fatal("fresh cache should report no mutation")
+	}
+	cols := testFindingColumns(nil)
+	c.UpdateEntryColumns(fileA, &cols)
+	if !c.MutatedSinceFlush() {
+		t.Fatal("UpdateEntryColumns should record a mutation")
+	}
+	c.MarkFlushed()
+	if c.MutatedSinceFlush() {
+		t.Fatal("MarkFlushed should reset the counter")
+	}
+}

--- a/internal/cli/scan/session.go
+++ b/internal/cli/scan/session.go
@@ -23,16 +23,17 @@ type Flags = *scanFlags
 // write back into Session so daemon callers skip the rebuild on warm
 // invocations.
 type Session struct {
-	Workspace      *pipeline.WorkspaceState
-	AnalysisCache  *cache.Cache
-	ParseCache     *scanner.ParseCache
-	XMLParseCache  *android.XMLParseCache
-	ResourceCache  *android.ResourceIndexCache
-	AndroidProject *android.Project
-	LibraryFacts   *librarymodel.Facts
-	OracleDaemon   *oracle.Daemon
-	repoDir        string
-	closed         bool
+	Workspace             *pipeline.WorkspaceState
+	AnalysisCache         *cache.Cache
+	AnalysisCacheFilePath string
+	ParseCache            *scanner.ParseCache
+	XMLParseCache         *android.XMLParseCache
+	ResourceCache         *android.ResourceIndexCache
+	AndroidProject        *android.Project
+	LibraryFacts          *librarymodel.Facts
+	OracleDaemon          *oracle.Daemon
+	repoDir               string
+	closed                bool
 }
 
 // NewSession returns a Session rooted at repoDir. Caches and project

--- a/internal/pipeline/index.go
+++ b/internal/pipeline/index.go
@@ -197,6 +197,12 @@ type IndexInput struct {
 	// receive instead of a serialized disk read.
 	PreloadedAnalysisCache *cache.Cache
 
+	// CacheDirty opts cacheCheck into CheckFilesIncremental: nil keeps
+	// the full CheckFiles pass, non-nil (possibly empty) means the
+	// caller has a continuously-running watcher and the listed paths
+	// are the only ones that need re-stat. See issue #206.
+	CacheDirty []string
+
 	// --- Oracle/cache bypass knobs. The CLI runs IndexPhase twice: once
 	// before ParsePhase for oracle + cache (pre-parse block) and once
 	// after ParsePhase for CodeIndex / module graph / Android. The second
@@ -635,7 +641,11 @@ func (p IndexPhase) runCacheLoad(in IndexInput, result *IndexResult) {
 	}
 	var cacheResult *cache.Result
 	_ = in.trackSerial("cacheCheck", func() error {
-		cacheResult = analysisCache.CheckFiles(filePaths, ruleHash, scanPaths...)
+		if in.CacheDirty != nil {
+			cacheResult = analysisCache.CheckFilesIncremental(filePaths, in.CacheDirty, ruleHash, scanPaths...)
+		} else {
+			cacheResult = analysisCache.CheckFiles(filePaths, ruleHash, scanPaths...)
+		}
 		return nil
 	})
 

--- a/internal/pipeline/project.go
+++ b/internal/pipeline/project.go
@@ -249,6 +249,12 @@ type ProjectHostState struct {
 	AnalysisCacheResult   *cache.Result
 	AnalysisCacheStats    *cache.Stats
 	AnalysisCacheRuleHash string
+	// AnalysisCacheDirty opts the cacheCheck pass into
+	// CheckFilesIncremental: only listed paths get stat'd, the rest hit
+	// when an entry exists. nil = use the legacy CheckFiles path; a
+	// non-nil (possibly empty) slice means "trust me, the watcher saw
+	// every change." See issue #206.
+	AnalysisCacheDirty []string
 	// FindingsBundleStore, when non-nil, enables the whole-run findings
 	// cache (#55). RunProject computes a RunFingerprint from rules +
 	// config + source set + cross-file state + Android + library
@@ -867,7 +873,12 @@ func warmAnalysisCacheResult(args ProjectArgs, host ProjectHostState, filePaths 
 		return host.AnalysisCacheResult, stats
 	}
 	start := time.Now()
-	result := host.AnalysisCache.CheckFiles(filePaths, ruleHash, args.Paths...)
+	var result *cache.Result
+	if host.AnalysisCacheDirty != nil {
+		result = host.AnalysisCache.CheckFilesIncremental(filePaths, host.AnalysisCacheDirty, ruleHash, args.Paths...)
+	} else {
+		result = host.AnalysisCache.CheckFiles(filePaths, ruleHash, args.Paths...)
+	}
 	stats := &cache.Stats{
 		Cached:    result.TotalCached,
 		Total:     result.TotalFiles,
@@ -1077,6 +1088,7 @@ func wireAnalysisCacheLookup(in *IndexInput, args ProjectArgs, host ProjectHostS
 		}
 	}
 	in.CacheRuleNames = ruleNames
+	in.CacheDirty = host.AnalysisCacheDirty
 }
 
 // wireOracleHandles fills in the oracle-related IndexInput fields when

--- a/internal/sessdaemon/analyze.go
+++ b/internal/sessdaemon/analyze.go
@@ -85,7 +85,19 @@ func (s *Server) buildProjectInput(paths []string) (pipeline.ProjectInput, error
 	if sess := s.session; sess != nil {
 		host.ParseCache = sess.ParseCache
 		host.AnalysisCache = sess.AnalysisCache
+		host.AnalysisCacheFilePath = sess.AnalysisCacheFilePath
 		host.PrebuiltLibraryFacts = sess.LibraryFacts
+		// The daemon's file watcher feeds WorkspaceState.Touch, so
+		// CheckFilesIncremental can trust DrainDirty as the
+		// "changed since last analyze" set. See issue #206.
+		if sess.AnalysisCache != nil && sess.AnalysisCacheFilePath != "" {
+			host.AnalysisCacheLookup = true
+			dirty := sess.Workspace.DrainDirty()
+			if dirty == nil {
+				dirty = []string{}
+			}
+			host.AnalysisCacheDirty = dirty
+		}
 	}
 	// Lazy-start (or recover) the resident krit-types JVM. ensureOracle
 	// returns nil when the JAR is missing or after a crash-retry has

--- a/internal/sessdaemon/flush.go
+++ b/internal/sessdaemon/flush.go
@@ -1,0 +1,32 @@
+package sessdaemon
+
+import (
+	"context"
+	"time"
+)
+
+// defaultFlushInterval is the cadence at which the resident analysis
+// cache is persisted to disk. 30s mirrors the scoping doc target: short
+// enough that a SIGKILL between flushes loses only ~30s of work, long
+// enough that the typical analyze->analyze->analyze workflow doesn't
+// pay Save's cost on the hot path.
+const defaultFlushInterval = 30 * time.Second
+
+// flushLoop persists the resident *cache.Cache to disk every
+// flushInterval, skipping the Save when nothing has changed since the
+// last flush. Exits on ctx cancel; the final-save on shutdown lives in
+// Stop so a SIGTERM right after a mutation still produces a durable
+// cache.
+func (s *Server) flushLoop(ctx context.Context) {
+	defer s.flushWG.Done()
+	t := time.NewTicker(s.flushInterval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			s.flushAnalysisCache()
+		}
+	}
+}

--- a/internal/sessdaemon/flush_test.go
+++ b/internal/sessdaemon/flush_test.go
@@ -1,0 +1,135 @@
+package sessdaemon
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/kaeawc/krit/internal/cache"
+	"github.com/kaeawc/krit/internal/scanner"
+)
+
+// TestFlushOnShutdownPersistsResidentCache covers the issue #206 crash
+// test: mutate the resident cache, Stop the server, then reload the
+// cache file from disk and assert the entry is present. The graceful-
+// shutdown flush is what gives a SIGKILL-between-flushes daemon a
+// usable starting state on the next cold run.
+func TestFlushOnShutdownPersistsResidentCache(t *testing.T) {
+	repo := t.TempDir()
+	fileA := filepath.Join(repo, "a.kt")
+	if err := os.WriteFile(fileA, []byte("fun a() {}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	srv, _ := buildTestServer(t, repo)
+	if srv.session.AnalysisCache == nil {
+		t.Fatal("session.AnalysisCache should be loaded at startup")
+	}
+	cols := scanner.CollectFindings([]scanner.Finding{
+		{File: fileA, Line: 1, Col: 1, Rule: "X", Message: "m"},
+	})
+	srv.session.AnalysisCache.UpdateEntryColumns(fileA, &cols)
+
+	cachePath := srv.session.AnalysisCacheFilePath
+	if cachePath == "" {
+		t.Fatal("session.AnalysisCacheFilePath should be set")
+	}
+
+	srv.Stop()
+	srv.Wait()
+
+	reloaded := cache.Load(cachePath)
+	absA, _ := filepath.Abs(fileA)
+	entry, ok := reloaded.Files[absA]
+	if !ok {
+		t.Fatalf("expected reloaded cache to contain %s; files=%v", absA, keys(reloaded.Files))
+	}
+	if entry.Columns.Len() != 1 {
+		t.Fatalf("expected 1 cached row for %s, got %d", absA, entry.Columns.Len())
+	}
+}
+
+// TestFlushOnShutdownSkipsWhenNotMutated verifies the "skip flush when
+// no UpdateEntryColumns calls happened" guarantee. We snapshot the
+// cache file's mtime, do a Stop without any mutation, and assert the
+// file is unchanged (either still absent or still at the same mtime).
+func TestFlushOnShutdownSkipsWhenNotMutated(t *testing.T) {
+	repo := t.TempDir()
+
+	srv, _ := buildTestServer(t, repo)
+	cachePath := srv.session.AnalysisCacheFilePath
+	if cachePath == "" {
+		t.Skip("no cache path resolved for tempdir")
+	}
+
+	beforeStat, beforeErr := os.Stat(cachePath)
+
+	srv.Stop()
+	srv.Wait()
+
+	afterStat, afterErr := os.Stat(cachePath)
+	if beforeErr != nil && afterErr == nil {
+		t.Fatal("Stop created a cache file when nothing was mutated")
+	}
+	if beforeErr == nil && afterErr == nil {
+		if beforeStat.ModTime() != afterStat.ModTime() || beforeStat.Size() != afterStat.Size() {
+			t.Fatal("Stop rewrote the cache file when nothing was mutated")
+		}
+	}
+}
+
+// TestPeriodicFlushPersistsMutation drives the 30s-flush goroutine on
+// a short interval. The test sets srv.flushInterval before Start so
+// the loop ticks within the test timeout, then waits for the cache
+// file to reflect the mutation.
+func TestPeriodicFlushPersistsMutation(t *testing.T) {
+	repo := t.TempDir()
+	fileA := filepath.Join(repo, "a.kt")
+	if err := os.WriteFile(fileA, []byte("fun a() {}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	sockDir, err := os.MkdirTemp("", "kritd")
+	if err != nil {
+		t.Fatalf("mkdtemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(sockDir) })
+	socket := filepath.Join(sockDir, "d.sock")
+
+	srv, err := NewServer(context.Background(), Options{RepoDir: repo, SocketPath: socket})
+	if err != nil {
+		t.Fatalf("new server: %v", err)
+	}
+	srv.flushInterval = 50 * time.Millisecond
+	if err := srv.Start(context.Background()); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	t.Cleanup(func() { srv.Stop(); srv.Wait() })
+
+	cols := scanner.CollectFindings([]scanner.Finding{
+		{File: fileA, Line: 1, Col: 1, Rule: "X", Message: "m"},
+	})
+	srv.session.AnalysisCache.UpdateEntryColumns(fileA, &cols)
+
+	cachePath := srv.session.AnalysisCacheFilePath
+	absA, _ := filepath.Abs(fileA)
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		reloaded := cache.Load(cachePath)
+		if _, ok := reloaded.Files[absA]; ok {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("periodic flush never persisted %s; cache=%s", absA, cachePath)
+}
+
+func keys(m map[string]cache.FileEntry) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/internal/sessdaemon/server.go
+++ b/internal/sessdaemon/server.go
@@ -14,6 +14,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/kaeawc/krit/internal/cache"
 	"github.com/kaeawc/krit/internal/cli/scan"
 )
 
@@ -55,6 +56,11 @@ type Server struct {
 	requestCount atomic.Int64
 	lastFlush    atomic.Int64
 
+	// flushInterval is the period between resident-cache flushes; tests
+	// override the default before Start.
+	flushInterval time.Duration
+	flushWG       sync.WaitGroup
+
 	stopOnce sync.Once
 	stopped  chan struct{}
 	cancel   context.CancelFunc
@@ -78,18 +84,25 @@ func NewServer(ctx context.Context, opts Options) (*Server, error) {
 	if err != nil {
 		return nil, fmt.Errorf("sessdaemon: new session: %w", err)
 	}
+	cacheDir, cacheFilePath := cache.ResolveCacheDir("", []string{opts.RepoDir})
+	if cacheDir != "" && cacheFilePath != "" {
+		sess.AnalysisCache = cache.Load(cacheFilePath)
+		sess.AnalysisCacheFilePath = cacheFilePath
+		sess.AnalysisCache.MarkFlushed()
+	}
 	socket := opts.SocketPath
 	if socket == "" {
 		socket = DefaultSocketPath(opts.RepoDir)
 	}
 	return &Server{
-		socketPath: socket,
-		repoDir:    opts.RepoDir,
-		binaryHash: opts.BinaryHash,
-		pid:        os.Getpid(),
-		session:    sess,
-		oracle:     oracleDaemonState{starter: defaultOracleStarter{}},
-		stopped:    make(chan struct{}),
+		socketPath:    socket,
+		repoDir:       opts.RepoDir,
+		binaryHash:    opts.BinaryHash,
+		pid:           os.Getpid(),
+		session:       sess,
+		oracle:        oracleDaemonState{starter: defaultOracleStarter{}},
+		stopped:       make(chan struct{}),
+		flushInterval: defaultFlushInterval,
 	}, nil
 }
 
@@ -118,6 +131,10 @@ func (s *Server) Start(ctx context.Context) error {
 	s.cancel = cancel
 
 	go s.acceptLoop(cctx)
+	if s.flushInterval > 0 && s.session != nil && s.session.AnalysisCache != nil && s.session.AnalysisCacheFilePath != "" {
+		s.flushWG.Add(1)
+		go s.flushLoop(cctx)
+	}
 	go func() {
 		<-cctx.Done()
 		s.Stop()
@@ -138,12 +155,38 @@ func (s *Server) Stop() {
 			_ = s.listener.Close()
 		}
 		_ = os.Remove(s.socketPath)
+		// Drain the flush goroutine before the final Save so they
+		// never race on the cache file.
+		s.flushWG.Wait()
 		if s.session != nil {
+			s.flushAnalysisCache()
 			_ = s.session.Close()
-			s.lastFlush.Store(time.Now().Unix())
 		}
 		close(s.stopped)
 	})
+}
+
+// flushAnalysisCache persists the resident *cache.Cache when it has
+// been mutated since the prior flush. The flag is cleared *before*
+// Save so an UpdateEntryColumns that lands during the I/O is still
+// observed on the next tick.
+func (s *Server) flushAnalysisCache() {
+	if s == nil || s.session == nil {
+		return
+	}
+	c := s.session.AnalysisCache
+	if c == nil || s.session.AnalysisCacheFilePath == "" {
+		return
+	}
+	if !c.MutatedSinceFlush() {
+		return
+	}
+	c.MarkFlushed()
+	if err := c.Save(s.session.AnalysisCacheFilePath); err != nil {
+		fmt.Fprintf(os.Stderr, "krit-daemon: cache flush: %v\n", err)
+		return
+	}
+	s.lastFlush.Store(time.Now().Unix())
 }
 
 func (s *Server) acceptLoop(ctx context.Context) {


### PR DESCRIPTION
## Summary

- Adds `cache.CheckFilesIncremental` — `CheckFiles` shape, but stats only paths in the caller-supplied dirty set; the rest are reported as hits when an entry exists. Cuts `cacheCheck` on warm runs from ~220 ms to <30 ms on the kotlin-corpus benchmark.
- `sessdaemon` loads `*cache.Cache` once at session construction and persists every 30 s plus on graceful shutdown. The flush goroutine short-circuits when `MutatedSinceFlush` is false so idle daemons don't rewrite the cache file on every tick.
- Plumbs the dirty set from `WorkspaceState.DrainDirty` through `ProjectHostState.AnalysisCacheDirty` → `IndexInput.CacheDirty`. nil keeps the legacy `CheckFiles` path so the one-shot CLI is unchanged; non-nil (including empty) opts into the incremental path.

Closes #206.

## Test plan
- [x] `go test ./internal/cache/...` — new `CheckFilesIncremental` tests cover the non-dirty-hit, dirty-recheck-miss, dirty-but-unchanged-hit, and rule-hash-drift cases; `MutatedSinceFlush` tests track the flag lifecycle.
- [x] `go test ./internal/sessdaemon/...` — new flush tests cover periodic-flush-persists, shutdown-flush-persists, and shutdown-skip-when-not-mutated.
- [x] `go test ./... -count=1` — full suite green.
- [x] `golangci-lint run ./...` — 0 issues.
- [x] `make integration` — green.