### PR TITLE
feat(daemon): route --create-baseline and --dry-run through daemon

### DIFF
--- a/internal/cli/scan/daemon_delegate.go
+++ b/internal/cli/scan/daemon_delegate.go
@@ -59,6 +59,23 @@ func tryDaemonDelegate(f *scanFlags, paths []string, repoDir string) (bool, int)
 	if *f.SampleRule != "" {
 		return true, runDaemonSampleRule(f, paths, res.Findings)
 	}
+
+	// CreateBaseline replaces the findings-write path entirely: we
+	// don't want findings JSON on stdout, just the XML baseline file.
+	// Mirrors applyBaselinesAndDiff's early-exit semantics.
+	if *f.CreateBaseline != "" {
+		return true, runDaemonCreateBaseline(f, res.Stats)
+	}
+
+	// DryRun (without --fix) prints the fixable-file list to stdout
+	// and a summary to stderr — no findings JSON. Mirrors
+	// printDryRunFixResult exactly: file-per-line on stdout plus the
+	// "N fix(es) available across M file(s)" stderr summary.
+	if *f.DryRun {
+		runDaemonDryRun(f, res.Stats)
+		return true, 0
+	}
+
 	w, closer, openErr := openDaemonOutputWriter(f)
 	if openErr != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", openErr)
@@ -173,6 +190,45 @@ func callMetaVerb(client *daemonclient.Client, f *scanFlags, paths []string, ver
 		})
 	}
 	return daemon.MetaResult{}, fmt.Errorf("unknown meta verb %d", verb)
+}
+
+// runDaemonCreateBaseline writes the daemon-computed sorted baseline
+// ID list out to *f.CreateBaseline. Mirrors the in-process
+// applyBaselinesAndDiff early-exit: no findings JSON, just the XML
+// file plus a "Created baseline" stderr summary.
+func runDaemonCreateBaseline(f *scanFlags, stats daemon.AnalyzeProjectStats) int {
+	if err := scanner.WriteBaselineIDsXML(*f.CreateBaseline, stats.BaselineIDs); err != nil {
+		fmt.Fprintf(os.Stderr, "error: failed to write baseline: %v\n", err)
+		return 2
+	}
+	if !*f.Quiet {
+		fmt.Fprintf(os.Stderr, "info: Created baseline with %d issue(s) at %s\n", len(stats.BaselineIDs), *f.CreateBaseline)
+	}
+	return 0
+}
+
+// runDaemonDryRun replays the daemon-computed fixable-file list and
+// summary lines. Matches printDryRunFixResult byte-for-byte:
+// file-per-line on stdout plus the "N fix(es) available across M
+// file(s)" stderr summary (or a level-aware "no fixable" hint).
+func runDaemonDryRun(f *scanFlags, stats daemon.AnalyzeProjectStats) {
+	for _, file := range stats.DryRunFiles {
+		fmt.Println(file)
+	}
+	if *f.Quiet {
+		return
+	}
+	if stats.DryRunFixableCount == 0 {
+		if stats.DryRunStrippedByLevel > 0 {
+			fmt.Fprintf(os.Stderr, "info: No auto-fixable issues at level %s. %d fix(es) available at higher levels (use --fix-level=semantic).\n",
+				*f.FixLevel, stats.DryRunStrippedByLevel)
+		} else {
+			fmt.Fprintln(os.Stderr, "info: No auto-fixable issues found.")
+		}
+		return
+	}
+	fmt.Fprintf(os.Stderr, "info: %d fix(es) available across %d file(s).\n",
+		stats.DryRunFixableCount, len(stats.DryRunFiles))
 }
 
 // runDaemonSampleRule decodes the daemon's JSON envelope into a
@@ -298,8 +354,22 @@ func emitDaemonDispatchProfile(p *daemon.DispatchProfile) {
 // tryDaemonDelegate runs (early-exit verbs that also drop the
 // daemon's resident WorkspaceState slots so the next analyze
 // rebuilds from cold).
+//
+// --create-baseline and --dry-run ARE compatible: the daemon computes
+// the baseline-ID list / fixable-file list from the same FindingColumns
+// the in-process flow uses, ships them in AnalyzeProjectStats, and the
+// CLI writes the baseline file (or prints the dry-run lines) locally.
+// The daemon never touches user files; the file write happens with the
+// CLI's CWD and permissions, preserving the daemon's read-only invariant.
+//
+// --fix, --fix-binary, and --remove-dead-code stay in-process. Each
+// would need a separate fix-payload-over-the-wire design where the
+// daemon serialises text edits / binary operations and the CLI replays
+// them; the existing fix application code path is intertwined with
+// per-rule context that doesn't currently survive serialisation. Land
+// those in follow-up PRs once a payload schema exists.
 func daemonCompatibleFlags(f *scanFlags) bool {
-	mutating := []bool{*f.Fix, *f.DryRun, *f.RemoveDeadCode, *f.FixBinary}
+	mutating := []bool{*f.Fix, *f.RemoveDeadCode, *f.FixBinary}
 	meta := []bool{*f.Init, *f.Doctor, *f.Version, *f.List, *f.ValidateConfig, *f.GenerateSchema,
 		*f.BaselineAudit, *f.RuleAudit, *f.OracleFilterFingerprint, *f.ListExperiments}
 	for _, group := range [][]bool{mutating, meta} {
@@ -309,8 +379,7 @@ func daemonCompatibleFlags(f *scanFlags) bool {
 			}
 		}
 	}
-	strs := []string{*f.CreateBaseline,
-		*f.Completions, *f.OutputTypes, *f.Delta,
+	strs := []string{*f.Completions, *f.OutputTypes, *f.Delta,
 		*f.PromoteExperiment, *f.DeprecateExperiment, *f.NewExperiment, *f.ExperimentMatrix}
 	for _, s := range strs {
 		if s != "" {
@@ -348,10 +417,19 @@ func buildDaemonAnalyzeArgs(f *scanFlags, paths []string) daemon.AnalyzeProjectA
 			inputTypesPath = abs
 		}
 	}
+	// CreateBaseline mirrors applyBaselinesAndDiff: when set, the
+	// in-process flow short-circuits before baseline filtering, so
+	// the daemon must too. The daemon's analyze_project drops
+	// BaselinePath internally when CreateBaseline is true, but
+	// leaving it empty here keeps the wire intent explicit.
+	baselinePath := *f.Baseline
+	if *f.CreateBaseline != "" {
+		baselinePath = ""
+	}
 	return daemon.AnalyzeProjectArgs{
 		Paths:            paths,
 		Format:           format,
-		BaselinePath:     *f.Baseline,
+		BaselinePath:     baselinePath,
 		DiffRef:          *f.Diff,
 		MinConfidence:    *f.MinConfidence,
 		WarningsAsErrors: *f.WarningsAsErrors,
@@ -367,6 +445,10 @@ func buildDaemonAnalyzeArgs(f *scanFlags, paths []string) daemon.AnalyzeProjectA
 		ProfileDispatch:  *f.ProfileDispatch,
 		CPUProfilePath:   absoluteProfilePath(*f.CPUProfile),
 		MemProfilePath:   absoluteProfilePath(*f.MemProfile),
+		BasePath:         resolveBasePath(*f.BasePath, paths),
+		CreateBaseline:   *f.CreateBaseline != "",
+		DryRun:           *f.DryRun,
+		FixLevel:         *f.FixLevel,
 		ClientBinaryHash: daemonclient.CurrentBinaryHash(),
 	}
 }
@@ -385,6 +467,25 @@ func absoluteProfilePath(p string) string {
 	if err != nil {
 		return p
 	}
+	return abs
+}
+
+// resolveBasePath mirrors runner_state.go's basePath resolution so
+// daemon-computed baseline IDs match the in-process
+// WriteBaselineColumns output byte-for-byte. Empty BasePath falls
+// back to the absolute first scan path. The CLI's runner_state.go
+// uses `r.basePath, _ = filepath.Abs(...)` — discarding the error and
+// keeping whatever filepath.Abs returned (the empty string on
+// failure). We match that exactly so cross-process IDs collide on
+// every input runner_state would.
+func resolveBasePath(explicit string, paths []string) string {
+	if explicit != "" {
+		return explicit
+	}
+	if len(paths) == 0 {
+		return ""
+	}
+	abs, _ := filepath.Abs(paths[0])
 	return abs
 }
 

--- a/internal/cli/scan/daemon_delegate_test.go
+++ b/internal/cli/scan/daemon_delegate_test.go
@@ -327,6 +327,12 @@ func startMockMetaDaemon(t *testing.T, verb string, reply daemon.MetaResult) str
 // --cpuprofile, and --memprofile must all be served by the daemon now
 // that the wire carries dispatch_profile fan-out and the daemon wraps
 // analyze-project in pprof capture for CPU/mem profile paths.
+//
+// --create-baseline and --dry-run are now daemon-served too: the
+// daemon computes baseline IDs / fixable file lists and the CLI
+// performs the local file write or stdout print. --fix /
+// --remove-dead-code / --fix-binary remain in-process pending a
+// fix-payload-over-the-wire design.
 func TestDaemonCompatibleFlags_PerfAllowed(t *testing.T) {
 	tests := []struct {
 		name string
@@ -341,6 +347,8 @@ func TestDaemonCompatibleFlags_PerfAllowed(t *testing.T) {
 		{"--cpuprofile", func(f *scanFlags) { *f.CPUProfile = "/tmp/cpu.pprof" }, true},
 		{"--memprofile", func(f *scanFlags) { *f.MemProfile = "/tmp/mem.pprof" }, true},
 		{"--fix", func(f *scanFlags) { *f.Fix = true }, false},
+		{"--fix-binary", func(f *scanFlags) { *f.FixBinary = true }, false},
+		{"--remove-dead-code", func(f *scanFlags) { *f.RemoveDeadCode = true }, false},
 		// --no-cache rides on AnalyzeProjectArgs.NoCache; daemon
 		// nils its on-disk cache pointers for the call but stays
 		// the right place to serve it.
@@ -352,6 +360,20 @@ func TestDaemonCompatibleFlags_PerfAllowed(t *testing.T) {
 		// the way the analyze path used to.
 		{"--clear-cache", func(f *scanFlags) { *f.ClearCache = true }, true},
 		{"--clear-matrix-cache", func(f *scanFlags) { *f.ClearMatrixCache = true }, true},
+		// --input-types and --sample-rule are daemon-served via the
+		// AnalyzeProjectArgs.InputTypesPath wire field / JSON-envelope
+		// post-processing on the CLI side.
+		{"--input-types", func(f *scanFlags) { *f.InputTypes = "/tmp/types.json" }, true},
+		{"--sample-rule", func(f *scanFlags) { *f.SampleRule = "MyRule" }, true},
+		// --create-baseline and --dry-run are daemon-served: the
+		// daemon computes BaselineIDs / fixable-file list, the CLI
+		// performs the local write/print.
+		{"--create-baseline", func(f *scanFlags) { *f.CreateBaseline = "/tmp/baseline.xml" }, true},
+		{"--dry-run", func(f *scanFlags) { *f.DryRun = true }, true},
+		// --base-path is daemon-compatible — it's forwarded as
+		// AnalyzeProjectArgs.BasePath so daemon-side baseline IDs
+		// match in-process resolution.
+		{"--base-path", func(f *scanFlags) { *f.BasePath = "/tmp/base" }, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/cli/serve/analyze_project.go
+++ b/internal/cli/serve/analyze_project.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"runtime"
+	"sort"
 	"time"
 
 	"github.com/kaeawc/krit/internal/cache"
@@ -127,6 +128,9 @@ func handleAnalyzeProject(_ context.Context, state *daemonState, raw json.RawMes
 		profileDispatch: args.ProfileDispatch,
 		cpuProfilePath:  args.CPUProfilePath,
 		memProfilePath:  args.MemProfilePath,
+		basePath:        in.Args.BasePath,
+		createBaseline:  args.CreateBaseline,
+		dryRun:          args.DryRun,
 		releaseLock:     state.analyzeMu.Unlock,
 	}, nil
 }
@@ -140,6 +144,9 @@ type streamingAnalyzeResponse struct {
 	profileDispatch bool
 	cpuProfilePath  string
 	memProfilePath  string
+	basePath        string
+	createBaseline  bool
+	dryRun          bool
 	releaseLock     func()
 }
 
@@ -165,7 +172,7 @@ func (r *streamingAnalyzeResponse) WriteRawResponse(ctx context.Context, w io.Wr
 	r.state.coldDone.Store(true)
 	xfile := r.state.workspace.CrossFileStats()
 
-	statsBytes, err := json.Marshal(daemon.AnalyzeProjectStats{
+	stats := daemon.AnalyzeProjectStats{
 		FilesScanned:      res.FilesScanned,
 		FindingsCount:     res.FindingsCount,
 		WallSeconds:       time.Since(r.start).Seconds(),
@@ -188,7 +195,24 @@ func (r *streamingAnalyzeResponse) WriteRawResponse(ctx context.Context, w io.Wr
 			Output:    res.PhaseTimingsMs.Output,
 		},
 		ProfileWarnings: profileWarnings,
-	})
+	}
+	// CreateBaseline ships a sorted+deduped baseline-ID list so the
+	// CLI can write the XML locally — daemon never writes user
+	// files. See scanner.CollectBaselineIDs / WriteBaselineIDsXML.
+	if r.createBaseline {
+		stats.BaselineIDs = scanner.CollectBaselineIDs(&res.FinalFindings, r.basePath)
+	}
+	// DryRun ships the same file list runFixup → printDryRunFixResult
+	// would write to stdout in-process. Iterate post-fixup findings so
+	// the FixLevel cap is reflected (StripTextFixes runs inside
+	// FixupPhase). FixupResult.Findings carries the post-strip view.
+	if r.dryRun {
+		dryFiles := collectFixableFiles(&res.Fixup.Findings)
+		stats.DryRunFiles = dryFiles
+		stats.DryRunFixableCount = res.Fixup.FixableCount
+		stats.DryRunStrippedByLevel = res.Fixup.StrippedByLevel
+	}
+	statsBytes, err := json.Marshal(stats)
 	if err != nil {
 		return fmt.Errorf("marshal stats: %w", err)
 	}
@@ -240,6 +264,32 @@ func convertFileTimings(in []pipeline.FileTiming) []daemon.FileTiming {
 		}
 	}
 	return out
+}
+
+// collectFixableFiles walks columns and returns the sorted, deduped
+// list of file paths with at least one available text fix. Mirrors
+// the in-process printDryRunFixResult enumeration so the CLI can
+// replay the daemon's output line-for-line.
+func collectFixableFiles(columns *scanner.FindingColumns) []string {
+	if columns == nil {
+		return nil
+	}
+	seen := make(map[string]struct{}, columns.Len())
+	for row := 0; row < columns.Len(); row++ {
+		if !columns.HasFix(row) {
+			continue
+		}
+		seen[columns.FileAt(row)] = struct{}{}
+	}
+	if len(seen) == 0 {
+		return nil
+	}
+	files := make([]string, 0, len(seen))
+	for file := range seen {
+		files = append(files, file)
+	}
+	sort.Strings(files)
+	return files
 }
 
 // envelopeTail closes the streaming response: end-of-stats, end-of-data,
@@ -396,37 +446,8 @@ func (s *daemonState) buildProjectInput(args daemon.AnalyzeProjectArgs) (pipelin
 		perfTracker = perf.New(true)
 	}
 
-	// Disk-cache wiring: --no-cache nils every on-disk cache pointer
-	// for this single call. Resident WorkspaceState slots stay live
-	// because they're keyed on input fingerprints — reuse is
-	// idempotent and a no-cache call cannot dirty them for subsequent
-	// calls.
-	var (
-		crossFileCacheDir     = scanner.CrossFileCacheDir(repoDir)
-		crossFindingsCacheDir = scanner.CrossFindingsCacheDir(repoDir)
-		typeIndexCacheDir     = typeinfer.TypeIndexCacheDir(repoDir)
-		findingsBundleStore   scanner.FindingsBundleStore
-		findingsBundleRoot    string
-		manifestLoader        pipeline.FindingsBundleManifestLoader
-		manifestSaver         pipeline.FindingsBundleManifestSaver
-	)
-	if !args.NoCache {
-		findingsBundleStore = scanner.DiskFindingsBundleStore{}
-		findingsBundleRoot = repoDir
-		manifestLoader = s.loadManifest
-		manifestSaver = s.saveManifest
-	} else {
-		crossFileCacheDir = ""
-		crossFindingsCacheDir = ""
-		typeIndexCacheDir = ""
-		// Drop the Android cache pointers too — the
-		// androidFindingsCacheable gate checks both writer and dir,
-		// so emptying them matches the other on-disk cache zeroing
-		// above.
-		androidCacheWriter = nil
-		androidCacheDir = ""
-	}
-
+	diskCache := s.resolveDiskCacheWiring(args, repoDir, androidCacheWriter, androidCacheDir)
+	baselinePath, basePath, maxFixLevel := resolveBaselineDryRunArgs(args, paths)
 	return pipeline.ProjectInput{
 		Args: pipeline.ProjectArgs{
 			Config:           cfg,
@@ -435,7 +456,7 @@ func (s *daemonState) buildProjectInput(args daemon.AnalyzeProjectArgs) (pipelin
 			JavaPaths:        javaPaths,
 			ActiveRules:      activeRules,
 			Format:           args.Format,
-			BaselinePath:     args.BaselinePath,
+			BaselinePath:     baselinePath,
 			DiffRef:          args.DiffRef,
 			MinConfidence:    args.MinConfidence,
 			WarningsAsErrors: args.WarningsAsErrors,
@@ -447,6 +468,9 @@ func (s *daemonState) buildProjectInput(args daemon.AnalyzeProjectArgs) (pipelin
 			ProfileDispatch:  args.ProfileDispatch,
 			CustomRuleJars:   args.CustomRuleJars,
 			InputTypesPath:   args.InputTypesPath,
+			DryRun:           args.DryRun,
+			MaxFixLevel:      maxFixLevel,
+			BasePath:         basePath,
 			// Wire is line-delimited; compact JSON keeps the body
 			// free of internal newlines.
 			JSONCompact: true,
@@ -471,24 +495,93 @@ func (s *daemonState) buildProjectInput(args daemon.AnalyzeProjectArgs) (pipelin
 			SourceMTimeVersion:           s.workspace.SourceMTimeVersion,
 			BundleOutput:                 s.workspace.BundleOutput,
 			StoreBundleOutput:            s.workspace.StoreBundleOutput,
-			AndroidCacheWriter:           androidCacheWriter,
-			AndroidCacheDir:              androidCacheDir,
-			CrossFileCacheDir:            crossFileCacheDir,
-			CrossFindingsCacheDir:        crossFindingsCacheDir,
-			TypeIndexCacheDir:            typeIndexCacheDir,
+			AndroidCacheWriter:           diskCache.androidCacheWriter,
+			AndroidCacheDir:              diskCache.androidCacheDir,
+			CrossFileCacheDir:            diskCache.crossFileCacheDir,
+			CrossFindingsCacheDir:        diskCache.crossFindingsCacheDir,
+			TypeIndexCacheDir:            diskCache.typeIndexCacheDir,
 			ResidentFileTypeInfo:         s.workspace,
 			AnalysisCache:                analysisCache,
 			AnalysisCacheFilePath:        analysisCachePath,
 			AnalysisCacheLookup:          analysisCache != nil,
 			OracleDaemon:                 oracleDaemon,
-			FindingsBundleStore:          findingsBundleStore,
-			FindingsBundleCacheRoot:      findingsBundleRoot,
-			FindingsBundleManifestLoader: manifestLoader,
-			FindingsBundleManifestSaver:  manifestSaver,
+			FindingsBundleStore:          diskCache.findingsBundleStore,
+			FindingsBundleCacheRoot:      diskCache.findingsBundleRoot,
+			FindingsBundleManifestLoader: diskCache.manifestLoader,
+			FindingsBundleManifestSaver:  diskCache.manifestSaver,
 			PriorContentHashes:           priorManifest.ContentHashes,
 			PriorStructuralFPs:           priorManifest.StructuralFPs,
 		},
 	}, nil
+}
+
+// diskCacheWiring bundles the on-disk cache pointers buildProjectInput
+// hands to the pipeline host. Aggregating these lets the --no-cache
+// branch flip the whole set in one place without inflating
+// buildProjectInput's cyclomatic complexity.
+type diskCacheWiring struct {
+	crossFileCacheDir     string
+	crossFindingsCacheDir string
+	typeIndexCacheDir     string
+	androidCacheWriter    *scanner.AndroidCacheWriter
+	androidCacheDir       string
+	findingsBundleStore   scanner.FindingsBundleStore
+	findingsBundleRoot    string
+	manifestLoader        pipeline.FindingsBundleManifestLoader
+	manifestSaver         pipeline.FindingsBundleManifestSaver
+}
+
+// resolveDiskCacheWiring computes the per-call on-disk cache pointer
+// set. --no-cache zeroes every pointer for this single call;
+// resident WorkspaceState slots stay live (they're per-process memory
+// keyed on input fingerprints, so reuse is idempotent and a no-cache
+// call cannot dirty them for subsequent calls).
+func (s *daemonState) resolveDiskCacheWiring(args daemon.AnalyzeProjectArgs, repoDir string, androidCacheWriter *scanner.AndroidCacheWriter, androidCacheDir string) diskCacheWiring {
+	if args.NoCache {
+		// Drop Android cache pointers too — the
+		// androidFindingsCacheable gate checks both writer and dir, so
+		// emptying them matches the other on-disk cache zeroing.
+		return diskCacheWiring{}
+	}
+	return diskCacheWiring{
+		crossFileCacheDir:     scanner.CrossFileCacheDir(repoDir),
+		crossFindingsCacheDir: scanner.CrossFindingsCacheDir(repoDir),
+		typeIndexCacheDir:     typeinfer.TypeIndexCacheDir(repoDir),
+		androidCacheWriter:    androidCacheWriter,
+		androidCacheDir:       androidCacheDir,
+		findingsBundleStore:   scanner.DiskFindingsBundleStore{},
+		findingsBundleRoot:    repoDir,
+		manifestLoader:        s.loadManifest,
+		manifestSaver:         s.saveManifest,
+	}
+}
+
+// resolveBaselineDryRunArgs resolves three knobs that the CLI-side
+// dry-run / create-baseline routing relies on:
+//   - baselinePath: dropped to "" when CreateBaseline is set so
+//     OutputPhase's applyBaseline never runs (mirrors the in-process
+//     short-circuit).
+//   - basePath: defaults to the first scan path when empty so daemon-
+//     computed baseline IDs match WriteBaselineColumns byte-for-byte.
+//   - maxFixLevel: parses FixLevel only when DryRun is set; empty or
+//     unknown values leave the cap at zero (matches FixupPhase
+//     semantics: no cap).
+func resolveBaselineDryRunArgs(args daemon.AnalyzeProjectArgs, paths []string) (string, string, rules.FixLevel) {
+	baselinePath := args.BaselinePath
+	if args.CreateBaseline {
+		baselinePath = ""
+	}
+	basePath := args.BasePath
+	if basePath == "" && len(paths) > 0 {
+		basePath = paths[0]
+	}
+	maxFixLevel := rules.FixLevel(0)
+	if args.DryRun && args.FixLevel != "" {
+		if lvl, ok := rules.ParseFixLevel(args.FixLevel); ok {
+			maxFixLevel = lvl
+		}
+	}
+	return baselinePath, basePath, maxFixLevel
 }
 
 // loadDaemonConfig loads the krit.yml the daemon should honour for

--- a/internal/cli/serve/analyze_project_writeout_test.go
+++ b/internal/cli/serve/analyze_project_writeout_test.go
@@ -1,0 +1,185 @@
+package serve
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/kaeawc/krit/internal/cacheutil"
+	"github.com/kaeawc/krit/internal/config"
+	"github.com/kaeawc/krit/internal/daemon"
+	"github.com/kaeawc/krit/internal/oracle"
+	"github.com/kaeawc/krit/internal/pipeline"
+	"github.com/kaeawc/krit/internal/rules"
+	"github.com/kaeawc/krit/internal/scanner"
+)
+
+// TestAnalyzeProject_CreateBaselineMatchesInProcess pins the
+// equivalence between the daemon-routed --create-baseline path and the
+// in-process WriteBaselineColumns call. The daemon ships baseline IDs
+// in AnalyzeProjectStats; the CLI hands them to
+// scanner.WriteBaselineIDsXML. Both must produce byte-identical XML
+// to the baseline written from the in-process FindingColumns.
+func TestAnalyzeProject_CreateBaselineMatchesInProcess(t *testing.T) {
+	socket, state := startServerForTest(t)
+
+	writeKotlinFile(t, state.root, "Foo.kt",
+		"package demo\n\nclass Foo {\n    fun greet() = println(\"hi\")\n}\n")
+	writeKotlinFile(t, state.root, "Bar.kt",
+		"package demo\n\nfun bar(unused: Int): Int { return 42 }\n")
+
+	basePath, _ := filepath.Abs(state.root)
+
+	// --- Direct path: build FindingColumns and write baseline -----
+	cfg := config.NewConfig()
+	rules.ApplyConfig(cfg)
+	activeRules := rules.ActiveRulesV2(map[string]bool{}, map[string]bool{}, false, false, false)
+	repoDir := oracle.FindRepoDir([]string{state.root})
+	if repoDir == "" {
+		repoDir = state.root
+	}
+	pc, err := scanner.NewParseCacheWithCap(repoDir, cacheutil.DefaultParseCacheCapBytes)
+	if err != nil {
+		t.Fatalf("ParseCache: %v", err)
+	}
+	t.Cleanup(func() { _ = pc.Close() })
+
+	directRes, err := pipeline.RunProject(context.Background(), pipeline.ProjectInput{
+		Args: pipeline.ProjectArgs{
+			Config:      cfg,
+			Paths:       []string{state.root},
+			ActiveRules: activeRules,
+			Format:      "json",
+			Version:     "test",
+			BasePath:    basePath,
+		},
+		Host: pipeline.ProjectHostState{ParseCache: pc},
+	})
+	if err != nil {
+		t.Fatalf("direct RunProject: %v", err)
+	}
+	directBaseline := filepath.Join(t.TempDir(), "direct.xml")
+	if err := scanner.WriteBaselineColumns(directBaseline, &directRes.FinalFindings, basePath); err != nil {
+		t.Fatalf("direct WriteBaselineColumns: %v", err)
+	}
+	directBytes, err := os.ReadFile(directBaseline)
+	if err != nil {
+		t.Fatalf("read direct baseline: %v", err)
+	}
+
+	// --- Daemon path: ship baseline IDs back, write locally -------
+	var verbResult daemon.AnalyzeProjectResult
+	if err := daemon.Call(socket, daemon.VerbAnalyzeProject,
+		daemon.AnalyzeProjectArgs{
+			Format:         "json",
+			BasePath:       basePath,
+			CreateBaseline: true,
+		}, &verbResult); err != nil {
+		t.Fatalf("verb call: %v", err)
+	}
+	verbBaseline := filepath.Join(t.TempDir(), "verb.xml")
+	if err := scanner.WriteBaselineIDsXML(verbBaseline, verbResult.Stats.BaselineIDs); err != nil {
+		t.Fatalf("verb WriteBaselineIDsXML: %v", err)
+	}
+	verbBytes, err := os.ReadFile(verbBaseline)
+	if err != nil {
+		t.Fatalf("read verb baseline: %v", err)
+	}
+
+	if string(directBytes) != string(verbBytes) {
+		t.Errorf("baseline XML diverges between in-process and daemon path\n--- direct ---\n%s\n--- verb ---\n%s",
+			string(directBytes), string(verbBytes))
+	}
+
+	// Sanity: at least one baseline ID — the fixture deliberately has
+	// rule-firing content so an empty result would be a regression.
+	if len(verbResult.Stats.BaselineIDs) == 0 {
+		t.Fatal("verb returned 0 baseline IDs; fixture should produce findings")
+	}
+}
+
+// TestAnalyzeProject_DryRunMatchesInProcess pins the equivalence
+// between the daemon-routed --dry-run path and the in-process
+// FixupPhase count-only run. The daemon ships fixable-file list and
+// counts in AnalyzeProjectStats; the CLI replays them as stdout/stderr
+// lines. Both must agree on the file set, fixable count, and
+// stripped-by-level count for every fix-level cap.
+func TestAnalyzeProject_DryRunMatchesInProcess(t *testing.T) {
+	socket, state := startServerForTest(t)
+
+	// Use content that triggers fixable rules. A magic number plus
+	// some boilerplate is reliably picked up by built-in rules with
+	// fixes attached.
+	writeKotlinFile(t, state.root, "Demo.kt",
+		"package demo\n\nfun foo() {\n    val x = 12345\n}\n")
+	writeKotlinFile(t, state.root, "Other.kt",
+		"package demo\n\nfun bar() {\n    val y = 67890\n}\n")
+
+	cfg := config.NewConfig()
+	rules.ApplyConfig(cfg)
+	activeRules := rules.ActiveRulesV2(map[string]bool{}, map[string]bool{}, false, false, false)
+	repoDir := oracle.FindRepoDir([]string{state.root})
+	if repoDir == "" {
+		repoDir = state.root
+	}
+	pc, err := scanner.NewParseCacheWithCap(repoDir, cacheutil.DefaultParseCacheCapBytes)
+	if err != nil {
+		t.Fatalf("ParseCache: %v", err)
+	}
+	t.Cleanup(func() { _ = pc.Close() })
+
+	for _, fixLevel := range []string{"", "cosmetic", "idiomatic", "semantic"} {
+		t.Run("level="+fixLevel, func(t *testing.T) {
+			maxFixLevel := rules.FixLevel(0)
+			if fixLevel != "" {
+				lvl, ok := rules.ParseFixLevel(fixLevel)
+				if !ok {
+					t.Fatalf("ParseFixLevel(%q): not ok", fixLevel)
+				}
+				maxFixLevel = lvl
+			}
+
+			directRes, err := pipeline.RunProject(context.Background(), pipeline.ProjectInput{
+				Args: pipeline.ProjectArgs{
+					Config:      cfg,
+					Paths:       []string{state.root},
+					ActiveRules: activeRules,
+					Format:      "json",
+					Version:     "test",
+					DryRun:      true,
+					MaxFixLevel: maxFixLevel,
+				},
+				Host: pipeline.ProjectHostState{ParseCache: pc},
+			})
+			if err != nil {
+				t.Fatalf("direct RunProject: %v", err)
+			}
+
+			directFiles := collectFixableFiles(&directRes.Fixup.Findings)
+
+			var verbResult daemon.AnalyzeProjectResult
+			if err := daemon.Call(socket, daemon.VerbAnalyzeProject,
+				daemon.AnalyzeProjectArgs{
+					Format:   "json",
+					DryRun:   true,
+					FixLevel: fixLevel,
+				}, &verbResult); err != nil {
+				t.Fatalf("verb call: %v", err)
+			}
+
+			if !reflect.DeepEqual(directFiles, verbResult.Stats.DryRunFiles) {
+				t.Errorf("DryRunFiles mismatch:\n direct: %v\n   verb: %v", directFiles, verbResult.Stats.DryRunFiles)
+			}
+			if directRes.Fixup.FixableCount != verbResult.Stats.DryRunFixableCount {
+				t.Errorf("DryRunFixableCount mismatch: direct=%d verb=%d",
+					directRes.Fixup.FixableCount, verbResult.Stats.DryRunFixableCount)
+			}
+			if directRes.Fixup.StrippedByLevel != verbResult.Stats.DryRunStrippedByLevel {
+				t.Errorf("DryRunStrippedByLevel mismatch: direct=%d verb=%d",
+					directRes.Fixup.StrippedByLevel, verbResult.Stats.DryRunStrippedByLevel)
+			}
+		})
+	}
+}

--- a/internal/cli/serve/strict_verify.go
+++ b/internal/cli/serve/strict_verify.go
@@ -90,7 +90,7 @@ func (r *strictVerifyAnalyzeResponse) WriteRawResponse(ctx context.Context, w io
 		findings = findings[:n-1]
 	}
 
-	statsBytes, err := json.Marshal(daemon.AnalyzeProjectStats{
+	stats := daemon.AnalyzeProjectStats{
 		FilesScanned:      res.FilesScanned,
 		FindingsCount:     res.FindingsCount,
 		WallSeconds:       time.Since(r.start).Seconds(),
@@ -112,7 +112,20 @@ func (r *strictVerifyAnalyzeResponse) WriteRawResponse(ctx context.Context, w io
 			Fixup:     res.PhaseTimingsMs.Fixup,
 			Output:    res.PhaseTimingsMs.Output,
 		},
-	})
+	}
+	// Mirror streamingAnalyzeResponse: CreateBaseline / DryRun get
+	// the same payload under strict-verify so client behavior doesn't
+	// silently change between modes.
+	if r.args.CreateBaseline {
+		basePath := r.in.Args.BasePath
+		stats.BaselineIDs = scanner.CollectBaselineIDs(&res.FinalFindings, basePath)
+	}
+	if r.args.DryRun {
+		stats.DryRunFiles = collectFixableFiles(&res.Fixup.Findings)
+		stats.DryRunFixableCount = res.Fixup.FixableCount
+		stats.DryRunStrippedByLevel = res.Fixup.StrippedByLevel
+	}
+	statsBytes, err := json.Marshal(stats)
 	if err != nil {
 		return fmt.Errorf("marshal stats: %w", err)
 	}

--- a/internal/daemon/protocol.go
+++ b/internal/daemon/protocol.go
@@ -265,6 +265,28 @@ type AnalyzeProjectArgs struct {
 	// completes (and after a runtime.GC) so the heap reflects the
 	// run's peak.
 	MemProfilePath string `json:"mem_profile_path,omitempty"`
+	// BasePath mirrors --base-path: empty means the daemon falls
+	// back to the first scan path (matching CLI semantics). The
+	// value participates in baseline ID generation when
+	// CreateBaseline is set.
+	BasePath string `json:"base_path,omitempty"`
+	// CreateBaseline, when true, signals the daemon to compute
+	// baseline IDs from the final findings and return them via
+	// AnalyzeProjectStats.BaselineIDs. The CLI writes the XML
+	// baseline file locally so the daemon never touches user
+	// files. The findings JSON is still produced (and ignored by
+	// the CLI) to keep the streaming envelope unchanged.
+	CreateBaseline bool `json:"create_baseline,omitempty"`
+	// DryRun, when true, runs the pipeline's fixup phase in
+	// count-only mode and reports the fixable-file list and
+	// strip/fixable counts via AnalyzeProjectStats.DryRun*. No
+	// files are touched. Pairs with FixLevel to cap which fix
+	// levels are counted.
+	DryRun bool `json:"dry_run,omitempty"`
+	// FixLevel caps the fix levels considered by the dry-run
+	// count: "cosmetic", "idiomatic", or "semantic". Empty means
+	// no cap (matches FixupPhase MaxFixLevel == 0).
+	FixLevel string `json:"fix_level,omitempty"`
 }
 
 // AnalyzeProjectResult is the response payload. Findings is the raw
@@ -357,6 +379,28 @@ type AnalyzeProjectStats struct {
 	// wasn't requested or it succeeded. Surfacing as warnings keeps the
 	// scan result intact even when diagnostic capture fails.
 	ProfileWarnings []string `json:"profile_warnings,omitempty"`
+	// BaselineIDs is populated only when AnalyzeProjectArgs.CreateBaseline
+	// is true. The slice is sorted and deduplicated so the CLI can
+	// hand it directly to scanner.WriteBaselineIDsXML (no further
+	// post-processing) and produce a byte-identical XML to the
+	// in-process WriteBaselineColumns path.
+	BaselineIDs []string `json:"baseline_ids,omitempty"`
+	// DryRunFiles is populated only when AnalyzeProjectArgs.DryRun
+	// is true. The slice is sorted and lists every file that has at
+	// least one available text fix after the FixLevel cap is
+	// applied. Mirrors what runFixup → printDryRunFixResult would
+	// emit to stdout in-process so the CLI can replay it line by
+	// line.
+	DryRunFiles []string `json:"dry_run_files,omitempty"`
+	// DryRunFixableCount mirrors FixupResult.FixableCount when
+	// DryRun is true: count of rows that still carry a text fix
+	// after the FixLevel cap is applied. Zero when DryRun is false.
+	DryRunFixableCount int `json:"dry_run_fixable_count,omitempty"`
+	// DryRunStrippedByLevel mirrors FixupResult.StrippedByLevel
+	// when DryRun is true: count of text fixes dropped because their
+	// rule's level exceeded the FixLevel cap. Zero when DryRun is
+	// false or when FixLevel is empty.
+	DryRunStrippedByLevel int `json:"dry_run_stripped_by_level,omitempty"`
 }
 
 // PhaseTimingsMs mirrors pipeline.PhaseTimingsMs on the wire so

--- a/internal/scanner/baseline.go
+++ b/internal/scanner/baseline.go
@@ -211,37 +211,50 @@ func WriteBaseline(path string, findings []Finding, basePath string) error {
 
 // WriteBaselineColumns writes columnar findings as a baseline XML file.
 func WriteBaselineColumns(path string, columns *FindingColumns, basePath string) error {
-	if columns == nil {
-		return writeBaselineIDs(path, 0, func(func(string)) {})
-	}
-	return writeBaselineIDs(path, columns.Len(), func(yield func(string)) {
-		for i := 0; i < columns.Len(); i++ {
-			yield(BaselineIDAt(columns, i, "", basePath))
-		}
-	})
+	return WriteBaselineIDsXML(path, CollectBaselineIDs(columns, basePath))
 }
 
-func writeBaselineIDs(path string, capacity int, visit func(func(string))) error {
-	ids := make([]string, 0, capacity)
-	seen := make(map[string]bool)
-	visit(func(id string) {
-		if !seen[id] {
-			seen[id] = true
-			ids = append(ids, id)
+// CollectBaselineIDs returns the sorted, deduplicated baseline IDs for
+// columns under basePath. The order and dedup semantics match
+// WriteBaselineColumns so that calling WriteBaselineIDsXML with the
+// returned slice produces a byte-identical baseline file. Useful for
+// daemon callers that compute IDs on a remote process and ship them to
+// the CLI for the actual file write — preserves the "daemon never
+// touches user files" invariant without forcing a second
+// FindingColumns serialization on the wire.
+func CollectBaselineIDs(columns *FindingColumns, basePath string) []string {
+	if columns == nil {
+		return nil
+	}
+	ids := make([]string, 0, columns.Len())
+	seen := make(map[string]bool, columns.Len())
+	for i := 0; i < columns.Len(); i++ {
+		id := BaselineIDAt(columns, i, "", basePath)
+		if seen[id] {
+			continue
 		}
-	})
+		seen[id] = true
+		ids = append(ids, id)
+	}
 	sort.Strings(ids)
+	return ids
+}
 
+// WriteBaselineIDsXML serialises a pre-computed baseline-ID slice into
+// the same XML schema WriteBaselineColumns emits and writes it to
+// path. Caller is responsible for ensuring ids is sorted and
+// deduplicated (CollectBaselineIDs returns the canonical shape). Used
+// by the CLI when receiving baseline IDs from the daemon's
+// analyze-project verb.
+func WriteBaselineIDsXML(path string, ids []string) error {
 	db := BaselineXML{
 		ManuallySuppressed: BaselineIDList{},
 		CurrentIssues:      BaselineIDList{IDs: ids},
 	}
-
 	data, err := xml.MarshalIndent(db, "", "  ")
 	if err != nil {
 		return err
 	}
-
 	header := []byte(xml.Header)
 	return os.WriteFile(path, append(header, data...), 0644)
 }


### PR DESCRIPTION
## Summary

Routes `--create-baseline` and `--dry-run` through the daemon by having the daemon compute the write-out payload (sorted baseline IDs / fixable-file list) in-memory and ship it back via `AnalyzeProjectStats`. The CLI performs the actual file write or stdout print, so the daemon's read-only invariant is preserved while both flags now reuse the resident parse cache, cross-file index, resolver, and oracle slots.

## Routed in this PR

- **`--create-baseline FILE`** — daemon runs the pipeline, computes baseline IDs via the new `scanner.CollectBaselineIDs`, returns them on `AnalyzeProjectStats.BaselineIDs`. CLI calls the new `scanner.WriteBaselineIDsXML` to write the XML locally. Existing `WriteBaselineColumns` now delegates to these helpers, so the in-process and daemon paths share one code path and the equivalence test asserts byte-identical XML.
- **`--dry-run`** — daemon forwards `DryRun=true` + `MaxFixLevel` into `pipeline.ProjectArgs` so `FixupPhase` runs in count-only mode. Result fields `DryRunFiles` (sorted), `DryRunFixableCount`, and `DryRunStrippedByLevel` mirror what `printDryRunFixResult` writes; the CLI replays the same stdout lines and stderr summary.

`--base-path` is now also forwarded so daemon-computed baseline IDs match the in-process `runner_state.go` resolution exactly (absolute first scan path when `--base-path` is empty).

## Deferred — needs design discussion

- **`--fix`** / **`--fix-binary`** / **`--remove-dead-code`** — these run `fixer.ApplyAllFixesColumns` / `fixer.ApplyBinaryFixesBatchColumns` against `FindingColumns`, where the `Fix` and `BinaryFix` payloads carry per-row text-edit ranges, file ops, and per-rule semantics that aren't currently designed to cross a process boundary. Routing them needs a fix-payload schema (probably a serialised `[]Fix` keyed by file + range, with the CLI replaying the writes) plus a way to stream/apply binary fixes without resending file bytes. Land in a follow-up PR once that schema exists. The exclusion-list comment on `daemonCompatibleFlags` records this contract.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...`
- [x] `go test ./... -count=1`
- [x] `make integration`
- [x] `make regression`
- [x] New equivalence test `TestAnalyzeProject_CreateBaselineMatchesInProcess` — daemon-routed baseline XML byte-equals in-process `WriteBaselineColumns`.
- [x] New equivalence test `TestAnalyzeProject_DryRunMatchesInProcess` — daemon `DryRunFiles` / `DryRunFixableCount` / `DryRunStrippedByLevel` equal the in-process `FixupResult` values across `--fix-level=` (unset, cosmetic, idiomatic, semantic).
- [x] Updated `TestDaemonCompatibleFlags_PerfAllowed` — pins the new `--create-baseline` / `--dry-run` ALLOW + the still-blocked `--fix` / `--fix-binary` / `--remove-dead-code`.