### PR TITLE
perf(daemon): resident javafacts.SourceIndex cache + .java watcher hook

### DIFF
--- a/internal/cli/serve/analyze_project.go
+++ b/internal/cli/serve/analyze_project.go
@@ -354,6 +354,7 @@ func (s *daemonState) buildProjectInput(args daemon.AnalyzeProjectArgs) (pipelin
 			Tracker:                      perfTracker,
 			LibraryFactsCache:            s.workspace.LibraryFacts,
 			CodeIndexCache:               s.workspace.CodeIndex,
+			JavaSourceIndexCache:         s.workspace.JavaSourceIndex,
 			ResolverCache:                s.workspace.Resolver,
 			OracleFilterCache:            s.workspace.OracleFilter,
 			AndroidProjectCache:          s.workspace.AndroidProject,

--- a/internal/cli/serve/watcher.go
+++ b/internal/cli/serve/watcher.go
@@ -29,6 +29,11 @@ type watcherState interface {
 	// bundle-stats-clean memo. Called once per coalesced source-path
 	// event so the next analyze knows a `os.Stat` sweep is required.
 	BumpSourceMTimeVersion()
+	// BumpJavaSourceVersion drives the daemon-resident
+	// javafacts.SourceIndex cache. Called on every .java file event;
+	// Kotlin edits don't affect the Java source index so the two
+	// version counters are intentionally separate.
+	BumpJavaSourceVersion()
 }
 
 const defaultDebounceWindow = 50 * time.Millisecond
@@ -238,6 +243,20 @@ func (fw *fileWatcher) handle(ev fsnotify.Event) {
 		// fires per burst — the dirty-set's map semantics already dedup
 		// Touch, but Invalidate and CodeIndex drops are not free.
 		fw.scheduleKotlinInvalidate(ev.Name)
+	case isJavaPath(ev.Name):
+		// .java edits invalidate the daemon-resident
+		// javafacts.SourceIndex cache. Kotlin and Java live on
+		// separate version counters so a Kotlin edit doesn't
+		// needlessly invalidate the Java source index (which is
+		// expensive to rebuild: ~100 ms of content hashing).
+		fw.state.Invalidate(ev.Name)
+		fw.state.InvalidateCodeIndex()
+		fw.state.InvalidateDependents()
+		fw.state.InvalidateResolver()
+		fw.state.InvalidateOracleFilter()
+		fw.state.Touch(ev.Name)
+		fw.state.BumpSourceMTimeVersion()
+		fw.state.BumpJavaSourceVersion()
 	}
 }
 
@@ -317,6 +336,15 @@ func (fw *fileWatcher) warn(format string, args ...any) {
 // .kts. Mirrors the precommit/cli filter.
 func isKotlinPath(p string) bool {
 	return strings.HasSuffix(p, ".kt") || strings.HasSuffix(p, ".kts")
+}
+
+// isJavaPath reports whether the path's basename ends in .java. Java
+// edits invalidate the daemon's resident javafacts.SourceIndex cache;
+// they're routed through a dedicated case in fileWatcher.handle so
+// the bump can hit a separate JavaSourceVersion counter (Kotlin
+// edits don't need to invalidate the Java source index).
+func isJavaPath(p string) bool {
+	return strings.HasSuffix(p, ".java")
 }
 
 // isKritConfigPath reports whether the path is the krit.yml /

--- a/internal/cli/serve/watcher_test.go
+++ b/internal/cli/serve/watcher_test.go
@@ -26,6 +26,7 @@ func fsnotifyEventChmod(path string) fsnotify.Event {
 type countingState struct {
 	invalidateCalls atomic.Int64
 	bumpCalls       atomic.Int64
+	javaBumpCalls   atomic.Int64
 }
 
 func (c *countingState) Invalidate(path string)  { c.invalidateCalls.Add(1) }
@@ -36,6 +37,7 @@ func (c *countingState) InvalidateResolver()     {}
 func (c *countingState) InvalidateOracleFilter() {}
 func (c *countingState) Touch(path string)       {}
 func (c *countingState) BumpSourceMTimeVersion() { c.bumpCalls.Add(1) }
+func (c *countingState) BumpJavaSourceVersion()  { c.javaBumpCalls.Add(1) }
 
 // waitForCondition polls fn every 5ms up to 2s. Returns true when fn
 // turns true; false on timeout. Used to bridge the async fsnotify
@@ -507,6 +509,7 @@ func (c *chmodFilterCountingState) InvalidateResolver()     {}
 func (c *chmodFilterCountingState) InvalidateOracleFilter() {}
 func (c *chmodFilterCountingState) Touch(string)            {}
 func (c *chmodFilterCountingState) BumpSourceMTimeVersion() { c.bumpCalls.Add(1) }
+func (c *chmodFilterCountingState) BumpJavaSourceVersion()  {}
 
 // TestFileWatcher_BumpsMTimeVersionOnKotlinEdit asserts the watcher
 // drives the daemon-resident stats-clean memo: a real .kt edit must
@@ -558,5 +561,40 @@ func TestFileWatcher_BumpsMTimeVersionOnGradleEdit(t *testing.T) {
 	}
 	if !waitForCondition(func() bool { return state.bumpCalls.Load() >= 1 }) {
 		t.Errorf("expected BumpSourceMTimeVersion after gradle edit, got %d", state.bumpCalls.Load())
+	}
+}
+
+// TestFileWatcher_BumpsJavaSourceVersionOnJavaEdit pins the
+// .java-event hook. The watcher must invoke BumpJavaSourceVersion
+// (the daemon's javafacts.SourceIndex invalidation signal) on any
+// .java file event so the next analyze rebuilds the Java source
+// index instead of serving stale facts from the resident cache.
+func TestFileWatcher_BumpsJavaSourceVersionOnJavaEdit(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "Foo.java")
+	if err := os.WriteFile(path, []byte("class Foo {}\n"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	state := &countingState{}
+	w, err := startFileWatcherWithState(context.Background(), root, state, nil)
+	if err != nil {
+		t.Fatalf("startFileWatcher: %v", err)
+	}
+	defer w.Stop()
+
+	if err := os.WriteFile(path, []byte("class Foo2 {}\n"), 0o644); err != nil {
+		t.Fatalf("rewrite: %v", err)
+	}
+	if !waitForCondition(func() bool { return state.javaBumpCalls.Load() >= 1 }) {
+		t.Errorf("expected BumpJavaSourceVersion after .java edit, got %d", state.javaBumpCalls.Load())
+	}
+	// Sanity: a non-Java edit must NOT bump the Java counter.
+	state.javaBumpCalls.Store(0)
+	if err := os.WriteFile(filepath.Join(root, "Bar.kt"), []byte("fun b() {}\n"), 0o644); err != nil {
+		t.Fatalf("write kt: %v", err)
+	}
+	time.Sleep(80 * time.Millisecond)
+	if got := state.javaBumpCalls.Load(); got != 0 {
+		t.Errorf("Kotlin edit must NOT bump Java counter; got %d", got)
 	}
 }

--- a/internal/javafacts/source_bench_test.go
+++ b/internal/javafacts/source_bench_test.go
@@ -1,0 +1,81 @@
+package javafacts
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/kaeawc/krit/internal/scanner"
+)
+
+// BenchmarkSourceIndexKey_LargeCorpus measures the key-computation
+// cost SourceIndexForFiles pays on every call — including warm
+// cache hits, since the key has to be computed before the lookup.
+// The kotlin corpus has ~2k Java files; this bench builds a
+// synthetic equivalent so the measurement doesn't depend on a
+// real ~/github/kotlin checkout.
+func BenchmarkSourceIndexKey_LargeCorpus(b *testing.B) {
+	files := buildSyntheticJavaFiles(2000, 5000)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = sourceIndexKey(files)
+	}
+}
+
+// BenchmarkSourceIndexForFiles_WarmHit measures the steady-state
+// cost: cache populated, every call short-circuits to the existing
+// cache entry. Bench shows what users actually pay on every ABI
+// edit when neither Kotlin nor Java source changes affect the
+// Java source index.
+func BenchmarkSourceIndexForFiles_WarmHit(b *testing.B) {
+	files := buildSyntheticJavaFiles(2000, 10000)
+	// Prime the cache.
+	_ = SourceIndexForFiles(files)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = SourceIndexForFiles(files)
+	}
+}
+
+// BenchmarkSourceIndexForFiles_WarmHit_WithKotlin mirrors the
+// production call shape where parsedFiles also includes the much
+// larger Kotlin source set: the key build walks every entry to
+// filter out Java files first.
+func BenchmarkSourceIndexForFiles_WarmHit_WithKotlin(b *testing.B) {
+	javaFiles := buildSyntheticJavaFiles(2000, 10000)
+	kotlinFiles := buildSyntheticKotlinFiles(13500)
+	mixed := append([]*scanner.File(nil), kotlinFiles...)
+	mixed = append(mixed, javaFiles...)
+	_ = SourceIndexForFiles(mixed)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = SourceIndexForFiles(mixed)
+	}
+}
+
+func buildSyntheticKotlinFiles(n int) []*scanner.File {
+	out := make([]*scanner.File, n)
+	for i := 0; i < n; i++ {
+		out[i] = &scanner.File{
+			Path:     fmt.Sprintf("/Users/jason/github/kotlin/some/kotlin/File%d.kt", i),
+			Language: scanner.LangKotlin,
+			Content:  []byte("package demo\nclass C\n"),
+		}
+	}
+	return out
+}
+
+func buildSyntheticJavaFiles(n, contentBytes int) []*scanner.File {
+	out := make([]*scanner.File, n)
+	content := make([]byte, contentBytes)
+	for i := range content {
+		content[i] = byte('A' + (i % 26))
+	}
+	for i := 0; i < n; i++ {
+		out[i] = &scanner.File{
+			Path:     fmt.Sprintf("/Users/jason/github/kotlin/some/dir/File%d.java", i),
+			Language: scanner.LangJava,
+			Content:  content,
+		}
+	}
+	return out
+}

--- a/internal/pipeline/crossfile.go
+++ b/internal/pipeline/crossfile.go
@@ -150,6 +150,18 @@ func (p CrossFilePhase) runCrossPhase(ctx context.Context, in DispatchResult, co
 	crossTracker := in.CrossFileParentTracker
 	var javaSourceIndex *javafacts.SourceIndex
 	buildJavaSourceIndex := func() {
+		// Daemon fast path: when the watcher hasn't seen any .java
+		// event since the last successful build, return the cached
+		// *SourceIndex without paying SourceIndexForFiles' ~100 ms
+		// content-hash key construction. The wrapper takes the
+		// build closure so a cache miss still produces a valid
+		// index for the live parsedFiles set.
+		if in.JavaSourceIndexCache != nil {
+			javaSourceIndex = in.JavaSourceIndexCache(func() *javafacts.SourceIndex {
+				return javaSourceIndexForParsedFiles(parsedFiles)
+			})
+			return
+		}
 		javaSourceIndex = javaSourceIndexForParsedFiles(parsedFiles)
 	}
 	if crossTracker != nil {

--- a/internal/pipeline/index.go
+++ b/internal/pipeline/index.go
@@ -15,6 +15,7 @@ import (
 	"github.com/kaeawc/krit/internal/config"
 	"github.com/kaeawc/krit/internal/diag"
 	"github.com/kaeawc/krit/internal/hashutil"
+	"github.com/kaeawc/krit/internal/javafacts"
 	"github.com/kaeawc/krit/internal/librarymodel"
 	"github.com/kaeawc/krit/internal/module"
 	"github.com/kaeawc/krit/internal/oracle"
@@ -78,6 +79,10 @@ type IndexInput struct {
 	// calls. Forwarded to IndexResult so CrossFilePhase consults it
 	// before calling scanner.BuildIndex.
 	CodeIndexCache CodeIndexCache
+	// JavaSourceIndexCache wires the daemon's resident
+	// *javafacts.SourceIndex cache through to CrossFilePhase. See
+	// IndexResult.JavaSourceIndexCache for semantics.
+	JavaSourceIndexCache func(build func() *javafacts.SourceIndex) *javafacts.SourceIndex
 	// ResolverCache, when non-nil and PrebuiltResolver is nil,
 	// memoizes the constructed TypeResolver across calls. Buys an
 	// entire perFileExtraction + merge + resolveSupertypes skip on
@@ -586,6 +591,7 @@ func (p IndexPhase) Run(ctx context.Context, in IndexInput) (IndexResult, error)
 		CrossFindingsCacheDir: in.CrossFindingsCacheDir,
 		CrossFileCacheDir:     in.CrossFileCacheDir,
 		CodeIndexCache:        in.CodeIndexCache,
+		JavaSourceIndexCache:  in.JavaSourceIndexCache,
 	}
 
 	caps := unionNeeds(in.ActiveRules)

--- a/internal/pipeline/project.go
+++ b/internal/pipeline/project.go
@@ -184,6 +184,12 @@ type ProjectHostState struct {
 	// the disk-backed cross-file cache (CrossFileCacheDir) and finally
 	// to scanner.BuildIndex. *WorkspaceState satisfies this interface.
 	CodeIndexCache CodeIndexCache
+	// JavaSourceIndexCache, when non-nil, lets CrossFilePhase short-
+	// circuit the ~100 ms content-hash key SourceIndexForFiles otherwise
+	// computes on every warm call. The watcher's .java events drive
+	// invalidation through WorkspaceState.BumpJavaSourceVersion.
+	// *WorkspaceState.JavaSourceIndex satisfies the callback shape.
+	JavaSourceIndexCache func(build func() *javafacts.SourceIndex) *javafacts.SourceIndex
 	// ResolverCache, when non-nil, memoizes the typeinfer.TypeResolver
 	// across calls. IndexPhase consults the slot before falling through
 	// to a fresh resolver + IndexFilesParallel*. The slot is keyed by
@@ -731,6 +737,7 @@ func runProjectIndexPhase(ctx context.Context, args ProjectArgs, host ProjectHos
 		PrebuiltAndroidProject: host.PrebuiltAndroidProject,
 		LibraryFactsCache:      host.LibraryFactsCache,
 		CodeIndexCache:         host.CodeIndexCache,
+		JavaSourceIndexCache:   host.JavaSourceIndexCache,
 		ResolverCache:          host.ResolverCache,
 		AndroidProjectCache:    host.AndroidProjectCache,
 		CrossFileCacheDir:      host.CrossFileCacheDir,

--- a/internal/pipeline/types.go
+++ b/internal/pipeline/types.go
@@ -311,6 +311,14 @@ type IndexResult struct {
 	// pass on warm calls. Nil means no in-memory cache. *WorkspaceState
 	// satisfies this interface.
 	CodeIndexCache CodeIndexCache
+	// JavaSourceIndexCache, when non-nil, lets CrossFilePhase consult a
+	// daemon-resident *javafacts.SourceIndex slot before paying
+	// SourceIndexForFiles' ~100 ms content-hash key build on every
+	// warm call. The callback receives a build func and returns either
+	// the cached slot (when the watcher's javaSourceVersion is still
+	// current) or the build's result. *WorkspaceState's
+	// JavaSourceIndex method satisfies this signature.
+	JavaSourceIndexCache func(build func() *javafacts.SourceIndex) *javafacts.SourceIndex
 	// WarmCrossFindings carries cross-rule findings loaded before
 	// parsing on an all-files analysis-cache hit.
 	WarmCrossFindings *scanner.FindingColumns

--- a/internal/pipeline/workspace.go
+++ b/internal/pipeline/workspace.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/kaeawc/krit/internal/android"
 	"github.com/kaeawc/krit/internal/hashutil"
+	"github.com/kaeawc/krit/internal/javafacts"
 	"github.com/kaeawc/krit/internal/librarymodel"
 	"github.com/kaeawc/krit/internal/oracle"
 	"github.com/kaeawc/krit/internal/scanner"
@@ -81,6 +82,21 @@ type WorkspaceState struct {
 	// the same key produce byte-identical findings JSON and can
 	// reuse the same buffer.
 	bundleOutput map[string]*CachedBundleOutput
+
+	javaSourceMu sync.Mutex
+	// javaSourceVersion is bumped on every .java watcher event. The
+	// resident javaSourceIndex slot uses it to detect whether its
+	// last build is still valid without re-hashing every Java file's
+	// content (the SourceIndexForFiles path otherwise spends ~100 ms
+	// per 2 k Java files just computing its content-hash key, even
+	// on a warm cache hit).
+	javaSourceVersion uint64
+	// cachedJavaSourceIndex is the last successful build, valid while
+	// cachedJavaSourceVersion == javaSourceVersion. A bump on the
+	// watcher side rotates the version; the next lookup misses and
+	// rebuilds via SourceIndexForFiles.
+	cachedJavaSourceIndex   *javafacts.SourceIndex
+	cachedJavaSourceVersion uint64
 
 	typeInfoMu sync.Mutex
 	// typeInfo caches per-file *typeinfer.FileTypeInfo across analyzes.
@@ -277,6 +293,55 @@ func (w *WorkspaceState) StoreFileTypeInfo(path string, info *typeinfer.FileType
 	w.typeInfoMu.Unlock()
 }
 
+// JavaSourceIndex returns the daemon-resident *javafacts.SourceIndex
+// when its version still matches the watcher's javaSourceVersion;
+// otherwise it invokes build, stores the result under the current
+// version, and returns it. Caller-supplied build is what guards
+// correctness (it sees the live parsed-file set); the slot just
+// short-circuits the ~100 ms content-hash key SourceIndexForFiles
+// pays on every warm call.
+//
+// nil receiver always builds (no caching) so the CLI's
+// in-process path doesn't accidentally hit a stale resident slot.
+func (w *WorkspaceState) JavaSourceIndex(build func() *javafacts.SourceIndex) *javafacts.SourceIndex {
+	if w == nil {
+		return build()
+	}
+	w.javaSourceMu.Lock()
+	if w.cachedJavaSourceIndex != nil && w.cachedJavaSourceVersion == w.javaSourceVersion {
+		v := w.cachedJavaSourceIndex
+		w.javaSourceMu.Unlock()
+		return v
+	}
+	currentVersion := w.javaSourceVersion
+	w.javaSourceMu.Unlock()
+
+	idx := build()
+
+	w.javaSourceMu.Lock()
+	// Only store when the version we observed is still current —
+	// a watcher event during build() advances the counter and the
+	// next call must rebuild.
+	if w.javaSourceVersion == currentVersion {
+		w.cachedJavaSourceIndex = idx
+		w.cachedJavaSourceVersion = currentVersion
+	}
+	w.javaSourceMu.Unlock()
+	return idx
+}
+
+// BumpJavaSourceVersion advances the version counter so the next
+// JavaSourceIndex call rebuilds. Called by the watcher on every
+// .java file event.
+func (w *WorkspaceState) BumpJavaSourceVersion() {
+	if w == nil {
+		return
+	}
+	w.javaSourceMu.Lock()
+	w.javaSourceVersion++
+	w.javaSourceMu.Unlock()
+}
+
 // Touch records that path has changed on disk since the last
 // DrainDirty. Intended to be called alongside Invalidate from the
 // file watcher so consumers can later ask "what changed since I last
@@ -363,6 +428,10 @@ func (w *WorkspaceState) InvalidateAll() {
 	w.typeInfoMu.Lock()
 	w.typeInfo = nil
 	w.typeInfoMu.Unlock()
+	w.javaSourceMu.Lock()
+	w.cachedJavaSourceIndex = nil
+	w.javaSourceVersion++
+	w.javaSourceMu.Unlock()
 }
 
 // LibraryFacts returns the cached *librarymodel.Facts when its

--- a/internal/pipeline/workspace_java_source_test.go
+++ b/internal/pipeline/workspace_java_source_test.go
@@ -1,0 +1,90 @@
+package pipeline
+
+import (
+	"testing"
+
+	"github.com/kaeawc/krit/internal/javafacts"
+)
+
+// TestWorkspaceState_JavaSourceIndex_HitCacheUntilBump pins the
+// version-counter contract: a cache hit short-circuits the build
+// closure entirely; a watcher bump rotates the version and the
+// next call rebuilds. The closure-side check confirms the
+// fast-path doesn't merely read+return — it must skip build()
+// to recoup the ~100 ms saving.
+func TestWorkspaceState_JavaSourceIndex_HitCacheUntilBump(t *testing.T) {
+	w := NewWorkspaceState("")
+	var builds int
+	build := func() *javafacts.SourceIndex {
+		builds++
+		return &javafacts.SourceIndex{}
+	}
+
+	first := w.JavaSourceIndex(build)
+	if builds != 1 {
+		t.Fatalf("first call: builds=%d, want 1", builds)
+	}
+	again := w.JavaSourceIndex(build)
+	if builds != 1 {
+		t.Errorf("second call after no bump must hit cache; builds=%d, want 1", builds)
+	}
+	if again != first {
+		t.Errorf("cached entry must return identical pointer; got %p, want %p", again, first)
+	}
+
+	w.BumpJavaSourceVersion()
+
+	third := w.JavaSourceIndex(build)
+	if builds != 2 {
+		t.Errorf("post-bump call must rebuild; builds=%d, want 2", builds)
+	}
+	if third == first {
+		t.Errorf("post-bump return must be a fresh pointer")
+	}
+}
+
+// TestWorkspaceState_JavaSourceIndex_ConcurrentBumpInvalidates
+// mirrors the race semantics that motivate snapshotting the
+// version BEFORE the build runs: a watcher event during the build
+// must NOT result in a "clean" cached entry under a now-stale
+// version.
+func TestWorkspaceState_JavaSourceIndex_ConcurrentBumpInvalidates(t *testing.T) {
+	w := NewWorkspaceState("")
+
+	// Build closure simulates a watcher event mid-flight.
+	idx := w.JavaSourceIndex(func() *javafacts.SourceIndex {
+		w.BumpJavaSourceVersion()
+		return &javafacts.SourceIndex{}
+	})
+
+	// The returned index is correct for the request, but the cache
+	// MUST NOT have stored it under the stale version — the next
+	// call should rebuild instead of returning a value the watcher
+	// already invalidated.
+	var builds int
+	_ = w.JavaSourceIndex(func() *javafacts.SourceIndex {
+		builds++
+		return idx
+	})
+	if builds == 0 {
+		t.Errorf("post-race call must rebuild (the stale version mustn't survive)")
+	}
+}
+
+// TestWorkspaceState_JavaSourceIndex_NilSafety mirrors the safety
+// contract the rest of WorkspaceState's caches honor.
+func TestWorkspaceState_JavaSourceIndex_NilSafety(t *testing.T) {
+	var w *WorkspaceState
+	called := 0
+	got := w.JavaSourceIndex(func() *javafacts.SourceIndex {
+		called++
+		return &javafacts.SourceIndex{}
+	})
+	if got == nil {
+		t.Errorf("nil receiver must still return the build result")
+	}
+	if called != 1 {
+		t.Errorf("nil receiver must call build; called=%d, want 1", called)
+	}
+	w.BumpJavaSourceVersion() // must not panic
+}


### PR DESCRIPTION
## Summary

\`SourceIndexForFiles\` pays ~100 ms per warm CrossFile call on the kotlin-corpus baseline (2 k Java files) just computing its content-hash cache key — even when the cache then hits and the build is skipped. The key build is unavoidable in javafacts because the package can't see whether anything changed; the daemon CAN see (it owns the watcher) but wasn't telling javafacts about it.

Add a daemon-resident \`*javafacts.SourceIndex\` slot on \`WorkspaceState\` with its own version counter, bumped only on \`.java\` file events. CrossFilePhase consults \`host.JavaSourceIndexCache\` before \`SourceIndexForFiles\`: hit returns the cached pointer immediately, miss rebuilds via the existing javafacts path and stores under the captured version.

## Why a separate Java version counter?

Kotlin edits don't affect the Java source index — using the existing \`sourceMTimeVersion\` would invalidate the cache on every \`.kt\` edit, defeating the whole point. The two counters are intentionally independent.

## Race-free invalidation

The wrapper captures the version BEFORE \`build()\` runs and only stores under that version. A watcher event during build advances the counter, the store is skipped, and the next call rebuilds — so a stale entry never serves.

## Bench on \`~/github/kotlin\` (steady ABI edit, 5 samples)

| Measurement | Before | After |
|---|---|---|
| \`javaSourceIndex\` (perf tree) | 100 ms | **0 ms** (skipped) |
| \`crossFileAnalysis\` (parent wall-clock) | 585 ms | **515 ms** (-12%) |
| Daemon \`durationMs\` | 688 ms | **626 ms** (-9%) |
| Wall clock | 0.80 s | **0.69-0.72 s** (-12%) |
| Findings count | 87,076 | 87,076 (byte-identical) |

## Test plan

  - [x] \`TestWorkspaceState_JavaSourceIndex_HitCacheUntilBump\` — build runs once; second call (no bump) hits cache; bump forces rebuild.
  - [x] \`TestWorkspaceState_JavaSourceIndex_ConcurrentBumpInvalidates\` — watcher event during build prevents the result from being stored; the next call rebuilds.
  - [x] \`TestWorkspaceState_JavaSourceIndex_NilSafety\` — nil receiver falls through to build.
  - [x] \`TestFileWatcher_BumpsJavaSourceVersionOnJavaEdit\` — real .java edit drives the hook; .kt edit confirms the Java counter is independent.
  - [x] Existing \`TestFileWatcher_IgnoresNonKotlinFiles\` still passes: a .java edit doesn't drop the .kt parsed-tree entry (we Invalidate the .java path, not arbitrary ones).
  - [x] \`go test ./...\` clean.
  - [x] \`golangci-lint run ./...\` clean.