### PR TITLE
feat(daemon): idle auto-shutdown via --idle-timeout

### DIFF
--- a/cmd/krit-daemon/main.go
+++ b/cmd/krit-daemon/main.go
@@ -28,6 +28,8 @@ func main() {
 	flag.BoolVar(verboseFlag, "v", false, "alias for --verbose")
 	strictVerifyFlag := flag.Bool("strict-verify", true,
 		"run an in-process baseline alongside every analyze and fail on divergence (issue #202; on by default during alpha)")
+	idleTimeoutFlag := flag.Duration("idle-timeout", 0,
+		"exit after this duration of no requests (e.g. 30m); 0 disables auto-shutdown")
 	flag.Parse()
 
 	if *versionFlag {
@@ -70,6 +72,7 @@ func main() {
 		RepoDir:      repo,
 		SocketPath:   *socketFlag,
 		StrictVerify: *strictVerifyFlag,
+		IdleTimeout:  *idleTimeoutFlag,
 	})
 	if err != nil {
 		log.Fatalf("krit-daemon: %v", err)

--- a/internal/cli/daemoncmd/start.go
+++ b/internal/cli/daemoncmd/start.go
@@ -30,7 +30,13 @@ func runStart(args []string) int {
 	socketFlag := fs.String("socket", "", "socket path (defaults to <repo>/.krit/daemon.sock)")
 	binaryFlag := fs.String("binary", "", "krit-daemon binary path (defaults to one next to krit)")
 	timeoutFlag := fs.Duration("timeout", startWaitTimeout, "how long to wait for the daemon to become ready")
+	idleTimeoutFlag := fs.Duration("idle-timeout", 0,
+		"daemon exits after this duration of no requests (e.g. 30m); 0 disables auto-shutdown")
 	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if *idleTimeoutFlag < 0 {
+		fmt.Fprintf(os.Stderr, "krit daemon start: --idle-timeout must be >= 0 (got %s)\n", *idleTimeoutFlag)
 		return 2
 	}
 
@@ -61,7 +67,7 @@ func runStart(args []string) int {
 		return 1
 	}
 
-	pid, err := spawnDaemon(binary, repo, socket)
+	pid, err := spawnDaemon(binary, repo, socket, *idleTimeoutFlag)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "krit daemon start: spawn: %v\n", err)
 		return 1
@@ -106,7 +112,7 @@ func resolveDaemonBinary(explicit string) (string, error) {
 // spawnDaemon launches krit-daemon detached via Setsid so a SIGHUP on
 // the parent terminal (e.g. closing the shell) doesn't take the
 // daemon down with it.
-func spawnDaemon(binary, repo, socket string) (int, error) {
+func spawnDaemon(binary, repo, socket string, idleTimeout time.Duration) (int, error) {
 	dotKrit := filepath.Join(repo, ".krit")
 	if err := os.MkdirAll(dotKrit, 0o755); err != nil {
 		return 0, fmt.Errorf("prepare .krit dir: %w", err)
@@ -121,6 +127,9 @@ func spawnDaemon(binary, repo, socket string) (int, error) {
 	args := []string{"--repo", repo}
 	if socket != "" {
 		args = append(args, "--socket", socket)
+	}
+	if idleTimeout > 0 {
+		args = append(args, "--idle-timeout", idleTimeout.String())
 	}
 	cmd := exec.CommandContext(context.Background(), binary, args...)
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}

--- a/internal/sessdaemon/idle_test.go
+++ b/internal/sessdaemon/idle_test.go
@@ -1,0 +1,113 @@
+package sessdaemon
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestIdleAutoShutdownStopsServer asserts that a daemon configured with
+// IdleTimeout self-stops after no requests for the configured window.
+// Validation criterion: Wait() returns within idleTimeout + slack when
+// no traffic arrives.
+func TestIdleAutoShutdownStopsServer(t *testing.T) {
+	repo := t.TempDir()
+	sockDir, err := os.MkdirTemp("", "kritd")
+	if err != nil {
+		t.Fatalf("mkdtemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(sockDir) })
+	socket := filepath.Join(sockDir, "d.sock")
+
+	idle := 300 * time.Millisecond
+	srv, err := NewServer(context.Background(), Options{
+		RepoDir:     repo,
+		SocketPath:  socket,
+		IdleTimeout: idle,
+	})
+	if err != nil {
+		t.Fatalf("new server: %v", err)
+	}
+	if err := srv.Start(context.Background()); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		srv.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// stopped — good
+	case <-time.After(idle + 2*time.Second):
+		srv.Stop()
+		t.Fatalf("daemon did not self-stop within %s of idle timeout %s", 2*time.Second, idle)
+	}
+}
+
+// TestIdleAutoShutdownResetsOnRequest asserts that incoming requests
+// reset the idle clock: a daemon with a short idle window stays alive
+// while a client sends health requests faster than the window.
+func TestIdleAutoShutdownResetsOnRequest(t *testing.T) {
+	repo := t.TempDir()
+	sockDir, err := os.MkdirTemp("", "kritd")
+	if err != nil {
+		t.Fatalf("mkdtemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(sockDir) })
+	socket := filepath.Join(sockDir, "d.sock")
+
+	idle := 500 * time.Millisecond
+	srv, err := NewServer(context.Background(), Options{
+		RepoDir:     repo,
+		SocketPath:  socket,
+		IdleTimeout: idle,
+	})
+	if err != nil {
+		t.Fatalf("new server: %v", err)
+	}
+	if err := srv.Start(context.Background()); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	t.Cleanup(func() {
+		srv.Stop()
+		srv.Wait()
+	})
+
+	// Drive health requests for ~1.2s at ~100ms cadence — longer than
+	// the idle window. The server must still be reachable at the end.
+	stop := time.After(1200 * time.Millisecond)
+	tick := time.NewTicker(100 * time.Millisecond)
+	defer tick.Stop()
+	for {
+		select {
+		case <-stop:
+			if _, err := Health(socket); err != nil {
+				t.Fatalf("daemon went away despite request traffic: %v", err)
+			}
+			return
+		case <-tick.C:
+			if _, err := Health(socket); err != nil {
+				t.Fatalf("health during traffic: %v", err)
+			}
+		}
+	}
+}
+
+// TestIdleAutoShutdownDisabledByDefault asserts the zero-value
+// IdleTimeout leaves the daemon running indefinitely. We can't wait
+// forever, so we wait past a duration that would have tripped any
+// reasonable watchdog and confirm the server still answers Health.
+func TestIdleAutoShutdownDisabledByDefault(t *testing.T) {
+	repo := t.TempDir()
+	socket := startTestServer(t, repo)
+
+	time.Sleep(400 * time.Millisecond)
+	if _, err := Health(socket); err != nil {
+		t.Fatalf("daemon should still be running with idle disabled: %v", err)
+	}
+}

--- a/internal/sessdaemon/server.go
+++ b/internal/sessdaemon/server.go
@@ -62,6 +62,9 @@ type Server struct {
 	flushInterval time.Duration
 	flushWG       sync.WaitGroup
 
+	idleTimeout  time.Duration
+	lastActivity atomic.Int64
+
 	stopOnce sync.Once
 	stopped  chan struct{}
 	cancel   context.CancelFunc
@@ -81,6 +84,14 @@ type Options struct {
 	// correctness oracle issue #202 added; on by default during alpha,
 	// opt-in post-stabilization.
 	StrictVerify bool
+
+	// IdleTimeout, when > 0, makes the daemon self-stop after no
+	// requests have been received for the given duration. Useful on
+	// laptops where leaving a long-lived process running drains battery
+	// and pins file descriptors across sleep/wake. Zero (the default)
+	// disables auto-shutdown — the operator must call `krit daemon
+	// stop` or send SIGTERM.
+	IdleTimeout time.Duration
 }
 
 // NewServer constructs a Server with a fresh scan.Session for opts.RepoDir.
@@ -88,6 +99,9 @@ type Options struct {
 func NewServer(ctx context.Context, opts Options) (*Server, error) {
 	if opts.RepoDir == "" {
 		return nil, errors.New("sessdaemon: RepoDir is required")
+	}
+	if opts.IdleTimeout < 0 {
+		return nil, fmt.Errorf("sessdaemon: IdleTimeout must be >= 0 (got %s)", opts.IdleTimeout)
 	}
 	sess, err := scan.NewSession(ctx, opts.RepoDir, nil)
 	if err != nil {
@@ -113,6 +127,7 @@ func NewServer(ctx context.Context, opts Options) (*Server, error) {
 		oracle:        oracleDaemonState{starter: defaultOracleStarter{}},
 		stopped:       make(chan struct{}),
 		flushInterval: defaultFlushInterval,
+		idleTimeout:   opts.IdleTimeout,
 	}, nil
 }
 
@@ -140,10 +155,14 @@ func (s *Server) Start(ctx context.Context) error {
 	cctx, cancel := context.WithCancel(ctx)
 	s.cancel = cancel
 
+	s.lastActivity.Store(time.Now().UnixNano())
 	go s.acceptLoop(cctx)
 	if s.flushInterval > 0 && s.session != nil && s.session.AnalysisCache != nil && s.session.AnalysisCacheFilePath != "" {
 		s.flushWG.Add(1)
 		go s.flushLoop(cctx)
+	}
+	if s.idleTimeout > 0 {
+		go s.idleWatchdog(cctx)
 	}
 	go func() {
 		<-cctx.Done()
@@ -240,6 +259,7 @@ func (s *Server) serveConn(ctx context.Context, conn net.Conn) {
 		return
 	}
 	s.requestCount.Add(1)
+	s.lastActivity.Store(time.Now().UnixNano())
 
 	switch req.Method {
 	case MethodAnalyze:
@@ -285,4 +305,30 @@ func (s *Server) handleShutdown(w io.Writer, req Request) {
 		_ = bw.Flush()
 	}
 	go s.Stop()
+}
+
+// idleWatchdog cancels the server context when no request has been
+// dispatched for idleTimeout. Polls at idleTimeout/4 (clamped to
+// >=100ms) so worst-case overshoot is roughly 25 percent. The
+// existing context-cancel teardown goroutine in Start drives Stop.
+func (s *Server) idleWatchdog(ctx context.Context) {
+	tick := s.idleTimeout / 4
+	if tick < 100*time.Millisecond {
+		tick = 100 * time.Millisecond
+	}
+	t := time.NewTicker(tick)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			last := time.Unix(0, s.lastActivity.Load())
+			if time.Since(last) >= s.idleTimeout {
+				fmt.Fprintf(os.Stderr, "krit-daemon: idle for %s, exiting\n", s.idleTimeout)
+				s.cancel()
+				return
+			}
+		}
+	}
 }


### PR DESCRIPTION
## Summary

Adds opt-in idle auto-shutdown to `sessdaemon` so the per-repo daemon
self-exits after a configurable window of no requests. Closes one of
the deferred items in #209: useful on laptops where leaving the
daemon running drains battery and pins file descriptors across
sleep/wake.

- `sessdaemon.Options.IdleTimeout` (zero disables — default behavior unchanged)
- `krit-daemon --idle-timeout DURATION`
- `krit daemon start --idle-timeout DURATION` (forwarded to the spawned daemon)

Watchdog cancels the server context when idle; the existing
teardown goroutine handles Stop. Polls at `IdleTimeout/4` (>=100ms
floor) — worst-case overshoot ~25%.

## Validation criteria

- `TestIdleAutoShutdownStopsServer` — daemon with 300ms idle window
  stops on its own within 2s with no traffic.
- `TestIdleAutoShutdownResetsOnRequest` — daemon with 500ms idle
  window stays alive across 1.2s of 100ms-cadence health requests.
- `TestIdleAutoShutdownDisabledByDefault` — zero IdleTimeout leaves
  the daemon running.
- `NewServer` rejects negative `IdleTimeout`.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...`
- [x] `go test ./... -count=1`
- [x] Focused: `go test ./internal/sessdaemon -run TestIdle -v`

Refs #209.