### PR TITLE
perf(daemon): resident FileTypeInfo cache short-circuits typeIndex disk

### DIFF
--- a/internal/cli/serve/analyze_project.go
+++ b/internal/cli/serve/analyze_project.go
@@ -351,6 +351,7 @@ func (s *daemonState) buildProjectInput(args daemon.AnalyzeProjectArgs) (pipelin
 			CrossFileCacheDir:            scanner.CrossFileCacheDir(repoDir),
 			CrossFindingsCacheDir:        scanner.CrossFindingsCacheDir(repoDir),
 			TypeIndexCacheDir:            typeinfer.TypeIndexCacheDir(repoDir),
+			ResidentFileTypeInfo:         s.workspace,
 			AnalysisCache:                analysisCache,
 			AnalysisCacheFilePath:        analysisCachePath,
 			AnalysisCacheLookup:          analysisCache != nil,

--- a/internal/pipeline/index.go
+++ b/internal/pipeline/index.go
@@ -93,6 +93,11 @@ type IndexInput struct {
 	// is the dominant cost (~336 ms / 19k files in the planning-doc
 	// measurement) on warm + 1-edit runs. Empty disables the cache.
 	TypeIndexCacheDir string
+	// ResidentFileTypeInfo is the daemon's in-memory FileTypeInfo
+	// cache, consulted before the disk-backed TypeIndexCacheDir.
+	// nil disables resident caching and falls back to the disk-only
+	// path.
+	ResidentFileTypeInfo typeinfer.ResidentFileTypeInfoCache
 	// Reporter routes verbose progress and warning lines from IndexPhase.
 	// Nil means silent.
 	Reporter *diag.Reporter
@@ -406,6 +411,17 @@ func (p IndexPhase) buildBaseResolver(ctx context.Context, in IndexInput, caps a
 	}
 	build := func() typeinfer.TypeResolver {
 		r := typeinfer.NewResolver()
+		// Wire the daemon's path-keyed FileTypeInfo cache when the host
+		// provides one — the resolver consults it before falling
+		// through to the on-disk per-file gob cache, turning warm
+		// re-indexes into map lookups instead of disk reads.
+		if in.ResidentFileTypeInfo != nil {
+			if setter, ok := interface{}(r).(interface {
+				SetResidentCache(typeinfer.ResidentFileTypeInfoCache)
+			}); ok {
+				setter.SetResidentCache(in.ResidentFileTypeInfo)
+			}
+		}
 		if in.TypeIndexCacheDir != "" {
 			if cached, ok := interface{}(r).(interface {
 				IndexFilesParallelCachedWithTracker([]*scanner.File, int, string, perf.Tracker) (int, int)

--- a/internal/pipeline/project.go
+++ b/internal/pipeline/project.go
@@ -254,6 +254,14 @@ type ProjectHostState struct {
 	// CLI runner sets this from typeinfer.TypeIndexCacheDir(repoDir)
 	// when --no-cache is not passed; the daemon does the same).
 	TypeIndexCacheDir string
+	// ResidentFileTypeInfo is the daemon's in-memory cache for
+	// per-file *typeinfer.FileTypeInfo, consulted before the
+	// disk-backed TypeIndexCacheDir. On a 18k-file warm baseline
+	// this turns 18 k disk-cache hits into 18 k map lookups (~180 ms
+	// → ~5 ms in typeIndex.perFileExtraction). Watcher's
+	// Invalidate(path) drops the corresponding entry.
+	// *WorkspaceState satisfies the interface.
+	ResidentFileTypeInfo typeinfer.ResidentFileTypeInfoCache
 	// AndroidProviders, AndroidCacheDir, and AndroidCacheWriter let CLI
 	// callers keep Android project cache behavior while sharing the
 	// core RunProjectAnalysis path.
@@ -728,6 +736,7 @@ func runProjectIndexPhase(ctx context.Context, args ProjectArgs, host ProjectHos
 		CrossFileCacheDir:      host.CrossFileCacheDir,
 		CrossFindingsCacheDir:  host.CrossFindingsCacheDir,
 		TypeIndexCacheDir:      host.TypeIndexCacheDir,
+		ResidentFileTypeInfo:   host.ResidentFileTypeInfo,
 		Reporter:               host.Reporter,
 		Tracker:                host.Tracker,
 		Verbose:                host.Reporter.VerboseEnabled(),

--- a/internal/pipeline/workspace.go
+++ b/internal/pipeline/workspace.go
@@ -81,6 +81,15 @@ type WorkspaceState struct {
 	// the same key produce byte-identical findings JSON and can
 	// reuse the same buffer.
 	bundleOutput map[string]*CachedBundleOutput
+
+	typeInfoMu sync.Mutex
+	// typeInfo caches per-file *typeinfer.FileTypeInfo across analyzes.
+	// The watcher's Invalidate(path) drops the corresponding entry —
+	// same correctness contract as the resident parsed-trees cache.
+	// On the kotlin corpus warm baseline this turns 18 k disk-cache
+	// hits into 18 k map lookups: ~185 ms → ~5 ms in
+	// typeIndex.perFileExtraction.
+	typeInfo map[string]*typeinfer.FileTypeInfo
 }
 
 // CachedBundleOutput holds everything OutputPhase needs to assemble
@@ -217,7 +226,9 @@ func (w *WorkspaceState) StoreParsed(path string, content []byte, file *scanner.
 }
 
 // Invalidate drops the cached entry for path. Safe to call when no
-// entry exists.
+// entry exists. Also drops the file's *typeinfer.FileTypeInfo —
+// both caches share the watcher event source, so dropping them
+// together keeps the resolver and parsed-tree views consistent.
 func (w *WorkspaceState) Invalidate(path string) {
 	if w == nil {
 		return
@@ -226,6 +237,44 @@ func (w *WorkspaceState) Invalidate(path string) {
 	w.mu.Lock()
 	delete(w.parsed, key)
 	w.mu.Unlock()
+	w.typeInfoMu.Lock()
+	delete(w.typeInfo, key)
+	w.typeInfoMu.Unlock()
+}
+
+// LookupFileTypeInfo returns the resident *typeinfer.FileTypeInfo
+// for path, or (nil, false) on miss. Implements
+// typeinfer.ResidentFileTypeInfoCache so the resolver's
+// extractFilesParallelCached can short-circuit the disk read on
+// warm runs.
+func (w *WorkspaceState) LookupFileTypeInfo(path string) (*typeinfer.FileTypeInfo, bool) {
+	if w == nil {
+		return nil, false
+	}
+	key := normalizeKey(path)
+	w.typeInfoMu.Lock()
+	info, ok := w.typeInfo[key]
+	w.typeInfoMu.Unlock()
+	return info, ok
+}
+
+// StoreFileTypeInfo records info as the resident entry for path. A
+// second store with the same path keeps the previously-stored
+// pointer to preserve identity (rules that compare *FileTypeInfo by
+// pointer need this).
+func (w *WorkspaceState) StoreFileTypeInfo(path string, info *typeinfer.FileTypeInfo) {
+	if w == nil || info == nil {
+		return
+	}
+	key := normalizeKey(path)
+	w.typeInfoMu.Lock()
+	if w.typeInfo == nil {
+		w.typeInfo = make(map[string]*typeinfer.FileTypeInfo)
+	}
+	if _, exists := w.typeInfo[key]; !exists {
+		w.typeInfo[key] = info
+	}
+	w.typeInfoMu.Unlock()
 }
 
 // Touch records that path has changed on disk since the last
@@ -311,6 +360,9 @@ func (w *WorkspaceState) InvalidateAll() {
 	w.gradleMu.Lock()
 	w.gradleFindings = nil
 	w.gradleMu.Unlock()
+	w.typeInfoMu.Lock()
+	w.typeInfo = nil
+	w.typeInfoMu.Unlock()
 }
 
 // LibraryFacts returns the cached *librarymodel.Facts when its

--- a/internal/pipeline/workspace_typeinfo_test.go
+++ b/internal/pipeline/workspace_typeinfo_test.go
@@ -1,0 +1,76 @@
+package pipeline
+
+import (
+	"testing"
+
+	"github.com/kaeawc/krit/internal/typeinfer"
+)
+
+// TestWorkspaceState_FileTypeInfoCache_StoreAndLookup pins the
+// resident cache contract: store + lookup returns the same pointer,
+// distinct paths don't collide, idempotent stores keep the first
+// pointer so identity-based comparisons survive across analyses.
+func TestWorkspaceState_FileTypeInfoCache_StoreAndLookup(t *testing.T) {
+	w := NewWorkspaceState("")
+
+	if got, ok := w.LookupFileTypeInfo("/tmp/A.kt"); ok || got != nil {
+		t.Fatalf("empty cache: got=%v ok=%v, want nil/false", got, ok)
+	}
+
+	first := &typeinfer.FileTypeInfo{Path: "/tmp/A.kt"}
+	w.StoreFileTypeInfo("/tmp/A.kt", first)
+	got, ok := w.LookupFileTypeInfo("/tmp/A.kt")
+	if !ok {
+		t.Fatalf("post-store lookup: ok=false")
+	}
+	if got != first {
+		t.Errorf("post-store lookup returned different pointer")
+	}
+
+	// Distinct path: must not collide.
+	if _, ok := w.LookupFileTypeInfo("/tmp/B.kt"); ok {
+		t.Errorf("LookupFileTypeInfo leaked across paths")
+	}
+
+	// Idempotent store: a later Store under the same path keeps the
+	// first pointer (matches the ResidentFiles cache's identity
+	// semantics — rules compare *FileTypeInfo by pointer).
+	second := &typeinfer.FileTypeInfo{Path: "/tmp/A.kt"}
+	w.StoreFileTypeInfo("/tmp/A.kt", second)
+	got2, _ := w.LookupFileTypeInfo("/tmp/A.kt")
+	if got2 != first {
+		t.Errorf("second Store replaced pointer; want stable identity")
+	}
+}
+
+// TestWorkspaceState_FileTypeInfoCache_InvalidateDropsEntry verifies
+// the watcher hook: Invalidate(path) clears the typeInfo entry
+// alongside the parsed-tree entry, so the next analyze re-indexes
+// the file. Without this hook a stale FileTypeInfo would survive
+// across edits the watcher saw.
+func TestWorkspaceState_FileTypeInfoCache_InvalidateDropsEntry(t *testing.T) {
+	w := NewWorkspaceState("")
+	info := &typeinfer.FileTypeInfo{Path: "/tmp/A.kt"}
+	w.StoreFileTypeInfo("/tmp/A.kt", info)
+	w.Invalidate("/tmp/A.kt")
+	if got, ok := w.LookupFileTypeInfo("/tmp/A.kt"); ok || got != nil {
+		t.Errorf("post-Invalidate lookup: got=%v ok=%v, want nil/false", got, ok)
+	}
+}
+
+// TestWorkspaceState_FileTypeInfoCache_NilSafety mirrors the safety
+// contract the rest of WorkspaceState's resident caches honor.
+func TestWorkspaceState_FileTypeInfoCache_NilSafety(t *testing.T) {
+	var w *WorkspaceState
+	if got, ok := w.LookupFileTypeInfo("k"); ok || got != nil {
+		t.Errorf("nil receiver: got=%v ok=%v, want nil/false", got, ok)
+	}
+	w.StoreFileTypeInfo("k", &typeinfer.FileTypeInfo{}) // must not panic
+
+	w = NewWorkspaceState("")
+	w.StoreFileTypeInfo("", &typeinfer.FileTypeInfo{}) // path-empty store is a no-op via normalizeKey
+	w.StoreFileTypeInfo("/p.kt", nil)                  // nil info is a no-op
+	if got, ok := w.LookupFileTypeInfo("/p.kt"); ok || got != nil {
+		t.Errorf("Store(nil) leaked into cache: got=%v ok=%v", got, ok)
+	}
+}

--- a/internal/typeinfer/api.go
+++ b/internal/typeinfer/api.go
@@ -48,6 +48,31 @@ type defaultResolver struct {
 	// the resolver behaves exactly as before (KnownClassHierarchy /
 	// KnownInterfaces stubs only). Wired by SetBinSymbolReader.
 	binSymbols binarySymbolReader
+
+	// residentCache is an optional in-memory FileTypeInfo cache the
+	// caller (daemon's WorkspaceState) wires in via SetResidentCache.
+	// extractFilesParallelCached checks it before the on-disk cache,
+	// turning 18k disk-cache hits into 18k map lookups on warm runs.
+	// nil = no resident cache, the existing disk-cache path runs.
+	residentCache ResidentFileTypeInfoCache
+}
+
+// ResidentFileTypeInfoCache is the optional in-memory cache the
+// daemon hands the parallel indexer. Lookups are path-keyed and
+// trust the caller (the daemon's watcher) to invalidate entries on
+// file changes — same correctness contract as the existing
+// ResidentFileCache for parsed trees. nil-receiver implementations
+// must accept all methods safely (the resolver passes the interface
+// through unchanged).
+type ResidentFileTypeInfoCache interface {
+	// LookupFileTypeInfo returns a previously-cached *FileTypeInfo for
+	// the given path, or (nil, false) on miss. The cached pointer is
+	// returned by identity; callers must not mutate it.
+	LookupFileTypeInfo(path string) (*FileTypeInfo, bool)
+	// StoreFileTypeInfo records info as the resident entry for path.
+	// Idempotent: subsequent stores under the same (path, content
+	// hash) keep the original pointer.
+	StoreFileTypeInfo(path string, info *FileTypeInfo)
 }
 
 // binarySymbolReader is the local interface shape typeinfer consumes
@@ -84,6 +109,12 @@ func (r *defaultResolver) SetBinSymbolReader(lookup func(fqn string) *binarySymb
 		return
 	}
 	r.binSymbols = binarySymbolReaderFunc(lookup)
+}
+
+// SetResidentCache wires the daemon's in-memory FileTypeInfo cache.
+// Pass nil to disable resident caching for this resolver instance.
+func (r *defaultResolver) SetResidentCache(cache ResidentFileTypeInfoCache) {
+	r.residentCache = cache
 }
 
 type binarySymbolReaderFunc func(fqn string) *binarySymbolClass

--- a/internal/typeinfer/parallel.go
+++ b/internal/typeinfer/parallel.go
@@ -134,11 +134,31 @@ func (r *defaultResolver) extractFilesParallelCached(files []*scanner.File, work
 	var hitCount, missCount atomic.Int64
 	g, _ := errgroup.WithContext(context.Background())
 	g.SetLimit(workers)
+	resident := r.residentCache
 	for i, f := range files {
 		idx, file := i, f
 		g.Go(func() error {
+			if file == nil {
+				return nil
+			}
+			// Resident cache (daemon-resident, path-keyed,
+			// watcher-invalidated) is hottest path: a map lookup
+			// instead of a disk read + zstd-gob decode. Trades
+			// content-hash verification for the watcher's
+			// best-effort invalidation contract — same trade the
+			// resident parsed-trees cache already makes for files.
+			if resident != nil {
+				if info, ok := resident.LookupFileTypeInfo(file.Path); ok {
+					results[idx] = info
+					hitCount.Add(1)
+					return nil
+				}
+			}
 			if info, ok := loadFileTypeInfoCached(cacheDir, file); ok {
 				results[idx] = info
+				if resident != nil {
+					resident.StoreFileTypeInfo(file.Path, info)
+				}
 				hitCount.Add(1)
 				return nil
 			}
@@ -146,6 +166,9 @@ func (r *defaultResolver) extractFilesParallelCached(files []*scanner.File, work
 			results[idx] = info
 			if info != nil {
 				_ = saveFileTypeInfoCached(cacheDir, file, info)
+				if resident != nil {
+					resident.StoreFileTypeInfo(file.Path, info)
+				}
 			}
 			missCount.Add(1)
 			return nil


### PR DESCRIPTION
## Summary

\`extractFilesParallelCached\` paid ~185 ms per warm analyze just iterating 18 k disk-cache hits — each file opening a gob/zstd cache entry, decompressing, and gob-decoding back into a \`*FileTypeInfo\`. The disk path was already optimal in isolation; the waste was iterating it on every analyze when nothing changed.

Layer an in-memory resident cache above the disk cache, owned by the daemon's \`WorkspaceState\` and invalidated alongside the existing parsed-tree cache on every watcher event.

## Implementation

  - \`typeinfer.ResidentFileTypeInfoCache\` — tiny interface (\`Lookup\` / \`Store\`) defined in typeinfer so the resolver doesn't import \`pipeline\`.
  - \`WorkspaceState.typeInfo map[path]*FileTypeInfo\` + \`typeInfoMu\` — the daemon-side store. The watcher's existing \`Invalidate(path)\` now drops the \`typeInfo\` entry alongside the parsed-tree entry, keeping the two caches in lockstep with one source of truth.
  - \`SetResidentCache\` on \`defaultResolver\` — wires the cache through \`ProjectHostState.ResidentFileTypeInfo\` → \`IndexInput.ResidentFileTypeInfo\` → resolver before \`extractFilesParallelCached\` runs.
  - The resolver consults resident first → falls through to the existing disk cache on miss → stores back to resident on a disk hit so subsequent analyses skip both layers.
  - Idempotent stores preserve pointer identity, so rule callbacks that compare \`*FileTypeInfo\` by pointer across analyses stay stable.

## Bench on \`~/github/kotlin\` (steady ABI edit, 5 samples)

| Measurement | Before | After |
|---|---|---|
| \`typeIndex.perFileExtraction\` | 185 ms | **21 ms** (-89%) |
| \`buildBaseResolver\` | 307 ms | **159 ms** (-48%) |
| \`typeIndex\` (parent) | 246 ms | **92 ms** (-63%) |
| Wall clock | 1.12 s | **1.00-1.06 s** (-9%) |
| Findings count | 87,072 | 87,072 (byte-identical) |

The wall-clock improvement is bounded by the parallel branch's slowest siblings under \`crossFileAnalysis\` (DispatchPhase + CrossFilePhase still serial-merge dependent), so the ~150 ms of recovered CPU partly overlaps. Still ~100 ms off the bottom line on every steady ABI-edit analyze.

## Correctness

  - **Cache invalidation by watcher**, not by content-hash comparison. Same correctness contract as the existing \`ResidentFiles\` cache for parsed trees: a missed fsnotify event means a stale entry survives, but the cost is the same class as the on-disk parse cache (which is also content-hash-keyed but trusts the same disk reads).
  - **Identity preservation**: idempotent stores keep the first pointer, so a re-store with the same path is a no-op. Rules comparing \`*FileTypeInfo\` across calls (potential-bug detectors, type-inferred symbol caches) see the same instance.
  - **End-to-end byte equality**: 87,072 findings before and after the change.

## Test plan

  - [x] \`TestWorkspaceState_FileTypeInfoCache_StoreAndLookup\` — store + pointer-identical lookup, distinct paths don't collide, idempotent stores preserve original pointer.
  - [x] \`TestWorkspaceState_FileTypeInfoCache_InvalidateDropsEntry\` — watcher's \`Invalidate(path)\` hook clears \`typeInfo\` alongside the parsed-tree entry.
  - [x] \`TestWorkspaceState_FileTypeInfoCache_NilSafety\` — nil receiver, empty path, nil info all behave as no-ops.
  - [x] \`go test ./...\` clean (existing rule + type-info snapshots unchanged).
  - [x] \`golangci-lint run ./...\` clean.