### PR TITLE
test: env-driven corpus paths via internal/corpustest

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,20 @@
+# Local-only path overrides for corpus benchmarks.
+#
+# These point synthetic and integration benchmarks at the developer's
+# checkout of upstream corpora without committing absolute paths into
+# the repo. .env is gitignored (see .gitignore); copy this file to
+# .env and edit the values to match your machine.
+#
+# Both variables are optional:
+#   - Synthetic benchmarks fall back to a generic "/corpus/..." prefix
+#     when the variable is unset — they only use the path as a string
+#     to size the synthetic data realistically.
+#   - Corpus-driven integration benchmarks t.Skip() when the variable
+#     is unset because they actually read the corpus from disk.
+#
+# Suggested checkouts (any nearby Kotlin/Android repos work):
+#   KOTLIN_CORPUS=/Users/you/github/kotlin
+#   SIGNAL_ANDROID_CORPUS=/Users/you/github/Signal-Android
+
+KOTLIN_CORPUS=
+SIGNAL_ANDROID_CORPUS=

--- a/internal/corpustest/corpustest.go
+++ b/internal/corpustest/corpustest.go
@@ -1,0 +1,87 @@
+// Package corpustest centralizes access to the KOTLIN_CORPUS and
+// SIGNAL_ANDROID_CORPUS environment variables that point benchmarks
+// and integration tests at an external source corpus. Keeping the
+// var names + fallback strings in one place means contributors can
+// override either via a gitignored .env (see .env.example) without
+// patching test files, and reviewers don't see absolute paths baked
+// into committed code.
+//
+// Two access patterns:
+//
+//   - KotlinCorpusPath() / SignalAndroidCorpusPath(): return the env
+//     value when set, or a generic "/corpus/<name>" placeholder when
+//     unset. Use this for synthetic benchmarks that only need a
+//     plausible-looking path STRING — they don't read from disk, so
+//     the placeholder is fine.
+//
+//   - RequireKotlinCorpus(tb) / RequireSignalAndroidCorpus(tb): when
+//     the env var is set, return the path; when unset, t.Skip the
+//     calling bench/test with a clear message. Use this for tests
+//     that actually READ the corpus from disk.
+package corpustest
+
+import (
+	"os"
+	"testing"
+)
+
+// EnvKotlinCorpus is the name of the env var pointing at the Kotlin
+// compiler corpus (https://github.com/JetBrains/kotlin) — Krit's
+// large-Kotlin reference workload.
+const EnvKotlinCorpus = "KOTLIN_CORPUS"
+
+// EnvSignalAndroidCorpus is the name of the env var pointing at the
+// Signal-Android corpus (https://github.com/signalapp/Signal-Android)
+// — Krit's reference Android workload.
+const EnvSignalAndroidCorpus = "SIGNAL_ANDROID_CORPUS"
+
+// PlaceholderKotlinCorpus is the path-shape placeholder used by
+// synthetic benchmarks when KOTLIN_CORPUS is unset. Looks like a
+// real path so file-path-length sensitive code paths (string
+// allocation, hash-key construction) measure realistically.
+const PlaceholderKotlinCorpus = "/corpus/kotlin"
+
+// PlaceholderSignalAndroidCorpus mirrors PlaceholderKotlinCorpus
+// for Signal-Android.
+const PlaceholderSignalAndroidCorpus = "/corpus/signal-android"
+
+// KotlinCorpusPath returns the value of KOTLIN_CORPUS, or
+// PlaceholderKotlinCorpus when the env var is unset.
+func KotlinCorpusPath() string {
+	if p := os.Getenv(EnvKotlinCorpus); p != "" {
+		return p
+	}
+	return PlaceholderKotlinCorpus
+}
+
+// SignalAndroidCorpusPath returns the value of SIGNAL_ANDROID_CORPUS,
+// or PlaceholderSignalAndroidCorpus when the env var is unset.
+func SignalAndroidCorpusPath() string {
+	if p := os.Getenv(EnvSignalAndroidCorpus); p != "" {
+		return p
+	}
+	return PlaceholderSignalAndroidCorpus
+}
+
+// RequireKotlinCorpus returns the value of KOTLIN_CORPUS, or skips
+// tb when the env var is unset. Use from benchmarks/tests that
+// actually read from the corpus directory.
+func RequireKotlinCorpus(tb testing.TB) string {
+	tb.Helper()
+	p := os.Getenv(EnvKotlinCorpus)
+	if p == "" {
+		tb.Skipf("%s not set; skipping corpus-driven test (see .env.example)", EnvKotlinCorpus)
+	}
+	return p
+}
+
+// RequireSignalAndroidCorpus mirrors RequireKotlinCorpus for the
+// Signal-Android corpus.
+func RequireSignalAndroidCorpus(tb testing.TB) string {
+	tb.Helper()
+	p := os.Getenv(EnvSignalAndroidCorpus)
+	if p == "" {
+		tb.Skipf("%s not set; skipping corpus-driven test (see .env.example)", EnvSignalAndroidCorpus)
+	}
+	return p
+}

--- a/internal/corpustest/corpustest_test.go
+++ b/internal/corpustest/corpustest_test.go
@@ -1,0 +1,79 @@
+package corpustest
+
+import (
+	"testing"
+)
+
+func TestKotlinCorpusPath_FallbackWhenUnset(t *testing.T) {
+	t.Setenv(EnvKotlinCorpus, "")
+	if got, want := KotlinCorpusPath(), PlaceholderKotlinCorpus; got != want {
+		t.Errorf("KotlinCorpusPath() = %q, want %q", got, want)
+	}
+}
+
+func TestKotlinCorpusPath_HonorsEnv(t *testing.T) {
+	t.Setenv(EnvKotlinCorpus, "/tmp/elsewhere/kotlin")
+	if got, want := KotlinCorpusPath(), "/tmp/elsewhere/kotlin"; got != want {
+		t.Errorf("KotlinCorpusPath() = %q, want %q", got, want)
+	}
+}
+
+func TestSignalAndroidCorpusPath_FallbackWhenUnset(t *testing.T) {
+	t.Setenv(EnvSignalAndroidCorpus, "")
+	if got, want := SignalAndroidCorpusPath(), PlaceholderSignalAndroidCorpus; got != want {
+		t.Errorf("SignalAndroidCorpusPath() = %q, want %q", got, want)
+	}
+}
+
+func TestSignalAndroidCorpusPath_HonorsEnv(t *testing.T) {
+	t.Setenv(EnvSignalAndroidCorpus, "/tmp/elsewhere/signal")
+	if got, want := SignalAndroidCorpusPath(), "/tmp/elsewhere/signal"; got != want {
+		t.Errorf("SignalAndroidCorpusPath() = %q, want %q", got, want)
+	}
+}
+
+// TestRequireKotlinCorpus_SkipsWhenUnset confirms a Require* call
+// fires t.Skip rather than returning an empty path — corpus-driven
+// benches must skip cleanly on machines without the checkout.
+func TestRequireKotlinCorpus_SkipsWhenUnset(t *testing.T) {
+	t.Setenv(EnvKotlinCorpus, "")
+	skipped := runSubtestAndReportSkip(t, func(tb testing.TB) {
+		_ = RequireKotlinCorpus(tb)
+	})
+	if !skipped {
+		t.Error("RequireKotlinCorpus did not skip when env unset")
+	}
+}
+
+func TestRequireSignalAndroidCorpus_SkipsWhenUnset(t *testing.T) {
+	t.Setenv(EnvSignalAndroidCorpus, "")
+	skipped := runSubtestAndReportSkip(t, func(tb testing.TB) {
+		_ = RequireSignalAndroidCorpus(tb)
+	})
+	if !skipped {
+		t.Error("RequireSignalAndroidCorpus did not skip when env unset")
+	}
+}
+
+func TestRequireKotlinCorpus_ReturnsPath(t *testing.T) {
+	t.Setenv(EnvKotlinCorpus, "/tmp/kotlin")
+	got := RequireKotlinCorpus(t)
+	if got != "/tmp/kotlin" {
+		t.Errorf("RequireKotlinCorpus() = %q, want %q", got, "/tmp/kotlin")
+	}
+}
+
+// runSubtestAndReportSkip runs fn inside a subtest, returning true
+// when the subtest skipped. Lets the Require* tests observe the
+// Skip outcome without aborting the parent. The defer captures the
+// Skipped() result via runtime.Goexit's deferred-call guarantee —
+// reading after fn() would never execute on skip.
+func runSubtestAndReportSkip(t *testing.T, fn func(tb testing.TB)) bool {
+	t.Helper()
+	skipped := false
+	t.Run("inner", func(sub *testing.T) {
+		defer func() { skipped = sub.Skipped() }()
+		fn(sub)
+	})
+	return skipped
+}

--- a/internal/daemon/client_bench_test.go
+++ b/internal/daemon/client_bench_test.go
@@ -9,14 +9,15 @@ import (
 
 // BenchmarkJSONUnmarshal_LargeFindingsEnvelope measures the per-call
 // cost of decoding the daemon's response envelope when the embedded
-// Data field carries a 30 MB findings JSON. The kotlin-corpus warm
-// baseline pays this every analyze even on a bundle hit, so a hand-
-// rolled framed-binary wire (Data length prefix + raw bytes) would
-// remove this from the critical path.
+// Data field carries a 30 MB findings JSON. The Kotlin compiler
+// corpus warm baseline pays this every analyze even on a bundle
+// hit, so a hand-rolled framed-binary wire (Data length prefix +
+// raw bytes) would remove this from the critical path.
 func BenchmarkJSONUnmarshal_LargeFindingsEnvelope(b *testing.B) {
-	// Synthesize a Response payload roughly mirroring the ~/github/kotlin
-	// warm baseline: ~30 MB of findings JSON inside the daemon's
-	// {"ok":true,"data":{"findings":...,"stats":...}} envelope.
+	// Synthesize a Response payload roughly mirroring the Kotlin
+	// compiler corpus warm baseline: ~30 MB of findings JSON inside
+	// the daemon's {"ok":true,"data":{"findings":...,"stats":...}}
+	// envelope.
 	findings := bytes.Repeat([]byte(`{"file":"src/dir/File.kt","line":42,"col":1,"ruleSet":"style","rule":"MaxLineLength","severity":"warning","message":"Line exceeds maximum length","fixable":false,"confidence":0.75},`), 87_000)
 	findings = findings[:len(findings)-1] // trim trailing comma
 	body := `{"findings":[` + string(findings) + `],"stats":{"ok":true}}`

--- a/internal/javafacts/source_bench_test.go
+++ b/internal/javafacts/source_bench_test.go
@@ -4,15 +4,16 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/kaeawc/krit/internal/corpustest"
 	"github.com/kaeawc/krit/internal/scanner"
 )
 
 // BenchmarkSourceIndexKey_LargeCorpus measures the key-computation
 // cost SourceIndexForFiles pays on every call — including warm
 // cache hits, since the key has to be computed before the lookup.
-// The kotlin corpus has ~2k Java files; this bench builds a
-// synthetic equivalent so the measurement doesn't depend on a
-// real ~/github/kotlin checkout.
+// The Kotlin compiler corpus has ~2k Java files; this bench builds
+// a synthetic equivalent so the measurement doesn't depend on a
+// real checkout.
 func BenchmarkSourceIndexKey_LargeCorpus(b *testing.B) {
 	files := buildSyntheticJavaFiles(2000, 5000)
 	b.ResetTimer()
@@ -54,9 +55,10 @@ func BenchmarkSourceIndexForFiles_WarmHit_WithKotlin(b *testing.B) {
 
 func buildSyntheticKotlinFiles(n int) []*scanner.File {
 	out := make([]*scanner.File, n)
+	corpus := corpustest.KotlinCorpusPath()
 	for i := 0; i < n; i++ {
 		out[i] = &scanner.File{
-			Path:     fmt.Sprintf("/Users/jason/github/kotlin/some/kotlin/File%d.kt", i),
+			Path:     fmt.Sprintf("%s/some/kotlin/File%d.kt", corpus, i),
 			Language: scanner.LangKotlin,
 			Content:  []byte("package demo\nclass C\n"),
 		}
@@ -70,9 +72,10 @@ func buildSyntheticJavaFiles(n, contentBytes int) []*scanner.File {
 	for i := range content {
 		content[i] = byte('A' + (i % 26))
 	}
+	corpus := corpustest.KotlinCorpusPath()
 	for i := 0; i < n; i++ {
 		out[i] = &scanner.File{
-			Path:     fmt.Sprintf("/Users/jason/github/kotlin/some/dir/File%d.java", i),
+			Path:     fmt.Sprintf("%s/some/dir/File%d.java", corpus, i),
 			Language: scanner.LangJava,
 			Content:  content,
 		}

--- a/internal/output/json_bench_test.go
+++ b/internal/output/json_bench_test.go
@@ -7,14 +7,16 @@ import (
 	"testing"
 	"time"
 
+	"github.com/kaeawc/krit/internal/corpustest"
 	"github.com/kaeawc/krit/internal/scanner"
 )
 
 // BenchmarkFormatJSONColumns_LargeCorpus measures the per-finding cost
 // of the JSON formatter against a synthetic 87,000-finding payload,
-// matching the warm-bundle output size on ~/github/kotlin. Reflection-
-// based json.Marshal dominates wall-time here, so a hand-written
-// finding encoder would show up immediately as a delta on this bench.
+// matching the warm-bundle output size on the Kotlin compiler corpus.
+// Reflection-based json.Marshal dominates wall-time here, so a hand-
+// written finding encoder would show up immediately as a delta on
+// this bench.
 func BenchmarkFormatJSONColumns_LargeCorpus(b *testing.B) {
 	cols := buildSyntheticColumns(87_000)
 	b.ResetTimer()
@@ -66,9 +68,10 @@ func BenchmarkFormatJSONColumns_Discard(b *testing.B) {
 
 func buildSyntheticColumns(n int) *scanner.FindingColumns {
 	collector := scanner.NewFindingCollector(n)
+	corpus := corpustest.KotlinCorpusPath()
 	for i := 0; i < n; i++ {
 		f := scanner.Finding{
-			File:       fmt.Sprintf("/Users/jason/github/kotlin/some/dir/File%d.kt", i%2000),
+			File:       fmt.Sprintf("%s/some/dir/File%d.kt", corpus, i%2000),
 			Line:       i%500 + 1,
 			Col:        i%80 + 1,
 			RuleSet:    pickRuleSet(i),


### PR DESCRIPTION
## Summary

Existing synthetic benchmarks baked the maintainer's home-directory absolute path (``/Users/jason/github/kotlin/...``) into their ``File.Path`` strings to size the synthetic data realistically. The path is used as a string only (no actual disk read), but committing it leaks ``$HOME`` into the repo and makes it awkward for other contributors to swap in their own corpus checkout.

Adds ``internal/corpustest`` with two access patterns:

| Function | Behavior | Use case |
|---|---|---|
| ``KotlinCorpusPath()`` | env value, or ``/corpus/kotlin`` placeholder | synthetic benches that only need a plausible-looking path string |
| ``SignalAndroidCorpusPath()`` | env value, or ``/corpus/signal-android`` placeholder | (same) |
| ``RequireKotlinCorpus(tb)`` | env value, or ``tb.Skip`` | benches/tests that actually read the corpus |
| ``RequireSignalAndroidCorpus(tb)`` | env value, or ``tb.Skip`` | (same) |

Three existing benchmarks moved over to ``KotlinCorpusPath()``:
- ``internal/output/json_bench_test.go``
- ``internal/javafacts/source_bench_test.go``
- ``internal/daemon/client_bench_test.go`` (comment-only)

Comments elsewhere that mention "kotlin corpus" / "Signal-Android corpus" by name (motivating optimizations with observed savings) stay — those are upstream project names, not paths.

## Test plan

- [x] ``go test ./internal/corpustest/ -v -count=1`` — 8 tests cover fallback + env-honoring + Skip-when-unset for both vars
- [x] ``go test ./internal/output/ ./internal/javafacts/ ./internal/daemon/ -count=1`` — modified bench files compile and tests pass
- [x] ``go test ./... -count=1`` (all packages green)
- [x] ``golangci-lint run ./...`` (0 issues)
- [x] Verified no remaining ``/Users/jason/github`` references via ``grep -rn /Users/jason/github --include='*.go'``

## Local setup

``.env`` is already gitignored. Copy ``.env.example`` to ``.env`` and edit the values:

\`\`\`
KOTLIN_CORPUS=/Users/you/github/kotlin
SIGNAL_ANDROID_CORPUS=/Users/you/github/Signal-Android
\`\`\`

Variables are optional — benchmarks fall back to a generic placeholder when unset.