### PR TITLE
fix(android): resolve scanPaths to abs in DetectProjectWithIndex

### DIFF
--- a/internal/android/detect.go
+++ b/internal/android/detect.go
@@ -34,6 +34,19 @@ func DetectProjectWithIndex(scanPaths []string, index trackedfiles.Index) *Proje
 	seen := make(map[string]bool)
 
 	for _, root := range scanPaths {
+		// Resolve to absolute up front: detectWalkDir SkipDirs any
+		// directory whose Name() starts with "." (catches .git,
+		// .gradle, etc.). When the caller passes "." as the root —
+		// which the CLI does when run from the project's CWD with
+		// no explicit path — WalkDir's first callback receives a
+		// DirEntry whose Name() is "." and the SkipDir fires on the
+		// root itself, leaving GradlePaths / ManifestPaths empty
+		// and silently dropping every Gradle/Android rule. abs is
+		// always a real basename so the hidden-dir guard targets
+		// only the dotfiles we mean to skip.
+		if abs, err := filepath.Abs(root); err == nil {
+			root = abs
+		}
 		info, err := os.Stat(root)
 		if err != nil {
 			continue

--- a/internal/android/detect_test.go
+++ b/internal/android/detect_test.go
@@ -127,6 +127,44 @@ func TestDetectProject_NonExistentPath(t *testing.T) {
 	}
 }
 
+// TestDetectProject_RelativeDotRoot_FindsGradle pins the fix for the
+// daemon-vs-in-process divergence flagged by the strict-verify
+// harness: with scanPaths=["."], detectWalkDir used to SkipDir on
+// the root entry itself because d.Name() is "." (matches the
+// hidden-dir prefix guard intended for .git/.gradle/etc.). The CLI
+// hits this path when run from the project's CWD with no explicit
+// argument; the daemon doesn't because cmd/krit-daemon always
+// resolves --repo to an absolute path before passing it through.
+//
+// Repro shape: a directory with a build.gradle.kts and a
+// settings.gradle.kts (no .git, no manifest) must yield GradlePaths
+// of length 1 when probed with ".".
+func TestDetectProject_RelativeDotRoot_FindsGradle(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "build.gradle.kts"), []byte("dependencies {}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "settings.gradle.kts"), []byte("rootProject.name = \"x\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Switch CWD into the tempdir so scanPaths=["."] resolves there.
+	// Restore on cleanup; t.TempDir cleanup expects an existing CWD.
+	prev, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(prev) })
+
+	proj := DetectProject([]string{"."})
+	if len(proj.GradlePaths) != 1 {
+		t.Fatalf("expected 1 GradlePath with root=\".\", got %d (project=%+v)", len(proj.GradlePaths), proj)
+	}
+}
+
 func TestDetectProjectWithIndex_UsesTrackedFileListing(t *testing.T) {
 	root := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(root, "app", "src", "main", "res", "layout"), 0o755); err != nil {


### PR DESCRIPTION
## Summary

Fixes a real daemon-vs-CLI finding divergence flushed out while testing the strict-verify harness landed in #249.

\`DetectProjectWithIndex\`'s \`WalkDir\` callback uses \`detectWalkDir\`, which \`SkipDir\`s any directory whose \`Name()\` starts with \`.\` — the hidden-dir guard intended for \`.git\`, \`.gradle\`, etc. When the caller passes \`.\` as the scan root (the CLI does this when run from the project's CWD with no explicit path), \`WalkDir\`'s first callback receives a \`DirEntry\` whose \`Name()\` is literally \`.\` and the \`SkipDir\` fires on the root itself. The walk never descends, \`GradlePaths\` / \`ManifestPaths\` come back empty, and every \`NeedsGradle\` / Android rule silently no-ops.

The daemon path doesn't hit this because \`cmd/krit-daemon\` always resolves \`--repo\` to an absolute path before passing it to \`serve.Run\`, so the \`WalkDir\` root's \`Name()\` is a real basename like \`kotlin-webservice\`.

## Repro

```
$ cd playground/kotlin-webservice
$ cp -r . /tmp/d && cd /tmp/d
$ krit --no-daemon -f json | jq '[.findings[].rule] | unique | length'
15
$ krit-daemon --repo $(pwd) &; krit -f json | jq '[.findings[].rule] | unique | length'
16   # +1 = DependenciesInRootProject on build.gradle.kts:17
```

## Fix

Resolve each scan root to an absolute path up front inside \`DetectProjectWithIndex\`. \`abs\` is always a real basename, so the hidden-dir guard only ever targets the dotfiles we actually mean to skip.

## Test plan

- [x] \`go test ./internal/android/ -count=1\` — all pass including new \`TestDetectProject_RelativeDotRoot_FindsGradle\`
- [x] \`go vet ./...\` clean
- [x] \`golangci-lint run ./internal/android/...\` — 0 issues
- [x] Manual: \`krit --no-daemon\` on the kotlin-webservice playground now produces 64 findings (was 63), matching the daemon path's output.

## Related

Surfaced by the strict-verify port in #249. Strict-verify itself didn't flag this because both the daemon and the harness's baseline ran the same absolute-path code path inside the daemon process. The divergence only manifests against \`krit --no-daemon\`, where the CLI passes \`.\` straight through to \`DetectProjectWithIndex\` from \`scan.runner\`.