### PR TITLE
feat(daemon): self-heal on socket unlink via periodic stat watchdog

### DIFF
--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -67,6 +67,17 @@ type Server struct {
 	// dispatched request. Read by the idle watchdog, written under the
 	// dispatch hot path — atomic to avoid contention.
 	lastActivity atomic.Int64
+
+	// SocketWatchdogInterval overrides the cadence of the
+	// socket-presence check. Zero (the default) uses
+	// socketWatchdogDefaultInterval. Exposed so tests can speed up
+	// the loop without waiting for the production interval.
+	SocketWatchdogInterval time.Duration
+	// SocketWatchdogDisabled, when true, suppresses the periodic
+	// os.Stat on the socket. Tests that drive a server through manual
+	// lifecycle calls set this so they don't race against the
+	// watchdog calling Stop.
+	SocketWatchdogDisabled bool
 }
 
 // reporter returns Server.Reporter, or a default stderr Reporter when nil.
@@ -140,8 +151,57 @@ func (s *Server) Start(ctx context.Context) error {
 		go s.idleWatchdog(cctx)
 	}
 
+	// socketWatchdog catches the phantom-socket failure mode: the
+	// dirent at s.socketPath has been unlinked (rm -rf .krit, errant
+	// test cleanup, IDE/Spotlight artifact) while the daemon process
+	// is still alive and bound to the now-orphan inode. New
+	// connections fail at connect(2) with ENOENT and clients silently
+	// fall back to in-process forever. Stop on detection so the next
+	// CLI invocation hits "no daemon, spawn fresh" rather than
+	// "daemon socket missing, give up".
+	s.wg.Add(1)
+	go s.socketWatchdog(cctx)
+
 	return nil
 }
+
+// socketWatchdog polls every socketWatchdogInterval for the socket
+// dirent and triggers Stop the first time os.Stat fails. The poll
+// cost is one os.Stat every few seconds — well below the budget for
+// a long-lived daemon process, and the alternative (clients silently
+// timing out forever) is worse. Skips the check while
+// SocketWatchdogDisabled is set so unit tests can opt out without a
+// custom mock.
+func (s *Server) socketWatchdog(ctx context.Context) {
+	defer s.wg.Done()
+	if s.SocketWatchdogDisabled || s.socketPath == "" {
+		return
+	}
+	tick := s.SocketWatchdogInterval
+	if tick <= 0 {
+		tick = socketWatchdogDefaultInterval
+	}
+	t := time.NewTicker(tick)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			if _, err := os.Stat(s.socketPath); err != nil {
+				s.reporter().Warnf("krit daemon: socket %s disappeared (%v); exiting so the next CLI invocation can respawn\n", s.socketPath, err)
+				go s.Stop()
+				return
+			}
+		}
+	}
+}
+
+// socketWatchdogDefaultInterval is the production cadence for the
+// socket-presence check. 5s balances detection latency (a single CLI
+// fallback at most) against the cost of one stat call per daemon
+// lifetime.
+const socketWatchdogDefaultInterval = 5 * time.Second
 
 // idleWatchdog calls Stop when no request has been dispatched for
 // IdleTimeout. Polls at IdleTimeout/4 (clamped to a minimum of one

--- a/internal/daemon/socket_watchdog_test.go
+++ b/internal/daemon/socket_watchdog_test.go
@@ -1,0 +1,140 @@
+package daemon
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestSocketWatchdog_StopsOnSocketUnlink pins the phantom-socket
+// failure mode: with the daemon process alive but its socket dirent
+// gone from the filesystem, new clients can't reach it (connect(2)
+// returns ENOENT on the missing path). Without the watchdog the
+// daemon sits there forever serving zero requests and CLI callers
+// silently fall back to in-process on every invocation.
+//
+// The watchdog polls os.Stat on its own socket on a tight interval
+// (production: 5s; here: 25ms) and calls Stop the first time the
+// stat fails so the next CLI invocation hits "no daemon, spawn
+// fresh" rather than "daemon socket missing, give up".
+//
+// See issue #247-followup.
+func TestSocketWatchdog_StopsOnSocketUnlink(t *testing.T) {
+	socket := filepath.Join(shortTempDir(t), "d.sock")
+	srv := NewServer(socket)
+	// Speed up detection so the test doesn't pay the production 5s.
+	srv.SocketWatchdogInterval = 25 * time.Millisecond
+	srv.Register("echo", func(_ context.Context, raw json.RawMessage) (any, error) {
+		var v any
+		_ = json.Unmarshal(raw, &v)
+		return v, nil
+	})
+	if err := srv.Start(context.Background()); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+
+	// Wait for the socket to become reachable before unlinking it —
+	// otherwise the watchdog may trigger on the brief window between
+	// MkdirAll and the kernel exposing the bound socket.
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if Available(socket) {
+			break
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	if !Available(socket) {
+		t.Fatal("server never became Available; cannot exercise watchdog")
+	}
+
+	// Sanity: socket is bound, server serves requests.
+	var got string
+	if err := Call(socket, "echo", "hi", &got); err != nil {
+		t.Fatalf("pre-unlink Call: %v", err)
+	}
+
+	// Unlink the dirent. The kernel keeps the bound socket alive on
+	// its open fd, but no new connect(2) can resolve the path.
+	if err := os.Remove(socket); err != nil {
+		t.Fatalf("os.Remove(socket): %v", err)
+	}
+
+	// The watchdog must notice within roughly one tick and Stop the
+	// server. Allow a generous slack (10× the tick) to ride out
+	// scheduler hiccups under -race / CI load.
+	stopDeadline := time.Now().Add(500 * time.Millisecond)
+	select {
+	case <-stoppedSignal(srv):
+		// Good — server stopped.
+	case <-time.After(time.Until(stopDeadline)):
+		t.Fatalf("socket watchdog did not stop the server within %s of unlink", 500*time.Millisecond)
+	}
+
+	// Subsequent Call must fail (server is down). The exact error
+	// shape varies by OS; the contract is "not nil" so the CLI knows
+	// to spawn fresh.
+	if err := Call(socket, "echo", "post", nil); err == nil {
+		t.Fatal("expected Call to fail after watchdog stop, got nil error")
+	} else if !errors.Is(err, os.ErrNotExist) && err.Error() == "" {
+		t.Fatalf("Call error after watchdog stop should be a real dial error; got %v", err)
+	}
+}
+
+// TestSocketWatchdog_Disabled exercises the opt-out: with
+// SocketWatchdogDisabled=true the goroutine returns immediately and
+// the server keeps running even when the socket dirent is unlinked.
+// Drives the bypass path tests outside this file rely on.
+func TestSocketWatchdog_Disabled(t *testing.T) {
+	socket := filepath.Join(shortTempDir(t), "d.sock")
+	srv := NewServer(socket)
+	srv.SocketWatchdogDisabled = true
+	srv.SocketWatchdogInterval = 25 * time.Millisecond // would-be fast tick
+	if err := srv.Start(context.Background()); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	t.Cleanup(srv.Stop)
+
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if Available(socket) {
+			break
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	if err := os.Remove(socket); err != nil {
+		t.Fatalf("os.Remove(socket): %v", err)
+	}
+
+	// Sleep for ten tick intervals; the watchdog would have fired by
+	// now if not disabled. The stopped channel must remain open.
+	time.Sleep(10 * 25 * time.Millisecond)
+	select {
+	case <-stoppedSignal(srv):
+		t.Fatal("server stopped despite SocketWatchdogDisabled=true")
+	default:
+		// Good — server is still up. Cleanup runs Stop explicitly.
+	}
+}
+
+// stoppedSignal exposes the server's internal stopped channel without
+// surfacing it as a public API. The closure pattern keeps the export
+// scoped to this test file.
+func stoppedSignal(s *Server) <-chan struct{} { return s.stopped }
+
+// shortTempDir returns a temp directory rooted under /tmp so the
+// resulting "<dir>/d.sock" path fits within sun_path's ~104-byte
+// limit on macOS. t.TempDir() roots under /var/folders/... which
+// blows the limit and makes bind() fail with EINVAL.
+func shortTempDir(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("/tmp", "krit-d-")
+	if err != nil {
+		t.Fatalf("mkdir temp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	return dir
+}


### PR DESCRIPTION
## Summary

Closes the third item under issue #247-followup: harden the daemon against the phantom-socket state where the Unix socket dirent has been unlinked from the filesystem while the daemon process stays alive. Observed under repeated CLI benchmarking on \`~/github/kotlin\` — likely from an external \`rm -rf .krit\`, an IDE/Spotlight artifact, or an errant test cleanup.

Without the watchdog, clients silently fall back to in-process on every invocation forever; the daemon sits there serving zero requests.

## Approach

I considered making \`daemon.Available()\` cope with the phantom state itself, but on macOS a unix socket bound to an unlinked path is genuinely unreachable from \`connect(2)\` — there's no path to resolve. \`Available()\` is already correctly reporting \"unreachable\". The fix has to live on the **daemon side**: detect the socket loss and clean-shutdown so the next CLI invocation triggers a fresh spawn.

Adds a \`socketWatchdog\` goroutine alongside the existing \`idleWatchdog\`. Polls \`os.Stat\` on its own socket every 5s (configurable), calls \`Stop()\` the first time the stat fails.

## Why a watchdog instead of self-rebind?

Self-rebind races concurrent in-flight requests and would require pausing the accept loop, removing the stale socket file (which may have been recreated by another process), and rebinding. Clean Stop + respawn-on-next-call is much simpler and lands the same user-visible outcome — the next CLI invocation works.

## Production cost

One \`os.Stat\` per 5 seconds for the lifetime of the daemon. Trivial compared to the alternative (clients silently broken until the user notices and runs \`krit daemon restart\`).

## Test plan

- [x] \`TestSocketWatchdog_StopsOnSocketUnlink\` (new): spawns a server, confirms it serves a request, \`os.Remove\`'s the socket, asserts \`Stop\` fires within ~250ms.
- [x] \`TestSocketWatchdog_Disabled\` (new): with \`SocketWatchdogDisabled=true\`, the server stays up for ten tick intervals after the socket is unlinked.
- [x] \`go test ./internal/daemon/ -race -count=1\` — clean, no races against the new goroutine.
- [x] \`go test ./internal/cli/serve/ ./internal/cli/daemoncmd/ ./cmd/krit/\` — pass.
- [x] \`golangci-lint run ./internal/daemon/...\` — 0 issues.

## Knobs

- \`Server.SocketWatchdogInterval\` overrides the production 5s cadence. Tests use 25ms.
- \`Server.SocketWatchdogDisabled\` opts out — for tests that drive a server through manual lifecycle calls and don't want to race against the watchdog.

## Related

Last of the three issue #247-followup items. Strict-verify port shipped as #249; the relative-root divergence fix as #250.