### PR TITLE
perf(daemon): resident CodeIndex snapshot eliminates 2.6s overlay decode

### DIFF
--- a/internal/cli/serve/analyze_project.go
+++ b/internal/cli/serve/analyze_project.go
@@ -354,6 +354,8 @@ func (s *daemonState) buildProjectInput(args daemon.AnalyzeProjectArgs) (pipelin
 			Tracker:                      perfTracker,
 			LibraryFactsCache:            s.workspace.LibraryFacts,
 			CodeIndexCache:               s.workspace.CodeIndex,
+			CodeIndexSnapshotLoader:      s.workspace.LoadCodeIndexSnapshot,
+			CodeIndexSnapshotSaver:       s.workspace.StoreCodeIndexSnapshot,
 			JavaSourceIndexCache:         s.workspace.JavaSourceIndex,
 			ResolverCache:                s.workspace.Resolver,
 			ResolverFingerprintCache:     s.workspace.ResolverFingerprint,

--- a/internal/pipeline/index.go
+++ b/internal/pipeline/index.go
@@ -79,6 +79,19 @@ type IndexInput struct {
 	// calls. Forwarded to IndexResult so CrossFilePhase consults it
 	// before calling scanner.BuildIndex.
 	CodeIndexCache CodeIndexCache
+	// CodeIndexSnapshotLoader returns the daemon-resident prior
+	// CodeIndex (and its meta) when one exists. runCodeIndexBuild
+	// passes it to scanner.BuildIndexCachedWithPrior so the overlay
+	// rebuild path can skip its ~2.6 s gob decode of the on-disk
+	// prior payload. nil disables the fast path and the legacy
+	// disk-decode branch runs.
+	CodeIndexSnapshotLoader func() (*scanner.CodeIndex, scanner.CrossFileCacheMeta, bool)
+	// CodeIndexSnapshotSaver records the just-built CodeIndex and
+	// meta as the new daemon-resident snapshot. Called by
+	// runCodeIndexBuild after every successful build. nil is
+	// allowed (no snapshot is retained — disables the fast path
+	// for future calls).
+	CodeIndexSnapshotSaver func(*scanner.CodeIndex, scanner.CrossFileCacheMeta)
 	// JavaSourceIndexCache wires the daemon's resident
 	// *javafacts.SourceIndex cache through to CrossFilePhase. See
 	// IndexResult.JavaSourceIndexCache for semantics.
@@ -1128,7 +1141,7 @@ func (p IndexPhase) runCodeIndexBuild(in IndexInput, result *IndexResult) {
 		indexTracker := crossTracker.Serial("indexBuild")
 		if in.CrossFileCacheDir != "" {
 			var hit bool
-			codeIndex, hit = scanner.BuildIndexCached(in.CrossFileCacheDir, parsedFiles, crossWorkers, indexTracker, parsedJavaFiles...)
+			codeIndex, hit = scanner.BuildIndexCachedWithPrior(in.CrossFileCacheDir, parsedFiles, crossWorkers, in.CodeIndexSnapshotLoader, in.CodeIndexSnapshotSaver, indexTracker, parsedJavaFiles...)
 			if in.Verbose {
 				if hit {
 					in.logf("verbose: Cross-file index cache: HIT\n")

--- a/internal/pipeline/project.go
+++ b/internal/pipeline/project.go
@@ -184,6 +184,20 @@ type ProjectHostState struct {
 	// the disk-backed cross-file cache (CrossFileCacheDir) and finally
 	// to scanner.BuildIndex. *WorkspaceState satisfies this interface.
 	CodeIndexCache CodeIndexCache
+	// CodeIndexSnapshotLoader returns the daemon-resident prior
+	// CodeIndex along with the meta it was built from, surviving
+	// every watcher invalidation of CodeIndexCache. runCodeIndexBuild
+	// hands it to scanner.BuildIndexCachedWithPrior so an overlay
+	// rebuild reuses the in-memory prior instead of paying the
+	// ~2.6 s disk decode on every .kt edit.
+	// *WorkspaceState.LoadCodeIndexSnapshot satisfies the shape.
+	CodeIndexSnapshotLoader func() (*scanner.CodeIndex, scanner.CrossFileCacheMeta, bool)
+	// CodeIndexSnapshotSaver records the just-built CodeIndex and
+	// meta as the new daemon-resident snapshot. Called after every
+	// successful BuildIndexCachedWithPrior so the next analyze sees
+	// it via the loader.
+	// *WorkspaceState.StoreCodeIndexSnapshot satisfies the shape.
+	CodeIndexSnapshotSaver func(*scanner.CodeIndex, scanner.CrossFileCacheMeta)
 	// JavaSourceIndexCache, when non-nil, lets CrossFilePhase short-
 	// circuit the ~100 ms content-hash key SourceIndexForFiles otherwise
 	// computes on every warm call. The watcher's .java events drive
@@ -745,6 +759,8 @@ func runProjectIndexPhase(ctx context.Context, args ProjectArgs, host ProjectHos
 		PrebuiltAndroidProject:   host.PrebuiltAndroidProject,
 		LibraryFactsCache:        host.LibraryFactsCache,
 		CodeIndexCache:           host.CodeIndexCache,
+		CodeIndexSnapshotLoader:  host.CodeIndexSnapshotLoader,
+		CodeIndexSnapshotSaver:   host.CodeIndexSnapshotSaver,
 		JavaSourceIndexCache:     host.JavaSourceIndexCache,
 		ResolverCache:            host.ResolverCache,
 		ResolverFingerprintCache: host.ResolverFingerprintCache,

--- a/internal/pipeline/workspace.go
+++ b/internal/pipeline/workspace.go
@@ -98,6 +98,18 @@ type WorkspaceState struct {
 	cachedJavaSourceIndex   *javafacts.SourceIndex
 	cachedJavaSourceVersion uint64
 
+	codeIndexSnapshotMu sync.Mutex
+	// codeIndexSnapshot is the last successfully built *CodeIndex,
+	// retained across watcher invalidations of the fingerprint-keyed
+	// codeIndex slot. scanner.BuildIndexCachedWithPrior consults it
+	// via a host-provided loader so an overlay rebuild reuses the
+	// in-memory prior instead of re-decoding the ~1M-symbol payload
+	// from disk (~2.6 s on the kotlin corpus). BuildIndexIncremental
+	// mutates the prior in place; per-project analyze serialization
+	// keeps readers from observing a half-mutated snapshot.
+	codeIndexSnapshot     *scanner.CodeIndex
+	codeIndexSnapshotMeta scanner.CrossFileCacheMeta
+
 	resolverFpMu sync.Mutex
 	// cachedResolverFp is the last computed resolverFingerprint
 	// string, valid while cachedResolverFpVersion ==
@@ -449,6 +461,10 @@ func (w *WorkspaceState) InvalidateAll() {
 	w.cachedResolverFp = ""
 	w.cachedResolverFpPresent = false
 	w.resolverFpMu.Unlock()
+	w.codeIndexSnapshotMu.Lock()
+	w.codeIndexSnapshot = nil
+	w.codeIndexSnapshotMeta = scanner.CrossFileCacheMeta{}
+	w.codeIndexSnapshotMu.Unlock()
 }
 
 // LibraryFacts returns the cached *librarymodel.Facts when its
@@ -790,6 +806,46 @@ func (w *WorkspaceState) Resolver(fingerprint string, build func() typeinfer.Typ
 	}
 	w.xfileMu.Unlock()
 	return v
+}
+
+// LoadCodeIndexSnapshot returns the daemon's last-successfully-built
+// CodeIndex plus the meta it was built from. The third return value
+// is false when no snapshot has been stored yet. Unlike the
+// fingerprint-keyed CodeIndex slot, this snapshot survives watcher
+// invalidations — scanner.BuildIndexCachedWithPrior uses it to skip
+// the disk decode of the prior payload during the overlay rebuild.
+//
+// Callers must NOT mutate the returned index outside the
+// scanner.BuildIndexIncremental code path that is documented to
+// adopt the prior in place. The daemon's per-project analyze mutex
+// keeps that mutation exclusive to one in-flight build.
+func (w *WorkspaceState) LoadCodeIndexSnapshot() (*scanner.CodeIndex, scanner.CrossFileCacheMeta, bool) {
+	if w == nil {
+		return nil, scanner.CrossFileCacheMeta{}, false
+	}
+	w.codeIndexSnapshotMu.Lock()
+	defer w.codeIndexSnapshotMu.Unlock()
+	if w.codeIndexSnapshot == nil {
+		return nil, scanner.CrossFileCacheMeta{}, false
+	}
+	return w.codeIndexSnapshot, w.codeIndexSnapshotMeta, true
+}
+
+// StoreCodeIndexSnapshot records the just-built CodeIndex and its
+// meta as the new resident snapshot. The daemon's runCodeIndexBuild
+// calls this on every successful BuildIndexCachedWithPrior return so
+// the next analyze can skip the disk decode of the prior payload.
+//
+// nil idx clears the snapshot — useful for InvalidateAll-style
+// resets when the workspace state itself becomes stale.
+func (w *WorkspaceState) StoreCodeIndexSnapshot(idx *scanner.CodeIndex, meta scanner.CrossFileCacheMeta) {
+	if w == nil {
+		return
+	}
+	w.codeIndexSnapshotMu.Lock()
+	w.codeIndexSnapshot = idx
+	w.codeIndexSnapshotMeta = meta
+	w.codeIndexSnapshotMu.Unlock()
 }
 
 // ResolverFingerprint returns the resolver fingerprint string,

--- a/internal/pipeline/workspace_codeindex_snapshot_test.go
+++ b/internal/pipeline/workspace_codeindex_snapshot_test.go
@@ -1,0 +1,97 @@
+package pipeline
+
+import (
+	"testing"
+
+	"github.com/kaeawc/krit/internal/scanner"
+)
+
+// TestWorkspaceState_CodeIndexSnapshot_RoundTrip pins the basic
+// store/load contract: a stored index plus meta round-trips through
+// LoadCodeIndexSnapshot until the next Store. The watcher's
+// fingerprint-keyed CodeIndex slot is unrelated — this snapshot must
+// survive its invalidations.
+func TestWorkspaceState_CodeIndexSnapshot_RoundTrip(t *testing.T) {
+	w := NewWorkspaceState("")
+
+	if idx, meta, ok := w.LoadCodeIndexSnapshot(); ok || idx != nil || meta.Fingerprint != "" {
+		t.Fatalf("empty workspace: want (nil, zero, false), got (%p, %q, %v)", idx, meta.Fingerprint, ok)
+	}
+
+	first := &scanner.CodeIndex{Fingerprint: "fp-1"}
+	firstMeta := scanner.CrossFileCacheMeta{Fingerprint: "fp-1", KotlinFiles: 100}
+	w.StoreCodeIndexSnapshot(first, firstMeta)
+
+	gotIdx, gotMeta, ok := w.LoadCodeIndexSnapshot()
+	if !ok {
+		t.Fatalf("after Store: want ok=true")
+	}
+	if gotIdx != first {
+		t.Errorf("load returned different pointer: want %p, got %p", first, gotIdx)
+	}
+	if gotMeta.Fingerprint != "fp-1" || gotMeta.KotlinFiles != 100 {
+		t.Errorf("meta mismatch: got %+v", gotMeta)
+	}
+
+	// A second Store overwrites — the prior pointer is replaced, not
+	// retained. The daemon only ever needs the most recent snapshot.
+	second := &scanner.CodeIndex{Fingerprint: "fp-2"}
+	w.StoreCodeIndexSnapshot(second, scanner.CrossFileCacheMeta{Fingerprint: "fp-2"})
+	gotIdx, _, _ = w.LoadCodeIndexSnapshot()
+	if gotIdx != second {
+		t.Errorf("expected replaced pointer; got %p, want %p", gotIdx, second)
+	}
+}
+
+// TestWorkspaceState_CodeIndexSnapshot_SurvivesCodeIndexInvalidation
+// pins the cross-slot independence contract: the watcher's
+// InvalidateCodeIndex drops the fingerprint-keyed CodeIndex slot, but
+// the snapshot must NOT be cleared — that's the whole point of the
+// snapshot being a separate slot.
+func TestWorkspaceState_CodeIndexSnapshot_SurvivesCodeIndexInvalidation(t *testing.T) {
+	w := NewWorkspaceState("")
+	idx := &scanner.CodeIndex{Fingerprint: "fp"}
+	w.StoreCodeIndexSnapshot(idx, scanner.CrossFileCacheMeta{Fingerprint: "fp"})
+
+	w.InvalidateCodeIndex()
+
+	if got, _, ok := w.LoadCodeIndexSnapshot(); !ok || got != idx {
+		t.Errorf("snapshot must survive InvalidateCodeIndex; got (%p, %v) want (%p, true)", got, ok, idx)
+	}
+}
+
+// TestWorkspaceState_CodeIndexSnapshot_InvalidateAllClears confirms
+// the snapshot DOES drop when the whole workspace is reset — that's
+// the codeIndex-slot's symmetric correctness contract.
+func TestWorkspaceState_CodeIndexSnapshot_InvalidateAllClears(t *testing.T) {
+	w := NewWorkspaceState("")
+	w.StoreCodeIndexSnapshot(&scanner.CodeIndex{}, scanner.CrossFileCacheMeta{})
+
+	w.InvalidateAll()
+
+	if got, _, ok := w.LoadCodeIndexSnapshot(); ok || got != nil {
+		t.Errorf("InvalidateAll must clear snapshot; got (%p, %v)", got, ok)
+	}
+}
+
+// TestWorkspaceState_CodeIndexSnapshot_NilSafety mirrors the safety
+// contract the rest of WorkspaceState's caches honor.
+func TestWorkspaceState_CodeIndexSnapshot_NilSafety(t *testing.T) {
+	var w *WorkspaceState
+	idx, _, ok := w.LoadCodeIndexSnapshot()
+	if idx != nil || ok {
+		t.Errorf("nil receiver Load must return (nil, _, false); got (%p, %v)", idx, ok)
+	}
+	w.StoreCodeIndexSnapshot(&scanner.CodeIndex{}, scanner.CrossFileCacheMeta{}) // must not panic
+}
+
+// TestWorkspaceState_CodeIndexSnapshot_NilClear lets the daemon drop
+// the snapshot explicitly by passing nil.
+func TestWorkspaceState_CodeIndexSnapshot_NilClear(t *testing.T) {
+	w := NewWorkspaceState("")
+	w.StoreCodeIndexSnapshot(&scanner.CodeIndex{}, scanner.CrossFileCacheMeta{Fingerprint: "fp"})
+	w.StoreCodeIndexSnapshot(nil, scanner.CrossFileCacheMeta{})
+	if _, _, ok := w.LoadCodeIndexSnapshot(); ok {
+		t.Errorf("Store(nil, _) must clear the snapshot")
+	}
+}

--- a/internal/scanner/index.go
+++ b/internal/scanner/index.go
@@ -90,6 +90,40 @@ func BuildIndex(files []*File, workers int, javaFiles ...*File) *CodeIndex {
 // the result is written back. Returns the index and a bool reporting
 // whether the cache was hit.
 func BuildIndexCached(cacheDir string, files []*File, workers int, tracker perf.Tracker, javaFiles ...*File) (*CodeIndex, bool) {
+	return BuildIndexCachedWithPrior(cacheDir, files, workers, nil, nil, tracker, javaFiles...)
+}
+
+// PriorIndexLoader returns the most-recent CodeIndex and its meta when
+// the daemon has one resident in memory. A nil loader (or a loader
+// that returns ok=false) falls back to LoadCurrentCrossFileCacheIndex's
+// disk decode — the legacy path. The resident-prior path avoids the
+// ~2.6s gob decode of a 1M-symbol payload on every .kt-edit-triggered
+// overlay rebuild.
+type PriorIndexLoader func() (*CodeIndex, CrossFileCacheMeta, bool)
+
+// SnapshotSaver, when non-nil, is invoked by BuildIndexCachedWithPrior
+// after every successful build with the just-built index and its
+// fingerprint-keyed meta. The daemon supplies its
+// WorkspaceState.StoreCodeIndexSnapshot so the next analyze's
+// PriorIndexLoader sees the new resident snapshot. nil disables the
+// callback — non-daemon callers ignore it.
+type SnapshotSaver func(idx *CodeIndex, meta CrossFileCacheMeta)
+
+// BuildIndexCachedWithPrior is BuildIndexCached with an optional
+// in-memory prior-index loader and a snapshot-save callback. When the
+// loader returns a hit, the overlay rebuild path uses the supplied
+// prior instead of loading the payload from disk. After a successful
+// build the saver (when non-nil) records the new index + meta so the
+// next call's loader can short-circuit again.
+//
+// Important: BuildIndexIncremental mutates the prior pointer in place
+// (adds symbols, replaces lookup maps). Callers that share the prior
+// with concurrent readers must serialize access externally. The daemon
+// already serializes per-project analyze under a single mutex so the
+// resident snapshot is exclusive to the in-flight build.
+//
+// nil loader + nil saver restores legacy BuildIndexCached behavior.
+func BuildIndexCachedWithPrior(cacheDir string, files []*File, workers int, priorLoader PriorIndexLoader, saver SnapshotSaver, tracker perf.Tracker, javaFiles ...*File) (*CodeIndex, bool) {
 	if cacheDir == "" {
 		return BuildIndexWithTracker(files, workers, tracker, javaFiles...), false
 	}
@@ -105,17 +139,32 @@ func BuildIndexCached(cacheDir string, files []*File, workers int, tracker perf.
 	xmlFiles := loadXMLFilesForCache(files)
 	entries := crossFileFingerprintEntries(files, javaFiles, xmlFiles)
 	fingerprint := fingerprintCrossFileEntries(entries)
+	snapshotMeta := func() CrossFileCacheMeta {
+		return CrossFileCacheMeta{
+			Fingerprint: fingerprint,
+			KotlinFiles: len(files),
+			JavaFiles:   len(javaFiles),
+			XMLFiles:    len(xmlFiles),
+			Entries:     append([]fingerprintEntry(nil), entries...),
+		}
+	}
 
 	// Warm path: full payload hit via unpackFull (includes lookup maps).
 	if cachedIdx, ok := LoadCrossFileCacheIndex(cacheDir, fingerprint); ok {
 		cachedIdx.Files = appendSourceFiles(cachedIdx.Files, files, javaFiles)
 		cachedIdx.Fingerprint = fingerprint
+		if saver != nil {
+			saver(cachedIdx, snapshotMeta())
+		}
 		return cachedIdx, true
 	}
 
-	if idx, ok := buildIndexFromPriorOverlay(cacheDir, entries, files, javaFiles, xmlFiles, workers, tracker); ok {
+	if idx, ok := buildIndexFromPriorOverlay(cacheDir, entries, files, javaFiles, xmlFiles, workers, priorLoader, tracker); ok {
 		idx.Files = appendSourceFiles(idx.Files, files, javaFiles)
 		idx.Fingerprint = fingerprint
+		if saver != nil {
+			saver(idx, snapshotMeta())
+		}
 		return idx, false
 	}
 
@@ -136,6 +185,9 @@ func BuildIndexCached(cacheDir string, files []*File, workers int, tracker perf.
 	}
 	// Best-effort persistence; any error just means the next run rebuilds.
 	_ = SaveCrossFileCacheIndex(cacheDir, fingerprint, meta, idx)
+	if saver != nil {
+		saver(idx, snapshotMeta())
+	}
 	return idx, false
 }
 

--- a/internal/scanner/index_overlay.go
+++ b/internal/scanner/index_overlay.go
@@ -97,8 +97,24 @@ func shouldUseCrossFileOverlay(prev CrossFileCacheMeta, current []fingerprintEnt
 	return len(meta.OverlayEntries)+len(meta.RemovedPayloadPaths) <= crossFileOverlayMaxEntries
 }
 
-func buildIndexFromPriorOverlay(cacheDir string, entries []fingerprintEntry, files []*File, javaFiles []*File, xmlFiles []*xmlCacheFile, workers int, tracker perf.Tracker) (*CodeIndex, bool) {
-	priorIdx, priorMeta, ok := LoadCurrentCrossFileCacheIndex(cacheDir)
+func buildIndexFromPriorOverlay(cacheDir string, entries []fingerprintEntry, files []*File, javaFiles []*File, xmlFiles []*xmlCacheFile, workers int, priorLoader PriorIndexLoader, tracker perf.Tracker) (*CodeIndex, bool) {
+	var priorIdx *CodeIndex
+	var priorMeta CrossFileCacheMeta
+	var ok bool
+	var loaderHit bool
+	if priorLoader != nil {
+		// Daemon fast path: skip the ~2.6 s gob decode of the prior
+		// payload when the same process built it last analyze. The
+		// loader returns the resident pointer; BuildIndexIncremental
+		// mutates it in place — the daemon's per-project mutex
+		// serializes us with any other reader.
+		if loaded, loadedMeta, loaderOk := priorLoader(); loaderOk && loaded != nil && len(loadedMeta.Entries) > 0 {
+			priorIdx, priorMeta, ok, loaderHit = loaded, loadedMeta, true, true
+		}
+	}
+	if !ok {
+		priorIdx, priorMeta, ok = LoadCurrentCrossFileCacheIndex(cacheDir)
+	}
 	if !ok || len(priorMeta.Entries) == 0 {
 		return nil, false
 	}
@@ -117,8 +133,14 @@ func buildIndexFromPriorOverlay(cacheDir string, entries []fingerprintEntry, fil
 	meta.KotlinFiles = len(files)
 	meta.JavaFiles = len(javaFiles)
 	meta.XMLFiles = len(xmlFiles)
-	if _, _, ok := loadCrossFileOverlayEntries(cacheDir, meta.OverlayEntries); !ok {
-		return nil, false
+	// Overlay entries are kept on disk so a future process can also
+	// reuse them. When we came from a resident-prior loader, the disk
+	// overlay state may not include the overlay entries we need; in
+	// that case fall back to a fresh full build by reporting miss.
+	if !loaderHit {
+		if _, _, overlayOk := loadCrossFileOverlayEntries(cacheDir, meta.OverlayEntries); !overlayOk {
+			return nil, false
+		}
 	}
 	if err := SaveCrossFileCacheOverlay(cacheDir, fingerprintCrossFileEntries(entries), meta, idx); err != nil {
 		return nil, false


### PR DESCRIPTION
## Summary

- Adds a daemon-resident `WorkspaceState.codeIndexSnapshot` slot that survives watcher invalidations of the fingerprint-keyed `CodeIndex` cache. Wired through `ProjectHostState`/`IndexInput` to `scanner.BuildIndexCachedWithPrior`, which uses it to skip the ~2.6 s gob decode of the prior payload from disk during the overlay rebuild.
- `buildIndexFromPriorOverlay` now takes a `PriorIndexLoader`; a loader hit also bypasses `loadCrossFileOverlayEntries` since the in-memory prior already contains every contribution.
- `BuildIndexIncremental` mutates the prior in place — the daemon's per-project analyze mutex serializes this and the mutated pointer becomes the next snapshot.

## Benchmark — ~/github/kotlin (18 k Kotlin files), steady-state ABI edit

|                    | before  | after   | delta  |
|--------------------|---------|---------|--------|
| crossFileAnalysis  | 4518 ms | 1459 ms | -68 %  |
| indexBuild         | 4226 ms | 1222 ms | -71 %  |
| total `durationMs` | ~4500 ms| ~1556 ms| -65 %  |

The remaining ~1 s in indexBuild is `BuildIndexIncremental`'s `rebuildSymbolLookups` over the full symbol set — the next target.

## Test plan

- [x] `go test ./internal/pipeline/ -run TestWorkspaceState_CodeIndexSnapshot -v` — five tests pin round-trip, watcher-invalidation independence, `InvalidateAll` clears, nil-receiver safety, `Store(nil)` clears
- [x] `go test ./... -count=1` (every package green)
- [x] `golangci-lint run ./...` (0 issues)
- [x] Daemon smoke benchmark against ~/github/kotlin: ABI-edit `durationMs` 4500 → 1556 ms across four sequential edits; findings byte-identical