### PR TITLE
perf(daemon): route warm cacheCheck through CheckFilesIncremental

### DIFF
--- a/internal/cli/serve/analyze_project.go
+++ b/internal/cli/serve/analyze_project.go
@@ -77,9 +77,24 @@ func handleAnalyzeProject(_ context.Context, state *daemonState, raw json.RawMes
 		// "no opinion" and the pipeline walks.
 		if dirty == nil {
 			in.Host.SourceSetDirty = []string{}
+			in.Host.AnalysisCacheDirty = []string{}
 		} else {
 			in.Host.SourceSetDirty = dirty
+			in.Host.AnalysisCacheDirty = dirty
 		}
+		// AnalysisCacheDirty opts cacheCheck into the incremental
+		// CheckFilesIncremental path: only files in the dirty set
+		// get the os.Stat + content-hash NeedsReanalysis check; the
+		// rest hit the cache directly. On the kotlin-corpus warm
+		// baseline this collapses ~245 ms of 18 k-file stat sweep
+		// to a map walk. The watcher's continuous presence is the
+		// correctness gate — same trust contract as the resident
+		// parsed-trees cache.
+		//
+		// Cold runs (first analyze after daemon start) leave
+		// AnalysisCacheDirty nil so CheckFiles still validates
+		// every cached entry against disk — the watcher hasn't been
+		// running long enough to vouch for "non-dirty == unchanged".
 	}
 
 	// Defer pipeline execution into WriteRawResponse so the

--- a/internal/cli/serve/analyze_project_cache_dirty_test.go
+++ b/internal/cli/serve/analyze_project_cache_dirty_test.go
@@ -1,0 +1,71 @@
+package serve
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/kaeawc/krit/internal/daemon"
+)
+
+// TestAnalyzeProject_WarmCallSetsAnalysisCacheDirty pins the
+// wire-through contract that opts cacheCheck into the incremental
+// CheckFilesIncremental path: a warm analyze (not the first cold
+// call) must populate Host.AnalysisCacheDirty with the watcher's
+// drained dirty set, even when that set is empty. nil signals
+// "use the legacy stat-every-file CheckFiles path" — only correct
+// for the first cold call where the watcher hasn't run yet.
+func TestAnalyzeProject_WarmCallSetsAnalysisCacheDirty(t *testing.T) {
+	socket, state := startServerForTest(t)
+	writeKotlinFile(t, state.root, "A.kt",
+		"package demo\n\nclass A {\n    fun a() {}\n}\n")
+
+	// First call is "cold": warms the daemon but doesn't exercise
+	// the incremental path (state.coldDone goes false→true here).
+	var first daemon.AnalyzeProjectResult
+	if err := daemon.Call(socket, daemon.VerbAnalyzeProject,
+		daemon.AnalyzeProjectArgs{}, &first); err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+	if first.Stats.Cold != true {
+		t.Errorf("first call must report Cold=true; got %v", first.Stats.Cold)
+	}
+
+	// Second call is warm. The daemon should now treat the
+	// (empty) dirty set as authoritative and route cacheCheck
+	// through CheckFilesIncremental — surfacing through the
+	// stats payload as DirtyFiles=0 on a clean run.
+	var second daemon.AnalyzeProjectResult
+	if err := daemon.Call(socket, daemon.VerbAnalyzeProject,
+		daemon.AnalyzeProjectArgs{}, &second); err != nil {
+		t.Fatalf("second call: %v", err)
+	}
+	if second.Stats.Cold {
+		t.Errorf("second call must report Cold=false; got %v", second.Stats.Cold)
+	}
+	if second.Stats.DirtyFiles != 0 {
+		t.Errorf("clean warm call: DirtyFiles=%d, want 0", second.Stats.DirtyFiles)
+	}
+	// FindingsBundleHit on the second call confirms the warm
+	// path actually fired (otherwise we'd be re-dispatching
+	// rules without consulting the cache at all).
+	if !second.Stats.FindingsBundleHit {
+		t.Errorf("expected FindingsBundleHit=true on byte-identical second call; got %+v", second.Stats)
+	}
+	// Sanity: findings count is stable across warm calls.
+	if first.Stats.FindingsCount != second.Stats.FindingsCount {
+		t.Errorf("findings drift across warm calls: %d vs %d",
+			first.Stats.FindingsCount, second.Stats.FindingsCount)
+	}
+	// And the formatted bytes are byte-identical (the bundle-hit
+	// fast path returned cached output).
+	var firstShape, secondShape map[string]json.RawMessage
+	if err := json.Unmarshal(first.Findings, &firstShape); err != nil {
+		t.Fatalf("decode first findings: %v", err)
+	}
+	if err := json.Unmarshal(second.Findings, &secondShape); err != nil {
+		t.Fatalf("decode second findings: %v", err)
+	}
+	if string(firstShape["findings"]) != string(secondShape["findings"]) {
+		t.Errorf("findings array drifted across warm calls")
+	}
+}


### PR DESCRIPTION
## Summary

\`cacheCheck\` runs \`NeedsReanalysis\` (os.Stat + content-hash compare) on every cached entry — 245 ms over 18 k files on the kotlin-corpus steady ABI edit, even when only one file actually changed. The watcher already tracks the dirty set; we just weren't passing it to \`cacheCheck\`.

\`cache.Cache.CheckFilesIncremental\` already exists (used by the CLI's in-process path when \`CacheDirty\` is non-nil) and skips the stat/hash check entirely for paths NOT in the dirty set. The daemon wasn't populating \`Host.AnalysisCacheDirty\`, so cacheCheck took the legacy stat-everything route on every analyze.

Wire \`AnalysisCacheDirty\` from the watcher's drained dirty set on warm calls (matching the existing \`SourceSetDirty\` hook). Cold calls (first analyze after daemon start) leave it nil so \`CheckFiles\` still validates every cached entry against disk — the watcher hasn't been running long enough to vouch for "non-dirty == unchanged" on a cold start.

## Bench on \`~/github/kotlin\` (steady ABI edit, 5 samples)

| Measurement | Before | After |
|---|---|---|
| \`cacheCheck\` (perf tree) | 245 ms | **20 ms** (-92%) |
| Wall clock | 1.12 s | **0.92-1.01 s** (-10%) |
| Findings count | 87,072 | 87,072 (byte-identical) |

## Correctness

  - **Cold path unchanged**: first analyze after daemon start still goes through \`CheckFiles\` (full stat sweep) because the watcher hasn't been running yet — \`coldDone\` is the gate.
  - **Warm path**: \`AnalysisCacheDirty\` is the watcher's drained dirty set. Non-dirty paths skip stat/hash check and hit the cache when an entry exists. The watcher's continuous presence is the correctness contract — same trust the resident parsed-trees cache already makes.
  - **End-to-end byte equality**: 87,072 findings across consecutive warm analyzes, with byte-identical findings JSON arrays.

## Test plan

  - [x] \`TestAnalyzeProject_WarmCallSetsAnalysisCacheDirty\` — end-to-end daemon contract: second (warm) call reports \`Cold=false\` / \`DirtyFiles=0\` / \`FindingsBundleHit=true\` and produces a byte-identical findings array vs the first call. Catches regressions where the dirty-set wire-through gets detached from the cacheCheck path.
  - [x] Existing \`TestCheckFilesIncremental_*\` tests confirm \`cache.Cache\` correctness; no changes to the cache package itself.
  - [x] \`go test ./...\` clean.
  - [x] \`golangci-lint run ./...\` clean.