### PR TITLE
feat(daemon): route --no-cache and --clear-cache through daemon

### DIFF
--- a/internal/cli/daemonclient/client.go
+++ b/internal/cli/daemonclient/client.go
@@ -388,3 +388,39 @@ func (c *Client) OracleFilterFingerprint(args daemon.OracleFilterFingerprintArgs
 	}
 	return result, nil
 }
+
+// ClearCache asks the daemon to delete its on-disk caches and drop
+// resident WorkspaceState slots. The caller's binary hash is injected
+// automatically when args.ClientBinaryHash is empty.
+func (c *Client) ClearCache(args daemon.ClearCacheArgs) (daemon.ClearCacheResult, error) {
+	if c == nil {
+		return daemon.ClearCacheResult{}, errors.New("daemonclient: nil client")
+	}
+	if args.ClientBinaryHash == "" {
+		args.ClientBinaryHash = currentBinaryHash()
+	}
+	var result daemon.ClearCacheResult
+	if err := daemon.Call(c.socketPath, daemon.VerbClearCache, args, &result); err != nil {
+		return daemon.ClearCacheResult{}, err
+	}
+	return result, nil
+}
+
+// ClearMatrixCache asks the daemon to delete the experiment-matrix
+// baseline cache. The matrix cache is not held resident in the daemon,
+// so this is purely a wrapped on-disk delete; the verb exists so a
+// running daemon can serve the request without spawning a fresh
+// in-process krit when the user passes --clear-matrix-cache.
+func (c *Client) ClearMatrixCache(args daemon.ClearMatrixCacheArgs) (daemon.ClearMatrixCacheResult, error) {
+	if c == nil {
+		return daemon.ClearMatrixCacheResult{}, errors.New("daemonclient: nil client")
+	}
+	if args.ClientBinaryHash == "" {
+		args.ClientBinaryHash = currentBinaryHash()
+	}
+	var result daemon.ClearMatrixCacheResult
+	if err := daemon.Call(c.socketPath, daemon.VerbClearMatrixCache, args, &result); err != nil {
+		return daemon.ClearMatrixCacheResult{}, err
+	}
+	return result, nil
+}

--- a/internal/cli/scan/daemon_delegate.go
+++ b/internal/cli/scan/daemon_delegate.go
@@ -198,6 +198,38 @@ func runDaemonSampleRule(f *scanFlags, paths []string, findingsJSON []byte) int 
 	return RunSampleFindingsColumns(columns, *f.SampleRule, *f.SampleCount, *f.SampleContext, basePath)
 }
 
+// tryDaemonClearCache routes --clear-cache through a running daemon
+// when one is reachable. Returning true means the daemon performed
+// the clear and the caller should exit 0; false means the caller
+// falls back to in-process clear-cache (which still works when no
+// daemon is up). --clear-matrix-cache stays in-process: the matrix
+// cache lives in ~/.cache/krit and the daemon binary doesn't link
+// the registration code, so there's nothing for it to coordinate.
+func tryDaemonClearCache(f *scanFlags, repoDir string) bool {
+	if f == nil || *f.NoDaemon || !*f.ClearCache {
+		return false
+	}
+	client, ok := daemonclient.TryConnect(repoDir, *f.DaemonSocket)
+	if !ok {
+		return false
+	}
+	res, err := client.ClearCache(daemon.ClearCacheArgs{})
+	if err != nil {
+		if daemonclient.IsBinaryHashMismatch(err) {
+			fmt.Fprintf(os.Stderr, "warning: krit daemon rejected request (%v); falling back to in-process. Restart it with: krit daemon restart\n", err)
+			return false
+		}
+		fmt.Fprintf(os.Stderr, "warning: krit daemon clear-cache failed (%v); falling back to in-process\n", err)
+		return false
+	}
+	if res.Cleared {
+		fmt.Fprintln(os.Stderr, "info: Cache cleared (via daemon).")
+	} else {
+		fmt.Fprintln(os.Stderr, "info: Cache clear completed with errors (via daemon).")
+	}
+	return true
+}
+
 // daemonCompatibleFlags reports whether the requested flag set can be
 // served by the daemon's analyze-project verb. Modes that write files,
 // invoke profiling, or run meta commands stay on the in-process path.
@@ -223,8 +255,14 @@ func daemonCompatibleFlags(f *scanFlags) bool {
 	meta := []bool{*f.Init, *f.Doctor, *f.Version, *f.List, *f.ValidateConfig, *f.GenerateSchema,
 		*f.BaselineAudit, *f.RuleAudit, *f.OracleFilterFingerprint, *f.ListExperiments}
 	profiling := []bool{*f.ProfileDispatch}
-	cacheOps := []bool{*f.NoCache, *f.ClearCache, *f.ClearMatrixCache}
-	for _, group := range [][]bool{mutating, meta, profiling, cacheOps} {
+	// --no-cache, --clear-cache, --clear-matrix-cache are now daemon-
+	// routable: --no-cache rides on AnalyzeProjectArgs.NoCache (the
+	// daemon nils every disk-cache pointer for this single call), the
+	// two clear-* flags are handled by tryDaemonCacheClear before
+	// tryDaemonDelegate runs (early-exit verbs that also drop the
+	// daemon's resident WorkspaceState slots so the next analyze
+	// rebuilds from cold).
+	for _, group := range [][]bool{mutating, meta, profiling} {
 		for _, on := range group {
 			if on {
 				return false
@@ -285,6 +323,7 @@ func buildDaemonAnalyzeArgs(f *scanFlags, paths []string) daemon.AnalyzeProjectA
 		ShowPerf:         *f.Perf || *f.PerfRules,
 		PerfRules:        *f.PerfRules,
 		InputTypesPath:   inputTypesPath,
+		NoCache:          *f.NoCache,
 		ClientBinaryHash: daemonclient.CurrentBinaryHash(),
 	}
 }

--- a/internal/cli/scan/daemon_delegate_test.go
+++ b/internal/cli/scan/daemon_delegate_test.go
@@ -339,6 +339,17 @@ func TestDaemonCompatibleFlags_PerfAllowed(t *testing.T) {
 		{"--perf and --perf-rules", func(f *scanFlags) { *f.Perf = true; *f.PerfRules = true }, true},
 		{"--profile-dispatch", func(f *scanFlags) { *f.ProfileDispatch = true }, false},
 		{"--fix", func(f *scanFlags) { *f.Fix = true }, false},
+		// --no-cache rides on AnalyzeProjectArgs.NoCache; daemon
+		// nils its on-disk cache pointers for the call but stays
+		// the right place to serve it.
+		{"--no-cache", func(f *scanFlags) { *f.NoCache = true }, true},
+		// --clear-cache and --clear-matrix-cache are early-exit
+		// verbs handled outside the analyze path (clear-cache via
+		// tryDaemonClearCache, clear-matrix-cache stays in-process),
+		// so daemonCompatibleFlags must NOT short-circuit on them
+		// the way the analyze path used to.
+		{"--clear-cache", func(f *scanFlags) { *f.ClearCache = true }, true},
+		{"--clear-matrix-cache", func(f *scanFlags) { *f.ClearMatrixCache = true }, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -348,6 +359,98 @@ func TestDaemonCompatibleFlags_PerfAllowed(t *testing.T) {
 				t.Errorf("daemonCompatibleFlags = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+// TestTryDaemonClearCache_NoClearFlagNoOp pins the entry-gate
+// contract: when --clear-cache is not set, tryDaemonClearCache must
+// not even attempt a dial.
+func TestTryDaemonClearCache_NoClearFlagNoOp(t *testing.T) {
+	root := newRoot(t)
+	f := freshScanFlags(t)
+	if tryDaemonClearCache(f, root) {
+		t.Fatalf("expected handled=false when --clear-cache is unset")
+	}
+}
+
+// TestTryDaemonClearCache_NoDaemonShortCircuits guards the
+// --no-daemon flag for the clear path: even if a socket is reachable
+// and --clear-cache is set, --no-daemon falls through to in-process.
+func TestTryDaemonClearCache_NoDaemonShortCircuits(t *testing.T) {
+	socketDir := startMockClearCacheDaemon(t, false)
+	root := newRoot(t)
+	linkSock(t, root, filepath.Join(socketDir, "d.sock"))
+	f := freshScanFlags(t)
+	*f.ClearCache = true
+	*f.NoDaemon = true
+	if tryDaemonClearCache(f, root) {
+		t.Fatalf("expected fall-through with --no-daemon")
+	}
+}
+
+// TestTryDaemonClearCache_HappyPath confirms the verb is invoked and
+// the CLI exits cleanly (code 0) when the daemon reports success.
+func TestTryDaemonClearCache_HappyPath(t *testing.T) {
+	socketDir := startMockClearCacheDaemon(t, true)
+	root := newRoot(t)
+	linkSock(t, root, filepath.Join(socketDir, "d.sock"))
+	f := freshScanFlags(t)
+	*f.ClearCache = true
+	if !tryDaemonClearCache(f, root) {
+		t.Fatalf("expected handled=true on daemon success")
+	}
+}
+
+// startMockClearCacheDaemon stands up a minimal daemon that
+// implements just enough of clear-cache to drive
+// tryDaemonClearCache assertions.
+func startMockClearCacheDaemon(t *testing.T, cleared bool) string {
+	t.Helper()
+	socketDir, err := os.MkdirTemp("/tmp", "krit-clear-srv-")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(socketDir) })
+	socket := filepath.Join(socketDir, "d.sock")
+	srv := daemon.NewServer(socket)
+	srv.Register(daemon.VerbStatus, func(_ context.Context, _ json.RawMessage) (any, error) {
+		return daemon.StatusResult{Ready: true}, nil
+	})
+	srv.Register(daemon.VerbShutdown, func(_ context.Context, _ json.RawMessage) (any, error) {
+		return map[string]bool{"ok": true}, nil
+	})
+	srv.Register(daemon.VerbClearCache, func(_ context.Context, _ json.RawMessage) (any, error) {
+		return daemon.ClearCacheResult{Cleared: cleared, ResidentInvalidated: true}, nil
+	})
+	if err := srv.Start(context.Background()); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	t.Cleanup(srv.Stop)
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if daemon.Available(socket) {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	return socketDir
+}
+
+// TestBuildDaemonAnalyzeArgs_ForwardsNoCache confirms --no-cache
+// propagates into AnalyzeProjectArgs.NoCache so the daemon honours
+// the on-disk-cache bypass.
+func TestBuildDaemonAnalyzeArgs_ForwardsNoCache(t *testing.T) {
+	f := freshScanFlags(t)
+	*f.NoCache = true
+	args := buildDaemonAnalyzeArgs(f, []string{"/tmp"})
+	if !args.NoCache {
+		t.Errorf("NoCache = false, want true")
+	}
+	// Negative — default is false.
+	f2 := freshScanFlags(t)
+	args2 := buildDaemonAnalyzeArgs(f2, []string{"/tmp"})
+	if args2.NoCache {
+		t.Errorf("NoCache = true with default flags, want false")
 	}
 }
 

--- a/internal/cli/scan/scan.go
+++ b/internal/cli/scan/scan.go
@@ -288,6 +288,9 @@ func Run() int {
 
 	ctx := context.Background()
 	repoDir := oracle.FindRepoDir(flag.Args())
+	if tryDaemonClearCache(f, repoDir) {
+		return 0
+	}
 	if handled, code := tryDaemonDelegate(f, flag.Args(), repoDir); handled {
 		return code
 	}

--- a/internal/cli/serve/analyze_project.go
+++ b/internal/cli/serve/analyze_project.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/kaeawc/krit/internal/cache"
 	"github.com/kaeawc/krit/internal/cacheutil"
 	"github.com/kaeawc/krit/internal/cli/clishared"
 	"github.com/kaeawc/krit/internal/config"
@@ -272,6 +273,13 @@ func (s *daemonState) buildProjectInput(args daemon.AnalyzeProjectArgs) (pipelin
 	if repoDir == "" {
 		repoDir = s.root
 	}
+	// --no-cache disables every on-disk cache for this single call:
+	// parse cache, AnalysisCache, findings bundle store, cross-file/
+	// findings/type-index disk shards. Resident WorkspaceState slots
+	// stay live — they're per-process memory keyed on input
+	// fingerprints, so a no-cache call can reuse them without
+	// dirtying state for subsequent calls. The next analyze without
+	// NoCache resumes normal cache behavior.
 	parseCache, err := s.parseCacheFor(repoDir, cacheutil.DefaultParseCacheCapBytes)
 	if err != nil {
 		// A failed parse cache isn't fatal — RunProject tolerates
@@ -281,12 +289,21 @@ func (s *daemonState) buildProjectInput(args daemon.AnalyzeProjectArgs) (pipelin
 		// read-only.
 		parseCache = nil
 	}
+	if args.NoCache {
+		parseCache = nil
+	}
 
 	// AnalysisCache is daemon-resident: lazy-loaded on first request,
 	// keyed by the resolved cache file path so distinct scan-path sets
 	// don't share an entry. DispatchPhase will merge new findings into
 	// it and persist to disk on each call.
-	analysisCache, analysisCachePath := s.analysisCacheFor(paths)
+	var (
+		analysisCache     *cache.Cache
+		analysisCachePath string
+	)
+	if !args.NoCache {
+		analysisCache, analysisCachePath = s.analysisCacheFor(paths)
+	}
 
 	// OracleDaemon is daemon-resident: lazy-started on first request
 	// when krit-types.jar is found. nil daemon means oracle stays
@@ -324,6 +341,31 @@ func (s *daemonState) buildProjectInput(args daemon.AnalyzeProjectArgs) (pipelin
 	var perfTracker perf.Tracker
 	if args.ShowPerf || args.PerfRules {
 		perfTracker = perf.New(true)
+	}
+
+	// Disk-cache wiring: --no-cache nils every on-disk cache pointer
+	// for this single call. Resident WorkspaceState slots stay live
+	// because they're keyed on input fingerprints — reuse is
+	// idempotent and a no-cache call cannot dirty them for subsequent
+	// calls.
+	var (
+		crossFileCacheDir     = scanner.CrossFileCacheDir(repoDir)
+		crossFindingsCacheDir = scanner.CrossFindingsCacheDir(repoDir)
+		typeIndexCacheDir     = typeinfer.TypeIndexCacheDir(repoDir)
+		findingsBundleStore   scanner.FindingsBundleStore
+		findingsBundleRoot    string
+		manifestLoader        pipeline.FindingsBundleManifestLoader
+		manifestSaver         pipeline.FindingsBundleManifestSaver
+	)
+	if !args.NoCache {
+		findingsBundleStore = scanner.DiskFindingsBundleStore{}
+		findingsBundleRoot = repoDir
+		manifestLoader = s.loadManifest
+		manifestSaver = s.saveManifest
+	} else {
+		crossFileCacheDir = ""
+		crossFindingsCacheDir = ""
+		typeIndexCacheDir = ""
 	}
 
 	return pipeline.ProjectInput{
@@ -369,18 +411,18 @@ func (s *daemonState) buildProjectInput(args daemon.AnalyzeProjectArgs) (pipelin
 			SourceMTimeVersion:           s.workspace.SourceMTimeVersion,
 			BundleOutput:                 s.workspace.BundleOutput,
 			StoreBundleOutput:            s.workspace.StoreBundleOutput,
-			CrossFileCacheDir:            scanner.CrossFileCacheDir(repoDir),
-			CrossFindingsCacheDir:        scanner.CrossFindingsCacheDir(repoDir),
-			TypeIndexCacheDir:            typeinfer.TypeIndexCacheDir(repoDir),
+			CrossFileCacheDir:            crossFileCacheDir,
+			CrossFindingsCacheDir:        crossFindingsCacheDir,
+			TypeIndexCacheDir:            typeIndexCacheDir,
 			ResidentFileTypeInfo:         s.workspace,
 			AnalysisCache:                analysisCache,
 			AnalysisCacheFilePath:        analysisCachePath,
 			AnalysisCacheLookup:          analysisCache != nil,
 			OracleDaemon:                 oracleDaemon,
-			FindingsBundleStore:          scanner.DiskFindingsBundleStore{},
-			FindingsBundleCacheRoot:      repoDir,
-			FindingsBundleManifestLoader: s.loadManifest,
-			FindingsBundleManifestSaver:  s.saveManifest,
+			FindingsBundleStore:          findingsBundleStore,
+			FindingsBundleCacheRoot:      findingsBundleRoot,
+			FindingsBundleManifestLoader: manifestLoader,
+			FindingsBundleManifestSaver:  manifestSaver,
 			PriorContentHashes:           priorManifest.ContentHashes,
 			PriorStructuralFPs:           priorManifest.StructuralFPs,
 		},

--- a/internal/cli/serve/cache_ops_test.go
+++ b/internal/cli/serve/cache_ops_test.go
@@ -1,0 +1,143 @@
+package serve
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kaeawc/krit/internal/daemon"
+)
+
+// TestAnalyzeProject_NoCacheBypassesDiskCache pins that NoCache=true
+// runs without populating the on-disk AnalysisCache and without
+// reading the FindingsBundle store. The two follow-up calls assert
+// that resident WorkspaceState slots aren't poisoned by the no-cache
+// run: the next NoCache=false call should still produce identical
+// findings and the daemon should still be in a valid warm state.
+func TestAnalyzeProject_NoCacheBypassesDiskCache(t *testing.T) {
+	socket, state := startServerForTest(t)
+	writeKotlinFile(t, state.root, "Foo.kt", "package demo\n\nclass Foo\n")
+
+	// Warm the daemon with a normal call so on-disk caches exist.
+	var warm daemon.AnalyzeProjectResult
+	if err := daemon.Call(socket, daemon.VerbAnalyzeProject,
+		daemon.AnalyzeProjectArgs{}, &warm); err != nil {
+		t.Fatalf("warm call: %v", err)
+	}
+
+	// Then a NoCache call must succeed and still return matching
+	// findings — nil-cache wiring shouldn't change the rule output.
+	var noCache daemon.AnalyzeProjectResult
+	if err := daemon.Call(socket, daemon.VerbAnalyzeProject,
+		daemon.AnalyzeProjectArgs{NoCache: true}, &noCache); err != nil {
+		t.Fatalf("no-cache call: %v", err)
+	}
+	if !jsonEq(warm.Findings, noCache.Findings) {
+		t.Errorf("no-cache findings diverged from warm findings\nwarm: %s\nnocache: %s", warm.Findings, noCache.Findings)
+	}
+
+	// And a NoCache=false call after the NoCache run must NOT have
+	// been poisoned: same shape findings, daemon still serves the
+	// request.
+	var followUp daemon.AnalyzeProjectResult
+	if err := daemon.Call(socket, daemon.VerbAnalyzeProject,
+		daemon.AnalyzeProjectArgs{}, &followUp); err != nil {
+		t.Fatalf("follow-up call: %v", err)
+	}
+	if !jsonEq(warm.Findings, followUp.Findings) {
+		t.Errorf("follow-up findings diverged after no-cache run\nwarm: %s\nfollowUp: %s", warm.Findings, followUp.Findings)
+	}
+}
+
+// TestClearCache_DropsResidentAndDiskState pins that the clear-cache
+// verb wipes the on-disk analysis cache file and resets the daemon's
+// WorkspaceState so the next analyze reports Cold=true.
+func TestClearCache_DropsResidentAndDiskState(t *testing.T) {
+	socket, state := startServerForTest(t)
+	writeKotlinFile(t, state.root, "Foo.kt", "package demo\n\nclass Foo\n")
+
+	// Prime the daemon: this populates the analysis-cache file and
+	// the resident workspace state.
+	var first daemon.AnalyzeProjectResult
+	if err := daemon.Call(socket, daemon.VerbAnalyzeProject,
+		daemon.AnalyzeProjectArgs{}, &first); err != nil {
+		t.Fatalf("prime call: %v", err)
+	}
+	if !first.Stats.Cold {
+		t.Fatalf("first call must be Cold; got %+v", first.Stats)
+	}
+
+	// Confirm the cache file actually exists on disk so the clear
+	// has something to remove.
+	cachePath := findAnalysisCachePath(state)
+	if cachePath == "" {
+		t.Skip("analysis cache path not available in this environment; skipping disk-clear assertion")
+	}
+	if _, err := os.Stat(cachePath); err != nil {
+		t.Skipf("analysis cache file not on disk after first analyze (%v); skipping", err)
+	}
+
+	var clear daemon.ClearCacheResult
+	if err := daemon.Call(socket, daemon.VerbClearCache, daemon.ClearCacheArgs{}, &clear); err != nil {
+		t.Fatalf("clear-cache: %v", err)
+	}
+	if !clear.Cleared {
+		t.Errorf("clear-cache: Cleared=false, want true; got %+v", clear)
+	}
+	if !clear.ResidentInvalidated {
+		t.Errorf("clear-cache: ResidentInvalidated=false, want true; got %+v", clear)
+	}
+	if _, err := os.Stat(cachePath); !os.IsNotExist(err) {
+		t.Errorf("expected analysis cache file removed; stat err=%v", err)
+	}
+
+	// After clear, the next analyze should report Cold=true again
+	// because coldDone was reset and resident slots were dropped.
+	var afterClear daemon.AnalyzeProjectResult
+	if err := daemon.Call(socket, daemon.VerbAnalyzeProject,
+		daemon.AnalyzeProjectArgs{}, &afterClear); err != nil {
+		t.Fatalf("post-clear analyze: %v", err)
+	}
+	if !afterClear.Stats.Cold {
+		t.Errorf("post-clear analyze must be Cold; got %+v", afterClear.Stats)
+	}
+}
+
+// findAnalysisCachePath returns the on-disk cache file the daemon uses
+// for the current root, or "" when none is registered yet.
+func findAnalysisCachePath(state *daemonState) string {
+	state.analysisCacheMu.Lock()
+	defer state.analysisCacheMu.Unlock()
+	for _, e := range state.analysisCacheByKey {
+		if e == nil {
+			continue
+		}
+		if e.path != "" {
+			return e.path
+		}
+	}
+	// Fall back to the conventional location relative to the daemon
+	// root if no entry has been registered yet (some test paths skip
+	// the analysis cache loader).
+	return filepath.Join(state.root, ".krit", "cache", "krit-analysis.cache")
+}
+
+// jsonEq compares two raw JSON payloads structurally after removing
+// dynamic fields (durationMs) that legitimately vary across calls.
+// Used to assert that NoCache and warm calls produce identical
+// findings regardless of timing.
+func jsonEq(a, b json.RawMessage) bool {
+	var av, bv map[string]any
+	if err := json.Unmarshal(a, &av); err != nil {
+		return false
+	}
+	if err := json.Unmarshal(b, &bv); err != nil {
+		return false
+	}
+	delete(av, "durationMs")
+	delete(bv, "durationMs")
+	abytes, _ := json.Marshal(av)
+	bbytes, _ := json.Marshal(bv)
+	return string(abytes) == string(bbytes)
+}

--- a/internal/cli/serve/clear_cache.go
+++ b/internal/cli/serve/clear_cache.go
@@ -1,0 +1,96 @@
+package serve
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/kaeawc/krit/internal/cache"
+	"github.com/kaeawc/krit/internal/cacheutil"
+	"github.com/kaeawc/krit/internal/daemon"
+	"github.com/kaeawc/krit/internal/scanner"
+)
+
+// handleClearCache implements the clear-cache verb. It mirrors the
+// in-process semantics of `krit --clear-cache`: every registered
+// cacheutil cache is cleared, the analysis cache file is removed,
+// and — uniquely to the daemon — the resident WorkspaceState slots
+// are dropped so the next analyze rebuilds from cold rather than
+// resurrecting state from in-memory snapshots that no longer have a
+// disk-cache backing.
+//
+// The matrix-cache subsystem (internal/cli/scan/matrix_cache.go) only
+// auto-registers itself when the scan package is linked. The daemon
+// shim binary doesn't link scan, so the matrix cache stays a CLI-side
+// concern; --clear-matrix-cache is intentionally NOT routed through
+// the daemon. The daemon's clear-cache verb still calls ClearAll()
+// because other subsystems that DO get registered from packages the
+// daemon imports get cleared this way.
+func handleClearCache(_ context.Context, state *daemonState, raw json.RawMessage) (any, error) {
+	var args daemon.ClearCacheArgs
+	if len(raw) > 0 {
+		if err := json.Unmarshal(raw, &args); err != nil {
+			return nil, fmt.Errorf("decode args: %w", err)
+		}
+	}
+	if daemonHash := daemonBinaryHash(); args.ClientBinaryHash != "" && daemonHash != "" && args.ClientBinaryHash != daemonHash {
+		return nil, fmt.Errorf("%s (daemon=%s client=%s)", daemon.ErrBinaryHashMismatchPrefix, daemonHash, args.ClientBinaryHash)
+	}
+
+	// Serialise against any concurrent analyze-project so we don't
+	// race a write-back into the file we're about to delete.
+	state.analyzeMu.Lock()
+	defer state.analyzeMu.Unlock()
+
+	var allErrs []error
+	if err := cacheutil.ClearAll(cacheutil.ClearContext{RepoDir: state.repoDir}); err != nil {
+		allErrs = append(allErrs, fmt.Errorf("cacheutil.ClearAll: %w", err))
+	}
+
+	// Drop the resident analysis-cache table; the next analyze re-
+	// loads from disk (which we're about to wipe) and finds nothing,
+	// so it rebuilds from scratch.
+	state.analysisCacheMu.Lock()
+	for _, entry := range state.analysisCacheByKey {
+		if entry == nil {
+			continue
+		}
+		if err := cache.Clear(entry.path); err != nil {
+			allErrs = append(allErrs, fmt.Errorf("cache.Clear %s: %w", entry.path, err))
+		}
+	}
+	state.analysisCacheByKey = make(map[string]*analysisCacheEntry)
+	state.analysisCacheMu.Unlock()
+
+	// Close + reset the resident parse cache so the next analyze
+	// reconstructs it against (now-empty) on-disk state.
+	state.resetParseCache()
+
+	// Drop every resident WorkspaceState slot so the daemon can't
+	// resurrect cached cross-file or per-file state from memory after
+	// the disk cache has been wiped.
+	state.workspace.InvalidateAll()
+	state.coldDone.Store(false)
+
+	state.manifestMu.Lock()
+	state.manifestCache = make(map[string]scanner.FindingsBundleManifest)
+	state.manifestMu.Unlock()
+
+	if len(allErrs) > 0 {
+		return daemon.ClearCacheResult{Cleared: false, ResidentInvalidated: true}, errors.Join(allErrs...)
+	}
+	return daemon.ClearCacheResult{Cleared: true, ResidentInvalidated: true}, nil
+}
+
+// resetParseCache closes the resident parse cache (if any) and rearms
+// the sync.Once so a subsequent parseCacheFor call rebuilds from
+// scratch. Used by clear-cache to ensure the next analyze sees an
+// empty parse cache instead of the in-memory copy from before the
+// clear.
+func (s *daemonState) resetParseCache() {
+	s.closeParseCache()
+	s.parseCacheOnce = sync.Once{}
+	s.parseCacheErr = nil
+}

--- a/internal/cli/serve/serve.go
+++ b/internal/cli/serve/serve.go
@@ -725,6 +725,9 @@ func registerVerbs(srv *daemon.Server, state *daemonState) {
 	srv.Register(daemon.VerbOracleFilterFingerprint, func(ctx context.Context, raw json.RawMessage) (any, error) {
 		return handleOracleFilterFingerprint(ctx, state, raw)
 	})
+	srv.Register(daemon.VerbClearCache, func(ctx context.Context, raw json.RawMessage) (any, error) {
+		return handleClearCache(ctx, state, raw)
+	})
 }
 
 // handleAnalyzeBuffer parses (or reuses a cached parse for) the buffer

--- a/internal/daemon/protocol.go
+++ b/internal/daemon/protocol.go
@@ -33,6 +33,8 @@ const (
 	VerbAnalyzeBuffer           = "analyze-buffer"
 	VerbAnalyzeBuffers          = "analyze-buffers"
 	VerbAnalyzeProject          = "analyze-project"
+	VerbClearCache              = "clear-cache"
+	VerbClearMatrixCache        = "clear-matrix-cache"
 	VerbListRules               = "list-rules"
 	VerbListExperiments         = "list-experiments"
 	VerbValidateConfig          = "validate-config"
@@ -49,6 +51,33 @@ const (
 // issue calls out, transported via the daemon's
 // `{ok:false,error:...}` envelope instead of a code field.
 const ErrBinaryHashMismatchPrefix = "binary hash mismatch"
+
+// ClearCacheArgs is the argument shape for the clear-cache verb.
+// ClientBinaryHash mirrors AnalyzeProjectArgs: empty disables the
+// handshake; non-empty values must match the daemon's hash or the
+// daemon refuses the request.
+type ClearCacheArgs struct {
+	ClientBinaryHash string `json:"client_binary_hash,omitempty"`
+}
+
+// ClearCacheResult reports the outcome of a clear-cache verb. Cleared
+// is true when the on-disk caches were removed. ResidentInvalidated is
+// true when the daemon also dropped its resident WorkspaceState slots
+// so the next analyze rebuilds from scratch.
+type ClearCacheResult struct {
+	Cleared             bool `json:"cleared"`
+	ResidentInvalidated bool `json:"resident_invalidated"`
+}
+
+// ClearMatrixCacheArgs / ClearMatrixCacheResult mirror ClearCacheArgs /
+// ClearCacheResult for the experiment-matrix baseline cache.
+type ClearMatrixCacheArgs struct {
+	ClientBinaryHash string `json:"client_binary_hash,omitempty"`
+}
+
+type ClearMatrixCacheResult struct {
+	Cleared bool `json:"cleared"`
+}
 
 // AbiHashArgs is the argument shape for the abi-hash verb.
 type AbiHashArgs struct {
@@ -207,6 +236,16 @@ type AnalyzeProjectArgs struct {
 	// ranking. Requires the dispatcher to record per-rule timings,
 	// which the tracker arms automatically when active.
 	PerfRules bool `json:"perf_rules,omitempty"`
+	// NoCache mirrors --no-cache: when true the daemon serves the
+	// request without consulting any on-disk cache (incremental
+	// AnalysisCache, parse cache, findings bundle, cross-file/
+	// findings/type-index disk shards) and without persisting back
+	// to those caches. Resident WorkspaceState slots stay live —
+	// they're per-process memory keyed on input fingerprints, so a
+	// no-cache call can reuse them safely without dirtying state for
+	// subsequent calls. This flag is per-call: the next analyze-
+	// project call without NoCache resumes normal cache behavior.
+	NoCache bool `json:"no_cache,omitempty"`
 }
 
 // AnalyzeProjectResult is the response payload. Findings is the raw


### PR DESCRIPTION
## Summary

Peels three cache-lifecycle flags off the daemon-incompatible list so the daemon can serve them without forcing in-process fallback. Continues the long-running effort to make daemon mode available for as many flags as possible.

## Routed through daemon

### \`--no-cache\` — added to \`AnalyzeProjectArgs\`

The daemon honours \`NoCache=true\` per-call by nil-ing every on-disk cache pointer for that single request:

- \`ParseCache\` set to nil
- \`AnalysisCache\` / \`AnalysisCacheFilePath\` / \`AnalysisCacheLookup\` skipped
- \`FindingsBundleStore\` / \`FindingsBundleCacheRoot\` / \`FindingsBundleManifest{Loader,Saver}\` skipped
- \`CrossFileCacheDir\` / \`CrossFindingsCacheDir\` / \`TypeIndexCacheDir\` set to ""

Resident \`WorkspaceState\` slots stay live. They're keyed on input fingerprints, so reuse is idempotent — a no-cache call CANNOT dirty them for subsequent calls. \`TestAnalyzeProject_NoCacheBypassesDiskCache\` pins this: warm → no-cache → warm produces identical findings, proving the resident slots aren't poisoned.

### \`--clear-cache\` — new \`clear-cache\` daemon verb

Mirrors in-process \`runClearCacheFlag\` semantics plus daemon-only resident invalidation:

1. \`cacheutil.ClearAll(ctx)\` — every registered cache cleared
2. \`cache.Clear(path)\` for every analysis cache file the daemon has loaded
3. Parse cache closed + sync.Once rearmed
4. \`WorkspaceState.InvalidateAll()\` — drops every resident cross-file / per-file slot
5. \`coldDone\` reset so the next analyze reports \`Cold=true\`
6. Manifest cache cleared

\`tryDaemonClearCache\` runs before \`tryDaemonDelegate\` in scan.go: if a daemon is reachable and \`--clear-cache\` is set, the daemon does the work and the CLI exits 0; otherwise the in-process \`runClearCacheFlag\` path runs as before. \`TestClearCache_DropsResidentAndDiskState\` pins both the disk-file removal and the \`Cold=true\` follow-up signal.

## Left in-process

### \`--clear-matrix-cache\`

The matrix-cache subsystem (\`internal/cli/scan/matrix_cache.go\`) auto-registers itself with \`cacheutil\` only when the \`scan\` package is linked. The standalone \`krit-daemon\` binary doesn't import \`scan\`, so there's no resident state for it to coordinate. The matrix cache also lives in \`~/.cache/krit/matrix-baseline\`, which is host-wide rather than per-repo — daemon coordination would not buy correctness.

## Test plan

- [x] \`go build ./...\`, \`go vet ./...\`, \`golangci-lint run ./...\` all clean
- [x] \`go test ./... -count=1\` — full suite passes
- [x] \`make lint-rules\` clean
- [x] New focused tests:
  - \`TestAnalyzeProject_NoCacheBypassesDiskCache\` — warm → no-cache → warm parity, no resident-cache poisoning
  - \`TestClearCache_DropsResidentAndDiskState\` — verb removes the analysis cache file and resets \`Cold\`
  - \`TestTryDaemonClearCache_*\` — gating, no-daemon fall-through, happy-path delegation
  - \`TestBuildDaemonAnalyzeArgs_ForwardsNoCache\` — flag wiring
  - Extended \`TestDaemonCompatibleFlags_PerfAllowed\` with \`--no-cache\`, \`--clear-cache\`, \`--clear-matrix-cache\` cases