### PR TITLE
fix(pipeline): generated-file filters must not alias caller's backing slice

### DIFF
--- a/internal/cli/scan/scan.go
+++ b/internal/cli/scan/scan.go
@@ -591,7 +591,13 @@ func countActiveV2(registry []*api.Rule) int {
 }
 
 func filterGeneratedPathStrings(paths []string) []string {
-	filtered := paths[:0]
+	// Allocate a fresh slice — callers (runner_state.go) alias the
+	// input via `r.javaPathsForDispatch = r.allJavaPaths` before
+	// filtering, so a paths[:0] in-place rewrite would corrupt the
+	// caller's r.allJavaPaths backing array. The tail of the original
+	// slice would then alias kept entries from the front, causing
+	// downstream parse/dispatch to process the same files multiple times.
+	filtered := make([]string, 0, len(paths))
 	for _, p := range paths {
 		if strings.Contains(filepath.ToSlash(p), "/generated/") {
 			continue

--- a/internal/cli/scan/scan_test.go
+++ b/internal/cli/scan/scan_test.go
@@ -1,0 +1,44 @@
+package scan
+
+import "testing"
+
+// TestFilterGeneratedPathStringsDoesNotAliasInput pins the regression where
+// filterGeneratedPathStrings used `paths[:0]`, mutating the caller's backing
+// array. In runner_state.go the CLI runner aliases r.javaPathsForDispatch =
+// r.allJavaPaths before filtering, so the [:0] rewrite left duplicate entries
+// in r.allJavaPaths' tail. Those duplicates then flowed into the pipeline,
+// causing cold runs to dispatch the same files multiple times and over-report
+// findings against warm runs that loaded a deduped per-file cache.
+func TestFilterGeneratedPathStringsDoesNotAliasInput(t *testing.T) {
+	input := []string{
+		"src/main/Foo.java",
+		"build/generated/source/kapt/main/Generated1.java",
+		"src/main/Bar.java",
+		"build/generated/source/kapt/main/Generated2.java",
+		"src/main/Baz.java",
+	}
+	original := append([]string(nil), input...)
+
+	// Mimic the CLI's aliasing pattern.
+	alias := input
+
+	filtered := filterGeneratedPathStrings(alias)
+
+	if got, want := len(filtered), 3; got != want {
+		t.Fatalf("filtered len = %d, want %d", got, want)
+	}
+	for i, v := range input {
+		if v != original[i] {
+			t.Fatalf("filterGeneratedPathStrings mutated caller's slice at %d: got %q, want %q", i, v, original[i])
+		}
+	}
+	seen := map[string]int{}
+	for _, p := range input {
+		seen[p]++
+	}
+	for p, c := range seen {
+		if c > 1 {
+			t.Fatalf("caller slice has duplicate %q after filter (count=%d) — filter must not share backing", p, c)
+		}
+	}
+}

--- a/internal/pipeline/generated_filter_alias_test.go
+++ b/internal/pipeline/generated_filter_alias_test.go
@@ -1,0 +1,70 @@
+package pipeline
+
+import (
+	"testing"
+
+	"github.com/kaeawc/krit/internal/scanner"
+)
+
+// TestFilterGeneratedSourcePathsDoesNotAliasInput pins the regression that
+// caused cold/warm finding-count divergence on the JetBrains/kotlin corpus:
+// filterGeneratedSourcePaths used `paths[:0]`, so it mutated the caller's
+// backing array in place. callers in runProjectAnalysis pass args.KotlinPaths
+// and args.JavaPaths (owned by the CLI runner's r.files / r.allJavaPaths);
+// the in-place rewrite left dupes in the runner's slices, and downstream
+// parse + dispatch then processed the same files multiple times on cold runs
+// (warm runs skipped dispatch via the per-file cache and so reported fewer
+// findings).
+func TestFilterGeneratedSourcePathsDoesNotAliasInput(t *testing.T) {
+	input := []string{
+		"src/Foo.kt",
+		"build/generated/source/kapt/Generated1.kt",
+		"src/Bar.kt",
+		"build/generated/source/kapt/Generated2.kt",
+		"src/Baz.kt",
+	}
+	original := append([]string(nil), input...)
+	alias := input
+
+	filtered := filterGeneratedSourcePaths(alias, false)
+
+	if got, want := len(filtered), 3; got != want {
+		t.Fatalf("filtered len = %d, want %d", got, want)
+	}
+	for i, v := range input {
+		if v != original[i] {
+			t.Fatalf("filterGeneratedSourcePaths mutated caller's slice at %d: got %q, want %q", i, v, original[i])
+		}
+	}
+}
+
+// TestFilterGeneratedSourceFilesWithAllowlistDoesNotAliasInput pins the
+// matching [:0] hazard on the *scanner.File variant.
+func TestFilterGeneratedSourceFilesWithAllowlistDoesNotAliasInput(t *testing.T) {
+	input := []*scanner.File{
+		{Path: "src/Foo.kt"},
+		{Path: "build/generated/source/kapt/Generated1.kt"},
+		{Path: "src/Bar.kt"},
+		{Path: "build/generated/source/kapt/Generated2.kt"},
+		{Path: "src/Baz.kt"},
+	}
+	originalPaths := make([]string, len(input))
+	for i, f := range input {
+		originalPaths[i] = f.Path
+	}
+	alias := input
+
+	filtered, dropped := filterGeneratedSourceFilesWithAllowlist(alias, nil)
+
+	if got, want := len(filtered), 3; got != want {
+		t.Fatalf("filtered len = %d, want %d", got, want)
+	}
+	if dropped != 2 {
+		t.Fatalf("dropped = %d, want 2", dropped)
+	}
+	for i, f := range input {
+		if f.Path != originalPaths[i] {
+			t.Fatalf("filterGeneratedSourceFilesWithAllowlist mutated caller's slice at %d: got %q, want %q", i, f.Path, originalPaths[i])
+		}
+	}
+}

--- a/internal/pipeline/parse.go
+++ b/internal/pipeline/parse.go
@@ -175,7 +175,12 @@ func DefaultKnownSafeGenerators() []string {
 }
 
 func filterGeneratedSourceFilesWithAllowlist(files []*scanner.File, allowlist []string) ([]*scanner.File, int) {
-	filtered := files[:0]
+	// Allocate a fresh slice — sibling [:0] filters in the path
+	// pipeline (filterGeneratedSourcePaths, filterGeneratedPathStrings)
+	// already cause caller-slice corruption when input is aliased. Match
+	// that fix here so future callers of this *File filter cannot
+	// re-introduce the bug by accident.
+	filtered := make([]*scanner.File, 0, len(files))
 	var droppedGenerated int
 	for _, f := range files {
 		if f == nil || !strings.Contains(f.Path, "/generated/") {

--- a/internal/pipeline/project.go
+++ b/internal/pipeline/project.go
@@ -2047,7 +2047,12 @@ func filterGeneratedSourcePaths(paths []string, includeGenerated bool) []string 
 	if includeGenerated {
 		return paths
 	}
-	filtered := paths[:0]
+	// Allocate a fresh slice — callers pass args.KotlinPaths /
+	// args.JavaPaths whose backing arrays are owned by the CLI runner.
+	// A paths[:0] in-place rewrite would mutate those caller slices
+	// and leave duplicate entries in their tails, causing parse and
+	// dispatch to process the same files multiple times.
+	filtered := make([]string, 0, len(paths))
 	for _, path := range paths {
 		if !strings.Contains(filepath.ToSlash(path), "/generated/") {
 			filtered = append(filtered, path)


### PR DESCRIPTION
## Summary

- `filterGeneratedPathStrings`, `filterGeneratedSourcePaths`, and `filterGeneratedSourceFilesWithAllowlist` all used `paths[:0]` / `files[:0]`. The CLI runner aliases `r.javaPathsForDispatch = r.allJavaPaths` before filtering, and the pipeline's warm-source-paths helper feeds `args.KotlinPaths` / `args.JavaPaths` straight in — the in-place rewrite left duplicate strings in the tail of the caller's slice, parse produced duplicate `*File` entries, and dispatch ran rules twice for each duplicate.
- Each filter now allocates a fresh slice with a comment pointing at the aliasing trap. Three regression tests pin the no-mutation contract.

## Reproduction (before fix)

```
cd ~/github/kotlin
rm -rf .krit
krit --perf 2>&1 | grep Found   # info: Found 88192 issue(s) ...
krit --perf 2>&1 | grep Found   # info: Found 87912 issue(s) ...
```

The 280-finding delta was cold over-counting (not warm under-counting): cold dispatched aliased duplicate file entries twice, while warm loaded each file once from the per-file cache. Both runs produced the same 87,153 unique `(rule, file, line, column)` tuples; cold simply had 1,038 duplicated tuples vs warm's 758.

Affected dups concentrated in `wasm/`, `repo/`, and `test-instrumenter/` because those subtrees contain the largest mix of generated and hand-written sources — i.e. the filter ran on slices long enough to expose the aliasing.

## After fix

```
cold: Found 87696 issue(s) in 7m5.908s
warm: Found 87696 issue(s) in 1.309s
```

`comm -23` / `-13` on the sorted `(rule, file, line, column)` tuples: zero cold-only, zero warm-only.

## Test plan

- [x] `go test ./internal/pipeline/ ./internal/cli/scan/ -run 'FilterGenerated|GeneratedFilter' -count=1 -v` — 3 new regression tests pass, existing generated-file tests still pass.
- [x] `go build`, `go vet`, `golangci-lint run`, `go test ./... -count=1` all clean.
- [x] Cold + warm run on JetBrains/kotlin checkout: byte-for-byte identical findings.