### PR TITLE
perf(daemon): resident XMLCacheFile cache + .xml watcher hook

### DIFF
--- a/internal/cli/serve/analyze_project.go
+++ b/internal/cli/serve/analyze_project.go
@@ -356,6 +356,7 @@ func (s *daemonState) buildProjectInput(args daemon.AnalyzeProjectArgs) (pipelin
 			CodeIndexCache:               s.workspace.CodeIndex,
 			CodeIndexSnapshotLoader:      s.workspace.LoadCodeIndexSnapshot,
 			CodeIndexSnapshotSaver:       s.workspace.StoreCodeIndexSnapshot,
+			XMLFilesLoader:               s.workspace.XMLFiles,
 			JavaSourceIndexCache:         s.workspace.JavaSourceIndex,
 			ResolverCache:                s.workspace.Resolver,
 			ResolverFingerprintCache:     s.workspace.ResolverFingerprint,

--- a/internal/cli/serve/watcher.go
+++ b/internal/cli/serve/watcher.go
@@ -34,6 +34,11 @@ type watcherState interface {
 	// Kotlin edits don't affect the Java source index so the two
 	// version counters are intentionally separate.
 	BumpJavaSourceVersion()
+	// BumpXMLFilesVersion drives the daemon-resident XMLCacheFile
+	// slot. Called on every .xml file event (layout/manifest/
+	// navigation). Kotlin/Java edits don't move XML hashes so the
+	// counter is kept independent.
+	BumpXMLFilesVersion()
 }
 
 const defaultDebounceWindow = 50 * time.Millisecond
@@ -257,6 +262,19 @@ func (fw *fileWatcher) handle(ev fsnotify.Event) {
 		fw.state.Touch(ev.Name)
 		fw.state.BumpSourceMTimeVersion()
 		fw.state.BumpJavaSourceVersion()
+	case isXMLPath(ev.Name):
+		// .xml edits (layouts/manifests/navigation) contribute to
+		// CodeIndex reference data, so drop the same downstream
+		// slots a .kt/.java edit drops AND rotate the dedicated
+		// XML version counter. Kotlin/Java edits don't move XML
+		// hashes so the counter stays independent — same shape
+		// as the .java case above.
+		fw.state.Invalidate(ev.Name)
+		fw.state.InvalidateCodeIndex()
+		fw.state.InvalidateDependents()
+		fw.state.Touch(ev.Name)
+		fw.state.BumpSourceMTimeVersion()
+		fw.state.BumpXMLFilesVersion()
 	}
 }
 
@@ -345,6 +363,14 @@ func isKotlinPath(p string) bool {
 // edits don't need to invalidate the Java source index).
 func isJavaPath(p string) bool {
 	return strings.HasSuffix(p, ".java")
+}
+
+// isXMLPath reports whether the path's basename ends in .xml. XML
+// edits invalidate the daemon's resident XMLCacheFile slot via a
+// separate XMLFilesVersion counter — Kotlin/Java edits don't touch
+// XML content so the slot can stay across most edits.
+func isXMLPath(p string) bool {
+	return strings.HasSuffix(p, ".xml")
 }
 
 // isKritConfigPath reports whether the path is the krit.yml /

--- a/internal/cli/serve/watcher_test.go
+++ b/internal/cli/serve/watcher_test.go
@@ -27,6 +27,7 @@ type countingState struct {
 	invalidateCalls atomic.Int64
 	bumpCalls       atomic.Int64
 	javaBumpCalls   atomic.Int64
+	xmlBumpCalls    atomic.Int64
 }
 
 func (c *countingState) Invalidate(path string)  { c.invalidateCalls.Add(1) }
@@ -38,6 +39,7 @@ func (c *countingState) InvalidateOracleFilter() {}
 func (c *countingState) Touch(path string)       {}
 func (c *countingState) BumpSourceMTimeVersion() { c.bumpCalls.Add(1) }
 func (c *countingState) BumpJavaSourceVersion()  { c.javaBumpCalls.Add(1) }
+func (c *countingState) BumpXMLFilesVersion()    { c.xmlBumpCalls.Add(1) }
 
 // waitForCondition polls fn every 5ms up to 2s. Returns true when fn
 // turns true; false on timeout. Used to bridge the async fsnotify
@@ -510,6 +512,7 @@ func (c *chmodFilterCountingState) InvalidateOracleFilter() {}
 func (c *chmodFilterCountingState) Touch(string)            {}
 func (c *chmodFilterCountingState) BumpSourceMTimeVersion() { c.bumpCalls.Add(1) }
 func (c *chmodFilterCountingState) BumpJavaSourceVersion()  {}
+func (c *chmodFilterCountingState) BumpXMLFilesVersion()    {}
 
 // TestFileWatcher_BumpsMTimeVersionOnKotlinEdit asserts the watcher
 // drives the daemon-resident stats-clean memo: a real .kt edit must
@@ -596,5 +599,41 @@ func TestFileWatcher_BumpsJavaSourceVersionOnJavaEdit(t *testing.T) {
 	time.Sleep(80 * time.Millisecond)
 	if got := state.javaBumpCalls.Load(); got != 0 {
 		t.Errorf("Kotlin edit must NOT bump Java counter; got %d", got)
+	}
+}
+
+// TestFileWatcher_BumpsXMLFilesVersionOnXMLEdit pins the .xml-event
+// hook. Edits to layout/manifest/navigation XMLs must invalidate the
+// daemon-resident XMLCacheFile slot so the next analyze re-walks the
+// project. Kotlin / Java edits, on the other hand, MUST NOT bump
+// the XML counter — XML content is independent and we want to reuse
+// the cached slice across the (much more common) source edits.
+func TestFileWatcher_BumpsXMLFilesVersionOnXMLEdit(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "layout.xml")
+	if err := os.WriteFile(path, []byte(`<View/>`), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	state := &countingState{}
+	w, err := startFileWatcherWithState(context.Background(), root, state, nil)
+	if err != nil {
+		t.Fatalf("startFileWatcher: %v", err)
+	}
+	defer w.Stop()
+
+	if err := os.WriteFile(path, []byte(`<TextView/>`), 0o644); err != nil {
+		t.Fatalf("rewrite: %v", err)
+	}
+	if !waitForCondition(func() bool { return state.xmlBumpCalls.Load() >= 1 }) {
+		t.Errorf("expected BumpXMLFilesVersion after .xml edit, got %d", state.xmlBumpCalls.Load())
+	}
+	// Sanity: a Kotlin edit must NOT bump the XML counter.
+	state.xmlBumpCalls.Store(0)
+	if err := os.WriteFile(filepath.Join(root, "Bar.kt"), []byte("fun b() {}\n"), 0o644); err != nil {
+		t.Fatalf("write kt: %v", err)
+	}
+	time.Sleep(80 * time.Millisecond)
+	if got := state.xmlBumpCalls.Load(); got != 0 {
+		t.Errorf("Kotlin edit must NOT bump XML counter; got %d", got)
 	}
 }

--- a/internal/pipeline/index.go
+++ b/internal/pipeline/index.go
@@ -92,6 +92,13 @@ type IndexInput struct {
 	// allowed (no snapshot is retained — disables the fast path
 	// for future calls).
 	CodeIndexSnapshotSaver func(*scanner.CodeIndex, scanner.CrossFileCacheMeta)
+	// XMLFilesLoader, when non-nil, short-circuits the
+	// scanner-internal disk walk that loads layout/manifest/
+	// navigation XMLs on every BuildIndexCachedWithLoaders call.
+	// The callback returns either the daemon's resident slice or
+	// the result of build. nil falls back to the unconditional
+	// walk — non-daemon callers keep their existing behavior.
+	XMLFilesLoader scanner.XMLFilesLoader
 	// JavaSourceIndexCache wires the daemon's resident
 	// *javafacts.SourceIndex cache through to CrossFilePhase. See
 	// IndexResult.JavaSourceIndexCache for semantics.
@@ -1141,7 +1148,7 @@ func (p IndexPhase) runCodeIndexBuild(in IndexInput, result *IndexResult) {
 		indexTracker := crossTracker.Serial("indexBuild")
 		if in.CrossFileCacheDir != "" {
 			var hit bool
-			codeIndex, hit = scanner.BuildIndexCachedWithPrior(in.CrossFileCacheDir, parsedFiles, crossWorkers, in.CodeIndexSnapshotLoader, in.CodeIndexSnapshotSaver, indexTracker, parsedJavaFiles...)
+			codeIndex, hit = scanner.BuildIndexCachedWithLoaders(in.CrossFileCacheDir, parsedFiles, crossWorkers, in.CodeIndexSnapshotLoader, in.CodeIndexSnapshotSaver, in.XMLFilesLoader, indexTracker, parsedJavaFiles...)
 			if in.Verbose {
 				if hit {
 					in.logf("verbose: Cross-file index cache: HIT\n")

--- a/internal/pipeline/project.go
+++ b/internal/pipeline/project.go
@@ -198,6 +198,12 @@ type ProjectHostState struct {
 	// it via the loader.
 	// *WorkspaceState.StoreCodeIndexSnapshot satisfies the shape.
 	CodeIndexSnapshotSaver func(*scanner.CodeIndex, scanner.CrossFileCacheMeta)
+	// XMLFilesLoader, when non-nil, short-circuits the scanner's
+	// disk walk for layout/manifest/navigation XMLs. The daemon
+	// supplies its WorkspaceState.XMLFiles wrapped to match the
+	// scanner.XMLFilesLoader signature so .xml watcher events drive
+	// invalidation through WorkspaceState.BumpXMLFilesVersion.
+	XMLFilesLoader scanner.XMLFilesLoader
 	// JavaSourceIndexCache, when non-nil, lets CrossFilePhase short-
 	// circuit the ~100 ms content-hash key SourceIndexForFiles otherwise
 	// computes on every warm call. The watcher's .java events drive
@@ -761,6 +767,7 @@ func runProjectIndexPhase(ctx context.Context, args ProjectArgs, host ProjectHos
 		CodeIndexCache:           host.CodeIndexCache,
 		CodeIndexSnapshotLoader:  host.CodeIndexSnapshotLoader,
 		CodeIndexSnapshotSaver:   host.CodeIndexSnapshotSaver,
+		XMLFilesLoader:           host.XMLFilesLoader,
 		JavaSourceIndexCache:     host.JavaSourceIndexCache,
 		ResolverCache:            host.ResolverCache,
 		ResolverFingerprintCache: host.ResolverFingerprintCache,

--- a/internal/pipeline/workspace.go
+++ b/internal/pipeline/workspace.go
@@ -98,6 +98,21 @@ type WorkspaceState struct {
 	cachedJavaSourceIndex   *javafacts.SourceIndex
 	cachedJavaSourceVersion uint64
 
+	xmlFilesMu sync.Mutex
+	// xmlFilesVersion is bumped on every .xml watcher event. The
+	// resident XMLCacheFile slot uses it to detect whether its last
+	// build is still valid without re-walking the project for layouts
+	// / manifests / navigation files (~200 ms on the kotlin compiler
+	// corpus's 520 XMLs; many seconds on Android-heavy repos with
+	// thousands of resource XMLs).
+	xmlFilesVersion uint64
+	// cachedXMLFiles is the last successful XML walk, valid while
+	// cachedXMLFilesVersion == xmlFilesVersion. A bump on the watcher
+	// side rotates the version; the next lookup misses and rebuilds
+	// via scanner.LoadXMLFilesForCache.
+	cachedXMLFiles        []*scanner.XMLCacheFile
+	cachedXMLFilesVersion uint64
+
 	codeIndexSnapshotMu sync.Mutex
 	// codeIndexSnapshot is the last successfully built *CodeIndex,
 	// retained across watcher invalidations of the fingerprint-keyed
@@ -367,6 +382,56 @@ func (w *WorkspaceState) BumpJavaSourceVersion() {
 	w.javaSourceMu.Unlock()
 }
 
+// XMLFiles returns the daemon-resident []*scanner.XMLCacheFile when
+// its version still matches the watcher's xmlFilesVersion; otherwise
+// it invokes build, stores the result under the current version, and
+// returns it. The build closure runs without the slot mutex held so
+// concurrent readers (none today — analyze is per-project serial)
+// would not block; a watcher event mid-build advances the counter and
+// the would-be store is skipped so the next call rebuilds.
+//
+// XML files contribute reference data to the cross-file index;
+// build() must scan the same root set scanner.LoadXMLFilesForCache
+// does so the cache is content-equivalent to a fresh walk. nil
+// receiver always builds — same safety contract as the other
+// resident caches.
+func (w *WorkspaceState) XMLFiles(build func() []*scanner.XMLCacheFile) []*scanner.XMLCacheFile {
+	if w == nil {
+		return build()
+	}
+	w.xmlFilesMu.Lock()
+	if w.cachedXMLFiles != nil && w.cachedXMLFilesVersion == w.xmlFilesVersion {
+		v := w.cachedXMLFiles
+		w.xmlFilesMu.Unlock()
+		return v
+	}
+	currentVersion := w.xmlFilesVersion
+	w.xmlFilesMu.Unlock()
+
+	files := build()
+
+	w.xmlFilesMu.Lock()
+	if w.xmlFilesVersion == currentVersion {
+		w.cachedXMLFiles = files
+		w.cachedXMLFilesVersion = currentVersion
+	}
+	w.xmlFilesMu.Unlock()
+	return files
+}
+
+// BumpXMLFilesVersion advances the version counter so the next
+// XMLFiles call rebuilds. Called by the watcher on every .xml file
+// event (layout/manifest/navigation changes can rotate the CodeIndex
+// fingerprint and the rule-set's XML reference targets).
+func (w *WorkspaceState) BumpXMLFilesVersion() {
+	if w == nil {
+		return
+	}
+	w.xmlFilesMu.Lock()
+	w.xmlFilesVersion++
+	w.xmlFilesMu.Unlock()
+}
+
 // Touch records that path has changed on disk since the last
 // DrainDirty. Intended to be called alongside Invalidate from the
 // file watcher so consumers can later ask "what changed since I last
@@ -457,6 +522,10 @@ func (w *WorkspaceState) InvalidateAll() {
 	w.cachedJavaSourceIndex = nil
 	w.javaSourceVersion++
 	w.javaSourceMu.Unlock()
+	w.xmlFilesMu.Lock()
+	w.cachedXMLFiles = nil
+	w.xmlFilesVersion++
+	w.xmlFilesMu.Unlock()
 	w.resolverFpMu.Lock()
 	w.cachedResolverFp = ""
 	w.cachedResolverFpPresent = false

--- a/internal/pipeline/workspace_xml_files_test.go
+++ b/internal/pipeline/workspace_xml_files_test.go
@@ -1,0 +1,108 @@
+package pipeline
+
+import (
+	"testing"
+
+	"github.com/kaeawc/krit/internal/scanner"
+)
+
+// TestWorkspaceState_XMLFiles_HitCacheUntilBump pins the version-
+// counter contract: a cache hit short-circuits the build closure
+// entirely; a watcher .xml bump rotates the counter and the next
+// call rebuilds. Mirrors the JavaSourceIndex contract from #264 —
+// the XML walk is the heavier of the two on Android-leaning corpora.
+func TestWorkspaceState_XMLFiles_HitCacheUntilBump(t *testing.T) {
+	w := NewWorkspaceState("")
+	var builds int
+	build := func() []*scanner.XMLCacheFile {
+		builds++
+		return []*scanner.XMLCacheFile{{Path: "a.xml"}}
+	}
+
+	first := w.XMLFiles(build)
+	if builds != 1 {
+		t.Fatalf("first call: builds=%d, want 1", builds)
+	}
+	again := w.XMLFiles(build)
+	if builds != 1 {
+		t.Errorf("second call after no bump must hit cache; builds=%d, want 1", builds)
+	}
+	if &again[0] != &first[0] {
+		t.Errorf("cached slice must return identical backing array; got fresh pointer")
+	}
+
+	w.BumpXMLFilesVersion()
+
+	_ = w.XMLFiles(build)
+	if builds != 2 {
+		t.Errorf("post-bump call must rebuild; builds=%d, want 2", builds)
+	}
+}
+
+// TestWorkspaceState_XMLFiles_ConcurrentBumpInvalidates mirrors the
+// race semantics that motivate snapshotting the version BEFORE the
+// build runs: a watcher event during the build must NOT result in a
+// "clean" cached entry under a now-stale version.
+func TestWorkspaceState_XMLFiles_ConcurrentBumpInvalidates(t *testing.T) {
+	w := NewWorkspaceState("")
+
+	files := w.XMLFiles(func() []*scanner.XMLCacheFile {
+		w.BumpXMLFilesVersion()
+		return []*scanner.XMLCacheFile{{Path: "a.xml"}}
+	})
+	if len(files) != 1 {
+		t.Errorf("returned slice must come from the build call; got %v", files)
+	}
+
+	var builds int
+	_ = w.XMLFiles(func() []*scanner.XMLCacheFile {
+		builds++
+		return files
+	})
+	if builds == 0 {
+		t.Errorf("post-race call must rebuild (the stale version mustn't survive)")
+	}
+}
+
+// TestWorkspaceState_XMLFiles_NilSafety mirrors the safety contract
+// the rest of WorkspaceState's caches honor.
+func TestWorkspaceState_XMLFiles_NilSafety(t *testing.T) {
+	var w *WorkspaceState
+	called := 0
+	got := w.XMLFiles(func() []*scanner.XMLCacheFile {
+		called++
+		return []*scanner.XMLCacheFile{{Path: "a.xml"}}
+	})
+	if len(got) != 1 {
+		t.Errorf("nil receiver must still return the build result; got %v", got)
+	}
+	if called != 1 {
+		t.Errorf("nil receiver must call build; called=%d, want 1", called)
+	}
+	w.BumpXMLFilesVersion() // must not panic
+}
+
+// TestWorkspaceState_XMLFiles_InvalidateAllClears confirms InvalidateAll
+// drops the XML slot alongside the other resident caches — symmetric
+// with the codeIndexSnapshot / javaSourceIndex resets.
+func TestWorkspaceState_XMLFiles_InvalidateAllClears(t *testing.T) {
+	w := NewWorkspaceState("")
+	var builds int
+	build := func() []*scanner.XMLCacheFile {
+		builds++
+		return []*scanner.XMLCacheFile{{Path: "a.xml"}}
+	}
+
+	_ = w.XMLFiles(build)
+	_ = w.XMLFiles(build)
+	if builds != 1 {
+		t.Fatalf("warm cache state: builds=%d, want 1", builds)
+	}
+
+	w.InvalidateAll()
+
+	_ = w.XMLFiles(build)
+	if builds != 2 {
+		t.Errorf("InvalidateAll must drop the XML slot; builds=%d, want 2", builds)
+	}
+}

--- a/internal/scanner/index.go
+++ b/internal/scanner/index.go
@@ -109,6 +109,20 @@ type PriorIndexLoader func() (*CodeIndex, CrossFileCacheMeta, bool)
 // callback — non-daemon callers ignore it.
 type SnapshotSaver func(idx *CodeIndex, meta CrossFileCacheMeta)
 
+// XMLFilesLoader, when non-nil, is consulted by
+// BuildIndexCachedWithPrior INSTEAD of the unconditional
+// loadXMLFilesForCache disk walk. The build closure is the fallback
+// — the daemon's version-gated slot calls it on a cache miss. nil
+// loader falls through to the legacy disk walk every call.
+//
+// On Android-heavy corpora the XML walk is one of the largest
+// remaining costs (~200 ms / 520 XMLs on the kotlin compiler corpus,
+// scaling roughly linearly to thousands of files on real Android
+// projects). A daemon that hasn't seen any .xml watcher event since
+// the last build returns the cached slice in O(1) instead of
+// repaying the walk + read + hash on every call.
+type XMLFilesLoader func(build func() []*XMLCacheFile) []*XMLCacheFile
+
 // BuildIndexCachedWithPrior is BuildIndexCached with an optional
 // in-memory prior-index loader and a snapshot-save callback. When the
 // loader returns a hit, the overlay rebuild path uses the supplied
@@ -124,6 +138,16 @@ type SnapshotSaver func(idx *CodeIndex, meta CrossFileCacheMeta)
 //
 // nil loader + nil saver restores legacy BuildIndexCached behavior.
 func BuildIndexCachedWithPrior(cacheDir string, files []*File, workers int, priorLoader PriorIndexLoader, saver SnapshotSaver, tracker perf.Tracker, javaFiles ...*File) (*CodeIndex, bool) {
+	return BuildIndexCachedWithLoaders(cacheDir, files, workers, priorLoader, saver, nil, tracker, javaFiles...)
+}
+
+// BuildIndexCachedWithLoaders extends BuildIndexCachedWithPrior with
+// an optional XMLFilesLoader so daemon callers can short-circuit the
+// ~200 ms disk walk that loads every layout / manifest / navigation
+// XML on each invocation. nil for either loader falls back to the
+// pre-cache disk path; the entry point exists as a separate symbol
+// so the historic BuildIndexCachedWithPrior signature stays stable.
+func BuildIndexCachedWithLoaders(cacheDir string, files []*File, workers int, priorLoader PriorIndexLoader, saver SnapshotSaver, xmlLoader XMLFilesLoader, tracker perf.Tracker, javaFiles ...*File) (*CodeIndex, bool) {
 	if cacheDir == "" {
 		return BuildIndexWithTracker(files, workers, tracker, javaFiles...), false
 	}
@@ -136,7 +160,12 @@ func BuildIndexCachedWithPrior(cacheDir string, files []*File, workers int, prio
 
 	// Pre-load XML files so fingerprint and reference extraction share
 	// one disk walk. Also gives the cache a complete file-set snapshot.
-	xmlFiles := loadXMLFilesForCache(files)
+	var xmlFiles []*XMLCacheFile
+	if xmlLoader != nil {
+		xmlFiles = xmlLoader(func() []*XMLCacheFile { return loadXMLFilesForCache(files) })
+	} else {
+		xmlFiles = loadXMLFilesForCache(files)
+	}
 	entries := crossFileFingerprintEntries(files, javaFiles, xmlFiles)
 	fingerprint := fingerprintCrossFileEntries(entries)
 	snapshotMeta := func() CrossFileCacheMeta {

--- a/internal/scanner/index_cache.go
+++ b/internal/scanner/index_cache.go
@@ -137,7 +137,7 @@ type fingerprintEntry struct {
 
 // crossFileFingerprintEntries snapshots every file contribution. Sorting makes
 // the eventual fingerprint order-independent.
-func crossFileFingerprintEntries(kotlinFiles, javaFiles []*File, xmlFiles []*xmlCacheFile) []fingerprintEntry {
+func crossFileFingerprintEntries(kotlinFiles, javaFiles []*File, xmlFiles []*XMLCacheFile) []fingerprintEntry {
 	entries := make([]fingerprintEntry, 0, len(kotlinFiles)+len(javaFiles)+len(xmlFiles))
 	for _, f := range kotlinFiles {
 		if f == nil {

--- a/internal/scanner/index_overlay.go
+++ b/internal/scanner/index_overlay.go
@@ -37,7 +37,7 @@ func diffCrossFileEntryPaths(oldEntries, newEntries []fingerprintEntry) (map[str
 	return removePaths, addPaths
 }
 
-func selectFilesByPath[T interface{ *File | *xmlCacheFile }](files []T, paths map[string]bool) []T {
+func selectFilesByPath[T interface{ *File | *XMLCacheFile }](files []T, paths map[string]bool) []T {
 	if len(paths) == 0 {
 		return nil
 	}
@@ -50,7 +50,7 @@ func selectFilesByPath[T interface{ *File | *xmlCacheFile }](files []T, paths ma
 		switch v := any(f).(type) {
 		case *File:
 			path = v.Path
-		case *xmlCacheFile:
+		case *XMLCacheFile:
 			path = v.Path
 		}
 		if paths[path] {
@@ -97,7 +97,7 @@ func shouldUseCrossFileOverlay(prev CrossFileCacheMeta, current []fingerprintEnt
 	return len(meta.OverlayEntries)+len(meta.RemovedPayloadPaths) <= crossFileOverlayMaxEntries
 }
 
-func buildIndexFromPriorOverlay(cacheDir string, entries []fingerprintEntry, files []*File, javaFiles []*File, xmlFiles []*xmlCacheFile, workers int, priorLoader PriorIndexLoader, tracker perf.Tracker) (*CodeIndex, bool) {
+func buildIndexFromPriorOverlay(cacheDir string, entries []fingerprintEntry, files []*File, javaFiles []*File, xmlFiles []*XMLCacheFile, workers int, priorLoader PriorIndexLoader, tracker perf.Tracker) (*CodeIndex, bool) {
 	var priorIdx *CodeIndex
 	var priorMeta CrossFileCacheMeta
 	var ok bool

--- a/internal/scanner/index_workers.go
+++ b/internal/scanner/index_workers.go
@@ -191,7 +191,7 @@ func buildJavaShardJobs(javaFiles []*File) []shardJob {
 	return jobs
 }
 
-func buildXMLShardJobs(xmlFiles []*xmlCacheFile) []shardJob {
+func buildXMLShardJobs(xmlFiles []*XMLCacheFile) []shardJob {
 	jobs := make([]shardJob, 0, len(xmlFiles))
 	for _, f := range xmlFiles {
 		if f == nil {
@@ -222,7 +222,7 @@ func buildXMLShardJobs(xmlFiles []*xmlCacheFile) []shardJob {
 // file's references and persisted back). A nil bloom means no shard
 // contributed any references, and callers should treat it as "no
 // prebuilt filter"; the rebuild path will create one.
-func collectIndexDataSharded(cacheDir string, files []*File, javaFiles []*File, xmlFiles []*xmlCacheFile, workers int, tracker perf.Tracker) ([]Symbol, []Reference, *bloom.BloomFilter) {
+func collectIndexDataSharded(cacheDir string, files []*File, javaFiles []*File, xmlFiles []*XMLCacheFile, workers int, tracker perf.Tracker) ([]Symbol, []Reference, *bloom.BloomFilter) {
 	if workers < 1 {
 		workers = 1
 	}
@@ -362,7 +362,7 @@ func collectIndexDataSharded(cacheDir string, files []*File, javaFiles []*File, 
 // collectIndexDataInternal is the shared body. A non-nil preloadedXML
 // skips the per-run XML disk walk and reuses the caller's read bytes;
 // nil falls back to a fresh walk.
-func collectIndexDataInternal(files []*File, workers int, tracker perf.Tracker, preloadedXML []*xmlCacheFile, javaFiles ...*File) ([]Symbol, []Reference) {
+func collectIndexDataInternal(files []*File, workers int, tracker perf.Tracker, preloadedXML []*XMLCacheFile, javaFiles ...*File) ([]Symbol, []Reference) {
 	var (
 		symbols []Symbol
 		refs    []Reference

--- a/internal/scanner/index_xml.go
+++ b/internal/scanner/index_xml.go
@@ -22,10 +22,10 @@ var classRefPatterns = []*regexp.Regexp{
 	regexp.MustCompile(`<([a-z][a-zA-Z0-9_.]+\.[A-Z][a-zA-Z0-9]*)`), // FQN as XML tag
 }
 
-// xmlCacheFile is a pre-loaded XML source whose content and hash are
+// XMLCacheFile is a pre-loaded XML source whose content and hash are
 // consumed by both the cross-file cache fingerprint and the reference
 // walk, so each file is read from disk once.
-type xmlCacheFile struct {
+type XMLCacheFile struct {
 	Path    string
 	Content []byte
 	Hash    string
@@ -61,8 +61,8 @@ func isXMLPrunedDir(base string) bool {
 	return strings.HasPrefix(base, "values")
 }
 
-func walkXMLFilesInRoot(root string) []*xmlCacheFile {
-	var local []*xmlCacheFile
+func walkXMLFilesInRoot(root string) []*XMLCacheFile {
+	var local []*XMLCacheFile
 	_ = filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
 		if err != nil || info.IsDir() {
 			if info != nil && info.IsDir() && isXMLPrunedDir(info.Name()) {
@@ -77,7 +77,7 @@ func walkXMLFilesInRoot(root string) []*xmlCacheFile {
 		if err != nil {
 			return nil //nolint:nilerr // skip-and-continue: per-file read/parse error inside Walk callback
 		}
-		local = append(local, &xmlCacheFile{
+		local = append(local, &XMLCacheFile{
 			Path:    path,
 			Content: content,
 			Hash:    contentHashForFile(path, content),
@@ -87,10 +87,19 @@ func walkXMLFilesInRoot(root string) []*xmlCacheFile {
 	return local
 }
 
+// LoadXMLFilesForCache is the exported wrapper around the package-
+// private XML walk. The daemon's resident-XML cache uses it as the
+// build closure when the slot misses or the .xml watcher version
+// has bumped — every other caller reaches the same code through
+// the unexported helper inside BuildIndexCachedWithPrior.
+func LoadXMLFilesForCache(ktFiles []*File) []*XMLCacheFile {
+	return loadXMLFilesForCache(ktFiles)
+}
+
 // loadXMLFilesForCache walks the project for XML reference-candidate
 // files, reads them, and hashes each. The result feeds both the cache
 // fingerprint and the reference extraction in a single I/O pass.
-func loadXMLFilesForCache(ktFiles []*File) []*xmlCacheFile {
+func loadXMLFilesForCache(ktFiles []*File) []*XMLCacheFile {
 	if len(ktFiles) == 0 {
 		return nil
 	}
@@ -104,7 +113,7 @@ func loadXMLFilesForCache(ktFiles []*File) []*xmlCacheFile {
 	var (
 		mu  sync.Mutex
 		wg  sync.WaitGroup
-		out []*xmlCacheFile
+		out []*XMLCacheFile
 	)
 	for r := range roots {
 		wg.Add(1)
@@ -129,15 +138,15 @@ func loadXMLFilesForCache(ktFiles []*File) []*xmlCacheFile {
 	return out
 }
 
-// sortXMLCacheFiles orders xmlCacheFile entries by path. It is the
+// sortXMLCacheFiles orders XMLCacheFile entries by path. It is the
 // canonical ordering for any aggregated XML file slice in the
 // scanner — exposed as a named helper so the determinism property is
 // documented and reusable for tests.
-func sortXMLCacheFiles(files []*xmlCacheFile) {
+func sortXMLCacheFiles(files []*XMLCacheFile) {
 	sort.Slice(files, func(i, j int) bool { return files[i].Path < files[j].Path })
 }
 
-func collectXMLReferencesFromLoaded(files []*xmlCacheFile) []Reference {
+func collectXMLReferencesFromLoaded(files []*XMLCacheFile) []Reference {
 	if len(files) == 0 {
 		return nil
 	}

--- a/internal/scanner/index_xml_determinism_test.go
+++ b/internal/scanner/index_xml_determinism_test.go
@@ -79,7 +79,7 @@ func TestLoadXMLFilesForCache_StableOrder(t *testing.T) {
 // for tests and future call sites: ascending path lex order, no
 // secondary key needed because Path is unique within a project.
 func TestSortXMLCacheFiles_TotalOrder(t *testing.T) {
-	in := []*xmlCacheFile{
+	in := []*XMLCacheFile{
 		{Path: "/c.xml"}, {Path: "/a.xml"}, {Path: "/b.xml"},
 	}
 	want := []string{"/a.xml", "/b.xml", "/c.xml"}
@@ -90,7 +90,7 @@ func TestSortXMLCacheFiles_TotalOrder(t *testing.T) {
 	}
 }
 
-func pathsOf(files []*xmlCacheFile) []string {
+func pathsOf(files []*XMLCacheFile) []string {
 	out := make([]string, len(files))
 	for i, f := range files {
 		out[i] = f.Path


### PR DESCRIPTION
## Summary

- Adds ``WorkspaceState.XMLFiles`` — a version-gated resident slot for ``scanner.XMLCacheFile`` that survives Kotlin/Java edits and only rebuilds when the watcher sees a ``.xml`` event. Same pattern as the ``JavaSourceIndex`` cache (#264) and ``ResolverFingerprint`` cache (#265).
- Plumbed through ``ProjectHostState`` → ``IndexInput`` → new ``scanner.BuildIndexCachedWithLoaders`` entry point. Legacy ``BuildIndexCachedWithPrior`` delegates with ``xmlLoader=nil`` so non-daemon callers are byte-for-byte unchanged.
- Watcher gains a dedicated ``.xml`` case that drops ``CodeIndex`` / ``Dependents`` (XML content contributes to cross-file refs) and bumps a dedicated counter. ``.kt`` / ``.java`` edits do NOT touch the XML counter — cross-slot independence keeps the cache warm across the common edit type.
- Renames the previously-unexported ``xmlCacheFile`` to ``XMLCacheFile`` so the type can cross packages; field names were already public.

## Benchmarks — steady-state ABI edit

### ~/github/kotlin (18 k Kotlin / 520 XMLs) — clean demo
|                    | before  | after   | delta  |
|--------------------|---------|---------|--------|
| ``indexBuild``     | 452 ms  | 268 ms  | -41 %  |
| total ``durationMs`` | ~865 ms | ~735 ms | -15 %  |

### ~/github/Signal-Android (3.5 k Kotlin / 9.9 k XMLs) — bundle-hit masked
Kotlin edits steady-state bundle-hit at ~77 ms total — XML cache benefit is masked. A forced bundle miss (Java edit) has Signal's ``indexBuild`` already at ~100 ms; the dominant cost there is ``androidPhase.resourceAnalysis`` (~10 s, separate code path outside this PR's scope).

## Test plan

- [x] ``go test ./internal/pipeline/ -run TestWorkspaceState_XMLFiles -v`` — round-trip, race, nil-safety, InvalidateAll
- [x] ``go test ./internal/cli/serve/ -run TestFileWatcher_BumpsXMLFilesVersion -v`` — ``.xml`` bumps the counter, ``.kt`` does NOT
- [x] ``go test ./... -count=1`` (all packages green)
- [x] ``golangci-lint run ./...`` (0 issues)
- [x] Daemon smoke on ~/github/kotlin: 4 sequential ABI edits at 711-1014 ms ``durationMs``, findings unchanged