### PR TITLE
Type-safety hardening and config primitive extraction

### DIFF
--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -22,6 +22,16 @@ import (
 
 const CacheFileName = "incremental.cache"
 
+// cachePayloadVersion is mixed into ComputeConfigHash so that a change to
+// the on-disk payload schema (FileEntry / FindingColumns JSON shape, the
+// columnar binary format, etc.) automatically invalidates older entries
+// instead of silently failing to deserialize at read time.
+//
+// Bump when the cached payload schema changes in a non-backwards-compatible
+// way. Old entries become unreachable (different RuleSetHash) and will be
+// garbage-collected by the next `krit cache clean` or LRU pass.
+const cachePayloadVersion = "v1"
+
 // DefaultDir returns Krit's repo-local incremental cache directory.
 func DefaultDir(repoDir string) string {
 	if repoDir == "" {
@@ -267,6 +277,11 @@ func ComputeConfigHash(ruleNames []string, cfg *config.Config, editorConfigEnabl
 
 	h := hashutil.Hasher().New()
 	h.Write([]byte(strings.Join(sorted, ",")))
+
+	// Schema version of the cached payload. Bumping cachePayloadVersion
+	// invalidates all prior entries.
+	h.Write([]byte("|payload="))
+	h.Write([]byte(cachePayloadVersion))
 
 	// Include editorconfig marker so "with editorconfig" and "without" produce different hashes
 	if editorConfigEnabled {

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -278,8 +278,6 @@ func ComputeConfigHash(ruleNames []string, cfg *config.Config, editorConfigEnabl
 	h := hashutil.Hasher().New()
 	h.Write([]byte(strings.Join(sorted, ",")))
 
-	// Schema version of the cached payload. Bumping cachePayloadVersion
-	// invalidates all prior entries.
 	h.Write([]byte("|payload="))
 	h.Write([]byte(cachePayloadVersion))
 

--- a/internal/cli/scan/depth.go
+++ b/internal/cli/scan/depth.go
@@ -63,7 +63,7 @@ func resolveDepthPreset(flagValue string, cfg *config.Config, w io.Writer) Depth
 			flagValue, validDepthList(), DepthBalanced)
 	}
 	if cfg != nil {
-		if raw := cfg.GetTopLevelString("analysis", "depth", ""); raw != "" {
+		if raw := cfg.Analysis().Depth; raw != "" {
 			if p, ok := parseDepthPreset(raw); ok && p != "" {
 				return p
 			}

--- a/internal/cli/scan/scan.go
+++ b/internal/cli/scan/scan.go
@@ -212,7 +212,7 @@ func resolveParseCacheCap(flagMB int, cfg *config.Config) int64 {
 		return int64(flagMB) * 1024 * 1024
 	}
 	if cfg != nil {
-		if mb := cfg.GetTopLevelInt("parseCache", "maxSizeMB", 0); mb != 0 {
+		if mb := cfg.ParseCache().MaxSizeMB; mb != 0 {
 			if mb < 0 {
 				return -1
 			}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -396,10 +396,7 @@ func (c *Config) ModuleTemplate() ModuleTemplateConfig {
 	}
 }
 
-// Analysis returns the typed `analysis:` block. Prefer this over
-// GetTopLevelString("analysis", ...) at call sites; the typed accessor
-// keeps the key name in one place and makes future schema additions
-// safer.
+// Analysis returns the typed `analysis:` block.
 func (c *Config) Analysis() AnalysisConfig {
 	return AnalysisConfig{
 		Depth: c.GetTopLevelString("analysis", "depth", ""),

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -27,6 +27,34 @@ type SLOConfig struct {
 	MaxErrorsPerKLOC   *float64
 }
 
+// AnalysisConfig is the typed shape of the top-level `analysis:` block.
+// Empty Depth means "not configured" — callers fall back to their own
+// default (typically the CLI-flag default).
+type AnalysisConfig struct {
+	Depth string
+}
+
+// ParseCacheConfig is the typed shape of the top-level `parseCache:`
+// block. Zero MaxSizeMB means "not configured" — caller decides whether
+// that disables the parse cache or applies its own default.
+type ParseCacheConfig struct {
+	MaxSizeMB int
+}
+
+// LSPConfig is the typed shape of the top-level `lsp:` block. Used by
+// the LSP server to extend the JVM classpath beyond what's auto-derived
+// from Gradle. Nil/empty Classpath means "no user override".
+type LSPConfig struct {
+	Classpath []string
+}
+
+// OracleConfig is the typed shape of the top-level `oracle:` block.
+// Used by the JVM-backed Kotlin Analysis API daemon. Nil/empty
+// Classpath means "no user override".
+type OracleConfig struct {
+	Classpath []string
+}
+
 // NewConfig creates an empty Config.
 func NewConfig() *Config {
 	return &Config{data: make(map[string]interface{})}
@@ -365,6 +393,37 @@ func (c *Config) ModuleTemplate() ModuleTemplateConfig {
 		FeatureRoot:        c.GetTopLevelString("module_template", "feature_root", ""),
 		RequiredSubmodules: c.GetTopLevelStringList("module_template", "required_submodules"),
 		RequiredPlugins:    c.GetTopLevelStringList("module_template", "required_plugins"),
+	}
+}
+
+// Analysis returns the typed `analysis:` block. Prefer this over
+// GetTopLevelString("analysis", ...) at call sites; the typed accessor
+// keeps the key name in one place and makes future schema additions
+// safer.
+func (c *Config) Analysis() AnalysisConfig {
+	return AnalysisConfig{
+		Depth: c.GetTopLevelString("analysis", "depth", ""),
+	}
+}
+
+// ParseCache returns the typed `parseCache:` block.
+func (c *Config) ParseCache() ParseCacheConfig {
+	return ParseCacheConfig{
+		MaxSizeMB: c.GetTopLevelInt("parseCache", "maxSizeMB", 0),
+	}
+}
+
+// LSP returns the typed `lsp:` block.
+func (c *Config) LSP() LSPConfig {
+	return LSPConfig{
+		Classpath: c.GetTopLevelStringList("lsp", "classpath"),
+	}
+}
+
+// Oracle returns the typed `oracle:` block.
+func (c *Config) Oracle() OracleConfig {
+	return OracleConfig{
+		Classpath: c.GetTopLevelStringList("oracle", "classpath"),
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -32,6 +32,58 @@ func NewConfig() *Config {
 	return &Config{data: make(map[string]interface{})}
 }
 
+// NewConfigFromData wraps the supplied map without copying. Intended
+// for tests and callers that already hold a typed-by-convention raw
+// map (e.g. fixtures). Passing nil yields an empty Config. The caller
+// must not mutate the map after handing it over.
+func NewConfigFromData(data map[string]interface{}) *Config {
+	if data == nil {
+		data = make(map[string]interface{})
+	}
+	return &Config{data: data}
+}
+
+// lookupValue walks data along path and returns the value at the leaf,
+// or (nil, false) if any segment is missing or not a map. Path lengths
+// of zero return (nil, false). This is the single primitive every
+// typed accessor on Config routes through, so the deep-map traversal
+// logic lives in one tested place.
+func lookupValue(data map[string]interface{}, path ...string) (interface{}, bool) {
+	if len(path) == 0 || data == nil {
+		return nil, false
+	}
+	cur := data
+	for i, k := range path {
+		v, ok := cur[k]
+		if !ok {
+			return nil, false
+		}
+		if i == len(path)-1 {
+			return v, true
+		}
+		next, ok := v.(map[string]interface{})
+		if !ok {
+			return nil, false
+		}
+		cur = next
+	}
+	return nil, false
+}
+
+// lookupMap is lookupValue with a map-typed result, returning (nil,
+// false) if the leaf is not a map[string]interface{}.
+func lookupMap(data map[string]interface{}, path ...string) (map[string]interface{}, bool) {
+	v, ok := lookupValue(data, path...)
+	if !ok {
+		return nil, false
+	}
+	m, ok := v.(map[string]interface{})
+	if !ok {
+		return nil, false
+	}
+	return m, true
+}
+
 // LoadConfig loads a YAML config file and returns a Config.
 // If path is empty, it auto-detects krit.yml or .krit.yml from the project root,
 // falling back to config/default-krit.yml relative to the executable.
@@ -156,18 +208,10 @@ func (c *Config) IsRuleActive(ruleSet, rule string) *bool {
 // IsRuleSetActive returns whether an entire ruleset is active.
 // Returns nil if not specified.
 func (c *Config) IsRuleSetActive(ruleSet string) *bool {
-	if c == nil || c.data == nil {
+	if c == nil {
 		return nil
 	}
-	rsData, ok := c.data[ruleSet]
-	if !ok {
-		return nil
-	}
-	rsMap, ok := rsData.(map[string]interface{})
-	if !ok {
-		return nil
-	}
-	v, ok := rsMap["active"]
+	v, ok := lookupValue(c.data, ruleSet, "active")
 	if !ok {
 		return nil
 	}
@@ -273,71 +317,42 @@ func (c *Config) Has(ruleSet, rule, key string) bool {
 
 // getRuleConfig returns the config map for a specific rule within a ruleset.
 func (c *Config) getRuleConfig(ruleSet, rule string) map[string]interface{} {
-	rsData, ok := c.data[ruleSet]
-	if !ok {
+	if c == nil {
 		return nil
 	}
-	rsMap, ok := rsData.(map[string]interface{})
-	if !ok {
-		return nil
-	}
-	ruleData, ok := rsMap[rule]
-	if !ok {
-		return nil
-	}
-	ruleMap, ok := ruleData.(map[string]interface{})
-	if !ok {
-		return nil
-	}
-	return ruleMap
+	m, _ := lookupMap(c.data, ruleSet, rule)
+	return m
 }
 
 // GetTopLevelString returns a string value from a top-level config section.
 // For example, GetTopLevelString("android", "enabled", "auto") reads android.enabled.
 func (c *Config) GetTopLevelString(section, key, defaultVal string) string {
-	if c == nil || c.data == nil {
+	if c == nil {
 		return defaultVal
 	}
-	secData, ok := c.data[section]
+	v, ok := lookupValue(c.data, section, key)
 	if !ok {
 		return defaultVal
 	}
-	secMap, ok := secData.(map[string]interface{})
-	if !ok {
-		return defaultVal
+	if s, ok := v.(string); ok {
+		return s
 	}
-	v, ok := secMap[key]
-	if !ok {
-		return defaultVal
-	}
-	s, ok := v.(string)
-	if !ok {
-		// Handle bool values serialized as native YAML types
-		if b, ok := v.(bool); ok {
-			if b {
-				return "true"
-			}
-			return "false"
+	// Handle bool values serialized as native YAML types
+	if b, ok := v.(bool); ok {
+		if b {
+			return "true"
 		}
-		return defaultVal
+		return "false"
 	}
-	return s
+	return defaultVal
 }
 
 // GetTopLevelStringList returns a string slice from a top-level section.
 func (c *Config) GetTopLevelStringList(section, key string) []string {
-	if c == nil || c.data == nil {
+	if c == nil {
 		return nil
 	}
-	secData, ok := c.data[section]
-	if !ok {
-		return nil
-	}
-	secMap, ok := secData.(map[string]interface{})
-	if !ok {
-		return nil
-	}
-	v, ok := secMap[key]
+	v, ok := lookupValue(c.data, section, key)
 	if !ok {
 		return nil
 	}
@@ -362,10 +377,10 @@ func (c *Config) TestSourcePathsOverride() []string {
 }
 
 func (c *Config) SLOs() []SLOConfig {
-	if c == nil || c.data == nil {
+	if c == nil {
 		return nil
 	}
-	raw, ok := c.data["slos"]
+	raw, ok := lookupValue(c.data, "slos")
 	if !ok {
 		return nil
 	}
@@ -410,18 +425,10 @@ func (c *Config) GetTopLevelList(key string) []string {
 // For example, GetTopLevelInt("parseCache", "maxSizeMB", 200) reads
 // parseCache.maxSizeMB.
 func (c *Config) GetTopLevelInt(section, key string, defaultVal int) int {
-	if c == nil || c.data == nil {
+	if c == nil {
 		return defaultVal
 	}
-	secData, ok := c.data[section]
-	if !ok {
-		return defaultVal
-	}
-	secMap, ok := secData.(map[string]interface{})
-	if !ok {
-		return defaultVal
-	}
-	v, ok := secMap[key]
+	v, ok := lookupValue(c.data, section, key)
 	if !ok {
 		return defaultVal
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1084,3 +1084,68 @@ func TestNewConfigFromDataNil(t *testing.T) {
 		t.Error("expected nil for empty-config lookup")
 	}
 }
+
+func TestTypedSections(t *testing.T) {
+	cfg := NewConfigFromData(map[string]interface{}{
+		"analysis": map[string]interface{}{"depth": "deep"},
+		"parseCache": map[string]interface{}{
+			"maxSizeMB": 512,
+		},
+		"lsp": map[string]interface{}{
+			"classpath": []interface{}{"/a.jar", "/b.jar"},
+		},
+		"oracle": map[string]interface{}{
+			"classpath": []interface{}{"/c.jar"},
+		},
+	})
+
+	if got := cfg.Analysis().Depth; got != "deep" {
+		t.Errorf("Analysis().Depth = %q, want %q", got, "deep")
+	}
+	if got := cfg.ParseCache().MaxSizeMB; got != 512 {
+		t.Errorf("ParseCache().MaxSizeMB = %d, want %d", got, 512)
+	}
+	lspCP := cfg.LSP().Classpath
+	if len(lspCP) != 2 || lspCP[0] != "/a.jar" || lspCP[1] != "/b.jar" {
+		t.Errorf("LSP().Classpath = %v, want [/a.jar /b.jar]", lspCP)
+	}
+	oracleCP := cfg.Oracle().Classpath
+	if len(oracleCP) != 1 || oracleCP[0] != "/c.jar" {
+		t.Errorf("Oracle().Classpath = %v, want [/c.jar]", oracleCP)
+	}
+}
+
+func TestTypedSectionsEmpty(t *testing.T) {
+	cfg := NewConfigFromData(nil)
+	if got := cfg.Analysis().Depth; got != "" {
+		t.Errorf("expected empty Depth on empty config, got %q", got)
+	}
+	if got := cfg.ParseCache().MaxSizeMB; got != 0 {
+		t.Errorf("expected MaxSizeMB=0 on empty config, got %d", got)
+	}
+	if got := cfg.LSP().Classpath; got != nil {
+		t.Errorf("expected nil LSP classpath on empty config, got %v", got)
+	}
+	if got := cfg.Oracle().Classpath; got != nil {
+		t.Errorf("expected nil Oracle classpath on empty config, got %v", got)
+	}
+}
+
+func TestTypedSectionsNilConfig(t *testing.T) {
+	var cfg *Config
+	// Each typed accessor must tolerate a nil receiver and return the
+	// zero value of its struct (matching the underlying GetTopLevel*
+	// contract).
+	if got := cfg.Analysis().Depth; got != "" {
+		t.Errorf("nil cfg Analysis().Depth = %q, want empty", got)
+	}
+	if got := cfg.ParseCache().MaxSizeMB; got != 0 {
+		t.Errorf("nil cfg ParseCache().MaxSizeMB = %d, want 0", got)
+	}
+	if got := cfg.LSP().Classpath; got != nil {
+		t.Errorf("nil cfg LSP().Classpath = %v, want nil", got)
+	}
+	if got := cfg.Oracle().Classpath; got != nil {
+		t.Errorf("nil cfg Oracle().Classpath = %v, want nil", got)
+	}
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -983,3 +983,104 @@ func TestLoadConfigInvalidTypes(t *testing.T) {
 		t.Error("expected active=true")
 	}
 }
+
+func TestLookupValue(t *testing.T) {
+	data := map[string]interface{}{
+		"top":   "value",
+		"deep":  map[string]interface{}{"a": map[string]interface{}{"b": 42}},
+		"mixed": map[string]interface{}{"leaf": []interface{}{"x", "y"}},
+	}
+
+	cases := []struct {
+		name    string
+		path    []string
+		want    interface{}
+		wantOk  bool
+		isSlice bool
+	}{
+		{"top-level hit", []string{"top"}, "value", true, false},
+		{"deep hit", []string{"deep", "a", "b"}, 42, true, false},
+		{"slice leaf", []string{"mixed", "leaf"}, nil, true, true},
+		{"missing top", []string{"nope"}, nil, false, false},
+		{"missing mid", []string{"deep", "nope", "b"}, nil, false, false},
+		{"missing leaf", []string{"deep", "a", "nope"}, nil, false, false},
+		{"path through non-map", []string{"top", "more"}, nil, false, false},
+		{"empty path", nil, nil, false, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := lookupValue(data, tc.path...)
+			if ok != tc.wantOk {
+				t.Fatalf("ok = %v, want %v (got = %v)", ok, tc.wantOk, got)
+			}
+			if !ok {
+				return
+			}
+			if tc.isSlice {
+				if _, isSlice := got.([]interface{}); !isSlice {
+					t.Errorf("expected []interface{}, got %T", got)
+				}
+				return
+			}
+			if got != tc.want {
+				t.Errorf("got = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestLookupValueNilData(t *testing.T) {
+	if _, ok := lookupValue(nil, "any"); ok {
+		t.Error("expected (nil, false) on nil data")
+	}
+}
+
+func TestLookupMap(t *testing.T) {
+	data := map[string]interface{}{
+		"section": map[string]interface{}{"key": "val"},
+		"scalar":  "not-a-map",
+	}
+	m, ok := lookupMap(data, "section")
+	if !ok {
+		t.Fatal("expected hit on section")
+	}
+	if m["key"] != "val" {
+		t.Errorf("expected key=val, got %v", m["key"])
+	}
+	if _, ok := lookupMap(data, "scalar"); ok {
+		t.Error("expected miss on scalar leaf")
+	}
+	if _, ok := lookupMap(data, "missing"); ok {
+		t.Error("expected miss on missing key")
+	}
+}
+
+func TestNewConfigFromData(t *testing.T) {
+	cfg := NewConfigFromData(map[string]interface{}{
+		"style": map[string]interface{}{
+			"MagicNumber": map[string]interface{}{
+				"active":    true,
+				"threshold": 7,
+			},
+		},
+	})
+	if active := cfg.IsRuleActive("style", "MagicNumber"); active == nil || !*active {
+		t.Errorf("expected active=true, got %v", active)
+	}
+	if got := cfg.GetInt("style", "MagicNumber", "threshold", 0); got != 7 {
+		t.Errorf("expected threshold=7, got %d", got)
+	}
+	if got := cfg.GetInt("style", "MagicNumber", "missing", 99); got != 99 {
+		t.Errorf("expected default 99 on missing key, got %d", got)
+	}
+}
+
+func TestNewConfigFromDataNil(t *testing.T) {
+	cfg := NewConfigFromData(nil)
+	if cfg == nil {
+		t.Fatal("expected non-nil config for nil data")
+	}
+	if cfg.IsRuleActive("x", "y") != nil {
+		t.Error("expected nil for empty-config lookup")
+	}
+}

--- a/internal/filefacts/filefacts.go
+++ b/internal/filefacts/filefacts.go
@@ -27,6 +27,32 @@ func slotTypeMismatch(slot string, want, got any) {
 	panic(fmt.Sprintf("filefacts: slot %q type mismatch: want %T, got %T", slot, want, got))
 }
 
+// loadOrStoreTyped is the shared cache-miss/cache-hit body for the
+// StringFact/FileFact/NodeFact accessors. Both assertions are
+// necessary: the first guards the cache-hit fast path, the second
+// guards against a concurrent writer storing a wrong-typed value
+// under the same key+slot (the LoadOrStore returns whichever value
+// the race produced, which is not guaranteed to be the one we just
+// computed).
+func loadOrStoreTyped[T any](sm *sync.Map, key any, slot string, compute func() T) T {
+	if cached, ok := sm.Load(key); ok {
+		typed, tok := cached.(T)
+		if !tok {
+			var zero T
+			slotTypeMismatch(slot, zero, cached)
+		}
+		return typed
+	}
+	v := compute()
+	actual, _ := sm.LoadOrStore(key, v)
+	typed, tok := actual.(T)
+	if !tok {
+		var zero T
+		slotTypeMismatch(slot, zero, actual)
+	}
+	return typed
+}
+
 // Cache memoizes per-file facts for a single analysis run. The zero
 // value is unusable; obtain one with NewCache. A nil *Cache is a valid
 // receiver and forces every accessor to recompute.
@@ -53,23 +79,7 @@ func StringFact[T any](c *Cache, key, slot string, compute func() T) T {
 	if c == nil || key == "" {
 		return compute()
 	}
-	k := stringSlotKey{key: key, slot: slot}
-	if cached, ok := c.stringSlots.Load(k); ok {
-		typed, tok := cached.(T)
-		if !tok {
-			var zero T
-			slotTypeMismatch(slot, zero, cached)
-		}
-		return typed
-	}
-	v := compute()
-	actual, _ := c.stringSlots.LoadOrStore(k, v)
-	typed, tok := actual.(T)
-	if !tok {
-		var zero T
-		slotTypeMismatch(slot, zero, actual)
-	}
-	return typed
+	return loadOrStoreTyped(&c.stringSlots, stringSlotKey{key: key, slot: slot}, slot, compute)
 }
 
 type fileSlotKey struct {
@@ -92,23 +102,7 @@ func FileFact[T any](c *Cache, file *scanner.File, slot string, compute func() T
 	if c == nil || file == nil {
 		return compute()
 	}
-	key := fileSlotKey{file: file, slot: slot}
-	if cached, ok := c.fileSlots.Load(key); ok {
-		typed, tok := cached.(T)
-		if !tok {
-			var zero T
-			slotTypeMismatch(slot, zero, cached)
-		}
-		return typed
-	}
-	v := compute()
-	actual, _ := c.fileSlots.LoadOrStore(key, v)
-	typed, tok := actual.(T)
-	if !tok {
-		var zero T
-		slotTypeMismatch(slot, zero, actual)
-	}
-	return typed
+	return loadOrStoreTyped(&c.fileSlots, fileSlotKey{file: file, slot: slot}, slot, compute)
 }
 
 // NodeFact returns a per-(file, node) derived value, computing on
@@ -118,23 +112,7 @@ func NodeFact[T any](c *Cache, file *scanner.File, idx uint32, slot string, comp
 	if c == nil || file == nil || idx == 0 {
 		return compute()
 	}
-	key := nodeSlotKey{file: file, idx: idx, slot: slot}
-	if cached, ok := c.nodeSlots.Load(key); ok {
-		typed, tok := cached.(T)
-		if !tok {
-			var zero T
-			slotTypeMismatch(slot, zero, cached)
-		}
-		return typed
-	}
-	v := compute()
-	actual, _ := c.nodeSlots.LoadOrStore(key, v)
-	typed, tok := actual.(T)
-	if !tok {
-		var zero T
-		slotTypeMismatch(slot, zero, actual)
-	}
-	return typed
+	return loadOrStoreTyped(&c.nodeSlots, nodeSlotKey{file: file, idx: idx, slot: slot}, slot, compute)
 }
 
 // NewCache returns a fresh, empty Cache. Use one Cache per analysis

--- a/internal/filefacts/filefacts.go
+++ b/internal/filefacts/filefacts.go
@@ -10,11 +10,22 @@
 package filefacts
 
 import (
+	"fmt"
 	"strings"
 	"sync"
 
 	"github.com/kaeawc/krit/internal/scanner"
 )
+
+// slotTypeMismatch panics with the offending slot key when a cache slot
+// is reused with a different generic instantiation. The slot is a
+// programmer-controlled constant, so a mismatch is a bug at the call
+// site, not a runtime data condition. Failing loud here surfaces the
+// offending slot instead of the opaque "interface conversion" panic the
+// runtime would otherwise produce.
+func slotTypeMismatch(slot string, want, got any) {
+	panic(fmt.Sprintf("filefacts: slot %q type mismatch: want %T, got %T", slot, want, got))
+}
 
 // Cache memoizes per-file facts for a single analysis run. The zero
 // value is unusable; obtain one with NewCache. A nil *Cache is a valid
@@ -44,11 +55,21 @@ func StringFact[T any](c *Cache, key, slot string, compute func() T) T {
 	}
 	k := stringSlotKey{key: key, slot: slot}
 	if cached, ok := c.stringSlots.Load(k); ok {
-		return cached.(T)
+		typed, tok := cached.(T)
+		if !tok {
+			var zero T
+			slotTypeMismatch(slot, zero, cached)
+		}
+		return typed
 	}
 	v := compute()
 	actual, _ := c.stringSlots.LoadOrStore(k, v)
-	return actual.(T)
+	typed, tok := actual.(T)
+	if !tok {
+		var zero T
+		slotTypeMismatch(slot, zero, actual)
+	}
+	return typed
 }
 
 type fileSlotKey struct {
@@ -73,11 +94,21 @@ func FileFact[T any](c *Cache, file *scanner.File, slot string, compute func() T
 	}
 	key := fileSlotKey{file: file, slot: slot}
 	if cached, ok := c.fileSlots.Load(key); ok {
-		return cached.(T)
+		typed, tok := cached.(T)
+		if !tok {
+			var zero T
+			slotTypeMismatch(slot, zero, cached)
+		}
+		return typed
 	}
 	v := compute()
 	actual, _ := c.fileSlots.LoadOrStore(key, v)
-	return actual.(T)
+	typed, tok := actual.(T)
+	if !tok {
+		var zero T
+		slotTypeMismatch(slot, zero, actual)
+	}
+	return typed
 }
 
 // NodeFact returns a per-(file, node) derived value, computing on
@@ -89,11 +120,21 @@ func NodeFact[T any](c *Cache, file *scanner.File, idx uint32, slot string, comp
 	}
 	key := nodeSlotKey{file: file, idx: idx, slot: slot}
 	if cached, ok := c.nodeSlots.Load(key); ok {
-		return cached.(T)
+		typed, tok := cached.(T)
+		if !tok {
+			var zero T
+			slotTypeMismatch(slot, zero, cached)
+		}
+		return typed
 	}
 	v := compute()
 	actual, _ := c.nodeSlots.LoadOrStore(key, v)
-	return actual.(T)
+	typed, tok := actual.(T)
+	if !tok {
+		var zero T
+		slotTypeMismatch(slot, zero, actual)
+	}
+	return typed
 }
 
 // NewCache returns a fresh, empty Cache. Use one Cache per analysis

--- a/internal/lsp/classpath.go
+++ b/internal/lsp/classpath.go
@@ -14,8 +14,8 @@ func lspClasspath(root string, cfg *config.Config, initClasspath []string) []str
 	var out []string
 	out = append(out, initClasspath...)
 	if cfg != nil {
-		out = append(out, cfg.GetTopLevelStringList("lsp", "classpath")...)
-		out = append(out, cfg.GetTopLevelStringList("oracle", "classpath")...)
+		out = append(out, cfg.LSP().Classpath...)
+		out = append(out, cfg.Oracle().Classpath...)
 	}
 	if env := os.Getenv("CLASSPATH"); env != "" {
 		out = append(out, filepath.SplitList(env)...)

--- a/internal/scanner/intern.go
+++ b/internal/scanner/intern.go
@@ -101,6 +101,17 @@ func internBytes(b []byte) string {
 	return globalStringPool.Intern(bytesToStringView(b))
 }
 
+// bytesToStringView returns a zero-copy string aliasing b's backing
+// array. The result MUST NOT outlive the caller's reference to b, and
+// b MUST NOT be mutated while the view is in use. Used only as the
+// lookup key into the StringPool: Intern's RLock-and-Load path reads
+// the view, and on insert the value is replaced with strings.Clone'd
+// storage before being stored, so no aliasing escapes the pool.
+//
+// UTF-8 validity: tree-sitter feeds valid-UTF-8 source bytes (we only
+// parse Kotlin/Java/XML/Gradle source files, which are required to be
+// UTF-8 by their respective specs). The view never escapes to a
+// boundary that re-validates UTF-8; map lookups operate on raw bytes.
 func bytesToStringView(b []byte) string {
 	if len(b) == 0 {
 		return ""


### PR DESCRIPTION
## Summary

Four focused commits addressing unsafe type assertions, silent cache schema drift, and untyped config traversal — all surfaced by an audit of unsafe casts / generic types in the codebase.

- **`22de758` — safety hardening.** `filefacts` generic helpers now use comma-ok + a descriptive `slotTypeMismatch` panic instead of blind `cached.(T)` (names the offending slot key instead of producing the opaque runtime panic). `scanner/intern.go` `bytesToStringView` gets a doc comment explaining the `unsafe.String` invariants. `cache.ComputeConfigHash` mixes in a `cachePayloadVersion` constant so a future on-disk schema bump invalidates prior entries via `RuleSetHash` instead of silently failing `json.Unmarshal` and dropping cached findings at read time.
- **`81467c8` — config primitive extraction.** Consolidate 15+ duplicated `data[k].(map[string]interface{})` traversal chains into one tested `lookupValue` primitive (plus `lookupMap` for the typed-map variant). Add `NewConfigFromData(map)` so tests can construct configs without YAML round-tripping.
- **`d472946` — typed section accessors.** Introduce `AnalysisConfig`, `ParseCacheConfig`, `LSPConfig`, `OracleConfig` paired with `Analysis()` / `ParseCache()` / `LSP()` / `Oracle()` accessors on `*Config`. Migrate the four callers (`cli/scan/depth.go`, `cli/scan/scan.go`, `lsp/classpath.go`). Section key names now live in exactly one place each.
- **`6cc5106` — simplify.** Collapse three near-identical Load/assert/LoadOrStore/assert blocks in `filefacts` into a single `loadOrStoreTyped` generic helper. Trim two narrating comments.

## Performance

Net-neutral across the board. Verified with `go build -gcflags='-m=2'` that the variadic `lookupValue(path ...string)` is stack-allocated and inlines at every call site. The comma-ok type-assertion form generates the same runtime check as the single-return form. `fmt.Sprintf` lives behind the cold panic path. Two extra `h.Write` calls in `ComputeConfigHash` are one-shot per run.

## Test plan
- [x] `go build -o krit ./cmd/krit/`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...` — 0 issues
- [x] `go test ./... -count=1` — full suite green
- [x] New tests in `internal/config/config_test.go`: `TestLookupValue` (8 subtests), `TestLookupValueNilData`, `TestLookupMap`, `TestNewConfigFromData{,Nil}`, `TestTypedSections{,Empty,NilConfig}`