### PR TITLE
feat(rules/api): type-safe fix capability model (autofix vs suggested)

### DIFF
--- a/internal/rules/api/fake.go
+++ b/internal/rules/api/fake.go
@@ -48,6 +48,12 @@ func WithFix(level FixLevel) FakeOption {
 	return func(r *Rule) { r.Fix = level }
 }
 
+// WithSuggestedFixes sets the rule's ordered suggested-fix declarations.
+// Mutually exclusive with WithFix at Register time.
+func WithSuggestedFixes(specs ...SuggestedFix) FakeOption {
+	return func(r *Rule) { r.SuggestedFixes = specs }
+}
+
 // WithConfidence sets the base confidence.
 func WithConfidence(c float64) FakeOption {
 	return func(r *Rule) { r.Confidence = c }

--- a/internal/rules/api/fixmode.go
+++ b/internal/rules/api/fixmode.go
@@ -1,0 +1,175 @@
+package api
+
+import "fmt"
+
+// FixMode classifies how a rule exposes fixes. Exactly one mode applies
+// to a registered rule; mixed declarations are rejected at Register
+// time. See Rule.FixMode for the derivation from Fix and SuggestedFixes.
+type FixMode int
+
+const (
+	// FixModeNone marks a diagnostic-only rule. The rule never emits
+	// any fix payload alongside its findings.
+	FixModeNone FixMode = iota
+	// FixModeAutofix marks a rule that emits a single automatic fix
+	// per finding. The fix safety tier is carried by Rule.Fix.
+	FixModeAutofix
+	// FixModeSuggested marks a rule that emits one or more ordered,
+	// user-selectable suggestions per finding. The slice order in
+	// Rule.SuggestedFixes is the recommended display and application
+	// order.
+	FixModeSuggested
+)
+
+// String returns the canonical token for a FixMode. Unknown values
+// fall back to "none" to match the FixLevel / Maturity stringer style.
+func (m FixMode) String() string {
+	switch m {
+	case FixModeAutofix:
+		return "autofix"
+	case FixModeSuggested:
+		return "suggested"
+	default:
+		return "none"
+	}
+}
+
+// SuggestedFix declares one entry in a rule's ordered suggested-fix
+// list. Position in Rule.SuggestedFixes is the recommended display and
+// application order; safer or stronger fixes should be listed first.
+type SuggestedFix struct {
+	// ID is a stable, rule-scoped identifier for this suggestion, e.g.
+	// "useApply" or "addOptIn". Must be non-empty and unique within a
+	// rule's SuggestedFixes.
+	ID string
+
+	// Title is a short human-readable description shown in IDE quick-fix
+	// menus, e.g. "Replace with apply { ... }". Must be non-empty.
+	Title string
+
+	// Level is the safety tier of this suggestion. FixNone is invalid;
+	// every suggestion must declare a non-zero tier so consumers can
+	// apply the same risk filtering they use for autofixes.
+	Level FixLevel
+}
+
+// AutofixRule is an optional marker interface that a rule's
+// Implementation may satisfy to make its autofix capability visible at
+// compile time. Mutually exclusive with SuggestedFixRule; an
+// Implementation must not satisfy both.
+type AutofixRule interface {
+	AutofixLevel() FixLevel
+}
+
+// SuggestedFixRule is an optional marker interface that a rule's
+// Implementation may satisfy to advertise ordered user-selectable
+// suggestions. Mutually exclusive with AutofixRule.
+type SuggestedFixRule interface {
+	SuggestedFixes() []SuggestedFix
+}
+
+// FixMode returns the fix mode advertised by this rule, derived from
+// Fix and SuggestedFixes. Register guarantees a registered rule is in
+// exactly one mode, so the result is well-defined for any rule that
+// passed Register.
+func (r *Rule) FixMode() FixMode {
+	if r == nil {
+		return FixModeNone
+	}
+	if len(r.SuggestedFixes) > 0 {
+		return FixModeSuggested
+	}
+	if r.Fix != FixNone {
+		return FixModeAutofix
+	}
+	return FixModeNone
+}
+
+// FixModeErrorKind classifies a FixModeError so callers can branch on
+// the specific invariant that was violated without parsing the message.
+type FixModeErrorKind int
+
+const (
+	// FixModeErrorMixedDeclaration: rule sets both Fix and SuggestedFixes.
+	FixModeErrorMixedDeclaration FixModeErrorKind = iota + 1
+	// FixModeErrorMixedInterface: Implementation satisfies both
+	// AutofixRule and SuggestedFixRule.
+	FixModeErrorMixedInterface
+	// FixModeErrorEmptyID: a SuggestedFix entry has an empty ID.
+	FixModeErrorEmptyID
+	// FixModeErrorEmptyTitle: a SuggestedFix entry has an empty Title.
+	FixModeErrorEmptyTitle
+	// FixModeErrorLevelNone: a SuggestedFix entry has Level == FixNone.
+	FixModeErrorLevelNone
+	// FixModeErrorDuplicateID: two SuggestedFix entries share an ID.
+	FixModeErrorDuplicateID
+)
+
+// FixModeError describes an invalid fix-mode declaration surfaced by
+// Rule.ValidateFixMode. The struct mirrors RelationError so callers can
+// distinguish error kinds with errors.As instead of substring matching.
+type FixModeError struct {
+	Rule  string
+	Kind  FixModeErrorKind
+	Index int    // index into SuggestedFixes when relevant, -1 otherwise
+	ID    string // suggestion ID when relevant
+}
+
+func (e *FixModeError) Error() string {
+	switch e.Kind {
+	case FixModeErrorMixedDeclaration:
+		return fmt.Sprintf("rule %q declares both an autofix and suggested fixes; a rule must pick exactly one fix mode", e.Rule)
+	case FixModeErrorMixedInterface:
+		return fmt.Sprintf("rule %q Implementation satisfies both AutofixRule and SuggestedFixRule; pick exactly one", e.Rule)
+	case FixModeErrorEmptyID:
+		return fmt.Sprintf("rule %q SuggestedFixes[%d]: ID is empty", e.Rule, e.Index)
+	case FixModeErrorEmptyTitle:
+		return fmt.Sprintf("rule %q SuggestedFixes[%d] (%s): Title is empty", e.Rule, e.Index, e.ID)
+	case FixModeErrorLevelNone:
+		return fmt.Sprintf("rule %q SuggestedFixes[%d] (%s): Level is FixNone; suggestions must declare a non-zero safety tier", e.Rule, e.Index, e.ID)
+	case FixModeErrorDuplicateID:
+		return fmt.Sprintf("rule %q SuggestedFixes: duplicate ID %q", e.Rule, e.ID)
+	default:
+		return fmt.Sprintf("rule %q: unknown fix-mode error", e.Rule)
+	}
+}
+
+// ValidateFixMode reports whether the rule's fix-mode declaration is
+// well-formed. Invoked from Register; tests may call it directly.
+// Errors are *FixModeError values so callers can branch with errors.As.
+func (r *Rule) ValidateFixMode() error {
+	if r == nil {
+		return nil
+	}
+	hasAutofix := r.Fix != FixNone
+	hasSuggested := len(r.SuggestedFixes) > 0
+	if hasAutofix && hasSuggested {
+		return &FixModeError{Rule: r.ID, Kind: FixModeErrorMixedDeclaration, Index: -1}
+	}
+	if hasSuggested {
+		seen := make(map[string]bool, len(r.SuggestedFixes))
+		for i, s := range r.SuggestedFixes {
+			if s.ID == "" {
+				return &FixModeError{Rule: r.ID, Kind: FixModeErrorEmptyID, Index: i}
+			}
+			if s.Title == "" {
+				return &FixModeError{Rule: r.ID, Kind: FixModeErrorEmptyTitle, Index: i, ID: s.ID}
+			}
+			if s.Level == FixNone {
+				return &FixModeError{Rule: r.ID, Kind: FixModeErrorLevelNone, Index: i, ID: s.ID}
+			}
+			if seen[s.ID] {
+				return &FixModeError{Rule: r.ID, Kind: FixModeErrorDuplicateID, Index: -1, ID: s.ID}
+			}
+			seen[s.ID] = true
+		}
+	}
+	if impl := r.Implementation; impl != nil {
+		_, isAutofix := impl.(AutofixRule)
+		_, isSuggested := impl.(SuggestedFixRule)
+		if isAutofix && isSuggested {
+			return &FixModeError{Rule: r.ID, Kind: FixModeErrorMixedInterface, Index: -1}
+		}
+	}
+	return nil
+}

--- a/internal/rules/api/fixmode_test.go
+++ b/internal/rules/api/fixmode_test.go
@@ -1,0 +1,292 @@
+package api
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestFixMode_String(t *testing.T) {
+	tests := []struct {
+		mode FixMode
+		want string
+	}{
+		{FixModeNone, "none"},
+		{FixModeAutofix, "autofix"},
+		{FixModeSuggested, "suggested"},
+		{FixMode(99), "none"},
+	}
+	for _, tt := range tests {
+		if got := tt.mode.String(); got != tt.want {
+			t.Errorf("FixMode(%d).String() = %q, want %q", tt.mode, got, tt.want)
+		}
+	}
+}
+
+func TestRule_FixMode(t *testing.T) {
+	tests := []struct {
+		name string
+		rule *Rule
+		want FixMode
+	}{
+		{"nil rule", nil, FixModeNone},
+		{"no fix", &Rule{ID: "x"}, FixModeNone},
+		{"autofix cosmetic", &Rule{ID: "x", Fix: FixCosmetic}, FixModeAutofix},
+		{"autofix idiomatic", &Rule{ID: "x", Fix: FixIdiomatic}, FixModeAutofix},
+		{"autofix semantic", &Rule{ID: "x", Fix: FixSemantic}, FixModeAutofix},
+		{
+			"suggested",
+			&Rule{ID: "x", SuggestedFixes: []SuggestedFix{{ID: "a", Title: "Apply A", Level: FixIdiomatic}}},
+			FixModeSuggested,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.rule.FixMode(); got != tt.want {
+				t.Errorf("FixMode() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRule_ValidateFixMode_Accepts(t *testing.T) {
+	tests := []struct {
+		name string
+		rule *Rule
+	}{
+		{"nil rule", nil},
+		{"no fix", &Rule{ID: "x"}},
+		{"autofix only", &Rule{ID: "x", Fix: FixIdiomatic}},
+		{
+			"suggested only",
+			&Rule{
+				ID: "x",
+				SuggestedFixes: []SuggestedFix{
+					{ID: "a", Title: "Apply A", Level: FixIdiomatic},
+					{ID: "b", Title: "Apply B", Level: FixCosmetic},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.rule.ValidateFixMode(); err != nil {
+				t.Errorf("ValidateFixMode() = %v, want nil", err)
+			}
+		})
+	}
+}
+
+func TestRule_ValidateFixMode_Rejects(t *testing.T) {
+	tests := []struct {
+		name     string
+		rule     *Rule
+		wantKind FixModeErrorKind
+	}{
+		{
+			"mixed declaration",
+			&Rule{
+				ID:  "MixedRule",
+				Fix: FixSemantic,
+				SuggestedFixes: []SuggestedFix{
+					{ID: "a", Title: "Apply A", Level: FixIdiomatic},
+				},
+			},
+			FixModeErrorMixedDeclaration,
+		},
+		{
+			"empty suggestion ID",
+			&Rule{
+				ID:             "x",
+				SuggestedFixes: []SuggestedFix{{ID: "", Title: "Apply A", Level: FixIdiomatic}},
+			},
+			FixModeErrorEmptyID,
+		},
+		{
+			"empty suggestion title",
+			&Rule{
+				ID:             "x",
+				SuggestedFixes: []SuggestedFix{{ID: "a", Title: "", Level: FixIdiomatic}},
+			},
+			FixModeErrorEmptyTitle,
+		},
+		{
+			"suggestion level none",
+			&Rule{
+				ID:             "x",
+				SuggestedFixes: []SuggestedFix{{ID: "a", Title: "Apply A", Level: FixNone}},
+			},
+			FixModeErrorLevelNone,
+		},
+		{
+			"duplicate suggestion ID",
+			&Rule{
+				ID: "x",
+				SuggestedFixes: []SuggestedFix{
+					{ID: "a", Title: "First", Level: FixCosmetic},
+					{ID: "a", Title: "Second", Level: FixIdiomatic},
+				},
+			},
+			FixModeErrorDuplicateID,
+		},
+		{
+			"mixed interface",
+			&Rule{ID: "MixedImpl", Implementation: fakeMixedImpl{}},
+			FixModeErrorMixedInterface,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.rule.ValidateFixMode()
+			if err == nil {
+				t.Fatalf("ValidateFixMode() = nil, want error of kind %v", tt.wantKind)
+			}
+			var fme *FixModeError
+			if !errors.As(err, &fme) {
+				t.Fatalf("ValidateFixMode() error type = %T, want *FixModeError", err)
+			}
+			if fme.Kind != tt.wantKind {
+				t.Errorf("Kind = %v, want %v (msg: %s)", fme.Kind, tt.wantKind, err)
+			}
+			if fme.Rule != tt.rule.ID {
+				t.Errorf("Rule = %q, want %q", fme.Rule, tt.rule.ID)
+			}
+		})
+	}
+}
+
+type fakeAutofixImpl struct{}
+
+func (fakeAutofixImpl) AutofixLevel() FixLevel { return FixIdiomatic }
+
+type fakeSuggestedImpl struct{}
+
+func (fakeSuggestedImpl) SuggestedFixes() []SuggestedFix {
+	return []SuggestedFix{{ID: "a", Title: "Apply A", Level: FixIdiomatic}}
+}
+
+type fakeMixedImpl struct{}
+
+func (fakeMixedImpl) AutofixLevel() FixLevel { return FixIdiomatic }
+func (fakeMixedImpl) SuggestedFixes() []SuggestedFix {
+	return []SuggestedFix{{ID: "a", Title: "Apply A", Level: FixIdiomatic}}
+}
+
+func TestRule_FixMode_InterfaceSatisfaction(t *testing.T) {
+	if _, ok := any(fakeAutofixImpl{}).(AutofixRule); !ok {
+		t.Error("fakeAutofixImpl should satisfy AutofixRule")
+	}
+	if _, ok := any(fakeSuggestedImpl{}).(SuggestedFixRule); !ok {
+		t.Error("fakeSuggestedImpl should satisfy SuggestedFixRule")
+	}
+}
+
+func TestRegister_PanicsOnMixedFixDeclaration(t *testing.T) {
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("Register did not panic on mixed Fix + SuggestedFixes")
+		}
+		msg, ok := r.(string)
+		if !ok {
+			t.Fatalf("panic value type = %T, want string", r)
+		}
+		if !strings.Contains(msg, "exactly one fix mode") {
+			t.Errorf("panic message %q should explain the constraint", msg)
+		}
+	}()
+	Register(&Rule{
+		ID:          "MixedRegister",
+		Description: "tries to declare both fix modes",
+		Check:       func(*Context) {},
+		Fix:         FixCosmetic,
+		SuggestedFixes: []SuggestedFix{
+			{ID: "a", Title: "Apply A", Level: FixIdiomatic},
+		},
+	})
+}
+
+func TestRegister_AcceptsValidModes(t *testing.T) {
+	tests := []struct {
+		name string
+		rule *Rule
+		want FixMode
+	}{
+		{
+			"no fix",
+			&Rule{
+				ID:          "DiagnosticOnly",
+				Description: "no-fix test rule",
+				Check:       func(*Context) {},
+			},
+			FixModeNone,
+		},
+		{
+			"autofix only",
+			&Rule{
+				ID:          "AutofixOnlyRegister",
+				Description: "autofix-only test rule",
+				Check:       func(*Context) {},
+				Fix:         FixIdiomatic,
+			},
+			FixModeAutofix,
+		},
+		{
+			"suggested only",
+			&Rule{
+				ID:          "SuggestedOnlyRegister",
+				Description: "suggested-only test rule",
+				Check:       func(*Context) {},
+				SuggestedFixes: []SuggestedFix{
+					{ID: "primary", Title: "Primary suggestion", Level: FixIdiomatic},
+					{ID: "fallback", Title: "Fallback suggestion", Level: FixCosmetic},
+				},
+			},
+			FixModeSuggested,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			before := len(Registry)
+			defer func() { Registry = Registry[:before] }()
+			Register(tt.rule)
+			if len(Registry) != before+1 {
+				t.Fatalf("Registry len = %d, want %d", len(Registry), before+1)
+			}
+			if got := Registry[before].FixMode(); got != tt.want {
+				t.Errorf("FixMode() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRegister_PreservesSuggestedFixOrdering(t *testing.T) {
+	before := len(Registry)
+	defer func() { Registry = Registry[:before] }()
+	Register(&Rule{
+		ID:          "OrderedSuggestions",
+		Description: "checks ordering is rule-owned",
+		Check:       func(*Context) {},
+		SuggestedFixes: []SuggestedFix{
+			{ID: "primary", Title: "Primary", Level: FixIdiomatic},
+			{ID: "fallback", Title: "Fallback", Level: FixCosmetic},
+		},
+	})
+	got := Registry[before].SuggestedFixes
+	if got[0].ID != "primary" || got[1].ID != "fallback" {
+		t.Errorf("ordering not preserved: %+v", got)
+	}
+}
+
+func TestFakeRule_WithSuggestedFixes(t *testing.T) {
+	r := FakeRule("x", WithSuggestedFixes(
+		SuggestedFix{ID: "a", Title: "Apply A", Level: FixIdiomatic},
+		SuggestedFix{ID: "b", Title: "Apply B", Level: FixCosmetic},
+	))
+	if r.FixMode() != FixModeSuggested {
+		t.Errorf("FixMode() = %v, want FixModeSuggested", r.FixMode())
+	}
+	if len(r.SuggestedFixes) != 2 || r.SuggestedFixes[1].ID != "b" {
+		t.Errorf("SuggestedFixes ordering wrong: %+v", r.SuggestedFixes)
+	}
+}

--- a/internal/rules/api/rule.go
+++ b/internal/rules/api/rule.go
@@ -918,6 +918,12 @@ type Rule struct {
 	// Fix metadata
 	Fix FixLevel // FixNone → not fixable
 
+	// SuggestedFixes declares an ordered list of user-selectable
+	// suggestions the rule can emit. Slice position is the recommended
+	// display and application order. Mutually exclusive with Fix; see
+	// SuggestedFix and FixMode for the full contract.
+	SuggestedFixes []SuggestedFix
+
 	// Cost is the rule's weight class. When left at CostUnset, the
 	// dispatcher derives a Cost from Needs / NodeTypes / JavaFacts via
 	// rules.CostFor. Rules may pin an explicit Cost when the derived
@@ -1293,6 +1299,9 @@ func Register(r *Rule) {
 	}
 	if r.Needs.Has(NeedsAggregate) && r.Aggregate == nil {
 		panic("api.Register: rule " + r.ID + " declares NeedsAggregate but Aggregate is nil")
+	}
+	if err := r.ValidateFixMode(); err != nil {
+		panic("api.Register: " + err.Error())
 	}
 	if r.IntroducedIn == "" {
 		r.IntroducedIn = DefaultIntroducedIn


### PR DESCRIPTION
## Summary

Introduces a registry-time, mutually-exclusive fix-mode contract on `api.Rule` so a rule can advertise exactly one fix mode: no fixes, autofixes, or ordered suggested fixes.

- `FixMode` enum (`None` / `Autofix` / `Suggested`) derived from `Rule.Fix` and the new `Rule.SuggestedFixes` slice via `Rule.FixMode()`.
- `SuggestedFix` struct with rule-owned ordering — slice position is the recommended display/application order; first entry is the primary quick fix.
- `AutofixRule` / `SuggestedFixRule` optional marker interfaces a rule `Implementation` may satisfy for compile-time visibility of its mode.
- `Rule.ValidateFixMode` returns a structured `*FixModeError` (mirroring `*RelationError`) so callers branch with `errors.As` instead of substring matching.
- `api.Register` panics when a rule declares both an autofix and suggested fixes, when a `SuggestedFix` entry is malformed (empty ID/Title, `FixNone` level, duplicate ID), or when an Implementation satisfies both marker interfaces.

Existing autofix-capable rules keep working unchanged — `Rule.Fix` semantics are preserved; the new model is opt-in via `SuggestedFixes`.

Closes #241.

## Validation criteria

- [x] `go build -o krit ./cmd/krit/`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...` (0 issues)
- [x] `go test ./... -count=1` (all packages pass)
- [x] `make lint-rules` (capability-drift gate clean)
- [x] New tests cover no-fix, autofix-only, suggested-fix-only, and mixed declarations (rejected at `Register` time and via `ValidateFixMode`)
- [x] Mixed-implementation case (Impl satisfies both marker interfaces) rejected
- [x] Suggested-fix ordering preserved through `Register`

## Test plan

- [x] `go test ./internal/rules/api/ -count=1 -v`
- [x] Existing rule registrations still load (full `go test ./...`)