### PR TITLE
perf(coroutines): drop KAA from WithContextInSuspendFunctionNoop

### DIFF
--- a/internal/rules/coroutines.go
+++ b/internal/rules/coroutines.go
@@ -1096,6 +1096,174 @@ func extractWithContextDispatcher(ctx *api.Context, callIdx uint32) string {
 	return ""
 }
 
+// withContextCallResolves returns true when a bare `withContext(...)` call in
+// `file` can be attributed to `kotlinx.coroutines.withContext`. The rule must
+// stay quiet when the file has no kotlinx.coroutines.withContext import (or
+// wildcard) or when a top-level/local function named `withContext` shadows the
+// stdlib symbol.
+func withContextCallResolves(file *scanner.File, callIdx uint32) bool {
+	if file == nil {
+		return false
+	}
+	if !fileImportsFQN(file, "kotlinx.coroutines.withContext") {
+		return false
+	}
+	if fileDeclaresFunctionNamed(file, "withContext") {
+		return false
+	}
+	// Reject member calls like `scope.withContext(...)` — only the bare
+	// identifier form resolves to the stdlib `kotlinx.coroutines.withContext`.
+	// Handle both the direct call (`withContext(d) {}`) and the trailing-
+	// lambda outer call shape (outer call_expression whose first child is the
+	// inner `withContext(d)` call_expression).
+	target := callIdx
+	if file.FlatType(target) == "call_expression" {
+		navExpr, args := flatCallExpressionParts(file, target)
+		if navExpr == 0 && args == 0 {
+			// Possibly the outer trailing-lambda wrapper; descend into the
+			// first nested call_expression child.
+			for child := file.FlatFirstChild(target); child != 0; child = file.FlatNextSib(child) {
+				if file.FlatType(child) == "call_expression" {
+					target = child
+					navExpr, _ = flatCallExpressionParts(file, target)
+					break
+				}
+			}
+		}
+		if navExpr != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// fileDeclaresFunctionNamed reports whether the file contains a
+// function_declaration named `name` anywhere (top-level, inside a class, or
+// nested). This is intentionally broad: any such shadow makes the bare
+// `withContext` reference ambiguous, so the rule refuses to fire.
+func fileDeclaresFunctionNamed(file *scanner.File, name string) bool {
+	if file == nil || name == "" {
+		return false
+	}
+	found := false
+	file.FlatWalkAllNodes(0, func(idx uint32) {
+		if found {
+			return
+		}
+		if file.FlatType(idx) != "function_declaration" {
+			return
+		}
+		if extractIdentifierFlat(file, idx) == name {
+			found = true
+		}
+	})
+	return found
+}
+
+// withContextSameScopeAncestor walks ancestors of `inner` looking for an
+// enclosing `withContext(dispatcher)` call. It stops at scope boundaries that
+// invalidate the comparison: function/class/object declarations and lambdas
+// whose owning call is NOT another `withContext` (e.g. `launch`, `async`,
+// `runBlocking`, `flow`, `coroutineScope`, `supervisorScope` — those create a
+// new coroutine context where re-stating the dispatcher is meaningful).
+//
+// The returned dispatcher is the outer parent's dispatcher string, or "" if no
+// matching ancestor was found within the same scope.
+func withContextSameScopeAncestor(ctx *api.Context, inner uint32, innerDispatcher string) string {
+	file := ctx.File
+	if file == nil {
+		return ""
+	}
+	for p, ok := file.FlatParent(inner); ok; p, ok = file.FlatParent(p) {
+		switch file.FlatType(p) {
+		case "function_declaration", "anonymous_function",
+			"class_declaration", "object_declaration",
+			"anonymous_initializer":
+			return ""
+		case "lambda_literal":
+			// Crossing a lambda is fine ONLY when the lambda is the trailing
+			// lambda of a `withContext(sameDispatcher)` call. Otherwise the
+			// lambda belongs to a launch/async/coroutineScope/flow/etc. — a
+			// separate coroutine context where re-stating the dispatcher is
+			// meaningful, not a no-op.
+			ownerCall := lambdaOwnerCall(file, p)
+			if ownerCall == 0 {
+				return ""
+			}
+			if flatCallNameAny(file, ownerCall) != "withContext" {
+				return ""
+			}
+			if !withContextCallResolves(file, lambdaOwnerInnerCall(file, ownerCall)) {
+				return ""
+			}
+			ownerDispatcher := extractWithContextDispatcher(ctx, ownerCall)
+			if ownerDispatcher == "" {
+				return ""
+			}
+			// Found the enclosing withContext via its trailing lambda. If the
+			// dispatchers match, that's the redundant nesting we want to
+			// flag. If not, the enclosing context is different, so the inner
+			// switch is intentional.
+			if ownerDispatcher == innerDispatcher {
+				return ownerDispatcher
+			}
+			return ""
+		case "call_expression":
+			// A call_expression on the path (e.g. the trailing-lambda outer
+			// wrapper of the inner call itself) is harmless; the lambda case
+			// above is what actually proves real enclosure.
+			continue
+		}
+	}
+	return ""
+}
+
+// lambdaOwnerCall returns the call_expression whose trailing lambda is the
+// given lambda_literal idx, or 0 when the lambda is not a trailing lambda of
+// a call. Handles both `name { body }` (lambda is a child of `call_suffix`)
+// and `name(args) { body }` (lambda is on the outer call's call_suffix while
+// the args live on a nested inner call_expression).
+func lambdaOwnerCall(file *scanner.File, lambda uint32) uint32 {
+	if file == nil || lambda == 0 {
+		return 0
+	}
+	p, ok := file.FlatParent(lambda)
+	if !ok {
+		return 0
+	}
+	// lambda_literal may be wrapped in annotated_lambda.
+	if file.FlatType(p) == "annotated_lambda" {
+		p, ok = file.FlatParent(p)
+		if !ok {
+			return 0
+		}
+	}
+	if file.FlatType(p) != "call_suffix" {
+		return 0
+	}
+	owner, ok := file.FlatParent(p)
+	if !ok || file.FlatType(owner) != "call_expression" {
+		return 0
+	}
+	return owner
+}
+
+// lambdaOwnerInnerCall returns the inner call_expression that carries
+// `withContext(args)` when the outer trailing-lambda call wraps it; otherwise
+// returns the outer call itself. This is the node `withContextCallResolves`
+// expects (must point at the bare-identifier call).
+func lambdaOwnerInnerCall(file *scanner.File, outer uint32) uint32 {
+	if file == nil || outer == 0 {
+		return 0
+	}
+	for child := file.FlatFirstChild(outer); child != 0; child = file.FlatNextSib(child) {
+		if file.FlatType(child) == "call_expression" {
+			return child
+		}
+	}
+	return outer
+}
+
 // LaunchWithoutCoroutineExceptionHandlerRule detects launch{} with throw but no handler.
 type LaunchWithoutCoroutineExceptionHandlerRule struct {
 	FlatDispatchBase

--- a/internal/rules/coroutines_test.go
+++ b/internal/rules/coroutines_test.go
@@ -1543,6 +1543,197 @@ suspend fun loadData() {
 	}
 }
 
+// --- WithContextInSuspendFunctionNoop regression tests ---
+
+// Different dispatchers — inner switch is meaningful.
+func TestWithContextInSuspendFunctionNoop_NegativeDifferentDispatchers(t *testing.T) {
+	findings := runRuleByName(t, "WithContextInSuspendFunctionNoop", `
+package test
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+suspend fun loadData() {
+    withContext(Dispatchers.IO) {
+        withContext(Dispatchers.Main) {
+            updateUi()
+        }
+    }
+}
+`)
+	if len(findings) != 0 {
+		t.Errorf("expected no findings, got %d", len(findings))
+	}
+}
+
+// Injected dispatcher variable — cannot prove symbolic equality, must stay quiet.
+func TestWithContextInSuspendFunctionNoop_NegativeInjectedDispatcher(t *testing.T) {
+	findings := runRuleByName(t, "WithContextInSuspendFunctionNoop", `
+package test
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+class Repo(private val io: CoroutineDispatcher) {
+    suspend fun loadData() {
+        withContext(io) {
+            withContext(Dispatchers.IO) {
+                fetch()
+            }
+        }
+    }
+}
+`)
+	if len(findings) != 0 {
+		t.Errorf("expected no findings, got %d", len(findings))
+	}
+}
+
+// Local function named withContext shadows kotlinx.coroutines.withContext.
+func TestWithContextInSuspendFunctionNoop_NegativeLocalShadow(t *testing.T) {
+	findings := runRuleByName(t, "WithContextInSuspendFunctionNoop", `
+package test
+import kotlinx.coroutines.Dispatchers
+suspend fun withContext(d: Any, block: suspend () -> Unit) { block() }
+suspend fun loadData() {
+    withContext(Dispatchers.IO) {
+        withContext(Dispatchers.IO) {
+            fetch()
+        }
+    }
+}
+`)
+	if len(findings) != 0 {
+		t.Errorf("expected no findings, got %d", len(findings))
+	}
+}
+
+// Missing kotlinx.coroutines.withContext import — bare call could be anything.
+func TestWithContextInSuspendFunctionNoop_NegativeMissingImport(t *testing.T) {
+	findings := runRuleByName(t, "WithContextInSuspendFunctionNoop", `
+package test
+import kotlinx.coroutines.Dispatchers
+suspend fun loadData() {
+    withContext(Dispatchers.IO) {
+        withContext(Dispatchers.IO) {
+            fetch()
+        }
+    }
+}
+`)
+	if len(findings) != 0 {
+		t.Errorf("expected no findings, got %d", len(findings))
+	}
+}
+
+// Intervening launch — different coroutine context, no redundancy.
+func TestWithContextInSuspendFunctionNoop_NegativeInterveningLaunch(t *testing.T) {
+	findings := runRuleByName(t, "WithContextInSuspendFunctionNoop", `
+package test
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+suspend fun loadData(scope: CoroutineScope) {
+    withContext(Dispatchers.IO) {
+        scope.launch {
+            withContext(Dispatchers.IO) {
+                fetch()
+            }
+        }
+    }
+}
+`)
+	if len(findings) != 0 {
+		t.Errorf("expected no findings, got %d", len(findings))
+	}
+}
+
+// Intervening coroutineScope { ... } — child coroutine builder, not a withContext;
+// don't bleed comparison through it.
+func TestWithContextInSuspendFunctionNoop_NegativeInterveningCoroutineScope(t *testing.T) {
+	findings := runRuleByName(t, "WithContextInSuspendFunctionNoop", `
+package test
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.withContext
+suspend fun loadData() {
+    withContext(Dispatchers.IO) {
+        coroutineScope {
+            withContext(Dispatchers.IO) {
+                fetch()
+            }
+        }
+    }
+}
+`)
+	if len(findings) != 0 {
+		t.Errorf("expected no findings, got %d", len(findings))
+	}
+}
+
+// Nested local function declaration boundary — inner withContext is in a
+// separate function body, do not compare against outer suspend function.
+func TestWithContextInSuspendFunctionNoop_NegativeNestedFunction(t *testing.T) {
+	findings := runRuleByName(t, "WithContextInSuspendFunctionNoop", `
+package test
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+suspend fun loadData() {
+    withContext(Dispatchers.IO) {
+        suspend fun helper() {
+            withContext(Dispatchers.IO) {
+                fetch()
+            }
+        }
+        helper()
+    }
+}
+`)
+	if len(findings) != 0 {
+		t.Errorf("expected no findings, got %d", len(findings))
+	}
+}
+
+// Comment containing the words "withContext" must not match anything; AST-based
+// dispatch already enforces this but lock the regression.
+func TestWithContextInSuspendFunctionNoop_NegativeCommentLookalike(t *testing.T) {
+	findings := runRuleByName(t, "WithContextInSuspendFunctionNoop", `
+package test
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+suspend fun loadData() {
+    // withContext(Dispatchers.IO) { withContext(Dispatchers.IO) { } }
+    val msg = "withContext(Dispatchers.IO) inside withContext(Dispatchers.IO)"
+    withContext(Dispatchers.IO) {
+        println(msg)
+    }
+}
+`)
+	if len(findings) != 0 {
+		t.Errorf("expected no findings, got %d", len(findings))
+	}
+}
+
+// Capability declaration must stay narrow: this rule does not need oracle or
+// type info.
+func TestWithContextInSuspendFunctionNoop_StaysASTOnly(t *testing.T) {
+	var rule *api.Rule
+	for _, r := range api.Registry {
+		if r.ID == "WithContextInSuspendFunctionNoop" {
+			rule = r
+			break
+		}
+	}
+	if rule == nil {
+		t.Fatal("WithContextInSuspendFunctionNoop not registered")
+	}
+	if rule.Needs != 0 {
+		t.Fatalf("WithContextInSuspendFunctionNoop Needs=%v, want 0 (AST + imports only)", rule.Needs)
+	}
+	if rule.OracleCallTargets != nil || rule.OracleDeclarationNeeds != nil || rule.Oracle != nil {
+		t.Fatalf("WithContextInSuspendFunctionNoop unexpectedly carries oracle metadata: %+v %+v %+v",
+			rule.Oracle, rule.OracleCallTargets, rule.OracleDeclarationNeeds)
+	}
+}
+
 // --- LaunchWithoutCoroutineExceptionHandler ---
 
 func TestLaunchWithoutCoroutineExceptionHandler_Positive(t *testing.T) {

--- a/internal/rules/language_support_lint_test.go
+++ b/internal/rules/language_support_lint_test.go
@@ -162,6 +162,5 @@ var grandfatheredTypeInfoRulesWithoutExplicitJavaSupport = map[string]bool{
 	"ViewHolder":                                     true,
 	"ViewTag":                                        true,
 	"Wakelock":                                       true,
-	"WithContextInSuspendFunctionNoop":               true,
 	"WrongConstant":                                  true,
 }

--- a/internal/rules/registry_coroutines.go
+++ b/internal/rules/registry_coroutines.go
@@ -1060,46 +1060,37 @@ func registerCoroutinesSupervisorScopeInEventHandler() {
 
 func registerCoroutinesWithContextInSuspendFunctionNoop() {
 	r := &WithContextInSuspendFunctionNoopRule{BaseRule: BaseRule{RuleName: "WithContextInSuspendFunctionNoop", RuleSetName: "coroutines", Sev: "info", Desc: "Detects nested withContext calls using the same dispatcher as the parent, which is redundant."}}
+	// Capability narrowing: this rule was previously declared
+	// NeedsTypeInfo|NeedsOracleCallTargets with an OracleCallTargetFilter for
+	// `withContext`. The actual check is entirely source-visible — it relies
+	// on the kotlinx.coroutines.withContext import (or wildcard), absence of
+	// a local function shadowing the name, the bare-identifier call shape,
+	// and a navigation-chain match for Dispatchers.X. No KAA/type-info fact
+	// is required, so the rule now declares zero capabilities.
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
 		NodeTypes:  []string{"call_expression"},
-		Needs:      api.NeedsTypeInfo | api.NeedsOracleCallTargets,
+		Languages:  []scanner.Language{scanner.LangKotlin},
 		Confidence: 0.75, Implementation: r,
-		OracleCallTargets:      &api.OracleCallTargetFilter{CalleeNames: []string{"withContext"}},
-		OracleDeclarationNeeds: &api.OracleDeclarationProfile{},
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			if flatCallExpressionName(file, idx) != "withContext" {
+				return
+			}
+			// The inner call must resolve to kotlinx.coroutines.withContext.
+			if !withContextCallResolves(file, idx) {
 				return
 			}
 			dispatcher := extractWithContextDispatcher(ctx, idx)
 			if dispatcher == "" {
 				return
 			}
-			skippedSelf := false
-			for p, ok := file.FlatParent(idx); ok; p, ok = file.FlatParent(p) {
-				if file.FlatType(p) == "function_declaration" {
-					break
-				}
-				if file.FlatType(p) != "call_expression" {
-					continue
-				}
-				if !skippedSelf && flatCallNameAny(file, p) == "withContext" {
-					pd := extractWithContextDispatcher(ctx, p)
-					if pd == dispatcher {
-						skippedSelf = true
-						continue
-					}
-				}
-				if flatCallNameAny(file, p) == "withContext" {
-					parentDispatcher := extractWithContextDispatcher(ctx, p)
-					if parentDispatcher == dispatcher {
-						ctx.EmitAt(file.FlatRow(idx)+1, file.FlatCol(idx)+1,
-							fmt.Sprintf("Redundant nested withContext(%s). The parent already switches to this dispatcher.", dispatcher))
-						return
-					}
-				}
+			parentDispatcher := withContextSameScopeAncestor(ctx, idx, dispatcher)
+			if parentDispatcher == "" || parentDispatcher != dispatcher {
+				return
 			}
+			ctx.EmitAt(file.FlatRow(idx)+1, file.FlatCol(idx)+1,
+				fmt.Sprintf("Redundant nested withContext(%s). The parent already switches to this dispatcher.", dispatcher))
 		},
 	})
 }

--- a/tests/fixtures/negative/coroutines/WithContextInSuspendFunctionNoop.kt
+++ b/tests/fixtures/negative/coroutines/WithContextInSuspendFunctionNoop.kt
@@ -1,12 +1,81 @@
 package test
 
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
-suspend fun loadData() {
+// Single withContext: no nesting.
+suspend fun loadOnce() {
     withContext(Dispatchers.IO) {
         fetch()
     }
 }
 
+// Inner uses a different dispatcher than the outer.
+suspend fun loadThenUi() {
+    withContext(Dispatchers.IO) {
+        withContext(Dispatchers.Main) {
+            updateUi()
+        }
+    }
+}
+
+// Injected/variable dispatcher: rule cannot prove symbolic equality.
+class Repo(private val io: CoroutineDispatcher) {
+    suspend fun load() {
+        withContext(io) {
+            withContext(Dispatchers.IO) {
+                fetch()
+            }
+        }
+    }
+}
+
+// Intervening coroutine builder (launch/coroutineScope) creates a new
+// context — re-stating the dispatcher is intentional, not a no-op.
+suspend fun loadInLaunch(scope: CoroutineScope) {
+    withContext(Dispatchers.IO) {
+        scope.launch {
+            withContext(Dispatchers.IO) {
+                fetch()
+            }
+        }
+    }
+}
+
+suspend fun loadInScope() {
+    withContext(Dispatchers.IO) {
+        coroutineScope {
+            withContext(Dispatchers.IO) {
+                fetch()
+            }
+        }
+    }
+}
+
+// Nested local function declaration is a fresh scope boundary.
+suspend fun loadViaHelper() {
+    withContext(Dispatchers.IO) {
+        suspend fun helper() {
+            withContext(Dispatchers.IO) {
+                fetch()
+            }
+        }
+        helper()
+    }
+}
+
+// Comments and strings that look like withContext must not fire.
+suspend fun lookalikes() {
+    // withContext(Dispatchers.IO) { withContext(Dispatchers.IO) { } }
+    val msg = "withContext(Dispatchers.IO) inside withContext(Dispatchers.IO)"
+    withContext(Dispatchers.IO) {
+        println(msg)
+    }
+}
+
+fun updateUi() {}
 suspend fun fetch() {}


### PR DESCRIPTION
## Summary

- Removes `NeedsTypeInfo | NeedsOracleCallTargets` (and oracle metadata) from `WithContextInSuspendFunctionNoop`; the rule now declares zero capabilities and runs purely on AST + imports.
- Replaces the old call-ancestor scan with a lambda-scoped walk (`withContextSameScopeAncestor`): redundant nesting is only flagged when the inner call is reached through the trailing lambda of another `withContext(sameDispatcher)` — any intervening `launch` / `coroutineScope` / nested function declaration / lambda terminates the comparison.
- Proves the inner call resolves to `kotlinx.coroutines.withContext` via `withContextCallResolves`: requires the kotlinx import, no local function shadow, and the bare-identifier call shape (rejects `scope.withContext(...)`).
- Expanded negatives (positive/negative fixtures + 8 new regression tests): different dispatchers, injected dispatcher variable, local-shadow function, missing import, intervening `launch`/`coroutineScope`, nested local function, and comment/string lookalikes.
- New capability-assertion test (`TestWithContextInSuspendFunctionNoop_StaysASTOnly`) locks `Needs == 0` and no oracle metadata so a future drift back to KAA fails loudly.

## Test plan

- [x] `go build -o krit ./cmd/krit/`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...`
- [x] `go test ./... -count=1`
- [x] `make lint-rules`