### PR TITLE
perf(daemon): version-gated resolver fingerprint cache

### DIFF
--- a/internal/cli/serve/analyze_project.go
+++ b/internal/cli/serve/analyze_project.go
@@ -356,6 +356,7 @@ func (s *daemonState) buildProjectInput(args daemon.AnalyzeProjectArgs) (pipelin
 			CodeIndexCache:               s.workspace.CodeIndex,
 			JavaSourceIndexCache:         s.workspace.JavaSourceIndex,
 			ResolverCache:                s.workspace.Resolver,
+			ResolverFingerprintCache:     s.workspace.ResolverFingerprint,
 			OracleFilterCache:            s.workspace.OracleFilter,
 			AndroidProjectCache:          s.workspace.AndroidProject,
 			GradleFindingsCache:          s.workspace.GradleFindings,

--- a/internal/pipeline/index.go
+++ b/internal/pipeline/index.go
@@ -88,6 +88,14 @@ type IndexInput struct {
 	// entire perFileExtraction + merge + resolveSupertypes skip on
 	// warm-no-change runs.
 	ResolverCache ResolverCache
+	// ResolverFingerprintCache, when non-nil, short-circuits the
+	// resolverFingerprint compute (which hashes every Kotlin file's
+	// content — ~135 ms on an 18 k-file corpus) when no source-path
+	// watcher event has fired since the last successful compute. The
+	// callback returns either the cached fingerprint or the result
+	// of build. nil disables the optimization and the fingerprint is
+	// computed on every call.
+	ResolverFingerprintCache func(build func() string) string
 	// AndroidProjectCache, when non-nil and PrebuiltAndroidProject is
 	// nil, memoizes the detected *android.Project across calls so
 	// detectAndroidProject skips its ~1s tree walk on warm reruns.
@@ -459,7 +467,15 @@ func (p IndexPhase) buildBaseResolver(ctx context.Context, in IndexInput, caps a
 		return r
 	}
 	if in.ResolverCache != nil {
-		return in.ResolverCache(resolverFingerprint(in.KotlinFiles), build), nil
+		var fp string
+		if in.ResolverFingerprintCache != nil {
+			fp = in.ResolverFingerprintCache(func() string {
+				return resolverFingerprint(in.KotlinFiles)
+			})
+		} else {
+			fp = resolverFingerprint(in.KotlinFiles)
+		}
+		return in.ResolverCache(fp, build), nil
 	}
 	return build(), nil
 }

--- a/internal/pipeline/project.go
+++ b/internal/pipeline/project.go
@@ -197,6 +197,14 @@ type ProjectHostState struct {
 	// files, so mismatches force a complete rebuild rather than a
 	// stale-entry leak. *WorkspaceState satisfies this interface.
 	ResolverCache ResolverCache
+	// ResolverFingerprintCache, when non-nil, short-circuits the
+	// resolverFingerprint compute that gates ResolverCache. The
+	// fingerprint hashes every Kotlin file's content; on the kotlin
+	// corpus that's ~135 ms even when the resolver itself is cached.
+	// The cache returns the prior fingerprint when no source-path
+	// watcher event has fired since the last successful compute.
+	// *WorkspaceState.ResolverFingerprint satisfies the callback shape.
+	ResolverFingerprintCache func(build func() string) string
 	// OracleFilterCache, when non-nil and Args.OracleEnabled is true,
 	// memoizes the oracle CallTargetFilterSummary across calls.
 	// RunProject computes the filter once per file-set + rule-set
@@ -731,32 +739,33 @@ func runProjectIndexPhase(ctx context.Context, args ProjectArgs, host ProjectHos
 		buildCodeIndex = true
 	}
 	indexInput := IndexInput{
-		ParseResult:            parseResult,
-		PrebuiltResolver:       host.PrebuiltResolver,
-		PrebuiltLibraryFacts:   host.PrebuiltLibraryFacts,
-		PrebuiltAndroidProject: host.PrebuiltAndroidProject,
-		LibraryFactsCache:      host.LibraryFactsCache,
-		CodeIndexCache:         host.CodeIndexCache,
-		JavaSourceIndexCache:   host.JavaSourceIndexCache,
-		ResolverCache:          host.ResolverCache,
-		AndroidProjectCache:    host.AndroidProjectCache,
-		CrossFileCacheDir:      host.CrossFileCacheDir,
-		CrossFindingsCacheDir:  host.CrossFindingsCacheDir,
-		TypeIndexCacheDir:      host.TypeIndexCacheDir,
-		ResidentFileTypeInfo:   host.ResidentFileTypeInfo,
-		Reporter:               host.Reporter,
-		Tracker:                host.Tracker,
-		Verbose:                host.Reporter.VerboseEnabled(),
-		BuildCodeIndex:         buildCodeIndex,
-		CrossFileParentTracker: crossTracker,
-		CrossFileJobsFlag:      args.Workers,
-		CrossFileJavaPaths:     args.JavaPaths,
-		ParseCache:             host.ParseCache,
-		BuildModuleIndex:       hasModuleAwareRule,
-		ModuleParentTracker:    moduleTracker,
-		ModuleScanRoot:         scanRoot,
-		ModuleJobsFlag:         args.Workers,
-		ModuleHasAwareRule:     hasModuleAwareRule,
+		ParseResult:              parseResult,
+		PrebuiltResolver:         host.PrebuiltResolver,
+		PrebuiltLibraryFacts:     host.PrebuiltLibraryFacts,
+		PrebuiltAndroidProject:   host.PrebuiltAndroidProject,
+		LibraryFactsCache:        host.LibraryFactsCache,
+		CodeIndexCache:           host.CodeIndexCache,
+		JavaSourceIndexCache:     host.JavaSourceIndexCache,
+		ResolverCache:            host.ResolverCache,
+		ResolverFingerprintCache: host.ResolverFingerprintCache,
+		AndroidProjectCache:      host.AndroidProjectCache,
+		CrossFileCacheDir:        host.CrossFileCacheDir,
+		CrossFindingsCacheDir:    host.CrossFindingsCacheDir,
+		TypeIndexCacheDir:        host.TypeIndexCacheDir,
+		ResidentFileTypeInfo:     host.ResidentFileTypeInfo,
+		Reporter:                 host.Reporter,
+		Tracker:                  host.Tracker,
+		Verbose:                  host.Reporter.VerboseEnabled(),
+		BuildCodeIndex:           buildCodeIndex,
+		CrossFileParentTracker:   crossTracker,
+		CrossFileJobsFlag:        args.Workers,
+		CrossFileJavaPaths:       args.JavaPaths,
+		ParseCache:               host.ParseCache,
+		BuildModuleIndex:         hasModuleAwareRule,
+		ModuleParentTracker:      moduleTracker,
+		ModuleScanRoot:           scanRoot,
+		ModuleJobsFlag:           args.Workers,
+		ModuleHasAwareRule:       hasModuleAwareRule,
 	}
 	wireOracleHandles(&indexInput, args, host, parseResult.KotlinFiles)
 	if warm.result == nil {

--- a/internal/pipeline/workspace.go
+++ b/internal/pipeline/workspace.go
@@ -98,6 +98,19 @@ type WorkspaceState struct {
 	cachedJavaSourceIndex   *javafacts.SourceIndex
 	cachedJavaSourceVersion uint64
 
+	resolverFpMu sync.Mutex
+	// cachedResolverFp is the last computed resolverFingerprint
+	// string, valid while cachedResolverFpVersion ==
+	// sourceMTimeVersion. Recomputing the fingerprint hashes 18 k
+	// Kotlin file contents (~135 ms on the kotlin corpus), so a
+	// resident memo gated on the watcher-driven source version skips
+	// that work whenever no Kotlin / Java / Gradle event has fired
+	// since the last successful compute. A nil receiver / empty
+	// fingerprint always recomputes (no caching).
+	cachedResolverFp        string
+	cachedResolverFpVersion uint64
+	cachedResolverFpPresent bool
+
 	typeInfoMu sync.Mutex
 	// typeInfo caches per-file *typeinfer.FileTypeInfo across analyzes.
 	// The watcher's Invalidate(path) drops the corresponding entry —
@@ -432,6 +445,10 @@ func (w *WorkspaceState) InvalidateAll() {
 	w.cachedJavaSourceIndex = nil
 	w.javaSourceVersion++
 	w.javaSourceMu.Unlock()
+	w.resolverFpMu.Lock()
+	w.cachedResolverFp = ""
+	w.cachedResolverFpPresent = false
+	w.resolverFpMu.Unlock()
 }
 
 // LibraryFacts returns the cached *librarymodel.Facts when its
@@ -773,6 +790,43 @@ func (w *WorkspaceState) Resolver(fingerprint string, build func() typeinfer.Typ
 	}
 	w.xfileMu.Unlock()
 	return v
+}
+
+// ResolverFingerprint returns the resolver fingerprint string,
+// reusing the last successful compute when no source-path watcher
+// event has fired since (i.e. sourceMTimeVersion is unchanged). On
+// a miss it snapshots the current version, invokes build (without
+// holding the mutex), and stores the result if the version is still
+// the snapshot — a concurrent watcher event between snapshot and
+// store invalidates the would-be entry so the next call recomputes.
+//
+// build must produce a fingerprint string deterministic in its
+// inputs; the cache only short-circuits when nothing watched has
+// changed, so build's inputs are guaranteed identical on a hit. A
+// nil receiver always builds (no caching).
+func (w *WorkspaceState) ResolverFingerprint(build func() string) string {
+	if w == nil {
+		return build()
+	}
+	currentVersion := w.sourceMTimeVersion.Load()
+	w.resolverFpMu.Lock()
+	if w.cachedResolverFpPresent && w.cachedResolverFpVersion == currentVersion {
+		v := w.cachedResolverFp
+		w.resolverFpMu.Unlock()
+		return v
+	}
+	w.resolverFpMu.Unlock()
+
+	fp := build()
+
+	w.resolverFpMu.Lock()
+	if w.sourceMTimeVersion.Load() == currentVersion {
+		w.cachedResolverFp = fp
+		w.cachedResolverFpVersion = currentVersion
+		w.cachedResolverFpPresent = true
+	}
+	w.resolverFpMu.Unlock()
+	return fp
 }
 
 // InvalidateResolver drops the cached resolver. Called when any

--- a/internal/pipeline/workspace_resolver_fp_test.go
+++ b/internal/pipeline/workspace_resolver_fp_test.go
@@ -1,0 +1,117 @@
+package pipeline
+
+import (
+	"testing"
+)
+
+// TestWorkspaceState_ResolverFingerprint_HitCacheUntilBump pins the
+// version-counter contract: a cache hit short-circuits the build
+// closure entirely; a watcher source-version bump rotates the
+// version and the next call rebuilds. The closure-side check
+// confirms the fast-path doesn't merely read+return — it must skip
+// build() to recoup the ~135 ms saving from hashing 18k Kotlin files.
+func TestWorkspaceState_ResolverFingerprint_HitCacheUntilBump(t *testing.T) {
+	w := NewWorkspaceState("")
+	var builds int
+	build := func() string {
+		builds++
+		return "fp-v1"
+	}
+
+	first := w.ResolverFingerprint(build)
+	if builds != 1 {
+		t.Fatalf("first call: builds=%d, want 1", builds)
+	}
+	again := w.ResolverFingerprint(build)
+	if builds != 1 {
+		t.Errorf("second call after no bump must hit cache; builds=%d, want 1", builds)
+	}
+	if again != first {
+		t.Errorf("cached fingerprint must match prior value; got %q, want %q", again, first)
+	}
+
+	w.BumpSourceMTimeVersion()
+
+	third := w.ResolverFingerprint(func() string {
+		builds++
+		return "fp-v2"
+	})
+	if builds != 2 {
+		t.Errorf("post-bump call must rebuild; builds=%d, want 2", builds)
+	}
+	if third != "fp-v2" {
+		t.Errorf("post-bump return must reflect fresh build; got %q, want %q", third, "fp-v2")
+	}
+}
+
+// TestWorkspaceState_ResolverFingerprint_ConcurrentBumpInvalidates
+// mirrors the race semantics that motivate snapshotting the version
+// BEFORE the build runs: a watcher event during the build must NOT
+// result in a "clean" cached entry under a now-stale version.
+func TestWorkspaceState_ResolverFingerprint_ConcurrentBumpInvalidates(t *testing.T) {
+	w := NewWorkspaceState("")
+
+	// Build closure simulates a watcher event mid-flight.
+	fp := w.ResolverFingerprint(func() string {
+		w.BumpSourceMTimeVersion()
+		return "fp-during-race"
+	})
+	if fp != "fp-during-race" {
+		t.Errorf("returned fingerprint must come from the build call; got %q", fp)
+	}
+
+	// The returned fingerprint is correct for the request, but the
+	// cache MUST NOT have stored it under the stale version — the
+	// next call should rebuild instead of returning a value the
+	// watcher already invalidated.
+	var builds int
+	_ = w.ResolverFingerprint(func() string {
+		builds++
+		return "fp-post-race"
+	})
+	if builds == 0 {
+		t.Errorf("post-race call must rebuild (the stale version mustn't survive)")
+	}
+}
+
+// TestWorkspaceState_ResolverFingerprint_NilSafety mirrors the
+// safety contract the rest of WorkspaceState's caches honor.
+func TestWorkspaceState_ResolverFingerprint_NilSafety(t *testing.T) {
+	var w *WorkspaceState
+	called := 0
+	got := w.ResolverFingerprint(func() string {
+		called++
+		return "fp-nil"
+	})
+	if got != "fp-nil" {
+		t.Errorf("nil receiver must still return the build result; got %q", got)
+	}
+	if called != 1 {
+		t.Errorf("nil receiver must call build; called=%d, want 1", called)
+	}
+}
+
+// TestWorkspaceState_ResolverFingerprint_InvalidateAllClears confirms
+// InvalidateAll drops the cached fingerprint alongside every other
+// resident slot — symmetric with the javaSourceIndex / resolver slots.
+func TestWorkspaceState_ResolverFingerprint_InvalidateAllClears(t *testing.T) {
+	w := NewWorkspaceState("")
+	var builds int
+	build := func() string {
+		builds++
+		return "fp"
+	}
+
+	_ = w.ResolverFingerprint(build)
+	_ = w.ResolverFingerprint(build)
+	if builds != 1 {
+		t.Fatalf("warm cache state: builds=%d, want 1", builds)
+	}
+
+	w.InvalidateAll()
+
+	_ = w.ResolverFingerprint(build)
+	if builds != 2 {
+		t.Errorf("InvalidateAll must drop the cached fingerprint; builds=%d, want 2", builds)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds a `sourceMTimeVersion`-gated memo for the resolver fingerprint string used to key `ResolverCache`. Skips the ~135 ms 18 k-file hash sweep when no source-path watcher event has fired since the last successful compute.
- Wired through `ProjectHostState` → `IndexInput` → `buildBaseResolver`; non-daemon callers pass `nil` and keep the unchanged hash-every-call behavior.
- Snapshots the version before `build` and only stores under that snapshot — a concurrent watcher bump invalidates the would-be entry. Mirrors the race-safe pattern from #264's `javafacts.SourceIndex` cache.

## Where it bites

The cache fires whenever `buildBaseResolver` runs without an intervening source change — primarily on bundle-miss-from-config-change paths (rule toggles, `krit.yml` edits) where the resolver inputs are unchanged but the findings bundle key rotated. On the steady-state ABI-edit benchmark this PR is a defensive no-op: the watcher's source-version bump on every content edit forces a fingerprint recompute (correctly — file contents changed).

The dominant remaining cost on that benchmark is `codeIndexBuild` (~4.2 s / 94 % of `crossFileAnalysis`) — next target.

## Test plan

- [x] `go test ./internal/pipeline/ -run TestWorkspaceState_ResolverFingerprint -v` — four new tests covering hit-after-build, post-bump rebuild, concurrent-bump race window, InvalidateAll clearing, nil-receiver safety
- [x] `go test ./... -count=1`
- [x] `golangci-lint run ./...`
- [x] Daemon smoke benchmark against ~/github/kotlin (18 k Kotlin files): warm steady-state 18-22 ms `durationMs`, ABI-edit unchanged (this PR doesn't target that path)