### PR TITLE
feat(daemon): route read-only meta verbs through daemon

### DIFF
--- a/internal/cli/daemonclient/client.go
+++ b/internal/cli/daemonclient/client.go
@@ -330,3 +330,61 @@ func (c *Client) Shutdown() error {
 	}
 	return daemon.Call(c.socketPath, daemon.VerbShutdown, nil, nil)
 }
+
+// ListRules dispatches the list-rules verb against the daemon and
+// returns the captured stdout/stderr/exit-code triple. The CLI replays
+// these against its own streams so daemon-routed and in-process
+// invocations of `--list-rules` are byte-equivalent.
+func (c *Client) ListRules(args daemon.ListRulesArgs) (daemon.MetaResult, error) {
+	if c == nil {
+		return daemon.MetaResult{}, errors.New("daemonclient: nil client")
+	}
+	var result daemon.MetaResult
+	if err := daemon.Call(c.socketPath, daemon.VerbListRules, args, &result); err != nil {
+		return daemon.MetaResult{}, err
+	}
+	return result, nil
+}
+
+// ListExperiments dispatches the list-experiments verb against the
+// daemon. Mirrors ListRules' captured-stream contract.
+func (c *Client) ListExperiments(args daemon.ListExperimentsArgs) (daemon.MetaResult, error) {
+	if c == nil {
+		return daemon.MetaResult{}, errors.New("daemonclient: nil client")
+	}
+	var result daemon.MetaResult
+	if err := daemon.Call(c.socketPath, daemon.VerbListExperiments, args, &result); err != nil {
+		return daemon.MetaResult{}, err
+	}
+	return result, nil
+}
+
+// ValidateConfig dispatches the validate-config verb against the
+// daemon. ConfigPath="" lets the daemon use its resident config; pass
+// an explicit path to validate a specific file (mirrors --config FILE
+// semantics).
+func (c *Client) ValidateConfig(args daemon.ValidateConfigArgs) (daemon.MetaResult, error) {
+	if c == nil {
+		return daemon.MetaResult{}, errors.New("daemonclient: nil client")
+	}
+	var result daemon.MetaResult
+	if err := daemon.Call(c.socketPath, daemon.VerbValidateConfig, args, &result); err != nil {
+		return daemon.MetaResult{}, err
+	}
+	return result, nil
+}
+
+// OracleFilterFingerprint dispatches the oracle-filter-fingerprint
+// verb. The daemon walks the requested paths, builds the active rule
+// set, and emits the JSON fingerprint report the CI drift gate
+// consumes — without invoking the krit-types JVM.
+func (c *Client) OracleFilterFingerprint(args daemon.OracleFilterFingerprintArgs) (daemon.MetaResult, error) {
+	if c == nil {
+		return daemon.MetaResult{}, errors.New("daemonclient: nil client")
+	}
+	var result daemon.MetaResult
+	if err := daemon.Call(c.socketPath, daemon.VerbOracleFilterFingerprint, args, &result); err != nil {
+		return daemon.MetaResult{}, err
+	}
+	return result, nil
+}

--- a/internal/cli/scan/daemon_delegate.go
+++ b/internal/cli/scan/daemon_delegate.go
@@ -20,6 +20,13 @@ func tryDaemonDelegate(f *scanFlags, paths []string, repoDir string) (bool, int)
 	if f == nil || *f.NoDaemon {
 		return false, 0
 	}
+	if verb, ok := metaVerbForFlags(f); ok {
+		client, ok := daemonclient.TryConnect(repoDir, *f.DaemonSocket)
+		if !ok {
+			return false, 0
+		}
+		return runDaemonMetaVerb(client, f, paths, verb)
+	}
 	if !daemonCompatibleFlags(f) {
 		return false, 0
 	}
@@ -55,6 +62,99 @@ func tryDaemonDelegate(f *scanFlags, paths []string, repoDir string) (bool, int)
 		return true, 2
 	}
 	return true, finalScanExit(os.Stderr, res.Stats.FindingsCount, time.Since(start), *f.Quiet)
+}
+
+// metaVerbName tags the routable read-only meta queries the daemon
+// can answer (list-rules, list-experiments, validate-config,
+// oracle-filter-fingerprint). Returned by metaVerbForFlags so the
+// dispatch in tryDaemonDelegate stays a single switch.
+type metaVerbName int
+
+const (
+	metaVerbNone metaVerbName = iota
+	metaVerbListRules
+	metaVerbListExperiments
+	metaVerbValidateConfig
+	metaVerbOracleFilterFingerprint
+)
+
+// metaVerbForFlags inspects f and returns which read-only meta verb
+// the daemon should answer (when any). Mutually exclusive with the
+// analyze-project route — these flags short-circuit before any rule
+// dispatch in the in-process path, and the daemon mirrors that.
+//
+// Returns metaVerbNone when no meta flag is set, OR when other
+// excluded flags would force in-process anyway (e.g. --custom-rule-jars
+// for list-rules, --config for validate-config). The caller falls
+// back to in-process in those cases.
+func metaVerbForFlags(f *scanFlags) (metaVerbName, bool) {
+	switch {
+	case *f.List:
+		// CustomRuleJars requires the krit-types JVM the daemon
+		// doesn't manage on behalf of meta queries; defer to
+		// in-process so plugin descriptors still surface.
+		if *f.CustomRuleJars != "" {
+			return metaVerbNone, false
+		}
+		return metaVerbListRules, true
+	case *f.ListExperiments:
+		return metaVerbListExperiments, true
+	case *f.ValidateConfig:
+		return metaVerbValidateConfig, true
+	case *f.OracleFilterFingerprint:
+		return metaVerbOracleFilterFingerprint, true
+	}
+	return metaVerbNone, false
+}
+
+// runDaemonMetaVerb dispatches verb against the connected client and
+// replays the captured Stdout/Stderr/ExitCode against the CLI's own
+// streams. Any daemon-side error falls back to in-process by
+// returning handled=false (matching the analyze-project route).
+func runDaemonMetaVerb(client *daemonclient.Client, f *scanFlags, paths []string, verb metaVerbName) (bool, int) {
+	res, err := callMetaVerb(client, f, paths, verb)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "warning: krit daemon call failed (%v); falling back to in-process\n", err)
+		return false, 0
+	}
+	if len(res.Stdout) > 0 {
+		_, _ = os.Stdout.Write(res.Stdout)
+	}
+	if len(res.Stderr) > 0 {
+		_, _ = os.Stderr.Write(res.Stderr)
+	}
+	return true, res.ExitCode
+}
+
+// callMetaVerb dispatches the appropriate daemonclient verb for
+// verb. Pulled out of runDaemonMetaVerb so the switch is local and
+// the caller stays small.
+func callMetaVerb(client *daemonclient.Client, f *scanFlags, paths []string, verb metaVerbName) (daemon.MetaResult, error) {
+	switch verb {
+	case metaVerbListRules:
+		return client.ListRules(daemon.ListRulesArgs{
+			Verbose:    *f.Verbose,
+			Maturity:   *f.Maturity,
+			TaxonomyID: *f.ListRulesCWE,
+		})
+	case metaVerbListExperiments:
+		// Mirror runner_state.go's effectiveFormat resolution so
+		// daemon-routed --list-experiments matches the in-process
+		// auto-promote-to-plain TTY behaviour.
+		return client.ListExperiments(daemon.ListExperimentsArgs{
+			Format: resolveEffectiveFormat(f),
+		})
+	case metaVerbValidateConfig:
+		return client.ValidateConfig(daemon.ValidateConfigArgs{
+			ConfigPath: *f.Config,
+		})
+	case metaVerbOracleFilterFingerprint:
+		return client.OracleFilterFingerprint(daemon.OracleFilterFingerprintArgs{
+			Paths:    paths,
+			AllRules: *f.AllRules,
+		})
+	}
+	return daemon.MetaResult{}, fmt.Errorf("unknown meta verb %d", verb)
 }
 
 // daemonCompatibleFlags reports whether the requested flag set can be

--- a/internal/cli/scan/daemon_delegate_test.go
+++ b/internal/cli/scan/daemon_delegate_test.go
@@ -237,6 +237,91 @@ func redirectStdout(t *testing.T) func() string {
 	}
 }
 
+// TestTryDaemonDelegate_ListRulesRoutesViaMetaVerb exercises the
+// read-only-meta route added in the daemon-readonly-verbs PR: the
+// CLI must dispatch --list-rules through the daemon's list-rules
+// verb (capturing stdout/stderr/exit) instead of falling back to the
+// in-process flag handler when a daemon is reachable.
+func TestTryDaemonDelegate_ListRulesRoutesViaMetaVerb(t *testing.T) {
+	socketDir := startMockMetaDaemon(t, "list-rules", daemon.MetaResult{
+		Stdout:   []byte("Available rules: from-daemon\n"),
+		ExitCode: 0,
+	})
+	root := newRoot(t)
+	linkSock(t, root, filepath.Join(socketDir, "d.sock"))
+
+	out := redirectStdout(t)
+	f := freshScanFlags(t)
+	*f.List = true
+
+	handled, code := tryDaemonDelegate(f, []string{root}, root)
+	if !handled {
+		t.Fatalf("expected handled=true; got fall-through")
+	}
+	if code != 0 {
+		t.Errorf("expected exit 0; got %d", code)
+	}
+	if got := out(); got != "Available rules: from-daemon\n" {
+		t.Errorf("expected daemon stdout replayed verbatim; got %q", got)
+	}
+}
+
+// TestTryDaemonDelegate_ListRulesWithCustomJarsFallsThrough pins the
+// CustomRuleJars carve-out: --custom-rule-jars requires the
+// krit-types JVM the daemon doesn't manage on behalf of meta queries,
+// so the CLI must fall back to in-process even with a daemon
+// reachable.
+func TestTryDaemonDelegate_ListRulesWithCustomJarsFallsThrough(t *testing.T) {
+	socketDir := startMockMetaDaemon(t, "list-rules", daemon.MetaResult{
+		Stdout:   []byte("daemon should NOT be called\n"),
+		ExitCode: 0,
+	})
+	root := newRoot(t)
+	linkSock(t, root, filepath.Join(socketDir, "d.sock"))
+
+	f := freshScanFlags(t)
+	*f.List = true
+	*f.CustomRuleJars = "/tmp/fake.jar"
+
+	handled, _ := tryDaemonDelegate(f, []string{root}, root)
+	if handled {
+		t.Fatalf("expected fall-through with --custom-rule-jars; got handled=true")
+	}
+}
+
+// startMockMetaDaemon spins up a mock daemon that registers a single
+// meta verb (verb name + canned MetaResult). Used by the delegate
+// tests above to assert routing without depending on the real
+// in-process meta-flag handlers.
+func startMockMetaDaemon(t *testing.T, verb string, reply daemon.MetaResult) string {
+	t.Helper()
+	socketDir, err := os.MkdirTemp("/tmp", "krit-deleg-meta-")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(socketDir) })
+	socket := filepath.Join(socketDir, "d.sock")
+	srv := daemon.NewServer(socket)
+	srv.Register(daemon.VerbStatus, func(_ context.Context, _ json.RawMessage) (any, error) {
+		return daemon.StatusResult{Ready: true}, nil
+	})
+	srv.Register(verb, func(_ context.Context, _ json.RawMessage) (any, error) {
+		return reply, nil
+	})
+	if err := srv.Start(context.Background()); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	t.Cleanup(srv.Stop)
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if daemon.Available(socket) {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	return socketDir
+}
+
 // TestDaemonCompatibleFlags_PerfAllowed pins the contract added with
 // daemon-side perf tracking: --perf and --perf-rules must be served
 // by the daemon (the pipeline wires its own perf.Tracker and emits

--- a/internal/cli/scan/early_exits.go
+++ b/internal/cli/scan/early_exits.go
@@ -75,20 +75,29 @@ func runListExperimentsFlag(listExperimentsFlag bool, effectiveFormat, version s
 	if !listExperimentsFlag {
 		return
 	}
-	if effectiveFormat == "plain" {
-		fmt.Print(ListExperimentsLifecyclePlain())
-	} else {
-		enc := json.NewEncoder(os.Stdout)
-		enc.SetIndent("", "  ")
-		_ = enc.Encode(struct {
-			Version     string                  `json:"version"`
-			Experiments []experiment.Definition `json:"experiments"`
-		}{
-			Version:     version,
-			Experiments: experiment.Definitions(),
-		})
-	}
+	WriteListExperiments(os.Stdout, effectiveFormat, version)
 	os.Exit(0)
+}
+
+// WriteListExperiments renders the --list-experiments output to w.
+// Pulled out of runListExperimentsFlag so the daemon's
+// list-experiments verb can capture stdout without going through
+// os.Exit. Format is "plain" or "json"; anything else defaults to
+// JSON to match the in-process behavior.
+func WriteListExperiments(w io.Writer, effectiveFormat, version string) {
+	if effectiveFormat == "plain" {
+		fmt.Fprint(w, ListExperimentsLifecyclePlain())
+		return
+	}
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	_ = enc.Encode(struct {
+		Version     string                  `json:"version"`
+		Experiments []experiment.Definition `json:"experiments"`
+	}{
+		Version:     version,
+		Experiments: experiment.Definitions(),
+	})
 }
 
 func runCompletionsFlag(shell string) {
@@ -231,24 +240,33 @@ func runValidateConfigFlag(validateConfigFlag bool, cfg *config.Config) {
 	if !validateConfigFlag {
 		return
 	}
+	os.Exit(ValidateConfigTo(os.Stderr, cfg))
+}
+
+// ValidateConfigTo runs --validate-config against cfg, writing every
+// error/warning line to stderrW. Returns the process exit code (0 on
+// success, 1 on validation errors). Pulled out of runValidateConfigFlag
+// so the daemon's validate-config verb can capture stderr without
+// going through os.Exit.
+func ValidateConfigTo(stderrW io.Writer, cfg *config.Config) int {
 	errs := schema.ValidateConfig(cfg)
 	hasError := false
 	for _, e := range errs {
-		fmt.Fprintf(os.Stderr, "%s\n", e)
+		fmt.Fprintf(stderrW, "%s\n", e)
 		if e.Level == "error" {
 			hasError = true
 		}
 	}
 	if hasError {
-		fmt.Fprintf(os.Stderr, "info: Config validation failed with %d issue(s).\n", len(errs))
-		os.Exit(1)
+		fmt.Fprintf(stderrW, "info: Config validation failed with %d issue(s).\n", len(errs))
+		return 1
 	}
 	if len(errs) > 0 {
-		fmt.Fprintf(os.Stderr, "info: Config validation passed with %d warning(s).\n", len(errs))
+		fmt.Fprintf(stderrW, "info: Config validation passed with %d warning(s).\n", len(errs))
 	} else {
-		fmt.Fprintf(os.Stderr, "info: Config validation passed.\n")
+		fmt.Fprintf(stderrW, "info: Config validation passed.\n")
 	}
-	os.Exit(0)
+	return 0
 }
 
 // listRulesSummary holds the aggregate counts emitted at the bottom of
@@ -285,13 +303,27 @@ func runListRulesFlag(listFlag, verboseFlag bool, maturityFilter, taxonomyID str
 // printListRules writes the --list-rules output. Split from
 // runListRulesFlag so tests can drive it without the os.Exit.
 func printListRules(w io.Writer, verboseFlag bool, maturityFilter, taxonomyID string, customRuleJars []string, paths []string) {
+	if code, ok := PrintListRules(w, os.Stderr, verboseFlag, maturityFilter, taxonomyID, customRuleJars, paths); !ok {
+		os.Exit(code)
+	}
+}
+
+// PrintListRules is the no-exit form of printListRules: it writes the
+// --list-rules output to stdoutW and any errors to stderrW, returning
+// (exitCode, ok). ok=true means the listing rendered successfully and
+// the caller can ignore exitCode; ok=false means stderrW received an
+// error message and the caller should exit with exitCode.
+//
+// Exposed so the daemon's list-rules verb can capture both streams
+// into MetaResult without going through os.Exit.
+func PrintListRules(stdoutW, stderrW io.Writer, verboseFlag bool, maturityFilter, taxonomyID string, customRuleJars []string, paths []string) (int, bool) {
 	var maturity api.Maturity
 	maturityFilterSet := false
 	if maturityFilter != "" {
 		m, ok := api.ParseMaturity(maturityFilter)
 		if !ok {
-			fmt.Fprintf(os.Stderr, "error: unknown --maturity value %q; valid: stable, experimental, deprecated\n", maturityFilter)
-			os.Exit(2)
+			fmt.Fprintf(stderrW, "error: unknown --maturity value %q; valid: stable, experimental, deprecated\n", maturityFilter)
+			return 2, false
 		}
 		maturity = m
 		maturityFilterSet = true
@@ -301,6 +333,7 @@ func printListRules(w io.Writer, verboseFlag bool, maturityFilter, taxonomyID st
 	if maturityFilterSet {
 		registry = api.MaturityFilter(registry, maturity)
 	}
+	w := stdoutW
 
 	var matcher api.TaxonomyMatcher
 	taxonomyID = strings.TrimSpace(taxonomyID)
@@ -365,6 +398,7 @@ func printListRules(w io.Writer, verboseFlag bool, maturityFilter, taxonomyID st
 		fmt.Fprintf(w, "\nTotal: %d rules (%d active by default, %d fixable)\n", total, active, fixable)
 	}
 	fmt.Fprintln(w, "A=active by default, F=fixable. Use -v for fix levels, --all-rules to enable all, --maturity to filter by lifecycle.")
+	return 0, true
 }
 
 func listPluginRuleDescriptors(customRuleJars []string, paths []string) []oracle.PluginRuleDescriptor {

--- a/internal/cli/scan/oracle_filter_fingerprint.go
+++ b/internal/cli/scan/oracle_filter_fingerprint.go
@@ -3,6 +3,7 @@ package scan
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"sort"
@@ -33,13 +34,22 @@ type oracleFingerprintReport struct {
 // runs only the byte-substring pre-filter, so CI can diff fingerprints
 // without a JVM on the runner.
 func RunOracleFilterFingerprint(paths []string, files []string, activeRules []*api.Rule, allRules bool) int {
+	return WriteOracleFilterFingerprint(os.Stdout, os.Stderr, paths, files, activeRules, allRules)
+}
+
+// WriteOracleFilterFingerprint is the no-direct-stderr/stdout variant
+// of RunOracleFilterFingerprint. Emits the JSON report to stdoutW and
+// any error messages to stderrW; returns the process exit code.
+// Pulled out so the daemon's oracle-filter-fingerprint verb can
+// capture both streams without writing to the daemon's own stdio.
+func WriteOracleFilterFingerprint(stdoutW, stderrW io.Writer, paths []string, files []string, activeRules []*api.Rule, allRules bool) int {
 	if len(paths) == 0 {
-		fmt.Fprintln(os.Stderr, "error: --oracle-filter-fingerprint requires at least one path")
+		fmt.Fprintln(stderrW, "error: --oracle-filter-fingerprint requires at least one path")
 		return 2
 	}
 	root, err := filepath.Abs(paths[0])
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "error: resolve root: %v\n", err)
+		fmt.Fprintf(stderrW, "error: resolve root: %v\n", err)
 		return 2
 	}
 
@@ -68,10 +78,10 @@ func RunOracleFilterFingerprint(paths []string, files []string, activeRules []*a
 		Root:        filepath.ToSlash(filepath.Base(root)),
 	}
 
-	enc := json.NewEncoder(os.Stdout)
+	enc := json.NewEncoder(stdoutW)
 	enc.SetIndent("", "  ")
 	if err := enc.Encode(report); err != nil {
-		fmt.Fprintf(os.Stderr, "error: encode: %v\n", err)
+		fmt.Fprintf(stderrW, "error: encode: %v\n", err)
 		return 2
 	}
 	return 0

--- a/internal/cli/serve/meta_verbs.go
+++ b/internal/cli/serve/meta_verbs.go
@@ -1,0 +1,147 @@
+package serve
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+
+	"github.com/kaeawc/krit/internal/cli/scan"
+	"github.com/kaeawc/krit/internal/config"
+	"github.com/kaeawc/krit/internal/daemon"
+	"github.com/kaeawc/krit/internal/rules"
+	"github.com/kaeawc/krit/internal/scanner"
+)
+
+// handleListRules implements the list-rules verb. Captures the same
+// listing the in-process --list-rules flag emits and returns it as
+// MetaResult.Stdout / Stderr / ExitCode. Plugin rules are not loaded
+// here — the CLI's daemon-compatibility gate already keeps callers
+// with --custom-rule-jars on the in-process path because plugin
+// discovery requires the krit-types JVM the daemon doesn't manage on
+// behalf of meta queries.
+func handleListRules(_ context.Context, _ *daemonState, raw json.RawMessage) (any, error) {
+	var args daemon.ListRulesArgs
+	if len(raw) > 0 {
+		if err := json.Unmarshal(raw, &args); err != nil {
+			return nil, fmt.Errorf("decode args: %w", err)
+		}
+	}
+	var stdout, stderr bytes.Buffer
+	code, _ := scan.PrintListRules(&stdout, &stderr, args.Verbose, args.Maturity, args.TaxonomyID, nil, nil)
+	return daemon.MetaResult{
+		Stdout:   stdout.Bytes(),
+		Stderr:   stderr.Bytes(),
+		ExitCode: code,
+	}, nil
+}
+
+// handleListExperiments implements the list-experiments verb. Mirrors
+// the in-process --list-experiments handler byte-for-byte (compiled-in
+// experiment catalog, no project context required).
+func handleListExperiments(_ context.Context, _ *daemonState, raw json.RawMessage) (any, error) {
+	var args daemon.ListExperimentsArgs
+	if len(raw) > 0 {
+		if err := json.Unmarshal(raw, &args); err != nil {
+			return nil, fmt.Errorf("decode args: %w", err)
+		}
+	}
+	var stdout bytes.Buffer
+	scan.WriteListExperiments(&stdout, args.Format, kritVersion())
+	return daemon.MetaResult{
+		Stdout:   stdout.Bytes(),
+		ExitCode: 0,
+	}, nil
+}
+
+// handleValidateConfig implements the validate-config verb. When
+// args.ConfigPath is non-empty the daemon loads that explicit config
+// for validation; otherwise it uses its already-loaded resident
+// config so subsequent calls don't repeat the krit.yml read.
+func handleValidateConfig(_ context.Context, state *daemonState, raw json.RawMessage) (any, error) {
+	var args daemon.ValidateConfigArgs
+	if len(raw) > 0 {
+		if err := json.Unmarshal(raw, &args); err != nil {
+			return nil, fmt.Errorf("decode args: %w", err)
+		}
+	}
+	cfg, err := state.configForValidation(args.ConfigPath)
+	if err != nil {
+		var stderr bytes.Buffer
+		fmt.Fprintf(&stderr, "error: load config: %v\n", err)
+		return daemon.MetaResult{Stderr: stderr.Bytes(), ExitCode: 2}, nil
+	}
+	var stderr bytes.Buffer
+	code := scan.ValidateConfigTo(&stderr, cfg)
+	return daemon.MetaResult{Stderr: stderr.Bytes(), ExitCode: code}, nil
+}
+
+// configForValidation returns the *config.Config validate-config
+// should check. ConfigPath="" reuses the daemon's resident config (the
+// hot path); a non-empty path forces a one-shot load so explicit
+// `--config FILE` invocations still get the file the user pointed at,
+// not the daemon's autodetected one.
+func (s *daemonState) configForValidation(explicitPath string) (*config.Config, error) {
+	if explicitPath == "" {
+		return s.ensureConfig()
+	}
+	cfg, err := config.LoadConfig(explicitPath)
+	if err != nil {
+		return nil, err
+	}
+	if cfg == nil {
+		cfg = config.NewConfig()
+	}
+	return cfg, nil
+}
+
+// handleOracleFilterFingerprint implements the
+// oracle-filter-fingerprint verb. Walks the requested scan paths for
+// Kotlin sources, builds the active rule set the same way the CLI
+// does (default + AllRules), and emits the JSON fingerprint report
+// the CI drift gate consumes. Does NOT invoke the krit-types JVM —
+// this is the byte-substring pre-filter only.
+func handleOracleFilterFingerprint(_ context.Context, state *daemonState, raw json.RawMessage) (any, error) {
+	var args daemon.OracleFilterFingerprintArgs
+	if len(raw) > 0 {
+		if err := json.Unmarshal(raw, &args); err != nil {
+			return nil, fmt.Errorf("decode args: %w", err)
+		}
+	}
+	paths := args.Paths
+	if len(paths) == 0 {
+		paths = []string{state.root}
+	}
+	cfg, err := state.ensureConfig()
+	if err != nil {
+		var stderr bytes.Buffer
+		fmt.Fprintf(&stderr, "error: load config: %v\n", err)
+		return daemon.MetaResult{Stderr: stderr.Bytes(), ExitCode: 2}, nil
+	}
+	rules.ApplyConfig(cfg)
+	experimental := cfg.GetTopLevelBool("experimental", false)
+	strict := cfg.GetTopLevelBool("strict", false)
+	activeRules := rules.ActiveRulesV2(nil, nil, args.AllRules, experimental, strict)
+
+	files, err := scanner.CollectKotlinFiles(paths, nil)
+	if err != nil {
+		var stderr bytes.Buffer
+		fmt.Fprintf(&stderr, "error: collect files: %v\n", err)
+		return daemon.MetaResult{Stderr: stderr.Bytes(), ExitCode: 2}, nil
+	}
+	// Sort for determinism — CollectKotlinFiles returns walk order;
+	// the in-process CLI path also normalises before fingerprinting via
+	// oracle.StableFingerprint, but pre-sort keeps the file list
+	// matching the CLI's collectFiles output for downstream consumers
+	// that do their own audit.
+	sort.Strings(files)
+
+	var stdout, stderr bytes.Buffer
+	code := scan.WriteOracleFilterFingerprint(&stdout, &stderr, paths, files, activeRules, args.AllRules)
+	return daemon.MetaResult{
+		Stdout:   stdout.Bytes(),
+		Stderr:   stderr.Bytes(),
+		ExitCode: code,
+	}, nil
+}

--- a/internal/cli/serve/meta_verbs_test.go
+++ b/internal/cli/serve/meta_verbs_test.go
@@ -1,0 +1,222 @@
+package serve
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kaeawc/krit/internal/daemon"
+)
+
+// TestListRulesVerb_RoundTrip exercises the daemon list-rules verb
+// end-to-end: register handler, dial socket, decode MetaResult.
+// Asserts the daemon emits the same canonical "Available rules:"
+// header and "A=active by default" footer the in-process flag
+// produces — guarding against silent drift if the listing format
+// changes only on one path.
+func TestListRulesVerb_RoundTrip(t *testing.T) {
+	socket, _ := startServerForTest(t)
+
+	var got daemon.MetaResult
+	if err := daemon.Call(socket, daemon.VerbListRules, daemon.ListRulesArgs{}, &got); err != nil {
+		t.Fatalf("call: %v", err)
+	}
+	if got.ExitCode != 0 {
+		t.Fatalf("expected exit 0, got %d (stderr=%q)", got.ExitCode, string(got.Stderr))
+	}
+	stdout := string(got.Stdout)
+	if !strings.HasPrefix(stdout, "Available rules:\n") {
+		t.Errorf("expected stdout to start with 'Available rules:'; got prefix %q", firstLine(stdout))
+	}
+	if !strings.Contains(stdout, "A=active by default") {
+		t.Errorf("expected legend footer in stdout; got tail %q", lastLine(stdout))
+	}
+}
+
+// TestListRulesVerb_BadMaturityReturnsExitCode2 pins the no-os.Exit
+// refactor: the daemon must surface bad-maturity errors via
+// MetaResult.ExitCode + Stderr instead of crashing the process.
+func TestListRulesVerb_BadMaturityReturnsExitCode2(t *testing.T) {
+	socket, _ := startServerForTest(t)
+
+	var got daemon.MetaResult
+	if err := daemon.Call(socket, daemon.VerbListRules, daemon.ListRulesArgs{Maturity: "bogus"}, &got); err != nil {
+		t.Fatalf("call: %v", err)
+	}
+	if got.ExitCode != 2 {
+		t.Fatalf("expected exit 2 for bad --maturity, got %d", got.ExitCode)
+	}
+	if !strings.Contains(string(got.Stderr), "unknown --maturity value") {
+		t.Errorf("expected error message in stderr; got %q", string(got.Stderr))
+	}
+}
+
+// TestListExperimentsVerb_JSONShape asserts the daemon emits the
+// canonical {"version":...,"experiments":[...]} JSON envelope when
+// Format is "json" — same as runListExperimentsFlag's default path.
+func TestListExperimentsVerb_JSONShape(t *testing.T) {
+	socket, _ := startServerForTest(t)
+
+	var got daemon.MetaResult
+	if err := daemon.Call(socket, daemon.VerbListExperiments, daemon.ListExperimentsArgs{Format: "json"}, &got); err != nil {
+		t.Fatalf("call: %v", err)
+	}
+	if got.ExitCode != 0 {
+		t.Fatalf("expected exit 0, got %d", got.ExitCode)
+	}
+	var env struct {
+		Version     string                   `json:"version"`
+		Experiments []map[string]interface{} `json:"experiments"`
+	}
+	if err := json.Unmarshal(got.Stdout, &env); err != nil {
+		t.Fatalf("decode envelope: %v\n%s", err, string(got.Stdout))
+	}
+	if env.Version == "" {
+		t.Errorf("expected non-empty version field")
+	}
+	if env.Experiments == nil {
+		t.Errorf("expected non-nil experiments slice")
+	}
+}
+
+// TestListExperimentsVerb_PlainHeader asserts the plain format
+// includes the "Experiments (N total)" header so the daemon path
+// matches ListExperimentsLifecyclePlain byte-for-byte.
+func TestListExperimentsVerb_PlainHeader(t *testing.T) {
+	socket, _ := startServerForTest(t)
+
+	var got daemon.MetaResult
+	if err := daemon.Call(socket, daemon.VerbListExperiments, daemon.ListExperimentsArgs{Format: "plain"}, &got); err != nil {
+		t.Fatalf("call: %v", err)
+	}
+	if got.ExitCode != 0 {
+		t.Fatalf("expected exit 0, got %d", got.ExitCode)
+	}
+	if !strings.HasPrefix(string(got.Stdout), "Experiments (") {
+		t.Errorf("expected plain header; got prefix %q", firstLine(string(got.Stdout)))
+	}
+}
+
+// TestValidateConfigVerb_ResidentConfigPasses exercises the
+// resident-config path: empty ConfigPath, daemon's autodetected
+// (and possibly absent) krit.yml validates cleanly.
+func TestValidateConfigVerb_ResidentConfigPasses(t *testing.T) {
+	socket, _ := startServerForTest(t)
+
+	var got daemon.MetaResult
+	if err := daemon.Call(socket, daemon.VerbValidateConfig, daemon.ValidateConfigArgs{}, &got); err != nil {
+		t.Fatalf("call: %v", err)
+	}
+	if got.ExitCode != 0 {
+		t.Fatalf("expected exit 0 for empty resident config, got %d (stderr=%q)", got.ExitCode, string(got.Stderr))
+	}
+	if !strings.Contains(string(got.Stderr), "Config validation passed") {
+		t.Errorf("expected pass message in stderr; got %q", string(got.Stderr))
+	}
+}
+
+// TestValidateConfigVerb_ExplicitPathLoadsFile pins the
+// --config FILE override path: an explicit ConfigPath forces a
+// one-shot load instead of reusing the resident config.
+func TestValidateConfigVerb_ExplicitPathLoadsFile(t *testing.T) {
+	socket, _ := startServerForTest(t)
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "krit.yml")
+	if err := os.WriteFile(cfgPath, []byte("style:\n  MagicNumber:\n    ignoreNumbers: ['0', '1']\n"), 0o644); err != nil {
+		t.Fatalf("write cfg: %v", err)
+	}
+
+	var got daemon.MetaResult
+	if err := daemon.Call(socket, daemon.VerbValidateConfig, daemon.ValidateConfigArgs{ConfigPath: cfgPath}, &got); err != nil {
+		t.Fatalf("call: %v", err)
+	}
+	if got.ExitCode != 0 {
+		t.Fatalf("expected exit 0 for valid explicit config, got %d (stderr=%q)", got.ExitCode, string(got.Stderr))
+	}
+}
+
+// TestOracleFilterFingerprintVerb_EmitsJSONReport drives the
+// fingerprint verb against an empty temp dir and asserts the
+// canonical report shape (ruleSet, fingerprint, oracleRules).
+func TestOracleFilterFingerprintVerb_EmitsJSONReport(t *testing.T) {
+	socket, state := startServerForTest(t)
+
+	// Drop a token Kotlin file so CollectKotlinFiles has something
+	// to walk; the fingerprint is stable for an empty marked-files
+	// set, which is fine for this round-trip assertion.
+	dir := state.root
+	if err := os.WriteFile(filepath.Join(dir, "Foo.kt"), []byte("fun main() {}\n"), 0o644); err != nil {
+		t.Fatalf("write Foo.kt: %v", err)
+	}
+
+	var got daemon.MetaResult
+	if err := daemon.Call(socket, daemon.VerbOracleFilterFingerprint,
+		daemon.OracleFilterFingerprintArgs{Paths: []string{dir}}, &got); err != nil {
+		t.Fatalf("call: %v", err)
+	}
+	if got.ExitCode != 0 {
+		t.Fatalf("expected exit 0, got %d (stderr=%q)", got.ExitCode, string(got.Stderr))
+	}
+	var report struct {
+		RuleSet     string   `json:"ruleSet"`
+		Fingerprint string   `json:"fingerprint"`
+		OracleRules []string `json:"oracleRules"`
+		Root        string   `json:"root"`
+	}
+	if err := json.Unmarshal(got.Stdout, &report); err != nil {
+		t.Fatalf("decode report: %v\n%s", err, string(got.Stdout))
+	}
+	if report.RuleSet != "default" {
+		t.Errorf("expected ruleSet=default, got %q", report.RuleSet)
+	}
+	if report.Fingerprint == "" {
+		t.Errorf("expected non-empty fingerprint")
+	}
+}
+
+// TestOracleFilterFingerprintVerb_AllRulesLabelsRuleSet flips
+// AllRules and confirms the report's "ruleSet" string changes —
+// guards against the daemon silently ignoring the AllRules arg.
+func TestOracleFilterFingerprintVerb_AllRulesLabelsRuleSet(t *testing.T) {
+	socket, state := startServerForTest(t)
+
+	if err := os.WriteFile(filepath.Join(state.root, "Foo.kt"), []byte("fun main() {}\n"), 0o644); err != nil {
+		t.Fatalf("write Foo.kt: %v", err)
+	}
+
+	var got daemon.MetaResult
+	if err := daemon.Call(socket, daemon.VerbOracleFilterFingerprint,
+		daemon.OracleFilterFingerprintArgs{Paths: []string{state.root}, AllRules: true}, &got); err != nil {
+		t.Fatalf("call: %v", err)
+	}
+	if got.ExitCode != 0 {
+		t.Fatalf("expected exit 0, got %d", got.ExitCode)
+	}
+	var report struct {
+		RuleSet string `json:"ruleSet"`
+	}
+	if err := json.Unmarshal(got.Stdout, &report); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if report.RuleSet != "all-rules" {
+		t.Errorf("expected ruleSet=all-rules with AllRules=true; got %q", report.RuleSet)
+	}
+}
+
+func firstLine(s string) string {
+	if i := strings.IndexByte(s, '\n'); i >= 0 {
+		return s[:i]
+	}
+	return s
+}
+
+func lastLine(s string) string {
+	s = strings.TrimRight(s, "\n")
+	if i := strings.LastIndexByte(s, '\n'); i >= 0 {
+		return s[i+1:]
+	}
+	return s
+}

--- a/internal/cli/serve/serve.go
+++ b/internal/cli/serve/serve.go
@@ -711,6 +711,18 @@ func registerVerbs(srv *daemon.Server, state *daemonState) {
 	srv.Register(daemon.VerbAnalyzeProject, func(ctx context.Context, raw json.RawMessage) (any, error) {
 		return handleAnalyzeProject(ctx, state, raw)
 	})
+	srv.Register(daemon.VerbListRules, func(ctx context.Context, raw json.RawMessage) (any, error) {
+		return handleListRules(ctx, state, raw)
+	})
+	srv.Register(daemon.VerbListExperiments, func(ctx context.Context, raw json.RawMessage) (any, error) {
+		return handleListExperiments(ctx, state, raw)
+	})
+	srv.Register(daemon.VerbValidateConfig, func(ctx context.Context, raw json.RawMessage) (any, error) {
+		return handleValidateConfig(ctx, state, raw)
+	})
+	srv.Register(daemon.VerbOracleFilterFingerprint, func(ctx context.Context, raw json.RawMessage) (any, error) {
+		return handleOracleFilterFingerprint(ctx, state, raw)
+	})
 }
 
 // handleAnalyzeBuffer parses (or reuses a cached parse for) the buffer

--- a/internal/daemon/protocol.go
+++ b/internal/daemon/protocol.go
@@ -27,12 +27,16 @@ type Response struct {
 
 // Built-in verb names.
 const (
-	VerbStatus         = "status"
-	VerbShutdown       = "shutdown"
-	VerbAbiHash        = "abi-hash"
-	VerbAnalyzeBuffer  = "analyze-buffer"
-	VerbAnalyzeBuffers = "analyze-buffers"
-	VerbAnalyzeProject = "analyze-project"
+	VerbStatus                  = "status"
+	VerbShutdown                = "shutdown"
+	VerbAbiHash                 = "abi-hash"
+	VerbAnalyzeBuffer           = "analyze-buffer"
+	VerbAnalyzeBuffers          = "analyze-buffers"
+	VerbAnalyzeProject          = "analyze-project"
+	VerbListRules               = "list-rules"
+	VerbListExperiments         = "list-experiments"
+	VerbValidateConfig          = "validate-config"
+	VerbOracleFilterFingerprint = "oracle-filter-fingerprint"
 )
 
 // ErrBinaryHashMismatchPrefix is the error.Error() prefix the daemon
@@ -263,4 +267,58 @@ type PhaseTimingsMs struct {
 	Android   int64 `json:"android"`
 	Fixup     int64 `json:"fixup"`
 	Output    int64 `json:"output"`
+}
+
+// MetaResult is the response payload shared by the read-only meta
+// verbs (list-rules, list-experiments, validate-config,
+// oracle-filter-fingerprint). The daemon captures the formatted bytes
+// the in-process flag handlers would have written and the exit code
+// they would have returned; the CLI replays them against its own
+// stdout/stderr + exit so daemon-routed and in-process invocations
+// remain byte-equivalent.
+type MetaResult struct {
+	Stdout   []byte `json:"stdout,omitempty"`
+	Stderr   []byte `json:"stderr,omitempty"`
+	ExitCode int    `json:"exit_code"`
+}
+
+// ListRulesArgs mirrors the --list-rules flag knobs. CustomRuleJars is
+// intentionally omitted: the daemon-compatibility gate already keeps
+// callers with --custom-rule-jars on the in-process path because plugin
+// rule discovery requires the krit-types JVM.
+type ListRulesArgs struct {
+	// Verbose mirrors -v: include fix levels, precision, maturity,
+	// description.
+	Verbose bool `json:"verbose,omitempty"`
+	// Maturity filters by lifecycle (stable, experimental, deprecated).
+	// Empty means no filter.
+	Maturity string `json:"maturity,omitempty"`
+	// TaxonomyID filters by --cwe (CWE / OWASP / SEI-CERT / MITRE).
+	TaxonomyID string `json:"taxonomy,omitempty"`
+}
+
+// ListExperimentsArgs mirrors the --list-experiments flag knobs.
+type ListExperimentsArgs struct {
+	// Format is the output format ("json" or "plain"). Empty defaults
+	// to "json" matching the CLI's default.
+	Format string `json:"format,omitempty"`
+}
+
+// ValidateConfigArgs is the validate-config payload. The daemon uses
+// its resident config (loaded from --root); the CLI may pass an
+// explicit path via ConfigPath to override.
+type ValidateConfigArgs struct {
+	// ConfigPath, when non-empty, is the absolute path of the
+	// krit.yml the daemon should validate. Empty means the daemon
+	// uses its already-loaded resident config.
+	ConfigPath string `json:"config_path,omitempty"`
+}
+
+// OracleFilterFingerprintArgs drives the oracle-filter-fingerprint
+// verb. Paths is the explicit scan target; empty falls back to the
+// daemon's --root. AllRules toggles the rule-set label between
+// "default" and "all-rules" and broadens activeRules.
+type OracleFilterFingerprintArgs struct {
+	Paths    []string `json:"paths,omitempty"`
+	AllRules bool     `json:"all_rules,omitempty"`
 }


### PR DESCRIPTION
## Summary

Peels four read-only meta queries off the daemon-incompatible-flags exclusion list so they hit the warm daemon instead of forcing in-process execution. Each new verb captures the same stdout/stderr/exit-code triple the in-process flag handlers would have written and returns it through a shared \`MetaResult\` envelope; the CLI replays those streams against its own stdio so daemon-routed and in-process invocations stay byte-equivalent.

### Routed
- \`--list-rules\` → \`VerbListRules\` (skipped when \`--custom-rule-jars\` is set; plugin discovery still needs the krit-types JVM the daemon doesn't manage on behalf of meta queries)
- \`--list-experiments\` → \`VerbListExperiments\`
- \`--validate-config\` → \`VerbValidateConfig\` (uses the daemon's resident config; an explicit \`--config FILE\` arg forces a one-shot load)
- \`--oracle-filter-fingerprint\` → \`VerbOracleFilterFingerprint\` (Kotlin-source walk + active rule set; no JVM)

### Left in-process (this PR)
- \`--rule-audit\` and \`--baseline-audit\` operate on the raw \`*scanner.FindingColumns\` produced by the full project scan after \`applyBaselinesAndDiff\`. Routing them via the daemon requires either a new verb that runs analyze-project + audit on the daemon side and returns the audit text, or surfacing raw FindingColumns over the wire — a meaningfully larger change than the rest of this bucket. Deferred to a follow-up so this PR stays small.

### Implementation notes
- New verbs: \`list-rules\`, \`list-experiments\`, \`validate-config\`, \`oracle-filter-fingerprint\` registered in \`registerVerbs\` next to \`analyze-project\`.
- Shared \`daemon.MetaResult { Stdout, Stderr, ExitCode }\` payload — kept generic so future read-only verbs can reuse it.
- Three in-process flag handlers (\`printListRules\`, \`runValidateConfigFlag\`, \`runListExperimentsFlag\`, \`RunOracleFilterFingerprint\`) gained no-os.Exit forms (\`PrintListRules\`, \`ValidateConfigTo\`, \`WriteListExperiments\`, \`WriteOracleFilterFingerprint\`) so the daemon can capture their output without the existing CLI behavior changing. Old wrappers preserved for direct callers and the existing CWE-filter test.
- \`tryDaemonDelegate\` gains a \`metaVerbForFlags\` switch that runs before the analyze-project compatibility check; on a daemon-side failure it falls back to in-process the same way the analyze path does.

## Test plan
- [x] \`go build ./...\`
- [x] \`go vet ./...\`
- [x] \`golangci-lint run ./...\` — 0 issues
- [x] \`go test ./... -count=1\` — all packages green
- [x] New \`internal/cli/serve/meta_verbs_test.go\`: round-trip + bad-input + format-flag coverage for each new verb (8 tests)
- [x] New \`internal/cli/scan/daemon_delegate_test.go\` cases: routes \`--list-rules\` via the meta verb; falls through when \`--custom-rule-jars\` is set