### PR TITLE
feat(daemon): fsnotify watcher with invalidation routing + mtime sweep (#203)

### DIFF
--- a/internal/daemon/watcher.go
+++ b/internal/daemon/watcher.go
@@ -1,0 +1,500 @@
+package daemon
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+
+	"github.com/kaeawc/krit/internal/config"
+	"github.com/kaeawc/krit/internal/fileignore"
+	"github.com/kaeawc/krit/internal/pipeline"
+)
+
+// Logger is the minimal logging surface the watcher needs. *diag.Reporter
+// satisfies it via Warnf; tests can substitute a counting fake. A nil
+// Logger silences output.
+type Logger interface {
+	Warnf(format string, args ...any)
+}
+
+// watcherState is the subset of pipeline.WorkspaceState the watcher
+// drives. The interface keeps tests fast (no real workspace) and lets
+// the daemon plug in a thin facade if it wraps WorkspaceState in
+// additional bookkeeping later.
+type watcherState interface {
+	Invalidate(path string)
+	InvalidateAll()
+	InvalidateCodeIndex()
+	InvalidateDependents()
+	InvalidateLibraryFacts()
+	InvalidateResolver()
+	InvalidateOracleFilter()
+	Touch(path string)
+}
+
+// WatcherEvent is a notification emitted on Watcher.Events for changes
+// the daemon must react to beyond cache invalidation: a config reload
+// or a self-binary swap requiring a restart.
+type WatcherEvent int
+
+const (
+	// EventConfigReload signals that krit.yml / .krit.yml changed. The
+	// daemon should drop its cached *config.Config and re-read on the
+	// next analyze.
+	EventConfigReload WatcherEvent = iota + 1
+	// EventShutdownRequest signals that the krit binary the daemon
+	// loaded has been overwritten on disk. The CLI restarts the
+	// daemon after observing the shutdown.
+	EventShutdownRequest
+)
+
+const (
+	defaultDebounceWindow = 50 * time.Millisecond
+	defaultSweepInterval  = 30 * time.Second
+)
+
+// Watcher pushes filesystem-change events into a WorkspaceState's
+// invalidation API and surfaces config / self-binary events on the
+// Events channel. It watches the repo recursively (one fsnotify watch
+// per directory, populated asynchronously after Start returns).
+//
+// The watcher is best-effort: a missed fsnotify event causes at worst
+// a stale parse, which the periodic mtime sweep catches within
+// SweepInterval.
+type Watcher struct {
+	ws      watcherState
+	repoDir string
+	log     Logger
+
+	binaryPath string
+
+	w *fsnotify.Watcher
+
+	debounceWindow time.Duration
+	sweepInterval  time.Duration
+
+	// onAndroidProjectChange fires when build.gradle / settings.gradle /
+	// version-catalog edits land. The daemon clears
+	// Session.AndroidProject in response. Nil is fine (no callback).
+	onAndroidProjectChange func()
+	// onResourceIndexChange fires when AndroidManifest.xml or res/**/*.xml
+	// edits land. The daemon clears its android.ResourceIndexCache.
+	onResourceIndexChange func()
+
+	// Events is the non-buffered notification channel. ConfigReload
+	// and ShutdownRequest are delivered here; consumers select on it
+	// with the daemon's main loop. A nil channel is fine (no consumer)
+	// — sends are non-blocking.
+	Events chan WatcherEvent
+
+	debounceMu sync.Mutex
+	debounce   map[string]*time.Timer
+
+	// tracked is the union of paths the watcher believes are clean —
+	// successfully parsed by the daemon and not yet observed dirty.
+	// The mtime sweep re-stats each entry every sweepInterval; any
+	// path whose mtime advanced past its tracked value is treated as
+	// a missed fsnotify event.
+	trackedMu sync.Mutex
+	tracked   map[string]int64
+
+	// counters for tests / observability.
+	codeIndexInvalidations atomic.Int64
+	sweepCatches           atomic.Int64
+
+	stopOnce sync.Once
+	started  atomic.Bool
+	stopped  chan struct{}
+	stopErr  error
+}
+
+// WatcherOption tunes a Watcher.
+type WatcherOption func(*Watcher)
+
+// WithDebounceWindow overrides the coalescing window. Default 50 ms.
+func WithDebounceWindow(d time.Duration) WatcherOption {
+	return func(w *Watcher) { w.debounceWindow = d }
+}
+
+// WithSweepInterval overrides the mtime sweep interval. Default 30 s.
+// Set to zero to disable the sweep (tests only — production must keep
+// it on as the missed-event safety net).
+func WithSweepInterval(d time.Duration) WatcherOption {
+	return func(w *Watcher) { w.sweepInterval = d }
+}
+
+// WithBinaryPath sets the krit binary path to watch. A write/rename/
+// remove on this path emits EventShutdownRequest. Empty disables the
+// self-binary watch.
+func WithBinaryPath(p string) WatcherOption {
+	return func(w *Watcher) { w.binaryPath = p }
+}
+
+// WithAndroidProjectCallback wires the build.gradle / version-catalog
+// edit hook so the daemon can clear Session.AndroidProject.
+func WithAndroidProjectCallback(fn func()) WatcherOption {
+	return func(w *Watcher) { w.onAndroidProjectChange = fn }
+}
+
+// WithResourceIndexCallback wires the AndroidManifest / res/**/*.xml
+// edit hook so the daemon can clear its android.ResourceIndexCache.
+func WithResourceIndexCallback(fn func()) WatcherOption {
+	return func(w *Watcher) { w.onResourceIndexChange = fn }
+}
+
+// NewWatcher constructs a Watcher bound to ws and repoDir. The
+// underlying fsnotify handle is created here; call Start to begin the
+// event loop and recursive directory walk. log may be nil.
+func NewWatcher(ws *pipeline.WorkspaceState, repoDir string, log Logger, opts ...WatcherOption) (*Watcher, error) {
+	return newWatcherWithState(ws, repoDir, log, opts...)
+}
+
+func newWatcherWithState(state watcherState, repoDir string, log Logger, opts ...WatcherOption) (*Watcher, error) {
+	if repoDir == "" {
+		return nil, errors.New("watcher: empty repoDir")
+	}
+	fw, err := fsnotify.NewWatcher()
+	if err != nil {
+		return nil, err
+	}
+	w := &Watcher{
+		ws:             state,
+		repoDir:        repoDir,
+		log:            log,
+		w:              fw,
+		debounceWindow: defaultDebounceWindow,
+		sweepInterval:  defaultSweepInterval,
+		Events:         make(chan WatcherEvent, 8),
+		debounce:       make(map[string]*time.Timer),
+		tracked:        make(map[string]int64),
+		stopped:        make(chan struct{}),
+	}
+	for _, opt := range opts {
+		opt(w)
+	}
+	return w, nil
+}
+
+// Start begins the event loop. Returns after the root directory is
+// registered; the rest of the tree is added asynchronously so startup
+// latency stays bounded. Stops when ctx is cancelled or Stop is
+// called.
+func (w *Watcher) Start(ctx context.Context) error {
+	if err := w.w.Add(w.repoDir); err != nil {
+		_ = w.w.Close()
+		return err
+	}
+	if w.binaryPath != "" {
+		if err := w.w.Add(filepath.Dir(w.binaryPath)); err != nil {
+			w.warn("watch binary dir %s: %v", filepath.Dir(w.binaryPath), err)
+		}
+	}
+	w.started.Store(true)
+	go w.populate()
+	go w.run(ctx)
+	if w.sweepInterval > 0 {
+		go w.sweepLoop(ctx)
+	}
+	return nil
+}
+
+// Stop closes the underlying fsnotify watcher and waits for the event
+// loop to exit. Safe to call multiple times and safe on a Watcher that
+// was never Started.
+func (w *Watcher) Stop() error {
+	w.stopOnce.Do(func() {
+		w.stopErr = w.w.Close()
+		// Cancel any debounce timers so they don't fire on a torn-down
+		// state after Stop returns.
+		w.debounceMu.Lock()
+		for k, t := range w.debounce {
+			t.Stop()
+			delete(w.debounce, k)
+		}
+		w.debounceMu.Unlock()
+		if w.started.Load() {
+			<-w.stopped
+		} else {
+			close(w.stopped)
+		}
+	})
+	return w.stopErr
+}
+
+// CodeIndexInvalidations returns the number of times the watcher has
+// called InvalidateCodeIndex. Used by the stress test to verify
+// debounce coalescing.
+func (w *Watcher) CodeIndexInvalidations() int64 { return w.codeIndexInvalidations.Load() }
+
+// SweepCatches returns the number of missed-fsnotify events the mtime
+// sweep has recovered.
+func (w *Watcher) SweepCatches() int64 { return w.sweepCatches.Load() }
+
+// Track records that the daemon believes path is clean — its mtime
+// will be snapshot for the sweep loop to compare against. Called by
+// the daemon whenever a file is parsed/analysed; the next sweep
+// surfaces a stale entry if fsnotify missed an event.
+func (w *Watcher) Track(path string) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return
+	}
+	key := filepath.Clean(path)
+	w.trackedMu.Lock()
+	w.tracked[key] = info.ModTime().UnixNano()
+	w.trackedMu.Unlock()
+}
+
+// Untrack drops path from the tracked set. Called when the file
+// disappears or the daemon stops caring about it.
+func (w *Watcher) Untrack(path string) {
+	key := filepath.Clean(path)
+	w.trackedMu.Lock()
+	delete(w.tracked, key)
+	w.trackedMu.Unlock()
+}
+
+func (w *Watcher) populate() {
+	if err := w.addRecursiveSkip(w.repoDir, true); err != nil {
+		w.warn("watch populate: %v", err)
+	}
+}
+
+func (w *Watcher) run(ctx context.Context) {
+	defer close(w.stopped)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case ev, ok := <-w.w.Events:
+			if !ok {
+				return
+			}
+			w.handle(ev)
+		case err, ok := <-w.w.Errors:
+			if !ok {
+				return
+			}
+			w.warn("watcher error: %v", err)
+		}
+	}
+}
+
+// handle dispatches a single fsnotify event.
+func (w *Watcher) handle(ev fsnotify.Event) {
+	if ev.Op&fsnotify.Create != 0 {
+		if info, err := os.Stat(ev.Name); err == nil && info.IsDir() {
+			if err := w.addRecursive(ev.Name); err != nil {
+				w.warn("watch new dir %s: %v", ev.Name, err)
+			}
+			return
+		}
+	}
+	if ev.Op&(fsnotify.Write|fsnotify.Create|fsnotify.Remove|fsnotify.Rename|fsnotify.Chmod) == 0 {
+		return
+	}
+	w.route(ev.Name)
+}
+
+// route dispatches the path to the right invalidation bucket. Tests
+// drive this directly to bypass fsnotify timing.
+func (w *Watcher) route(path string) {
+	switch {
+	case w.binaryPath != "" && filepath.Clean(path) == filepath.Clean(w.binaryPath):
+		w.emit(EventShutdownRequest)
+	case isKritConfigPath(path):
+		w.ws.InvalidateAll()
+		w.ws.Touch(path)
+		w.emit(EventConfigReload)
+	case isLibraryConfigPath(path):
+		w.ws.InvalidateLibraryFacts()
+		w.ws.InvalidateCodeIndex()
+		w.ws.InvalidateDependents()
+		w.ws.Touch(path)
+		if w.onAndroidProjectChange != nil {
+			w.onAndroidProjectChange()
+		}
+	case isAndroidResourcePath(path):
+		w.ws.Touch(path)
+		if w.onResourceIndexChange != nil {
+			w.onResourceIndexChange()
+		}
+	case isSourcePath(path):
+		w.scheduleSourceInvalidate(path)
+	}
+}
+
+func (w *Watcher) emit(e WatcherEvent) {
+	if w.Events == nil {
+		return
+	}
+	select {
+	case w.Events <- e:
+	default:
+		// A blocked consumer must not silence shutdown signals; the
+		// daemon's correctness depends on observing them.
+		w.warn("watcher: dropped event %d (consumer not draining)", int(e))
+	}
+}
+
+// scheduleSourceInvalidate coalesces rapid Write+Write+Chmod
+// sequences (editors emit several events per save) into a single
+// invalidation pass per path within debounceWindow.
+func (w *Watcher) scheduleSourceInvalidate(path string) {
+	w.debounceMu.Lock()
+	if t, ok := w.debounce[path]; ok {
+		t.Stop()
+	}
+	w.debounce[path] = time.AfterFunc(w.debounceWindow, func() {
+		w.debounceMu.Lock()
+		delete(w.debounce, path)
+		w.debounceMu.Unlock()
+		w.fireSourceInvalidate(path)
+	})
+	w.debounceMu.Unlock()
+}
+
+func (w *Watcher) fireSourceInvalidate(path string) {
+	w.ws.Invalidate(path)
+	w.ws.Touch(path)
+	w.ws.InvalidateCodeIndex()
+	w.ws.InvalidateResolver()
+	w.ws.InvalidateDependents()
+	w.ws.InvalidateOracleFilter()
+	w.codeIndexInvalidations.Add(1)
+	w.Untrack(path)
+}
+
+func (w *Watcher) addRecursive(dir string) error {
+	return w.addRecursiveSkip(dir, false)
+}
+
+func (w *Watcher) addRecursiveSkip(dir string, skipRoot bool) error {
+	return filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			w.warn("walk %s: %v", path, err)
+			return nil
+		}
+		if !info.IsDir() {
+			return nil
+		}
+		base := filepath.Base(path)
+		if fileignore.DefaultPrunedDir(base) && path != dir {
+			return filepath.SkipDir
+		}
+		if base == ".krit" && path != dir {
+			return filepath.SkipDir
+		}
+		if skipRoot && path == dir {
+			return nil
+		}
+		if err := w.w.Add(path); err != nil {
+			w.warn("watch %s: %v", path, err)
+		}
+		return nil
+	})
+}
+
+// sweepLoop re-stats every tracked path every sweepInterval. Paths
+// whose mtime advanced past the tracked value are treated as missed
+// fsnotify events and routed through the standard invalidation path.
+func (w *Watcher) sweepLoop(ctx context.Context) {
+	t := time.NewTicker(w.sweepInterval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-w.stopped:
+			return
+		case <-t.C:
+			w.sweepOnce()
+		}
+	}
+}
+
+func (w *Watcher) sweepOnce() {
+	w.trackedMu.Lock()
+	snapshot := make(map[string]int64, len(w.tracked))
+	for k, v := range w.tracked {
+		snapshot[k] = v
+	}
+	w.trackedMu.Unlock()
+
+	for path, tracked := range snapshot {
+		info, err := os.Stat(path)
+		if err != nil {
+			if os.IsNotExist(err) {
+				w.sweepCatches.Add(1)
+				w.route(path)
+				w.Untrack(path)
+			}
+			continue
+		}
+		mtime := info.ModTime().UnixNano()
+		if mtime != tracked {
+			w.sweepCatches.Add(1)
+			w.route(path)
+		}
+	}
+}
+
+func (w *Watcher) warn(format string, args ...any) {
+	if w.log == nil {
+		return
+	}
+	w.log.Warnf(format, args...)
+}
+
+// --- path classification ---
+
+func isSourcePath(p string) bool {
+	return strings.HasSuffix(p, ".kt") || strings.HasSuffix(p, ".kts") || strings.HasSuffix(p, ".java")
+}
+
+func isKritConfigPath(p string) bool {
+	base := filepath.Base(p)
+	for _, name := range config.Filenames {
+		if base == name {
+			return true
+		}
+	}
+	return false
+}
+
+func isLibraryConfigPath(p string) bool {
+	base := filepath.Base(p)
+	switch base {
+	case "build.gradle", "build.gradle.kts",
+		"settings.gradle", "settings.gradle.kts":
+		return true
+	}
+	return strings.HasSuffix(base, ".versions.toml")
+}
+
+// isAndroidResourcePath reports whether p is an AndroidManifest.xml or
+// a resource XML under a res/ directory.
+func isAndroidResourcePath(p string) bool {
+	base := filepath.Base(p)
+	if base == "AndroidManifest.xml" {
+		return true
+	}
+	if !strings.HasSuffix(base, ".xml") {
+		return false
+	}
+	// res/**/*.xml — require a "res" component anywhere above the file.
+	clean := filepath.ToSlash(filepath.Clean(p))
+	for _, seg := range strings.Split(filepath.ToSlash(filepath.Dir(clean)), "/") {
+		if seg == "res" {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/daemon/watcher_test.go
+++ b/internal/daemon/watcher_test.go
@@ -1,0 +1,431 @@
+package daemon
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/kaeawc/krit/internal/pipeline"
+)
+
+// countingState tracks watcher-driven invalidation calls so unit
+// tests can assert routing without spinning up the real workspace.
+type countingState struct {
+	mu             sync.Mutex
+	invalidate     int
+	invalidateAll  int
+	codeIndex      int
+	dependents     int
+	library        int
+	resolver       int
+	oracle         int
+	touch          int
+	lastTouched    string
+	lastInvalidate string
+}
+
+func (c *countingState) Invalidate(p string) {
+	c.mu.Lock()
+	c.invalidate++
+	c.lastInvalidate = p
+	c.mu.Unlock()
+}
+func (c *countingState) InvalidateAll() { c.mu.Lock(); c.invalidateAll++; c.mu.Unlock() }
+func (c *countingState) InvalidateCodeIndex() {
+	c.mu.Lock()
+	c.codeIndex++
+	c.mu.Unlock()
+}
+func (c *countingState) InvalidateDependents() {
+	c.mu.Lock()
+	c.dependents++
+	c.mu.Unlock()
+}
+func (c *countingState) InvalidateLibraryFacts() {
+	c.mu.Lock()
+	c.library++
+	c.mu.Unlock()
+}
+func (c *countingState) InvalidateResolver() {
+	c.mu.Lock()
+	c.resolver++
+	c.mu.Unlock()
+}
+func (c *countingState) InvalidateOracleFilter() {
+	c.mu.Lock()
+	c.oracle++
+	c.mu.Unlock()
+}
+func (c *countingState) Touch(p string) {
+	c.mu.Lock()
+	c.touch++
+	c.lastTouched = p
+	c.mu.Unlock()
+}
+
+type stateSnapshot struct {
+	invalidate     int
+	invalidateAll  int
+	codeIndex      int
+	dependents     int
+	library        int
+	resolver       int
+	oracle         int
+	touch          int
+	lastTouched    string
+	lastInvalidate string
+}
+
+func (c *countingState) snapshot() stateSnapshot {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return stateSnapshot{
+		invalidate:     c.invalidate,
+		invalidateAll:  c.invalidateAll,
+		codeIndex:      c.codeIndex,
+		dependents:     c.dependents,
+		library:        c.library,
+		resolver:       c.resolver,
+		oracle:         c.oracle,
+		touch:          c.touch,
+		lastTouched:    c.lastTouched,
+		lastInvalidate: c.lastInvalidate,
+	}
+}
+
+func waitFor(t *testing.T, fn func() bool) bool {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if fn() {
+			return true
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	return fn()
+}
+
+// TestRouting_TableDriven feeds synthetic paths through route() and
+// asserts the correct invalidate buckets fire. fsnotify is bypassed so
+// the assertions are deterministic.
+func TestRouting_TableDriven(t *testing.T) {
+	cases := []struct {
+		name        string
+		path        string
+		assertState func(t *testing.T, s stateSnapshot)
+		assertEvent WatcherEvent // 0 = none
+	}{
+		{
+			name: "kotlin source",
+			path: "/repo/src/main/kotlin/Foo.kt",
+			assertState: func(t *testing.T, s stateSnapshot) {
+				if s.invalidate != 1 || s.codeIndex != 1 || s.dependents != 1 || s.resolver != 1 || s.oracle != 1 {
+					t.Fatalf("kotlin: %+v", s)
+				}
+			},
+		},
+		{
+			name: "kts script",
+			path: "/repo/buildSrc/foo.kts",
+			assertState: func(t *testing.T, s stateSnapshot) {
+				if s.invalidate != 1 || s.codeIndex != 1 {
+					t.Fatalf("kts: %+v", s)
+				}
+			},
+		},
+		{
+			name: "java source",
+			path: "/repo/src/Bar.java",
+			assertState: func(t *testing.T, s stateSnapshot) {
+				if s.invalidate != 1 || s.codeIndex != 1 {
+					t.Fatalf("java: %+v", s)
+				}
+			},
+		},
+		{
+			name: "gradle build script",
+			path: "/repo/app/build.gradle.kts",
+			assertState: func(t *testing.T, s stateSnapshot) {
+				if s.library != 1 || s.codeIndex != 1 || s.dependents != 1 {
+					t.Fatalf("gradle: %+v", s)
+				}
+			},
+		},
+		{
+			name: "version catalog",
+			path: "/repo/gradle/libs.versions.toml",
+			assertState: func(t *testing.T, s stateSnapshot) {
+				if s.library != 1 {
+					t.Fatalf("toml: %+v", s)
+				}
+			},
+		},
+		{
+			name: "krit.yml",
+			path: "/repo/krit.yml",
+			assertState: func(t *testing.T, s stateSnapshot) {
+				if s.invalidateAll != 1 {
+					t.Fatalf("config: %+v", s)
+				}
+			},
+			assertEvent: EventConfigReload,
+		},
+		{
+			name: "AndroidManifest",
+			path: "/repo/app/src/main/AndroidManifest.xml",
+			assertState: func(t *testing.T, s stateSnapshot) {
+				if s.touch != 1 {
+					t.Fatalf("manifest: %+v", s)
+				}
+			},
+		},
+		{
+			name: "res xml",
+			path: "/repo/app/src/main/res/layout/foo.xml",
+			assertState: func(t *testing.T, s stateSnapshot) {
+				if s.touch != 1 {
+					t.Fatalf("res: %+v", s)
+				}
+			},
+		},
+		{
+			name: "unrelated file",
+			path: "/repo/README.md",
+			assertState: func(t *testing.T, s stateSnapshot) {
+				if s.invalidate != 0 || s.codeIndex != 0 || s.touch != 0 {
+					t.Fatalf("readme: %+v", s)
+				}
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			state := &countingState{}
+			var androidCleared, resourceCleared atomic.Int32
+			w, err := newWatcherWithState(state, t.TempDir(), nil,
+				WithDebounceWindow(time.Millisecond),
+				WithSweepInterval(0),
+				WithAndroidProjectCallback(func() { androidCleared.Add(1) }),
+				WithResourceIndexCallback(func() { resourceCleared.Add(1) }),
+			)
+			if err != nil {
+				t.Fatalf("new: %v", err)
+			}
+			defer w.Stop()
+			w.route(tc.path)
+			// Wait for debounce timer to fire for source-path cases.
+			waitFor(t, func() bool {
+				s := state.snapshot()
+				return s.invalidate > 0 || s.codeIndex > 0 || s.touch > 0 || s.invalidateAll > 0 || s.library > 0
+			})
+			tc.assertState(t, state.snapshot())
+			if tc.assertEvent != 0 {
+				select {
+				case got := <-w.Events:
+					if got != tc.assertEvent {
+						t.Fatalf("event: got %v want %v", got, tc.assertEvent)
+					}
+				case <-time.After(time.Second):
+					t.Fatal("no event")
+				}
+			}
+		})
+	}
+}
+
+// TestIntegration_RealFsnotify writes a real .kt file and asserts the
+// daemon-resident WorkspaceState.parsed map drops the entry.
+func TestIntegration_RealFsnotify(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "Foo.kt")
+	if err := os.WriteFile(path, []byte("fun a() {}\n"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	ws := pipeline.NewWorkspaceState(root)
+	if _, err := ws.ParseFile(context.Background(), path, []byte("fun a() {}\n")); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if got := ws.Stats().ParsedEntries; got != 1 {
+		t.Fatalf("setup: %d", got)
+	}
+
+	w, err := NewWatcher(ws, root, nil, WithDebounceWindow(5*time.Millisecond), WithSweepInterval(0))
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	if err := w.Start(context.Background()); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	defer w.Stop()
+
+	if err := os.WriteFile(path, []byte("fun a() { 42 }\n"), 0o644); err != nil {
+		t.Fatalf("rewrite: %v", err)
+	}
+	if !waitFor(t, func() bool { return ws.Stats().ParsedEntries == 0 }) {
+		t.Fatalf("entry survived: %+v", ws.Stats())
+	}
+}
+
+// TestStress_DebounceCoalesces fires many writes in rapid succession
+// and asserts the watcher coalesces them into one InvalidateCodeIndex
+// call per file.
+func TestStress_DebounceCoalesces(t *testing.T) {
+	state := &countingState{}
+	w, err := newWatcherWithState(state, t.TempDir(), nil,
+		WithDebounceWindow(20*time.Millisecond),
+		WithSweepInterval(0),
+	)
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	defer w.Stop()
+
+	// 50 logical files, 4 events each (Write+Write+Chmod+Write).
+	const files = 50
+	const eventsPerFile = 4
+	for i := 0; i < files; i++ {
+		p := filepath.Join("/repo", "F"+strconv.Itoa(i)+".kt")
+		for j := 0; j < eventsPerFile; j++ {
+			w.route(p)
+		}
+	}
+	// Wait for debouncer to drain.
+	waitFor(t, func() bool { return w.CodeIndexInvalidations() == files })
+	got := w.CodeIndexInvalidations()
+	if got != files {
+		t.Fatalf("expected %d invalidations after coalescing, got %d (state=%+v)", files, got, state.snapshot())
+	}
+}
+
+// TestMtimeSweep_CatchesMissedEvent simulates a missed fsnotify event
+// by mutating mtime on a tracked file without triggering the
+// underlying watcher, and asserts the sweep recovers the change.
+func TestMtimeSweep_CatchesMissedEvent(t *testing.T) {
+	state := &countingState{}
+	root := t.TempDir()
+	w, err := newWatcherWithState(state, root, nil,
+		WithDebounceWindow(time.Millisecond),
+		WithSweepInterval(20*time.Millisecond),
+	)
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	// Don't Start() — we drive the sweep directly. Stop() is safe on
+	// an un-Started watcher.
+	defer w.Stop()
+
+	path := filepath.Join(root, "Stale.kt")
+	if err := os.WriteFile(path, []byte("a"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	// Track the file with its current mtime.
+	w.Track(path)
+	// Mutate the file's mtime artificially (no fsnotify delivery).
+	future := time.Now().Add(time.Minute)
+	if err := os.Chtimes(path, future, future); err != nil {
+		t.Fatalf("chtimes: %v", err)
+	}
+	w.sweepOnce()
+	if w.SweepCatches() == 0 {
+		t.Fatalf("sweep did not catch missed event: state=%+v", state.snapshot())
+	}
+	if !waitFor(t, func() bool { return state.snapshot().codeIndex > 0 }) {
+		t.Fatalf("expected InvalidateCodeIndex via sweep route, got %+v", state.snapshot())
+	}
+}
+
+// TestBinaryPath_EmitsShutdown asserts a write to the watched krit
+// binary path emits EventShutdownRequest.
+func TestBinaryPath_EmitsShutdown(t *testing.T) {
+	state := &countingState{}
+	bin := "/tmp/krit"
+	w, err := newWatcherWithState(state, t.TempDir(), nil,
+		WithBinaryPath(bin),
+		WithDebounceWindow(time.Millisecond),
+		WithSweepInterval(0),
+	)
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	defer w.Stop()
+	w.route(bin)
+	select {
+	case got := <-w.Events:
+		if got != EventShutdownRequest {
+			t.Fatalf("want ShutdownRequest, got %v", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("no shutdown event")
+	}
+}
+
+// TestStop_Idempotent verifies Stop is safe to call multiple times.
+func TestStop_Idempotent(t *testing.T) {
+	state := &countingState{}
+	w, err := newWatcherWithState(state, t.TempDir(), nil, WithSweepInterval(0))
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	if err := w.Start(context.Background()); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	if err := w.Stop(); err != nil {
+		t.Fatalf("stop1: %v", err)
+	}
+	if err := w.Stop(); err != nil {
+		t.Fatalf("stop2: %v", err)
+	}
+}
+
+// TestRouting_AndroidResource asserts the resource-index callback fires
+// for both AndroidManifest.xml and res/**/*.xml.
+func TestRouting_AndroidResource(t *testing.T) {
+	for _, p := range []string{
+		"/repo/app/src/main/AndroidManifest.xml",
+		"/repo/app/src/main/res/values/strings.xml",
+		"/repo/app/src/main/res/layout/main.xml",
+	} {
+		state := &countingState{}
+		var calls atomic.Int32
+		w, err := newWatcherWithState(state, t.TempDir(), nil,
+			WithDebounceWindow(time.Millisecond),
+			WithSweepInterval(0),
+			WithResourceIndexCallback(func() { calls.Add(1) }),
+		)
+		if err != nil {
+			t.Fatalf("new: %v", err)
+		}
+		w.route(p)
+		_ = w.Stop()
+		if calls.Load() != 1 {
+			t.Fatalf("%s: callbacks=%d", p, calls.Load())
+		}
+	}
+}
+
+// TestPathClassification spot-checks the helpers against negative
+// lookalikes — a file named `res.xml` outside a res/ dir must not
+// route as an Android resource.
+func TestPathClassification(t *testing.T) {
+	cases := []struct {
+		path string
+		want bool
+	}{
+		{"/a/res/x.xml", true},
+		{"/a/src/main/res/layout/foo.xml", true},
+		{"/a/AndroidManifest.xml", true},
+		{"/a/notres/x.xml", false},
+		{"/a/build.gradle", false},
+		{"/a/Foo.kt", false},
+	}
+	for _, tc := range cases {
+		if got := isAndroidResourcePath(tc.path); got != tc.want {
+			t.Errorf("isAndroidResourcePath(%q) = %v want %v", tc.path, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
Closes #203.

## Summary
- Adds `internal/daemon/watcher.go`: an fsnotify-backed `Watcher` that pushes filesystem-change events into `pipeline.WorkspaceState.Invalidate*`, debounces editor-save bursts within a 50 ms window, and runs a periodic 30 s mtime sweep as a missed-event safety net.
- Routing: `.kt`/`.kts`/`.java` → per-file + cross-file invalidation; `build.gradle*` / `settings.gradle*` / `*.versions.toml` → `InvalidateLibraryFacts` + Android-project callback; `krit.yml` / `.krit.yml` → `InvalidateAll` + `EventConfigReload`; `AndroidManifest.xml` / `res/**/*.xml` → optional resource-cache callback; krit binary swap → `EventShutdownRequest`.
- Tests cover the issue's evaluation cases: table-driven routing, real-fsnotify integration, debounce-coalesces-burst stress, mtime-sweep recovery of missed events, binary-swap shutdown signalling, Stop idempotency. Race detector clean.

## Validation criteria (from issue #203)
- [x] Unit test injects synthetic events, asserts the right `Invalidate*` calls fire (table-driven) — `TestRouting_TableDriven`.
- [x] Integration test: real fsnotify, write a `.kt` file, `WorkspaceState.parsed` drops the entry — `TestIntegration_RealFsnotify`.
- [x] Stress: many rapid events coalesce to one `InvalidateCodeIndex` per file — `TestStress_DebounceCoalesces`.
- [x] Mtime sweep catches a missed fsnotify event — `TestMtimeSweep_CatchesMissedEvent`.
- [ ] Divergence harness (#202) — out of scope here; covered by sibling PR.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run ./internal/daemon/`
- [x] `go test ./... -count=1`
- [x] `go test ./internal/daemon/ ./internal/cli/serve/ -count=1 -race`
- [x] `make lint-rules`