### PR TITLE
perf(daemon): memory ceiling + LRU eviction for parsed cache (#209)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /krit-lsp
 /krit-mcp
 /krit-changelog
+/krit-daemon
 cmd/profile/
 cmd/debug-index/
 

--- a/internal/cli/serve/serve.go
+++ b/internal/cli/serve/serve.go
@@ -103,6 +103,7 @@ func Run(args []string) int {
 	socketFlag := fs.String("socket", "", "Unix socket path (default <root>/.krit/daemon.sock)")
 	stopFlag := fs.Bool("stop", false, "Stop a running daemon at --socket")
 	idleFlag := fs.Duration("idle-timeout", 30*time.Minute, "Auto-shutdown after no request for this duration; 0 disables")
+	maxParseBytesFlag := fs.Int64("max-parse-bytes", 0, "Cap on resident parsed-file bytes; over the cap, LRU entries are evicted. 0 disables")
 	noWatcherFlag := fs.Bool("no-watcher", false, "Disable filesystem watching for cache invalidation")
 	// --strict-verify reruns every analyze in-process from cold caches
 	// and fails the response on row-level divergence vs the daemon's
@@ -135,6 +136,7 @@ func Run(args []string) int {
 
 	state := newDaemonState(root)
 	state.strictVerify = *strictVerifyFlag
+	state.workspace.SetMaxParsedBytes(*maxParseBytesFlag)
 	warmStart := time.Now()
 	if err := state.warm(); err != nil {
 		fmt.Fprintf(os.Stderr, "krit serve: warm: %v\n", err)

--- a/internal/pipeline/workspace.go
+++ b/internal/pipeline/workspace.go
@@ -1,6 +1,7 @@
 package pipeline
 
 import (
+	"container/list"
 	"context"
 	"path/filepath"
 	"sort"
@@ -29,6 +30,20 @@ type WorkspaceState struct {
 
 	mu     sync.RWMutex
 	parsed map[string]parsedEntry
+	// parsedLRU orders parsed entries by access recency; front = MRU,
+	// back = LRU. Each element's Value is the entry's key (string).
+	// Guarded by mu.
+	parsedLRU *list.List
+	// parsedBytes sums bytes across resident parsed entries
+	// (approximated by file.Content length). Guarded by mu.
+	parsedBytes int64
+	// maxParsedBytes caps parsedBytes; when > 0, inserts that would
+	// push the total over evict LRU entries until the new total fits.
+	// Zero (the default) disables eviction. Read atomically on the
+	// hot path so a cache hit can skip LRU promotion (and the write
+	// lock) when no cap is active.
+	maxParsedBytes  atomic.Int64
+	parsedEvictions atomic.Int64
 	// dirty tracks paths that have been invalidated since the last
 	// DrainDirty call. Populated by Touch (intended to be called
 	// alongside Invalidate from the file watcher); drained by daemon
@@ -158,6 +173,12 @@ type xfileSlot[T any] struct {
 type parsedEntry struct {
 	contentHash string
 	file        *scanner.File
+	// bytes approximates the entry's resident cost via
+	// len(file.Content). Walking the tree-sitter AST to size it
+	// exactly would defeat the point of a fast cache; source size is
+	// a monotonic proxy that's enough to bound growth.
+	bytes int64
+	elem  *list.Element
 }
 
 // NewWorkspaceState returns an empty workspace state rooted at repoRoot.
@@ -165,8 +186,47 @@ type parsedEntry struct {
 // extension; passing "" is valid.
 func NewWorkspaceState(repoRoot string) *WorkspaceState {
 	return &WorkspaceState{
-		repoRoot: repoRoot,
-		parsed:   make(map[string]parsedEntry),
+		repoRoot:  repoRoot,
+		parsed:    make(map[string]parsedEntry),
+		parsedLRU: list.New(),
+	}
+}
+
+// SetMaxParsedBytes sets the resident byte cap for the parsed cache.
+// n <= 0 disables eviction (unlimited, the default). Lowering n below
+// the current parsedBytes evicts LRU entries until parsedBytes <= n.
+func (w *WorkspaceState) SetMaxParsedBytes(n int64) {
+	if w == nil {
+		return
+	}
+	if n < 0 {
+		n = 0
+	}
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.maxParsedBytes.Store(n)
+	w.evictLRULocked()
+}
+
+// evictLRULocked drops back-of-list entries until parsedBytes fits
+// under maxParsedBytes. Caller holds w.mu. Cap of 0 disables.
+func (w *WorkspaceState) evictLRULocked() {
+	maxBytes := w.maxParsedBytes.Load()
+	if maxBytes <= 0 {
+		return
+	}
+	for w.parsedBytes > maxBytes {
+		oldest := w.parsedLRU.Back()
+		if oldest == nil {
+			return
+		}
+		key := oldest.Value.(string)
+		w.parsedLRU.Remove(oldest)
+		if e, ok := w.parsed[key]; ok {
+			w.parsedBytes -= e.bytes
+			delete(w.parsed, key)
+		}
+		w.parsedEvictions.Add(1)
 	}
 }
 
@@ -199,6 +259,7 @@ func (w *WorkspaceState) ParseFileWithHit(ctx context.Context, path string, cont
 	entry, ok := w.parsed[key]
 	w.mu.RUnlock()
 	if ok && entry.contentHash == hash {
+		w.promoteLRU(key, entry.elem)
 		w.hits.Add(1)
 		return entry.file, true, nil
 	}
@@ -214,14 +275,62 @@ func (w *WorkspaceState) ParseFileWithHit(ctx context.Context, path string, cont
 	// identity. The freshly parsed file is discarded; same content,
 	// same content hash.
 	if existing, ok := w.parsed[key]; ok && existing.contentHash == hash {
+		if existing.elem != nil && w.maxParsedBytes.Load() > 0 {
+			w.parsedLRU.MoveToFront(existing.elem)
+		}
 		w.mu.Unlock()
 		w.hits.Add(1)
 		return existing.file, true, nil
 	}
-	w.parsed[key] = parsedEntry{contentHash: hash, file: file}
+	w.storeParsedLocked(key, parsedEntry{
+		contentHash: hash,
+		file:        file,
+		bytes:       fileResidentBytes(file),
+	})
 	w.mu.Unlock()
 	w.misses.Add(1)
 	return file, false, nil
+}
+
+// promoteLRU moves the entry for key to the front of parsedLRU when
+// the cached element identity still matches elem. Skips work entirely
+// when no cap is active so the cache-hit fast path stays RLock-only —
+// LRU order doesn't matter without eviction, and SetMaxParsedBytes
+// rebuilds order from current insertion sequence if a cap is enabled
+// later. The elem identity guard catches a racing Invalidate +
+// re-insert between the RLock read and the Lock here.
+func (w *WorkspaceState) promoteLRU(key string, elem *list.Element) {
+	if w == nil || elem == nil || w.maxParsedBytes.Load() == 0 {
+		return
+	}
+	w.mu.Lock()
+	if e, ok := w.parsed[key]; ok && e.elem == elem {
+		w.parsedLRU.MoveToFront(elem)
+	}
+	w.mu.Unlock()
+}
+
+// storeParsedLocked installs entry under key, replacing any prior
+// entry's LRU node + byte accounting, then runs eviction. Caller
+// holds w.mu.
+func (w *WorkspaceState) storeParsedLocked(key string, entry parsedEntry) {
+	if prior, ok := w.parsed[key]; ok {
+		if prior.elem != nil {
+			w.parsedLRU.Remove(prior.elem)
+		}
+		w.parsedBytes -= prior.bytes
+	}
+	entry.elem = w.parsedLRU.PushFront(key)
+	w.parsedBytes += entry.bytes
+	w.parsed[key] = entry
+	w.evictLRULocked()
+}
+
+func fileResidentBytes(f *scanner.File) int64 {
+	if f == nil {
+		return 0
+	}
+	return int64(len(f.Content))
 }
 
 // LookupParsedByPath returns the cached *scanner.File for path
@@ -259,10 +368,17 @@ func (w *WorkspaceState) StoreParsed(path string, content []byte, file *scanner.
 	hash := hashutil.Default().HashContent(key, content)
 	w.mu.Lock()
 	if existing, ok := w.parsed[key]; ok && existing.contentHash == hash {
+		if existing.elem != nil && w.maxParsedBytes.Load() > 0 {
+			w.parsedLRU.MoveToFront(existing.elem)
+		}
 		w.mu.Unlock()
 		return
 	}
-	w.parsed[key] = parsedEntry{contentHash: hash, file: file}
+	w.storeParsedLocked(key, parsedEntry{
+		contentHash: hash,
+		file:        file,
+		bytes:       fileResidentBytes(file),
+	})
 	w.mu.Unlock()
 }
 
@@ -276,7 +392,13 @@ func (w *WorkspaceState) Invalidate(path string) {
 	}
 	key := normalizeKey(path)
 	w.mu.Lock()
-	delete(w.parsed, key)
+	if e, ok := w.parsed[key]; ok {
+		if e.elem != nil {
+			w.parsedLRU.Remove(e.elem)
+		}
+		w.parsedBytes -= e.bytes
+		delete(w.parsed, key)
+	}
 	w.mu.Unlock()
 	w.typeInfoMu.Lock()
 	delete(w.typeInfo, key)
@@ -436,6 +558,8 @@ func (w *WorkspaceState) InvalidateAll() {
 	}
 	w.mu.Lock()
 	w.parsed = make(map[string]parsedEntry)
+	w.parsedLRU.Init()
+	w.parsedBytes = 0
 	w.dirty = nil
 	w.mu.Unlock()
 
@@ -943,9 +1067,12 @@ func (w *WorkspaceState) InvalidateOracleFilter() {
 // WorkspaceStats is a point-in-time snapshot of cache utilisation,
 // useful for testing and verbose logging.
 type WorkspaceStats struct {
-	ParsedEntries int
-	Hits          int64
-	Misses        int64
+	ParsedEntries   int
+	ParsedBytes     int64
+	MaxParsedBytes  int64
+	ParsedEvictions int64
+	Hits            int64
+	Misses          int64
 }
 
 // Stats returns a snapshot of the current cache state.
@@ -955,11 +1082,15 @@ func (w *WorkspaceState) Stats() WorkspaceStats {
 	}
 	w.mu.RLock()
 	n := len(w.parsed)
+	bytes := w.parsedBytes
 	w.mu.RUnlock()
 	return WorkspaceStats{
-		ParsedEntries: n,
-		Hits:          w.hits.Load(),
-		Misses:        w.misses.Load(),
+		ParsedEntries:   n,
+		ParsedBytes:     bytes,
+		MaxParsedBytes:  w.maxParsedBytes.Load(),
+		ParsedEvictions: w.parsedEvictions.Load(),
+		Hits:            w.hits.Load(),
+		Misses:          w.misses.Load(),
 	}
 }
 

--- a/internal/pipeline/workspace_lru_test.go
+++ b/internal/pipeline/workspace_lru_test.go
@@ -1,0 +1,219 @@
+package pipeline
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// kotlinOfSize produces parseable Kotlin source of roughly target
+// bytes. Used so each cache entry has a known, distinct content-hash
+// and a predictable len(file.Content) that drives byte accounting.
+func kotlinOfSize(name string, target int) []byte {
+	// Each fun line adds ~30 bytes; pad with a comment block to hit target.
+	const header = "package demo\n\nclass %s {\n    fun greet() = \"hi\"\n}\n"
+	src := fmt.Sprintf(header, name)
+	if len(src) >= target {
+		return []byte(src)
+	}
+	pad := strings.Repeat("// pad\n", (target-len(src))/7+1)
+	return []byte(src + pad)
+}
+
+func TestWorkspaceState_LRUEvictsOldestWhenOverCap(t *testing.T) {
+	ws := NewWorkspaceState("/tmp/test")
+	ctx := context.Background()
+
+	a := kotlinOfSize("A", 200)
+	b := kotlinOfSize("B", 200)
+	c := kotlinOfSize("C", 200)
+
+	// Cap big enough for two entries but not three.
+	ws.SetMaxParsedBytes(int64(len(a) + len(b) + 1))
+
+	if _, err := ws.ParseFile(ctx, "A.kt", a); err != nil {
+		t.Fatalf("parse A: %v", err)
+	}
+	if _, err := ws.ParseFile(ctx, "B.kt", b); err != nil {
+		t.Fatalf("parse B: %v", err)
+	}
+	// A is now LRU. Inserting C must evict A.
+	if _, err := ws.ParseFile(ctx, "C.kt", c); err != nil {
+		t.Fatalf("parse C: %v", err)
+	}
+
+	stats := ws.Stats()
+	if stats.ParsedEntries != 2 {
+		t.Errorf("entries: got %d, want 2", stats.ParsedEntries)
+	}
+	if stats.ParsedBytes > stats.MaxParsedBytes {
+		t.Errorf("parsedBytes %d exceeds cap %d", stats.ParsedBytes, stats.MaxParsedBytes)
+	}
+	if stats.ParsedEvictions != 1 {
+		t.Errorf("evictions: got %d, want 1", stats.ParsedEvictions)
+	}
+	if _, ok := ws.LookupParsedByPath("A.kt"); ok {
+		t.Error("A.kt should have been evicted")
+	}
+	if _, ok := ws.LookupParsedByPath("B.kt"); !ok {
+		t.Error("B.kt should still be resident")
+	}
+	if _, ok := ws.LookupParsedByPath("C.kt"); !ok {
+		t.Error("C.kt should be resident (just inserted)")
+	}
+}
+
+func TestWorkspaceState_LRUHitPromotesToMRU(t *testing.T) {
+	ws := NewWorkspaceState("/tmp/test")
+	ctx := context.Background()
+
+	a := kotlinOfSize("A", 200)
+	b := kotlinOfSize("B", 200)
+	c := kotlinOfSize("C", 200)
+
+	ws.SetMaxParsedBytes(int64(len(a) + len(b) + 1))
+
+	if _, err := ws.ParseFile(ctx, "A.kt", a); err != nil {
+		t.Fatalf("parse A: %v", err)
+	}
+	if _, err := ws.ParseFile(ctx, "B.kt", b); err != nil {
+		t.Fatalf("parse B: %v", err)
+	}
+	// Hit on A promotes A to MRU; now B is LRU.
+	if _, err := ws.ParseFile(ctx, "A.kt", a); err != nil {
+		t.Fatalf("re-parse A: %v", err)
+	}
+	// Inserting C must now evict B, not A.
+	if _, err := ws.ParseFile(ctx, "C.kt", c); err != nil {
+		t.Fatalf("parse C: %v", err)
+	}
+
+	if _, ok := ws.LookupParsedByPath("A.kt"); !ok {
+		t.Error("A.kt should have survived after promotion")
+	}
+	if _, ok := ws.LookupParsedByPath("B.kt"); ok {
+		t.Error("B.kt should have been evicted (was LRU after A promotion)")
+	}
+	if _, ok := ws.LookupParsedByPath("C.kt"); !ok {
+		t.Error("C.kt should be resident")
+	}
+}
+
+func TestWorkspaceState_InvalidateUpdatesBytes(t *testing.T) {
+	ws := NewWorkspaceState("/tmp/test")
+	ctx := context.Background()
+	a := kotlinOfSize("A", 300)
+
+	if _, err := ws.ParseFile(ctx, "A.kt", a); err != nil {
+		t.Fatalf("parse A: %v", err)
+	}
+	before := ws.Stats()
+	if before.ParsedBytes == 0 {
+		t.Fatal("ParsedBytes should be non-zero after first parse")
+	}
+
+	ws.Invalidate("A.kt")
+	after := ws.Stats()
+	if after.ParsedEntries != 0 {
+		t.Errorf("entries after invalidate: got %d, want 0", after.ParsedEntries)
+	}
+	if after.ParsedBytes != 0 {
+		t.Errorf("bytes after invalidate: got %d, want 0", after.ParsedBytes)
+	}
+}
+
+func TestWorkspaceState_InvalidateAllResetsAccounting(t *testing.T) {
+	ws := NewWorkspaceState("/tmp/test")
+	ctx := context.Background()
+	for i := 0; i < 5; i++ {
+		path := fmt.Sprintf("F%d.kt", i)
+		if _, err := ws.ParseFile(ctx, path, kotlinOfSize(fmt.Sprintf("F%d", i), 200)); err != nil {
+			t.Fatalf("parse %s: %v", path, err)
+		}
+	}
+	if ws.Stats().ParsedBytes == 0 {
+		t.Fatal("ParsedBytes should be non-zero before InvalidateAll")
+	}
+	ws.InvalidateAll()
+	stats := ws.Stats()
+	if stats.ParsedEntries != 0 || stats.ParsedBytes != 0 {
+		t.Errorf("after InvalidateAll: entries=%d bytes=%d, want both 0", stats.ParsedEntries, stats.ParsedBytes)
+	}
+	// Re-insert should still work and account correctly.
+	if _, err := ws.ParseFile(ctx, "G.kt", kotlinOfSize("G", 200)); err != nil {
+		t.Fatalf("parse after reset: %v", err)
+	}
+	if ws.Stats().ParsedEntries != 1 {
+		t.Errorf("re-insert: entries=%d, want 1", ws.Stats().ParsedEntries)
+	}
+}
+
+func TestWorkspaceState_SetMaxParsedBytesEvictsImmediately(t *testing.T) {
+	ws := NewWorkspaceState("/tmp/test")
+	ctx := context.Background()
+
+	srcs := make([][]byte, 4)
+	for i := range srcs {
+		srcs[i] = kotlinOfSize(fmt.Sprintf("F%d", i), 200)
+		if _, err := ws.ParseFile(ctx, fmt.Sprintf("F%d.kt", i), srcs[i]); err != nil {
+			t.Fatalf("parse F%d: %v", i, err)
+		}
+	}
+	// Drop the cap below current usage; eviction should run.
+	ws.SetMaxParsedBytes(int64(len(srcs[0]) + 1))
+	stats := ws.Stats()
+	if stats.ParsedEntries != 1 {
+		t.Errorf("after shrink: entries=%d, want 1", stats.ParsedEntries)
+	}
+	if stats.ParsedBytes > stats.MaxParsedBytes {
+		t.Errorf("after shrink: bytes %d > cap %d", stats.ParsedBytes, stats.MaxParsedBytes)
+	}
+	if stats.ParsedEvictions < 3 {
+		t.Errorf("after shrink: evictions=%d, want >=3", stats.ParsedEvictions)
+	}
+}
+
+func TestWorkspaceState_ZeroCapDisablesEviction(t *testing.T) {
+	ws := NewWorkspaceState("/tmp/test")
+	ctx := context.Background()
+	// Default cap is 0 (unlimited).
+	for i := 0; i < 50; i++ {
+		path := fmt.Sprintf("F%d.kt", i)
+		if _, err := ws.ParseFile(ctx, path, kotlinOfSize(fmt.Sprintf("F%d", i), 500)); err != nil {
+			t.Fatalf("parse %s: %v", path, err)
+		}
+	}
+	stats := ws.Stats()
+	if stats.ParsedEntries != 50 {
+		t.Errorf("entries: got %d, want 50 (no cap)", stats.ParsedEntries)
+	}
+	if stats.ParsedEvictions != 0 {
+		t.Errorf("evictions: got %d, want 0 (unlimited)", stats.ParsedEvictions)
+	}
+}
+
+func TestWorkspaceState_ContentChangeReusesByteSlot(t *testing.T) {
+	ws := NewWorkspaceState("/tmp/test")
+	ctx := context.Background()
+	a1 := kotlinOfSize("A", 200)
+	a2 := kotlinOfSize("A", 400) // same path, different content & size
+
+	if _, err := ws.ParseFile(ctx, "A.kt", a1); err != nil {
+		t.Fatalf("first: %v", err)
+	}
+	firstBytes := ws.Stats().ParsedBytes
+	if _, err := ws.ParseFile(ctx, "A.kt", a2); err != nil {
+		t.Fatalf("second: %v", err)
+	}
+	stats := ws.Stats()
+	if stats.ParsedEntries != 1 {
+		t.Errorf("entries: got %d, want 1 (same path)", stats.ParsedEntries)
+	}
+	if stats.ParsedBytes == firstBytes {
+		t.Errorf("bytes did not update on content change: %d", stats.ParsedBytes)
+	}
+	if stats.ParsedBytes != int64(len(a2)) {
+		t.Errorf("bytes: got %d, want %d", stats.ParsedBytes, len(a2))
+	}
+}


### PR DESCRIPTION
## Summary

- Adds opt-in byte cap + LRU eviction to `WorkspaceState.parsed`. Previously unbounded.
- Wires `--max-parse-bytes` flag on `krit serve` (default 0 = disabled, preserving current behavior).
- Surfaces `ParsedBytes`, `MaxParsedBytes`, `ParsedEvictions` via `WorkspaceStats`.

Addresses the **Memory ceiling + LRU eviction** item from the v2 daemon tracking issue #209.

## Implementation notes

- Per-entry resident cost is approximated by `len(file.Content)` — a cheap monotonic proxy that's enough to bound growth without walking the tree-sitter AST on every insert.
- Hot-path cost is gated: when the cap is 0 (default), cache hits stay `RLock`-only and skip LRU promotion. Only daemons that opt into a cap pay the per-hit write-lock.
- `SetMaxParsedBytes` evicts immediately when shrinking below current usage. Tested.

## Validation criteria

| Behavior | Test |
| --- | --- |
| LRU evicts oldest entry over cap | `TestWorkspaceState_LRUEvictsOldestWhenOverCap` |
| Cache hit promotes entry, protecting it from next eviction | `TestWorkspaceState_LRUHitPromotesToMRU` |
| `Invalidate` decrements `parsedBytes` | `TestWorkspaceState_InvalidateUpdatesBytes` |
| `InvalidateAll` resets accounting | `TestWorkspaceState_InvalidateAllResetsAccounting` |
| `SetMaxParsedBytes` evicts immediately when shrunk | `TestWorkspaceState_SetMaxParsedBytesEvictsImmediately` |
| Default (cap=0) disables eviction entirely | `TestWorkspaceState_ZeroCapDisablesEviction` |
| Re-parse of same path updates byte slot, not entry count | `TestWorkspaceState_ContentChangeReusesByteSlot` |

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...`
- [x] `go test ./... -count=1`
- [x] `make integration`
- [x] `make regression`