### PR TITLE
perf(rules): byte-prefilter VisibleForTesting declaration walk

### DIFF
--- a/internal/rules/release_engineering.go
+++ b/internal/rules/release_engineering.go
@@ -1,6 +1,7 @@
 package rules
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -861,6 +862,18 @@ func (r *VisibleForTestingCallerInNonTestRule) check(ctx *api.Context) {
 		if file == nil || file.FlatTree == nil {
 			continue
 		}
+		// Byte-level prefilter: skip files that don't contain the
+		// string "VisibleForTesting" anywhere. The annotation name
+		// is mandatory on every target site (Kotlin/Java don't
+		// permit wildcard-imported annotations to be elided at the
+		// declaration), so the absence of those bytes guarantees no
+		// declaration walk can match. Same shape as the R.-byte
+		// prefilter in resource-source rules. On the Signal-Android
+		// corpus this skips ~98 % of the 4 600 files without
+		// touching the parsed tree.
+		if !visibleForTestingAnnotationMayMatch(file) {
+			continue
+		}
 		file.FlatWalkAllNodes(0, func(idx uint32) {
 			if file.FlatType(idx) != "function_declaration" {
 				return
@@ -935,6 +948,21 @@ func (r *VisibleForTestingCallerInNonTestRule) check(ctx *api.Context) {
 		})
 	}
 }
+
+// visibleForTestingAnnotationMayMatch reports whether file's source
+// bytes contain the literal "VisibleForTesting" anywhere. Kotlin and
+// Java require the annotation name to be syntactically present at the
+// declaration (no wildcard alias mechanism elides it), so a file
+// without those bytes cannot contain a target. The check skips the
+// flat-tree walk for every non-matching file.
+func visibleForTestingAnnotationMayMatch(file *scanner.File) bool {
+	if file == nil || len(file.Content) == 0 {
+		return false
+	}
+	return bytes.Contains(file.Content, visibleForTestingAnnotationBytes)
+}
+
+var visibleForTestingAnnotationBytes = []byte("VisibleForTesting")
 
 type visibleForTestingTarget struct {
 	name    string


### PR DESCRIPTION
## Summary

``VisibleForTestingCallerInNonTest``'s first pass walked every file's full flat tree looking for ``function_declaration`` nodes with the ``@VisibleForTesting`` annotation. On Signal-Android that's ~4 600 files even though only the ~50 files carrying the annotation can possibly contribute targets.

Add a byte-level prefilter — same shape as the ``R.``-byte prefilter in #261's resource-source rules. Skip any file whose source bytes don't contain the literal ``"VisibleForTesting"`` anywhere. Kotlin/Java require the annotation name to be syntactically present at the declaration site (no wildcard-alias mechanism elides it), so absence of those bytes guarantees no declaration can match.

## Benchmark — Signal-Android, steady-state Java edit

|                    | rule cost |
|--------------------|-----------|
| pre-#286 baseline  | 472 ms |
| after #286         | 195 ms |
| after #287         | 181 ms |
| **after this PR**  | **71 ms** |

Total Signal Java-edit ``durationMs`` ~517 ms → ~440 ms.

## Correctness

- All 8 existing ``TestVisibleForTestingCallerInNonTest`` subtests pass unchanged.
- Cold-run findings count on Signal-Android: 1 VFT finding out of 2318 total (matches pre-PR).
- False-negative risk: only if a target's annotation reaches the declaration via some name other than the literal ``"VisibleForTesting"`` bytes — which the language doesn't permit.

## Test plan

- [x] ``go test ./internal/rules/ -run "VisibleForTesting" -v``
- [x] ``go test ./... -count=1``
- [x] ``golangci-lint run ./...`` (0 issues)
- [x] Daemon smoke on ``~/github/Signal-Android``: 4 sequential Java edits at 390-487 ms ``durationMs``, findings count byte-identical to cold-run baseline