### PR TITLE
fix(coroutines): tighten RedundantSuspendModifier scope handling

### DIFF
--- a/internal/rules/coroutines.go
+++ b/internal/rules/coroutines.go
@@ -399,6 +399,53 @@ var commonNonSuspendCallees = map[string]bool{
 	"String": true, "Int": true, "Long": true, "Float": true, "Double": true,
 }
 
+// walkCallsRespectingScope walks descendants of root, invoking fn on every
+// call_expression whose enclosing function scope is `root`. The walk stops
+// descending into nested function declarations, anonymous functions, classes,
+// objects, and object literals because their bodies define their own scopes
+// and any suspend calls inside them do not belong to the parent function.
+// Lambda literals are intentionally NOT excluded: lambdas passed to inline
+// functions (withContext, coroutineScope, runCatching, apply, let, also, ...)
+// execute in the enclosing suspend context, and without resolver-level
+// knowledge of inlineness we keep the conservative behavior of treating
+// lambdas as part of the parent scope.
+//
+// The callback returns true to keep walking and false to stop the entire walk.
+func walkCallsRespectingScope(file *scanner.File, root uint32, fn func(uint32) bool) {
+	if file == nil || file.FlatTree == nil || fn == nil {
+		return
+	}
+	stopped := false
+	var walk func(idx uint32)
+	walk = func(idx uint32) {
+		if stopped {
+			return
+		}
+		for child := file.FlatTree.Nodes[idx].FirstChild; child != 0; child = file.FlatTree.Nodes[child].NextSib {
+			if stopped {
+				return
+			}
+			ct := file.FlatType(child)
+			switch ct {
+			case "function_declaration",
+				"anonymous_function",
+				"class_declaration",
+				"object_declaration",
+				"object_literal":
+				// Skip: nested scope owns its own suspend context.
+				continue
+			case "call_expression":
+				if !fn(child) {
+					stopped = true
+					return
+				}
+			}
+			walk(child)
+		}
+	}
+	walk(root)
+}
+
 // SleepInsteadOfDelayRule detects Thread.sleep() usage inside suspend functions
 // and coroutine builder lambdas (launch, async, runBlocking, withContext, etc.).
 type SleepInsteadOfDelayRule struct {

--- a/internal/rules/registry_coroutines.go
+++ b/internal/rules/registry_coroutines.go
@@ -213,7 +213,10 @@ func registerCoroutinesRedundantSuspendModifier() {
 			}
 			if file.FlatHasModifier(idx, "open") ||
 				file.FlatHasModifier(idx, "abstract") ||
-				file.FlatHasModifier(idx, "override") {
+				file.FlatHasModifier(idx, "override") ||
+				file.FlatHasModifier(idx, "actual") ||
+				file.FlatHasModifier(idx, "expect") ||
+				file.FlatHasModifier(idx, "external") {
 				return
 			}
 			for p, ok := file.FlatParent(idx); ok; p, ok = file.FlatParent(p) {
@@ -233,28 +236,28 @@ func registerCoroutinesRedundantSuspendModifier() {
 			}
 			hasSuspendCall := false
 			hasUnresolvedCall := false
-			file.FlatWalkNodes(body, "call_expression", func(callIdx uint32) {
+			walkCallsRespectingScope(file, body, func(callIdx uint32) bool {
 				if hasSuspendCall {
-					return
+					return false
 				}
 				provenNonSuspend := false
 				if oracleLookup != nil {
 					if isSuspend, ok := oracleLookupCallTargetSuspendFlat(oracleLookup, file, callIdx); ok {
 						if isSuspend {
 							hasSuspendCall = true
-							return
+							return false
 						}
 						provenNonSuspend = true
 					}
 					if ct := oracleLookupCallTargetFlat(oracleLookup, file, callIdx); ct != "" {
 						if knownSuspendFQNs[ct] {
 							hasSuspendCall = true
-							return
+							return false
 						}
 						for _, prefix := range suspendFQNPrefixes {
 							if strings.HasPrefix(ct, prefix) {
 								hasSuspendCall = true
-								return
+								return false
 							}
 						}
 					}
@@ -265,7 +268,7 @@ func registerCoroutinesRedundantSuspendModifier() {
 						strings.HasPrefix(callText, name+"{") || strings.HasPrefix(callText, name+"<") ||
 						strings.Contains(callText, "."+name+"(") {
 						hasSuspendCall = true
-						return
+						return false
 					}
 				}
 				if ctx.Resolver != nil {
@@ -274,7 +277,7 @@ func registerCoroutinesRedundantSuspendModifier() {
 						callName := resolvedType.Name
 						if callName != "" && knownSuspendFunctions[callName] {
 							hasSuspendCall = true
-							return
+							return false
 						}
 					}
 					funcIdent, _ := file.FlatFindChild(callIdx, "simple_identifier")
@@ -284,7 +287,7 @@ func registerCoroutinesRedundantSuspendModifier() {
 						if resolvedByName != nil && resolvedByName.Kind != typeinfer.TypeUnknown {
 							if strings.Contains(resolvedByName.FQN, "kotlinx.coroutines") {
 								hasSuspendCall = true
-								return
+								return false
 							}
 						}
 					}
@@ -304,6 +307,7 @@ func registerCoroutinesRedundantSuspendModifier() {
 						}
 					}
 				}
+				return true
 			})
 			if !hasSuspendCall && hasUnresolvedCall {
 				return

--- a/tests/fixtures/negative/coroutines/RedundantSuspendModifier.kt
+++ b/tests/fixtures/negative/coroutines/RedundantSuspendModifier.kt
@@ -43,3 +43,45 @@ suspend fun loadProduct(api: BillingApi, id: String) {
     val product = api.queryProduct(id)
     println(product)
 }
+
+// actual / expect functions are part of a multiplatform contract; their
+// modifier is locked by the declaration on the other side and must not be
+// reported as redundant even when the body lacks suspend calls.
+actual suspend fun actualPlatformContract() {
+    println("platform impl with no suspend calls in this body")
+}
+
+expect suspend fun expectPlatformContract()
+
+// external suspend declarations have no body we can inspect.
+external suspend fun externalDeclaration()
+
+// Lambda passed to an inline builder must still count: withContext is the
+// most common case and its lambda body's delay() proves the outer modifier
+// is necessary even though our walk also catches withContext itself.
+suspend fun lambdaInsideInlineBuilder() {
+    kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.IO) {
+        delay(50)
+    }
+}
+
+// runCatching is a non-coroutine inline builder. Its lambda runs in the
+// enclosing suspend context, so a delay() inside it justifies the modifier.
+suspend fun lambdaInsideRunCatching() {
+    runCatching {
+        delay(10)
+    }
+}
+
+// Suspend calls inside `apply`/`let`/`also`/`run` lambdas execute in the
+// enclosing suspend context too.
+class Repo {
+    var count: Int = 0
+}
+
+suspend fun lambdaInsideApply(repo: Repo) {
+    repo.apply {
+        delay(1)
+        count++
+    }
+}

--- a/tests/fixtures/positive/coroutines/RedundantSuspendModifier.kt
+++ b/tests/fixtures/positive/coroutines/RedundantSuspendModifier.kt
@@ -1,5 +1,7 @@
 package fixtures.positive.coroutines
 
+import kotlinx.coroutines.delay
+
 suspend fun simple() {
     println("no suspend calls here")
 }
@@ -8,4 +10,34 @@ fun helper() = Unit
 
 suspend fun onlyProjectNonSuspendCalls() {
     helper()
+}
+
+// Nested suspend fun owns its own scope. The outer body itself has no
+// suspend calls, so the outer modifier is redundant even though the inner
+// function calls delay.
+suspend fun nestedSuspendOwnsItsScope() {
+    suspend fun inner() {
+        delay(1)
+    }
+    println("outer has nothing suspending")
+}
+
+// Anonymous function with a suspend body should not lend its calls to the
+// parent: parent body has no suspending work of its own.
+suspend fun anonymousFunctionScopeLeak() {
+    val produce: suspend () -> Unit = suspend fun() {
+        delay(1)
+    }
+    println(produce)
+}
+
+// Nested object literal with a member that calls suspend APIs should not
+// affect the outer modifier.
+suspend fun nestedObjectScopeLeak() {
+    val box = object {
+        suspend fun work() {
+            delay(1)
+        }
+    }
+    println(box)
 }


### PR DESCRIPTION
## Summary

- Skip nested function/anonymous-function/class/object/object-literal bodies when scanning a suspend function for suspend calls, so suspend work that lives in a nested scope no longer keeps the outer modifier from being flagged.
- Treat `actual`, `expect`, and `external` declarations like `open`/`abstract`/`override`: their modifier is contract-locked and must not be reported even when the local body has no suspend calls.
- Extract `walkCallsRespectingScope` in `internal/rules/coroutines.go` with an explicit early-exit return value, replacing the unbounded `FlatWalkNodes` traversal that ignored scope boundaries.
- Lambda literals (`apply`, `let`, `withContext`, `runCatching`, ...) intentionally still count toward the outer scope to stay conservative without resolver-level inlineness facts.
- New positive fixtures cover nested suspend fun, anonymous-function, and object-literal scope leaks. New negative fixtures cover actual/expect/external contracts and lambdas inside inline builders.

## Test plan

- [x] `go build -o krit ./cmd/krit/`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...` (0 issues)
- [x] `go test ./internal/rules/ -run 'RedundantSuspend|TestPositive|TestNegative' -count=1`
- [x] `make lint-rules`