### PR TITLE
test(bisect): close issue #214 acceptance criteria + docs

### DIFF
--- a/docs/snapshots.md
+++ b/docs/snapshots.md
@@ -296,6 +296,74 @@ When changing the on-disk shape of a `Blob`, `Metrics`, or
    migrator; readers from older krit versions refuse to read v(N+1)
    data with the upgrade hint above.
 
+## Bisect-structure: explaining breakages
+
+Snapshots are the substrate. On top of them, the `breakage`,
+`bisect-structure`, and `delta-risk` verbs turn the timeline into a
+failure-localization layer: given a failure (test, build, runtime, or
+a krit-finding regression), point at the commit *and* the structural
+change that pushed the codebase into the failure mode, with a
+confidence score.
+
+### Recording events
+
+```bash
+# Ingest a JUnit XML report from CI
+krit breakage record --kind junit --from junit.xml --commit "$SHA"
+
+# Ingest `go test -json` output
+go test -json ./... | krit breakage record --kind gotest --commit "$SHA"
+
+# Or hand-write `{events: [...]}` JSON
+krit breakage record --kind generic --from events.json --commit "$SHA"
+
+# List what's stored
+krit breakage list
+```
+
+Events live in `.krit/snapshots/breakage_events.json` next to the
+captured manifests, deduplicated by `HashID(kind, signature, sha,
+source)` so re-ingesting the same CI run is idempotent.
+
+A `krit snapshot capture` on a commit that introduces new findings
+also writes synthetic `krit-finding-regression` events automatically —
+self-bootstrap. No external integration is required to start
+producing signal.
+
+### Bisecting
+
+```bash
+krit bisect-structure --from <good-sha> --to <bad-sha> --event <id>
+```
+
+The output is a ranked list of `(commit, module, reason, confidence)`
+candidates fused across four tiers:
+
+| Tier | Signal                                                          | Prior |
+|------|-----------------------------------------------------------------|-------|
+| 1    | Stack frame maps to a symbol in the snapshot graph              | 0.95  |
+| 2    | Test file owns module (parallel `src/test` / `src/androidTest`) | 0.85  |
+| 3    | Symbol/module touched in the diff between adjacent snapshots    | 0.60  |
+| 4    | Historical co-occurrence — module previously implicated         | 0.50  |
+
+Each tier contributes signals independently; the dispatcher takes the
+max prior per `(commit, module)` bucket and boosts by the number of
+agreeing tiers. `--max-results` caps the candidate list (default 10),
+`--format json` emits the full structure.
+
+### Delta-risk
+
+```bash
+krit delta-risk --from <sha> --to <sha>
+```
+
+Without a specific event, score a structural delta against historical
+breakage patterns. The candidate vector is per-module deltas in LOC,
+fan-in/fan-out, cyclomatic complexity, files, symbols, and
+public-API surface; the score is the maximum cosine similarity
+against any historical event's delta vector. Higher means the current
+delta looks more like a previously-recorded breakage.
+
 ## MCP
 
 The `snapshot` MCP tool exposes the read-only operations to AI agents:

--- a/internal/bisect/deltarisk_corpus_test.go
+++ b/internal/bisect/deltarisk_corpus_test.go
@@ -1,0 +1,212 @@
+package bisect
+
+import (
+	"fmt"
+	"math"
+	"math/rand"
+	"path/filepath"
+	"testing"
+
+	"github.com/kaeawc/krit/internal/breakage"
+	"github.com/kaeawc/krit/internal/snapshot"
+)
+
+const (
+	labelBreakage = "breakage"
+	labelBenign   = "benign"
+
+	// corpusSize is the per-class commit count. 8 + 8 gives 64 pairwise
+	// comparisons for AUC, enough resolution that AUC steps in 1/64
+	// increments — fine for an 0.85 floor without being slow.
+	corpusSize = 8
+
+	// minAUC is the rank-quality floor delta-risk must clear. Random
+	// baseline is 0.5; 0.85 leaves margin for the cosine score to be
+	// noisy without going flaky.
+	minAUC = 0.85
+)
+
+// TestScoreDeltaBeatsRandomOnLabeledCorpus is the acceptance baseline
+// the bisect-structure PRD calls out: on a synthetic corpus of labeled
+// breakage and benign commits, delta-risk's cosine score against the
+// historical event ledger must rank breakages above benign deltas
+// measurably better than a coin flip.
+//
+// The corpus models the failure mode the design sketch motivates:
+// breakage commits share the same fan-in / cyclomatic-growth shape on
+// the same module (':core'), benign commits perturb unrelated modules
+// in unrelated directions. Random would deliver AUC ~= 0.5; we require
+// AUC >= minAUC and the top-ranked event to be labeled "breakage."
+func TestScoreDeltaBeatsRandomOnLabeledCorpus(t *testing.T) {
+	dir := t.TempDir()
+	root := filepath.Join(dir, ".krit", "snapshots")
+
+	// Every breakage / benign commit diffs against this baseline so the
+	// historical-event delta vector and the candidate delta vector are
+	// directly comparable.
+	const baseSHA = "0000000000000000000000000000000000000000"
+	captureBlob(t, root, baseSHA, 1,
+		[]snapshot.Module{{Path: ":core"}, {Path: ":app"}, {Path: ":util"}},
+		[]snapshot.File{
+			{Path: "core/A.kt", Module: ":core"},
+			{Path: "app/B.kt", Module: ":app"},
+			{Path: "util/C.kt", Module: ":util"},
+		},
+		nil,
+		&snapshot.Metrics{Modules: []snapshot.ModuleMetrics{
+			{Path: ":core", LOC: 100, Cyclomatic: 10, FanIn: 4, FanOut: 2},
+			{Path: ":app", LOC: 100, Cyclomatic: 10, FanIn: 0, FanOut: 3},
+			{Path: ":util", LOC: 100, Cyclomatic: 10, FanIn: 2, FanOut: 0},
+		}})
+
+	rng := rand.New(rand.NewSource(0xBEEF))
+
+	var historical []breakage.Event
+	for i := 0; i < corpusSize; i++ {
+		sha := fmt.Sprintf("b%039d", i+1)
+		captureBreakageCommit(t, root, sha, int64(100+i), jitter(rng))
+		historical = append(historical, breakage.Event{
+			ID:          fmt.Sprintf("evt-break-%d", i),
+			CommitSHA:   sha,
+			FailureKind: breakage.KindTestFailure,
+			Module:      ":core",
+			Signature:   "fanin-blowup",
+			OccurredAt:  int64(100 + i),
+		})
+	}
+
+	var samples []labeledSample
+	for i := 0; i < corpusSize; i++ {
+		sha := fmt.Sprintf("c%039d", i+1)
+		captureBreakageCommit(t, root, sha, int64(200+i), jitter(rng))
+		samples = append(samples, labeledSample{sha: sha, label: labelBreakage})
+	}
+	for i := 0; i < corpusSize; i++ {
+		sha := fmt.Sprintf("d%039d", i+1)
+		captureBenignCommit(t, root, sha, int64(300+i), rng)
+		samples = append(samples, labeledSample{sha: sha, label: labelBenign})
+	}
+
+	for i := range samples {
+		res, err := ScoreDelta(DeltaRiskInput{
+			SnapshotsRoot:    root,
+			FromSHA:          baseSHA,
+			ToSHA:            samples[i].sha,
+			HistoricalEvents: historical,
+			MaxMatches:       1,
+		})
+		if err != nil {
+			t.Fatalf("ScoreDelta %s: %v", samples[i].sha, err)
+		}
+		samples[i].score = res.Score
+	}
+
+	if auc := computeAUC(samples); auc < minAUC {
+		t.Fatalf("AUC = %.3f, want >= %.2f (random baseline is 0.5)", auc, minAUC)
+	}
+
+	bestLabel, bestScore := samples[0].label, samples[0].score
+	for _, s := range samples[1:] {
+		if s.score > bestScore {
+			bestScore = s.score
+			bestLabel = s.label
+		}
+	}
+	if bestLabel != labelBreakage {
+		t.Fatalf("top-ranked sample = %q, want %q (score=%.3f)", bestLabel, labelBreakage, bestScore)
+	}
+}
+
+// jitter returns symmetric noise in [-2, 2). Breakage growth deltas
+// stay positive even at the floor: with base +20 LOC / +8 cyclomatic /
+// +6 fan-in, jitter cannot flip a delta to zero or negative.
+func jitter(rng *rand.Rand) float64 {
+	return rng.Float64()*4 - 2
+}
+
+// captureBreakageCommit lays down a snapshot whose module-delta vector
+// matches the historical "fan-in blowup on :core" pattern.
+func captureBreakageCommit(t *testing.T, root, sha string, capturedAt int64, jitter float64) {
+	t.Helper()
+	captureBlob(t, root, sha, capturedAt,
+		[]snapshot.Module{{Path: ":core"}, {Path: ":app"}, {Path: ":util"}},
+		[]snapshot.File{
+			{Path: "core/A.kt", Module: ":core"},
+			{Path: "app/B.kt", Module: ":app"},
+			{Path: "util/C.kt", Module: ":util"},
+		},
+		nil,
+		&snapshot.Metrics{Modules: []snapshot.ModuleMetrics{
+			{Path: ":core", LOC: 100 + int(math.Round(20+jitter)), Cyclomatic: 10 + int(math.Round(8+jitter)), FanIn: 4 + int(math.Round(6+jitter)), FanOut: 2},
+			{Path: ":app", LOC: 100, Cyclomatic: 10, FanIn: 0, FanOut: 3},
+			{Path: ":util", LOC: 100, Cyclomatic: 10, FanIn: 2, FanOut: 0},
+		}})
+}
+
+// captureBenignCommit perturbs an unrelated module in an unrelated
+// direction. Cosine against the historical pattern should be ~0.
+func captureBenignCommit(t *testing.T, root, sha string, capturedAt int64, rng *rand.Rand) {
+	t.Helper()
+	mods := []snapshot.ModuleMetrics{
+		{Path: ":core", LOC: 100, Cyclomatic: 10, FanIn: 4, FanOut: 2},
+		{Path: ":app", LOC: 100, Cyclomatic: 10, FanIn: 0, FanOut: 3},
+		{Path: ":util", LOC: 100, Cyclomatic: 10, FanIn: 2, FanOut: 0},
+	}
+	if rng.Intn(2) == 0 {
+		mods[1].LOC += 30
+		mods[1].FanOut -= 2
+	} else {
+		mods[2].LOC -= 15
+		mods[2].Cyclomatic -= 4
+	}
+	captureBlob(t, root, sha, capturedAt,
+		[]snapshot.Module{{Path: ":core"}, {Path: ":app"}, {Path: ":util"}},
+		[]snapshot.File{
+			{Path: "core/A.kt", Module: ":core"},
+			{Path: "app/B.kt", Module: ":app"},
+			{Path: "util/C.kt", Module: ":util"},
+		},
+		nil,
+		&snapshot.Metrics{Modules: mods})
+}
+
+// labeledSample is one labeled candidate commit used in the corpus test.
+type labeledSample struct {
+	sha   string
+	label string
+	score float64
+}
+
+// computeAUC returns the area under the ROC curve treating "breakage"
+// as the positive class. 1.0 is perfect separation, 0.5 is random.
+func computeAUC(samples []labeledSample) float64 {
+	var pos, neg int
+	for _, s := range samples {
+		if s.label == labelBreakage {
+			pos++
+		} else {
+			neg++
+		}
+	}
+	if pos == 0 || neg == 0 {
+		return 0
+	}
+	var concordant, ties float64
+	for _, p := range samples {
+		if p.label != labelBreakage {
+			continue
+		}
+		for _, n := range samples {
+			if n.label == labelBreakage {
+				continue
+			}
+			switch {
+			case p.score > n.score:
+				concordant++
+			case p.score == n.score:
+				ties += 0.5
+			}
+		}
+	}
+	return (concordant + ties) / float64(pos*neg)
+}

--- a/internal/cli/bisect/bisect_test.go
+++ b/internal/cli/bisect/bisect_test.go
@@ -1,0 +1,147 @@
+package bisect
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kaeawc/krit/internal/breakage"
+	"github.com/kaeawc/krit/internal/snapshot"
+)
+
+// captureStdout swaps os.Stdout for the duration of fn and returns
+// what fn writes. Kept local so the package test has no test-only
+// dependency leaks.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stdout = w
+	done := make(chan struct{})
+	var buf bytes.Buffer
+	go func() {
+		_, _ = io.Copy(&buf, r)
+		close(done)
+	}()
+	fn()
+	_ = w.Close()
+	<-done
+	os.Stdout = orig
+	return buf.String()
+}
+
+// seedTimeline lays down two captured snapshots plus a breakage event
+// whose top stack frame maps into the bad-side blob. The fixture is
+// the minimum the CLI needs to print a non-empty candidate list.
+func seedTimeline(t *testing.T, repoRoot string) string {
+	t.Helper()
+	root := snapshot.SnapshotsDir(repoRoot)
+
+	const goodSHA = "1111111111111111111111111111111111111111"
+	const badSHA = "2222222222222222222222222222222222222222"
+
+	for _, sha := range []string{goodSHA, badSHA} {
+		blob := &snapshot.Blob{
+			SchemaVersion: snapshot.SchemaVersion,
+			CommitSHA:     sha,
+			CapturedAt:    1,
+			Modules:       []snapshot.Module{{Path: ":core"}},
+			Files:         []snapshot.File{{Path: "core/Order.kt", Module: ":core"}},
+			Symbols:       []snapshot.Symbol{{FQN: "com.acme.Order", File: "core/Order.kt"}},
+		}
+		if _, err := snapshot.Save(root, blob); err != nil {
+			t.Fatalf("save blob %s: %v", sha, err)
+		}
+		man := &snapshot.Manifest{
+			SchemaVersion: snapshot.ManifestSchemaVersion,
+			CommitSHA:     sha,
+			CapturedAt:    1,
+			BlobSchema:    snapshot.SchemaVersion,
+			Files:         1, Modules: 1, Symbols: 1,
+		}
+		if _, err := snapshot.SaveManifest(root, man); err != nil {
+			t.Fatalf("save manifest %s: %v", sha, err)
+		}
+	}
+
+	ev := breakage.Event{
+		OccurredAt:  1,
+		CommitSHA:   badSHA,
+		FailureKind: breakage.KindRuntimeFailure,
+		Signature:   "npe in order.place",
+		Source:      breakage.SourceCI,
+		Frames:      []string{"com.acme.Order.place(Order.kt:42)"},
+		Message:     "NPE in Order.place",
+	}
+	ev.ID = breakage.HashID(ev.FailureKind, ev.Signature, ev.CommitSHA, ev.Source)
+	if _, err := breakage.Record(root, ev); err != nil {
+		t.Fatalf("record event: %v", err)
+	}
+	return ev.ID
+}
+
+func TestRunCLIPrintsCandidates(t *testing.T) {
+	repoRoot := t.TempDir()
+	eventID := seedTimeline(t, repoRoot)
+
+	out := captureStdout(t, func() {
+		code := Run([]string{
+			"--repo", repoRoot,
+			"--from", "1111111111111111111111111111111111111111",
+			"--to", "2222222222222222222222222222222222222222",
+			"--event", eventID,
+			"--format", "json",
+		})
+		if code != 0 {
+			t.Fatalf("Run exit = %d", code)
+		}
+	})
+
+	var result struct {
+		Candidates []struct {
+			Module     string  `json:"module"`
+			Confidence float64 `json:"confidence"`
+		} `json:"candidates"`
+	}
+	if err := json.Unmarshal([]byte(out), &result); err != nil {
+		t.Fatalf("decode: %v: %s", err, out)
+	}
+	if len(result.Candidates) == 0 {
+		t.Fatalf("no candidates printed: %s", out)
+	}
+	if result.Candidates[0].Module != ":core" {
+		t.Fatalf("top module = %q, want :core", result.Candidates[0].Module)
+	}
+	if result.Candidates[0].Confidence < 0.5 {
+		t.Fatalf("top confidence = %g, want >= 0.5", result.Candidates[0].Confidence)
+	}
+}
+
+func TestRunCLIRejectsMissingEvent(t *testing.T) {
+	code := Run([]string{"--from", "a", "--to", "b"})
+	if code == 0 {
+		t.Fatalf("Run with no --event should fail, got 0")
+	}
+}
+
+func TestRunCLIUnknownEventID(t *testing.T) {
+	repoRoot := t.TempDir()
+	// snapshots dir doesn't exist yet — exercise the "no event" path
+	if err := os.MkdirAll(filepath.Join(repoRoot, ".krit", "snapshots"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	code := Run([]string{
+		"--repo", repoRoot,
+		"--from", "a", "--to", "b",
+		"--event", "does-not-exist",
+	})
+	if code == 0 {
+		t.Fatalf("Run with unknown event should fail, got 0")
+	}
+}

--- a/internal/cli/breakage/breakage_test.go
+++ b/internal/cli/breakage/breakage_test.go
@@ -1,0 +1,144 @@
+package breakage
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	brk "github.com/kaeawc/krit/internal/breakage"
+	snap "github.com/kaeawc/krit/internal/snapshot"
+)
+
+// captureStdout swaps os.Stdout for the duration of fn and returns
+// what fn writes. Kept local so this package has no test-only
+// dependency on other CLI packages.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stdout = w
+	done := make(chan struct{})
+	var buf bytes.Buffer
+	go func() {
+		_, _ = io.Copy(&buf, r)
+		close(done)
+	}()
+	fn()
+	_ = w.Close()
+	<-done
+	os.Stdout = orig
+	return buf.String()
+}
+
+const junitFixture = `<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+  <testsuite name="OrderTests">
+    <testcase classname="com.acme.OrderTest" name="testPlace" file="OrderTest.kt">
+      <failure message="expected 1 but got 2" type="AssertionError">stack trace here</failure>
+    </testcase>
+    <testcase classname="com.acme.OrderTest" name="testCancel"/>
+  </testsuite>
+</testsuites>`
+
+func TestRunRecordJUnitAndList(t *testing.T) {
+	repoRoot := t.TempDir()
+	junitPath := filepath.Join(repoRoot, "junit.xml")
+	if err := os.WriteFile(junitPath, []byte(junitFixture), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	code := Run([]string{
+		"record",
+		"--repo", repoRoot,
+		"--kind", "junit",
+		"--from", junitPath,
+		"--commit", "1111111111111111111111111111111111111111",
+	})
+	if code != 0 {
+		t.Fatalf("record exit = %d", code)
+	}
+
+	root := snap.SnapshotsDir(repoRoot)
+	events, err := brk.LoadAll(root)
+	if err != nil {
+		t.Fatalf("LoadAll: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("len(events) = %d, want 1 (only the failed case)", len(events))
+	}
+	if events[0].FailureKind != brk.KindTestFailure {
+		t.Errorf("kind = %q, want %q", events[0].FailureKind, brk.KindTestFailure)
+	}
+	if events[0].Symbol != "com.acme.OrderTest.testPlace" {
+		t.Errorf("symbol = %q", events[0].Symbol)
+	}
+
+	out := captureStdout(t, func() {
+		code := Run([]string{"list", "--repo", repoRoot})
+		if code != 0 {
+			t.Fatalf("list exit = %d", code)
+		}
+	})
+	var listed []brk.Event
+	if err := json.Unmarshal([]byte(out), &listed); err != nil {
+		t.Fatalf("decode list: %v: %s", err, out)
+	}
+	if len(listed) != 1 {
+		t.Fatalf("list len = %d, want 1: %s", len(listed), out)
+	}
+}
+
+func TestRunDedupesRecordedEvents(t *testing.T) {
+	repoRoot := t.TempDir()
+	path := filepath.Join(repoRoot, "j.xml")
+	if err := os.WriteFile(path, []byte(junitFixture), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	for i := 0; i < 2; i++ {
+		code := Run([]string{
+			"record",
+			"--repo", repoRoot,
+			"--kind", "junit",
+			"--from", path,
+			"--commit", "1111111111111111111111111111111111111111",
+		})
+		if code != 0 {
+			t.Fatalf("record %d exit = %d", i, code)
+		}
+	}
+	events, err := brk.LoadAll(snap.SnapshotsDir(repoRoot))
+	if err != nil {
+		t.Fatalf("LoadAll: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("dedup failed: len = %d", len(events))
+	}
+}
+
+func TestRunRejectsUnknownKind(t *testing.T) {
+	repoRoot := t.TempDir()
+	code := Run([]string{
+		"record",
+		"--repo", repoRoot,
+		"--kind", "no-such-format",
+		"--commit", "1111111111111111111111111111111111111111",
+	})
+	if code == 0 {
+		t.Fatalf("expected non-zero exit for unknown kind")
+	}
+}
+
+func TestRunUnknownSubcommand(t *testing.T) {
+	if code := Run([]string{"bogus"}); code == 0 {
+		t.Fatalf("expected non-zero exit for unknown subcommand")
+	}
+	if code := Run(nil); code == 0 {
+		t.Fatalf("expected non-zero exit for no args")
+	}
+}

--- a/internal/cli/deltarisk/deltarisk_test.go
+++ b/internal/cli/deltarisk/deltarisk_test.go
@@ -1,0 +1,124 @@
+package deltarisk
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/kaeawc/krit/internal/snapshot"
+)
+
+// captureStdout swaps os.Stdout for the duration of fn and returns
+// what fn writes. Kept local so this package has no test-only
+// dependency on other CLI packages.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stdout = w
+	done := make(chan struct{})
+	var buf bytes.Buffer
+	go func() {
+		_, _ = io.Copy(&buf, r)
+		close(done)
+	}()
+	fn()
+	_ = w.Close()
+	<-done
+	os.Stdout = orig
+	return buf.String()
+}
+
+// seedTwoSnapshots writes two captured snapshots with diverging
+// per-module metrics so the cli has a non-empty vector to print.
+func seedTwoSnapshots(t *testing.T, repoRoot string) (fromSHA, toSHA string) {
+	t.Helper()
+	root := snapshot.SnapshotsDir(repoRoot)
+	fromSHA = "1111111111111111111111111111111111111111"
+	toSHA = "2222222222222222222222222222222222222222"
+
+	for i, sha := range []string{fromSHA, toSHA} {
+		blob := &snapshot.Blob{
+			SchemaVersion: snapshot.SchemaVersion,
+			CommitSHA:     sha,
+			CapturedAt:    int64(i + 1),
+			Modules:       []snapshot.Module{{Path: ":core"}},
+			Files:         []snapshot.File{{Path: "core/A.kt", Module: ":core"}},
+		}
+		if _, err := snapshot.Save(root, blob); err != nil {
+			t.Fatalf("Save %s: %v", sha, err)
+		}
+		mods := []snapshot.ModuleMetrics{{Path: ":core", LOC: 100, Cyclomatic: 10, FanIn: 1}}
+		if i == 1 {
+			mods[0].LOC = 200
+			mods[0].Cyclomatic = 20
+			mods[0].FanIn = 5
+		}
+		metrics := &snapshot.Metrics{
+			SchemaVersion: snapshot.MetricsSchemaVersion,
+			CommitSHA:     sha,
+			CapturedAt:    int64(i + 1),
+			Modules:       mods,
+			Files:         []snapshot.FileMetrics{{Path: "core/A.kt", Module: ":core", LOC: mods[0].LOC, Cyclomatic: mods[0].Cyclomatic}},
+		}
+		if _, err := snapshot.SaveMetrics(root, metrics); err != nil {
+			t.Fatalf("SaveMetrics %s: %v", sha, err)
+		}
+		man := &snapshot.Manifest{
+			SchemaVersion: snapshot.ManifestSchemaVersion,
+			CommitSHA:     sha,
+			CapturedAt:    int64(i + 1),
+			BlobSchema:    snapshot.SchemaVersion,
+			MetricsSchema: snapshot.MetricsSchemaVersion,
+			Files:         1, Modules: 1,
+		}
+		if _, err := snapshot.SaveManifest(root, man); err != nil {
+			t.Fatalf("SaveManifest %s: %v", sha, err)
+		}
+	}
+	return fromSHA, toSHA
+}
+
+func TestRunDeltaRiskJSON(t *testing.T) {
+	repoRoot := t.TempDir()
+	from, to := seedTwoSnapshots(t, repoRoot)
+
+	out := captureStdout(t, func() {
+		code := Run([]string{
+			"--repo", repoRoot,
+			"--from", from,
+			"--to", to,
+			"--format", "json",
+		})
+		if code != 0 {
+			t.Fatalf("Run exit = %d", code)
+		}
+	})
+
+	var res struct {
+		Vector map[string]float64 `json:"vector"`
+	}
+	if err := json.Unmarshal([]byte(out), &res); err != nil {
+		t.Fatalf("decode: %v: %s", err, out)
+	}
+	if _, ok := res.Vector[":core::loc"]; !ok {
+		t.Fatalf("vector missing :core::loc: %+v", res.Vector)
+	}
+	if got := res.Vector[":core::loc"]; got != 100 {
+		t.Errorf(":core::loc = %g, want 100", got)
+	}
+}
+
+func TestRunDeltaRiskRequiresBothSHAs(t *testing.T) {
+	if code := Run([]string{"--from", "abc"}); code == 0 {
+		t.Fatalf("missing --to should fail")
+	}
+	if code := Run([]string{"--to", "abc"}); code == 0 {
+		t.Fatalf("missing --from should fail")
+	}
+}


### PR DESCRIPTION
## Summary

Lock down the remaining acceptance criteria from #214 ("bisect-structure: explainable bisection from breakage events to structural deltas"). The core machinery shipped in #240; this PR finishes the issue by adding the labeled-corpus benchmark called out in the acceptance section, end-to-end CLI smoke tests for the three new verbs, and user-facing documentation.

- **Corpus benchmark** ([internal/bisect/deltarisk_corpus_test.go](internal/bisect/deltarisk_corpus_test.go)): synthetic ledger of 8 breakage commits sharing a `:core` fan-in / cyclomatic-growth shape and 8 benign commits perturbing unrelated modules. `ScoreDelta` must clear AUC >= 0.85 against the 0.5 random baseline and rank a breakage sample top-1. Defines the baseline the PRD asked for.

- **CLI smoke tests** for [bisect-structure](internal/cli/bisect/bisect_test.go), [breakage](internal/cli/breakage/breakage_test.go), and [delta-risk](internal/cli/deltarisk/deltarisk_test.go): JUnit ingest + dedupe + list, stack-frame bisect over a 2-snapshot timeline, delta-risk vector extraction. Each test file keeps a local `captureStdout` per the existing convention.

- **Docs** ([docs/snapshots.md](docs/snapshots.md)): new "Bisect-structure: explaining breakages" section documenting the three verbs, the four-tier fusion table, and the self-bootstrap behaviour on capture.

Closes #214.

## Test plan

- [x] `go build -o krit ./cmd/krit/`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...`
- [x] `go test ./... -count=1`
- [x] `go test ./internal/bisect/ -run TestScoreDeltaBeatsRandomOnLabeledCorpus -v` (passes; AUC clears 0.85)
- [x] `go test ./internal/cli/{bisect,breakage,deltarisk}/ -v` (all pass)