### PR TITLE
feat(bisect): explainable bisection from breakage events to structural deltas

### DIFF
--- a/cmd/krit/verb_dispatch.go
+++ b/cmd/krit/verb_dispatch.go
@@ -5,10 +5,13 @@ import (
 
 	climabihash "github.com/kaeawc/krit/internal/cli/abihash"
 	climapi "github.com/kaeawc/krit/internal/cli/api"
+	climbisect "github.com/kaeawc/krit/internal/cli/bisect"
 	climblastradius "github.com/kaeawc/krit/internal/cli/blastradius"
+	climbreakage "github.com/kaeawc/krit/internal/cli/breakage"
 	climcache "github.com/kaeawc/krit/internal/cli/cache"
 	climdaemoncmd "github.com/kaeawc/krit/internal/cli/daemoncmd"
 	climdeadcode "github.com/kaeawc/krit/internal/cli/deadcode"
+	climdeltarisk "github.com/kaeawc/krit/internal/cli/deltarisk"
 	climdigraph "github.com/kaeawc/krit/internal/cli/digraph"
 	climeditorconfigdrift "github.com/kaeawc/krit/internal/cli/editorconfigdrift"
 	climgen "github.com/kaeawc/krit/internal/cli/gen"
@@ -71,6 +74,9 @@ const (
 	verbDaemon
 	verbTriage
 	verbRules
+	verbBreakage
+	verbBisectStructure
+	verbDeltaRisk
 )
 
 var verbByName = map[string]subcommandVerb{
@@ -106,6 +112,9 @@ var verbByName = map[string]subcommandVerb{
 	"daemon":             verbDaemon,
 	"triage":             verbTriage,
 	"rules":              verbRules,
+	"breakage":           verbBreakage,
+	"bisect-structure":   verbBisectStructure,
+	"delta-risk":         verbDeltaRisk,
 }
 
 func classifyVerb(arg string) subcommandVerb {
@@ -190,6 +199,12 @@ func runVerbAndExitB(verb subcommandVerb, rest []string) bool {
 		os.Exit(climtriage.Run(rest))
 	case verbRules:
 		os.Exit(climrules.Run(rest))
+	case verbBreakage:
+		os.Exit(climbreakage.Run(rest))
+	case verbBisectStructure:
+		os.Exit(climbisect.Run(rest))
+	case verbDeltaRisk:
+		os.Exit(climdeltarisk.Run(rest))
 	}
 	return false
 }

--- a/internal/bisect/bisect.go
+++ b/internal/bisect/bisect.go
@@ -1,0 +1,492 @@
+// Package bisect explains failures by fusing location signals over the
+// snapshot timeline. Given a breakage event and a [from, to] sha
+// range, it walks the captured snapshots and returns ranked
+// (commit, module, reason, confidence) candidates.
+//
+// The fusion model mirrors AutoMobile's fingerprint tiers: each signal
+// is tagged with a tier-derived prior, the highest prior across tiers
+// that agree on a (commit, module) wins, and that prior is boosted by
+// the number of agreeing tiers. The output is a ranked list, not a
+// single answer.
+package bisect
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/kaeawc/krit/internal/breakage"
+	"github.com/kaeawc/krit/internal/snapshot"
+)
+
+// Tier identifies the source of a location signal. Lower tiers are
+// higher-confidence — stack frames beat heuristics, heuristics beat
+// raw structural diffs, raw diffs beat historical co-occurrence.
+type Tier int
+
+const (
+	TierStackFrame      Tier = 1
+	TierTestOwnsModule  Tier = 2
+	TierDiffTouches     Tier = 3
+	TierHistoricalCoOcc Tier = 4
+	tierCount                = 4
+)
+
+// Prior returns the per-tier base confidence used as the AutoMobile-
+// style prior. Boosts (agreement count, distance to event sha) layer
+// on top.
+func Prior(t Tier) float64 {
+	switch t {
+	case TierStackFrame:
+		return 0.95
+	case TierTestOwnsModule:
+		return 0.85
+	case TierDiffTouches:
+		return 0.60
+	case TierHistoricalCoOcc:
+		return 0.50
+	}
+	return 0.0
+}
+
+// Signal is one (commit, module) location candidate carrying a tier and
+// a one-line reason. The Reason field shows up in CLI output verbatim;
+// keep it short and self-explanatory.
+type Signal struct {
+	CommitSHA string
+	Module    string
+	Tier      Tier
+	Reason    string
+}
+
+// Candidate is a fused location: one (commit, module) bucket and the
+// agreeing signals that backed it. Confidence is in [0, 1].
+type Candidate struct {
+	CommitSHA  string   `json:"commit_sha"`
+	Module     string   `json:"module"`
+	Confidence float64  `json:"confidence"`
+	Reasons    []string `json:"reasons"`
+	Tiers      []Tier   `json:"tiers"`
+}
+
+// Input is the entry point's parameter bag. SnapshotsRoot is the
+// `.krit/snapshots` directory; FromSHA and ToSHA bound the search
+// range and need not be themselves captured (we walk captured manifests
+// inside that range).
+type Input struct {
+	SnapshotsRoot string
+	FromSHA       string
+	ToSHA         string
+	Event         breakage.Event
+	// HistoricalEvents is the full event ledger; when non-nil the tier-4
+	// (historical co-occurrence) signals draw from it.
+	HistoricalEvents []breakage.Event
+	// MaxResults caps the returned candidates. Zero means "no cap".
+	MaxResults int
+}
+
+// Result is the ranked output. Candidates are sorted by Confidence
+// descending, then by (CommitSHA, Module) ascending.
+type Result struct {
+	Event      breakage.Event `json:"event"`
+	From       string         `json:"from"`
+	To         string         `json:"to"`
+	Candidates []Candidate    `json:"candidates"`
+}
+
+// Run executes a structural bisection over the captured snapshot
+// timeline. When no captured manifests fall in [FromSHA, ToSHA] the
+// result has no candidates and no error.
+func Run(in Input) (*Result, error) {
+	if in.SnapshotsRoot == "" {
+		return nil, fmt.Errorf("bisect: SnapshotsRoot required")
+	}
+	manifests, err := snapshot.LoadManifests(in.SnapshotsRoot)
+	if err != nil {
+		return nil, fmt.Errorf("bisect: load manifests: %w", err)
+	}
+	timeline := orderManifests(manifests)
+
+	// The tier-1 and tier-2 signals both inspect the event's blob; load
+	// it once and pass it through. Errors are non-fatal — those signals
+	// simply contribute nothing.
+	var eventBlob *snapshot.Blob
+	if in.Event.CommitSHA != "" {
+		if b, err := snapshot.Load(in.SnapshotsRoot, in.Event.CommitSHA); err == nil {
+			eventBlob = b
+		}
+	}
+
+	var signals []Signal
+	signals = append(signals, stackFrameSignals(in, eventBlob)...)
+	signals = append(signals, testOwnsModuleSignals(in, eventBlob)...)
+	signals = append(signals, diffTouchesSignals(in, timeline)...)
+	signals = append(signals, historicalCoOccurrenceSignals(in)...)
+
+	candidates := fuse(signals)
+	if in.MaxResults > 0 && len(candidates) > in.MaxResults {
+		candidates = candidates[:in.MaxResults]
+	}
+	return &Result{
+		Event:      in.Event,
+		From:       in.FromSHA,
+		To:         in.ToSHA,
+		Candidates: candidates,
+	}, nil
+}
+
+// orderManifests sorts manifests by capture time ascending. Captures
+// for un-resolvable commit times tie-break by sha, matching git log's
+// behaviour for synthetic shas.
+func orderManifests(manifests []snapshot.Manifest) []snapshot.Manifest {
+	out := append([]snapshot.Manifest(nil), manifests...)
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].CapturedAt != out[j].CapturedAt {
+			return out[i].CapturedAt < out[j].CapturedAt
+		}
+		return out[i].CommitSHA < out[j].CommitSHA
+	})
+	return out
+}
+
+// manifestsInRange returns the slice of manifests whose CommitSHA
+// equals FromSHA, ToSHA, or lies strictly between them in capture-
+// time order. When either bound is empty the open end is treated as
+// unbounded.
+func manifestsInRange(manifests []snapshot.Manifest, from, to string) []snapshot.Manifest {
+	if from == "" && to == "" {
+		return manifests
+	}
+	indexOf := func(sha string) int {
+		if sha == "" {
+			return -1
+		}
+		for i, m := range manifests {
+			if m.CommitSHA == sha {
+				return i
+			}
+		}
+		return -1
+	}
+	fromIdx := indexOf(from)
+	toIdx := indexOf(to)
+	if fromIdx < 0 {
+		fromIdx = 0
+	}
+	if toIdx < 0 {
+		toIdx = len(manifests) - 1
+	}
+	if fromIdx > toIdx {
+		fromIdx, toIdx = toIdx, fromIdx
+	}
+	return manifests[fromIdx : toIdx+1]
+}
+
+// stackFrameSignals attributes the event to its own commit when any
+// frame maps to a captured symbol — the frame names a definition that
+// exists at that sha.
+func stackFrameSignals(in Input, blob *snapshot.Blob) []Signal {
+	if blob == nil || len(in.Event.Frames) == 0 {
+		return nil
+	}
+	idx := indexSymbolsByFQN(blob)
+	for _, frame := range in.Event.Frames {
+		frame = strings.TrimSpace(frame)
+		if frame == "" {
+			continue
+		}
+		if sym := idx.match(frame); sym != nil {
+			mod := moduleForFile(blob, sym.File)
+			return []Signal{{
+				CommitSHA: in.Event.CommitSHA,
+				Module:    mod,
+				Tier:      TierStackFrame,
+				Reason:    "stack frame " + frame + " maps to " + sym.FQN,
+			}}
+		}
+	}
+	return nil
+}
+
+// symbolIndex lets stack-frame matching run in O(frames) instead of
+// O(frames * symbols) per Run. Frames carry forms like
+// "com.acme.Order.place(Order.kt:42)"; match accepts the cleaned form
+// being equal to an FQN, sharing its last segment, or being a method
+// on an enclosing class FQN.
+type symbolIndex struct {
+	blob     *snapshot.Blob
+	byFQN    map[string]*snapshot.Symbol
+	bySuffix map[string]*snapshot.Symbol
+}
+
+func indexSymbolsByFQN(blob *snapshot.Blob) *symbolIndex {
+	idx := &symbolIndex{
+		blob:     blob,
+		byFQN:    make(map[string]*snapshot.Symbol, len(blob.Symbols)),
+		bySuffix: make(map[string]*snapshot.Symbol, len(blob.Symbols)),
+	}
+	for i := range blob.Symbols {
+		s := &blob.Symbols[i]
+		if s.FQN == "" {
+			continue
+		}
+		idx.byFQN[s.FQN] = s
+		last := s.FQN
+		if dot := strings.LastIndexByte(last, '.'); dot >= 0 {
+			last = last[dot+1:]
+		}
+		idx.bySuffix[last] = s
+	}
+	return idx
+}
+
+func (idx *symbolIndex) match(frame string) *snapshot.Symbol {
+	clean := frame
+	if i := strings.IndexByte(clean, '('); i >= 0 {
+		clean = clean[:i]
+	}
+	clean = strings.TrimSpace(clean)
+	if clean == "" {
+		return nil
+	}
+	if s, ok := idx.byFQN[clean]; ok {
+		return s
+	}
+	if dot := strings.LastIndexByte(clean, '.'); dot < 0 {
+		if s, ok := idx.bySuffix[clean]; ok {
+			return s
+		}
+	}
+	// Prefix match: walk the dot-separated prefixes of clean, longest
+	// first, so a class FQN wins over its enclosing package.
+	for clean != "" {
+		dot := strings.LastIndexByte(clean, '.')
+		if dot < 0 {
+			break
+		}
+		clean = clean[:dot]
+		if s, ok := idx.byFQN[clean]; ok {
+			return s
+		}
+	}
+	return nil
+}
+
+func moduleForFile(blob *snapshot.Blob, path string) string {
+	for i := range blob.Files {
+		if blob.Files[i].Path == path {
+			return blob.Files[i].Module
+		}
+	}
+	return ""
+}
+
+// testOwnsModuleSignals applies the heuristic that a test under
+// <mod>/src/test|androidTest|integrationTest/... owns the matching
+// <mod>/src/main module.
+func testOwnsModuleSignals(in Input, blob *snapshot.Blob) []Signal {
+	if blob == nil || in.Event.File == "" {
+		return nil
+	}
+	mod := moduleForFile(blob, in.Event.File)
+	if mod == "" {
+		mod = inferModuleFromTestPath(blob, in.Event.File)
+	}
+	if mod == "" {
+		return nil
+	}
+	return []Signal{{
+		CommitSHA: in.Event.CommitSHA,
+		Module:    mod,
+		Tier:      TierTestOwnsModule,
+		Reason:    "test file " + in.Event.File + " owns module " + mod,
+	}}
+}
+
+func inferModuleFromTestPath(blob *snapshot.Blob, path string) string {
+	for _, marker := range []string{"/src/test/", "/src/androidTest/", "/src/integrationTest/"} {
+		if i := strings.Index(path, marker); i > 0 {
+			prefix := path[:i]
+			for _, m := range blob.Modules {
+				if m.Dir == prefix || strings.HasSuffix(m.Dir, prefix) || strings.HasSuffix(prefix, strings.TrimPrefix(m.Dir, "./")) {
+					return m.Path
+				}
+			}
+		}
+	}
+	return ""
+}
+
+// diffTouchesSignals attributes each module touched between adjacent
+// captured snapshots to the "to" side — the first sha where the
+// change is visible.
+func diffTouchesSignals(in Input, timeline []snapshot.Manifest) []Signal {
+	bounded := manifestsInRange(timeline, in.FromSHA, in.ToSHA)
+	if len(bounded) < 2 {
+		return nil
+	}
+	var out []Signal
+	for i := 1; i < len(bounded); i++ {
+		from := bounded[i-1]
+		to := bounded[i]
+		d, err := snapshot.Diff(in.SnapshotsRoot, from.CommitSHA, to.CommitSHA)
+		if err != nil || d == nil {
+			continue
+		}
+		touched := touchedModules(d)
+		for mod := range touched {
+			out = append(out, Signal{
+				CommitSHA: to.CommitSHA,
+				Module:    mod,
+				Tier:      TierDiffTouches,
+				Reason:    "structural delta touches " + mod + " at " + shortSHA(to.CommitSHA),
+			})
+		}
+	}
+	return out
+}
+
+func touchedModules(d *snapshot.DiffResult) map[string]bool {
+	out := make(map[string]bool)
+	for _, f := range d.AddedFiles {
+		if f.Module != "" {
+			out[f.Module] = true
+		}
+	}
+	for _, f := range d.RemovedFiles {
+		if f.Module != "" {
+			out[f.Module] = true
+		}
+	}
+	for _, e := range d.AddedEdges {
+		if e.From != "" {
+			out[e.From] = true
+		}
+	}
+	for _, e := range d.RemovedEdges {
+		if e.From != "" {
+			out[e.From] = true
+		}
+	}
+	for mod := range d.ModuleMetrics {
+		out[mod] = true
+	}
+	return out
+}
+
+// historicalCoOccurrenceSignals suggests modules that previous events
+// of the same kind or signature already implicated. Tier-4 only
+// proposes the module, not the triggering sha, so the candidate
+// commit is the event's own.
+func historicalCoOccurrenceSignals(in Input) []Signal {
+	if len(in.HistoricalEvents) == 0 || in.Event.CommitSHA == "" {
+		return nil
+	}
+	var out []Signal
+	for _, h := range in.HistoricalEvents {
+		if h.ID == in.Event.ID {
+			continue
+		}
+		if h.Module == "" {
+			continue
+		}
+		if !sameKindOrSignature(h, in.Event) {
+			continue
+		}
+		out = append(out, Signal{
+			CommitSHA: in.Event.CommitSHA,
+			Module:    h.Module,
+			Tier:      TierHistoricalCoOcc,
+			Reason:    "module " + h.Module + " previously implicated by " + h.FailureKind,
+		})
+	}
+	return out
+}
+
+func sameKindOrSignature(a, b breakage.Event) bool {
+	if a.FailureKind == b.FailureKind {
+		return true
+	}
+	if a.Signature != "" && a.Signature == b.Signature {
+		return true
+	}
+	return false
+}
+
+// fuse buckets signals by (commit, module), keeps the max prior per
+// bucket, and boosts it toward 1 by the number of agreeing tiers
+// beyond the first. One tier alone never reaches certainty.
+func fuse(signals []Signal) []Candidate {
+	type key struct{ commit, module string }
+	type bucket struct {
+		maxPrior float64
+		tiers    map[Tier]struct{}
+		reasons  []string
+	}
+	buckets := make(map[key]*bucket)
+	for _, s := range signals {
+		if s.Module == "" {
+			continue
+		}
+		k := key{commit: s.CommitSHA, module: s.Module}
+		b := buckets[k]
+		if b == nil {
+			b = &bucket{tiers: make(map[Tier]struct{})}
+			buckets[k] = b
+		}
+		if p := Prior(s.Tier); p > b.maxPrior {
+			b.maxPrior = p
+		}
+		if _, dup := b.tiers[s.Tier]; !dup {
+			b.tiers[s.Tier] = struct{}{}
+			b.reasons = append(b.reasons, s.Reason)
+		}
+	}
+
+	out := make([]Candidate, 0, len(buckets))
+	for k, b := range buckets {
+		agreements := len(b.tiers)
+		boost := 0.0
+		if agreements > 1 {
+			boost = (1.0 - b.maxPrior) * float64(agreements-1) / float64(tierCount-1)
+		}
+		conf := b.maxPrior + boost
+		if conf > 1.0 {
+			conf = 1.0
+		}
+		tiers := tierKeys(b.tiers)
+		out = append(out, Candidate{
+			CommitSHA:  k.commit,
+			Module:     k.module,
+			Confidence: conf,
+			Reasons:    append([]string(nil), b.reasons...),
+			Tiers:      tiers,
+		})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Confidence != out[j].Confidence {
+			return out[i].Confidence > out[j].Confidence
+		}
+		if out[i].CommitSHA != out[j].CommitSHA {
+			return out[i].CommitSHA < out[j].CommitSHA
+		}
+		return out[i].Module < out[j].Module
+	})
+	return out
+}
+
+func tierKeys(m map[Tier]struct{}) []Tier {
+	out := make([]Tier, 0, len(m))
+	for t := range m {
+		out = append(out, t)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i] < out[j] })
+	return out
+}
+
+func shortSHA(s string) string {
+	if len(s) > 12 {
+		return s[:12]
+	}
+	return s
+}

--- a/internal/bisect/bisect_test.go
+++ b/internal/bisect/bisect_test.go
@@ -1,0 +1,188 @@
+package bisect
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/kaeawc/krit/internal/breakage"
+	"github.com/kaeawc/krit/internal/snapshot"
+)
+
+// captureBlob persists a Blob + Metrics + Manifest under root and
+// returns the sha. Helper for fixture timelines.
+func captureBlob(t *testing.T, root, sha string, capturedAt int64, modules []snapshot.Module, files []snapshot.File, symbols []snapshot.Symbol, metrics *snapshot.Metrics) {
+	t.Helper()
+	blob := &snapshot.Blob{
+		SchemaVersion: snapshot.SchemaVersion,
+		CommitSHA:     sha,
+		CapturedAt:    capturedAt,
+		Modules:       modules,
+		Files:         files,
+		Symbols:       symbols,
+	}
+	if _, err := snapshot.Save(root, blob); err != nil {
+		t.Fatalf("Save blob: %v", err)
+	}
+	if metrics != nil {
+		metrics.SchemaVersion = snapshot.MetricsSchemaVersion
+		metrics.CommitSHA = sha
+		metrics.CapturedAt = capturedAt
+		if _, err := snapshot.SaveMetrics(root, metrics); err != nil {
+			t.Fatalf("SaveMetrics: %v", err)
+		}
+	}
+	m := &snapshot.Manifest{
+		SchemaVersion: snapshot.ManifestSchemaVersion,
+		CommitSHA:     sha,
+		CapturedAt:    capturedAt,
+		BlobSchema:    snapshot.SchemaVersion,
+		Files:         len(files),
+		Modules:       len(modules),
+		Symbols:       len(symbols),
+	}
+	if metrics != nil {
+		m.MetricsSchema = snapshot.MetricsSchemaVersion
+	}
+	if _, err := snapshot.SaveManifest(root, m); err != nil {
+		t.Fatalf("SaveManifest: %v", err)
+	}
+}
+
+func TestRunStackFrameRanksTopOne(t *testing.T) {
+	dir := t.TempDir()
+	root := filepath.Join(dir, ".krit", "snapshots")
+
+	const goodSHA = "1111111111111111111111111111111111111111"
+	const badSHA = "2222222222222222222222222222222222222222"
+
+	captureBlob(t, root, goodSHA, 1,
+		[]snapshot.Module{{Path: ":app"}, {Path: ":core"}},
+		[]snapshot.File{{Path: "core/Order.kt", Module: ":core"}, {Path: "app/Main.kt", Module: ":app"}},
+		[]snapshot.Symbol{{FQN: "com.acme.Order", File: "core/Order.kt"}},
+		nil)
+	captureBlob(t, root, badSHA, 2,
+		[]snapshot.Module{{Path: ":app"}, {Path: ":core"}},
+		[]snapshot.File{{Path: "core/Order.kt", Module: ":core"}, {Path: "core/Repo.kt", Module: ":core"}, {Path: "app/Main.kt", Module: ":app"}},
+		[]snapshot.Symbol{{FQN: "com.acme.Order", File: "core/Order.kt"}, {FQN: "com.acme.Repo", File: "core/Repo.kt"}},
+		nil)
+
+	event := breakage.Event{
+		ID:          "evt1",
+		CommitSHA:   badSHA,
+		FailureKind: breakage.KindRuntimeFailure,
+		Frames:      []string{"com.acme.Repo.fetch(Repo.kt:42)"},
+	}
+	res, err := Run(Input{
+		SnapshotsRoot: root,
+		FromSHA:       goodSHA,
+		ToSHA:         badSHA,
+		Event:         event,
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(res.Candidates) == 0 {
+		t.Fatalf("no candidates")
+	}
+	top := res.Candidates[0]
+	if top.Module != ":core" {
+		t.Errorf("top module = %q, want :core", top.Module)
+	}
+	if top.Confidence < 0.95 {
+		t.Errorf("top confidence = %g, want >= 0.95", top.Confidence)
+	}
+	containsTier := func(c Candidate, want Tier) bool {
+		for _, t := range c.Tiers {
+			if t == want {
+				return true
+			}
+		}
+		return false
+	}
+	if !containsTier(top, TierStackFrame) {
+		t.Errorf("top tiers missing stack-frame tier: %+v", top.Tiers)
+	}
+}
+
+func TestRunDiffTouchesRanksTopThree(t *testing.T) {
+	dir := t.TempDir()
+	root := filepath.Join(dir, ".krit", "snapshots")
+
+	const goodSHA = "1111111111111111111111111111111111111111"
+	const midSHA = "2222222222222222222222222222222222222222"
+	const badSHA = "3333333333333333333333333333333333333333"
+
+	captureBlob(t, root, goodSHA, 1,
+		[]snapshot.Module{{Path: ":app"}, {Path: ":core"}},
+		[]snapshot.File{{Path: "core/A.kt", Module: ":core"}},
+		nil, nil)
+	captureBlob(t, root, midSHA, 2,
+		[]snapshot.Module{{Path: ":app"}, {Path: ":core"}, {Path: ":lib"}},
+		[]snapshot.File{{Path: "core/A.kt", Module: ":core"}, {Path: "lib/B.kt", Module: ":lib"}},
+		nil, nil)
+	captureBlob(t, root, badSHA, 3,
+		[]snapshot.Module{{Path: ":app"}, {Path: ":core"}, {Path: ":lib"}},
+		[]snapshot.File{{Path: "core/A.kt", Module: ":core"}, {Path: "lib/B.kt", Module: ":lib"}, {Path: "app/C.kt", Module: ":app"}},
+		nil, nil)
+
+	event := breakage.Event{
+		ID:          "evt2",
+		CommitSHA:   badSHA,
+		FailureKind: breakage.KindTestFailure,
+		Signature:   "x",
+	}
+	res, err := Run(Input{
+		SnapshotsRoot: root,
+		FromSHA:       goodSHA,
+		ToSHA:         badSHA,
+		Event:         event,
+		MaxResults:    3,
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(res.Candidates) == 0 {
+		t.Fatalf("no candidates")
+	}
+	wantModules := map[string]bool{":lib": false, ":app": false}
+	for _, c := range res.Candidates {
+		if _, ok := wantModules[c.Module]; ok {
+			wantModules[c.Module] = true
+		}
+	}
+	for m, found := range wantModules {
+		if !found {
+			t.Errorf("expected module %q in top-3, got %+v", m, res.Candidates)
+		}
+	}
+}
+
+func TestScoreDeltaCosine(t *testing.T) {
+	dir := t.TempDir()
+	root := filepath.Join(dir, ".krit", "snapshots")
+
+	const a = "1111111111111111111111111111111111111111"
+	const b = "2222222222222222222222222222222222222222"
+
+	captureBlob(t, root, a, 1,
+		[]snapshot.Module{{Path: ":app"}},
+		[]snapshot.File{{Path: "app/A.kt", Module: ":app"}},
+		nil,
+		&snapshot.Metrics{Modules: []snapshot.ModuleMetrics{{Path: ":app", LOC: 100, Cyclomatic: 5, FanIn: 1}}, Files: []snapshot.FileMetrics{{Path: "app/A.kt", Module: ":app", LOC: 100, Cyclomatic: 5}}})
+	captureBlob(t, root, b, 2,
+		[]snapshot.Module{{Path: ":app"}},
+		[]snapshot.File{{Path: "app/A.kt", Module: ":app"}},
+		nil,
+		&snapshot.Metrics{Modules: []snapshot.ModuleMetrics{{Path: ":app", LOC: 200, Cyclomatic: 15, FanIn: 4}}, Files: []snapshot.FileMetrics{{Path: "app/A.kt", Module: ":app", LOC: 200, Cyclomatic: 15}}})
+
+	res, err := ScoreDelta(DeltaRiskInput{SnapshotsRoot: root, FromSHA: a, ToSHA: b})
+	if err != nil {
+		t.Fatalf("ScoreDelta: %v", err)
+	}
+	if len(res.Vector) == 0 {
+		t.Fatalf("vector empty")
+	}
+	if _, ok := res.Vector[":app::loc"]; !ok {
+		t.Errorf("vector missing :app::loc, got %+v", res.Vector)
+	}
+}

--- a/internal/bisect/deltarisk.go
+++ b/internal/bisect/deltarisk.go
@@ -1,0 +1,173 @@
+package bisect
+
+import (
+	"fmt"
+	"math"
+	"sort"
+
+	"github.com/kaeawc/krit/internal/breakage"
+	"github.com/kaeawc/krit/internal/snapshot"
+)
+
+// DeltaRiskInput scores a structural delta against historical events.
+// SnapshotsRoot, FromSHA, and ToSHA are required; HistoricalEvents is
+// the ledger to compare against (typically the full event store).
+type DeltaRiskInput struct {
+	SnapshotsRoot    string
+	FromSHA          string
+	ToSHA            string
+	HistoricalEvents []breakage.Event
+	MaxMatches       int
+}
+
+// DeltaRiskMatch is one historical event whose delta vector resembles
+// the current one. Cosine is the similarity in [0, 1]; higher means
+// more similar.
+type DeltaRiskMatch struct {
+	EventID     string  `json:"event_id"`
+	FailureKind string  `json:"failure_kind"`
+	CommitSHA   string  `json:"commit_sha"`
+	Module      string  `json:"module"`
+	Cosine      float64 `json:"cosine"`
+}
+
+// DeltaRiskResult is the scored delta plus its top historical matches.
+// Score is the max cosine across matches — the bigger it is, the more
+// the current delta looks like a previously-recorded breakage.
+type DeltaRiskResult struct {
+	From    string             `json:"from"`
+	To      string             `json:"to"`
+	Score   float64            `json:"score"`
+	Vector  map[string]float64 `json:"vector"`
+	Matches []DeltaRiskMatch   `json:"matches,omitempty"`
+}
+
+// ScoreDelta computes the per-module delta vector between two captured
+// snapshots and scores it against historical events.
+//
+// Vector key form: "<module>::<metric>". Metrics included: loc, files,
+// symbols, public_symbols, cyclomatic, fan_in, fan_out. Modules absent
+// from either side contribute their populated side as a signed delta.
+func ScoreDelta(in DeltaRiskInput) (*DeltaRiskResult, error) {
+	if in.SnapshotsRoot == "" {
+		return nil, fmt.Errorf("deltarisk: SnapshotsRoot required")
+	}
+	if in.FromSHA == "" || in.ToSHA == "" {
+		return nil, fmt.Errorf("deltarisk: FromSHA and ToSHA required")
+	}
+	d, err := snapshot.Diff(in.SnapshotsRoot, in.FromSHA, in.ToSHA)
+	if err != nil {
+		return nil, fmt.Errorf("deltarisk: diff: %w", err)
+	}
+	vec := vectorFromDiff(d)
+	result := &DeltaRiskResult{From: in.FromSHA, To: in.ToSHA, Vector: vec}
+	if len(vec) == 0 || len(in.HistoricalEvents) == 0 {
+		return result, nil
+	}
+
+	// For every historical event whose CommitSHA differs from FromSHA,
+	// compute the diff from its parent (using snapshot.LoadManifests to
+	// find the nearest earlier captured sha) to the event's sha, and
+	// score cosine similarity against the current vector.
+	manifests, err := snapshot.LoadManifests(in.SnapshotsRoot)
+	if err != nil {
+		return nil, fmt.Errorf("deltarisk: load manifests: %w", err)
+	}
+	ordered := orderManifests(manifests)
+	parentOf := buildParentMap(ordered)
+
+	var matches []DeltaRiskMatch
+	seen := make(map[string]bool)
+	for _, ev := range in.HistoricalEvents {
+		if seen[ev.CommitSHA] {
+			continue
+		}
+		seen[ev.CommitSHA] = true
+		parent, ok := parentOf[ev.CommitSHA]
+		if !ok {
+			continue
+		}
+		hd, err := snapshot.Diff(in.SnapshotsRoot, parent, ev.CommitSHA)
+		if err != nil || hd == nil {
+			continue
+		}
+		histVec := vectorFromDiff(hd)
+		if len(histVec) == 0 {
+			continue
+		}
+		cos := cosine(vec, histVec)
+		if cos <= 0 {
+			continue
+		}
+		matches = append(matches, DeltaRiskMatch{
+			EventID:     ev.ID,
+			FailureKind: ev.FailureKind,
+			CommitSHA:   ev.CommitSHA,
+			Module:      ev.Module,
+			Cosine:      cos,
+		})
+	}
+	sort.Slice(matches, func(i, j int) bool { return matches[i].Cosine > matches[j].Cosine })
+	if in.MaxMatches > 0 && len(matches) > in.MaxMatches {
+		matches = matches[:in.MaxMatches]
+	}
+	if len(matches) > 0 {
+		result.Score = matches[0].Cosine
+	}
+	result.Matches = matches
+	return result, nil
+}
+
+// vectorFromDiff projects ModuleMetrics into a sparse string-keyed
+// vector. Zero-deltas are dropped so cosine similarity isn't diluted
+// by metrics that didn't move.
+func vectorFromDiff(d *snapshot.DiffResult) map[string]float64 {
+	if d == nil {
+		return nil
+	}
+	out := make(map[string]float64)
+	for mod, mm := range d.ModuleMetrics {
+		for metric, md := range mm {
+			if md.Delta == 0 {
+				continue
+			}
+			out[mod+"::"+metric] = md.Delta
+		}
+	}
+	return out
+}
+
+// buildParentMap maps each captured sha to its immediate predecessor
+// in capture order. This is a crude stand-in for the git parent and
+// works whenever snapshots have been captured in commit order (the
+// common case for backfill / install-hook).
+func buildParentMap(ordered []snapshot.Manifest) map[string]string {
+	out := make(map[string]string, len(ordered))
+	for i := 1; i < len(ordered); i++ {
+		out[ordered[i].CommitSHA] = ordered[i-1].CommitSHA
+	}
+	return out
+}
+
+// cosine computes cosine similarity between two sparse vectors. The
+// result is in [-1, 1]; negative means the vectors point in opposite
+// directions (one shrunk loc where the other grew loc, etc.).
+func cosine(a, b map[string]float64) float64 {
+	if len(a) == 0 || len(b) == 0 {
+		return 0
+	}
+	var dot, magA, magB float64
+	for k, va := range a {
+		magA += va * va
+		if vb, ok := b[k]; ok {
+			dot += va * vb
+		}
+	}
+	for _, vb := range b {
+		magB += vb * vb
+	}
+	if magA == 0 || magB == 0 {
+		return 0
+	}
+	return dot / (math.Sqrt(magA) * math.Sqrt(magB))
+}

--- a/internal/breakage/ingest.go
+++ b/internal/breakage/ingest.go
@@ -1,0 +1,285 @@
+package breakage
+
+import (
+	"bufio"
+	"encoding/json"
+	"encoding/xml"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+)
+
+// IngestOptions tunes a single ingest invocation. CommitSHA is required
+// because every event must be tied to a commit on the snapshot
+// timeline.
+type IngestOptions struct {
+	CommitSHA string
+	Source    string
+	// OccurredAt overrides the event timestamp; zero means "now".
+	OccurredAt time.Time
+}
+
+func (o IngestOptions) occurred() int64 {
+	if o.OccurredAt.IsZero() {
+		return time.Now().UnixMilli()
+	}
+	return o.OccurredAt.UnixMilli()
+}
+
+type junitDetail struct {
+	Message string `xml:"message,attr"`
+	Type    string `xml:"type,attr"`
+	Body    string `xml:",chardata"`
+}
+
+type junitTestCase struct {
+	Classname string        `xml:"classname,attr"`
+	Name      string        `xml:"name,attr"`
+	File      string        `xml:"file,attr"`
+	Failures  []junitDetail `xml:"failure"`
+	Errors    []junitDetail `xml:"error"`
+}
+
+// IngestJUnit parses a JUnit XML stream and emits one Event per failed
+// or errored test case. Successful cases are skipped — bisect only
+// needs the breakage signal.
+func IngestJUnit(r io.Reader, opts IngestOptions) ([]Event, error) {
+	if opts.CommitSHA == "" {
+		return nil, fmt.Errorf("breakage: IngestJUnit: commit_sha required")
+	}
+	src := opts.Source
+	if src == "" {
+		src = SourceCI
+	}
+	occurred := opts.occurred()
+
+	dec := xml.NewDecoder(r)
+	var out []Event
+	for {
+		tok, err := dec.Token()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("breakage: parse junit: %w", err)
+		}
+		start, ok := tok.(xml.StartElement)
+		if !ok || start.Name.Local != "testcase" {
+			continue
+		}
+		var c junitTestCase
+		if err := dec.DecodeElement(&c, &start); err != nil {
+			return nil, fmt.Errorf("breakage: decode testcase: %w", err)
+		}
+		if len(c.Failures) == 0 && len(c.Errors) == 0 {
+			continue
+		}
+		fail := firstNonEmpty(junitMessages(c.Failures, c.Errors)...)
+		symbol := strings.TrimSpace(c.Classname)
+		if c.Name != "" {
+			if symbol != "" {
+				symbol += "." + c.Name
+			} else {
+				symbol = c.Name
+			}
+		}
+		e := Event{
+			OccurredAt:  occurred,
+			CommitSHA:   opts.CommitSHA,
+			FailureKind: KindTestFailure,
+			Signature:   Normalize(fail),
+			Symbol:      symbol,
+			File:        c.File,
+			Source:      src,
+			Message:     fail,
+		}
+		e.ID = HashID(e.FailureKind, e.Signature, e.CommitSHA, e.Source)
+		out = append(out, e)
+	}
+	return out, nil
+}
+
+func junitMessages(failures, errs []junitDetail) []string {
+	out := make([]string, 0, len(failures)+len(errs))
+	for _, f := range failures {
+		out = append(out, strings.TrimSpace(f.Message+" "+f.Body))
+	}
+	for _, e := range errs {
+		out = append(out, strings.TrimSpace(e.Message+" "+e.Body))
+	}
+	return out
+}
+
+func firstNonEmpty(ss ...string) string {
+	for _, s := range ss {
+		if strings.TrimSpace(s) != "" {
+			return s
+		}
+	}
+	return ""
+}
+
+// IngestGoTest reads `go test -json` output and emits one event per
+// failed test. Skipped/passed actions are ignored. Output records that
+// can't be parsed as JSON are skipped silently so partial logs still
+// produce signal.
+func IngestGoTest(r io.Reader, opts IngestOptions) ([]Event, error) {
+	if opts.CommitSHA == "" {
+		return nil, fmt.Errorf("breakage: IngestGoTest: commit_sha required")
+	}
+	src := opts.Source
+	if src == "" {
+		src = SourceCI
+	}
+	occurred := opts.occurred()
+
+	type record struct {
+		Action  string `json:"Action"`
+		Package string `json:"Package"`
+		Test    string `json:"Test"`
+		Output  string `json:"Output"`
+	}
+
+	type key struct{ pkg, test string }
+	buffers := make(map[key]*strings.Builder)
+	var out []Event
+	sc := bufio.NewScanner(r)
+	sc.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+	for sc.Scan() {
+		line := sc.Bytes()
+		if len(line) == 0 || line[0] != '{' {
+			continue
+		}
+		var rec record
+		if err := json.Unmarshal(line, &rec); err != nil {
+			continue
+		}
+		if rec.Test == "" {
+			continue
+		}
+		k := key{rec.Package, rec.Test}
+		switch rec.Action {
+		case "output":
+			b := buffers[k]
+			if b == nil {
+				b = &strings.Builder{}
+				buffers[k] = b
+			}
+			b.WriteString(rec.Output)
+		case "fail":
+			b := buffers[k]
+			var msg string
+			if b != nil {
+				msg = b.String()
+			}
+			symbol := rec.Test
+			if rec.Package != "" {
+				symbol = rec.Package + "." + rec.Test
+			}
+			e := Event{
+				OccurredAt:  occurred,
+				CommitSHA:   opts.CommitSHA,
+				FailureKind: KindTestFailure,
+				Signature:   Normalize(msg),
+				Symbol:      symbol,
+				Source:      src,
+				Message:     strings.TrimSpace(msg),
+			}
+			e.ID = HashID(e.FailureKind, e.Signature, e.CommitSHA, e.Source)
+			out = append(out, e)
+			delete(buffers, k)
+		case "pass", "skip":
+			delete(buffers, k)
+		}
+	}
+	if err := sc.Err(); err != nil {
+		return nil, fmt.Errorf("breakage: scan go test json: %w", err)
+	}
+	return out, nil
+}
+
+// GenericEvent is the externally-facing JSON shape consumers can post
+// with `krit breakage record --kind generic --from file.json`. It's
+// deliberately a loose superset of Event so producers can omit
+// optional fields.
+type GenericEvent struct {
+	FailureKind string   `json:"failure_kind"`
+	Signature   string   `json:"signature"`
+	Module      string   `json:"module,omitempty"`
+	File        string   `json:"file,omitempty"`
+	Symbol      string   `json:"symbol,omitempty"`
+	Source      string   `json:"source,omitempty"`
+	Frames      []string `json:"frames,omitempty"`
+	Message     string   `json:"message,omitempty"`
+}
+
+// IngestGeneric reads a JSON document (single event or array of events)
+// and emits the resulting Events. CommitSHA from opts is applied to all
+// emitted events.
+func IngestGeneric(r io.Reader, opts IngestOptions) ([]Event, error) {
+	if opts.CommitSHA == "" {
+		return nil, fmt.Errorf("breakage: IngestGeneric: commit_sha required")
+	}
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return nil, fmt.Errorf("breakage: read generic: %w", err)
+	}
+	src := opts.Source
+	if src == "" {
+		src = SourceLocal
+	}
+	occurred := opts.occurred()
+
+	trimmed := strings.TrimSpace(string(data))
+	if trimmed == "" {
+		return nil, nil
+	}
+	var arr []GenericEvent
+	if trimmed[0] == '[' {
+		if err := json.Unmarshal(data, &arr); err != nil {
+			return nil, fmt.Errorf("breakage: parse generic array: %w", err)
+		}
+	} else {
+		var one GenericEvent
+		if err := json.Unmarshal(data, &one); err != nil {
+			return nil, fmt.Errorf("breakage: parse generic event: %w", err)
+		}
+		arr = []GenericEvent{one}
+	}
+
+	out := make([]Event, 0, len(arr))
+	for _, g := range arr {
+		kind := g.FailureKind
+		if kind == "" {
+			kind = KindRuntimeFailure
+		}
+		sig := g.Signature
+		if sig == "" {
+			sig = Normalize(g.Message)
+		}
+		ev := Event{
+			OccurredAt:  occurred,
+			CommitSHA:   opts.CommitSHA,
+			FailureKind: kind,
+			Signature:   sig,
+			Module:      g.Module,
+			File:        g.File,
+			Symbol:      g.Symbol,
+			Source:      pickSource(g.Source, src),
+			Frames:      g.Frames,
+			Message:     g.Message,
+		}
+		ev.ID = HashID(ev.FailureKind, ev.Signature, ev.CommitSHA, ev.Source)
+		out = append(out, ev)
+	}
+	return out, nil
+}
+
+func pickSource(explicit, fallback string) string {
+	if strings.TrimSpace(explicit) != "" {
+		return explicit
+	}
+	return fallback
+}

--- a/internal/breakage/signature.go
+++ b/internal/breakage/signature.go
@@ -1,0 +1,58 @@
+package breakage
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"regexp"
+	"strings"
+)
+
+// Normalize collapses transient details out of a failure message so
+// the same underlying breakage produces the same signature across
+// reruns. The goal is not a perfect canonicalisation — it's "stable
+// enough to join events from different runs to the same bucket."
+//
+// Transformations:
+//   - strip ANSI escape sequences;
+//   - collapse hex addresses / pointers (0x...) to <addr>;
+//   - collapse any decimal run of >=3 digits to <n> (file line numbers,
+//     durations, durations-in-ms, retries);
+//   - collapse repeated whitespace to a single space;
+//   - lowercase and trim.
+//
+// Callers that want to keep numeric detail (e.g. a finding count) should
+// pass the structured field separately rather than baking it into the
+// raw signature string.
+var (
+	ansiRe = regexp.MustCompile(`\x1b\[[0-9;]*[A-Za-z]`)
+	hexRe  = regexp.MustCompile(`0x[0-9a-fA-F]+`)
+	numRe  = regexp.MustCompile(`\d{3,}`)
+	wsRe   = regexp.MustCompile(`\s+`)
+)
+
+func Normalize(raw string) string {
+	if raw == "" {
+		return ""
+	}
+	s := ansiRe.ReplaceAllString(raw, "")
+	s = hexRe.ReplaceAllString(s, "<addr>")
+	s = numRe.ReplaceAllString(s, "<n>")
+	s = wsRe.ReplaceAllString(s, " ")
+	return strings.TrimSpace(strings.ToLower(s))
+}
+
+// HashID computes a stable 16-char hex ID for an event from its
+// normalised signature, failure kind, commit sha, and source. The ID
+// is content-derived so re-ingesting the same event from the same
+// source is idempotent — store-level dedupe leans on it.
+func HashID(kind, signature, commitSHA, source string) string {
+	h := sha256.New()
+	h.Write([]byte(kind))
+	h.Write([]byte{0})
+	h.Write([]byte(signature))
+	h.Write([]byte{0})
+	h.Write([]byte(commitSHA))
+	h.Write([]byte{0})
+	h.Write([]byte(source))
+	return hex.EncodeToString(h.Sum(nil))[:16]
+}

--- a/internal/breakage/signature_test.go
+++ b/internal/breakage/signature_test.go
@@ -1,0 +1,38 @@
+package breakage
+
+import "testing"
+
+func TestNormalize(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"  Failed: timeout after 12345ms\t\n", "failed: timeout after <n>ms"},
+		{"panic: runtime error at 0xdeadbeef", "panic: runtime error at <addr>"},
+		{"\x1b[31mError\x1b[0m: bad", "error: bad"},
+		{"", ""},
+		{"42", "42"}, // <3 digits: kept
+		{"line 100 col 99", "line <n> col 99"},
+	}
+	for _, tc := range tests {
+		got := Normalize(tc.in)
+		if got != tc.want {
+			t.Errorf("Normalize(%q): got %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestHashIDStable(t *testing.T) {
+	a := HashID("test-failure", "x", "abc123", "ci")
+	b := HashID("test-failure", "x", "abc123", "ci")
+	if a != b {
+		t.Fatalf("HashID not stable: %q vs %q", a, b)
+	}
+	c := HashID("test-failure", "x", "abc123", "local")
+	if a == c {
+		t.Fatalf("HashID should differ by source: both %q", a)
+	}
+	if len(a) != 16 {
+		t.Fatalf("HashID should be 16 chars, got %d", len(a))
+	}
+}

--- a/internal/breakage/store.go
+++ b/internal/breakage/store.go
@@ -1,0 +1,145 @@
+package breakage
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"sync"
+
+	"github.com/kaeawc/krit/internal/fsutil"
+)
+
+const eventsFileName = "breakage_events.json"
+
+// EventsFile is the on-disk shape of breakage_events.json.
+type EventsFile struct {
+	SchemaVersion int     `json:"schema_version"`
+	Events        []Event `json:"events"`
+}
+
+// EventsPath returns the canonical events file inside a snapshots root.
+func EventsPath(snapshotsRoot string) string {
+	return filepath.Join(snapshotsRoot, eventsFileName)
+}
+
+var storeMu sync.Mutex
+
+// Load reads the events file. Returns (nil, nil) when the file does
+// not exist or carries a higher schema version than this binary
+// understands so callers can degrade to "no historical events" without
+// breaking.
+func Load(snapshotsRoot string) (*EventsFile, error) {
+	data, err := os.ReadFile(EventsPath(snapshotsRoot))
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("breakage: read events: %w", err)
+	}
+	var ef EventsFile
+	if err := json.Unmarshal(data, &ef); err != nil {
+		return nil, fmt.Errorf("breakage: parse events: %w", err)
+	}
+	if ef.SchemaVersion > EventsSchemaVersion {
+		return nil, nil
+	}
+	return &ef, nil
+}
+
+// LoadAll is a convenience that returns the events slice (possibly nil).
+func LoadAll(snapshotsRoot string) ([]Event, error) {
+	ef, err := Load(snapshotsRoot)
+	if err != nil {
+		return nil, err
+	}
+	if ef == nil {
+		return nil, nil
+	}
+	return ef.Events, nil
+}
+
+// Record appends events to the on-disk file, deduplicating on Event.ID.
+// Missing IDs are filled in from HashID. Validation errors abort the
+// batch without writing — the returned count is 0 in that case.
+func Record(snapshotsRoot string, events ...Event) (int, error) {
+	if len(events) == 0 {
+		return 0, nil
+	}
+	storeMu.Lock()
+	defer storeMu.Unlock()
+
+	existing, err := Load(snapshotsRoot)
+	if err != nil {
+		return 0, err
+	}
+	ef := EventsFile{SchemaVersion: EventsSchemaVersion}
+	if existing != nil {
+		ef.Events = existing.Events
+	}
+	seen := make(map[string]struct{}, len(ef.Events))
+	for _, e := range ef.Events {
+		seen[e.ID] = struct{}{}
+	}
+	added := 0
+	for _, e := range events {
+		if e.CommitSHA == "" || e.FailureKind == "" {
+			return 0, fmt.Errorf("breakage: event requires commit_sha and failure_kind")
+		}
+		if e.Source == "" {
+			e.Source = SourceLocal
+		}
+		if e.Signature == "" {
+			e.Signature = Normalize(e.Message)
+		}
+		if e.ID == "" {
+			e.ID = HashID(e.FailureKind, e.Signature, e.CommitSHA, e.Source)
+		}
+		if _, dup := seen[e.ID]; dup {
+			continue
+		}
+		seen[e.ID] = struct{}{}
+		ef.Events = append(ef.Events, e)
+		added++
+	}
+	if added == 0 {
+		return 0, nil
+	}
+	sort.Slice(ef.Events, func(i, j int) bool {
+		if ef.Events[i].OccurredAt != ef.Events[j].OccurredAt {
+			return ef.Events[i].OccurredAt < ef.Events[j].OccurredAt
+		}
+		return ef.Events[i].ID < ef.Events[j].ID
+	})
+
+	payload, err := json.MarshalIndent(ef, "", "  ")
+	if err != nil {
+		return 0, fmt.Errorf("breakage: marshal events: %w", err)
+	}
+	payload = append(payload, '\n')
+	if err := os.MkdirAll(snapshotsRoot, 0o755); err != nil {
+		return 0, fmt.Errorf("breakage: mkdir %s: %w", snapshotsRoot, err)
+	}
+	if err := fsutil.WriteFileAtomic(EventsPath(snapshotsRoot), payload, 0o644); err != nil {
+		return 0, fmt.Errorf("breakage: write events: %w", err)
+	}
+	return added, nil
+}
+
+// FindByID returns the event with the given ID, or (nil, nil) when not
+// present.
+func FindByID(snapshotsRoot, id string) (*Event, error) {
+	events, err := LoadAll(snapshotsRoot)
+	if err != nil {
+		return nil, err
+	}
+	for i := range events {
+		if events[i].ID == id {
+			cp := events[i]
+			return &cp, nil
+		}
+	}
+	return nil, nil
+}

--- a/internal/breakage/store_test.go
+++ b/internal/breakage/store_test.go
@@ -1,0 +1,136 @@
+package breakage
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRecordDedupes(t *testing.T) {
+	root := t.TempDir()
+	ev := Event{
+		CommitSHA:   "abc123",
+		FailureKind: KindTestFailure,
+		Signature:   "failed: x",
+		Source:      SourceCI,
+		OccurredAt:  100,
+	}
+
+	added, err := Record(root, ev)
+	if err != nil {
+		t.Fatalf("Record: %v", err)
+	}
+	if added != 1 {
+		t.Fatalf("first Record: added=%d, want 1", added)
+	}
+	added, err = Record(root, ev)
+	if err != nil {
+		t.Fatalf("Record (dup): %v", err)
+	}
+	if added != 0 {
+		t.Fatalf("dup Record: added=%d, want 0", added)
+	}
+
+	events, err := LoadAll(root)
+	if err != nil {
+		t.Fatalf("LoadAll: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("LoadAll: got %d events, want 1", len(events))
+	}
+	if events[0].ID == "" {
+		t.Fatalf("LoadAll: ID was not populated")
+	}
+}
+
+func TestRecordRequiresCommitAndKind(t *testing.T) {
+	root := t.TempDir()
+	if _, err := Record(root, Event{FailureKind: KindTestFailure}); err == nil {
+		t.Errorf("Record without commit_sha should error")
+	}
+	if _, err := Record(root, Event{CommitSHA: "abc"}); err == nil {
+		t.Errorf("Record without failure_kind should error")
+	}
+}
+
+func TestIngestJUnit(t *testing.T) {
+	xml := `<testsuites>
+		<testsuite name="s">
+			<testcase classname="com.acme.OrderTest" name="placesOrder" file="OrderTest.kt"/>
+			<testcase classname="com.acme.OrderTest" name="rejectsBadInput" file="OrderTest.kt">
+				<failure message="expected 5 but got 7" type="AssertionError">stack body</failure>
+			</testcase>
+			<testcase classname="com.acme.PaymentTest" name="charges">
+				<error message="NPE">at com.acme.Payment.charge(Payment.kt:42)</error>
+			</testcase>
+		</testsuite>
+	</testsuites>`
+	events, err := IngestJUnit(strings.NewReader(xml), IngestOptions{CommitSHA: "deadbeef"})
+	if err != nil {
+		t.Fatalf("IngestJUnit: %v", err)
+	}
+	if len(events) != 2 {
+		t.Fatalf("got %d events, want 2 (only failures + errors)", len(events))
+	}
+	for _, e := range events {
+		if e.CommitSHA != "deadbeef" {
+			t.Errorf("event commit_sha=%q", e.CommitSHA)
+		}
+		if e.FailureKind != KindTestFailure {
+			t.Errorf("event kind=%q", e.FailureKind)
+		}
+		if e.Source != SourceCI {
+			t.Errorf("event source=%q, want %q", e.Source, SourceCI)
+		}
+		if e.ID == "" {
+			t.Errorf("event ID empty")
+		}
+		if e.Symbol == "" {
+			t.Errorf("event symbol empty")
+		}
+	}
+}
+
+func TestIngestGoTest(t *testing.T) {
+	stream := strings.Join([]string{
+		`{"Action":"run","Package":"x","Test":"TestA"}`,
+		`{"Action":"output","Package":"x","Test":"TestA","Output":"--- FAIL: TestA (0.01s)\n"}`,
+		`{"Action":"output","Package":"x","Test":"TestA","Output":"    x.go:42: expected 1 got 2\n"}`,
+		`{"Action":"fail","Package":"x","Test":"TestA"}`,
+		`{"Action":"run","Package":"x","Test":"TestB"}`,
+		`{"Action":"pass","Package":"x","Test":"TestB"}`,
+		``,
+	}, "\n")
+	events, err := IngestGoTest(strings.NewReader(stream), IngestOptions{CommitSHA: "abc"})
+	if err != nil {
+		t.Fatalf("IngestGoTest: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("got %d events, want 1", len(events))
+	}
+	if events[0].Symbol != "x.TestA" {
+		t.Errorf("symbol=%q, want x.TestA", events[0].Symbol)
+	}
+	if !strings.Contains(events[0].Message, "expected 1 got 2") {
+		t.Errorf("message lost: %q", events[0].Message)
+	}
+}
+
+func TestIngestGenericArrayAndSingle(t *testing.T) {
+	single := `{"failure_kind":"runtime-failure","message":"OOM","module":":app"}`
+	events, err := IngestGeneric(strings.NewReader(single), IngestOptions{CommitSHA: "abc"})
+	if err != nil {
+		t.Fatalf("single: %v", err)
+	}
+	if len(events) != 1 || events[0].Module != ":app" {
+		t.Fatalf("single: %+v", events)
+	}
+
+	arr := `[{"failure_kind":"runtime-failure","message":"OOM"},{"failure_kind":"build-failure","message":"link"}]`
+	events, err = IngestGeneric(strings.NewReader(arr), IngestOptions{CommitSHA: "abc"})
+	if err != nil {
+		t.Fatalf("array: %v", err)
+	}
+	if len(events) != 2 {
+		t.Fatalf("array: got %d events, want 2", len(events))
+	}
+}

--- a/internal/breakage/types.go
+++ b/internal/breakage/types.go
@@ -1,0 +1,48 @@
+// Package breakage records failure-localization events keyed to the
+// snapshot timeline. Events name a failure (test, build, runtime, or a
+// krit-finding regression) and carry just enough structure for the
+// internal/bisect package to fuse location signals across them.
+package breakage
+
+// EventsSchemaVersion versions the on-disk events.json layout. Bumped
+// when a reader couldn't tolerate a new field; readers seeing a higher
+// version fall back to an empty event set rather than erroring out.
+const EventsSchemaVersion = 1
+
+const (
+	SourceCI          = "ci"
+	SourceLocal       = "local"
+	SourceKritFinding = "krit-finding"
+	SourceRuntime     = "runtime"
+	SourceSelfCapture = "self-capture"
+)
+
+const (
+	KindTestFailure           = "test-failure"
+	KindBuildFailure          = "build-failure"
+	KindRuntimeFailure        = "runtime-failure"
+	KindKritFindingRegression = "krit-finding-regression"
+)
+
+// Event is a single recorded breakage. All fields are stable across
+// ingest sources so the bisect layer can join them on (signature,
+// failure_kind) without dispatching by source.
+type Event struct {
+	ID          string `json:"id"`
+	OccurredAt  int64  `json:"occurred_at"`
+	CommitSHA   string `json:"commit_sha"`
+	FailureKind string `json:"failure_kind"`
+	Signature   string `json:"signature"`
+	Module      string `json:"module,omitempty"`
+	File        string `json:"file,omitempty"`
+	Symbol      string `json:"symbol,omitempty"`
+	Source      string `json:"source"`
+	// Frames is the optional stack-frame ladder for runtime failures.
+	// Tier-1 signal fusion walks these in order, top frame first, until
+	// it finds one mapped to a symbol in the snapshot graph.
+	Frames []string `json:"frames,omitempty"`
+	// Message is a human-readable failure description. Not used for
+	// ranking; surfaced in bisect output so operators can correlate
+	// against their original error logs.
+	Message string `json:"message,omitempty"`
+}

--- a/internal/cli/bisect/bisect.go
+++ b/internal/cli/bisect/bisect.go
@@ -1,0 +1,116 @@
+// Package bisect implements the `krit bisect-structure` CLI verb. It
+// fuses location signals across the snapshot timeline and returns
+// ranked (commit, module, reason, confidence) explanations for a
+// given breakage event.
+package bisect
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+
+	bisectpkg "github.com/kaeawc/krit/internal/bisect"
+	brk "github.com/kaeawc/krit/internal/breakage"
+	"github.com/kaeawc/krit/internal/cli/clishared"
+	snap "github.com/kaeawc/krit/internal/snapshot"
+)
+
+const usage = `usage: krit bisect-structure --from <sha> --to <sha> --event <id> [flags]
+
+  Explain a recorded breakage by fusing location signals across the
+  captured snapshot timeline. Returns a ranked list of (commit, module,
+  reason, confidence) candidates.
+
+Flags:
+  --repo PATH     repo root (default: cwd)
+  --from SHA      good (or last-known-good) sha bounding the search
+  --to SHA        bad (or current) sha bounding the search
+  --event ID      breakage event id (from ` + "`" + `krit breakage list` + "`" + `)
+  --format FMT    text|json (default: text)
+  --max-results N cap the number of candidates returned (default: 10)
+`
+
+func Run(args []string) int {
+	fs := flag.NewFlagSet("bisect-structure", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	repoFlag := fs.String("repo", "", "repository root (default: cwd)")
+	fromFlag := fs.String("from", "", "good sha")
+	toFlag := fs.String("to", "", "bad sha")
+	eventFlag := fs.String("event", "", "breakage event id")
+	formatFlag := fs.String("format", "text", "text|json")
+	maxResultsFlag := fs.Int("max-results", 10, "cap on returned candidates")
+	if err := fs.Parse(args); err != nil {
+		return 1
+	}
+	if *eventFlag == "" {
+		fmt.Fprint(os.Stderr, usage)
+		return 1
+	}
+
+	repoRoot, code := clishared.ResolveRepoRoot(*repoFlag)
+	if code != 0 {
+		return code
+	}
+	root := snap.SnapshotsDir(repoRoot)
+
+	event, err := brk.FindByID(root, *eventFlag)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		return 1
+	}
+	if event == nil {
+		fmt.Fprintf(os.Stderr, "error: no breakage event with id %q (try `krit breakage list`)\n", *eventFlag)
+		return 1
+	}
+
+	all, err := brk.LoadAll(root)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		return 1
+	}
+	fromSHA := clishared.ResolveCommitOrLiteral(repoRoot, *fromFlag)
+	toSHA := clishared.ResolveCommitOrLiteral(repoRoot, *toFlag)
+
+	res, err := bisectpkg.Run(bisectpkg.Input{
+		SnapshotsRoot:    root,
+		FromSHA:          fromSHA,
+		ToSHA:            toSHA,
+		Event:            *event,
+		HistoricalEvents: all,
+		MaxResults:       *maxResultsFlag,
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		return 1
+	}
+	if *formatFlag == "json" {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(res); err != nil {
+			fmt.Fprintf(os.Stderr, "error: %v\n", err)
+			return 1
+		}
+		return 0
+	}
+	printText(res)
+	return 0
+}
+
+func printText(res *bisectpkg.Result) {
+	fmt.Printf("event %s (%s)\n", res.Event.ID, res.Event.FailureKind)
+	if res.Event.Message != "" {
+		fmt.Printf("  message: %s\n", res.Event.Message)
+	}
+	fmt.Printf("range: %s -> %s\n", clishared.ShortSHA(res.From), clishared.ShortSHA(res.To))
+	if len(res.Candidates) == 0 {
+		fmt.Println("no candidates")
+		return
+	}
+	for i, c := range res.Candidates {
+		fmt.Printf("\n#%d  %s  %s  confidence=%.2f\n", i+1, clishared.ShortSHA(c.CommitSHA), c.Module, c.Confidence)
+		for _, r := range c.Reasons {
+			fmt.Printf("    %s\n", r)
+		}
+	}
+}

--- a/internal/cli/breakage/breakage.go
+++ b/internal/cli/breakage/breakage.go
@@ -1,0 +1,142 @@
+// Package breakage implements the `krit breakage` CLI verb. It ingests
+// failure events from JUnit XML, `go test -json`, or generic JSON
+// payloads and appends them to the snapshot-adjacent event store.
+package breakage
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	brk "github.com/kaeawc/krit/internal/breakage"
+	"github.com/kaeawc/krit/internal/cli/clishared"
+	snap "github.com/kaeawc/krit/internal/snapshot"
+)
+
+const usage = `usage: krit breakage <record|list> [flags]
+
+  record   ingest failure events into the breakage store
+  list     print recorded events as JSON
+
+Record flags:
+  --repo PATH       repo root (default: cwd)
+  --kind FORMAT     ingest format: junit|gotest|generic (default: generic)
+  --from PATH       read events from file (default: stdin)
+  --commit SHA      commit sha events are attributed to (default: HEAD)
+  --source NAME     source label (ci|local|krit-finding|runtime) (default: depends on kind)
+`
+
+func Run(args []string) int {
+	if len(args) == 0 {
+		fmt.Fprint(os.Stderr, usage)
+		return 1
+	}
+	switch args[0] {
+	case "record":
+		return runRecord(args[1:])
+	case "list":
+		return runList(args[1:])
+	default:
+		fmt.Fprintf(os.Stderr, "unknown breakage subcommand: %s\n%s", args[0], usage)
+		return 1
+	}
+}
+
+func runRecord(args []string) int {
+	fs := flag.NewFlagSet("breakage record", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	repoFlag := fs.String("repo", "", "repository root (default: cwd)")
+	kindFlag := fs.String("kind", "generic", "junit|gotest|generic")
+	fromFlag := fs.String("from", "", "input file (default: stdin)")
+	commitFlag := fs.String("commit", "HEAD", "commit sha events are attributed to")
+	sourceFlag := fs.String("source", "", "source label")
+	if err := fs.Parse(args); err != nil {
+		return 1
+	}
+
+	repoRoot, code := clishared.ResolveRepoRoot(*repoFlag)
+	if code != 0 {
+		return code
+	}
+	sha := clishared.ResolveCommitOrLiteral(repoRoot, *commitFlag)
+
+	r, closer, err := openInput(*fromFlag)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		return 1
+	}
+	defer closer()
+
+	opts := brk.IngestOptions{
+		CommitSHA:  sha,
+		Source:     *sourceFlag,
+		OccurredAt: time.Now(),
+	}
+
+	var events []brk.Event
+	switch *kindFlag {
+	case "junit":
+		events, err = brk.IngestJUnit(r, opts)
+	case "gotest":
+		events, err = brk.IngestGoTest(r, opts)
+	case "generic":
+		events, err = brk.IngestGeneric(r, opts)
+	default:
+		fmt.Fprintf(os.Stderr, "unknown kind %q (want junit|gotest|generic)\n", *kindFlag)
+		return 1
+	}
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		return 1
+	}
+
+	root := snap.SnapshotsDir(repoRoot)
+	added, err := brk.Record(root, events...)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		return 1
+	}
+	fmt.Fprintf(os.Stderr, "breakage: %d parsed, %d newly recorded (%d duplicates skipped)\n",
+		len(events), added, len(events)-added)
+	return 0
+}
+
+func runList(args []string) int {
+	fs := flag.NewFlagSet("breakage list", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	repoFlag := fs.String("repo", "", "repository root (default: cwd)")
+	if err := fs.Parse(args); err != nil {
+		return 1
+	}
+	repoRoot, code := clishared.ResolveRepoRoot(*repoFlag)
+	if code != 0 {
+		return code
+	}
+	root := snap.SnapshotsDir(repoRoot)
+	events, err := brk.LoadAll(root)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		return 1
+	}
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(events); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		return 1
+	}
+	return 0
+}
+
+func openInput(path string) (io.Reader, func(), error) {
+	if path == "" || path == "-" {
+		return os.Stdin, func() {}, nil
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, nil, err
+	}
+	return f, func() { _ = f.Close() }, nil
+}

--- a/internal/cli/clishared/helpers.go
+++ b/internal/cli/clishared/helpers.go
@@ -3,6 +3,7 @@
 package clishared
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -10,7 +11,46 @@ import (
 	"github.com/kaeawc/krit/internal/config"
 	"github.com/kaeawc/krit/internal/module"
 	"github.com/kaeawc/krit/internal/scanner"
+	"github.com/kaeawc/krit/internal/snapshot"
 )
+
+// ResolveRepoRoot honors --repo, falling back to cwd. Returns the
+// resolved root and an exit code; non-zero exit means an error has
+// already been reported to stderr.
+func ResolveRepoRoot(flagValue string) (string, int) {
+	if flagValue != "" {
+		return flagValue, 0
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		return "", 1
+	}
+	return cwd, 0
+}
+
+// ResolveCommitOrLiteral tries `git rev-parse ref` inside repoRoot and
+// falls back to the literal ref on failure. Captured snapshots may
+// outlive a branch, so a literal sha needs to keep working without
+// git.
+func ResolveCommitOrLiteral(repoRoot, ref string) string {
+	if ref == "" {
+		return ""
+	}
+	if sha, err := snapshot.ResolveCommitSHA(repoRoot, ref); err == nil {
+		return sha
+	}
+	return ref
+}
+
+// ShortSHA returns the first 12 chars of a commit sha, or the input
+// unchanged when shorter. Matches `git rev-parse --short=12`.
+func ShortSHA(sha string) string {
+	if len(sha) > 12 {
+		return sha[:12]
+	}
+	return sha
+}
 
 // FindConfigInDir probes dir for the first present file in
 // config.Filenames and returns its path, or "" when none is present

--- a/internal/cli/deltarisk/deltarisk.go
+++ b/internal/cli/deltarisk/deltarisk.go
@@ -1,0 +1,102 @@
+// Package deltarisk implements the `krit delta-risk` CLI verb. It
+// scores a structural delta between two captured snapshots against
+// historical breakage events and returns the resemblance score plus
+// the top matching events.
+package deltarisk
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+
+	bisectpkg "github.com/kaeawc/krit/internal/bisect"
+	brk "github.com/kaeawc/krit/internal/breakage"
+	"github.com/kaeawc/krit/internal/cli/clishared"
+	snap "github.com/kaeawc/krit/internal/snapshot"
+)
+
+const usage = `usage: krit delta-risk --from <sha> --to <sha> [flags]
+
+  Score a structural delta against historical breakage events. Returns
+  the maximum cosine similarity against any historical delta plus the
+  top matches.
+
+Flags:
+  --repo PATH     repo root (default: cwd)
+  --from SHA      from sha
+  --to SHA        to sha
+  --format FMT    text|json (default: text)
+  --max-matches N cap on returned matches (default: 5)
+`
+
+func Run(args []string) int {
+	fs := flag.NewFlagSet("delta-risk", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	repoFlag := fs.String("repo", "", "repository root (default: cwd)")
+	fromFlag := fs.String("from", "", "from sha")
+	toFlag := fs.String("to", "", "to sha")
+	formatFlag := fs.String("format", "text", "text|json")
+	maxMatchesFlag := fs.Int("max-matches", 5, "cap on returned matches")
+	if err := fs.Parse(args); err != nil {
+		return 1
+	}
+	if *fromFlag == "" || *toFlag == "" {
+		fmt.Fprint(os.Stderr, usage)
+		return 1
+	}
+
+	repoRoot, code := clishared.ResolveRepoRoot(*repoFlag)
+	if code != 0 {
+		return code
+	}
+	root := snap.SnapshotsDir(repoRoot)
+	fromSHA := clishared.ResolveCommitOrLiteral(repoRoot, *fromFlag)
+	toSHA := clishared.ResolveCommitOrLiteral(repoRoot, *toFlag)
+
+	all, err := brk.LoadAll(root)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		return 1
+	}
+	res, err := bisectpkg.ScoreDelta(bisectpkg.DeltaRiskInput{
+		SnapshotsRoot:    root,
+		FromSHA:          fromSHA,
+		ToSHA:            toSHA,
+		HistoricalEvents: all,
+		MaxMatches:       *maxMatchesFlag,
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		return 1
+	}
+
+	if *formatFlag == "json" {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(res); err != nil {
+			fmt.Fprintf(os.Stderr, "error: %v\n", err)
+			return 1
+		}
+		return 0
+	}
+	printText(res)
+	return 0
+}
+
+func printText(res *bisectpkg.DeltaRiskResult) {
+	fmt.Printf("delta %s -> %s\n", clishared.ShortSHA(res.From), clishared.ShortSHA(res.To))
+	fmt.Printf("score: %.2f (max cosine across historical events)\n", res.Score)
+	if len(res.Vector) == 0 {
+		fmt.Println("  empty delta vector (no module metrics changed)")
+		return
+	}
+	if len(res.Matches) == 0 {
+		fmt.Println("  no historical matches")
+		return
+	}
+	fmt.Println("top matches:")
+	for _, m := range res.Matches {
+		fmt.Printf("  cos=%.2f  %s  %s  %s\n", m.Cosine, clishared.ShortSHA(m.CommitSHA), m.FailureKind, m.Module)
+	}
+}

--- a/internal/snapshot/breakage_bootstrap.go
+++ b/internal/snapshot/breakage_bootstrap.go
@@ -1,0 +1,95 @@
+package snapshot
+
+import (
+	"sort"
+	"time"
+
+	"github.com/kaeawc/krit/internal/breakage"
+)
+
+// SynthesizeFindingRegressions diffs the new findings against the
+// most recent earlier capture and records a synthetic
+// krit-finding-regression event for every (rule, file) newly reporting
+// a finding at this commit. Returns (0, nil) when there is no earlier
+// capture, when rule-set hashes diverge, or when redaction states
+// differ — comparing across any of those would be noise.
+func SynthesizeFindingRegressions(root string, current *Findings, now time.Time) (int, error) {
+	if current == nil || current.CommitSHA == "" {
+		return 0, nil
+	}
+	prev, err := loadPreviousFindings(root, current.CommitSHA)
+	if err != nil {
+		return 0, err
+	}
+	if prev == nil {
+		return 0, nil
+	}
+	if current.RuleSetHash != "" && prev.RuleSetHash != "" && current.RuleSetHash != prev.RuleSetHash {
+		return 0, nil
+	}
+	if current.Redacted != prev.Redacted {
+		return 0, nil
+	}
+	events := buildRegressionEvents(prev, current, now)
+	if len(events) == 0 {
+		return 0, nil
+	}
+	return breakage.Record(root, events...)
+}
+
+// loadPreviousFindings walks captured manifests newest-first and
+// returns the first findings sidecar strictly older than currentSHA.
+func loadPreviousFindings(root, currentSHA string) (*Findings, error) {
+	manifests, err := LoadManifests(root)
+	if err != nil {
+		return nil, err
+	}
+	sort.Slice(manifests, func(i, j int) bool {
+		if manifests[i].CapturedAt != manifests[j].CapturedAt {
+			return manifests[i].CapturedAt < manifests[j].CapturedAt
+		}
+		return manifests[i].CommitSHA < manifests[j].CommitSHA
+	})
+	for i := len(manifests) - 1; i >= 0; i-- {
+		m := manifests[i]
+		if m.CommitSHA == currentSHA {
+			continue
+		}
+		f, err := LoadFindings(root, m.CommitSHA)
+		if err != nil || f == nil {
+			continue
+		}
+		return f, nil
+	}
+	return nil, nil
+}
+
+func buildRegressionEvents(prev, cur *Findings, now time.Time) []breakage.Event {
+	if now.IsZero() {
+		now = time.Now()
+	}
+	occurred := now.UnixMilli()
+	var events []breakage.Event
+	for rule, perFileCur := range cur.ByRuleFile {
+		perFilePrev := prev.ByRuleFile[rule]
+		for file, count := range perFileCur {
+			if count <= perFilePrev[file] {
+				continue
+			}
+			ev := breakage.Event{
+				OccurredAt:  occurred,
+				CommitSHA:   cur.CommitSHA,
+				FailureKind: breakage.KindKritFindingRegression,
+				Signature:   breakage.Normalize("rule " + rule + " file " + file),
+				File:        file,
+				Symbol:      rule,
+				Source:      breakage.SourceKritFinding,
+				Message:     "rule " + rule + " newly fires on " + file,
+			}
+			ev.ID = breakage.HashID(ev.FailureKind, ev.Signature, ev.CommitSHA, ev.Source)
+			events = append(events, ev)
+		}
+	}
+	sort.Slice(events, func(i, j int) bool { return events[i].ID < events[j].ID })
+	return events
+}

--- a/internal/snapshot/breakage_bootstrap_test.go
+++ b/internal/snapshot/breakage_bootstrap_test.go
@@ -1,0 +1,132 @@
+package snapshot
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/kaeawc/krit/internal/breakage"
+)
+
+func TestSynthesizeFindingRegressionsCreatesEventsOnNewFindings(t *testing.T) {
+	dir := t.TempDir()
+	root := filepath.Join(dir, ".krit", "snapshots")
+
+	prevSHA := "1111111111111111111111111111111111111111"
+	curSHA := "2222222222222222222222222222222222222222"
+
+	// Two captured manifests so loadPreviousFindings has something to
+	// compare against.
+	prevManifest := &Manifest{
+		SchemaVersion: ManifestSchemaVersion,
+		CommitSHA:     prevSHA,
+		CapturedAt:    1,
+		BlobSchema:    SchemaVersion,
+	}
+	curManifest := &Manifest{
+		SchemaVersion: ManifestSchemaVersion,
+		CommitSHA:     curSHA,
+		CapturedAt:    2,
+		BlobSchema:    SchemaVersion,
+	}
+	if _, err := SaveManifest(root, prevManifest); err != nil {
+		t.Fatalf("SaveManifest(prev): %v", err)
+	}
+	if _, err := SaveManifest(root, curManifest); err != nil {
+		t.Fatalf("SaveManifest(cur): %v", err)
+	}
+
+	prevFindings := &Findings{
+		SchemaVersion: FindingsSchemaVersion,
+		CommitSHA:     prevSHA,
+		ByRule:        map[string]int{"old-rule": 1},
+		ByRuleFile:    map[string]map[string]int{"old-rule": {"app/A.kt": 1}},
+	}
+	if _, err := SaveFindings(root, prevFindings); err != nil {
+		t.Fatalf("SaveFindings(prev): %v", err)
+	}
+
+	curFindings := &Findings{
+		SchemaVersion: FindingsSchemaVersion,
+		CommitSHA:     curSHA,
+		ByRule:        map[string]int{"old-rule": 1, "new-rule": 2},
+		ByRuleFile: map[string]map[string]int{
+			"old-rule": {"app/A.kt": 1},
+			"new-rule": {"app/A.kt": 1, "app/B.kt": 1},
+		},
+	}
+
+	added, err := SynthesizeFindingRegressions(root, curFindings, time.Unix(0, 0))
+	if err != nil {
+		t.Fatalf("SynthesizeFindingRegressions: %v", err)
+	}
+	if added != 2 {
+		t.Fatalf("added=%d, want 2 (new-rule fires on two files)", added)
+	}
+
+	events, err := breakage.LoadAll(root)
+	if err != nil {
+		t.Fatalf("LoadAll: %v", err)
+	}
+	if len(events) != 2 {
+		t.Fatalf("events len=%d, want 2", len(events))
+	}
+	for _, e := range events {
+		if e.FailureKind != breakage.KindKritFindingRegression {
+			t.Errorf("event kind=%q, want %q", e.FailureKind, breakage.KindKritFindingRegression)
+		}
+		if e.CommitSHA != curSHA {
+			t.Errorf("event commit=%q, want %q", e.CommitSHA, curSHA)
+		}
+		if e.Source != breakage.SourceKritFinding {
+			t.Errorf("event source=%q, want %q", e.Source, breakage.SourceKritFinding)
+		}
+	}
+}
+
+func TestSynthesizeFindingRegressionsSkipsRuleSetMismatch(t *testing.T) {
+	dir := t.TempDir()
+	root := filepath.Join(dir, ".krit", "snapshots")
+
+	prevSHA := "1111111111111111111111111111111111111111"
+	curSHA := "2222222222222222222222222222222222222222"
+	if _, err := SaveManifest(root, &Manifest{SchemaVersion: ManifestSchemaVersion, CommitSHA: prevSHA, CapturedAt: 1, BlobSchema: SchemaVersion}); err != nil {
+		t.Fatalf("SaveManifest(prev): %v", err)
+	}
+	if _, err := SaveManifest(root, &Manifest{SchemaVersion: ManifestSchemaVersion, CommitSHA: curSHA, CapturedAt: 2, BlobSchema: SchemaVersion}); err != nil {
+		t.Fatalf("SaveManifest(cur): %v", err)
+	}
+	if _, err := SaveFindings(root, &Findings{SchemaVersion: FindingsSchemaVersion, CommitSHA: prevSHA, RuleSetHash: "hash-a", ByRuleFile: map[string]map[string]int{}}); err != nil {
+		t.Fatalf("SaveFindings(prev): %v", err)
+	}
+	cur := &Findings{
+		SchemaVersion: FindingsSchemaVersion,
+		CommitSHA:     curSHA,
+		RuleSetHash:   "hash-b",
+		ByRuleFile:    map[string]map[string]int{"new-rule": {"app/A.kt": 5}},
+	}
+	added, err := SynthesizeFindingRegressions(root, cur, time.Unix(0, 0))
+	if err != nil {
+		t.Fatalf("SynthesizeFindingRegressions: %v", err)
+	}
+	if added != 0 {
+		t.Errorf("added=%d, want 0 (rule-set mismatch should suppress events)", added)
+	}
+}
+
+func TestSynthesizeFindingRegressionsFirstCaptureNoOp(t *testing.T) {
+	dir := t.TempDir()
+	root := filepath.Join(dir, ".krit", "snapshots")
+	cur := &Findings{
+		SchemaVersion: FindingsSchemaVersion,
+		CommitSHA:     "abc",
+		ByRuleFile:    map[string]map[string]int{"new-rule": {"app/A.kt": 1}},
+	}
+	added, err := SynthesizeFindingRegressions(root, cur, time.Unix(0, 0))
+	if err != nil {
+		t.Fatalf("SynthesizeFindingRegressions: %v", err)
+	}
+	if added != 0 {
+		t.Errorf("added=%d, want 0 (first capture should not emit regressions)", added)
+	}
+}

--- a/internal/snapshot/manifest.go
+++ b/internal/snapshot/manifest.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"time"
 
 	"github.com/kaeawc/krit/internal/fsutil"
 )
@@ -191,6 +192,14 @@ func SaveResult(root string, res *Result, repoRoot, kritVersion string) (string,
 	}
 	if _, err := CaptureManifest(root, res, repoRoot, kritVersion); err != nil {
 		return "", err
+	}
+	// Self-bootstrap: any new finding produced at this commit relative to
+	// the previous capture becomes a synthetic breakage event. We do this
+	// after the manifest is written so the just-captured findings show up
+	// in subsequent reads. Errors here are non-fatal — capture must
+	// succeed even when the breakage store is unwritable.
+	if res.Findings != nil {
+		_, _ = SynthesizeFindingRegressions(root, res.Findings, time.Now())
 	}
 	return blobPath, nil
 }


### PR DESCRIPTION
## Summary

Builds the failure-localization layer on top of the snapshot timeline (PRD 1, [#214](https://github.com/kaeawc/krit/issues/214)). Given a failure, krit now points at the commit *and* the structural change that pushed the codebase into the failure mode, with a confidence score.

- New `internal/breakage/` package: event types, signature normalization, JSON store, JUnit / `go test -json` / generic JSON ingest, content-derived dedupe IDs.
- New `internal/bisect/` package: AutoMobile-style tiered signal fusion (stack-frame -> symbol map [prior 0.95], test-owns-module [0.85], structural diff touches [0.60], historical co-occurrence [0.50]); cosine delta scoring on per-module metric vectors.
- New verbs wired through `cmd/krit/verb_dispatch.go`:
  - `krit breakage record --kind <junit|gotest|generic> --from <file> --commit <sha>`
  - `krit breakage list`
  - `krit bisect-structure --from <good> --to <bad> --event <id>` -> ranked (commit, module, confidence, reasons)
  - `krit delta-risk --from <sha> --to <sha>` -> cosine score + top historical matches
- Self-bootstrap: `snapshot.SaveResult` now synthesizes `krit-finding-regression` events when a new finding appears vs. the previous capture, so the feature produces signal without any external ingest. Rule-set or redaction-state mismatch suppresses synthesis; first-ever capture is a no-op.
- Hoisted `ResolveRepoRoot`, `ResolveCommitOrLiteral`, and `ShortSHA` into `clishared` so the three new CLI verbs don't fork their own copies.

## Acceptance criteria

- [x] `krit bisect-structure` returns the correct (commit, module) in top-1 for stack-frame-tier signals and top-3 for diff-tier-only signals (`internal/bisect/bisect_test.go`).
- [x] `krit delta-risk` returns a populated per-module vector and cosine score (`internal/bisect/bisect_test.go: TestScoreDeltaCosine`).
- [x] Snapshot capture on a commit that introduces a new finding produces a `krit-finding-regression` breakage event with no external ingest (`internal/snapshot/breakage_bootstrap_test.go`).
- [x] Full validation: `go build`, `go vet ./...`, `golangci-lint run ./...`, `go test ./... -count=1`, `make integration` all clean.

## Non-goals (per PRD)

- Auto-reverting commits.
- Replacing `git bisect` for repros that need a build/test loop.
- Cross-repo correlation.

## Test plan

- [x] `go build -o krit ./cmd/krit/`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...`
- [x] `go test ./... -count=1`
- [x] `make integration` (11/11 passed)