### PR TITLE
[codex] Auto-start daemon for scan

### DIFF
--- a/cmd/krit/daemon_cmd_test.go
+++ b/cmd/krit/daemon_cmd_test.go
@@ -288,7 +288,7 @@ func TestDaemonAnalyzeProject_RoundTrip(t *testing.T) {
 	}
 	t.Cleanup(func() { _, _, _ = runKrit(t, "daemon", "stop", "--repo", repo) })
 
-	stdout, stderr, code := runKrit(t, "--no-type-inference", "--no-type-oracle", "-q", "-f", "json", repo)
+	stdout, stderr, code := runKrit(t, "--no-type-inference", "--no-type-oracle", "-f", "json", repo)
 	// Findings present -> exit 1; the test directory is clean iff no
 	// rules fired, but the seeded UnusedVariable should fire.
 	if code != 1 {

--- a/cmd/krit/krit_init_integration_test.go
+++ b/cmd/krit/krit_init_integration_test.go
@@ -37,6 +37,9 @@ func copyDir(t *testing.T, src, dst string) {
 		if info.IsDir() {
 			return os.MkdirAll(target, 0o755)
 		}
+		if !info.Mode().IsRegular() {
+			return nil
+		}
 		data, err := os.ReadFile(path)
 		if err != nil {
 			return err

--- a/cmd/krit/main_test.go
+++ b/cmd/krit/main_test.go
@@ -31,6 +31,9 @@ func TestMain(m *testing.M) {
 	if err := cmd.Run(); err != nil {
 		log.Fatalf("failed to build krit binary: %v", err)
 	}
+	if err := os.Setenv("KRIT_NO_DAEMON_AUTOSTART", "1"); err != nil {
+		log.Fatalf("failed to set test env: %v", err)
+	}
 
 	code := m.Run()
 
@@ -522,7 +525,7 @@ func keysOf(m map[string]interface{}) []string {
 }
 
 func TestPlaygroundWebService(t *testing.T) {
-	out, err := exec.Command(binPath, "-f", "json", "-no-type-inference", "-no-type-oracle", "-q", "../../playground/kotlin-webservice/").CombinedOutput()
+	out, err := exec.Command(binPath, "--no-daemon", "-f", "json", "-no-type-inference", "-no-type-oracle", "-q", "../../playground/kotlin-webservice/").CombinedOutput()
 	if err != nil {
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
@@ -545,7 +548,7 @@ func TestPlaygroundWebService(t *testing.T) {
 }
 
 func TestPlaygroundAndroidApp(t *testing.T) {
-	out, err := exec.Command(binPath, "-f", "json", "-no-type-inference", "-no-type-oracle", "-q", "../../playground/android-app/").CombinedOutput()
+	out, err := exec.Command(binPath, "--no-daemon", "-f", "json", "-no-type-inference", "-no-type-oracle", "-q", "../../playground/android-app/").CombinedOutput()
 	if err != nil {
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {

--- a/cmd/krit/regression_test.go
+++ b/cmd/krit/regression_test.go
@@ -103,6 +103,7 @@ func runRegressionScan(t *testing.T, projectPath string) []normalizedFinding {
 	}
 
 	out, err := exec.Command(binPath,
+		"--no-daemon",
 		"-f", "json",
 		"-no-cache",
 		"-no-type-inference",

--- a/internal/cli/initcmd/main_test.go
+++ b/internal/cli/initcmd/main_test.go
@@ -46,6 +46,9 @@ func copyDir(t *testing.T, src, dst string) {
 		if info.IsDir() {
 			return os.MkdirAll(target, 0o755)
 		}
+		if !info.Mode().IsRegular() {
+			return nil
+		}
 		data, err := os.ReadFile(path)
 		if err != nil {
 			return err

--- a/internal/cli/scan/daemon_delegate.go
+++ b/internal/cli/scan/daemon_delegate.go
@@ -14,12 +14,15 @@ import (
 	"github.com/kaeawc/krit/internal/scanner"
 )
 
+var ensureDaemonForScan = daemonclient.EnsureCompatible
+
 // tryDaemonDelegate attempts to dispatch the current scan through a
-// running krit daemon. handled=true means the daemon produced the
-// output and the caller should exit with the returned code;
-// handled=false means the caller falls back to the in-process path.
-// Fallback is silent except for the daemon-talked-but-failed case,
-// which logs a warning and continues.
+// compatible krit daemon, starting or replacing one when needed.
+// handled=true means the daemon produced the output and the caller
+// should exit with the returned code; handled=false means the caller
+// falls back to the in-process path. Fallback is silent except when
+// daemon startup or a daemon call fails after the flag set has been
+// accepted for delegation.
 func tryDaemonDelegate(f *scanFlags, paths []string, repoDir string) (bool, int) {
 	if f == nil || *f.NoDaemon {
 		return false, 0
@@ -34,11 +37,37 @@ func tryDaemonDelegate(f *scanFlags, paths []string, repoDir string) (bool, int)
 	if !daemonCompatibleFlags(f) {
 		return false, 0
 	}
-	client, ok := daemonclient.TryConnect(repoDir, *f.DaemonSocket)
+	if *f.DaemonSocket != "" {
+		client, ok := daemonclient.TryConnect(repoDir, *f.DaemonSocket)
+		if !ok {
+			return false, 0
+		}
+		return runDaemonAnalyze(client, f, paths)
+	}
+	if daemonAutoStartDisabled() {
+		client, ok := daemonclient.TryConnect(repoDir, "")
+		if !ok {
+			return false, 0
+		}
+		return runDaemonAnalyze(client, f, paths)
+	}
+	client, ok, err := ensureDaemonForScan(repoDir, daemonclient.SpawnOptions{
+		Binary:      daemonBinaryForScan(),
+		WaitTimeout: 30 * time.Second,
+		LogPath:     filepath.Join(repoDir, ".krit", "daemon.log"),
+		AutoRestart: true,
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "warning: krit daemon unavailable (%v); falling back to in-process\n", err)
+		return false, 0
+	}
 	if !ok {
 		return false, 0
 	}
+	return runDaemonAnalyze(client, f, paths)
+}
 
+func runDaemonAnalyze(client *daemonclient.Client, f *scanFlags, paths []string) (bool, int) {
 	start := time.Now()
 	res, err := client.AnalyzeProject(buildDaemonAnalyzeArgs(f, paths))
 	if err != nil {
@@ -50,7 +79,9 @@ func tryDaemonDelegate(f *scanFlags, paths []string, repoDir string) (bool, int)
 		return false, 0
 	}
 
-	fmt.Fprintln(os.Stderr, "info: using daemon")
+	if !*f.Quiet {
+		fmt.Fprintln(os.Stderr, "info: using daemon")
+	}
 	if handled, code := dispatchDaemonShortCircuits(f, paths, res); handled {
 		return true, code
 	}
@@ -338,6 +369,18 @@ func emitDaemonDispatchProfile(p *daemon.DispatchProfile) {
 		}
 	}
 	reportDispatchProfile(timings, p.Workers, time.Duration(p.WallMs)*time.Millisecond)
+}
+
+func daemonBinaryForScan() string {
+	exe, err := os.Executable()
+	if err != nil {
+		return ""
+	}
+	return exe
+}
+
+func daemonAutoStartDisabled() bool {
+	return os.Getenv("KRIT_NO_DAEMON_AUTOSTART") == "1"
 }
 
 // daemonCompatibleFlags reports whether the requested flag set can be

--- a/internal/cli/scan/daemon_delegate_test.go
+++ b/internal/cli/scan/daemon_delegate_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/kaeawc/krit/internal/cli/daemonclient"
 	"github.com/kaeawc/krit/internal/daemon"
 )
 
@@ -31,36 +32,66 @@ func TestTryDaemonDelegate_NoDaemonShortCircuits(t *testing.T) {
 	}
 }
 
-// TestTryDaemonDelegate_NoSocketFallsBack is the auto-detect path:
-// no daemon listening, no fallback flag, the CLI should simply hand
-// off to in-process by returning handled=false.
-func TestTryDaemonDelegate_NoSocketFallsBack(t *testing.T) {
+// TestTryDaemonDelegate_StartFailureFallsBack is the auto-start path:
+// if no daemon can be started, the CLI should hand off to in-process
+// by returning handled=false.
+func TestTryDaemonDelegate_StartFailureFallsBack(t *testing.T) {
 	root := newRoot(t)
 	f := freshScanFlags(t)
+	stubEnsureDaemonForScan(t, func(string, daemonclient.SpawnOptions) (*daemonclient.Client, bool, error) {
+		return nil, false, fmt.Errorf("boom")
+	})
 
 	handled, _ := tryDaemonDelegate(f, []string{root}, root)
 	if handled {
-		t.Fatalf("expected fall-through when no daemon is reachable")
+		t.Fatalf("expected fall-through when daemon start fails")
 	}
 }
 
-// TestTryDaemonDelegate_StaleSocketFallsBack pins the kill -9 case:
-// a leftover socket inode with no listener must not propagate as an
-// error — the CLI should silently drop into in-process mode.
-func TestTryDaemonDelegate_StaleSocketFallsBack(t *testing.T) {
+func TestTryDaemonDelegate_AutoStartDisabledKeepsExistingDiscoveryBehavior(t *testing.T) {
+	t.Setenv("KRIT_NO_DAEMON_AUTOSTART", "1")
 	root := newRoot(t)
-	socket := daemon.DefaultSocketPath(root)
-	if err := os.MkdirAll(filepath.Dir(socket), 0o755); err != nil {
-		t.Fatalf("mkdir: %v", err)
-	}
-	if err := os.WriteFile(socket, []byte{}, 0o600); err != nil {
-		t.Fatalf("create stale: %v", err)
-	}
 	f := freshScanFlags(t)
+	stubEnsureDaemonForScan(t, func(string, daemonclient.SpawnOptions) (*daemonclient.Client, bool, error) {
+		t.Fatal("ensureDaemonForScan should not be called when autostart is disabled")
+		return nil, false, nil
+	})
 
 	handled, _ := tryDaemonDelegate(f, []string{root}, root)
 	if handled {
-		t.Fatalf("expected fall-through on stale socket; got handled=true")
+		t.Fatalf("expected fall-through with autostart disabled and no running daemon")
+	}
+}
+
+func TestTryDaemonDelegate_AutoStartsDaemon(t *testing.T) {
+	socketDir := startMockDaemon(t, mockBehavior{
+		findings:      `{"rules":["X"],"line":[1]}`,
+		findingsCount: 1,
+	})
+	root := newRoot(t)
+	f := freshScanFlags(t)
+	stubEnsureDaemonForScan(t, func(repoRoot string, opts daemonclient.SpawnOptions) (*daemonclient.Client, bool, error) {
+		if repoRoot != root {
+			t.Fatalf("repoRoot = %q, want %q", repoRoot, root)
+		}
+		if !opts.AutoRestart {
+			t.Fatal("AutoRestart = false, want true")
+		}
+		linkSock(t, root, filepath.Join(socketDir, "d.sock"))
+		client, ok := daemonclient.Discover(root)
+		return client, ok, nil
+	})
+
+	out := redirectStdout(t)
+	handled, code := tryDaemonDelegate(f, []string{root}, root)
+	if !handled {
+		t.Fatalf("expected handled=true after daemon auto-start")
+	}
+	if code != 1 {
+		t.Fatalf("code = %d, want 1", code)
+	}
+	if want := `{"rules":["X"],"line":[1]}`; out() != want {
+		t.Errorf("findings byte mismatch:\n got %q\nwant %q", out(), want)
 	}
 }
 
@@ -128,6 +159,13 @@ func freshScanFlags(t *testing.T) *scanFlags {
 	t.Helper()
 	fs := flag.NewFlagSet("scan-test", flag.ContinueOnError)
 	return registerScanFlags(fs)
+}
+
+func stubEnsureDaemonForScan(t *testing.T, fn func(string, daemonclient.SpawnOptions) (*daemonclient.Client, bool, error)) {
+	t.Helper()
+	orig := ensureDaemonForScan
+	ensureDaemonForScan = fn
+	t.Cleanup(func() { ensureDaemonForScan = orig })
 }
 
 // linkSock places root/.krit/daemon.sock pointing at socket so the

--- a/internal/onboarding/tui/init_tui_test.go
+++ b/internal/onboarding/tui/init_tui_test.go
@@ -702,6 +702,9 @@ func copyDirForTest(t *testing.T, src, dst string) {
 		if info.IsDir() {
 			return os.MkdirAll(target, 0o755)
 		}
+		if !info.Mode().IsRegular() {
+			return nil
+		}
 		data, err := os.ReadFile(path)
 		if err != nil {
 			return err

--- a/internal/onboarding/tui/main_test.go
+++ b/internal/onboarding/tui/main_test.go
@@ -23,6 +23,9 @@ func TestMain(m *testing.M) {
 	if err := cmd.Run(); err != nil {
 		log.Fatalf("failed to build krit binary: %v", err)
 	}
+	if err := os.Setenv("KRIT_NO_DAEMON_AUTOSTART", "1"); err != nil {
+		log.Fatalf("failed to set test env: %v", err)
+	}
 
 	code := m.Run()
 	os.RemoveAll(tmp)


### PR DESCRIPTION
## Summary
- Auto-start or refresh a compatible daemon for daemon-compatible scan requests.
- Keep explicit --daemon-socket discovery-only behavior and preserve --no-daemon as the opt-out.
- Add KRIT_NO_DAEMON_AUTOSTART=1 for test environments that need the old discovery-only behavior.

## Validation
- go test ./internal/cli/scan ./internal/cli/daemonclient -count=1
- go test ./cmd/krit -run 'TestDaemonAnalyzeProject_RoundTrip|TestDaemonStartStatusStop' -count=1 -timeout=2m
- go test ./internal/onboarding/tui -run TestInitSubcommandHeadless -count=1 -timeout=2m

## Probe
- Plain scan against ~/kaeawc/kotlin-cli-example auto-started the daemon and then reused it on the second scan.