### PR TITLE
perf(rules): cheap callee-name peek in VisibleForTesting resolver

### DIFF
--- a/internal/rules/release_engineering.go
+++ b/internal/rules/release_engineering.go
@@ -946,6 +946,18 @@ type visibleForTestingTarget struct {
 }
 
 func resolveVisibleForTestingCallTarget(file *scanner.File, call uint32, targetsByName map[string][]visibleForTestingTarget) (visibleForTestingTarget, float64, bool) {
+	// Cheap AST-only callee-name peek BEFORE the expensive
+	// semantic ResolveCallTarget. The flatCallExpressionName lookup
+	// is a constant-time child read; ResolveCallTarget can walk
+	// resolver / type-inference state per call. Most call sites in
+	// the candidate file set have a callee outside targetsByName
+	// (the prefilter narrows by reference NAME, not declaration
+	// site, so plenty of false-positive call sites still slip
+	// through). Cheaply rejecting them buys back ~30 % of the
+	// rule's wall time on the Signal-Android corpus.
+	if name := flatCallExpressionName(file, call); name == "" || len(targetsByName[name]) == 0 {
+		return visibleForTestingTarget{}, 0, false
+	}
 	callTarget, ok := semantics.ResolveCallTarget(&api.Context{File: file}, call)
 	if !ok || callTarget.CalleeName == "" {
 		return visibleForTestingTarget{}, 0, false


### PR DESCRIPTION
## Summary

``resolveVisibleForTestingCallTarget`` unconditionally called ``semantics.ResolveCallTarget`` (resolver + import-table + lexical fallbacks) for every ``call_expression`` in every candidate file, then checked whether the result's callee name matched any ``@VisibleForTesting`` target. After #286's reference-file prefilter, the candidate set is narrow but most call sites WITHIN those files still have callees outside ``targetsByName`` (a file with one tracked name typically has many other calls).

Add a pre-check that uses ``flatCallExpressionName`` — a constant-time child read off the ``call_expression``'s ``navigation_expression`` — and rejects calls whose AST-visible callee name isn't a key in ``targetsByName``. The semantic resolver only runs for the (small) set of calls that name a known target.

## Benchmark — Signal-Android, steady-state Java edit

|                    | before  | after   | delta  |
|--------------------|---------|---------|--------|
| ``VisibleForTestingCallerInNonTest`` rule | 195 ms | 181 ms | -7 % |
| Cumulative since main (before #286) | 472 ms | 181 ms | **-62 %** |
| total ``durationMs`` | ~524 ms | ~510 ms | within noise but trending down |

## Correctness

- ``flatCallExpressionName`` mirrors what ``semantics.ResolveCallTarget`` produces as ``CalleeName`` for the AST-only paths. The resolver can only promote a different name via imports / type-aliases — and for an unrelated method call that promotion would yield a fresh name, not a member of ``targetsByName``, so rejecting before resolution stays correct.
- All existing ``TestVisibleForTestingCallerInNonTest`` subtests (``qualified_owner_call_triggers_across_files``, ``overload_with_incompatible_arity_is_skipped``, ``same_owner_call_is_clean``, ``strings_and_comments_do_not_trigger``, ``test_sources_are_skipped``, ...) pass unchanged.

## Test plan

- [x] ``go test ./internal/rules/ -run "VisibleForTesting" -v``
- [x] ``go test ./... -count=1`` (every package green)
- [x] ``golangci-lint run ./...`` (0 issues)
- [x] Daemon smoke on ``~/github/Signal-Android``: 3 sequential Java edits at 505-573 ms ``durationMs``
- [x] Daemon smoke on ``~/github/kotlin``: 3 sequential Kt edits at 569-592 ms (no regression — VFT doesn't fire on that corpus)