### PR TITLE
feat(daemon): surface FindingColumns on wire; route --rule-audit, --baseline-audit, --delta

### DIFF
--- a/docs/daemon-flag-routing.md
+++ b/docs/daemon-flag-routing.md
@@ -129,26 +129,18 @@ larger change than wiring a flag through.
 
 ## Audits that ship with the analysis
 
-`--baseline-audit` and `--rule-audit` are listed in the in-process bucket
-because they are short-circuits that *consume* the live findings produced by
-the same scan invocation. `RunBaselineAuditColumns`
-(`internal/cli/scan/baseline_audit.go:34`) and the rule-audit short-circuit
-(`internal/cli/scan/output_shortcircuits.go:30`, dispatching to
-`RunRuleAuditColumns` at `internal/cli/scan/rule_audit.go:75`) both take a
-`*scanner.FindingColumns` produced by the in-process analysis path and emit a
-report instead of normal findings.
-
-The daemon today returns serialized `Findings` bytes via
-`AnalyzeProject` (`internal/cli/scan/daemon_delegate.go:48`), not the
-column-oriented `FindingColumns` structure these audits walk. Routing audit
-flags through the daemon would require either teaching the audits to operate
-on serialized output (losing efficient access to per-finding columns) or
-extending the daemon wire to return `FindingColumns` directly.
-
-These flags are listed here for completeness — Bucket A's owner may decide to
-move them onto the daemon path once `FindingColumns` is reachable over the
-wire. If/when that happens, drop them from the meta bucket in
-`daemonCompatibleFlags`.
+`--baseline-audit` and `--rule-audit` are **now routed via daemon**. The
+daemon emits an optional `columns` segment in the analyze-project response
+when `AnalyzeProjectArgs.IncludeColumns` is true (the CLI sets it whenever
+`--baseline-audit`, `--rule-audit`, or `--delta` is present). The CLI
+deserialises the segment into a `*scanner.FindingColumns` and replays
+`RunBaselineAuditColumns` (`internal/cli/scan/baseline_audit.go:34`) /
+`RunRuleAuditColumns` (`internal/cli/scan/rule_audit.go:75`) locally,
+producing the same audit output the in-process flow does. The non-audit
+common path stays on the original `{findings,stats[,dispatch_profile]}`
+envelope: the `columns` field is `omitempty` and the fast-scan response
+decoder treats it as another optional segment after `dispatch_profile`
+(see `scanOptionalColumns` in `internal/daemon/response_scan.go`).
 
 ## Oracle I/O & sampling
 
@@ -172,20 +164,17 @@ new feature, not a routing tweak.
 
 ### `--delta`
 
-`filterColumnsByDelta` at `internal/cli/scan/delta.go:18` shells out to `git
-worktree add` for the base ref, re-execs `krit` itself inside the worktree to
-produce a baseline JSON report, and then filters the current-scan findings to
-only those NOT present in the baseline. The orchestration is entirely a CLI-
-side wrapper: the *base* sub-scan can already hit the daemon (it's just
-another `krit` invocation), so the only thing daemon-routing the wrapper
-would save is the parent-process `git worktree add` — which is the dominant
-cost.
-
-Daemon routing would mean either teaching the daemon how to spawn worktrees
-(adds filesystem-mutating side effects to a long-lived service) or returning
-`FindingColumns` from the wire so the CLI can run the diff client-side
-without re-execing. The latter is the same wire change the audit short-
-circuits would benefit from; revisit together.
+`--delta` is **now routed via daemon** for the current-tree scan portion.
+The CLI still owns the `git worktree add` + re-exec pass that produces the
+base-ref snapshot (daemon-side worktree management would add filesystem-
+mutating side effects to a long-lived service — explicitly out of scope).
+Once the daemon serves the current-tree scan with `IncludeColumns=true`
+the CLI applies `filterColumnsNewSince` (`internal/cli/scan/delta.go:111`)
+locally against the deserialised `FindingColumns` and re-emits the filtered
+set via `pipeline.OutputPhase{}.Run` so format, base path, and warning
+promotion match the in-process flow. The wire addition was shared with
+`--rule-audit` / `--baseline-audit`; see "Audits that ship with the
+analysis" above for the response-shape rationale.
 
 ## Adding a new flag
 

--- a/internal/cli/scan/daemon_columns.go
+++ b/internal/cli/scan/daemon_columns.go
@@ -1,0 +1,186 @@
+package scan
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/kaeawc/krit/internal/cli/clishared"
+	"github.com/kaeawc/krit/internal/experiment"
+	"github.com/kaeawc/krit/internal/pipeline"
+	"github.com/kaeawc/krit/internal/rules"
+	api "github.com/kaeawc/krit/internal/rules/api"
+	"github.com/kaeawc/krit/internal/scanner"
+)
+
+// decodeDaemonColumns parses the wire-form FindingColumns segment
+// shipped under AnalyzeProjectResult.Columns. An empty payload is
+// surfaced as a typed error so the caller can fall back to the
+// in-process path; the daemon should only omit the segment when the
+// CLI didn't request it via AnalyzeProjectArgs.IncludeColumns, so an
+// audit / delta path seeing nil columns means a daemon-side bug.
+func decodeDaemonColumns(raw json.RawMessage) (*scanner.FindingColumns, error) {
+	if len(raw) == 0 {
+		return nil, fmt.Errorf("daemon response missing columns payload")
+	}
+	cols := &scanner.FindingColumns{}
+	if err := json.Unmarshal(raw, cols); err != nil {
+		return nil, fmt.Errorf("decode columns: %w", err)
+	}
+	return cols, nil
+}
+
+// runDaemonRuleAudit replays RunRuleAuditColumns against the daemon-
+// shipped FindingColumns. The CLI mirrors the in-process
+// outputPhase short-circuit so audit output is byte-identical
+// regardless of which path executed the scan.
+func runDaemonRuleAudit(f *scanFlags, paths []string, rawColumns json.RawMessage) int {
+	cols, err := decodeDaemonColumns(rawColumns)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: --rule-audit via daemon: %v\n", err)
+		return 2
+	}
+	return RunRuleAuditColumns(cols, RuleAuditOpts{
+		MinFindings:    *f.RuleAuditMin,
+		DetailRules:    *f.RuleAuditDetails,
+		SamplesPerRule: *f.RuleAuditSamples,
+		SampleContext:  *f.RuleAuditContext,
+		ClusterFilter:  *f.RuleAuditCluster,
+		Targets:        paths,
+		Format:         resolveEffectiveFormat(f),
+	})
+}
+
+// runDaemonBaselineAudit resolves the baseline path the same way the
+// in-process flow does, loads it, then replays
+// RunBaselineAuditColumns against the daemon-shipped columns.
+func runDaemonBaselineAudit(f *scanFlags, paths []string, rawColumns json.RawMessage) int {
+	cols, err := decodeDaemonColumns(rawColumns)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: --baseline-audit via daemon: %v\n", err)
+		return 2
+	}
+	baselinePath, err := ResolveBaselineAuditPath(*f.Baseline, paths)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		return 2
+	}
+	baseline, err := scanner.LoadBaseline(baselinePath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: failed to load baseline: %v\n", err)
+		return 2
+	}
+	basePath := *f.BasePath
+	if basePath == "" && len(paths) > 0 {
+		basePath, _ = filepath.Abs(paths[0])
+	}
+	return RunBaselineAuditColumns(cols, baseline, baselinePath, basePath, paths, resolveEffectiveFormat(f))
+}
+
+// runDaemonDelta replays the in-process --delta flow against the
+// daemon-shipped columns. The base-ref worktree spawn + re-exec still
+// happens client-side (daemon-side worktree management would add
+// filesystem-mutating side effects to a long-lived service); only the
+// current-tree scan was routed through the daemon. After filtering
+// the daemon-supplied columns by base-ref baseline IDs the CLI
+// re-emits the filtered findings locally via pipeline.OutputPhase so
+// the output format (json / plain / sarif / checkstyle) matches the
+// CLI's --format / --report choice.
+func runDaemonDelta(f *scanFlags, paths []string, rawColumns json.RawMessage) int {
+	cols, err := decodeDaemonColumns(rawColumns)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: --delta via daemon: %v\n", err)
+		return 2
+	}
+	if *f.Baseline != "" {
+		fmt.Fprintln(os.Stderr, "error: --delta and --baseline are mutually exclusive")
+		return 2
+	}
+	basePath := *f.BasePath
+	if basePath == "" && len(paths) > 0 {
+		basePath, _ = filepath.Abs(paths[0])
+	}
+	beforeCount := cols.Len()
+	baseIDs, err := deltaBaseFindingIDsForFlags(*f.Delta, f, paths)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: --delta %s: %v\n", *f.Delta, err)
+		return 2
+	}
+	filtered := filterColumnsNewSince(cols, baseIDs, basePath)
+	if *f.Verbose {
+		fmt.Fprintf(os.Stderr, "verbose: --delta %s filtered %d → %d new findings\n",
+			*f.Delta, beforeCount, filtered.Len())
+	}
+	return emitDaemonFilteredColumns(f, paths, &filtered, basePath)
+}
+
+// emitDaemonFilteredColumns writes a column-filter result (currently
+// only --delta) to the user-requested output sink in the user-
+// requested format. The daemon's pre-filter findings JSON is
+// discarded; this path re-runs pipeline.OutputPhase locally so the
+// filtered set goes through the same formatter the in-process path
+// uses. ActiveRules / Version metadata are taken from the CLI's
+// resident rule registry to keep fixLevel / effort annotations in
+// the JSON output identical to the in-process emit.
+func emitDaemonFilteredColumns(f *scanFlags, paths []string, columns *scanner.FindingColumns, basePath string) int {
+	w, closer, openErr := openDaemonOutputWriter(f)
+	if openErr != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", openErr)
+		return 2
+	}
+	defer func() {
+		if err := closer(); err != nil {
+			fmt.Fprintf(os.Stderr, "error: close output: %v\n", err)
+		}
+	}()
+
+	format := resolveEffectiveFormat(f)
+	// JSONCompact mirrors runner.outputPhase: stay compact only when
+	// -o (output file) is set, so terminal output stays indented.
+	jsonCompact := *f.Output != ""
+	activeRules := activeRulesForDaemonEmit(f)
+	out, err := (pipeline.OutputPhase{}).Run(context.Background(), pipeline.OutputInput{
+		FixupResult: pipeline.FixupResult{
+			CrossFileResult: pipeline.CrossFileResult{
+				DispatchResult: pipeline.DispatchResult{
+					IndexResult: pipeline.IndexResult{
+						ParseResult: pipeline.ParseResult{
+							Paths:       paths,
+							ActiveRules: activeRules,
+						},
+					},
+					Findings: *columns,
+				},
+			},
+		},
+		Writer:           w,
+		Format:           format,
+		BasePath:         basePath,
+		StartTime:        time.Now(),
+		Version:          Version,
+		ExperimentNames:  experiment.Current().Names(),
+		JSONCompact:      jsonCompact,
+		WarningsAsErrors: *f.WarningsAsErrors,
+		MinConfidence:    *f.MinConfidence,
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		return 2
+	}
+	_ = out
+	return 0
+}
+
+// activeRulesForDaemonEmit resolves the active rule set the daemon-
+// served --delta emit needs to attach fixLevel / effort metadata to
+// JSON output. Mirrors rules.ActiveRulesV2 with the flags the daemon
+// path admits (NO custom-rule-jars: daemon-eligibility gate keeps
+// callers with --custom-rule-jars on the in-process path).
+func activeRulesForDaemonEmit(f *scanFlags) []*api.Rule {
+	disabledSet := clishared.ParseRuleNameSetCSV(*f.DisableRules)
+	enabledSet := clishared.ParseRuleNameSetCSV(*f.EnableRules)
+	return rules.ActiveRulesV2(disabledSet, enabledSet, *f.AllRules, *f.Experimental, *f.Strict)
+}

--- a/internal/cli/scan/daemon_delegate.go
+++ b/internal/cli/scan/daemon_delegate.go
@@ -51,44 +51,66 @@ func tryDaemonDelegate(f *scanFlags, paths []string, repoDir string) (bool, int)
 	}
 
 	fmt.Fprintln(os.Stderr, "info: using daemon")
-	// --sample-rule short-circuits the normal write path: the daemon
-	// returns the full JSON envelope, the CLI parses it back into
-	// columns, and the sampler prints a deterministic per-rule sample
-	// to stdout. Forwarding the JSON envelope through the writer would
-	// be confusing for an interactive flag, so it is consumed here.
-	if *f.SampleRule != "" {
+	if handled, code := dispatchDaemonShortCircuits(f, paths, res); handled {
+		return true, code
+	}
+	return true, writeDaemonFindings(f, res, start)
+}
+
+// dispatchDaemonShortCircuits handles the per-flag post-response
+// branches that consume the daemon's findings JSON (or its columns
+// segment) instead of streaming bytes to the output writer. Pulled
+// out of tryDaemonDelegate so the per-call body stays under the
+// gocyclo cap as new column-consuming flags (--rule-audit,
+// --baseline-audit, --delta) join the daemon path.
+//
+// handled=false means no short-circuit fired and the caller should
+// fall through to writeDaemonFindings; handled=true returns the
+// short-circuit's exit code as-is.
+func dispatchDaemonShortCircuits(f *scanFlags, paths []string, res daemon.AnalyzeProjectResult) (handled bool, code int) {
+	switch {
+	case *f.SampleRule != "":
+		// --sample-rule consumes the JSON envelope and prints a
+		// deterministic per-rule sample. Forwarding the envelope
+		// verbatim would be confusing for an interactive flag.
 		return true, runDaemonSampleRule(f, paths, res.Findings)
-	}
-
-	// CreateBaseline replaces the findings-write path entirely: we
-	// don't want findings JSON on stdout, just the XML baseline file.
-	// Mirrors applyBaselinesAndDiff's early-exit semantics.
-	if *f.CreateBaseline != "" {
+	case *f.CreateBaseline != "":
+		// CreateBaseline replaces the findings-write path entirely:
+		// no findings JSON, just the XML baseline file.
 		return true, runDaemonCreateBaseline(f, res.Stats)
-	}
-
-	// DryRun (without --fix) prints the fixable-file list to stdout
-	// and a summary to stderr — no findings JSON. Mirrors
-	// printDryRunFixResult exactly: file-per-line on stdout plus the
-	// "N fix(es) available across M file(s)" stderr summary.
-	if *f.DryRun {
+	case *f.DryRun:
+		// DryRun prints the fixable-file list + summary lines; no
+		// findings JSON. Mirrors printDryRunFixResult byte-for-byte.
 		runDaemonDryRun(f, res.Stats)
 		return true, 0
+	case *f.RuleAudit:
+		return true, runDaemonRuleAudit(f, paths, res.Columns)
+	case *f.BaselineAudit:
+		return true, runDaemonBaselineAudit(f, paths, res.Columns)
+	case *f.Delta != "":
+		return true, runDaemonDelta(f, paths, res.Columns)
 	}
+	return false, 0
+}
 
+// writeDaemonFindings handles the common path: stream the daemon's
+// findings JSON to the configured output writer, surface any
+// profile warnings, render the dispatch-profile table when armed,
+// and produce the final exit code.
+func writeDaemonFindings(f *scanFlags, res daemon.AnalyzeProjectResult, start time.Time) int {
 	w, closer, openErr := openDaemonOutputWriter(f)
 	if openErr != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", openErr)
-		return true, 2
+		return 2
 	}
 	if _, err := w.Write(res.Findings); err != nil {
 		_ = closer()
 		fmt.Fprintf(os.Stderr, "error: write findings: %v\n", err)
-		return true, 2
+		return 2
 	}
 	if err := closer(); err != nil {
 		fmt.Fprintf(os.Stderr, "error: close output: %v\n", err)
-		return true, 2
+		return 2
 	}
 	for _, msg := range res.Stats.ProfileWarnings {
 		fmt.Fprintf(os.Stderr, "warning: %s\n", msg)
@@ -96,7 +118,7 @@ func tryDaemonDelegate(f *scanFlags, paths []string, repoDir string) (bool, int)
 	if *f.ProfileDispatch && res.DispatchProfile != nil && len(res.DispatchProfile.Timings) > 0 {
 		emitDaemonDispatchProfile(res.DispatchProfile)
 	}
-	return true, finalScanExit(os.Stderr, res.Stats.FindingsCount, time.Since(start), *f.Quiet)
+	return finalScanExit(os.Stderr, res.Stats.FindingsCount, time.Since(start), *f.Quiet)
 }
 
 // metaVerbName tags the routable read-only meta queries the daemon
@@ -362,6 +384,15 @@ func emitDaemonDispatchProfile(p *daemon.DispatchProfile) {
 // The daemon never touches user files; the file write happens with the
 // CLI's CWD and permissions, preserving the daemon's read-only invariant.
 //
+// --rule-audit, --baseline-audit, and --delta are daemon-compatible
+// too: the daemon ships post-pipeline FindingColumns on the wire
+// (under AnalyzeProjectResult.Columns) when AnalyzeProjectArgs.
+// IncludeColumns is true, and the CLI runs the audit / delta filter
+// locally against the deserialized columns. --delta's worktree
+// orchestration stays CLI-side (daemon-side worktree spawning would
+// add filesystem side-effects to a long-lived service); only the
+// current-tree scan and the delta diff step are daemon-routable.
+//
 // --fix, --fix-binary, and --remove-dead-code stay in-process. Each
 // would need a separate fix-payload-over-the-wire design where the
 // daemon serialises text edits / binary operations and the CLI replays
@@ -371,7 +402,7 @@ func emitDaemonDispatchProfile(p *daemon.DispatchProfile) {
 func daemonCompatibleFlags(f *scanFlags) bool {
 	mutating := []bool{*f.Fix, *f.RemoveDeadCode, *f.FixBinary}
 	meta := []bool{*f.Init, *f.Doctor, *f.Version, *f.List, *f.ValidateConfig, *f.GenerateSchema,
-		*f.BaselineAudit, *f.RuleAudit, *f.OracleFilterFingerprint, *f.ListExperiments}
+		*f.OracleFilterFingerprint, *f.ListExperiments}
 	for _, group := range [][]bool{mutating, meta} {
 		for _, on := range group {
 			if on {
@@ -379,7 +410,7 @@ func daemonCompatibleFlags(f *scanFlags) bool {
 			}
 		}
 	}
-	strs := []string{*f.Completions, *f.OutputTypes, *f.Delta,
+	strs := []string{*f.Completions, *f.OutputTypes,
 		*f.PromoteExperiment, *f.DeprecateExperiment, *f.NewExperiment, *f.ExperimentMatrix}
 	for _, s := range strs {
 		if s != "" {
@@ -426,6 +457,19 @@ func buildDaemonAnalyzeArgs(f *scanFlags, paths []string) daemon.AnalyzeProjectA
 	if *f.CreateBaseline != "" {
 		baselinePath = ""
 	}
+	// --rule-audit / --baseline-audit / --delta need the post-pipeline
+	// FindingColumns shipped back so the CLI can run the audit or
+	// delta filter locally. The daemon ships the columns alongside
+	// the normal findings JSON only when IncludeColumns is true so
+	// non-audit / non-delta scans stay on the original
+	// {findings,stats[,dispatch_profile]} wire shape.
+	//
+	// Also force JSON format when --rule-audit's caller picked a
+	// non-default --format: the audit short-circuit consumes columns
+	// directly and discards the findings JSON, but the daemon still
+	// streams it. --baseline-audit / --delta tolerate any format on
+	// the daemon side because the bytes are discarded the same way.
+	includeColumns := *f.RuleAudit || *f.BaselineAudit || *f.Delta != ""
 	return daemon.AnalyzeProjectArgs{
 		Paths:            paths,
 		Format:           format,
@@ -449,6 +493,7 @@ func buildDaemonAnalyzeArgs(f *scanFlags, paths []string) daemon.AnalyzeProjectA
 		CreateBaseline:   *f.CreateBaseline != "",
 		DryRun:           *f.DryRun,
 		FixLevel:         *f.FixLevel,
+		IncludeColumns:   includeColumns,
 		ClientBinaryHash: daemonclient.CurrentBinaryHash(),
 	}
 }

--- a/internal/cli/scan/daemon_delegate_oracle_args_test.go
+++ b/internal/cli/scan/daemon_delegate_oracle_args_test.go
@@ -9,8 +9,12 @@ import (
 
 // TestDaemonCompatibleFlags_OracleArgsAllowed pins the oracle I/O and
 // sampling bucket: --input-types and --sample-rule are now wire-routable
-// (the CLI absolutizes the path / re-runs the sampler on returned JSON);
-// --output-types and --delta deliberately remain in-process.
+// (the CLI absolutizes the path / re-runs the sampler on returned JSON).
+// --delta is daemon-served via the AnalyzeProjectResult.Columns wire
+// segment: the daemon ships post-pipeline FindingColumns, the CLI
+// applies the delta filter against the base-ref worktree snapshot
+// locally. --output-types deliberately remains in-process (no
+// rule-dispatch dump-only daemon verb yet — tracked separately).
 func TestDaemonCompatibleFlags_OracleArgsAllowed(t *testing.T) {
 	tests := []struct {
 		name string
@@ -20,7 +24,7 @@ func TestDaemonCompatibleFlags_OracleArgsAllowed(t *testing.T) {
 		{"--input-types", func(f *scanFlags) { *f.InputTypes = "/tmp/types.json" }, true},
 		{"--sample-rule", func(f *scanFlags) { *f.SampleRule = "MyRule" }, true},
 		{"--output-types", func(f *scanFlags) { *f.OutputTypes = "/tmp/out.json" }, false},
-		{"--delta", func(f *scanFlags) { *f.Delta = "main" }, false},
+		{"--delta", func(f *scanFlags) { *f.Delta = "main" }, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/cli/scan/daemon_delegate_test.go
+++ b/internal/cli/scan/daemon_delegate_test.go
@@ -330,9 +330,14 @@ func startMockMetaDaemon(t *testing.T, verb string, reply daemon.MetaResult) str
 //
 // --create-baseline and --dry-run are now daemon-served too: the
 // daemon computes baseline IDs / fixable file lists and the CLI
-// performs the local file write or stdout print. --fix /
-// --remove-dead-code / --fix-binary remain in-process pending a
-// fix-payload-over-the-wire design.
+// performs the local file write or stdout print.
+//
+// --rule-audit, --baseline-audit, and --delta are daemon-served via
+// the AnalyzeProjectResult.Columns wire segment (IncludeColumns=true
+// asks the daemon to ship post-pipeline FindingColumns alongside the
+// findings JSON). The CLI runs the audit / delta filter locally.
+// --fix / --remove-dead-code / --fix-binary remain in-process pending
+// a fix-payload-over-the-wire design.
 func TestDaemonCompatibleFlags_PerfAllowed(t *testing.T) {
 	tests := []struct {
 		name string
@@ -370,6 +375,12 @@ func TestDaemonCompatibleFlags_PerfAllowed(t *testing.T) {
 		// performs the local write/print.
 		{"--create-baseline", func(f *scanFlags) { *f.CreateBaseline = "/tmp/baseline.xml" }, true},
 		{"--dry-run", func(f *scanFlags) { *f.DryRun = true }, true},
+		// --rule-audit and --baseline-audit are daemon-served: the
+		// daemon ships FindingColumns on the wire under the optional
+		// "columns" segment and the CLI replays
+		// RunRuleAuditColumns / RunBaselineAuditColumns locally.
+		{"--rule-audit", func(f *scanFlags) { *f.RuleAudit = true }, true},
+		{"--baseline-audit", func(f *scanFlags) { *f.BaselineAudit = true }, true},
 		// --base-path is daemon-compatible — it's forwarded as
 		// AnalyzeProjectArgs.BasePath so daemon-side baseline IDs
 		// match in-process resolution.
@@ -458,6 +469,36 @@ func startMockClearCacheDaemon(t *testing.T, cleared bool) string {
 		time.Sleep(5 * time.Millisecond)
 	}
 	return socketDir
+}
+
+// TestBuildDaemonAnalyzeArgs_ForwardsIncludeColumns confirms each
+// column-consuming flag (--rule-audit, --baseline-audit, --delta)
+// flips AnalyzeProjectArgs.IncludeColumns to true so the daemon
+// emits the post-pipeline FindingColumns under the optional
+// "columns" wire segment. Other flag sets keep it false to preserve
+// the original {findings,stats[,dispatch_profile]} envelope.
+func TestBuildDaemonAnalyzeArgs_ForwardsIncludeColumns(t *testing.T) {
+	tests := []struct {
+		name string
+		set  func(*scanFlags)
+		want bool
+	}{
+		{"default", func(*scanFlags) {}, false},
+		{"--rule-audit", func(f *scanFlags) { *f.RuleAudit = true }, true},
+		{"--baseline-audit", func(f *scanFlags) { *f.BaselineAudit = true }, true},
+		{"--delta", func(f *scanFlags) { *f.Delta = "main" }, true},
+		{"--rule-audit and --delta", func(f *scanFlags) { *f.RuleAudit = true; *f.Delta = "main" }, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := freshScanFlags(t)
+			tt.set(f)
+			args := buildDaemonAnalyzeArgs(f, []string{"/tmp"})
+			if args.IncludeColumns != tt.want {
+				t.Errorf("IncludeColumns = %v, want %v", args.IncludeColumns, tt.want)
+			}
+		})
+	}
 }
 
 // TestBuildDaemonAnalyzeArgs_ForwardsNoCache confirms --no-cache

--- a/internal/cli/scan/delta.go
+++ b/internal/cli/scan/delta.go
@@ -16,14 +16,18 @@ import (
 )
 
 func (r *runner) filterColumnsByDelta(ref string) (scanner.FindingColumns, error) {
-	baseIDs, err := r.deltaBaseFindingIDs(ref)
+	baseIDs, err := deltaBaseFindingIDsForFlags(ref, r.f, r.paths)
 	if err != nil {
 		return scanner.FindingColumns{}, err
 	}
 	return filterColumnsNewSince(r.allColumns, baseIDs, r.basePath), nil
 }
 
-func (r *runner) deltaBaseFindingIDs(ref string) (map[string]bool, error) {
+// deltaBaseFindingIDsForFlags spawns a base-ref worktree and re-execs
+// krit against it to collect the baseline finding IDs the current run
+// will subtract. Factored out of runner.deltaBaseFindingIDs so the
+// daemon-routed --delta path can call it without owning a runner.
+func deltaBaseFindingIDsForFlags(ref string, f *scanFlags, paths []string) (map[string]bool, error) {
 	repoRoot, err := gitRepoRoot()
 	if err != nil {
 		return nil, err
@@ -44,7 +48,7 @@ func (r *runner) deltaBaseFindingIDs(ref string) (map[string]bool, error) {
 	if err != nil {
 		return nil, err
 	}
-	args := r.deltaSnapshotArgs(repoRoot, tmp)
+	args := deltaSnapshotArgsForFlags(f, paths, repoRoot, tmp)
 	cmd := exec.CommandContext(context.Background(), exe, args...)
 	cmd.Dir = tmp
 	var stderr bytes.Buffer
@@ -68,41 +72,41 @@ func (r *runner) deltaBaseFindingIDs(ref string) (map[string]bool, error) {
 	return ids, nil
 }
 
-func (r *runner) deltaSnapshotArgs(repoRoot, tmp string) []string {
+func deltaSnapshotArgsForFlags(f *scanFlags, paths []string, repoRoot, tmp string) []string {
 	args := []string{
 		"--format", "json",
 		"-q",
 		"--no-cache",
 		"--base-path", tmp,
 	}
-	if *r.f.NoTypeInfer {
+	if *f.NoTypeInfer {
 		args = append(args, "--no-type-inference")
 	}
-	if *r.f.NoTypeOracle {
+	if *f.NoTypeOracle {
 		args = append(args, "--no-type-oracle")
 	}
-	if *r.f.NoFir {
+	if *f.NoFir {
 		args = append(args, "--no-fir")
 	}
-	if *r.f.Fir {
+	if *f.Fir {
 		args = append(args, "--fir")
 	}
-	if *r.f.IncludeGenerated {
+	if *f.IncludeGenerated {
 		args = append(args, "--include-generated")
 	}
-	if *r.f.AllRules {
+	if *f.AllRules {
 		args = append(args, "--all-rules")
 	}
-	if *r.f.DisableRules != "" {
-		args = append(args, "--disable-rules", *r.f.DisableRules)
+	if *f.DisableRules != "" {
+		args = append(args, "--disable-rules", *f.DisableRules)
 	}
-	if *r.f.EnableRules != "" {
-		args = append(args, "--enable-rules", *r.f.EnableRules)
+	if *f.EnableRules != "" {
+		args = append(args, "--enable-rules", *f.EnableRules)
 	}
-	if *r.f.Config != "" {
-		args = append(args, "--config", mapPathToWorktree(repoRoot, tmp, *r.f.Config))
+	if *f.Config != "" {
+		args = append(args, "--config", mapPathToWorktree(repoRoot, tmp, *f.Config))
 	}
-	for _, path := range r.paths {
+	for _, path := range paths {
 		args = append(args, mapPathToWorktree(repoRoot, tmp, path))
 	}
 	return args

--- a/internal/cli/serve/analyze_project.go
+++ b/internal/cli/serve/analyze_project.go
@@ -131,6 +131,7 @@ func handleAnalyzeProject(_ context.Context, state *daemonState, raw json.RawMes
 		basePath:        in.Args.BasePath,
 		createBaseline:  args.CreateBaseline,
 		dryRun:          args.DryRun,
+		includeColumns:  args.IncludeColumns,
 		releaseLock:     state.analyzeMu.Unlock,
 	}, nil
 }
@@ -147,6 +148,7 @@ type streamingAnalyzeResponse struct {
 	basePath        string
 	createBaseline  bool
 	dryRun          bool
+	includeColumns  bool
 	releaseLock     func()
 }
 
@@ -236,6 +238,24 @@ func (r *streamingAnalyzeResponse) WriteRawResponse(ctx context.Context, w io.Wr
 			return err
 		}
 		if _, err := w.Write(profileBytes); err != nil {
+			return err
+		}
+	}
+	if r.includeColumns {
+		// Ship the post-pipeline FindingColumns so CLI-side audit /
+		// delta paths (--rule-audit, --baseline-audit, --delta) can
+		// run their column-oriented work locally without needing to
+		// reconstruct the column index from the findings JSON. The
+		// segment is only emitted when the caller opts in so non-
+		// audit scans keep the original envelope shape.
+		columnsBytes, err := json.Marshal(&res.FinalFindings)
+		if err != nil {
+			return fmt.Errorf("marshal columns: %w", err)
+		}
+		if _, err := w.Write([]byte(`,"columns":`)); err != nil {
+			return err
+		}
+		if _, err := w.Write(columnsBytes); err != nil {
 			return err
 		}
 	}

--- a/internal/cli/serve/analyze_project_writeout_test.go
+++ b/internal/cli/serve/analyze_project_writeout_test.go
@@ -2,6 +2,7 @@ package serve
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -181,5 +182,109 @@ func TestAnalyzeProject_DryRunMatchesInProcess(t *testing.T) {
 					directRes.Fixup.StrippedByLevel, verbResult.Stats.DryRunStrippedByLevel)
 			}
 		})
+	}
+}
+
+// TestAnalyzeProject_IncludeColumnsMatchesInProcess pins the
+// equivalence between the daemon-routed IncludeColumns path (used by
+// --rule-audit, --baseline-audit, --delta) and the in-process
+// FinalFindings produced by RunProject. The daemon ships its post-
+// pipeline FindingColumns over the wire; the CLI decodes them and
+// runs audits / delta filters locally. Both must agree on every
+// finding row (file/line/rule/message) for byte-identical audit
+// output.
+func TestAnalyzeProject_IncludeColumnsMatchesInProcess(t *testing.T) {
+	socket, state := startServerForTest(t)
+
+	writeKotlinFile(t, state.root, "Foo.kt",
+		"package demo\n\nclass Foo {\n    fun greet() = println(\"hi\")\n}\n")
+	writeKotlinFile(t, state.root, "Bar.kt",
+		"package demo\n\nfun bar(unused: Int): Int { return 42 }\n")
+
+	basePath, _ := filepath.Abs(state.root)
+
+	cfg := config.NewConfig()
+	rules.ApplyConfig(cfg)
+	activeRules := rules.ActiveRulesV2(map[string]bool{}, map[string]bool{}, false, false, false)
+	repoDir := oracle.FindRepoDir([]string{state.root})
+	if repoDir == "" {
+		repoDir = state.root
+	}
+	pc, err := scanner.NewParseCacheWithCap(repoDir, cacheutil.DefaultParseCacheCapBytes)
+	if err != nil {
+		t.Fatalf("ParseCache: %v", err)
+	}
+	t.Cleanup(func() { _ = pc.Close() })
+
+	directRes, err := pipeline.RunProject(context.Background(), pipeline.ProjectInput{
+		Args: pipeline.ProjectArgs{
+			Config:      cfg,
+			Paths:       []string{state.root},
+			ActiveRules: activeRules,
+			Format:      "json",
+			Version:     "test",
+			BasePath:    basePath,
+		},
+		Host: pipeline.ProjectHostState{ParseCache: pc},
+	})
+	if err != nil {
+		t.Fatalf("direct RunProject: %v", err)
+	}
+
+	var verbResult daemon.AnalyzeProjectResult
+	if err := daemon.Call(socket, daemon.VerbAnalyzeProject,
+		daemon.AnalyzeProjectArgs{
+			Format:         "json",
+			BasePath:       basePath,
+			IncludeColumns: true,
+		}, &verbResult); err != nil {
+		t.Fatalf("verb call: %v", err)
+	}
+
+	if len(verbResult.Columns) == 0 {
+		t.Fatal("expected non-empty columns payload from daemon when IncludeColumns=true")
+	}
+	var verbColumns scanner.FindingColumns
+	if err := json.Unmarshal(verbResult.Columns, &verbColumns); err != nil {
+		t.Fatalf("decode columns: %v", err)
+	}
+
+	if directRes.FinalFindings.Len() != verbColumns.Len() {
+		t.Fatalf("Len mismatch: direct=%d verb=%d", directRes.FinalFindings.Len(), verbColumns.Len())
+	}
+	for row := 0; row < directRes.FinalFindings.Len(); row++ {
+		if got, want := verbColumns.FileAt(row), directRes.FinalFindings.FileAt(row); got != want {
+			t.Errorf("row %d File mismatch: direct=%q verb=%q", row, want, got)
+		}
+		if got, want := verbColumns.LineAt(row), directRes.FinalFindings.LineAt(row); got != want {
+			t.Errorf("row %d Line mismatch: direct=%d verb=%d", row, want, got)
+		}
+		if got, want := verbColumns.RuleAt(row), directRes.FinalFindings.RuleAt(row); got != want {
+			t.Errorf("row %d Rule mismatch: direct=%q verb=%q", row, want, got)
+		}
+		if got, want := verbColumns.MessageAt(row), directRes.FinalFindings.MessageAt(row); got != want {
+			t.Errorf("row %d Message mismatch: direct=%q verb=%q", row, want, got)
+		}
+	}
+}
+
+// TestAnalyzeProject_IncludeColumnsAbsentByDefault pins the
+// no-regression contract: when IncludeColumns is false (the default)
+// the response carries no Columns segment so non-audit / non-delta
+// scans stay on the original wire envelope shape the fast-scan
+// response decoder is keyed on.
+func TestAnalyzeProject_IncludeColumnsAbsentByDefault(t *testing.T) {
+	socket, state := startServerForTest(t)
+
+	writeKotlinFile(t, state.root, "Demo.kt",
+		"package demo\n\nfun foo() {}\n")
+
+	var verbResult daemon.AnalyzeProjectResult
+	if err := daemon.Call(socket, daemon.VerbAnalyzeProject,
+		daemon.AnalyzeProjectArgs{Format: "json"}, &verbResult); err != nil {
+		t.Fatalf("verb call: %v", err)
+	}
+	if len(verbResult.Columns) != 0 {
+		t.Errorf("Columns = %s; want empty on default IncludeColumns=false response", verbResult.Columns)
 	}
 }

--- a/internal/daemon/protocol.go
+++ b/internal/daemon/protocol.go
@@ -287,6 +287,16 @@ type AnalyzeProjectArgs struct {
 	// count: "cosmetic", "idiomatic", or "semantic". Empty means
 	// no cap (matches FixupPhase MaxFixLevel == 0).
 	FixLevel string `json:"fix_level,omitempty"`
+	// IncludeColumns, when true, asks the daemon to serialize the
+	// post-pipeline scanner.FindingColumns into the response under
+	// the optional "columns" segment. Used by CLI flows that need to
+	// post-process column-oriented findings (--rule-audit,
+	// --baseline-audit, --delta) — the daemon ships columns alongside
+	// the normal findings JSON and the CLI runs the audit / delta
+	// filter locally. Empty/false keeps the response envelope on the
+	// existing {findings,stats[,dispatch_profile]} shape so common
+	// scans stay byte-identical.
+	IncludeColumns bool `json:"include_columns,omitempty"`
 }
 
 // AnalyzeProjectResult is the response payload. Findings is the raw
@@ -301,6 +311,16 @@ type AnalyzeProjectResult struct {
 	// envelope keeps the {findings,stats} shape the fast-scan
 	// response decoder is keyed on (see ScanAnalyzeProjectResponse).
 	DispatchProfile *DispatchProfile `json:"dispatch_profile,omitempty"`
+	// Columns carries the post-pipeline FindingColumns JSON payload
+	// when AnalyzeProjectArgs.IncludeColumns is true. The raw bytes
+	// are the output of scanner.FindingColumns.MarshalJSON; CLI
+	// callers feed them into json.Unmarshal on a *FindingColumns
+	// before handing the columns to RunRuleAuditColumns /
+	// RunBaselineAuditColumns / filterColumnsNewSince. Nil/absent
+	// keeps the response on the original wire shape so non-audit /
+	// non-delta scans hit the fast-scan response decoder's
+	// {findings,stats[,dispatch_profile]} path.
+	Columns json.RawMessage `json:"columns,omitempty"`
 }
 
 // DispatchProfile carries the per-file dispatch timing fan-out the

--- a/internal/daemon/response_scan.go
+++ b/internal/daemon/response_scan.go
@@ -87,7 +87,15 @@ func scanOKEnvelope(line []byte, findingsStart int, out *AnalyzeProjectResult) (
 	// per-file timing fan-out. The latter only appears when the
 	// CLI passed --profile-dispatch; the common case still hits
 	// the original 2-byte tail check.
-	profileStart, profileEnd, tailStart, ok := scanOptionalDispatchProfile(line, statsEnd)
+	profileStart, profileEnd, profileTail, ok := scanOptionalDispatchProfile(line, statsEnd)
+	if !ok {
+		return false, nil
+	}
+	// An optional `,"columns":<obj>` may follow the profile (or
+	// stats when no profile was emitted). Populated only when the
+	// CLI passed --rule-audit / --baseline-audit / --delta —
+	// otherwise this branch is a no-op and the tail stays `}}`.
+	columnsStart, columnsEnd, tailStart, ok := scanOptionalColumns(line, profileTail)
 	if !ok {
 		return false, nil
 	}
@@ -105,6 +113,11 @@ func scanOKEnvelope(line []byte, findingsStart int, out *AnalyzeProjectResult) (
 		}
 	} else {
 		out.DispatchProfile = nil
+	}
+	if columnsEnd > columnsStart {
+		out.Columns = append(out.Columns[:0], line[columnsStart:columnsEnd]...)
+	} else {
+		out.Columns = nil
 	}
 	return true, nil
 }
@@ -126,6 +139,25 @@ func scanOptionalDispatchProfile(line []byte, statsEnd int) (profileStart, profi
 		return 0, 0, 0, false
 	}
 	return profileStart, end, end, true
+}
+
+// scanOptionalColumns walks the optional columns segment that may
+// follow stats (or dispatch_profile, when both are emitted). Returns
+// the [start,end) byte range of the columns object (zero-zero when
+// absent) plus the tail-start index the caller uses to locate the
+// closing `}}`. ok=false means a malformed columns value — the outer
+// scanner falls back to json.Unmarshal in that case.
+func scanOptionalColumns(line []byte, prevEnd int) (columnsStart, columnsEnd, tailStart int, ok bool) {
+	const columnsKey = `,"columns":`
+	if !hasPrefixAt(line, prevEnd, columnsKey) {
+		return 0, 0, prevEnd, true
+	}
+	columnsStart = prevEnd + len(columnsKey)
+	end, err := jsonValueEnd(line, columnsStart)
+	if err != nil {
+		return 0, 0, 0, false
+	}
+	return columnsStart, end, end, true
 }
 
 // scanErrorEnvelope handles the {"ok":false,"error":"..."} branch.

--- a/internal/daemon/response_scan_test.go
+++ b/internal/daemon/response_scan_test.go
@@ -169,6 +169,92 @@ func TestScanAnalyzeProjectResponse_DispatchProfileAbsent(t *testing.T) {
 	}
 }
 
+// TestScanAnalyzeProjectResponse_ColumnsPresent confirms the fast
+// scanner extracts the optional columns object the daemon emits when
+// --rule-audit / --baseline-audit / --delta is set (the
+// AnalyzeProjectArgs.IncludeColumns flag asks for it). Without this
+// branch the scanner would either fall back to json.Unmarshal
+// (correct but slow) or drop the field on the floor — both of which
+// would prevent the CLI from running the audit / delta locally.
+func TestScanAnalyzeProjectResponse_ColumnsPresent(t *testing.T) {
+	stats := AnalyzeProjectStats{FindingsCount: 1, WallSeconds: 0.1}
+	statsBytes, _ := json.Marshal(stats)
+	// Minimal but valid FindingColumns JSON. The scanner only walks
+	// the byte range; the bytes are forwarded to the CLI for full
+	// json.Unmarshal into a *scanner.FindingColumns there.
+	columns := `{"files":["A.kt"],"rules":["R"],"ruleSets":["s"],"messages":["m"],"fileIdx":[0],"line":[1],"col":[1],"ruleSetIdx":[0],"ruleIdx":[0],"severityID":[1],"messageIdx":[0],"confidence":[100],"fixStart":[0],"binaryFixStart":[0],"n":1}`
+	envelope := []byte(`{"ok":true,"data":{"findings":[],"stats":` + string(statsBytes) +
+		`,"columns":` + columns + `}}` + "\n")
+
+	var got AnalyzeProjectResult
+	handled, err := ScanAnalyzeProjectResponse(envelope, &got)
+	if !handled {
+		t.Fatalf("columns envelope must be handled by fast path; envelope=%s", envelope)
+	}
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if string(got.Columns) != columns {
+		t.Errorf("Columns mismatch:\n got: %s\nwant: %s", got.Columns, columns)
+	}
+	if got.DispatchProfile != nil {
+		t.Errorf("DispatchProfile = %+v; want nil when only columns segment is present", got.DispatchProfile)
+	}
+}
+
+// TestScanAnalyzeProjectResponse_ColumnsAbsent pins the no-regression
+// contract: when --rule-audit / --baseline-audit / --delta are off
+// the envelope shape stays identical to the pre-PR shape and
+// out.Columns is nil. Mirrors the equivalent DispatchProfileAbsent
+// test added in #283 for the dispatch_profile segment.
+func TestScanAnalyzeProjectResponse_ColumnsAbsent(t *testing.T) {
+	stats := AnalyzeProjectStats{FindingsCount: 0}
+	statsBytes, _ := json.Marshal(stats)
+	envelope := []byte(`{"ok":true,"data":{"findings":[],"stats":` + string(statsBytes) + `}}` + "\n")
+
+	got := AnalyzeProjectResult{Columns: json.RawMessage(`{"stale":true}`)}
+	handled, err := ScanAnalyzeProjectResponse(envelope, &got)
+	if !handled {
+		t.Fatalf("plain envelope must be handled by fast path; envelope=%s", envelope)
+	}
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if got.Columns != nil {
+		t.Errorf("Columns = %s; want nil after scan of columns-less envelope", got.Columns)
+	}
+}
+
+// TestScanAnalyzeProjectResponse_DispatchProfileAndColumns confirms
+// the fast scanner handles both optional segments in the documented
+// order (dispatch_profile, then columns). Belt-and-braces against a
+// future scanner refactor that walks segments in the wrong order.
+func TestScanAnalyzeProjectResponse_DispatchProfileAndColumns(t *testing.T) {
+	stats := AnalyzeProjectStats{FindingsCount: 0}
+	statsBytes, _ := json.Marshal(stats)
+	profile := DispatchProfile{WallMs: 5, Workers: 2, Timings: []FileTiming{{Path: "x.kt", Size: 8, RunMs: 1, TotalMs: 1, Findings: 0}}}
+	profileBytes, _ := json.Marshal(profile)
+	columns := `{"files":[],"n":0}`
+	envelope := []byte(`{"ok":true,"data":{"findings":[],"stats":` + string(statsBytes) +
+		`,"dispatch_profile":` + string(profileBytes) +
+		`,"columns":` + columns + `}}` + "\n")
+
+	var got AnalyzeProjectResult
+	handled, err := ScanAnalyzeProjectResponse(envelope, &got)
+	if !handled {
+		t.Fatalf("dispatch_profile+columns envelope must be handled by fast path; envelope=%s", envelope)
+	}
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if got.DispatchProfile == nil || got.DispatchProfile.Workers != 2 {
+		t.Errorf("DispatchProfile not parsed: %+v", got.DispatchProfile)
+	}
+	if string(got.Columns) != columns {
+		t.Errorf("Columns mismatch:\n got: %s\nwant: %s", got.Columns, columns)
+	}
+}
+
 // TestScanAnalyzeProjectResponse_ErrorEnvelope handles the
 // {"ok":false,"error":"msg"} shape — daemon refuses, CLI surfaces.
 func TestScanAnalyzeProjectResponse_ErrorEnvelope(t *testing.T) {


### PR DESCRIPTION
## Summary

- Extends `daemon.AnalyzeProjectResult` with an optional `Columns` segment serialized via `scanner.FindingColumns.MarshalJSON` — gated by a new `AnalyzeProjectArgs.IncludeColumns` flag the CLI sets whenever `--rule-audit`, `--baseline-audit`, or `--delta` is present. Follows the omitempty-trailing-segment precedent set by #282 (BaselineIDs) and #283 (DispatchProfile).
- Removes `--rule-audit`, `--baseline-audit`, and `--delta` from `daemonCompatibleFlags`. CLI deserialises the columns and replays `RunRuleAuditColumns` / `RunBaselineAuditColumns` / `filterColumnsNewSince` locally; daemon never touches user files.
- `--delta`'s worktree orchestration stays CLI-side (daemon-side worktree spawning would add filesystem-mutating side effects to a long-lived service). Only the current-tree scan routes through the daemon; the CLI re-emits the filtered columns via `pipeline.OutputPhase` so format / base path / warning promotion match the in-process flow.

References issue #284 item 1. Items 2-5 in #284 remain open.

## Wire format

The response envelope grows an optional trailing segment:

```
{"ok":true,"data":{"findings":[...],"stats":{...}[,"dispatch_profile":{...}][,"columns":{...}]}}
```

The fast-scan response decoder (`internal/daemon/response_scan.go`) handles `columns` the same way it handles `dispatch_profile` — `scanOptionalColumns` walks the optional segment with the existing `jsonValueEnd` balanced-bracket scanner. Non-audit / non-delta scans hit the original 2-byte tail check unchanged.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...`
- [x] `go test ./... -count=1`
- [x] `make integration`
- [x] New regression tests:
  - `TestScanAnalyzeProjectResponse_ColumnsPresent` / `_Absent` / `_DispatchProfileAndColumns` — fast-scanner contract for the new segment.
  - `TestAnalyzeProject_IncludeColumnsMatchesInProcess` / `_AbsentByDefault` — daemon-shipped columns row-equivalent to in-process `FinalFindings`; default envelope unchanged.
  - `TestBuildDaemonAnalyzeArgs_ForwardsIncludeColumns` — flag-to-wire propagation for each consumer flag.
  - Existing `TestDaemonCompatibleFlags_PerfAllowed` extended with `--rule-audit` / `--baseline-audit` admissions; `TestDaemonCompatibleFlags_OracleArgsAllowed` updated to admit `--delta`.