### PR TITLE
feat(daemon): route --input-types and --sample-rule through daemon

### DIFF
--- a/docs/daemon-flag-routing.md
+++ b/docs/daemon-flag-routing.md
@@ -150,6 +150,43 @@ move them onto the daemon path once `FindingColumns` is reachable over the
 wire. If/when that happens, drop them from the meta bucket in
 `daemonCompatibleFlags`.
 
+## Oracle I/O & sampling
+
+This bucket lists flags that look related to `--input-types` (which IS daemon-
+routable) but stay in-process for distinct reasons.
+
+### `--output-types`
+
+`runOutputTypesFlag` at `internal/cli/scan/early_exits.go:404` is a standalone
+oracle dump: it locates `krit-types.jar`, runs the JVM (or honors
+`--no-cache-oracle` to bypass the cache), writes the resulting JSON to the
+caller-supplied path, and exits *before* any rules are loaded or fired. The
+daemon's `AnalyzeProject` verb is a rule-running path; routing `--output-types`
+through it would either (a) need a brand-new dump-only verb that duplicates
+what the daemon's resident `OracleDaemon` already produces internally, or
+(b) waste the rule-dispatch work the user explicitly asked to skip.
+
+Daemon routing would only make sense if we added a wire verb like
+`DumpOracle` that returns the oracle daemon's current snapshot. That's a
+new feature, not a routing tweak.
+
+### `--delta`
+
+`filterColumnsByDelta` at `internal/cli/scan/delta.go:18` shells out to `git
+worktree add` for the base ref, re-execs `krit` itself inside the worktree to
+produce a baseline JSON report, and then filters the current-scan findings to
+only those NOT present in the baseline. The orchestration is entirely a CLI-
+side wrapper: the *base* sub-scan can already hit the daemon (it's just
+another `krit` invocation), so the only thing daemon-routing the wrapper
+would save is the parent-process `git worktree add` — which is the dominant
+cost.
+
+Daemon routing would mean either teaching the daemon how to spawn worktrees
+(adds filesystem-mutating side effects to a long-lived service) or returning
+`FindingColumns` from the wire so the CLI can run the diff client-side
+without re-execing. The latter is the same wire change the audit short-
+circuits would benefit from; revisit together.
+
 ## Adding a new flag
 
 When introducing a new CLI flag, decide which bucket it belongs in:

--- a/internal/cli/scan/daemon_delegate.go
+++ b/internal/cli/scan/daemon_delegate.go
@@ -1,13 +1,17 @@
 package scan
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/kaeawc/krit/internal/cli/daemonclient"
 	"github.com/kaeawc/krit/internal/daemon"
+	"github.com/kaeawc/krit/internal/output"
+	"github.com/kaeawc/krit/internal/scanner"
 )
 
 // tryDaemonDelegate attempts to dispatch the current scan through a
@@ -47,6 +51,14 @@ func tryDaemonDelegate(f *scanFlags, paths []string, repoDir string) (bool, int)
 	}
 
 	fmt.Fprintln(os.Stderr, "info: using daemon")
+	// --sample-rule short-circuits the normal write path: the daemon
+	// returns the full JSON envelope, the CLI parses it back into
+	// columns, and the sampler prints a deterministic per-rule sample
+	// to stdout. Forwarding the JSON envelope through the writer would
+	// be confusing for an interactive flag, so it is consumed here.
+	if *f.SampleRule != "" {
+		return true, runDaemonSampleRule(f, paths, res.Findings)
+	}
 	w, closer, openErr := openDaemonOutputWriter(f)
 	if openErr != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", openErr)
@@ -157,6 +169,35 @@ func callMetaVerb(client *daemonclient.Client, f *scanFlags, paths []string, ver
 	return daemon.MetaResult{}, fmt.Errorf("unknown meta verb %d", verb)
 }
 
+// runDaemonSampleRule decodes the daemon's JSON envelope into a
+// FindingColumns and runs the sampler. Mirrors the in-process
+// runner.outputPhase short-circuit so users see the same human output
+// regardless of whether the daemon served the call.
+func runDaemonSampleRule(f *scanFlags, paths []string, findingsJSON []byte) int {
+	var report output.JSONReport
+	if err := json.Unmarshal(findingsJSON, &report); err != nil {
+		fmt.Fprintf(os.Stderr, "error: decode daemon findings: %v\n", err)
+		return 2
+	}
+	collector := scanner.NewFindingCollector(len(report.Findings))
+	for _, finding := range report.Findings {
+		collector.Append(scanner.Finding{
+			File:    finding.File,
+			Line:    finding.Line,
+			Col:     finding.Column,
+			RuleSet: finding.RuleSet,
+			Rule:    finding.Rule,
+			Message: finding.Message,
+		})
+	}
+	columns := collector.Columns()
+	basePath := *f.BasePath
+	if basePath == "" && len(paths) > 0 {
+		basePath, _ = filepath.Abs(paths[0])
+	}
+	return RunSampleFindingsColumns(columns, *f.SampleRule, *f.SampleCount, *f.SampleContext, basePath)
+}
+
 // daemonCompatibleFlags reports whether the requested flag set can be
 // served by the daemon's analyze-project verb. Modes that write files,
 // invoke profiling, or run meta commands stay on the in-process path.
@@ -191,7 +232,7 @@ func daemonCompatibleFlags(f *scanFlags) bool {
 		}
 	}
 	strs := []string{*f.CreateBaseline, *f.CPUProfile, *f.MemProfile,
-		*f.Completions, *f.SampleRule, *f.InputTypes, *f.OutputTypes, *f.Delta,
+		*f.Completions, *f.OutputTypes, *f.Delta,
 		*f.PromoteExperiment, *f.DeprecateExperiment, *f.NewExperiment, *f.ExperimentMatrix}
 	for _, s := range strs {
 		if s != "" {
@@ -210,6 +251,25 @@ func buildDaemonAnalyzeArgs(f *scanFlags, paths []string) daemon.AnalyzeProjectA
 	if *f.Report != "" {
 		format = *f.Report
 	}
+	// --sample-rule asks for JSON findings post-processed on the CLI
+	// side. Force the daemon to emit JSON regardless of the user's
+	// --format choice so the writer can decode the envelope. The
+	// human-formatted sampler output is then printed by the CLI.
+	if *f.SampleRule != "" {
+		format = "json"
+	}
+	// Resolve --input-types to an absolute path before forwarding:
+	// the daemon process has its own CWD (the project root) and a
+	// caller-relative path would resolve elsewhere. filepath.Abs
+	// only fails when CWD is unreadable; in that case forward the
+	// raw value so the daemon can return a clean "open" error rather
+	// than silently swallowing the flag.
+	inputTypesPath := *f.InputTypes
+	if inputTypesPath != "" {
+		if abs, err := filepath.Abs(inputTypesPath); err == nil {
+			inputTypesPath = abs
+		}
+	}
 	return daemon.AnalyzeProjectArgs{
 		Paths:            paths,
 		Format:           format,
@@ -224,6 +284,7 @@ func buildDaemonAnalyzeArgs(f *scanFlags, paths []string) daemon.AnalyzeProjectA
 		DisableRules:     *f.DisableRules,
 		ShowPerf:         *f.Perf || *f.PerfRules,
 		PerfRules:        *f.PerfRules,
+		InputTypesPath:   inputTypesPath,
 		ClientBinaryHash: daemonclient.CurrentBinaryHash(),
 	}
 }

--- a/internal/cli/scan/daemon_delegate_oracle_args_test.go
+++ b/internal/cli/scan/daemon_delegate_oracle_args_test.go
@@ -1,0 +1,138 @@
+package scan
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestDaemonCompatibleFlags_OracleArgsAllowed pins the oracle I/O and
+// sampling bucket: --input-types and --sample-rule are now wire-routable
+// (the CLI absolutizes the path / re-runs the sampler on returned JSON);
+// --output-types and --delta deliberately remain in-process.
+func TestDaemonCompatibleFlags_OracleArgsAllowed(t *testing.T) {
+	tests := []struct {
+		name string
+		set  func(*scanFlags)
+		want bool
+	}{
+		{"--input-types", func(f *scanFlags) { *f.InputTypes = "/tmp/types.json" }, true},
+		{"--sample-rule", func(f *scanFlags) { *f.SampleRule = "MyRule" }, true},
+		{"--output-types", func(f *scanFlags) { *f.OutputTypes = "/tmp/out.json" }, false},
+		{"--delta", func(f *scanFlags) { *f.Delta = "main" }, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := freshScanFlags(t)
+			tt.set(f)
+			if got := daemonCompatibleFlags(f); got != tt.want {
+				t.Errorf("daemonCompatibleFlags = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestBuildDaemonAnalyzeArgs_InputTypesAbsolutised confirms the CLI
+// resolves --input-types against the caller's CWD before forwarding so
+// the daemon (which runs from the project root) can open the file. A
+// path that already is absolute must round-trip unchanged.
+func TestBuildDaemonAnalyzeArgs_InputTypesAbsolutised(t *testing.T) {
+	f := freshScanFlags(t)
+	*f.InputTypes = "rel/types.json"
+	args := buildDaemonAnalyzeArgs(f, []string{"/tmp"})
+	if !filepath.IsAbs(args.InputTypesPath) {
+		t.Errorf("expected absolute path; got %q", args.InputTypesPath)
+	}
+	if !strings.HasSuffix(args.InputTypesPath, "rel/types.json") {
+		t.Errorf("unexpected suffix: %q", args.InputTypesPath)
+	}
+
+	g := freshScanFlags(t)
+	*g.InputTypes = "/abs/types.json"
+	args2 := buildDaemonAnalyzeArgs(g, []string{"/tmp"})
+	if args2.InputTypesPath != "/abs/types.json" {
+		t.Errorf("absolute path mutated: %q", args2.InputTypesPath)
+	}
+}
+
+// TestBuildDaemonAnalyzeArgs_SampleRuleForcesJSON pins the format
+// override the sampler short-circuit relies on: regardless of the
+// user's --format / --report choice, the daemon must return JSON so
+// the CLI can decode the envelope back into FindingColumns.
+func TestBuildDaemonAnalyzeArgs_SampleRuleForcesJSON(t *testing.T) {
+	f := freshScanFlags(t)
+	*f.Format = "plain"
+	*f.SampleRule = "MyRule"
+	args := buildDaemonAnalyzeArgs(f, []string{"/tmp"})
+	if args.Format != "json" {
+		t.Errorf("Format = %q, want json", args.Format)
+	}
+}
+
+// TestTryDaemonDelegate_SampleRuleConsumesEnvelope drives the sampler
+// short-circuit end-to-end: the mock daemon returns a JSONReport
+// envelope, the CLI parses it, runs RunSampleFindingsColumns, and
+// emits the per-rule sample to stdout instead of forwarding the JSON
+// blob verbatim.
+func TestTryDaemonDelegate_SampleRuleConsumesEnvelope(t *testing.T) {
+	envelope := mustJSON(t, map[string]any{
+		"success":    true,
+		"version":    "test",
+		"durationMs": 0,
+		"files":      1,
+		"rules":      1,
+		"findings": []map[string]any{
+			{
+				"file":     "Foo.kt",
+				"line":     1,
+				"column":   1,
+				"ruleSet":  "test",
+				"rule":     "MyRule",
+				"severity": "warning",
+				"message":  "match",
+			},
+		},
+		"summary": map[string]any{
+			"total":     1,
+			"byRuleSet": map[string]int{},
+			"byRule":    map[string]int{},
+			"fixable":   0,
+		},
+	})
+	socketDir := startMockDaemon(t, mockBehavior{findings: envelope, findingsCount: 1})
+	root := newRoot(t)
+	linkSock(t, root, filepath.Join(socketDir, "d.sock"))
+
+	out := redirectStdout(t)
+	f := freshScanFlags(t)
+	*f.SampleRule = "MyRule"
+	*f.SampleCount = 1
+	handled, code := tryDaemonDelegate(f, []string{root}, root)
+	if !handled {
+		t.Fatalf("expected handled=true on sample-rule delegation")
+	}
+	if code != 0 {
+		t.Errorf("expected exit 0 (sampler success); got %d", code)
+	}
+	captured := out()
+	if !strings.Contains(captured, "MyRule") {
+		t.Errorf("expected sampler output to mention rule; got %q", captured)
+	}
+	// Guard against the regression where the JSON envelope leaks
+	// through verbatim instead of being consumed.
+	if strings.Contains(captured, `"findings"`) {
+		t.Errorf("sampler output leaked raw JSON envelope; got %q", captured)
+	}
+}
+
+// mustJSON marshals v or fails the test. Local helper to keep the
+// envelope-construction inline in the test that uses it.
+func mustJSON(t *testing.T, v any) string {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return string(b)
+}

--- a/internal/cli/serve/analyze_project.go
+++ b/internal/cli/serve/analyze_project.go
@@ -340,10 +340,11 @@ func (s *daemonState) buildProjectInput(args daemon.AnalyzeProjectArgs) (pipelin
 			WarningsAsErrors: args.WarningsAsErrors,
 			IncludeGenerated: args.IncludeGenerated,
 			Version:          kritVersion(),
-			OracleEnabled:    oracleDaemon != nil,
+			OracleEnabled:    oracleDaemon != nil || args.InputTypesPath != "",
 			ShowPerf:         args.ShowPerf || args.PerfRules,
 			PerfRules:        args.PerfRules,
 			CustomRuleJars:   args.CustomRuleJars,
+			InputTypesPath:   args.InputTypesPath,
 			// Wire is line-delimited; compact JSON keeps the body
 			// free of internal newlines.
 			JSONCompact: true,

--- a/internal/cli/serve/analyze_project_input_types_test.go
+++ b/internal/cli/serve/analyze_project_input_types_test.go
@@ -1,0 +1,67 @@
+package serve
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kaeawc/krit/internal/daemon"
+)
+
+// TestAnalyzeProject_InputTypesPathHonoured asserts that an explicit
+// --input-types JSON path is forwarded through the verb wire and lands
+// in the pipeline. The daemon does not have a krit-types.jar in its
+// search path (TempDir root), so without InputTypesPath it would
+// silently leave OracleEnabled=false. With InputTypesPath set to a
+// readable oracle JSON dump, the verb should accept the request and
+// return findings without erroring on the missing JVM.
+//
+// The test does NOT assert that any particular oracle-backed finding
+// fires — that would require pinning a specific rule's KAA dependence.
+// It asserts the wire contract: the path is accepted and the call
+// completes successfully.
+func TestAnalyzeProject_InputTypesPathHonoured(t *testing.T) {
+	socket, state := startServerForTest(t)
+	writeKotlinFile(t, state.root, "Foo.kt", "package demo\n\nclass Foo\n")
+
+	// Minimal valid oracle JSON dump: valid envelope, empty file map.
+	// IndexPhase.runAutoDetectOracle reads this via NewLazyLookup +
+	// Preload; an empty Files map is a no-op merge into the resolver.
+	oraclePath := filepath.Join(state.root, "types.json")
+	if err := os.WriteFile(oraclePath, []byte(`{"version":1,"kotlinVersion":"","files":{},"dependencies":{}}`), 0o644); err != nil {
+		t.Fatalf("write oracle: %v", err)
+	}
+
+	var got daemon.AnalyzeProjectResult
+	if err := daemon.Call(socket, daemon.VerbAnalyzeProject,
+		daemon.AnalyzeProjectArgs{
+			InputTypesPath: oraclePath,
+		}, &got); err != nil {
+		t.Fatalf("call: %v", err)
+	}
+	if len(got.Findings) == 0 {
+		t.Fatal("expected findings JSON envelope")
+	}
+}
+
+// TestAnalyzeProject_InputTypesPathInvalidStillReturnsFindings pins
+// the documented graceful-degrade behaviour: a malformed oracle JSON
+// path warns through the lazy lookup error callback but does not fail
+// the verb. Rules that don't need the oracle still produce findings.
+func TestAnalyzeProject_InputTypesPathInvalidStillReturnsFindings(t *testing.T) {
+	socket, state := startServerForTest(t)
+	writeKotlinFile(t, state.root, "Foo.kt", "package demo\n\nclass Foo\n")
+
+	bogusPath := filepath.Join(state.root, "missing-types.json")
+
+	var got daemon.AnalyzeProjectResult
+	if err := daemon.Call(socket, daemon.VerbAnalyzeProject,
+		daemon.AnalyzeProjectArgs{
+			InputTypesPath: bogusPath,
+		}, &got); err != nil {
+		t.Fatalf("call: %v", err)
+	}
+	if len(got.Findings) == 0 {
+		t.Fatal("expected non-empty Findings JSON envelope")
+	}
+}

--- a/internal/daemon/protocol.go
+++ b/internal/daemon/protocol.go
@@ -177,6 +177,13 @@ type AnalyzeProjectArgs struct {
 	// CustomRuleJars are Kotlin custom-rule plugin jars loaded by the
 	// resident krit-types daemon.
 	CustomRuleJars []string `json:"custom_rule_jars,omitempty"`
+	// InputTypesPath mirrors --input-types: an absolute path to a
+	// prebuilt oracle JSON dump. When non-empty, the daemon bypasses
+	// its resident OracleDaemon for this call and loads the dump
+	// directly. The path is read by the daemon process, so callers
+	// must hand the daemon a path it can open (the CLI resolves to
+	// absolute before forwarding).
+	InputTypesPath string `json:"input_types_path,omitempty"`
 	// RequireWarm, when true, makes the verb fail fast (with a typed
 	// error) instead of paying cold-warm cost. Clients that want a
 	// hard SLA set this — useful for IDE workflows that can show a

--- a/internal/pipeline/project.go
+++ b/internal/pipeline/project.go
@@ -94,6 +94,12 @@ type ProjectArgs struct {
 	// CustomRuleJars are Kotlin custom-rule plugin jars loaded by the
 	// krit-types daemon and merged into the standard finding stream.
 	CustomRuleJars []string
+	// InputTypesPath mirrors --input-types: an explicit oracle JSON
+	// path that bypasses the krit-types JVM (one-shot or daemon) and
+	// loads the prebuilt facts directly. When non-empty the daemon
+	// host skips its resident OracleDaemon for this call so the
+	// auto-detect oracle path can honour the user-supplied dump.
+	InputTypesPath string
 	// TargetedResolution, when true, runs active rules' expression
 	// selectors through the configured expression resolver before
 	// dispatch. The pass is optional: missing resolver/sink or a rule
@@ -784,6 +790,7 @@ func runProjectIndexPhase(ctx context.Context, args ProjectArgs, host ProjectHos
 		ModuleScanRoot:           scanRoot,
 		ModuleJobsFlag:           args.Workers,
 		ModuleHasAwareRule:       hasModuleAwareRule,
+		InputTypesPath:           args.InputTypesPath,
 	}
 	wireOracleHandles(&indexInput, args, host, parseResult.KotlinFiles)
 	if warm.result == nil {
@@ -1246,7 +1253,20 @@ func wireAnalysisCacheLookup(in *IndexInput, args ProjectArgs, host ProjectHostS
 // daemon handle. Extracted from RunProject to keep its cyclomatic
 // complexity manageable.
 func wireOracleHandles(in *IndexInput, args ProjectArgs, host ProjectHostState, kotlinFiles []*scanner.File) {
-	if !args.OracleEnabled || host.OracleDaemon == nil {
+	if !args.OracleEnabled {
+		return
+	}
+	// --input-types points at a prebuilt oracle JSON; skip the JVM
+	// daemon entirely so runOracle takes the auto-detect path that
+	// honours InputTypesPath. The user-supplied dump is the source of
+	// truth for this call — burning JVM time would be wasted work and
+	// would also lose any oracle deltas the dump captured.
+	if args.InputTypesPath != "" {
+		in.OracleEnabled = true
+		in.OracleScanPaths = args.Paths
+		return
+	}
+	if host.OracleDaemon == nil {
 		return
 	}
 	in.OracleEnabled = true


### PR DESCRIPTION
## Summary

Peels the **oracle I/O & sampling** bucket off the in-process exclusion list:
two of the four flags become daemon-routable; the other two get documented
rationale for staying in-process.

### Newly routable

- `--input-types <path>` — the CLI absolutizes the path against the caller's
  CWD (the daemon process has its own CWD), forwards via
  `AnalyzeProjectArgs.InputTypesPath` → `ProjectArgs.InputTypesPath`. The
  pipeline's `wireOracleHandles` skips the resident `OracleDaemon` when
  `InputTypesPath` is set so `runOracle` takes the auto-detect path that
  loads the user-supplied dump directly. No JVM round-trip; no wasted work.
- `--sample-rule <ruleID>` — the daemon still runs the analysis; the CLI
  forces `Format=json` on the wire, decodes the envelope into a
  `FindingColumns` via `scanner.NewFindingCollector`, and re-runs the same
  `RunSampleFindingsColumns` short-circuit it would have used in-process.

### Stays in-process (documented)

- `--output-types` is a "skip rules entirely, dump oracle JSON" mode. Routing
  it through the daemon's `AnalyzeProject` verb would either need a brand-new
  dump-only verb or waste the rule-dispatch the user explicitly skipped.
- `--delta` shells out to `git worktree add` and re-execs `krit` itself for
  the base ref. The orchestration is a CLI-side wrapper; the sub-scan can
  already hit the daemon. Routing the wrapper would require either daemon-
  side worktree management (unsafe side effects in a long-lived service) or
  the same `FindingColumns`-on-the-wire change the audit short-circuits would
  benefit from — revisit together.

## Test plan

- [x] New unit tests in `internal/cli/scan/daemon_delegate_oracle_args_test.go` cover the compatibility-flag transitions, path absolutization, JSON-format override, and end-to-end `--sample-rule` envelope consumption against a mock daemon.
- [x] New round-trip tests in `internal/cli/serve/analyze_project_input_types_test.go` confirm the daemon honors the wire field and degrades cleanly on a missing path.
- [x] `go build ./...`, `go vet ./...`, `golangci-lint run ./...` clean.
- [x] `go test ./... -count=1` passes (the `TestFileWatcher_DebounceEditorSavePattern` flake is pre-existing on `main`).