### PR TITLE
perf(daemon): wire AndroidCacheWriter + decouple XML keys from Java facts

### DIFF
--- a/internal/cli/serve/analyze_project.go
+++ b/internal/cli/serve/analyze_project.go
@@ -273,6 +273,7 @@ func (s *daemonState) buildProjectInput(args daemon.AnalyzeProjectArgs) (pipelin
 	if repoDir == "" {
 		repoDir = s.root
 	}
+	androidCacheWriter, androidCacheDir := s.androidCacheWriterFor(repoDir)
 	// --no-cache disables every on-disk cache for this single call:
 	// parse cache, AnalysisCache, findings bundle store, cross-file/
 	// findings/type-index disk shards. Resident WorkspaceState slots
@@ -366,6 +367,12 @@ func (s *daemonState) buildProjectInput(args daemon.AnalyzeProjectArgs) (pipelin
 		crossFileCacheDir = ""
 		crossFindingsCacheDir = ""
 		typeIndexCacheDir = ""
+		// Drop the Android cache pointers too — the
+		// androidFindingsCacheable gate checks both writer and dir,
+		// so emptying them matches the other on-disk cache zeroing
+		// above.
+		androidCacheWriter = nil
+		androidCacheDir = ""
 	}
 
 	return pipeline.ProjectInput{
@@ -411,6 +418,8 @@ func (s *daemonState) buildProjectInput(args daemon.AnalyzeProjectArgs) (pipelin
 			SourceMTimeVersion:           s.workspace.SourceMTimeVersion,
 			BundleOutput:                 s.workspace.BundleOutput,
 			StoreBundleOutput:            s.workspace.StoreBundleOutput,
+			AndroidCacheWriter:           androidCacheWriter,
+			AndroidCacheDir:              androidCacheDir,
 			CrossFileCacheDir:            crossFileCacheDir,
 			CrossFindingsCacheDir:        crossFindingsCacheDir,
 			TypeIndexCacheDir:            typeIndexCacheDir,

--- a/internal/cli/serve/daemon_state_test.go
+++ b/internal/cli/serve/daemon_state_test.go
@@ -126,3 +126,36 @@ func TestDaemonStateCloseParseCacheIdempotent(t *testing.T) {
 		t.Errorf("expected parseCache to be nil after close, got %p", state.parseCache)
 	}
 }
+
+// TestDaemonStateAndroidCacheWriterLifecycle pins the lazy-init +
+// idempotent-close contract for the resident Android findings
+// cache writer. Mirrors the parse cache pattern: first call builds,
+// repeated calls return the same instance; closing twice must not
+// panic.
+func TestDaemonStateAndroidCacheWriterLifecycle(t *testing.T) {
+	state := newDaemonState(t.TempDir())
+	w1, dir1 := state.androidCacheWriterFor(state.root)
+	if w1 == nil || dir1 == "" {
+		t.Fatalf("first androidCacheWriterFor returned (%p, %q), want non-empty", w1, dir1)
+	}
+	w2, dir2 := state.androidCacheWriterFor(state.root)
+	if w2 != w1 || dir2 != dir1 {
+		t.Errorf("second call did not reuse the resident writer: got (%p,%q) want (%p,%q)", w2, dir2, w1, dir1)
+	}
+	state.closeAndroidCacheWriter()
+	state.closeAndroidCacheWriter() // must not panic
+	if state.androidCacheWriter != nil {
+		t.Errorf("expected androidCacheWriter to be nil after close, got %p", state.androidCacheWriter)
+	}
+}
+
+// TestDaemonStateAndroidCacheWriterEmptyRepo: with no repoDir the
+// helper must return (nil, "") and stay that way — the AndroidPhase
+// treats a nil writer as "caching disabled" and degrades gracefully.
+func TestDaemonStateAndroidCacheWriterEmptyRepo(t *testing.T) {
+	state := newDaemonState("")
+	w, dir := state.androidCacheWriterFor("")
+	if w != nil || dir != "" {
+		t.Errorf("empty-repo path: want (nil, \"\"), got (%p, %q)", w, dir)
+	}
+}

--- a/internal/cli/serve/serve.go
+++ b/internal/cli/serve/serve.go
@@ -225,6 +225,20 @@ type daemonState struct {
 	parseCache     *scanner.ParseCache
 	parseCacheErr  error
 
+	// androidCacheWriterOnce gates lazy construction of the resident
+	// Android findings cache writer + cache-dir path. The CLI runner
+	// pairs these so AndroidPhase can persist resource/manifest/icon
+	// rule results between runs; the daemon previously left both
+	// fields zero, which made the entire androidFindingsCacheable
+	// gate evaluate to false and forced every analyze to rerun all
+	// resource rules (~8 s on the Signal-Android corpus). One
+	// resident writer is shared across analyze calls — the async
+	// writer queues per Save, so concurrent analyze serialization is
+	// not required.
+	androidCacheWriterOnce sync.Once
+	androidCacheWriter     *scanner.AndroidCacheWriter
+	androidCacheDir        string
+
 	// analysisCacheMu guards lazy construction of the resident
 	// *cache.Cache + its file path, scoped per scan-path set. Pipeline
 	// dispatch merges per-file findings into the cache and saves it on
@@ -605,6 +619,39 @@ func (s *daemonState) closeParseCache() {
 	}
 	_ = s.parseCache.Close()
 	s.parseCache = nil
+}
+
+// androidCacheWriterFor returns the daemon's resident
+// AndroidCacheWriter and its on-disk cache directory, constructing
+// both lazily on the first call. Returns (nil, "") when repoDir is
+// empty — the AndroidPhase treats a nil writer as "caching disabled"
+// and just skips the persistence step, so the rest of the analyze
+// still runs correctly without it. workers is the worker count
+// passed to NewAndroidCacheWriter; the daemon picks a fixed small
+// value because the writer caps it to 4 internally.
+func (s *daemonState) androidCacheWriterFor(repoDir string) (*scanner.AndroidCacheWriter, string) {
+	if s == nil {
+		return nil, ""
+	}
+	s.androidCacheWriterOnce.Do(func() {
+		if repoDir == "" {
+			return
+		}
+		s.androidCacheDir = scanner.AndroidFindingsCacheDir(repoDir)
+		s.androidCacheWriter = scanner.NewAndroidCacheWriter(2)
+	})
+	return s.androidCacheWriter, s.androidCacheDir
+}
+
+// closeAndroidCacheWriter flushes queued Android cache writes and
+// releases the writer. Called from Server shutdown; safe to call
+// when no writer exists.
+func (s *daemonState) closeAndroidCacheWriter() {
+	if s == nil || s.androidCacheWriter == nil {
+		return
+	}
+	_ = s.androidCacheWriter.Close()
+	s.androidCacheWriter = nil
 }
 
 func (s *daemonState) warm() error {

--- a/internal/pipeline/android_keys.go
+++ b/internal/pipeline/android_keys.go
@@ -13,13 +13,23 @@ import (
 // resourceKey is the cache key for the dispatcher's per-resDir resource
 // rules. The active resource-deps mask is folded in so toggling the
 // rule set's resource needs flips the key correctly.
+//
+// JavaSemanticFactsFP is intentionally NOT folded in: resource rules
+// dispatch on files with scanner.LangXML, and the only consumer of
+// ctx.JavaSemanticFacts (semantic_rule_helpers.javaSemanticCallFact)
+// hard-gates on scanner.LangJava and returns no facts otherwise. So
+// rotating Java semantic facts (which happens on every .java edit
+// when JavaFacts-needing rules are active) cannot change resource
+// findings — including the fingerprint would force a full
+// resourceRuleChecks rerun on every Java edit even though the
+// resource-rule output is byte-identical. Same reasoning applies to
+// the other XML-only keys below.
 func (in AndroidInput) resourceKey(resDir, resDirFP string, deps rules.AndroidDataDependency, valueKinds android.ValuesScanKind) string {
 	return scanner.AndroidFindingsKey(scanner.AndroidFindingsKeyInputs{
-		Kind:                scanner.AndroidFindingsKindResources,
-		RuleHash:            in.RuleHash,
-		LibraryFactsFP:      in.LibraryFactsFP,
-		JavaSemanticFactsFP: in.JavaSemanticFactsFP,
-		InputFP:             resDirFP,
+		Kind:           scanner.AndroidFindingsKindResources,
+		RuleHash:       in.RuleHash,
+		LibraryFactsFP: in.LibraryFactsFP,
+		InputFP:        resDirFP,
 		// Pack (resDir path, deps mask, valueKinds mask) into Extra so
 		// rule-set masks flipping invalidates the cache and so two
 		// identical-content resDirs at different paths don't share an
@@ -41,24 +51,26 @@ func uintptrToHex(v uint64) string {
 	return string(buf[:])
 }
 
+// manifestKey / manifestBundleKey: manifest rules dispatch on
+// scanner.LangXML AndroidManifest.xml files. JavaSemanticFactsFP is
+// dropped for the same reason as resourceKey — manifest rules cannot
+// observe Java semantic facts. See the resourceKey comment.
 func (in AndroidInput) manifestKey(contentHash, bundleFP string) string {
 	return scanner.AndroidFindingsKey(scanner.AndroidFindingsKeyInputs{
-		Kind:                scanner.AndroidFindingsKindManifest,
-		RuleHash:            in.RuleHash,
-		LibraryFactsFP:      in.LibraryFactsFP,
-		JavaSemanticFactsFP: in.JavaSemanticFactsFP,
-		InputFP:             contentHash,
-		Extra:               bundleFP,
+		Kind:           scanner.AndroidFindingsKindManifest,
+		RuleHash:       in.RuleHash,
+		LibraryFactsFP: in.LibraryFactsFP,
+		InputFP:        contentHash,
+		Extra:          bundleFP,
 	})
 }
 
 func (in AndroidInput) manifestBundleKey(bundleFP string) string {
 	return scanner.AndroidFindingsKey(scanner.AndroidFindingsKeyInputs{
-		Kind:                scanner.AndroidFindingsKindManifestBundle,
-		RuleHash:            in.RuleHash,
-		LibraryFactsFP:      in.LibraryFactsFP,
-		JavaSemanticFactsFP: in.JavaSemanticFactsFP,
-		InputFP:             bundleFP,
+		Kind:           scanner.AndroidFindingsKindManifestBundle,
+		RuleHash:       in.RuleHash,
+		LibraryFactsFP: in.LibraryFactsFP,
+		InputFP:        bundleFP,
 	})
 }
 
@@ -79,14 +91,14 @@ func (in AndroidInput) resourceSourceKey(srcPath, srcContentHash, mergedIdxFP st
 	})
 }
 
+// resourceBundleKey: XML-only path, same reasoning as resourceKey.
 func (in AndroidInput) resourceBundleKey(mergedFP string, deps rules.AndroidDataDependency, valueKinds android.ValuesScanKind) string {
 	return scanner.AndroidFindingsKey(scanner.AndroidFindingsKeyInputs{
-		Kind:                scanner.AndroidFindingsKindResourceBundle,
-		RuleHash:            in.RuleHash,
-		LibraryFactsFP:      in.LibraryFactsFP,
-		JavaSemanticFactsFP: in.JavaSemanticFactsFP,
-		InputFP:             mergedFP,
-		Extra:               uintptrToHex(uint64(deps)) + "\x00" + uintptrToHex(uint64(valueKinds)),
+		Kind:           scanner.AndroidFindingsKindResourceBundle,
+		RuleHash:       in.RuleHash,
+		LibraryFactsFP: in.LibraryFactsFP,
+		InputFP:        mergedFP,
+		Extra:          uintptrToHex(uint64(deps)) + "\x00" + uintptrToHex(uint64(valueKinds)),
 	})
 }
 
@@ -101,24 +113,25 @@ func (in AndroidInput) resourceSourceIndexBundleKey(mergedFP string, deps rules.
 	})
 }
 
+// iconKey / iconBundleKey: icon rules walk drawable PNGs/SVGs. They
+// don't run rule code against Java/Kotlin source, so the semantic-
+// facts contribution is irrelevant. Same reasoning as resourceKey.
 func (in AndroidInput) iconKey(resDir, resDirFP string) string {
 	return scanner.AndroidFindingsKey(scanner.AndroidFindingsKeyInputs{
-		Kind:                scanner.AndroidFindingsKindIcons,
-		RuleHash:            in.RuleHash,
-		LibraryFactsFP:      in.LibraryFactsFP,
-		JavaSemanticFactsFP: in.JavaSemanticFactsFP,
-		InputFP:             resDirFP,
-		Extra:               resDir,
+		Kind:           scanner.AndroidFindingsKindIcons,
+		RuleHash:       in.RuleHash,
+		LibraryFactsFP: in.LibraryFactsFP,
+		InputFP:        resDirFP,
+		Extra:          resDir,
 	})
 }
 
 func (in AndroidInput) iconBundleKey(mergedFP string) string {
 	return scanner.AndroidFindingsKey(scanner.AndroidFindingsKeyInputs{
-		Kind:                scanner.AndroidFindingsKindIconBundle,
-		RuleHash:            in.RuleHash,
-		LibraryFactsFP:      in.LibraryFactsFP,
-		JavaSemanticFactsFP: in.JavaSemanticFactsFP,
-		InputFP:             mergedFP,
+		Kind:           scanner.AndroidFindingsKindIconBundle,
+		RuleHash:       in.RuleHash,
+		LibraryFactsFP: in.LibraryFactsFP,
+		InputFP:        mergedFP,
 	})
 }
 

--- a/internal/pipeline/android_keys_java_facts_test.go
+++ b/internal/pipeline/android_keys_java_facts_test.go
@@ -1,0 +1,94 @@
+package pipeline
+
+import (
+	"testing"
+
+	"github.com/kaeawc/krit/internal/android"
+	"github.com/kaeawc/krit/internal/rules"
+)
+
+// TestAndroidKeys_StableAcrossJavaSemanticFactsFP pins the contract
+// that XML-only Android cache keys (resource, manifest, icon, plus
+// their bundle variants) MUST NOT change when only
+// JavaSemanticFactsFP rotates. Folding semantic-facts into these
+// keys would invalidate the entire Android cache on every .java
+// edit even though the underlying rules can't observe Java semantic
+// facts (their dispatch language is LangXML and the only consumer
+// of ctx.JavaSemanticFacts hard-gates on LangJava). The full path
+// breakdown lives next to each key constructor in android_keys.go.
+func TestAndroidKeys_StableAcrossJavaSemanticFactsFP(t *testing.T) {
+	mkInput := func(javaFP string) AndroidInput {
+		return AndroidInput{
+			RuleHash:            "rh",
+			LibraryFactsFP:      "lf",
+			JavaSemanticFactsFP: javaFP,
+		}
+	}
+	a := mkInput("java-v1")
+	b := mkInput("java-v2")
+
+	type stableCase struct {
+		name string
+		fn   func(in AndroidInput) string
+	}
+	cases := []stableCase{
+		{"resourceKey", func(in AndroidInput) string {
+			return in.resourceKey("/res", "fp", rules.AndroidDepLayout, android.ValuesScanStrings)
+		}},
+		{"resourceBundleKey", func(in AndroidInput) string {
+			return in.resourceBundleKey("merged", rules.AndroidDepLayout, android.ValuesScanStrings)
+		}},
+		{"manifestKey", func(in AndroidInput) string {
+			return in.manifestKey("content", "bundle")
+		}},
+		{"manifestBundleKey", func(in AndroidInput) string {
+			return in.manifestBundleKey("bundle")
+		}},
+		{"iconKey", func(in AndroidInput) string {
+			return in.iconKey("/res", "fp")
+		}},
+		{"iconBundleKey", func(in AndroidInput) string {
+			return in.iconBundleKey("merged")
+		}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got, want := c.fn(a), c.fn(b); got != want {
+				t.Errorf("%s changed when only JavaSemanticFactsFP rotated\n  java-v1: %s\n  java-v2: %s", c.name, got, want)
+			}
+		})
+	}
+}
+
+// TestAndroidKeys_RuleHashStillInvalidates is the regression-critical
+// counterpart: dropping JavaSemanticFactsFP must NOT also break the
+// other key contributions. RuleHash changes (e.g. toggling a rule
+// on/off via config) must still rotate every key so a different
+// rule set never serves another rule set's cached findings.
+func TestAndroidKeys_RuleHashStillInvalidates(t *testing.T) {
+	a := AndroidInput{RuleHash: "rh-1", LibraryFactsFP: "lf"}
+	b := AndroidInput{RuleHash: "rh-2", LibraryFactsFP: "lf"}
+	if a.resourceKey("/res", "fp", rules.AndroidDepLayout, android.ValuesScanNone) ==
+		b.resourceKey("/res", "fp", rules.AndroidDepLayout, android.ValuesScanNone) {
+		t.Error("resourceKey did not change when RuleHash rotated")
+	}
+	if a.manifestKey("content", "bundle") == b.manifestKey("content", "bundle") {
+		t.Error("manifestKey did not change when RuleHash rotated")
+	}
+	if a.iconKey("/res", "fp") == b.iconKey("/res", "fp") {
+		t.Error("iconKey did not change when RuleHash rotated")
+	}
+}
+
+// TestAndroidKeys_LibraryFactsStillInvalidates: library facts (Gradle
+// SDK versions, dependency closure) can legitimately affect resource
+// rule output (e.g. a rule that gates on minSdk). Dropping
+// JavaSemanticFactsFP must not also un-gate this contribution.
+func TestAndroidKeys_LibraryFactsStillInvalidates(t *testing.T) {
+	a := AndroidInput{RuleHash: "rh", LibraryFactsFP: "lf-1"}
+	b := AndroidInput{RuleHash: "rh", LibraryFactsFP: "lf-2"}
+	if a.resourceKey("/res", "fp", rules.AndroidDepLayout, android.ValuesScanNone) ==
+		b.resourceKey("/res", "fp", rules.AndroidDepLayout, android.ValuesScanNone) {
+		t.Error("resourceKey did not change when LibraryFactsFP rotated")
+	}
+}


### PR DESCRIPTION
## Summary

Two coupled fixes that turn the daemon's Android findings cache from \"never reused\" into \"reused on every analyze that doesn't touch resources.\"

1. **Wire `AndroidCacheWriter` + `AndroidCacheDir` in the daemon.** The CLI runner sets these from `runner_state.go`; the daemon left both fields zero, so `ProjectHostState.androidFindingsCacheable` evaluated to false and `AndroidPhase.runResourceSubphase` / `loadCachedResourceFindings` always missed. The fix mirrors the lazy-init pattern of `parseCacheFor` — one resident writer per daemon, async-bounded internally.

2. **Drop `JavaSemanticFactsFP` from XML-only cache keys** (`resourceKey`, `manifestKey`, `iconKey` and their bundle variants). Java semantic facts rotate on every `.java` edit when any active Java-applicable rule needs them, but XML-only rule paths cannot observe these facts: dispatch happens on `LangXML` files and the only consumer (`semantic_rule_helpers.javaSemanticCallFact`) hard-gates on `LangJava`. Dropping is both safe and necessary for the cache to fire across the most common edit type. `RuleHash` and `LibraryFactsFP` stay — they can legitimately affect XML rule output.

## Benchmarks — steady-state Java-edit ABI loop

### `~/github/Signal-Android` (3.5 k Kt / 9.9 k XML / 464 manifests)
|                    | before    | after   | delta  |
|--------------------|-----------|---------|--------|
| `androidPhase`     | 10 403 ms | 86 ms   | **-99 %** |
| `resourceRuleChecks` | 9 609 ms | 0 ms    | full warm hit |
| `resourceDirScan`  | 720 ms    | 0 ms    | `tryWarmResourceSubphase` hit |
| total `durationMs` | ~10 000 ms| ~800 ms | **-92 %** |

### `~/github/kotlin` (18 k Kt, no Android resources)
Unchanged at ~0.79 s — the change only touches code paths Android projects exercise.

## Test plan

- [x] `internal/pipeline/android_keys_java_facts_test.go` — XML-only keys stable across `JavaSemanticFactsFP` rotation; RuleHash + LibraryFactsFP still invalidate
- [x] `internal/cli/serve/daemon_state_test.go` — `androidCacheWriterFor` lifecycle + empty-repo guards
- [x] `go test ./... -count=1` (all packages green)
- [x] `golangci-lint run ./...` (0 issues)
- [x] Daemon smoke against `~/github/Signal-Android`: 4 sequential Java edits at 685-1020 ms `durationMs`, findings unchanged
- [x] Daemon smoke against `~/github/kotlin`: 4 sequential Kt edits at 753-817 ms, no regression