### PR TITLE
feat(daemon): wire strict-verify divergence harness into analyze (#202)

### DIFF
--- a/cmd/krit-daemon/main.go
+++ b/cmd/krit-daemon/main.go
@@ -26,6 +26,8 @@ func main() {
 	socketFlag := flag.String("socket", "", "socket path (defaults to <repo>/.krit/daemon.sock)")
 	verboseFlag := flag.Bool("verbose", false, "log lifecycle events to stderr")
 	flag.BoolVar(verboseFlag, "v", false, "alias for --verbose")
+	strictVerifyFlag := flag.Bool("strict-verify", true,
+		"run an in-process baseline alongside every analyze and fail on divergence (issue #202; on by default during alpha)")
 	flag.Parse()
 
 	if *versionFlag {
@@ -65,8 +67,9 @@ func main() {
 	defer cancel()
 
 	srv, err := sessdaemon.NewServer(ctx, sessdaemon.Options{
-		RepoDir:    repo,
-		SocketPath: *socketFlag,
+		RepoDir:      repo,
+		SocketPath:   *socketFlag,
+		StrictVerify: *strictVerifyFlag,
 	})
 	if err != nil {
 		log.Fatalf("krit-daemon: %v", err)

--- a/internal/daemon/divergence.go
+++ b/internal/daemon/divergence.go
@@ -6,6 +6,9 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
+	"strings"
+	"time"
 
 	"github.com/kaeawc/krit/internal/scanner"
 )
@@ -14,6 +17,63 @@ const (
 	sideDaemon   = "daemon"
 	sideBaseline = "baseline"
 )
+
+// DivergenceLogDir is the per-repo directory under which strict-verify
+// writes divergence logs. NextDivergenceLogPath produces sequenced file
+// names within this directory.
+const DivergenceLogDir = ".krit"
+
+// NextDivergenceLogPath returns the next available
+// `${repoDir}/.krit/daemon-divergence-NNNN.log` path. NNNN is a
+// zero-padded four-digit sequence; on overflow (NNNN > 9999) the
+// timestamp form `daemon-divergence-<unixNanos>.log` is used so we
+// never collide silently. The directory is created on demand.
+func NextDivergenceLogPath(repoDir string) (string, error) {
+	dir := filepath.Join(repoDir, DivergenceLogDir)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", fmt.Errorf("divergence: prepare log dir: %w", err)
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return "", fmt.Errorf("divergence: read log dir: %w", err)
+	}
+	maxSeq := -1
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		n, ok := parseDivergenceSeq(e.Name())
+		if !ok {
+			continue
+		}
+		if n > maxSeq {
+			maxSeq = n
+		}
+	}
+	next := maxSeq + 1
+	if next > 9999 {
+		return filepath.Join(dir, fmt.Sprintf("daemon-divergence-%d.log", time.Now().UnixNano())), nil
+	}
+	return filepath.Join(dir, fmt.Sprintf("daemon-divergence-%04d.log", next)), nil
+}
+
+func parseDivergenceSeq(name string) (int, bool) {
+	const prefix = "daemon-divergence-"
+	const suffix = ".log"
+	mid, ok := strings.CutPrefix(name, prefix)
+	if !ok {
+		return 0, false
+	}
+	mid, ok = strings.CutSuffix(mid, suffix)
+	if !ok || len(mid) != 4 {
+		return 0, false
+	}
+	n, err := strconv.Atoi(mid)
+	if err != nil || n < 0 {
+		return 0, false
+	}
+	return n, true
+}
 
 // Diff describes how a daemon analyze result differs from a freshly-computed
 // in-process baseline. AddedByDaemon are rows the daemon emitted that the

--- a/internal/daemon/divergence_test.go
+++ b/internal/daemon/divergence_test.go
@@ -185,6 +185,44 @@ func TestDiffWriteLogCleanProducesEmptyFile(t *testing.T) {
 	}
 }
 
+func TestNextDivergenceLogPathSequencesNumbers(t *testing.T) {
+	repo := t.TempDir()
+
+	first, err := NextDivergenceLogPath(repo)
+	if err != nil {
+		t.Fatalf("first NextDivergenceLogPath: %v", err)
+	}
+	wantFirst := filepath.Join(repo, ".krit", "daemon-divergence-0000.log")
+	if first != wantFirst {
+		t.Fatalf("first path = %s, want %s", first, wantFirst)
+	}
+	// Materialize the file so the next call sees it.
+	if err := os.WriteFile(first, nil, 0o644); err != nil {
+		t.Fatalf("touch: %v", err)
+	}
+
+	second, err := NextDivergenceLogPath(repo)
+	if err != nil {
+		t.Fatalf("second NextDivergenceLogPath: %v", err)
+	}
+	wantSecond := filepath.Join(repo, ".krit", "daemon-divergence-0001.log")
+	if second != wantSecond {
+		t.Fatalf("second path = %s, want %s", second, wantSecond)
+	}
+
+	// Unrelated files in the same dir must be ignored.
+	if err := os.WriteFile(filepath.Join(repo, ".krit", "stray.log"), nil, 0o644); err != nil {
+		t.Fatalf("stray: %v", err)
+	}
+	third, err := NextDivergenceLogPath(repo)
+	if err != nil {
+		t.Fatalf("third NextDivergenceLogPath: %v", err)
+	}
+	if third != filepath.Join(repo, ".krit", "daemon-divergence-0001.log") {
+		t.Fatalf("third path = %s; stray file should not bump the sequence", third)
+	}
+}
+
 func TestCompareDeterministicOrdering(t *testing.T) {
 	rows := []scanner.Finding{
 		{File: "z.kt", Line: 1, RuleSet: "perf", Rule: "Foo", Severity: "warning", Message: "z"},

--- a/internal/sessdaemon/analyze.go
+++ b/internal/sessdaemon/analyze.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/kaeawc/krit/internal/cacheutil"
 	"github.com/kaeawc/krit/internal/config"
+	"github.com/kaeawc/krit/internal/daemon"
 	"github.com/kaeawc/krit/internal/pipeline"
 	"github.com/kaeawc/krit/internal/rules"
 	"github.com/kaeawc/krit/internal/scanner"
@@ -53,6 +54,17 @@ func (s *Server) handleAnalyze(ctx context.Context, w *bufio.Writer, req Request
 	if err != nil {
 		_ = writeError(w, req.ID, ErrCodeInternal, "run: "+err.Error())
 		return
+	}
+
+	if s.strictVerify {
+		if logPath, divErr := s.runStrictVerify(ctx, params.Paths, &res.CrossFileResult.Findings); divErr != nil {
+			msg := "strict-verify: " + divErr.Error()
+			if logPath != "" {
+				msg += " (log: " + logPath + ")"
+			}
+			_ = writeError(w, req.ID, ErrCodeInternal, msg)
+			return
+		}
 	}
 
 	enc := json.NewEncoder(w)
@@ -130,6 +142,53 @@ func (s *Server) buildProjectInput(paths []string) (pipeline.ProjectInput, error
 		},
 		Host: host,
 	}, nil
+}
+
+// runStrictVerify runs a fresh in-process baseline against the same
+// paths the daemon just analyzed and compares the two finding sets via
+// daemon.Compare. On divergence it persists a structured log under
+// `${repoDir}/.krit/daemon-divergence-NNNN.log` and returns a non-nil
+// error so the caller fails the analyze response. The baseline runs
+// with an empty ProjectHostState so no resident cache contaminates the
+// comparison.
+func (s *Server) runStrictVerify(ctx context.Context, paths []string, daemonCols *scanner.FindingColumns) (string, error) {
+	cfg := config.NewConfig()
+	rules.ApplyConfig(cfg)
+	activeRules := rules.ActiveRulesV2(nil, nil, false, false, false)
+
+	pc, err := scanner.NewParseCacheWithCap(s.repoDir, cacheutil.DefaultParseCacheCapBytes)
+	if err != nil {
+		return "", fmt.Errorf("baseline parse cache: %w", err)
+	}
+	defer pc.Close() //nolint:errcheck // best effort
+
+	baseline, err := pipeline.RunProjectAnalysis(ctx, pipeline.ProjectInput{
+		Args: pipeline.ProjectArgs{
+			Config:      cfg,
+			Paths:       paths,
+			ActiveRules: activeRules,
+			Format:      "json",
+			Version:     "daemon",
+		},
+		Host: pipeline.ProjectHostState{ParseCache: pc},
+	})
+	if err != nil {
+		return "", fmt.Errorf("baseline analyze: %w", err)
+	}
+
+	diff := daemon.Compare(daemonCols, &baseline.CrossFileResult.Findings)
+	if diff.IsClean() {
+		return "", nil
+	}
+	logPath, pathErr := daemon.NextDivergenceLogPath(s.repoDir)
+	if pathErr != nil {
+		return "", fmt.Errorf("divergence detected; failed to allocate log path: %w", pathErr)
+	}
+	if writeErr := diff.WriteLog(logPath); writeErr != nil {
+		return logPath, fmt.Errorf("divergence detected; failed to write log: %w", writeErr)
+	}
+	return logPath, fmt.Errorf("divergence: %d added, %d dropped across %d files",
+		len(diff.AddedByDaemon), len(diff.DroppedByDaemon), len(diff.PathsTouched))
 }
 
 func emitFindings(enc *json.Encoder, cols *scanner.FindingColumns) error {

--- a/internal/sessdaemon/server.go
+++ b/internal/sessdaemon/server.go
@@ -35,10 +35,11 @@ const writeBufSize = 64 * 1024
 // scan.Session that the analyze verb drives, and serializes all
 // verb dispatch behind a single mutex on the session.
 type Server struct {
-	socketPath string
-	repoDir    string
-	binaryHash string
-	pid        int
+	socketPath   string
+	repoDir      string
+	binaryHash   string
+	pid          int
+	strictVerify bool
 
 	session *scan.Session
 
@@ -72,6 +73,14 @@ type Options struct {
 	RepoDir    string
 	SocketPath string // overrides DefaultSocketPath
 	BinaryHash string // optional; surfaced in health
+	// StrictVerify, when true, makes every analyze request also run a
+	// fresh in-process baseline (a cold scan.Session against the same
+	// paths) and compare the two sets of findings via daemon.Compare.
+	// Any divergence is fatal to the response and is written to
+	// `${repoDir}/.krit/daemon-divergence-NNNN.log`. This is the
+	// correctness oracle issue #202 added; on by default during alpha,
+	// opt-in post-stabilization.
+	StrictVerify bool
 }
 
 // NewServer constructs a Server with a fresh scan.Session for opts.RepoDir.
@@ -99,6 +108,7 @@ func NewServer(ctx context.Context, opts Options) (*Server, error) {
 		repoDir:       opts.RepoDir,
 		binaryHash:    opts.BinaryHash,
 		pid:           os.Getpid(),
+		strictVerify:  opts.StrictVerify,
 		session:       sess,
 		oracle:        oracleDaemonState{starter: defaultOracleStarter{}},
 		stopped:       make(chan struct{}),

--- a/internal/sessdaemon/server_test.go
+++ b/internal/sessdaemon/server_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"testing"
 	"time"
 
@@ -144,6 +145,35 @@ func TestUnknownMethod(t *testing.T) {
 	}
 }
 
+// TestAnalyzeStrictVerifyCleanRunMatchesBaseline is the issue-#202
+// happy path: with StrictVerify on, analyzing a small repo where the
+// daemon's resident-state run matches a fresh baseline must succeed
+// (no error response) and must NOT produce a divergence log.
+func TestAnalyzeStrictVerifyCleanRunMatchesBaseline(t *testing.T) {
+	repo := t.TempDir()
+	writeFile(t, repo, "Foo.kt",
+		"package demo\n\nclass Foo {\n    fun greet(): String { return \"hi\" }\n}\n")
+	writeFile(t, repo, "Bar.kt",
+		"package demo\n\nfun bar(unused: Int): Int { return 42 }\n")
+
+	socket := startTestServerWithOptions(t, Options{RepoDir: repo, StrictVerify: true})
+
+	res, err := Analyze(socket, AnalyzeParams{Paths: []string{repo}})
+	if err != nil {
+		t.Fatalf("strict-verify analyze: %v", err)
+	}
+	if res.Summary.FindingsCount != len(res.Findings) {
+		t.Errorf("FindingsCount=%d but streamed=%d", res.Summary.FindingsCount, len(res.Findings))
+	}
+	logDir := filepath.Join(repo, ".krit")
+	entries, _ := os.ReadDir(logDir)
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), "daemon-divergence-") {
+			t.Fatalf("clean strict-verify produced divergence log %s", e.Name())
+		}
+	}
+}
+
 // --- helpers ------------------------------------------------------------
 
 func buildTestServer(t *testing.T, repo string) (*Server, string) {
@@ -175,6 +205,30 @@ func startTestServer(t *testing.T, repo string) string {
 	t.Helper()
 	_, socket := buildTestServer(t, repo)
 	return socket
+}
+
+func startTestServerWithOptions(t *testing.T, opts Options) string {
+	t.Helper()
+	if opts.SocketPath == "" {
+		sockDir, err := os.MkdirTemp("", "kritd")
+		if err != nil {
+			t.Fatalf("mkdtemp: %v", err)
+		}
+		t.Cleanup(func() { _ = os.RemoveAll(sockDir) })
+		opts.SocketPath = filepath.Join(sockDir, "d.sock")
+	}
+	srv, err := NewServer(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("new server: %v", err)
+	}
+	if err := srv.Start(context.Background()); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	t.Cleanup(func() {
+		srv.Stop()
+		srv.Wait()
+	})
+	return opts.SocketPath
 }
 
 func writeFile(t *testing.T, dir, name, body string) {


### PR DESCRIPTION
## Summary

Closes #202. The `internal/daemon` Compare/Diff oracle already existed; this PR wires it into the production daemon analyze path so a divergence between the resident-cache run and a fresh in-process baseline becomes a fatal response with a structured log.

- Adds `daemon.NextDivergenceLogPath` — sequenced `${repoDir}/.krit/daemon-divergence-NNNN.log` (zero-padded; falls back to a timestamp filename past 9999).
- Adds `sessdaemon.Options.StrictVerify` and `Server.runStrictVerify`. When on, every analyze request also runs `pipeline.RunProjectAnalysis` against an empty `ProjectHostState` (cold parse cache, no shared state) and `Compare`s the results.
- On divergence, the analyze response is replaced with a JSON-RPC error referencing the log path; the log is one JSON object per row, daemon-added rows first then baseline-dropped, already grep-friendly per the issue.
- Adds `--strict-verify` flag to `krit-daemon` (default on during alpha; flip via flag once stable).

## Validation

- `go build -o krit ./cmd/krit/`
- `go vet ./...`
- `golangci-lint run ./...` — 0 issues
- `go test ./internal/daemon/ ./internal/sessdaemon/ -count=1` — all pass
- `go test ./... -count=1` — all pass

New tests:
- `TestNextDivergenceLogPathSequencesNumbers` — covers the NNNN sequence and that stray files in `.krit/` are ignored.
- `TestAnalyzeStrictVerifyCleanRunMatchesBaseline` — end-to-end: a small Kotlin repo where daemon and baseline match must succeed and must NOT produce a divergence log.

The existing `TestCompareWithInjectedWorkspaceMutation` already satisfies the issue's mutation-injection unit test for `Compare`.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...`
- [x] `go test ./... -count=1`