### PR TITLE
perf(daemon): resident parse cache, AndroidProject cache, Chmod-event filter

### DIFF
--- a/internal/cli/serve/analyze_project.go
+++ b/internal/cli/serve/analyze_project.go
@@ -326,6 +326,7 @@ func (s *daemonState) buildProjectInput(args daemon.AnalyzeProjectArgs) (pipelin
 			CodeIndexCache:               s.workspace.CodeIndex,
 			ResolverCache:                s.workspace.Resolver,
 			OracleFilterCache:            s.workspace.OracleFilter,
+			AndroidProjectCache:          s.workspace.AndroidProject,
 			CrossFileCacheDir:            scanner.CrossFileCacheDir(repoDir),
 			CrossFindingsCacheDir:        scanner.CrossFindingsCacheDir(repoDir),
 			TypeIndexCacheDir:            typeinfer.TypeIndexCacheDir(repoDir),

--- a/internal/cli/serve/analyze_project.go
+++ b/internal/cli/serve/analyze_project.go
@@ -321,6 +321,7 @@ func (s *daemonState) buildProjectInput(args daemon.AnalyzeProjectArgs) (pipelin
 		},
 		Host: pipeline.ProjectHostState{
 			ParseCache:                   parseCache,
+			ResidentFiles:                s.workspace,
 			LibraryFactsCache:            s.workspace.LibraryFacts,
 			CodeIndexCache:               s.workspace.CodeIndex,
 			ResolverCache:                s.workspace.Resolver,

--- a/internal/cli/serve/analyze_project.go
+++ b/internal/cli/serve/analyze_project.go
@@ -327,6 +327,7 @@ func (s *daemonState) buildProjectInput(args daemon.AnalyzeProjectArgs) (pipelin
 			ResolverCache:                s.workspace.Resolver,
 			OracleFilterCache:            s.workspace.OracleFilter,
 			AndroidProjectCache:          s.workspace.AndroidProject,
+			GradleFindingsCache:          s.workspace.GradleFindings,
 			CrossFileCacheDir:            scanner.CrossFileCacheDir(repoDir),
 			CrossFindingsCacheDir:        scanner.CrossFindingsCacheDir(repoDir),
 			TypeIndexCacheDir:            typeinfer.TypeIndexCacheDir(repoDir),

--- a/internal/cli/serve/watcher.go
+++ b/internal/cli/serve/watcher.go
@@ -188,7 +188,21 @@ func (fw *fileWatcher) handle(ev fsnotify.Event) {
 			return
 		}
 	}
-	if ev.Op&(fsnotify.Write|fsnotify.Create|fsnotify.Remove|fsnotify.Rename|fsnotify.Chmod) == 0 {
+	// Chmod alone never changes file content. On macOS, kqueue emits
+	// spurious Chmod events when other processes stat or open watched
+	// files (Spotlight, git, finder previews, anti-virus tools). On a
+	// heavily-trafficked monorepo that meant every analyze drained a
+	// burst of Chmod events for build.gradle.kts and unrelated .kt
+	// paths, each one triggering InvalidateLibraryFacts /
+	// scheduleKotlinInvalidate. That blew the AndroidProject /
+	// LibraryFacts / resolver / per-file parsed-tree slots and forced
+	// a full ~1 s rebuild on every call.
+	//
+	// Drop Chmod entirely: content-changing edits always also emit
+	// Write, Create, Remove, or Rename (modern editors' atomic-save
+	// dance is rename+create, never bare chmod).
+	relevant := ev.Op & (fsnotify.Write | fsnotify.Create | fsnotify.Remove | fsnotify.Rename)
+	if relevant == 0 {
 		return
 	}
 	// Library-config paths come first — build.gradle.kts also matches

--- a/internal/cli/serve/watcher_test.go
+++ b/internal/cli/serve/watcher_test.go
@@ -493,7 +493,7 @@ type chmodFilterCountingState struct {
 	libraryFactsInvalidations atomic.Int64
 }
 
-func (c *chmodFilterCountingState) Invalidate(string)  { c.invalidateCalls.Add(1) }
+func (c *chmodFilterCountingState) Invalidate(string)       { c.invalidateCalls.Add(1) }
 func (c *chmodFilterCountingState) InvalidateCodeIndex()    {}
 func (c *chmodFilterCountingState) InvalidateDependents()   {}
 func (c *chmodFilterCountingState) InvalidateLibraryFacts() { c.libraryFactsInvalidations.Add(1) }

--- a/internal/cli/serve/watcher_test.go
+++ b/internal/cli/serve/watcher_test.go
@@ -8,10 +8,16 @@ import (
 	"testing"
 	"time"
 
+	"github.com/fsnotify/fsnotify"
+
 	"github.com/kaeawc/krit/internal/librarymodel"
 	"github.com/kaeawc/krit/internal/pipeline"
 	"github.com/kaeawc/krit/internal/scanner"
 )
+
+func fsnotifyEventChmod(path string) fsnotify.Event {
+	return fsnotify.Event{Name: path, Op: fsnotify.Chmod}
+}
 
 // countingState is a watcherState fake that counts Invalidate calls.
 type countingState struct {
@@ -443,3 +449,54 @@ func TestIsKotlinPath(t *testing.T) {
 		}
 	}
 }
+
+// TestFileWatcher_IgnoresChmodOnlyEvents asserts the watcher does NOT
+// drop cached cross-file slots when fsnotify emits a Chmod-only event
+// for a library-config or Kotlin path. On macOS, kqueue emits spurious
+// Chmod events whenever another process stats or opens a watched file
+// (Spotlight, git, finder previews). Pre-fix, those events fired
+// InvalidateLibraryFacts on every analyze and rebuilt the AndroidProject
+// / resolver / per-file parsed-tree slots — costing ~1s each.
+func TestFileWatcher_IgnoresChmodOnlyEvents(t *testing.T) {
+	root := t.TempDir()
+	gradlePath := filepath.Join(root, "build.gradle.kts")
+	ktPath := filepath.Join(root, "Foo.kt")
+	for _, p := range []string{gradlePath, ktPath} {
+		if err := os.WriteFile(p, []byte("// init\n"), 0o644); err != nil {
+			t.Fatalf("write %s: %v", p, err)
+		}
+	}
+	state := &chmodFilterCountingState{}
+	w, err := startFileWatcherWithState(context.Background(), root, state, nil)
+	if err != nil {
+		t.Fatalf("startFileWatcher: %v", err)
+	}
+	defer w.Stop()
+
+	// Inject a Chmod-only event directly through handle() — going
+	// through os.Chmod would also trigger a Stat() that on some
+	// platforms emits Write, defeating the test's purpose.
+	w.handle(fsnotifyEventChmod(gradlePath))
+	w.handle(fsnotifyEventChmod(ktPath))
+	time.Sleep(20 * time.Millisecond)
+
+	if got := state.libraryFactsInvalidations.Load(); got != 0 {
+		t.Errorf("InvalidateLibraryFacts fired %d times on Chmod-only event; want 0", got)
+	}
+	if got := state.invalidateCalls.Load(); got != 0 {
+		t.Errorf("Invalidate fired %d times on Chmod-only event; want 0", got)
+	}
+}
+
+type chmodFilterCountingState struct {
+	invalidateCalls           atomic.Int64
+	libraryFactsInvalidations atomic.Int64
+}
+
+func (c *chmodFilterCountingState) Invalidate(string)  { c.invalidateCalls.Add(1) }
+func (c *chmodFilterCountingState) InvalidateCodeIndex()    {}
+func (c *chmodFilterCountingState) InvalidateDependents()   {}
+func (c *chmodFilterCountingState) InvalidateLibraryFacts() { c.libraryFactsInvalidations.Add(1) }
+func (c *chmodFilterCountingState) InvalidateResolver()     {}
+func (c *chmodFilterCountingState) InvalidateOracleFilter() {}
+func (c *chmodFilterCountingState) Touch(string)            {}

--- a/internal/hashutil/memo.go
+++ b/internal/hashutil/memo.go
@@ -176,26 +176,37 @@ func (m *Memo) HashFileRaw(path string, provider func() ([]byte, error)) ([32]by
 // callers that already hold the file bytes (e.g. after reading once
 // into memory for parsing).
 func (m *Memo) HashContent(path string, content []byte) string {
-	hx := HashHex(content)
 	if m == nil || path == "" {
-		return hx
+		return HashHex(content)
 	}
 	info, err := os.Stat(path)
 	if err != nil {
-		return hx
+		return HashHex(content)
 	}
 	size := info.Size()
 	modNano := info.ModTime().UnixNano()
-	var raw [32]byte
-	b, _ := hex.DecodeString(hx)
-	copy(raw[:], b)
 
+	// Stat-first lookup: a hit returns the prior hex without ever
+	// re-hashing the content. On a 13k-file kotlin corpus that turns
+	// resolverFingerprint's per-file SHA-256 into a per-file stat
+	// (10x cheaper). Mismatch granularity is bounded by mtime — fsnotify
+	// edits flip mtime, so a stale entry can only survive content-only
+	// rewrites that don't touch mtime (rare; same risk class as parse
+	// cache).
 	m.mu.Lock()
 	if e, ok := m.entries[path]; ok && e.size == size && e.modNano == modNano && e.hex != "" {
 		m.mu.Unlock()
 		m.hits.Add(1)
 		return e.hex
 	}
+	m.mu.Unlock()
+
+	hx := HashHex(content)
+	var raw [32]byte
+	b, _ := hex.DecodeString(hx)
+	copy(raw[:], b)
+
+	m.mu.Lock()
 	m.entries[path] = memoEntry{size: size, modNano: modNano, hex: hx, raw: raw}
 	m.mu.Unlock()
 	m.misses.Add(1)

--- a/internal/pipeline/android.go
+++ b/internal/pipeline/android.go
@@ -72,6 +72,11 @@ type AndroidInput struct {
 	// CacheWriter persists fresh cache entries asynchronously. When nil,
 	// the phase falls back to the un-cached path.
 	CacheWriter *scanner.AndroidCacheWriter
+	// GradleFindingsCache, when non-nil, memoizes per-gradle-file
+	// findings across analyzes. Daemon callers wire this to a
+	// WorkspaceState-resident map; cache keys include the content
+	// hash + rule hash so config changes invalidate. CLI passes nil.
+	GradleFindingsCache func(key string, build func() scanner.FindingColumns) scanner.FindingColumns
 }
 
 // AndroidResult is the output of the Android phase.
@@ -800,6 +805,29 @@ func (p AndroidPhase) runGradlePhase(in AndroidInput, collector *scanner.Finding
 	}
 	memo := hashutil.Default()
 	for _, path := range in.Project.GradlePaths {
+		// In-memory daemon cache: keyed by (contentHash, ruleHash) so a
+		// rule-config change forces a fresh dispatch. Falls through to
+		// the disk-cache and uncached paths when no resident cache is
+		// wired (CLI path).
+		if in.GradleFindingsCache != nil {
+			contentHash, herr := memo.HashFile(path, nil)
+			if herr == nil {
+				key := path + "\x00" + contentHash + "\x00" + in.RuleHash
+				var rpdur, rdur time.Duration
+				cols := in.GradleFindingsCache(key, func() scanner.FindingColumns {
+					c, rp, rd := p.runGradleOne(in, path)
+					rpdur, rdur = rp, rd
+					return c
+				})
+				readParseDur += rpdur
+				rulesDur += rdur
+				collector.AppendColumns(&cols)
+				if bundleCollector != nil {
+					bundleCollector.AppendColumns(&cols)
+				}
+				continue
+			}
+		}
 		if cacheable {
 			contentHash, err := memo.HashFile(path, nil)
 			if err != nil {

--- a/internal/pipeline/index.go
+++ b/internal/pipeline/index.go
@@ -83,6 +83,10 @@ type IndexInput struct {
 	// entire perFileExtraction + merge + resolveSupertypes skip on
 	// warm-no-change runs.
 	ResolverCache ResolverCache
+	// AndroidProjectCache, when non-nil and PrebuiltAndroidProject is
+	// nil, memoizes the detected *android.Project across calls so
+	// detectAndroidProject skips its ~1s tree walk on warm reruns.
+	AndroidProjectCache AndroidProjectCache
 	// TypeIndexCacheDir, when non-empty, enables the per-file
 	// FileTypeInfo cache (typeinfer.IndexFilesParallelCachedWithTracker).
 	// Unchanged files are read from disk instead of re-extracted, which
@@ -491,10 +495,14 @@ func (p IndexPhase) detectAndroidProject(in IndexInput, result *IndexResult) {
 	if p.SkipAndroid {
 		return
 	}
-	if in.PrebuiltAndroidProject != nil {
+	build := func() *android.Project { return android.DetectProject(in.Paths) }
+	switch {
+	case in.PrebuiltAndroidProject != nil:
 		result.AndroidProject = in.PrebuiltAndroidProject
-	} else {
-		result.AndroidProject = android.DetectProject(in.Paths)
+	case in.AndroidProjectCache != nil:
+		result.AndroidProject = in.AndroidProjectCache(androidProjectFingerprint(in.Paths), build)
+	default:
+		result.AndroidProject = build()
 	}
 	if result.LibraryFacts == nil && result.AndroidProject != nil {
 		gradle := result.AndroidProject.GradlePaths
@@ -507,6 +515,29 @@ func (p IndexPhase) detectAndroidProject(in IndexInput, result *IndexResult) {
 			result.LibraryFacts = build()
 		}
 	}
+}
+
+// androidProjectFingerprint hashes the sorted absolute scan-path set
+// used as the cache key for AndroidProjectCache. The watcher's
+// InvalidateLibraryFacts hook drops the slot on build.gradle /
+// version-catalog edits, so a stable fingerprint for the same paths
+// is enough to detect "different project root" mismatches without
+// reflecting per-Gradle-file content (that's the library-facts slot's
+// job).
+func androidProjectFingerprint(paths []string) string {
+	if len(paths) == 0 {
+		return ""
+	}
+	abs := make([]string, 0, len(paths))
+	for _, p := range paths {
+		if a, err := filepath.Abs(p); err == nil {
+			abs = append(abs, a)
+		} else {
+			abs = append(abs, p)
+		}
+	}
+	sort.Strings(abs)
+	return hashutil.HashHex([]byte(strings.Join(abs, "\x00")))
 }
 
 // computeRuleHash ensures result.RuleHash is set, deriving it from the

--- a/internal/pipeline/parse.go
+++ b/internal/pipeline/parse.go
@@ -66,16 +66,17 @@ func (p ParsePhase) Run(ctx context.Context, in ParseInput) (ParseResult, error)
 	}
 
 	var (
-		kotlinFiles []*scanner.File
-		parseErrs   []error
+		kotlinFiles  []*scanner.File
+		parseErrs    []error
+		residentHits int
 	)
 	parseStart := time.Now()
 	_ = in.trackSerial("parse", func() error {
-		kotlinFiles, parseErrs = scanner.ScanFilesCached(kotlinPaths, workers, in.ParseCache)
+		kotlinFiles, parseErrs, residentHits = scanWithResident(kotlinPaths, workers, in.ParseCache, in.ResidentFiles, scanner.ScanFilesCached)
 		return nil
 	})
-	in.logf("verbose: Parsed %d files in %v (%d errors, %d workers)\n",
-		len(kotlinFiles), time.Since(parseStart).Round(time.Millisecond), len(parseErrs), workers)
+	in.logf("verbose: Parsed %d files in %v (%d errors, %d workers, %d resident hits)\n",
+		len(kotlinFiles), time.Since(parseStart).Round(time.Millisecond), len(parseErrs), workers, residentHits)
 
 	// Filter generated Kotlin files unless explicitly requested. Generated
 	// dirs contain codegen output that dwarfs hand-written sources and
@@ -130,7 +131,7 @@ func (p ParsePhase) Run(ctx context.Context, in ParseInput) (ParseResult, error)
 			parseErrs = append(parseErrs, javaErr)
 		} else if len(javaPaths) > 0 {
 			var javaParseErrs []error
-			javaFiles, javaParseErrs = scanner.ScanJavaFilesCached(javaPaths, workers, in.ParseCache)
+			javaFiles, javaParseErrs, _ = scanWithResident(javaPaths, workers, in.ParseCache, in.ResidentFiles, scanner.ScanJavaFilesCached)
 			parseErrs = append(parseErrs, javaParseErrs...)
 			if !in.IncludeGenerated {
 				javaFiles, _ = filterGeneratedSourceFilesWithAllowlist(javaFiles, in.IncludeGeneratedAllowlist)
@@ -207,6 +208,15 @@ func installSourceSuppression(f *scanner.File, ruleExcludes map[string][]string,
 	if f == nil || f.FlatTree == nil {
 		return
 	}
+	// Resident-cache hits arrive with Suppression already built from a
+	// prior analyze. Rules-config changes invalidate the whole resident
+	// cache (via WorkspaceState.InvalidateAll), so a non-nil Suppression
+	// can be trusted for the current run — rebuilding it would walk the
+	// flat tree for every file, costing ~50µs each (~700ms on a 13k-file
+	// corpus).
+	if f.Suppression != nil && f.SuppressionIdx != nil {
+		return
+	}
 	f.Suppression = scanner.BuildSuppressionFilter(f, nil, ruleExcludes, "").WithRuleAliases(ruleAliases)
 	f.SuppressionIdx = f.Suppression.Annotations()
 }
@@ -246,6 +256,48 @@ func NeedsJavaSourceDispatch(rules []*api.Rule) bool {
 // source set, and Java source rules need Java ASTs for per-file dispatch.
 func NeedsJavaBeforeDispatch(rules []*api.Rule) bool {
 	return unionNeeds(rules).Has(api.NeedsParsedFiles) || NeedsJavaSourceDispatch(rules)
+}
+
+// scanWithResident partitions paths into resident-cache hits (returned
+// without any disk read) and misses (forwarded to scan). The returned
+// file slice preserves the order: resident hits first in input order,
+// then freshly-scanned misses. Newly-parsed files are stored back in
+// the resident cache so the next call can short-circuit.
+//
+// A nil cache disables the fast path entirely — the function then
+// just forwards every path to scan, matching the pre-#254 behavior.
+// Errors from scan are returned unchanged.
+func scanWithResident(
+	paths []string,
+	workers int,
+	pc *scanner.ParseCache,
+	cache ResidentFileCache,
+	scan func([]string, int, *scanner.ParseCache) ([]*scanner.File, []error),
+) ([]*scanner.File, []error, int) {
+	if cache == nil || len(paths) == 0 {
+		files, errs := scan(paths, workers, pc)
+		return files, errs, 0
+	}
+	hits := make([]*scanner.File, 0, len(paths))
+	misses := make([]string, 0)
+	for _, p := range paths {
+		if f, ok := cache.LookupParsedByPath(p); ok {
+			hits = append(hits, f)
+			continue
+		}
+		misses = append(misses, p)
+	}
+	freshFiles, errs := scan(misses, workers, pc)
+	for _, f := range freshFiles {
+		if f == nil {
+			continue
+		}
+		cache.StoreParsed(f.Path, f.Content, f)
+	}
+	out := make([]*scanner.File, 0, len(hits)+len(freshFiles))
+	out = append(out, hits...)
+	out = append(out, freshFiles...)
+	return out, errs, len(hits)
 }
 
 // Compile-time check: ParsePhase satisfies Phase[ParseInput, ParseResult].

--- a/internal/pipeline/parse_test.go
+++ b/internal/pipeline/parse_test.go
@@ -480,3 +480,74 @@ func TestParsePhase_Run_ContextCancel(t *testing.T) {
 		t.Errorf("Phase = %q, want parse", pe.Phase)
 	}
 }
+
+// TestParsePhase_Run_ResidentCache verifies the ResidentFileCache fast
+// path is consulted before any disk read. A counting fake returns
+// pre-baked *scanner.File pointers on hit; the test asserts the
+// returned files include the cached pointers and that ParsePhase did
+// not re-read the cached paths from disk.
+func TestParsePhase_Run_ResidentCache(t *testing.T) {
+	dir := t.TempDir()
+	hotPath := filepath.Join(dir, "Hot.kt")
+	coldPath := filepath.Join(dir, "Cold.kt")
+	writeKt(t, hotPath, "class Hot {}\n")
+	writeKt(t, coldPath, "class Cold {}\n")
+
+	// Pre-parse Hot.kt so we can hand a real *scanner.File to the cache.
+	hotFile, err := scanner.ParseFile(hotPath)
+	if err != nil {
+		t.Fatalf("pre-parse Hot.kt: %v", err)
+	}
+
+	cache := &fakeResidentCache{
+		entries: map[string]*scanner.File{hotPath: hotFile},
+	}
+
+	in := ParseInput{
+		Paths:         []string{dir},
+		KotlinPaths:   []string{hotPath, coldPath},
+		ResidentFiles: cache,
+	}
+	res, err := (ParsePhase{}).Run(context.Background(), in)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if cache.lookups != 2 {
+		t.Errorf("LookupParsedByPath calls = %d, want 2", cache.lookups)
+	}
+	// Cold.kt was a miss — must have been stored back into the cache.
+	if cache.stores != 1 {
+		t.Errorf("StoreParsed calls = %d, want 1 (Cold.kt miss)", cache.stores)
+	}
+	// Hot.kt must be returned by identity (same pointer the cache held).
+	var foundHotByIdentity bool
+	for _, f := range res.KotlinFiles {
+		if f == hotFile {
+			foundHotByIdentity = true
+			break
+		}
+	}
+	if !foundHotByIdentity {
+		t.Errorf("ResidentFileCache hit was not returned by pointer identity")
+	}
+}
+
+type fakeResidentCache struct {
+	entries map[string]*scanner.File
+	lookups int
+	stores  int
+}
+
+func (f *fakeResidentCache) LookupParsedByPath(path string) (*scanner.File, bool) {
+	f.lookups++
+	file, ok := f.entries[path]
+	return file, ok
+}
+
+func (f *fakeResidentCache) StoreParsed(path string, _ []byte, file *scanner.File) {
+	f.stores++
+	if f.entries == nil {
+		f.entries = map[string]*scanner.File{}
+	}
+	f.entries[path] = file
+}

--- a/internal/pipeline/project.go
+++ b/internal/pipeline/project.go
@@ -193,6 +193,15 @@ type ProjectHostState struct {
 	// fingerprint and threads it into IndexInput.PrebuiltOracleCallFilter.
 	// *WorkspaceState satisfies this interface.
 	OracleFilterCache OracleFilterCache
+	// AndroidProjectCache, when non-nil, memoizes the detected
+	// *android.Project across calls. IndexPhase.detectAndroidProject
+	// consults the slot before falling through to android.DetectProject
+	// (which walks the source tree for AndroidManifest.xml + build.gradle
+	// markers — ~1s on a 60k-file corpus). The fingerprint is the
+	// repo-root scan-path set; the watcher's InvalidateLibraryFacts hook
+	// (fired on build.gradle / version-catalog edits) also drops this
+	// slot. *WorkspaceState satisfies this interface.
+	AndroidProjectCache AndroidProjectCache
 	// CrossFileCacheDir, when non-empty, enables the on-disk cross-file
 	// CodeIndex cache (zstd-encoded shards under .krit/crossfile-cache).
 	// Independent of CodeIndexCache: the disk cache is shared across
@@ -676,6 +685,7 @@ func runProjectIndexPhase(ctx context.Context, args ProjectArgs, host ProjectHos
 		LibraryFactsCache:      host.LibraryFactsCache,
 		CodeIndexCache:         host.CodeIndexCache,
 		ResolverCache:          host.ResolverCache,
+		AndroidProjectCache:    host.AndroidProjectCache,
 		CrossFileCacheDir:      host.CrossFileCacheDir,
 		CrossFindingsCacheDir:  host.CrossFindingsCacheDir,
 		TypeIndexCacheDir:      host.TypeIndexCacheDir,
@@ -860,7 +870,7 @@ func allowWarmResourceSourceDelta(args ProjectArgs, host ProjectHostState, warm 
 	}
 	project := host.PrebuiltAndroidProject
 	if project == nil {
-		project = android.DetectProject(args.Paths)
+		project = cachedDetectAndroidProject(args, host)
 	}
 	if project == nil || project.IsEmpty() || len(project.ResDirs) == 0 {
 		return false
@@ -1689,6 +1699,21 @@ func filesForPaths(paths []string, lang scanner.Language) []*scanner.File {
 	return files
 }
 
+// cachedDetectAndroidProject routes the project-fingerprint and
+// resource-source paths through the same daemon-resident
+// AndroidProjectCache that IndexPhase.detectAndroidProject uses, so
+// preparseBundleFingerprint doesn't pay the ~1s DetectProject tree walk
+// twice per analyze. Falls back to a fresh DetectProject when the host
+// has no cache wired (CLI path).
+func cachedDetectAndroidProject(args ProjectArgs, host ProjectHostState) *android.Project {
+	if host.AndroidProjectCache == nil {
+		return android.DetectProject(args.Paths)
+	}
+	return host.AndroidProjectCache(androidProjectFingerprint(args.Paths), func() *android.Project {
+		return android.DetectProject(args.Paths)
+	})
+}
+
 func preparseProjectFingerprints(args ProjectArgs, host ProjectHostState) (string, string) {
 	project := host.PrebuiltAndroidProject
 	if host.PrebuiltLibraryFacts != nil {
@@ -1699,7 +1724,7 @@ func preparseProjectFingerprints(args ProjectArgs, host ProjectHostState) (strin
 		return androidFP, host.PrebuiltLibraryFacts.Fingerprint()
 	}
 	if project == nil {
-		project = android.DetectProject(args.Paths)
+		project = cachedDetectAndroidProject(args, host)
 	}
 	if project == nil {
 		return "", ""

--- a/internal/pipeline/project.go
+++ b/internal/pipeline/project.go
@@ -202,6 +202,13 @@ type ProjectHostState struct {
 	// (fired on build.gradle / version-catalog edits) also drops this
 	// slot. *WorkspaceState satisfies this interface.
 	AndroidProjectCache AndroidProjectCache
+	// GradleFindingsCache, when non-nil, memoizes per-gradle-file
+	// rule-dispatch findings across analyzes (~7ms each × hundreds of
+	// gradle files on a kotlin-style monorepo = ~1.4s saved per warm
+	// analyze). Daemon callers wire WorkspaceState.GradleFindings.
+	// CLI passes nil — the existing on-disk AndroidCacheWriter path
+	// covers that case.
+	GradleFindingsCache func(key string, build func() scanner.FindingColumns) scanner.FindingColumns
 	// CrossFileCacheDir, when non-empty, enables the on-disk cross-file
 	// CodeIndex cache (zstd-encoded shards under .krit/crossfile-cache).
 	// Independent of CodeIndexCache: the disk cache is shared across
@@ -1312,6 +1319,7 @@ func runAndroidPhaseAndMerge(ctx context.Context, args ProjectArgs, host Project
 		JavaSemanticFactsFP: indexResult.JavaSemanticFacts.Fingerprint(),
 		CacheDir:            host.AndroidCacheDir,
 		CacheWriter:         host.AndroidCacheWriter,
+		GradleFindingsCache: host.GradleFindingsCache,
 	})
 	if err != nil {
 		return fmt.Errorf("android: %w", err)

--- a/internal/pipeline/project.go
+++ b/internal/pipeline/project.go
@@ -149,6 +149,10 @@ type ProjectHostState struct {
 	// cached FlatTree. The daemon constructs one at startup and reuses
 	// it across calls.
 	ParseCache *scanner.ParseCache
+	// ResidentFiles, when non-nil, is the daemon's per-path *scanner.File
+	// cache. ParsePhase checks it before any disk read. See
+	// ParseInput.ResidentFiles.
+	ResidentFiles ResidentFileCache
 	// PrebuiltResolver, when non-nil, short-circuits resolver
 	// construction inside IndexPhase. The daemon keeps one resident.
 	PrebuiltResolver typeinfer.TypeResolver
@@ -843,6 +847,7 @@ func runProjectParsePhase(ctx context.Context, args ProjectArgs, host ProjectHos
 		Reporter:           host.Reporter,
 		Tracker:            host.Tracker,
 		ParseCache:         host.ParseCache,
+		ResidentFiles:      host.ResidentFiles,
 	})
 }
 

--- a/internal/pipeline/types.go
+++ b/internal/pipeline/types.go
@@ -99,6 +99,22 @@ type ParseInput struct {
 	// previously-cached FlatTree. Misses trigger a normal parse and a
 	// cache write-back. Nil disables the cache entirely.
 	ParseCache *scanner.ParseCache
+	// ResidentFiles, when non-nil, is checked by path before any disk
+	// read. A hit skips the os.ReadFile + content-hash + parse-cache
+	// lookup entirely — saving ~100µs/file at kotlin-corpus scale.
+	// The watcher's Invalidate(path) hook is the correctness boundary;
+	// callers wire this to a daemon-resident WorkspaceState.
+	ResidentFiles ResidentFileCache
+}
+
+// ResidentFileCache is the optional fast-path the daemon hands the
+// parse phase. Implementations are expected to be path-keyed and safe
+// for concurrent use. The watcher invalidates entries on file events;
+// the parse phase can trust the path-only lookup as long as the
+// watcher is wired (the daemon's contract — CLI passes nil).
+type ResidentFileCache interface {
+	LookupParsedByPath(path string) (*scanner.File, bool)
+	StoreParsed(path string, content []byte, file *scanner.File)
 }
 
 // logf forwards verbose progress lines to Reporter when set.

--- a/internal/pipeline/types.go
+++ b/internal/pipeline/types.go
@@ -346,6 +346,15 @@ type ResolverCache = XFileCache[typeinfer.TypeResolver]
 // fresh classification.
 type OracleFilterCache = XFileCache[*oracle.CallTargetFilterSummary]
 
+// AndroidProjectCache memoizes the detected *android.Project across
+// RunProject calls. DetectProject walks the project tree for
+// AndroidManifest.xml / build.gradle / src/main/res markers, which
+// costs ~1s on a 60k-file corpus even when nothing changed. The
+// watcher invalidates this slot whenever a build.gradle / version
+// catalog changes (same hook as LibraryFactsCache), so a non-nil
+// cached value is safe to reuse for the current run.
+type AndroidProjectCache = XFileCache[*android.Project]
+
 // FileTiming captures per-file dispatch timing recorded when
 // IndexResult.ProfileDispatch is set.
 type FileTiming struct {

--- a/internal/pipeline/workspace.go
+++ b/internal/pipeline/workspace.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"sync/atomic"
 
+	"github.com/kaeawc/krit/internal/android"
 	"github.com/kaeawc/krit/internal/hashutil"
 	"github.com/kaeawc/krit/internal/librarymodel"
 	"github.com/kaeawc/krit/internal/oracle"
@@ -43,12 +44,13 @@ type WorkspaceState struct {
 	// fingerprint discards the prior value and rebuilds. Slots are
 	// independent so a libraryFacts rebuild doesn't drop the
 	// (much more expensive) codeIndex.
-	xfileMu      sync.Mutex
-	libraryFacts xfileSlot[*librarymodel.Facts]
-	codeIndex    xfileSlot[*scanner.CodeIndex]
-	dependents   xfileSlot[*scanner.DependentsIndex]
-	resolver     xfileSlot[typeinfer.TypeResolver]
-	oracleFilter xfileSlot[*oracle.CallTargetFilterSummary]
+	xfileMu        sync.Mutex
+	libraryFacts   xfileSlot[*librarymodel.Facts]
+	codeIndex      xfileSlot[*scanner.CodeIndex]
+	dependents     xfileSlot[*scanner.DependentsIndex]
+	resolver       xfileSlot[typeinfer.TypeResolver]
+	oracleFilter   xfileSlot[*oracle.CallTargetFilterSummary]
+	androidProject xfileSlot[*android.Project]
 }
 
 // xfileSlot pairs a fingerprint with a value. Zero value means
@@ -260,6 +262,7 @@ func (w *WorkspaceState) InvalidateAll() {
 	w.dependents = xfileSlot[*scanner.DependentsIndex]{}
 	w.resolver = xfileSlot[typeinfer.TypeResolver]{}
 	w.oracleFilter = xfileSlot[*oracle.CallTargetFilterSummary]{}
+	w.androidProject = xfileSlot[*android.Project]{}
 	w.xfileMu.Unlock()
 }
 
@@ -394,14 +397,45 @@ func (w *WorkspaceState) CrossFileStats() CrossFileStats {
 
 // InvalidateLibraryFacts drops the cached *librarymodel.Facts. Called
 // when a Gradle build script or version catalog changes — the next
-// LibraryFacts call rebuilds.
+// LibraryFacts call rebuilds. Also drops the AndroidProject cache
+// since its GradlePaths set could have changed.
 func (w *WorkspaceState) InvalidateLibraryFacts() {
 	if w == nil {
 		return
 	}
 	w.xfileMu.Lock()
 	w.libraryFacts = xfileSlot[*librarymodel.Facts]{}
+	w.androidProject = xfileSlot[*android.Project]{}
 	w.xfileMu.Unlock()
+}
+
+// AndroidProject memoizes the detected Android project across calls.
+// fingerprint must capture every input that affects detection (today
+// just the project root, since DetectProject is path-only and the
+// watcher invalidates this slot whenever a build.gradle / version
+// catalog changes). nil receiver always builds (no caching).
+func (w *WorkspaceState) AndroidProject(fingerprint string, build func() *android.Project) *android.Project {
+	if w == nil || fingerprint == "" {
+		return build()
+	}
+	w.xfileMu.Lock()
+	if w.androidProject.present && w.androidProject.fingerprint == fingerprint {
+		v := w.androidProject.value
+		w.xfileMu.Unlock()
+		return v
+	}
+	w.xfileMu.Unlock()
+
+	v := build()
+
+	w.xfileMu.Lock()
+	if w.androidProject.present && w.androidProject.fingerprint == fingerprint {
+		v = w.androidProject.value
+	} else {
+		w.androidProject = xfileSlot[*android.Project]{fingerprint: fingerprint, value: v, present: true}
+	}
+	w.xfileMu.Unlock()
+	return v
 }
 
 // InvalidateCodeIndex drops the cached *scanner.CodeIndex. Called

--- a/internal/pipeline/workspace.go
+++ b/internal/pipeline/workspace.go
@@ -128,6 +128,48 @@ func (w *WorkspaceState) ParseFileWithHit(ctx context.Context, path string, cont
 	return file, false, nil
 }
 
+// LookupParsedByPath returns the cached *scanner.File for path
+// without re-reading or re-hashing content. The watcher's Invalidate
+// hook is the correctness boundary: if the file changed and fsnotify
+// missed the event, the caller will replay a stale parse — same
+// best-effort contract the watcher already promises.
+//
+// Returns (nil, false) when no entry exists for path. Pointer-stable:
+// repeated calls return the same *scanner.File until Invalidate
+// drops it.
+func (w *WorkspaceState) LookupParsedByPath(path string) (*scanner.File, bool) {
+	if w == nil {
+		return nil, false
+	}
+	key := normalizeKey(path)
+	w.mu.RLock()
+	entry, ok := w.parsed[key]
+	w.mu.RUnlock()
+	if !ok {
+		return nil, false
+	}
+	return entry.file, true
+}
+
+// StoreParsed records file as the cached entry for path. content is
+// hashed and stored alongside so ParseFileWithHit callers (LSP/MCP)
+// can still content-gate. Idempotent: a second StoreParsed for the
+// same (path, content hash) is a no-op.
+func (w *WorkspaceState) StoreParsed(path string, content []byte, file *scanner.File) {
+	if w == nil || file == nil {
+		return
+	}
+	key := normalizeKey(path)
+	hash := hashutil.Default().HashContent(key, content)
+	w.mu.Lock()
+	if existing, ok := w.parsed[key]; ok && existing.contentHash == hash {
+		w.mu.Unlock()
+		return
+	}
+	w.parsed[key] = parsedEntry{contentHash: hash, file: file}
+	w.mu.Unlock()
+}
+
 // Invalidate drops the cached entry for path. Safe to call when no
 // entry exists.
 func (w *WorkspaceState) Invalidate(path string) {

--- a/internal/pipeline/workspace.go
+++ b/internal/pipeline/workspace.go
@@ -51,6 +51,9 @@ type WorkspaceState struct {
 	resolver       xfileSlot[typeinfer.TypeResolver]
 	oracleFilter   xfileSlot[*oracle.CallTargetFilterSummary]
 	androidProject xfileSlot[*android.Project]
+
+	gradleMu       sync.Mutex
+	gradleFindings map[string]scanner.FindingColumns
 }
 
 // xfileSlot pairs a fingerprint with a value. Zero value means
@@ -264,6 +267,9 @@ func (w *WorkspaceState) InvalidateAll() {
 	w.oracleFilter = xfileSlot[*oracle.CallTargetFilterSummary]{}
 	w.androidProject = xfileSlot[*android.Project]{}
 	w.xfileMu.Unlock()
+	w.gradleMu.Lock()
+	w.gradleFindings = nil
+	w.gradleMu.Unlock()
 }
 
 // LibraryFacts returns the cached *librarymodel.Facts when its
@@ -407,6 +413,44 @@ func (w *WorkspaceState) InvalidateLibraryFacts() {
 	w.libraryFacts = xfileSlot[*librarymodel.Facts]{}
 	w.androidProject = xfileSlot[*android.Project]{}
 	w.xfileMu.Unlock()
+	w.gradleMu.Lock()
+	w.gradleFindings = nil
+	w.gradleMu.Unlock()
+}
+
+// GradleFindings memoizes per-file gradle rule findings across
+// analyzes, keyed by (content hash + rule hash). On a 200-gradle-file
+// monorepo (kotlin) the per-file Read+Parse+Dispatch cost is ~7 ms
+// each, ~1.4 s total per warm analyze — even though gradle files
+// rarely change. Memoizing the findings drops this to ~0 ms on warm
+// reruns.
+//
+// The watcher's InvalidateLibraryFacts hook (fired on build.gradle /
+// version-catalog edits) clears the whole map, so any gradle dependency
+// change forces re-run of every gradle rule. nil receiver disables
+// caching.
+func (w *WorkspaceState) GradleFindings(key string, build func() scanner.FindingColumns) scanner.FindingColumns {
+	if w == nil || key == "" {
+		return build()
+	}
+	w.gradleMu.Lock()
+	if w.gradleFindings != nil {
+		if cached, ok := w.gradleFindings[key]; ok {
+			w.gradleMu.Unlock()
+			return cached
+		}
+	}
+	w.gradleMu.Unlock()
+
+	v := build()
+
+	w.gradleMu.Lock()
+	if w.gradleFindings == nil {
+		w.gradleFindings = make(map[string]scanner.FindingColumns)
+	}
+	w.gradleFindings[key] = v
+	w.gradleMu.Unlock()
+	return v
 }
 
 // AndroidProject memoizes the detected Android project across calls.

--- a/internal/pipeline/workspace_test.go
+++ b/internal/pipeline/workspace_test.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/kaeawc/krit/internal/android"
 	"github.com/kaeawc/krit/internal/librarymodel"
 	"github.com/kaeawc/krit/internal/oracle"
 	"github.com/kaeawc/krit/internal/scanner"
@@ -466,4 +467,57 @@ func TestWorkspaceState_StoreParsedIdempotent(t *testing.T) {
 	if got != first {
 		t.Errorf("StoreParsed replaced pointer for same content hash")
 	}
+}
+
+// TestWorkspaceState_AndroidProjectCachesByFingerprint verifies the
+// memoization contract: same fingerprint reuses the cached pointer
+// without firing build; different fingerprint forces a rebuild.
+func TestWorkspaceState_AndroidProjectCachesByFingerprint(t *testing.T) {
+	w := NewWorkspaceState("")
+	var builds int
+	first := w.AndroidProject("fp-a", func() *android.Project {
+		builds++
+		return &android.Project{ManifestPaths: []string{"AndroidManifest.xml"}}
+	})
+	if builds != 1 {
+		t.Fatalf("AndroidProject builds = %d, want 1", builds)
+	}
+	again := w.AndroidProject("fp-a", func() *android.Project {
+		builds++
+		return &android.Project{}
+	})
+	if builds != 1 {
+		t.Errorf("AndroidProject builds = %d after hit, want 1", builds)
+	}
+	if again != first {
+		t.Errorf("AndroidProject returned different pointer for same fingerprint")
+	}
+	_ = w.AndroidProject("fp-b", func() *android.Project { builds++; return &android.Project{} })
+	if builds != 2 {
+		t.Errorf("AndroidProject builds = %d after fp mismatch, want 2", builds)
+	}
+}
+
+// TestWorkspaceState_InvalidateLibraryFactsDropsAndroid verifies the
+// watcher's InvalidateLibraryFacts hook also drops the AndroidProject
+// slot — the two share the build.gradle dependency boundary, so a
+// build script edit must invalidate both.
+func TestWorkspaceState_InvalidateLibraryFactsDropsAndroid(t *testing.T) {
+	w := NewWorkspaceState("")
+	w.AndroidProject("fp", func() *android.Project { return &android.Project{} })
+	if !w.CrossFileStats().HasLibraryFacts && w.androidProject.present {
+		// confirm initial population path
+	}
+	w.LibraryFacts("lf", func() *librarymodel.Facts { return &librarymodel.Facts{} })
+
+	w.InvalidateLibraryFacts()
+
+	if w.CrossFileStats().HasLibraryFacts {
+		t.Errorf("LibraryFacts not invalidated")
+	}
+	w.xfileMu.Lock()
+	if w.androidProject.present {
+		t.Errorf("AndroidProject slot survived InvalidateLibraryFacts")
+	}
+	w.xfileMu.Unlock()
 }

--- a/internal/pipeline/workspace_test.go
+++ b/internal/pipeline/workspace_test.go
@@ -505,10 +505,10 @@ func TestWorkspaceState_AndroidProjectCachesByFingerprint(t *testing.T) {
 func TestWorkspaceState_InvalidateLibraryFactsDropsAndroid(t *testing.T) {
 	w := NewWorkspaceState("")
 	w.AndroidProject("fp", func() *android.Project { return &android.Project{} })
-	if !w.CrossFileStats().HasLibraryFacts && w.androidProject.present {
-		// confirm initial population path
-	}
 	w.LibraryFacts("lf", func() *librarymodel.Facts { return &librarymodel.Facts{} })
+	if !w.CrossFileStats().HasLibraryFacts {
+		t.Fatal("setup: LibraryFacts slot should be populated")
+	}
 
 	w.InvalidateLibraryFacts()
 
@@ -520,4 +520,43 @@ func TestWorkspaceState_InvalidateLibraryFactsDropsAndroid(t *testing.T) {
 		t.Errorf("AndroidProject slot survived InvalidateLibraryFacts")
 	}
 	w.xfileMu.Unlock()
+}
+
+// TestWorkspaceState_GradleFindingsMemoizes verifies the per-gradle-
+// file findings cache: same key reuses the cached result without
+// firing build; different key triggers build; InvalidateLibraryFacts
+// drops the whole map.
+func TestWorkspaceState_GradleFindingsMemoizes(t *testing.T) {
+	w := NewWorkspaceState("")
+	var builds int
+	first := w.GradleFindings("k1", func() scanner.FindingColumns {
+		builds++
+		return scanner.FindingColumns{}
+	})
+	if builds != 1 {
+		t.Fatalf("GradleFindings builds = %d after first call, want 1", builds)
+	}
+	_ = w.GradleFindings("k1", func() scanner.FindingColumns {
+		builds++
+		return scanner.FindingColumns{}
+	})
+	if builds != 1 {
+		t.Errorf("GradleFindings builds = %d after hit, want 1", builds)
+	}
+	_ = w.GradleFindings("k2", func() scanner.FindingColumns {
+		builds++
+		return scanner.FindingColumns{}
+	})
+	if builds != 2 {
+		t.Errorf("GradleFindings builds = %d after distinct key, want 2", builds)
+	}
+	_ = first
+	w.InvalidateLibraryFacts()
+	_ = w.GradleFindings("k1", func() scanner.FindingColumns {
+		builds++
+		return scanner.FindingColumns{}
+	})
+	if builds != 3 {
+		t.Errorf("GradleFindings builds = %d after InvalidateLibraryFacts, want 3", builds)
+	}
 }

--- a/internal/pipeline/workspace_test.go
+++ b/internal/pipeline/workspace_test.go
@@ -411,3 +411,59 @@ func TestWorkspaceState_InvalidateAllClearsDependents(t *testing.T) {
 		t.Error("InvalidateAll should clear Dependents")
 	}
 }
+
+// TestWorkspaceState_LookupAndStoreParsed verifies the path-only fast
+// path: StoreParsed populates the cache, LookupParsedByPath returns
+// the same *scanner.File pointer, and Invalidate drops it.
+func TestWorkspaceState_LookupAndStoreParsed(t *testing.T) {
+	w := NewWorkspaceState("")
+
+	if _, ok := w.LookupParsedByPath("/tmp/missing.kt"); ok {
+		t.Errorf("LookupParsedByPath on empty cache returned ok=true")
+	}
+
+	content := []byte("class Foo {}\n")
+	file, err := ParseSingle(context.Background(), "/tmp/foo.kt", content)
+	if err != nil {
+		t.Fatalf("ParseSingle: %v", err)
+	}
+	w.StoreParsed("/tmp/foo.kt", content, file)
+
+	got, ok := w.LookupParsedByPath("/tmp/foo.kt")
+	if !ok {
+		t.Fatalf("LookupParsedByPath after StoreParsed: ok=false")
+	}
+	if got != file {
+		t.Errorf("LookupParsedByPath returned different pointer than StoreParsed")
+	}
+
+	w.Invalidate("/tmp/foo.kt")
+	if _, ok := w.LookupParsedByPath("/tmp/foo.kt"); ok {
+		t.Errorf("LookupParsedByPath after Invalidate: ok=true")
+	}
+}
+
+// TestWorkspaceState_StoreParsedIdempotent verifies a second
+// StoreParsed for the same (path, content hash) does not replace the
+// existing entry — callers can race without losing pointer identity.
+func TestWorkspaceState_StoreParsedIdempotent(t *testing.T) {
+	w := NewWorkspaceState("")
+	content := []byte("class Foo {}\n")
+	first, err := ParseSingle(context.Background(), "/tmp/foo.kt", content)
+	if err != nil {
+		t.Fatalf("ParseSingle: %v", err)
+	}
+	w.StoreParsed("/tmp/foo.kt", content, first)
+
+	// Second store with same hash must keep the first pointer.
+	second, err := ParseSingle(context.Background(), "/tmp/foo.kt", content)
+	if err != nil {
+		t.Fatalf("ParseSingle: %v", err)
+	}
+	w.StoreParsed("/tmp/foo.kt", content, second)
+
+	got, _ := w.LookupParsedByPath("/tmp/foo.kt")
+	if got != first {
+		t.Errorf("StoreParsed replaced pointer for same content hash")
+	}
+}


### PR DESCRIPTION
## Summary

Five changes that together drop the daemon's "warm + 1 kt ABI edit" cost on `~/github/kotlin` from ~7.2 s (post-#253) to ~2.2 s by holding more state resident across analyzes and ignoring noisy fsnotify events that were trashing those caches.

1. **resident parsed-files cache** (`perf(daemon): hold *scanner.File parsed-trees resident across analyzes`) — WorkspaceState already retained per-path parsed entries for the LSP/MCP direct-call seam, but the project pipeline never consulted it. Every analyze ran ScanFilesCached, which calls `os.ReadFile` + content-hash + ParseCache.Load for every file (~1.4 s for 13 k files on warm runs). Add `LookupParsedByPath` / `StoreParsed`, plumb a `ResidentFileCache` interface through `ParseInput` / `ProjectHostState`, and let ParsePhase partition input paths into resident hits vs. scan misses. `installSourceSuppression` skips its tree walk when the resident file already has Suppression populated.

2. **Chmod-event filter** (`fix(daemon): ignore Chmod-only fsnotify events`) — On macOS, kqueue emits spurious Chmod events whenever another process stats or opens a watched file (Spotlight, git, finder, IDE language servers). On a busy monorepo every analyze drained a burst of these for `build.gradle.kts` and unrelated `.kt` paths, each one treated as a real edit. That fired `InvalidateLibraryFacts` / `scheduleKotlinInvalidate` and blew the AndroidProject / resolver / per-file parsed-tree slots — ~3 s of rebuild per call. Content-changing edits always also emit Write/Create/Remove/Rename, so dropping Chmod loses nothing real.

3. **AndroidProject cache** (`perf(daemon): cache detected android.Project across analyzes`) — `android.DetectProject` walks the project tree for AndroidManifest.xml / build.gradle / src/main/res markers (~1 s on 60 k-file corpus). Both `IndexPhase.detectAndroidProject` and `preparseProjectFingerprints` call it on every analyze. New `AndroidProjectCache` slot on WorkspaceState, keyed by the sorted scan-path set; the watcher's `InvalidateLibraryFacts` hook (Gradle / version-catalog edits) drops it.

4. **stat-first HashContent** (`perf(hashutil): stat-first lookup in Memo.HashContent to skip SHA-256`) — `HashContent` always hashed content first, then consulted the `(path,size,mtime)` memo. Stat first; return cached hex without re-hashing when the entry is current. Helps `resolverFingerprint`, bundle fingerprints, and per-file content-hash maps.

5. **per-gradle-file findings cache** (`perf(daemon): cache per-gradle-file rule findings across analyzes`) — On the kotlin repo ~200 build.gradle.kts files are read+parsed+rule-dispatched on every analyze (~1.4 s, ~7 ms each). New `GradleFindings` map on WorkspaceState keyed by `(path, content-hash, rule-hash)`. AndroidPhase's gradle subphase consults it before falling through to the existing disk-cache or uncached paths. Same `InvalidateLibraryFacts` hook clears the whole map.

## Results on `~/github/kotlin` (16,504 Kotlin + 1,990 Java files)

| Scenario | Pre-#253 | Post-#253 | This PR |
|---|---|---|---|
| Warm baseline | 0.62 s | 0.62 s | **0.57 s** |
| ABI edit (first cold, fresh resident) | 91 s | 7.2 s | **4.81 s** |
| ABI edit (rerun, no further edits) | 38 s | 0.62 s | **0.57 s** |
| ABI edit (steady, full warm) | 38 s | ~5.0 s | **2.17 s** |

## Test plan
- [x] `go test ./...` passes (full suite)
- [x] `golangci-lint run ./...` clean
- [x] `go vet ./...` clean
- [x] New unit tests:
  - `TestParsePhase_Run_ResidentCache` — ResidentFileCache hits return pre-baked pointers without re-parsing
  - `TestWorkspaceState_LookupAndStoreParsed` — round-trip + Invalidate drops entry
  - `TestWorkspaceState_StoreParsedIdempotent` — same hash preserves pointer identity
  - `TestWorkspaceState_AndroidProjectCachesByFingerprint` — memoization contract
  - `TestWorkspaceState_InvalidateLibraryFactsDropsAndroid` — shared boundary with Gradle hook
  - `TestWorkspaceState_GradleFindingsMemoizes` — gradle findings cache hit/miss/invalidate
  - `TestFileWatcher_IgnoresChmodOnlyEvents` — Chmod-only events do not fire invalidation
- [x] Bench against `~/github/kotlin` confirms the numbers above