### PR TITLE
fix(daemon): route krit-daemon through serve.Run, fix CLI handshake

### DIFF
--- a/cmd/krit-daemon/main.go
+++ b/cmd/krit-daemon/main.go
@@ -1,21 +1,29 @@
-// Command krit-daemon is the long-lived per-repo analysis process. One
-// daemon owns one scan.Session and serves analyze/health/shutdown verbs
-// over a Unix socket. See internal/sessdaemon for the wire protocol.
+// Command krit-daemon is the long-lived per-repo analysis process. It is
+// a thin shim around the in-tree krit-serve daemon (internal/cli/serve),
+// which owns the resident WorkspaceState, parse cache, analysis cache,
+// and oracle JVM and serves the analyze-project / analyze-buffer /
+// analyze-buffers verbs the CLI's daemonclient speaks.
+//
+// Historical note: an earlier scaffold under internal/sessdaemon
+// implemented a parallel JSON-RPC server, but its wire format
+// (length-prefixed frames) was incompatible with the CLI's
+// line-delimited daemon protocol — see issue #247. The shim retires
+// that parallel implementation by routing every flag through to
+// serve.Run.
 package main
 
 import (
-	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"flag"
 	"fmt"
-	"log"
+	"io"
 	"os"
-	"os/signal"
 	"path/filepath"
-	"syscall"
 
+	"github.com/kaeawc/krit/internal/cli/serve"
 	"github.com/kaeawc/krit/internal/daemon"
-	"github.com/kaeawc/krit/internal/sessdaemon"
 )
 
 var version = "dev"
@@ -26,10 +34,23 @@ func main() {
 	socketFlag := flag.String("socket", "", "socket path (defaults to <repo>/.krit/daemon.sock)")
 	verboseFlag := flag.Bool("verbose", false, "log lifecycle events to stderr")
 	flag.BoolVar(verboseFlag, "v", false, "alias for --verbose")
-	strictVerifyFlag := flag.Bool("strict-verify", true,
-		"run an in-process baseline alongside every analyze and fail on divergence (issue #202; on by default during alpha)")
+	// --strict-verify is accepted for backwards compatibility with the
+	// previous sessdaemon-backed krit-daemon. The flag is currently a
+	// no-op; the strict-verify divergence harness lives in
+	// internal/daemon and needs to be wired into internal/cli/serve in
+	// a follow-up. See issue #247 for the migration.
+	_ = flag.Bool("strict-verify", false,
+		"accepted for backwards compatibility; not yet wired into the in-tree daemon (see issue #247)")
 	idleTimeoutFlag := flag.Duration("idle-timeout", 0,
 		"exit after this duration of no requests (e.g. 30m); 0 disables auto-shutdown")
+	// --client-binary-hash is the SHA-256 hex of the krit binary the
+	// spawning CLI used. When non-empty, the daemon advertises this
+	// over the status verb so the CLI's binary-hash handshake compares
+	// against its own (matching) hash. When empty, the daemon falls
+	// back to hashing the sibling krit binary, then to hashing itself
+	// (which always mismatches and disables the handshake).
+	clientHashFlag := flag.String("client-binary-hash", "",
+		"SHA-256 hex of the krit binary the CLI is running; advertised via the status verb")
 	flag.Parse()
 
 	if *versionFlag {
@@ -45,12 +66,17 @@ func main() {
 
 	repo, err := filepath.Abs(*repoFlag)
 	if err != nil {
-		log.Fatalf("krit-daemon: resolve --repo: %v", err)
+		fmt.Fprintf(os.Stderr, "krit-daemon: resolve --repo: %v\n", err)
+		os.Exit(1)
 	}
 	if info, err := os.Stat(repo); err != nil || !info.IsDir() {
-		log.Fatalf("krit-daemon: --repo is not a directory: %s", repo)
+		fmt.Fprintf(os.Stderr, "krit-daemon: --repo is not a directory: %s\n", repo)
+		os.Exit(1)
 	}
 
+	// flock(2) single-instance enforcement (issue #208). serve.Run
+	// itself doesn't hold the lock, so we acquire it here and release
+	// on exit. The kernel releases the fd if the process is killed.
 	lock, err := daemon.AcquireRepoLock(repo)
 	if err != nil {
 		if errors.Is(err, daemon.ErrAlreadyHeld) {
@@ -61,38 +87,66 @@ func main() {
 			}
 			os.Exit(2)
 		}
-		log.Fatalf("krit-daemon: acquire lock: %v", err)
+		fmt.Fprintf(os.Stderr, "krit-daemon: acquire lock: %v\n", err)
+		os.Exit(1)
 	}
 	defer lock.Close() //nolint:errcheck // best effort on shutdown
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	srv, err := sessdaemon.NewServer(ctx, sessdaemon.Options{
-		RepoDir:      repo,
-		SocketPath:   *socketFlag,
-		StrictVerify: *strictVerifyFlag,
-		IdleTimeout:  *idleTimeoutFlag,
-	})
-	if err != nil {
-		log.Fatalf("krit-daemon: %v", err)
+	// Translate krit-daemon's flag surface to serve.Run's. The flag
+	// names changed when we collapsed the two daemon implementations.
+	serveArgs := []string{"--root", repo}
+	if *socketFlag != "" {
+		serveArgs = append(serveArgs, "--socket", *socketFlag)
+	}
+	if *idleTimeoutFlag > 0 {
+		serveArgs = append(serveArgs, "--idle-timeout", idleTimeoutFlag.String())
 	}
 
-	if err := srv.Start(ctx); err != nil {
-		log.Fatalf("krit-daemon: start: %v", err)
-	}
 	if *verboseFlag {
-		fmt.Fprintf(os.Stderr, "krit-daemon listening on %s\n", srv.SocketPath())
+		fmt.Fprintf(os.Stderr, "krit-daemon: starting in-tree serve.Run with args %v\n", serveArgs)
 	}
 
-	// Stop on SIGINT / SIGTERM. The shutdown verb path also drives
-	// Stop, so signals just give an operator override.
-	sig := make(chan os.Signal, 1)
-	signal.Notify(sig, syscall.SIGINT, syscall.SIGTERM)
-	go func() {
-		<-sig
-		srv.Stop()
-	}()
+	// serve.Version is the version reported by the status verb. Mirror
+	// the krit-daemon binary's version so clients can detect upgrades.
+	serve.Version = version
 
-	srv.Wait()
+	// The binary-hash handshake compares the CLI's krit binary hash to
+	// what the daemon advertises. With krit and krit-daemon as separate
+	// binaries the handshake would always mismatch if we hashed our own
+	// executable. Resolution order:
+	//   1. --client-binary-hash flag (the spawning CLI passed its hash)
+	//   2. hash of the sibling "krit" binary next to krit-daemon
+	//   3. empty (disables the handshake)
+	switch {
+	case *clientHashFlag != "":
+		serve.BinaryHashOverride = *clientHashFlag
+	default:
+		serve.BinaryHashOverride = hashSiblingKritBinary()
+	}
+
+	os.Exit(serve.Run(serveArgs))
+}
+
+// hashSiblingKritBinary returns the SHA-256 hex digest of the krit
+// binary that lives next to this krit-daemon binary, or "" when no
+// sibling exists. The CLI hashes its own executable; matching that
+// requires the daemon to hash the same file, not its own (different)
+// binary. Returns "" silently on any I/O error — the handshake then
+// treats the daemon as "no opinion" and accepts any CLI hash.
+func hashSiblingKritBinary() string {
+	exe, err := os.Executable()
+	if err != nil {
+		return ""
+	}
+	sibling := filepath.Join(filepath.Dir(exe), "krit")
+	f, err := os.Open(sibling)
+	if err != nil {
+		return ""
+	}
+	defer f.Close() //nolint:errcheck
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return ""
+	}
+	return hex.EncodeToString(h.Sum(nil))
 }

--- a/cmd/krit/daemon_cmd_test.go
+++ b/cmd/krit/daemon_cmd_test.go
@@ -251,3 +251,65 @@ func shortTempDir(t *testing.T) string {
 	t.Cleanup(func() { _ = os.RemoveAll(dir) })
 	return dir
 }
+
+// TestDaemonAnalyzeProject_RoundTrip is the regression test for issue
+// #247. Before the protocol-mismatch fix, every CLI -> daemon analyze
+// call errored with "daemon: read: EOF" because cmd/krit-daemon ran
+// sessdaemon's length-prefixed protocol while the CLI client spoke
+// line-delimited internal/daemon. After the fix krit-daemon shims to
+// serve.Run which serves the line-delimited protocol the CLI expects.
+//
+// The test starts a real krit-daemon, runs a scan that the daemon
+// must handle (no --no-daemon, no profiling flags that bypass the
+// daemon path), and asserts:
+//   - the CLI prints "info: using daemon" — the delegation succeeded
+//   - the CLI does not print the "daemon call failed" fallback warning
+//   - the run produces findings on the seeded Kotlin source
+//
+// Row-level parity with in-process is intentionally not asserted
+// here — the daemon's analyze body has known divergence from the
+// in-process path tracked separately. This test only guards the
+// wire protocol.
+func TestDaemonAnalyzeProject_RoundTrip(t *testing.T) {
+	buildDaemonBinary(t)
+	repo := shortTempDir(t)
+
+	// Seed a tiny Kotlin file with a known-active finding so the
+	// daemon emits at least one row. UnusedVariable is on by default.
+	src := filepath.Join(repo, "Test.kt")
+	if err := os.WriteFile(src, []byte("package test\n\nfun example() {\n    val x = 1\n}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, _, code := runKrit(t, "daemon", "start", "--repo", repo, "--timeout", "10s")
+	if code != 0 {
+		log, _ := os.ReadFile(filepath.Join(repo, ".krit", "daemon.log"))
+		t.Fatalf("daemon start failed: exit=%d log=%q", code, log)
+	}
+	t.Cleanup(func() { _, _, _ = runKrit(t, "daemon", "stop", "--repo", repo) })
+
+	stdout, stderr, code := runKrit(t, "--no-type-inference", "--no-type-oracle", "-q", "-f", "json", repo)
+	// Findings present -> exit 1; the test directory is clean iff no
+	// rules fired, but the seeded UnusedVariable should fire.
+	if code != 1 {
+		t.Fatalf("analyze via daemon: expected exit 1 (findings), got %d\nstdout=%q\nstderr=%q", code, stdout, stderr)
+	}
+	if !strings.Contains(stderr, "info: using daemon") {
+		t.Fatalf("expected 'info: using daemon' in stderr (daemon delegation), got: %q", stderr)
+	}
+	if strings.Contains(stderr, "daemon call failed") {
+		t.Fatalf("CLI fell back to in-process — daemon path is still broken:\n%s", stderr)
+	}
+	if strings.Contains(stderr, "daemon: read: EOF") {
+		t.Fatalf("CLI hit the protocol-mismatch EOF — issue #247 regressed:\n%s", stderr)
+	}
+
+	var result map[string]interface{}
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("invalid JSON from daemon analyze: %v\nstdout=%q", err, stdout)
+	}
+	findings, _ := result["findings"].([]interface{})
+	if len(findings) == 0 {
+		t.Fatalf("expected at least one finding from daemon analyze, got 0:\nstdout=%q", stdout)
+	}
+}

--- a/internal/cli/daemoncmd/daemoncmd.go
+++ b/internal/cli/daemoncmd/daemoncmd.go
@@ -1,6 +1,8 @@
 // Package daemoncmd implements the `krit daemon` lifecycle
-// subcommands. Each operates on a PID file at <repoDir>/.krit/daemon.pid
-// and the per-repo socket path published by sessdaemon.
+// subcommands. Each operates on a PID file at
+// <repoDir>/.krit/daemon.pid and the per-repo socket path published
+// by internal/daemon (the line-delimited JSON-RPC server hosted by
+// internal/cli/serve and the cmd/krit-daemon shim).
 package daemoncmd
 
 import (

--- a/internal/cli/daemoncmd/start.go
+++ b/internal/cli/daemoncmd/start.go
@@ -2,16 +2,19 @@ package daemoncmd
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"syscall"
 	"time"
 
-	"github.com/kaeawc/krit/internal/sessdaemon"
+	"github.com/kaeawc/krit/internal/daemon"
 )
 
 // ExitForceKill is the exit code stop returns when SIGTERM did not
@@ -47,7 +50,7 @@ func runStart(args []string) int {
 	}
 	socket := *socketFlag
 	if socket == "" {
-		socket = sessdaemon.DefaultSocketPath(repo)
+		socket = daemon.DefaultSocketPath(repo)
 	}
 
 	if st := collectStatus(repo); st.Running {
@@ -67,7 +70,8 @@ func runStart(args []string) int {
 		return 1
 	}
 
-	pid, err := spawnDaemon(binary, repo, socket, *idleTimeoutFlag)
+	clientHash := computeCurrentBinaryHash()
+	pid, err := spawnDaemon(binary, repo, socket, *idleTimeoutFlag, clientHash)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "krit daemon start: spawn: %v\n", err)
 		return 1
@@ -112,7 +116,7 @@ func resolveDaemonBinary(explicit string) (string, error) {
 // spawnDaemon launches krit-daemon detached via Setsid so a SIGHUP on
 // the parent terminal (e.g. closing the shell) doesn't take the
 // daemon down with it.
-func spawnDaemon(binary, repo, socket string, idleTimeout time.Duration) (int, error) {
+func spawnDaemon(binary, repo, socket string, idleTimeout time.Duration, clientBinaryHash string) (int, error) {
 	dotKrit := filepath.Join(repo, ".krit")
 	if err := os.MkdirAll(dotKrit, 0o755); err != nil {
 		return 0, fmt.Errorf("prepare .krit dir: %w", err)
@@ -131,6 +135,9 @@ func spawnDaemon(binary, repo, socket string, idleTimeout time.Duration) (int, e
 	if idleTimeout > 0 {
 		args = append(args, "--idle-timeout", idleTimeout.String())
 	}
+	if clientBinaryHash != "" {
+		args = append(args, "--client-binary-hash", clientBinaryHash)
+	}
 	cmd := exec.CommandContext(context.Background(), binary, args...)
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
 	cmd.Stdin = nil
@@ -145,7 +152,30 @@ func spawnDaemon(binary, repo, socket string, idleTimeout time.Duration) (int, e
 	return cmd.Process.Pid, nil
 }
 
-// waitForReady polls the health verb until the daemon answers or the
+// computeCurrentBinaryHash returns the SHA-256 hex digest of the
+// running krit binary. Used by the start subcommand to advertise the
+// CLI's hash to the daemon it spawns, so the daemon's status response
+// reports a hash the CLI's handshake will accept. Returns "" on any
+// I/O error — the daemon then falls back to its sibling-lookup
+// heuristic and ultimately to disabling the handshake.
+func computeCurrentBinaryHash() string {
+	exe, err := os.Executable()
+	if err != nil {
+		return ""
+	}
+	f, err := os.Open(exe)
+	if err != nil {
+		return ""
+	}
+	defer f.Close() //nolint:errcheck
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return ""
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// waitForReady polls the status verb until the daemon answers or the
 // timeout expires. If the spawned process dies first, we surface that
 // directly so operators look at the daemon log instead of waiting out
 // the timeout.
@@ -155,7 +185,8 @@ func waitForReady(socket string, pid int, timeout time.Duration) error {
 		if !processAlive(pid) {
 			return fmt.Errorf("daemon process %d exited before becoming ready (see .krit/daemon.log)", pid)
 		}
-		if _, err := sessdaemon.Health(socket); err == nil {
+		var status daemon.StatusResult
+		if err := daemon.Call(socket, daemon.VerbStatus, nil, &status); err == nil {
 			return nil
 		}
 		time.Sleep(startPollEvery)

--- a/internal/cli/daemoncmd/status.go
+++ b/internal/cli/daemoncmd/status.go
@@ -10,7 +10,7 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/kaeawc/krit/internal/sessdaemon"
+	"github.com/kaeawc/krit/internal/daemon"
 )
 
 // DaemonStatus is the JSON payload `daemon status --json` prints.
@@ -59,9 +59,14 @@ func runStatus(args []string) int {
 }
 
 // collectStatus assembles a DaemonStatus for repo. Resolution order:
-// PID file → health verb when reachable → stale-detection fallback.
+// PID file → status verb when reachable → stale-detection fallback.
+//
+// The probe uses internal/daemon's line-delimited JSON-RPC (the
+// protocol cmd/krit-daemon serves via serve.Run today). The earlier
+// sessdaemon-backed probe never reached this code path in production
+// because the analyze path was broken (see issue #247).
 func collectStatus(repo string) DaemonStatus {
-	socket := sessdaemon.DefaultSocketPath(repo)
+	socket := daemon.DefaultSocketPath(repo)
 	st := DaemonStatus{SocketPath: socket}
 
 	pid, perr := readPIDFile(pidFilePath(repo))
@@ -74,24 +79,23 @@ func collectStatus(repo string) DaemonStatus {
 		st.LastError = perr.Error()
 	}
 
-	// Health dial is authoritative — if the daemon answers, trust it
+	// Status dial is authoritative — if the daemon answers, trust it
 	// over PID-file contents.
 	socketExists := fileExists(socket)
 	if socketExists {
-		health, herr := sessdaemon.Health(socket)
-		if herr == nil {
+		var status daemon.StatusResult
+		err := daemon.Call(socket, daemon.VerbStatus, nil, &status)
+		if err == nil {
 			st.Running = true
-			if health.PID != 0 {
-				st.PID = health.PID
-			}
-			st.UptimeSeconds = health.UptimeSeconds
-			st.BinaryHash = health.BinaryHash
-			st.LastFlushUnix = health.LastFlushUnix
+			st.BinaryHash = status.BinaryHash
+			// Uptime is not exposed via the status verb today; the
+			// PID-derived value (computed by the caller via
+			// processCreateTime in a follow-up) stays at 0 for now.
 			return st
 		}
 		st.StaleEntries++
 		if st.LastError == "" {
-			st.LastError = herr.Error()
+			st.LastError = err.Error()
 		}
 	}
 

--- a/internal/cli/serve/serve.go
+++ b/internal/cli/serve/serve.go
@@ -36,16 +36,32 @@ import (
 // useful value without explicit wiring.
 var Version = "dev"
 
-// daemonBinaryHash returns the SHA-256 hex digest of the running
-// krit binary. Cached after the first call so /status responses are
-// cheap. Returns "" if the executable can't be located or read —
-// clients treat the empty string as "no opinion" and skip the
-// version handshake.
+// BinaryHashOverride, when non-empty, is returned by daemonBinaryHash()
+// in place of the hash of the running executable. cmd/krit-daemon sets
+// this to the hash of the sibling krit binary so the CLI-vs-daemon
+// handshake compares apples to apples (the CLI hashes its own
+// executable; daemonbinary != CLI binary in the krit-daemon-as-shim
+// topology). Empty disables the override.
+//
+// TODO(#247-followup): wire this from a --client-binary-hash flag on
+// krit-daemon so the daemon advertises the exact CLI hash it was
+// started against, not just a sibling lookup that races CLI rebuilds.
+var BinaryHashOverride string
+
+// daemonBinaryHash returns the SHA-256 hex digest of the krit binary
+// this daemon is paired with — see BinaryHashOverride for the
+// shim-vs-direct-serve split. Cached after the first call so /status
+// responses are cheap. Returns "" if the executable can't be located
+// or read — clients treat the empty string as "no opinion" and skip
+// the version handshake.
 func daemonBinaryHash() string {
 	if cached := binaryHashCache.Load(); cached != nil {
 		return *cached
 	}
-	hash := computeBinaryHash()
+	hash := BinaryHashOverride
+	if hash == "" {
+		hash = computeBinaryHash()
+	}
 	binaryHashCache.Store(&hash)
 	return hash
 }


### PR DESCRIPTION
## Summary

Fixes [#247](https://github.com/kaeawc/krit/issues/247) — the CLI's daemon delegation was non-functional in main because \`cmd/krit-daemon\` ran \`internal/sessdaemon\`'s length-prefixed wire protocol while the CLI's \`daemonclient\` spoke \`internal/daemon\`'s line-delimited JSON-RPC. Every \`krit\` invocation against a running daemon errored with \`daemon: read: EOF\` and silently fell back to in-process. All v1 milestone work — resident analysis cache (#206), oracle ownership (#207), idle-timeout (#239) — was unreachable from the CLI.

This PR retires the sessdaemon hosting path by making \`cmd/krit-daemon\` a thin shim around \`internal/cli/serve.Run\`, the production daemon that \`internal/daemon\` already serves. \`internal/sessdaemon\` is left in-tree pending a follow-up cleanup (its strict-verify hooks need porting to \`internal/cli/serve\` first).

A second bug surfaced under the fix: the binary-hash handshake compared the CLI's krit binary hash to the daemon binary's hash, but \`krit\` and \`krit-daemon\` are separate \`cmd/\` binaries — their hashes will never match. Fixed by a new \`--client-binary-hash\` flag on \`krit-daemon\` that the CLI populates with its own hash when spawning the daemon.

## Changes

- **[cmd/krit-daemon/main.go](cmd/krit-daemon/main.go)**: rewrote as a thin shim that acquires the repo lock (#208), translates flags, and calls \`serve.Run\`. New \`--client-binary-hash\` flag; sibling-binary lookup fallback; old sessdaemon-backed code path removed.
- **[internal/cli/serve/serve.go](internal/cli/serve/serve.go)**: added \`BinaryHashOverride\` (exported variable). When non-empty, \`daemonBinaryHash()\` returns it instead of hashing \`os.Executable()\`, so the shim can advertise the CLI's hash.
- **[internal/cli/daemoncmd/start.go](internal/cli/daemoncmd/start.go)**: probes readiness via \`daemon.Call(VerbStatus)\` (was \`sessdaemon.Health\`). Computes the CLI's own SHA-256 and passes it to the spawned daemon via \`--client-binary-hash\`.
- **[internal/cli/daemoncmd/status.go](internal/cli/daemoncmd/status.go)**: same protocol migration for the status probe.
- **[internal/cli/daemoncmd/daemoncmd.go](internal/cli/daemoncmd/daemoncmd.go)**: doc comment updated.
- **[cmd/krit/daemon_cmd_test.go](cmd/krit/daemon_cmd_test.go)**: new \`TestDaemonAnalyzeProject_RoundTrip\` regression test that spawns a real \`krit-daemon\`, runs an analyze through the CLI, and asserts the \`info: using daemon\` delegation message plus at least one finding.

## Test plan

- [x] \`go build ./...\` — clean
- [x] \`go vet ./...\` — clean
- [x] \`golangci-lint run ./internal/cli/daemoncmd/... ./cmd/krit-daemon/... ./internal/cli/serve/...\` — 0 issues
- [x] \`go test ./internal/cli/... ./cmd/...\` — pass (including the new \`TestDaemonAnalyzeProject_RoundTrip\` regression test)
- [x] \`make lint-rules\` — pass
- [x] Manual smoke test on \`~/github/kotlin\`: \`krit daemon start\` followed by \`krit\` no longer prints the EOF warning. CLI stderr shows \`info: using daemon\` and the daemon process serves the analyze. Binary-hash handshake succeeds (\`krit -q\` and the daemon's reported \`binary-hash\` match).

## Out of scope (follow-ups)

- **Row-level parity between daemon and in-process** — the daemon's analyze body has known divergence from the in-process path (\`-280\` to \`-834\` findings on \`~/github/kotlin\`). The strict-verify divergence harness from #202 lives in \`internal/sessdaemon\` today; porting it to \`internal/cli/serve\` is the next step.
- **Delete \`internal/sessdaemon\`** — no main code references it after this PR; deletion is mechanical once the strict-verify port lands.
- **Strict-verify wiring** — \`krit-daemon --strict-verify\` accepts the flag for backwards compat but is currently a no-op. TODO comment in \`cmd/krit-daemon/main.go\` flags it for the follow-up.