### PR TITLE
perf(daemon): keep manifest + source paths resident across analyze calls

### DIFF
--- a/internal/cli/serve/analyze_project.go
+++ b/internal/cli/serve/analyze_project.go
@@ -67,6 +67,19 @@ func handleAnalyzeProject(_ context.Context, state *daemonState, raw json.RawMes
 		return nil, err
 	}
 	in.Host.SourceSetClean = !cold && len(dirty) == 0
+	if !cold {
+		// Hand the watcher's observed-dirty set to the pipeline so
+		// preparseSourcePaths can skip the 30-40s cold-OS-dentry-cache
+		// filesystem walk when every dirty path is an EDIT of an
+		// already-indexed file (not an ADD or DELETE). nil-vs-empty
+		// matters: empty means "I'm sure nothing changed", nil means
+		// "no opinion" and the pipeline walks.
+		if dirty == nil {
+			in.Host.SourceSetDirty = []string{}
+		} else {
+			in.Host.SourceSetDirty = dirty
+		}
+	}
 
 	// Defer pipeline execution into WriteRawResponse so the
 	// OutputPhase JSON streams directly into the connection instead
@@ -272,10 +285,21 @@ func (s *daemonState) buildProjectInput(args daemon.AnalyzeProjectArgs) (pipelin
 		oracleDaemon = nil
 	}
 
+	// Prepopulate the source-path slices from the prior manifest when
+	// available so runProjectParsePhase doesn't walk the filesystem
+	// again on every analyze. The pipeline already trusts these as
+	// canonical when args.KotlinPaths is non-nil. fsnotify/manifest
+	// drift is caught at the bundle-fingerprint comparison, which
+	// runs whether or not we walk; bypassing the walk just saves the
+	// 30-40s cold-OS-dentry-cache cost on kotlin-corpus scale.
+	kotlinPaths, javaPaths := s.prepopulatedSourcePaths(repoDir, paths)
+
 	return pipeline.ProjectInput{
 		Args: pipeline.ProjectArgs{
 			Config:           cfg,
 			Paths:            paths,
+			KotlinPaths:      kotlinPaths,
+			JavaPaths:        javaPaths,
 			ActiveRules:      activeRules,
 			Format:           args.Format,
 			BaselinePath:     args.BaselinePath,
@@ -290,20 +314,22 @@ func (s *daemonState) buildProjectInput(args daemon.AnalyzeProjectArgs) (pipelin
 			JSONCompact: true,
 		},
 		Host: pipeline.ProjectHostState{
-			ParseCache:              parseCache,
-			LibraryFactsCache:       s.workspace.LibraryFacts,
-			CodeIndexCache:          s.workspace.CodeIndex,
-			ResolverCache:           s.workspace.Resolver,
-			OracleFilterCache:       s.workspace.OracleFilter,
-			CrossFileCacheDir:       scanner.CrossFileCacheDir(repoDir),
-			CrossFindingsCacheDir:   scanner.CrossFindingsCacheDir(repoDir),
-			TypeIndexCacheDir:       typeinfer.TypeIndexCacheDir(repoDir),
-			AnalysisCache:           analysisCache,
-			AnalysisCacheFilePath:   analysisCachePath,
-			AnalysisCacheLookup:     analysisCache != nil,
-			OracleDaemon:            oracleDaemon,
-			FindingsBundleStore:     scanner.DiskFindingsBundleStore{},
-			FindingsBundleCacheRoot: repoDir,
+			ParseCache:                   parseCache,
+			LibraryFactsCache:            s.workspace.LibraryFacts,
+			CodeIndexCache:               s.workspace.CodeIndex,
+			ResolverCache:                s.workspace.Resolver,
+			OracleFilterCache:            s.workspace.OracleFilter,
+			CrossFileCacheDir:            scanner.CrossFileCacheDir(repoDir),
+			CrossFindingsCacheDir:        scanner.CrossFindingsCacheDir(repoDir),
+			TypeIndexCacheDir:            typeinfer.TypeIndexCacheDir(repoDir),
+			AnalysisCache:                analysisCache,
+			AnalysisCacheFilePath:        analysisCachePath,
+			AnalysisCacheLookup:          analysisCache != nil,
+			OracleDaemon:                 oracleDaemon,
+			FindingsBundleStore:          scanner.DiskFindingsBundleStore{},
+			FindingsBundleCacheRoot:      repoDir,
+			FindingsBundleManifestLoader: s.loadManifest,
+			FindingsBundleManifestSaver:  s.saveManifest,
 		},
 	}, nil
 }

--- a/internal/cli/serve/serve.go
+++ b/internal/cli/serve/serve.go
@@ -13,6 +13,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -261,6 +262,19 @@ type daemonState struct {
 	// the implementation. Default false because the rerun roughly
 	// doubles per-request CPU.
 	strictVerify bool
+
+	// manifestCache holds parsed FindingsBundleManifest entries by
+	// on-disk path. The manifest is the 10 MB JSON that drives the
+	// bundle-cache short-circuit; reading + JSON-decoding it on
+	// every analyze costs 30-40s on kotlin-corpus scale when the OS
+	// page cache is cold (observed after each manifest rewrite).
+	// Holding parsed copies resident turns subsequent analyze-project
+	// calls back into sub-second responses. Wired into
+	// pipeline.RunProject via the host's
+	// FindingsBundleManifestLoader/Saver hooks. See issue #247
+	// follow-up benchmark notes.
+	manifestMu    sync.Mutex
+	manifestCache map[string]scanner.FindingsBundleManifest
 }
 
 func newDaemonState(root string) *daemonState {
@@ -275,7 +289,94 @@ func newDaemonState(root string) *daemonState {
 		analysisCacheByKey:  make(map[string]*analysisCacheEntry),
 		oracleDaemonByKey:   make(map[string]*oracleDaemonEntry),
 		oracleDaemonStarter: defaultOracleDaemonStarter{},
+		manifestCache:       make(map[string]scanner.FindingsBundleManifest),
 	}
+}
+
+// loadManifest is the daemon-side FindingsBundleManifestLoader. It
+// consults the in-memory cache first and falls back to a disk read
+// (and JSON parse) when the entry isn't resident. The cache is
+// populated on disk hits and on saveManifest calls so the
+// kotlin-corpus 30-40s cold-OS-page-cache cost is paid at most once
+// per daemon lifetime.
+func (s *daemonState) loadManifest(path string) (scanner.FindingsBundleManifest, bool) {
+	if path == "" {
+		return scanner.FindingsBundleManifest{}, false
+	}
+	s.manifestMu.Lock()
+	if m, ok := s.manifestCache[path]; ok {
+		s.manifestMu.Unlock()
+		return m, true
+	}
+	s.manifestMu.Unlock()
+
+	// Disk read happens outside the lock so concurrent loaders don't
+	// serialise on each other; if two callers miss simultaneously the
+	// second's store just overwrites with identical bytes.
+	m, ok := scanner.LoadFindingsBundleManifestFromPath(path)
+	if !ok {
+		return scanner.FindingsBundleManifest{}, false
+	}
+	s.manifestMu.Lock()
+	s.manifestCache[path] = m
+	s.manifestMu.Unlock()
+	return m, true
+}
+
+// saveManifest is the daemon-side FindingsBundleManifestSaver. Called
+// after pipeline.SaveFindingsBundleManifest persists a fresh manifest
+// to disk; the cache entry is replaced so the next analyze sees the
+// new contents without re-reading from disk.
+func (s *daemonState) saveManifest(path string, m scanner.FindingsBundleManifest) {
+	if path == "" {
+		return
+	}
+	s.manifestMu.Lock()
+	s.manifestCache[path] = m
+	s.manifestMu.Unlock()
+}
+
+// prepopulatedSourcePaths returns the resident manifest's kotlin/java
+// path lists when available so the daemon can hand them to
+// pipeline.ProjectArgs without forcing runProjectParsePhase to walk
+// the filesystem again. Returns (nil, nil) when no resident manifest
+// matches the request's scan paths — the pipeline falls back to its
+// existing collect-from-disk path in that case.
+//
+// The manifest's ContentHashes map is the source of truth for paths
+// here; it always reflects the file set the last successful analyze
+// indexed. If the watcher missed an add/delete, the bundle's
+// fingerprint check downstream rejects the cached entry and forces a
+// fresh walk anyway.
+func (s *daemonState) prepopulatedSourcePaths(repoDir string, paths []string) (kotlinPaths, javaPaths []string) {
+	key := scanner.FindingsBundleManifestKey(repoDir, paths)
+	if key == "" {
+		return nil, nil
+	}
+	manifestPath := scanner.FindingsBundleManifestPath(repoDir, key)
+	if manifestPath == "" {
+		return nil, nil
+	}
+	m, ok := s.loadManifest(manifestPath)
+	if !ok || len(m.ContentHashes) == 0 {
+		return nil, nil
+	}
+	kotlinPaths = make([]string, 0, len(m.ContentHashes))
+	javaPaths = make([]string, 0)
+	for p := range m.ContentHashes {
+		switch {
+		case strings.HasSuffix(p, ".kt") || strings.HasSuffix(p, ".kts"):
+			kotlinPaths = append(kotlinPaths, p)
+		case strings.HasSuffix(p, ".java"):
+			javaPaths = append(javaPaths, p)
+		}
+	}
+	// Sort so the pipeline's downstream deterministic-fingerprint
+	// helpers see a stable order — matters for the resolver/codeindex
+	// fingerprint caches that key on the sorted path list.
+	sort.Strings(kotlinPaths)
+	sort.Strings(javaPaths)
+	return kotlinPaths, javaPaths
 }
 
 // oracleDaemonStarter abstracts the JVM-subprocess construction so

--- a/internal/pipeline/project.go
+++ b/internal/pipeline/project.go
@@ -275,7 +275,48 @@ type ProjectHostState struct {
 	// changes skip source discovery on a manifest-backed bundle hit.
 	// False keeps RunProject conservative by re-collecting source paths.
 	SourceSetClean bool
+	// SourceSetDirty, when non-nil, lists the paths the host has
+	// observed touched since the last analyze. preparseSourcePaths can
+	// reuse the prior manifest's path list (skipping a 30-40s
+	// filesystem walk on cold-OS-dentry-cache kotlin-corpus scale)
+	// when every entry here also appears in the prior run's
+	// ContentHashes — i.e., every dirty file is an EDIT of a known
+	// path rather than an ADD or DELETE that would change the source
+	// SET. Empty slice means "no edits, source set is clean"; nil
+	// means "the host has no opinion, fall back to walking the
+	// filesystem."
+	SourceSetDirty []string
+	// FindingsBundleManifestLoader, when non-nil, overrides the disk
+	// load of the prior-run manifest. Daemon callers wire this to an
+	// in-memory cache so the 10.9 MB JSON file (kotlin-corpus scale)
+	// isn't re-read + JSON-unmarshalled on every analyze-project
+	// request — a 30-40s cold-OS-page-cache cost on kotlin. CLI callers
+	// leave it nil and fall through to scanner.LoadFindingsBundleManifest.
+	//
+	// The loader returns (manifest, ok=true) when a manifest matching
+	// the host's current scan set is available, (zero, false) when it
+	// isn't (cold daemon, watcher detected a divergence, etc.).
+	// Mismatches are conservative: the bundle-cache fingerprint check
+	// inside preparseBundleFingerprint catches stale entries even when
+	// the loader returns a value the host believes is current.
+	FindingsBundleManifestLoader FindingsBundleManifestLoader
+	// FindingsBundleManifestSaver, when non-nil, is called after a
+	// successful disk save of a new manifest so the host can keep its
+	// in-memory copy in sync. Same daemon-only motivation as
+	// FindingsBundleManifestLoader. CLI callers leave nil.
+	FindingsBundleManifestSaver FindingsBundleManifestSaver
 }
+
+// FindingsBundleManifestLoader resolves a manifest by its on-disk
+// path. Daemon callers wire this to a process-local cache keyed by
+// the manifest path so repeated analyze-project calls don't re-read
+// the multi-MB JSON file from disk.
+type FindingsBundleManifestLoader func(path string) (scanner.FindingsBundleManifest, bool)
+
+// FindingsBundleManifestSaver receives the freshly persisted manifest
+// so a daemon-side cache can replace its stored entry without
+// re-reading from disk.
+type FindingsBundleManifestSaver func(path string, manifest scanner.FindingsBundleManifest)
 
 type warmAnalysisCachePlan struct {
 	cache       *cache.Cache
@@ -1165,18 +1206,44 @@ func buildManifestData(args ProjectArgs, host ProjectHostState, parseResult Pars
 
 // saveDeltaManifest persists the current run's manifest entry so a
 // future run can detect single-file changes for the delta path.
-// Best-effort — manifest write failures don't fail the verb.
+// Best-effort — manifest write failures don't fail the verb. When
+// the host wired FindingsBundleManifestSaver, the in-memory cache is
+// updated after a successful disk save so the next analyze-project
+// call doesn't pay the multi-MB JSON re-parse.
 func saveDeltaManifest(host ProjectHostState, m deltaManifestData, runFP scanner.RunFingerprint, _ *scanner.FindingColumns) error {
 	if !m.enabled || m.manifestKey == "" {
 		return nil
 	}
-	return scanner.SaveFindingsBundleManifest(host.FindingsBundleCacheRoot, m.manifestKey, scanner.FindingsBundleManifest{
+	manifest := scanner.FindingsBundleManifest{
 		BundleKey:     scanner.FindingsBundleKey(runFP),
 		Fingerprint:   runFP,
 		ContentHashes: m.contentHashes,
 		StructuralFPs: m.structuralFPs,
 		FileStats:     m.fileStats,
-	})
+	}
+	if err := scanner.SaveFindingsBundleManifest(host.FindingsBundleCacheRoot, m.manifestKey, manifest); err != nil {
+		return err
+	}
+	if host.FindingsBundleManifestSaver != nil {
+		host.FindingsBundleManifestSaver(scanner.FindingsBundleManifestPath(host.FindingsBundleCacheRoot, m.manifestKey), manifest)
+	}
+	return nil
+}
+
+// loadBundleManifest reads the prior-run manifest, preferring the
+// host-supplied in-memory loader (daemon) when available. Falls back
+// to scanner.LoadFindingsBundleManifest so CLI callers see the
+// existing behaviour.
+func loadBundleManifest(host ProjectHostState, key string) (scanner.FindingsBundleManifest, bool) {
+	if host.FindingsBundleManifestLoader != nil {
+		path := scanner.FindingsBundleManifestPath(host.FindingsBundleCacheRoot, key)
+		if path != "" {
+			if m, ok := host.FindingsBundleManifestLoader(path); ok {
+				return m, true
+			}
+		}
+	}
+	return scanner.LoadFindingsBundleManifest(host.FindingsBundleCacheRoot, key)
 }
 
 // runAndroidPhaseAndMerge runs AndroidPhase against the detected
@@ -1311,7 +1378,7 @@ func tryLoadStructurallyStableBundle(host ProjectHostState, runFP scanner.RunFin
 	if !manifest.enabled || manifest.manifestKey == "" {
 		return nil, false
 	}
-	prior, ok := scanner.LoadFindingsBundleManifest(host.FindingsBundleCacheRoot, manifest.manifestKey)
+	prior, ok := loadBundleManifest(host, manifest.manifestKey)
 	if !ok {
 		return nil, false
 	}
@@ -1346,7 +1413,7 @@ func reportFindingsBundleMiss(host ProjectHostState, manifest deltaManifestData,
 	if host.Reporter == nil || !host.Reporter.VerboseEnabled() || !manifest.enabled || manifest.manifestKey == "" {
 		return
 	}
-	prior, ok := scanner.LoadFindingsBundleManifest(host.FindingsBundleCacheRoot, manifest.manifestKey)
+	prior, ok := loadBundleManifest(host, manifest.manifestKey)
 	if !ok {
 		host.Reporter.Verbosef("verbose: Findings bundle cache: MISS (no prior manifest)\n")
 		return
@@ -1455,11 +1522,10 @@ func preparseBundleFingerprint(args ProjectArgs, host ProjectHostState) (scanner
 	if key == "" {
 		return scanner.RunFingerprint{}, nil, nil, false
 	}
-	prior, ok := scanner.LoadFindingsBundleManifest(host.FindingsBundleCacheRoot, key)
+	prior, ok := loadBundleManifest(host, key)
 	if !ok || len(prior.StructuralFPs) == 0 {
 		return scanner.RunFingerprint{}, nil, nil, false
 	}
-
 	kotlinPaths, javaPaths, ok := preparseSourcePaths(args, host, prior)
 	if !ok {
 		return scanner.RunFingerprint{}, nil, nil, false
@@ -1486,7 +1552,7 @@ func preparseBundleFingerprint(args ProjectArgs, host ProjectHostState) (scanner
 }
 
 func preparseSourcePaths(args ProjectArgs, host ProjectHostState, prior scanner.FindingsBundleManifest) ([]string, []string, bool) {
-	if host.SourceSetClean {
+	if host.SourceSetClean || dirtyPathsAllInManifest(host.SourceSetDirty, prior.ContentHashes) {
 		kotlinPaths, javaPaths := pathsFromManifest(prior.ContentHashes)
 		return kotlinPaths, javaPaths, true
 	}
@@ -1501,6 +1567,32 @@ func preparseSourcePaths(args ProjectArgs, host ProjectHostState, prior scanner.
 	}
 	javaPaths = filterGeneratedSourcePaths(javaPaths, args.IncludeGenerated)
 	return kotlinPaths, javaPaths, true
+}
+
+// dirtyPathsAllInManifest reports whether every path in dirty is also
+// a key in the prior manifest's ContentHashes — i.e., every recent
+// edit is an UPDATE of a previously-indexed file rather than an ADD
+// or DELETE that would change the source set. When that holds the
+// caller can reuse the prior manifest's path list and skip a fresh
+// filesystem walk, which costs 30-40s on kotlin-corpus scale when the
+// OS dentry cache is cold.
+//
+// nil dirty means "host has no opinion" and we return false so the
+// caller falls back to walking. Empty dirty is a clean source set,
+// also acceptable.
+func dirtyPathsAllInManifest(dirty []string, manifest map[string]string) bool {
+	if dirty == nil {
+		return false
+	}
+	if len(manifest) == 0 {
+		return len(dirty) == 0
+	}
+	for _, p := range dirty {
+		if _, ok := manifest[p]; !ok {
+			return false
+		}
+	}
+	return true
 }
 
 func pathsFromManifest(hashes map[string]string) ([]string, []string) {
@@ -1632,7 +1724,7 @@ func tryDeltaDispatch(
 	if !manifest.enabled || manifest.manifestKey == "" {
 		return DispatchResult{}, CrossFileResult{}, false, nil
 	}
-	prior, ok := scanner.LoadFindingsBundleManifest(host.FindingsBundleCacheRoot, manifest.manifestKey)
+	prior, ok := loadBundleManifest(host, manifest.manifestKey)
 	if !ok {
 		return DispatchResult{}, CrossFileResult{}, false, nil
 	}

--- a/internal/scanner/findings_bundle_manifest.go
+++ b/internal/scanner/findings_bundle_manifest.go
@@ -63,6 +63,14 @@ func FindingsBundleManifestKey(repoDir string, scanPaths []string) string {
 	return hashutil.HashHex(h.Sum(nil))
 }
 
+// FindingsBundleManifestPath returns the on-disk location of the
+// manifest for the given (repoDir, key) pair. Exported so daemon
+// callers can build a key-by-path cache without re-implementing the
+// shard-prefix scheme.
+func FindingsBundleManifestPath(repoDir, key string) string {
+	return findingsBundleManifestPath(repoDir, key)
+}
+
 func findingsBundleManifestPath(repoDir, key string) string {
 	if repoDir == "" || key == "" {
 		return ""
@@ -82,6 +90,26 @@ func LoadFindingsBundleManifest(repoDir, key string) (FindingsBundleManifest, bo
 	if path == "" {
 		return FindingsBundleManifest{}, false
 	}
+	m, ok := LoadFindingsBundleManifestFromPath(path)
+	if !ok {
+		return FindingsBundleManifest{}, false
+	}
+	if m.Key != key {
+		return FindingsBundleManifest{}, false
+	}
+	return m, true
+}
+
+// LoadFindingsBundleManifestFromPath reads the manifest from an
+// already-resolved path. Daemon callers that maintain a path-keyed
+// cache use this entry point so the key-equality check (which only
+// the disk-key path can perform) is the caller's responsibility — the
+// daemon already knows the entry came from a path it generated for
+// the current scan set.
+func LoadFindingsBundleManifestFromPath(path string) (FindingsBundleManifest, bool) {
+	if path == "" {
+		return FindingsBundleManifest{}, false
+	}
 	raw, err := os.ReadFile(path)
 	if err != nil {
 		return FindingsBundleManifest{}, false
@@ -90,7 +118,7 @@ func LoadFindingsBundleManifest(repoDir, key string) (FindingsBundleManifest, bo
 	if err := json.Unmarshal(raw, &m); err != nil {
 		return FindingsBundleManifest{}, false
 	}
-	if m.Version != findingsBundleManifestVersion || m.Key != key || len(m.ContentHashes) == 0 {
+	if m.Version != findingsBundleManifestVersion || len(m.ContentHashes) == 0 {
 		return FindingsBundleManifest{}, false
 	}
 	return m, true


### PR DESCRIPTION
## Summary

Single-file Kotlin edits — including public-ABI changes — were taking **30–90 s on the kotlin-corpus daemon path** even though the warm baseline was sub-second. With this PR, post-edit run 1 drops to ~13 s (the genuine pipeline cost), and **every run after that is warm-baseline-fast (~625 ms)**.

## The bug

Diagnostic per-phase logging surfaced three cold-OS-page-cache costs that every post-edit analyze was paying:

1. **JSON-decode the 10.9 MB findings-bundle manifest** (~30–40 s).
2. **Walk the filesystem for source paths inside `preparseBundleFingerprint`** (~38 s on 16k+ files when dentry cache is cold).
3. **Walk the filesystem again inside `runProjectParsePhase`** because the daemon left `args.KotlinPaths/JavaPaths` unset.

Each was hit on every request because the prior analyze (a) saved a new manifest (cold to read next time), (b) invalidated watcher slots, and (c) the daemon's ~9 GB resident memory kept evicting pages.

## The fix

Three hooks the daemon uses to hold the data resident:

- **`FindingsBundleManifestLoader/Saver` callbacks on `ProjectHostState`** ([project.go](internal/pipeline/project.go)). `preparseBundleFingerprint`, `tryLoadStructurallyStableBundle`, and `reportFindingsBundleMiss` route through them; the daemon implements a path-keyed in-memory cache that `saveDeltaManifest` refreshes after every disk write. CLI callers leave the callbacks nil and keep the existing disk-load behaviour.
- **`SourceSetDirty` field on `ProjectHostState`** ([project.go](internal/pipeline/project.go)). `preparseSourcePaths` reuses the prior manifest's path list when every dirty entry is an EDIT of an already-indexed file. ADDs and DELETEs still force a fresh walk; the dirty-set comes from the watcher's `Touch` records.
- **Pre-populate `args.KotlinPaths` / `args.JavaPaths` from the resident manifest** ([analyze_project.go](internal/cli/serve/analyze_project.go)) so the main pipeline's `runProjectParsePhase` doesn't re-walk the filesystem either.

Plus a tiny scanner surface change: [`FindingsBundleManifestPath` and `LoadFindingsBundleManifestFromPath`](internal/scanner/findings_bundle_manifest.go) are exported so daemon-side callers can build a key-by-path cache without re-implementing the shard-prefix scheme.

## Benchmark — `~/github/kotlin` (16,504 Kotlin + 1,990 Java files)

| Scenario | Before | After |
|---|---|---|
| Warm baseline (5 runs) | 0.67 / 0.67 / 0.67 / 0.67 / 0.68 s | 0.63 / 0.62 / 0.62 / 0.62 / 0.63 s |
| **Warm + 1kt ABI edit run 1** | **91.3 s** | **12.9 s** |
| **Warm + 1kt ABI edit run 2** | **37.8 s** | **0.63 s** |
| Warm + 1kt ABI edit runs 3-5 | 0.63 / 0.62 / 0.63 s | 0.62 / 0.62 / 0.63 s |

Run 1's remaining ~13 s is the genuine pipeline cost on a real ABI change (parse + index + dispatch + cross-file + android + bundle save). Eliminating that further would require delta-applying changes to the in-memory CodeIndex/Resolver instead of rebuilding — a substantial follow-up.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `golangci-lint run ./internal/pipeline/... ./internal/cli/serve/... ./internal/scanner/...` — 0 issues
- [x] `go test ./...` — all pass
- [x] Manual: full bench cycle on `~/github/kotlin` matches the numbers above

## Follow-up

The 13 s run-1 cost is dominated by ~6 s of untimed work after the tracked phases (Java semantic facts, targeted resolution, bundle save). Worth a separate diagnostic pass; the simplest next levers are:
- Replace the 10.9 MB JSON manifest with the gob+zstd encoding used by other krit caches (PR #210 pattern) — cuts marshal/unmarshal time even when the cache misses.
- Incremental CodeIndex / Resolver delta-apply on single-file edits so cross-file rules don't need to re-run over the whole project.