### PR TITLE
perf(rules): drop KAA from LogConditional, tighten receiver proof

### DIFF
--- a/internal/rules/android_base_test.go
+++ b/internal/rules/android_base_test.go
@@ -1,8 +1,12 @@
 package rules_test
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/kaeawc/krit/internal/scanner"
 )
 
 // --- ContentDescriptionRule ---
@@ -82,6 +86,7 @@ fun MyScreen() {
 func TestLogConditional_Positive(t *testing.T) {
 	findings := runRuleByName(t, "LogConditional", `
 package test
+import android.util.Log
 fun doWork() {
     Log.d("TAG", "doing work")
 }`)
@@ -93,6 +98,7 @@ fun doWork() {
 func TestLogConditional_Negative(t *testing.T) {
 	findings := runRuleByName(t, "LogConditional", `
 package test
+import android.util.Log
 fun doWork() {
     if (Log.isLoggable("TAG", Log.DEBUG)) {
         Log.d("TAG", "doing work")
@@ -100,6 +106,104 @@ fun doWork() {
 }`)
 	if len(findings) != 0 {
 		t.Errorf("expected no findings, got %d", len(findings))
+	}
+}
+
+func TestLogConditional_NegativeBuildConfigDebugGuard(t *testing.T) {
+	findings := runRuleByName(t, "LogConditional", `
+package test
+import android.util.Log
+fun doWork() {
+    if (BuildConfig.DEBUG) {
+        Log.d("TAG", "doing work")
+    }
+}`)
+	if len(findings) != 0 {
+		t.Errorf("expected no findings inside BuildConfig.DEBUG guard, got %d", len(findings))
+	}
+}
+
+func TestLogConditional_NegativeTimberLog(t *testing.T) {
+	// timber.log.Log lookalike (same simple name "Log", different FQN);
+	// must not be misclassified as android.util.Log.
+	findings := runRuleByName(t, "LogConditional", `
+package test
+import timber.log.Log
+fun doWork() {
+    Log.d("TAG", "timber call")
+}`)
+	if len(findings) != 0 {
+		t.Errorf("expected no findings for timber.log.Log, got %d", len(findings))
+	}
+}
+
+func TestLogConditional_NegativeSlf4jLogger(t *testing.T) {
+	findings := runRuleByName(t, "LogConditional", `
+package test
+import org.slf4j.LoggerFactory
+private val log = LoggerFactory.getLogger("X")
+fun doWork() {
+    log.debug("hello")
+}`)
+	if len(findings) != 0 {
+		t.Errorf("expected no findings for slf4j logger, got %d", len(findings))
+	}
+}
+
+func TestLogConditional_NegativeKotlinLoggingKLogger(t *testing.T) {
+	findings := runRuleByName(t, "LogConditional", `
+package test
+import mu.KotlinLogging
+private val logger = KotlinLogging.logger {}
+fun doWork() {
+    logger.debug { "hello" }
+}`)
+	if len(findings) != 0 {
+		t.Errorf("expected no findings for kotlin-logging KLogger, got %d", len(findings))
+	}
+}
+
+func TestLogConditional_NegativeLocalLogClassLookalike(t *testing.T) {
+	// A same-file `class Log` lookalike must not be misclassified as
+	// android.util.Log even when the receiver name matches.
+	findings := runRuleByName(t, "LogConditional", `
+package test
+class Log {
+    fun d(tag: String, msg: String) {}
+}
+fun doWork() {
+    val Log = Log()
+    Log.d("TAG", "lookalike")
+}`)
+	if len(findings) != 0 {
+		t.Errorf("expected no findings for local Log lookalike, got %d", len(findings))
+	}
+}
+
+func TestLogConditional_NegativeTestSource(t *testing.T) {
+	t.Helper()
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "src", "test", "java", "com", "example", "MyTest.kt")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	code := `package test
+import android.util.Log
+class MyTest {
+    fun runs() {
+        Log.d("TAG", "from test")
+    }
+}`
+	if err := os.WriteFile(path, []byte(code), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	file, err := scanner.ParseFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	findings := runRuleByNameOnFile(t, "LogConditional", file)
+	if len(findings) != 0 {
+		t.Errorf("expected no findings in test source path, got %d", len(findings))
 	}
 }
 

--- a/internal/rules/registry_android_rules.go
+++ b/internal/rules/registry_android_rules.go
@@ -137,12 +137,16 @@ func registerAndroidRules() {
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Description(), Sev: api.Severity(r.Sev),
 			NodeTypes:  []string{"call_expression"},
-			Needs:      api.NeedsTypeInfo | api.NeedsOracleCallTargets,
+			Needs:      api.NeedsTypeInfo,
 			Confidence: 0.75, Implementation: r,
-			OracleCallTargets:      &api.OracleCallTargetFilter{CalleeNames: []string{"v", "d", "i", "println", "isLoggable"}},
-			OracleDeclarationNeeds: &api.OracleDeclarationProfile{},
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
+				// Test sources frequently log without guards on purpose
+				// (debugging assertion failures, JUnit/Robolectric output).
+				// Skip them to match user expectations and AOSP lint behavior.
+				if scanner.IsTestFile(file.Path) {
+					return
+				}
 				if !logCallIsAndroidLog(ctx, idx) {
 					return
 				}
@@ -150,7 +154,7 @@ func registerAndroidRules() {
 					return
 				}
 				ctx.EmitAt(file.FlatRow(idx)+1, 1,
-					"Unconditional logging call. Wrap in Log.isLoggable() for performance.")
+					"Unconditional logging call. Wrap in Log.isLoggable() or BuildConfig.DEBUG for performance.")
 			},
 		})
 	}

--- a/internal/rules/semantic_rule_helpers.go
+++ b/internal/rules/semantic_rule_helpers.go
@@ -371,41 +371,127 @@ func logCallIsAndroidLog(ctx *api.Context, call uint32) bool {
 		return semanticTargetOwnerMatches(target.QualifiedName, "android.util.Log")
 	}
 	receiver := flatReceiverNameFromCall(ctx.File, call)
-	if receiver != "Log" && receiver != "android.util.Log" {
-		return false
-	}
-	if ctx.Resolver != nil {
-		if fqn := ctx.Resolver.ResolveImport("Log", ctx.File); fqn != "" {
-			return fqn == "android.util.Log"
+	switch receiver {
+	case "Log":
+		// Require an import of `android.util.Log` so Timber.Log,
+		// slf4j Logger aliases, kotlin-logging KLogger, and same-file
+		// `class Log` lookalikes are not misclassified as
+		// android.util.Log. The resolver already shadows imports with
+		// same-file declarations of the simple name; the filefacts
+		// fallback still rejects when the file imports anything other
+		// than android.util.Log under the simple name `Log`.
+		if ctx.Resolver != nil {
+			return ctx.Resolver.ResolveImport("Log", ctx.File) == "android.util.Log"
 		}
+		return fileImportsFQN(ctx.File, "android.util.Log") &&
+			!fileDeclaresSimpleTypeNameLocal(ctx.File, "Log")
+	case "android.util.Log":
+		return true
+	default:
 		return false
 	}
-	return receiver == "Log" || receiver == "android.util.Log"
 }
 
+// fileDeclaresSimpleTypeNameLocal reports whether `file` declares a
+// top-level class / interface / object / type alias whose simple name is
+// `name`. Used to reject same-file lookalikes (e.g. a local `class Log`)
+// when the resolver is unavailable.
+func fileDeclaresSimpleTypeNameLocal(file *scanner.File, name string) bool {
+	if file == nil || name == "" {
+		return false
+	}
+	found := false
+	for _, kind := range []string{"class_declaration", "object_declaration", "type_alias", "interface_declaration"} {
+		file.FlatWalkNodes(0, kind, func(decl uint32) {
+			if found {
+				return
+			}
+			if semantics.DeclarationName(file, decl) == name {
+				found = true
+			}
+		})
+		if found {
+			return true
+		}
+	}
+	return false
+}
+
+// hasAndroidLogGuardFlat reports whether `call` is wrapped in a debug-only
+// guard recognized by AOSP Android lint: either
+//   - `if (Log.isLoggable(...))`, or
+//   - `if (BuildConfig.DEBUG)`
+//
+// The walk stops at the nearest scope boundary (function/class/lambda) so an
+// `isLoggable` guard inside a sibling block does not satisfy this call.
 func hasAndroidLogGuardFlat(ctx *api.Context, call uint32) bool {
 	file := ctx.File
 	for p, ok := file.FlatParent(call); ok; p, ok = file.FlatParent(p) {
 		switch file.FlatType(p) {
 		case "if_expression":
+			condition, _ := ifConditionAndThenBodyFlat(file, p)
+			if condition != 0 && conditionIsBuildConfigDebugFlat(file, condition) {
+				return true
+			}
 			found := false
 			file.FlatWalkNodes(p, "call_expression", func(c uint32) {
 				if found || c == call || flatCallExpressionName(file, c) != "isLoggable" {
 					return
 				}
-				if semanticResolvedTargetMatches(ctx, c, "android.util.Log.isLoggable") ||
-					(flatReceiverNameFromCall(file, c) == "Log" && (ctx.Resolver == nil || ctx.Resolver.ResolveImport("Log", file) == "android.util.Log")) {
+				if semanticResolvedTargetMatches(ctx, c, "android.util.Log.isLoggable") {
+					found = true
+					return
+				}
+				if flatReceiverNameFromCall(file, c) != "Log" {
+					return
+				}
+				if ctx.Resolver != nil {
+					if ctx.Resolver.ResolveImport("Log", file) == "android.util.Log" {
+						found = true
+					}
+					return
+				}
+				// Resolver missing: accept the guard only when the
+				// file actually imports android.util.Log and does
+				// not declare a same-file `Log` lookalike.
+				if fileImportsFQN(file, "android.util.Log") &&
+					!fileDeclaresSimpleTypeNameLocal(file, "Log") {
 					found = true
 				}
 			})
 			if found {
 				return true
 			}
-		case "function_declaration", "class_declaration", "lambda_literal", "source_file":
+		case "function_declaration", "method_declaration",
+			"class_declaration", "object_declaration",
+			"lambda_literal", "anonymous_function",
+			"source_file":
 			return false
 		}
 	}
 	return false
+}
+
+// conditionIsBuildConfigDebugFlat reports whether `cond` is a non-negated
+// BuildConfig.DEBUG reference (optionally parenthesized). The release-
+// engineering BuildConfigDebugInverted rule handles the negated form
+// separately; here we only treat the positive guard as a no-fire signal.
+func conditionIsBuildConfigDebugFlat(file *scanner.File, cond uint32) bool {
+	if file == nil || cond == 0 {
+		return false
+	}
+	text := strings.TrimSpace(file.FlatNodeText(cond))
+	for strings.HasPrefix(text, "(") && strings.HasSuffix(text, ")") {
+		inner := strings.TrimSpace(text[1 : len(text)-1])
+		if inner == text {
+			break
+		}
+		text = inner
+	}
+	if strings.HasPrefix(text, "!") {
+		return false
+	}
+	return text == "BuildConfig.DEBUG" || strings.HasSuffix(text, ".BuildConfig.DEBUG")
 }
 
 func wakeLockAcquireCall(ctx *api.Context, call uint32) bool {


### PR DESCRIPTION
## Summary
- Drop `NeedsOracleCallTargets` / `OracleDeclarationNeeds` from `LogConditional` so the rule runs entirely off source-level type info, eliminating its KAA workload.
- Accept `if (BuildConfig.DEBUG)` (non-negated, paren-stripped) as a valid guard alongside `Log.isLoggable(...)`, matching AOSP lint behavior.
- Tighten receiver proof for the simple name `Log`: require an `android.util.Log` import (resolver-first, filefacts fallback) and reject same-file `class Log` / `object Log` / `interface Log` / `typealias Log` lookalikes via a new `fileDeclaresSimpleTypeNameLocal` helper.
- Extend the scope-walk in `hasAndroidLogGuardFlat` to stop at `method_declaration`, `object_declaration`, and `anonymous_function` so sibling-scope guards no longer leak through.
- Skip test sources (`scanner.IsTestFile`) where unguarded logging is idiomatic, and add negative regression tests for `BuildConfig.DEBUG`, `timber.log.Log`, slf4j `Logger`, kotlin-logging `KLogger`, same-file `class Log` lookalikes, and `src/test/` paths.

## Test plan
- [x] `go build -o krit ./cmd/krit/`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...`
- [x] `go test ./... -count=1`
- [x] `make lint-rules`