### PR TITLE
fix(android): tighten HardcodedText receiver and template handling

### DIFF
--- a/internal/rules/android.go
+++ b/internal/rules/android.go
@@ -157,35 +157,6 @@ var hardcodedTextComposeCallees = map[string]bool{
 	"ListItem":               true,
 }
 
-// fileHasHardcodedTextAndroidImport returns true when the parsed file
-// imports any package under hardcodedTextAndroidImportPrefixes. It
-// reads `import_header` nodes directly so the check is lexical-state
-// aware and ignores commented-out imports.
-func fileHasHardcodedTextAndroidImport(ctx *api.Context) bool {
-	file := ctx.File
-	if file == nil {
-		return false
-	}
-	found := false
-	file.FlatWalkNodes(0, "import_header", func(node uint32) {
-		if found {
-			return
-		}
-		ident, ok := file.FlatFindChild(node, "identifier")
-		if !ok {
-			return
-		}
-		fqn := file.FlatNodeText(ident)
-		for _, prefix := range hardcodedTextAndroidImportPrefixes {
-			if strings.HasPrefix(fqn, prefix) {
-				found = true
-				return
-			}
-		}
-	})
-	return found
-}
-
 // hardcodedTextStringLiteralIsPureInterpolation returns true when the
 // string at valueText is a Kotlin string literal whose entire content
 // is interpolation — e.g. `"$x"`, `"${a + b}"`, `"$a$b"`. Such templates
@@ -269,7 +240,7 @@ func hardcodedTextReceiverProven(ctx *api.Context, callExpr uint32) bool {
 	if !hardcodedTextComposeCallees[name] {
 		return false
 	}
-	return fileHasHardcodedTextAndroidImport(ctx)
+	return fileFactsCache().Imports(file).HasAnyPrefix(hardcodedTextAndroidImportPrefixes...)
 }
 
 func (r *HardcodedTextRule) check(ctx *api.Context) {

--- a/internal/rules/android.go
+++ b/internal/rules/android.go
@@ -110,6 +110,211 @@ type HardcodedTextRule struct {
 // Classified per roadmap/17.
 func (r *HardcodedTextRule) Confidence() float64 { return 0.75 }
 
+// hardcodedTextAndroidImportPrefixes are the import package prefixes
+// that signal a file participates in Android UI / Compose code. The
+// HardcodedText rule only fires when at least one such import is
+// present, otherwise the named-argument form `text = "…"` is too
+// ambiguous (data-class constructors, builders, exception helpers
+// all share the spelling).
+var hardcodedTextAndroidImportPrefixes = []string{
+	"android.widget.",
+	"android.view.",
+	"android.app.",
+	"android.content.",
+	"androidx.compose.",
+	"androidx.appcompat.",
+	"androidx.fragment.",
+	"androidx.preference.",
+	"com.google.android.material.",
+}
+
+// hardcodedTextComposeCallees is a conservative set of well-known
+// Compose UI composables whose `text = "…"` argument is virtually
+// always user-facing. Used as a fallback when imports are missing
+// (e.g. a single-file snippet) so the existing positive fixtures
+// keep firing without an explicit import_header.
+var hardcodedTextComposeCallees = map[string]bool{
+	"Text":                   true,
+	"OutlinedText":           true,
+	"TextField":              true,
+	"OutlinedTextField":      true,
+	"BasicText":              true,
+	"BasicTextField":         true,
+	"Button":                 true,
+	"TextButton":             true,
+	"OutlinedButton":         true,
+	"FilledTonalButton":      true,
+	"ElevatedButton":         true,
+	"Snackbar":               true,
+	"TopAppBar":              true,
+	"CenterAlignedTopAppBar": true,
+	"AlertDialog":            true,
+	"NavigationBarItem":      true,
+	"NavigationRailItem":     true,
+	"Tab":                    true,
+	"LeadingIconTab":         true,
+	"DropdownMenuItem":       true,
+	"ListItem":               true,
+}
+
+// fileHasHardcodedTextAndroidImport returns true when the parsed file
+// imports any package under hardcodedTextAndroidImportPrefixes. It
+// reads `import_header` nodes directly so the check is lexical-state
+// aware and ignores commented-out imports.
+func fileHasHardcodedTextAndroidImport(ctx *api.Context) bool {
+	file := ctx.File
+	if file == nil {
+		return false
+	}
+	found := false
+	file.FlatWalkNodes(0, "import_header", func(node uint32) {
+		if found {
+			return
+		}
+		ident, ok := file.FlatFindChild(node, "identifier")
+		if !ok {
+			return
+		}
+		fqn := file.FlatNodeText(ident)
+		for _, prefix := range hardcodedTextAndroidImportPrefixes {
+			if strings.HasPrefix(fqn, prefix) {
+				found = true
+				return
+			}
+		}
+	})
+	return found
+}
+
+// hardcodedTextStringLiteralIsPureInterpolation returns true when the
+// string at valueText is a Kotlin string literal whose entire content
+// is interpolation — e.g. `"$x"`, `"${a + b}"`, `"$a$b"`. Such templates
+// carry no localizable literal text and must not fire HardcodedText.
+//
+// Raw triple-quoted strings (`"""…"""`) are NOT treated as pure
+// interpolation because the bracketing is different and the interior
+// is still a hardcoded string from a localization point of view.
+func hardcodedTextStringLiteralIsPureInterpolation(valueText string) bool {
+	if len(valueText) < 2 || valueText[0] != '"' {
+		return false
+	}
+	// Triple-quoted raw strings: not interpolation-only.
+	if strings.HasPrefix(valueText, `"""`) {
+		return false
+	}
+	// Strip surrounding quotes — the lexer guarantees a matching close
+	// quote for parser-accepted source. If we can't find one, bail.
+	end := strings.LastIndexByte(valueText, '"')
+	if end <= 0 {
+		return false
+	}
+	inner := valueText[1:end]
+	if inner == "" {
+		return false
+	}
+	for i := 0; i < len(inner); {
+		c := inner[i]
+		if c != '$' {
+			return false
+		}
+		i++
+		if i >= len(inner) {
+			return false
+		}
+		if inner[i] == '{' {
+			depth := 1
+			i++
+			for i < len(inner) && depth > 0 {
+				switch inner[i] {
+				case '{':
+					depth++
+				case '}':
+					depth--
+				}
+				i++
+			}
+			continue
+		}
+		// Bare `$ident` — consume an identifier run.
+		for i < len(inner) {
+			ch := inner[i]
+			if ch == '_' || ch == '.' ||
+				(ch >= 'a' && ch <= 'z') ||
+				(ch >= 'A' && ch <= 'Z') ||
+				(ch >= '0' && ch <= '9') {
+				i++
+				continue
+			}
+			break
+		}
+	}
+	return true
+}
+
+// hardcodedTextReceiverProven returns true when the call_expression at
+// idx targets a known Compose UI composable by name. The guard is
+// deliberately conservative — Kotlin's `Foo(text = "…")` is also the
+// shape of a data-class constructor, exception helper, or arbitrary
+// builder, so absent receiver-type evidence we restrict the rule to
+// the well-known Compose composables whose `text`/`title`/etc named
+// argument is virtually always user-facing copy.
+//
+// We additionally require the file to import at least one
+// Android/Compose package — without that signal there is no reason
+// to believe the call is on Compose at all (the callee name could be
+// from any framework).
+func hardcodedTextReceiverProven(ctx *api.Context, callExpr uint32) bool {
+	file := ctx.File
+	name := flatCallExpressionName(file, callExpr)
+	if !hardcodedTextComposeCallees[name] {
+		return false
+	}
+	return fileHasHardcodedTextAndroidImport(ctx)
+}
+
+func (r *HardcodedTextRule) check(ctx *api.Context) {
+	idx, file := ctx.Idx, ctx.File
+	_, args := flatCallExpressionParts(file, idx)
+	if args == 0 {
+		return
+	}
+	if !hardcodedTextReceiverProven(ctx, idx) {
+		return
+	}
+	for child := file.FlatFirstChild(args); child != 0; child = file.FlatNextSib(child) {
+		if file.FlatType(child) != "value_argument" {
+			continue
+		}
+		label := flatValueArgumentLabel(file, child)
+		if !hardcodedTextLabels[label] {
+			continue
+		}
+		exprIdx := flatValueArgumentExpression(file, child)
+		if exprIdx == 0 {
+			continue
+		}
+		valueText := strings.TrimSpace(file.FlatNodeText(exprIdx))
+		if valueText == "" || valueText[0] != '"' {
+			continue
+		}
+		// Skip strings already wrapped in a resource lookup. The
+		// `Contains` form catches concatenations like
+		// `"Hello " + getString(R.string.world)` as well as
+		// `stringResource(R.string.hello)` / `context.getString(...)`.
+		if strings.Contains(valueText, "stringResource(") || strings.Contains(valueText, "getString(") {
+			continue
+		}
+		// Skip pure-interpolation templates — they carry no static
+		// literal text to localize.
+		if hardcodedTextStringLiteralIsPureInterpolation(valueText) {
+			continue
+		}
+		ctx.EmitAt(file.FlatRow(idx)+1, 1,
+			"Hardcoded text. Use string resources for localization.")
+		return
+	}
+}
+
 // LogDetectorRule detects unconditional logging calls.
 type LogDetectorRule struct {
 	FlatDispatchBase

--- a/internal/rules/android_base_test.go
+++ b/internal/rules/android_base_test.go
@@ -47,6 +47,7 @@ fun MyScreen() {
 func TestHardcodedText_Positive(t *testing.T) {
 	findings := runRuleByName(t, "HardcodedText", `
 package test
+import androidx.compose.material.Text
 fun MyScreen() {
     Text(text = "Hello World")
 }`)
@@ -58,6 +59,7 @@ fun MyScreen() {
 func TestHardcodedText_Negative(t *testing.T) {
 	findings := runRuleByName(t, "HardcodedText", `
 package test
+import androidx.compose.material.Text
 fun MyScreen() {
     Text(text = stringResource(R.string.hello))
 }`)
@@ -69,11 +71,67 @@ fun MyScreen() {
 func TestHardcodedText_Negative_GetString(t *testing.T) {
 	findings := runRuleByName(t, "HardcodedText", `
 package test
+import androidx.compose.material.Text
 fun MyScreen() {
     Text(title = getString(R.string.hello))
 }`)
 	if len(findings) != 0 {
 		t.Errorf("expected no findings for getString usage, got %d", len(findings))
+	}
+}
+
+// Data-class constructor with the same `text =` named-argument shape.
+// Must not fire — the callee is not a known Compose composable.
+func TestHardcodedText_Negative_DataClassConstructor(t *testing.T) {
+	findings := runRuleByName(t, "HardcodedText", `
+package test
+import androidx.compose.material.Text
+data class LogEntry(val text: String, val description: String)
+fun build() = LogEntry(text = "raw log line", description = "raw description")`)
+	if len(findings) != 0 {
+		t.Errorf("expected no findings for data-class constructor, got %d", len(findings))
+	}
+}
+
+// Pure interpolation — no static literal text to localize.
+func TestHardcodedText_Negative_PureInterpolation(t *testing.T) {
+	findings := runRuleByName(t, "HardcodedText", `
+package test
+import androidx.compose.material.Text
+fun MyScreen(name: String) {
+    Text(text = "$name")
+    Text(text = "${name.uppercase()}")
+    Text(text = "$name$name")
+}`)
+	if len(findings) != 0 {
+		t.Errorf("expected no findings for pure-interpolation templates, got %d", len(findings))
+	}
+}
+
+// Without any Android/Compose import the rule must stay silent — the
+// callee name alone is too ambiguous (could be a domain class).
+func TestHardcodedText_Negative_NoAndroidImport(t *testing.T) {
+	findings := runRuleByName(t, "HardcodedText", `
+package test
+fun render() {
+    Text(text = "raw label")
+}`)
+	if len(findings) != 0 {
+		t.Errorf("expected no findings when no Android/Compose import is present, got %d", len(findings))
+	}
+}
+
+// String concatenation that still includes a resource lookup must
+// not fire — the Contains check already covers `getString(`.
+func TestHardcodedText_Negative_ConcatWithGetString(t *testing.T) {
+	findings := runRuleByName(t, "HardcodedText", `
+package test
+import androidx.compose.material.Text
+fun MyScreen() {
+    Text(text = "Hello " + getString(R.string.world))
+}`)
+	if len(findings) != 0 {
+		t.Errorf("expected no findings for concat including getString, got %d", len(findings))
 	}
 }
 

--- a/internal/rules/registry_android_rules.go
+++ b/internal/rules/registry_android_rules.go
@@ -93,38 +93,7 @@ func registerAndroidRules() {
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Description(), Sev: api.Severity(r.Sev),
 			NodeTypes: []string{"call_expression"}, Confidence: 0.75, Implementation: r,
-			Check: func(ctx *api.Context) {
-				idx, file := ctx.Idx, ctx.File
-				_, args := flatCallExpressionParts(file, idx)
-				if args == 0 {
-					return
-				}
-				for i := 0; i < file.FlatChildCount(args); i++ {
-					child := file.FlatChild(args, i)
-					if file.FlatType(child) != "value_argument" {
-						continue
-					}
-					argText := strings.TrimSpace(file.FlatNodeText(child))
-					eqIdx := strings.Index(argText, "=")
-					if eqIdx < 0 {
-						continue
-					}
-					label := strings.TrimSpace(argText[:eqIdx])
-					if !hardcodedTextLabels[label] {
-						continue
-					}
-					valueText := strings.TrimSpace(argText[eqIdx+1:])
-					if valueText == "" || valueText[0] != '"' {
-						continue
-					}
-					if strings.Contains(valueText, "stringResource(") || strings.Contains(valueText, "getString(") {
-						continue
-					}
-					ctx.EmitAt(file.FlatRow(idx)+1, 1,
-						"Hardcoded text. Use string resources for localization.")
-					return
-				}
-			},
+			Check: r.check,
 		})
 	}
 	{

--- a/tests/fixtures/negative/android-lint/HardcodedText.kt
+++ b/tests/fixtures/negative/android-lint/HardcodedText.kt
@@ -4,6 +4,26 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 
 @Composable
-fun Greeting() {
+fun Greeting(name: String) {
+    // Resource lookup — must not fire.
     Text(text = stringResource(R.string.hello))
+    // Concatenation that still includes a resource lookup — also OK.
+    Text(text = "Hello " + getString(R.string.world))
+    // Pure interpolation — no literal text to localize.
+    Text(text = "$name")
+    Text(text = "${name.uppercase()}")
+    Text(text = "$name$name")
+}
+
+// Non-Compose, non-Android data class. Even with a `text =` named arg,
+// this must not fire — the file has no Android/Compose-relevant import
+// and the callee is not in the known Compose set.
+data class LogEntry(val text: String, val description: String)
+
+fun build(): LogEntry = LogEntry(text = "raw log line", description = "raw description")
+
+// Lower-case callee — not a composable. Must not fire even though the
+// file imports Compose above.
+fun emit(message: String) {
+    error(description = "boom: $message")
 }


### PR DESCRIPTION
## Summary

- Restrict `HardcodedText` to a conservative allowlist of known Compose UI composables (`Text`, `Button`, `Snackbar`, dialog/tab/nav items, ...) so `Foo(text = "…")` data-class constructors, exception helpers, and arbitrary builders no longer trip the rule.
- Require the file to import at least one Android/Compose package (`androidx.compose.`, `android.widget.`, `com.google.android.material.`, ...) via the cached `ImportFacts.HasAnyPrefix`, which is wildcard- and alias-aware.
- Parse named arguments from the flat AST (`flatValueArgumentLabel` / `flatValueArgumentExpression`) instead of substring-splitting the raw argument text, so labels containing `=` inside string templates no longer confuse the matcher.
- Skip pure-interpolation Kotlin templates (`"$x"`, `"${name.uppercase()}"`, `"$a$b"`) — they carry no static literal text to localize.
- Adds regression tests for data-class constructors, pure interpolation, missing Android import, and `getString(...)` concatenations; expands the negative fixture with the same scenarios.

## Test plan

- [x] `go build -o krit ./cmd/krit/`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...`
- [x] `go test ./... -count=1`
- [x] `make lint-rules`