### PR TITLE
perf(daemon): delta-update CodeIndex symbol lookups on incremental rebuild

### DIFF
--- a/internal/scanner/index.go
+++ b/internal/scanner/index.go
@@ -229,6 +229,12 @@ func BuildIndexFromDataWithTracker(symbols []Symbol, refs []Reference, tracker p
 // removed and the supplied fresh contributions added. It is used by the
 // cross-file overlay cache so a small edit can update the lookup maps without
 // rescanning unchanged files or rewriting the compacted full payload.
+//
+// The lookup maps are updated by per-symbol/per-reference delta on both
+// the remove and add sides — for a single-file edit (~10–30 symbols,
+// ~100 refs) this is O(changed) rather than the O(total) rebuild that
+// rebuildSymbolLookups would do, which buys ~1 s on the kotlin corpus
+// (1 M symbols).
 func BuildIndexIncremental(base *CodeIndex, removePaths map[string]bool, addSymbols []Symbol, addRefs []Reference) *CodeIndex {
 	if base == nil {
 		return BuildIndexFromData(addSymbols, addRefs)
@@ -238,7 +244,9 @@ func BuildIndexIncremental(base *CodeIndex, removePaths map[string]bool, addSymb
 	}
 	if len(addSymbols) > 0 {
 		base.Symbols = append(base.Symbols, addSymbols...)
-		base.rebuildSymbolLookups()
+		for _, sym := range addSymbols {
+			base.addSymbolToLookups(sym)
+		}
 	}
 	if len(addRefs) > 0 {
 		base.References = append(base.References, addRefs...)
@@ -304,30 +312,62 @@ func buildCodeIndexWithBloom(symbols []Symbol, refs []Reference, prebuilt *bloom
 	}
 
 	for _, sym := range idx.Symbols {
-		idx.symbolsByName[sym.Name] = append(idx.symbolsByName[sym.Name], sym)
-		if sym.FQN != "" {
-			idx.symbolsByFQN[sym.FQN] = sym
-			if sym.FQN != sym.Name {
-				idx.symbolsByName[sym.FQN] = append(idx.symbolsByName[sym.FQN], sym)
-			}
-		}
+		idx.addSymbolToLookups(sym)
 	}
 	idx.buildReferenceLookups(prebuilt == nil)
 
 	return idx
 }
 
-func (idx *CodeIndex) rebuildSymbolLookups() {
-	idx.symbolsByName = make(map[string][]Symbol)
-	idx.symbolsByFQN = make(map[string]Symbol)
-	for _, sym := range idx.Symbols {
-		idx.symbolsByName[sym.Name] = append(idx.symbolsByName[sym.Name], sym)
-		if sym.FQN != "" {
-			idx.symbolsByFQN[sym.FQN] = sym
-			if sym.FQN != sym.Name {
-				idx.symbolsByName[sym.FQN] = append(idx.symbolsByName[sym.FQN], sym)
-			}
+// addSymbolToLookups inserts sym into symbolsByName + symbolsByFQN.
+// Used by both the initial buildCodeIndexWithBloom loop and the
+// incremental BuildIndexIncremental path so both produce identical
+// map state for the same input set.
+func (idx *CodeIndex) addSymbolToLookups(sym Symbol) {
+	idx.symbolsByName[sym.Name] = append(idx.symbolsByName[sym.Name], sym)
+	if sym.FQN != "" {
+		idx.symbolsByFQN[sym.FQN] = sym
+		if sym.FQN != sym.Name {
+			idx.symbolsByName[sym.FQN] = append(idx.symbolsByName[sym.FQN], sym)
 		}
+	}
+}
+
+// removeSymbolFromLookups deletes sym's entries from symbolsByName +
+// symbolsByFQN. Inverse of addSymbolToLookups — symbol equality is
+// by full struct value, which matches how rebuildSymbolLookups
+// originally inserted them.
+func (idx *CodeIndex) removeSymbolFromLookups(sym Symbol) {
+	dropSymbolFromSlice(idx.symbolsByName, sym.Name, sym)
+	if sym.FQN != "" {
+		if existing, ok := idx.symbolsByFQN[sym.FQN]; ok && existing == sym {
+			delete(idx.symbolsByFQN, sym.FQN)
+		}
+		if sym.FQN != sym.Name {
+			dropSymbolFromSlice(idx.symbolsByName, sym.FQN, sym)
+		}
+	}
+}
+
+// dropSymbolFromSlice removes target from m[key] (using struct
+// equality). If the resulting slice is empty, the key is removed
+// outright so warm-cache iteration order matches the post-rebuild
+// shape.
+func dropSymbolFromSlice(m map[string][]Symbol, key string, target Symbol) {
+	syms, ok := m[key]
+	if !ok {
+		return
+	}
+	dst := syms[:0]
+	for _, s := range syms {
+		if s != target {
+			dst = append(dst, s)
+		}
+	}
+	if len(dst) == 0 {
+		delete(m, key)
+	} else {
+		m[key] = dst
 	}
 }
 
@@ -336,14 +376,24 @@ func (idx *CodeIndex) removeFileContributions(paths map[string]bool) {
 		return
 	}
 	if len(idx.Symbols) > 0 {
+		// Filter the canonical slice while collecting the dropped
+		// symbols so we can apply per-symbol map deletions instead
+		// of rebuilding both maps from scratch. On a single-file
+		// edit this turns a ~1 s rebuild over 1 M symbols into a
+		// ~30-symbol map mutation.
 		dst := idx.Symbols[:0]
+		var removed []Symbol
 		for _, sym := range idx.Symbols {
-			if !paths[sym.File] {
+			if paths[sym.File] {
+				removed = append(removed, sym)
+			} else {
 				dst = append(dst, sym)
 			}
 		}
 		idx.Symbols = dst
-		idx.rebuildSymbolLookups()
+		for _, sym := range removed {
+			idx.removeSymbolFromLookups(sym)
+		}
 	}
 	if len(idx.References) > 0 {
 		dst := idx.References[:0]

--- a/internal/scanner/index_symbol_delta_test.go
+++ b/internal/scanner/index_symbol_delta_test.go
@@ -1,0 +1,113 @@
+package scanner
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+)
+
+// TestSymbolLookups_DeltaEqualsFullRebuild pins the regression-critical
+// equivalence: applying add/remove deltas through BuildIndexIncremental
+// produces the same lookup maps as building from the equivalent final
+// symbol set with rebuildSymbolLookups. If this drifts, ReferenceCount,
+// SymbolByFQN, and downstream rule queries silently disagree across
+// daemon analyzes and one-shot CLI runs.
+func TestSymbolLookups_DeltaEqualsFullRebuild(t *testing.T) {
+	// Seed with a mixed set: same Name in multiple files (slice-bucket
+	// in symbolsByName), FQN equal to Name and distinct from Name
+	// (both branches of the addSymbolToLookups conditional).
+	initial := []Symbol{
+		{Name: "Foo", Kind: "class", File: "a.kt", FQN: "p.a.Foo"},
+		{Name: "Foo", Kind: "class", File: "b.kt", FQN: "p.b.Foo"}, // same Name, different file/FQN
+		{Name: "Bar", Kind: "function", File: "a.kt", FQN: "Bar"},  // FQN == Name
+		{Name: "Baz", Kind: "object", File: "c.kt", FQN: "p.c.Baz"},
+	}
+
+	delta := BuildIndexFromData(append([]Symbol(nil), initial...), nil)
+	BuildIndexIncremental(delta, map[string]bool{"b.kt": true}, []Symbol{
+		{Name: "Quux", Kind: "class", File: "b.kt", FQN: "p.b.Quux"},
+		{Name: "Baz", Kind: "object", File: "b.kt", FQN: "p.b.Baz"}, // same Name as existing
+	}, nil)
+
+	// Compute the equivalent post-delta symbol set explicitly and
+	// build fresh — apples-to-apples comparison target.
+	wanted := []Symbol{
+		{Name: "Foo", Kind: "class", File: "a.kt", FQN: "p.a.Foo"},
+		{Name: "Bar", Kind: "function", File: "a.kt", FQN: "Bar"},
+		{Name: "Baz", Kind: "object", File: "c.kt", FQN: "p.c.Baz"},
+		{Name: "Quux", Kind: "class", File: "b.kt", FQN: "p.b.Quux"},
+		{Name: "Baz", Kind: "object", File: "b.kt", FQN: "p.b.Baz"},
+	}
+	want := BuildIndexFromData(wanted, nil)
+
+	if !equalSymbolsByName(delta.symbolsByName, want.symbolsByName) {
+		t.Errorf("symbolsByName diverged from full rebuild\n delta=%v\n want=%v", delta.symbolsByName, want.symbolsByName)
+	}
+	if !reflect.DeepEqual(delta.symbolsByFQN, want.symbolsByFQN) {
+		t.Errorf("symbolsByFQN diverged from full rebuild\n delta=%v\n want=%v", delta.symbolsByFQN, want.symbolsByFQN)
+	}
+}
+
+// TestRemoveAllInstancesDeletesKey confirms the slice-bucket cleanup —
+// when every symbol under a name key is removed, the key must be
+// deleted outright so callers iterating maps see no empty buckets.
+// rebuildSymbolLookups never leaves empty slices either, so this
+// matches the post-rebuild shape.
+func TestRemoveAllInstancesDeletesKey(t *testing.T) {
+	idx := BuildIndexFromData([]Symbol{
+		{Name: "Only", Kind: "class", File: "a.kt", FQN: "p.Only"},
+	}, nil)
+	if _, ok := idx.symbolsByName["Only"]; !ok {
+		t.Fatalf("setup: Only key missing before remove")
+	}
+	BuildIndexIncremental(idx, map[string]bool{"a.kt": true}, nil, nil)
+	if syms, ok := idx.symbolsByName["Only"]; ok {
+		t.Errorf("remove-all left dangling map key: %v", syms)
+	}
+	if _, ok := idx.symbolsByFQN["p.Only"]; ok {
+		t.Errorf("FQN entry survived remove-all")
+	}
+}
+
+// TestRemoveOneOfManyKeepsSurvivors confirms the slice-bucket pruning
+// preserves untouched symbols. The current rebuildSymbolLookups path
+// produces a slice in the original insertion order — the delta path
+// must too so downstream order-sensitive callers (rare but possible)
+// don't silently shift.
+func TestRemoveOneOfManyKeepsSurvivors(t *testing.T) {
+	idx := BuildIndexFromData([]Symbol{
+		{Name: "Shared", File: "a.kt", FQN: "p.a.Shared"},
+		{Name: "Shared", File: "b.kt", FQN: "p.b.Shared"},
+		{Name: "Shared", File: "c.kt", FQN: "p.c.Shared"},
+	}, nil)
+	BuildIndexIncremental(idx, map[string]bool{"b.kt": true}, nil, nil)
+	got := idx.symbolsByName["Shared"]
+	wantFiles := []string{"a.kt", "c.kt"}
+	gotFiles := make([]string, len(got))
+	for i, s := range got {
+		gotFiles[i] = s.File
+	}
+	if !reflect.DeepEqual(gotFiles, wantFiles) {
+		t.Errorf("survivor order/contents diverged: got %v, want %v", gotFiles, wantFiles)
+	}
+}
+
+func equalSymbolsByName(a, b map[string][]Symbol) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, va := range a {
+		vb, ok := b[k]
+		if !ok || len(va) != len(vb) {
+			return false
+		}
+		ac := append([]Symbol(nil), va...)
+		bc := append([]Symbol(nil), vb...)
+		sort.Slice(ac, func(i, j int) bool { return ac[i].File < ac[j].File })
+		sort.Slice(bc, func(i, j int) bool { return bc[i].File < bc[j].File })
+		if !reflect.DeepEqual(ac, bc) {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
## Summary

- Replaces the O(total) ``rebuildSymbolLookups`` calls inside ``BuildIndexIncremental`` / ``removeFileContributions`` with O(changed) per-symbol map deltas. On the kotlin corpus the rebuild iterated ~1 M symbols ~770 ms even when the edit touched ~10–30 symbols.
- New helpers ``addSymbolToLookups`` / ``removeSymbolFromLookups`` / ``dropSymbolFromSlice`` keep map state byte-identical to the prior full rebuild (same insertion order in slice buckets, empty buckets deleted outright). The cold ``buildCodeIndexWithBloom`` path now reuses ``addSymbolToLookups`` so both paths share one loop and can't drift.
- ``rebuildSymbolLookups`` is deleted — every caller migrated; lint flagged it otherwise.

## Benchmark — ~/github/kotlin (18 k Kotlin files), steady-state ABI edit

|                    | before  | after   | delta  |
|--------------------|---------|---------|--------|
| ``indexBuild``     | 1222 ms | 452 ms  | -63 %  |
| ``crossFileAnalysis`` | 1459 ms | 748 ms  | -49 %  |
| total ``durationMs`` | ~1556 ms | ~865 ms | -44 %  |

Cumulative since #252: 38 s → 0.86 s ABI edit.

## Test plan

- [x] ``go test ./internal/scanner/ -run "TestSymbolLookups|TestRemoveAll|TestRemoveOneOf|TestBuildIndexIncremental" -v`` — four tests cover delta-vs-rebuild equivalence (same Name multi-file, FQN==Name), empty-bucket deletion, survivor-order preservation
- [x] ``go test ./... -count=1`` (every package green)
- [x] ``golangci-lint run ./...`` (0 issues)
- [x] Daemon smoke benchmark against ~/github/kotlin: 4 sequential ABI edits at 859-952 ms ``durationMs``, findings byte-identical