### PR TITLE
revert(daemon): un-wire AndroidCacheWriter (issue #254)

### DIFF
--- a/internal/cli/serve/analyze_project.go
+++ b/internal/cli/serve/analyze_project.go
@@ -375,7 +375,12 @@ func (s *daemonState) buildProjectInput(args daemon.AnalyzeProjectArgs) (pipelin
 	if repoDir == "" {
 		repoDir = s.root
 	}
-	androidCacheWriter, androidCacheDir := s.androidCacheWriterFor(repoDir)
+	// AndroidCacheWriter / AndroidCacheDir are intentionally left
+	// unwired on the daemon path. See issue #254: with them set, warm
+	// post-edit analyze runs collapse from ~87 k findings to ~62
+	// starting on the second run. Re-enable once the regression is
+	// understood.
+
 	// --no-cache disables every on-disk cache for this single call:
 	// parse cache, AnalysisCache, findings bundle store, cross-file/
 	// findings/type-index disk shards. Resident WorkspaceState slots
@@ -446,7 +451,7 @@ func (s *daemonState) buildProjectInput(args daemon.AnalyzeProjectArgs) (pipelin
 		perfTracker = perf.New(true)
 	}
 
-	diskCache := s.resolveDiskCacheWiring(args, repoDir, androidCacheWriter, androidCacheDir)
+	diskCache := s.resolveDiskCacheWiring(args, repoDir)
 	baselinePath, basePath, maxFixLevel := resolveBaselineDryRunArgs(args, paths)
 	return pipeline.ProjectInput{
 		Args: pipeline.ProjectArgs{
@@ -495,8 +500,6 @@ func (s *daemonState) buildProjectInput(args daemon.AnalyzeProjectArgs) (pipelin
 			SourceMTimeVersion:           s.workspace.SourceMTimeVersion,
 			BundleOutput:                 s.workspace.BundleOutput,
 			StoreBundleOutput:            s.workspace.StoreBundleOutput,
-			AndroidCacheWriter:           diskCache.androidCacheWriter,
-			AndroidCacheDir:              diskCache.androidCacheDir,
 			CrossFileCacheDir:            diskCache.crossFileCacheDir,
 			CrossFindingsCacheDir:        diskCache.crossFindingsCacheDir,
 			TypeIndexCacheDir:            diskCache.typeIndexCacheDir,
@@ -523,8 +526,6 @@ type diskCacheWiring struct {
 	crossFileCacheDir     string
 	crossFindingsCacheDir string
 	typeIndexCacheDir     string
-	androidCacheWriter    *scanner.AndroidCacheWriter
-	androidCacheDir       string
 	findingsBundleStore   scanner.FindingsBundleStore
 	findingsBundleRoot    string
 	manifestLoader        pipeline.FindingsBundleManifestLoader
@@ -536,19 +537,14 @@ type diskCacheWiring struct {
 // resident WorkspaceState slots stay live (they're per-process memory
 // keyed on input fingerprints, so reuse is idempotent and a no-cache
 // call cannot dirty them for subsequent calls).
-func (s *daemonState) resolveDiskCacheWiring(args daemon.AnalyzeProjectArgs, repoDir string, androidCacheWriter *scanner.AndroidCacheWriter, androidCacheDir string) diskCacheWiring {
+func (s *daemonState) resolveDiskCacheWiring(args daemon.AnalyzeProjectArgs, repoDir string) diskCacheWiring {
 	if args.NoCache {
-		// Drop Android cache pointers too — the
-		// androidFindingsCacheable gate checks both writer and dir, so
-		// emptying them matches the other on-disk cache zeroing.
 		return diskCacheWiring{}
 	}
 	return diskCacheWiring{
 		crossFileCacheDir:     scanner.CrossFileCacheDir(repoDir),
 		crossFindingsCacheDir: scanner.CrossFindingsCacheDir(repoDir),
 		typeIndexCacheDir:     typeinfer.TypeIndexCacheDir(repoDir),
-		androidCacheWriter:    androidCacheWriter,
-		androidCacheDir:       androidCacheDir,
 		findingsBundleStore:   scanner.DiskFindingsBundleStore{},
 		findingsBundleRoot:    repoDir,
 		manifestLoader:        s.loadManifest,

--- a/internal/cli/serve/daemon_state_test.go
+++ b/internal/cli/serve/daemon_state_test.go
@@ -126,36 +126,3 @@ func TestDaemonStateCloseParseCacheIdempotent(t *testing.T) {
 		t.Errorf("expected parseCache to be nil after close, got %p", state.parseCache)
 	}
 }
-
-// TestDaemonStateAndroidCacheWriterLifecycle pins the lazy-init +
-// idempotent-close contract for the resident Android findings
-// cache writer. Mirrors the parse cache pattern: first call builds,
-// repeated calls return the same instance; closing twice must not
-// panic.
-func TestDaemonStateAndroidCacheWriterLifecycle(t *testing.T) {
-	state := newDaemonState(t.TempDir())
-	w1, dir1 := state.androidCacheWriterFor(state.root)
-	if w1 == nil || dir1 == "" {
-		t.Fatalf("first androidCacheWriterFor returned (%p, %q), want non-empty", w1, dir1)
-	}
-	w2, dir2 := state.androidCacheWriterFor(state.root)
-	if w2 != w1 || dir2 != dir1 {
-		t.Errorf("second call did not reuse the resident writer: got (%p,%q) want (%p,%q)", w2, dir2, w1, dir1)
-	}
-	state.closeAndroidCacheWriter()
-	state.closeAndroidCacheWriter() // must not panic
-	if state.androidCacheWriter != nil {
-		t.Errorf("expected androidCacheWriter to be nil after close, got %p", state.androidCacheWriter)
-	}
-}
-
-// TestDaemonStateAndroidCacheWriterEmptyRepo: with no repoDir the
-// helper must return (nil, "") and stay that way — the AndroidPhase
-// treats a nil writer as "caching disabled" and degrades gracefully.
-func TestDaemonStateAndroidCacheWriterEmptyRepo(t *testing.T) {
-	state := newDaemonState("")
-	w, dir := state.androidCacheWriterFor("")
-	if w != nil || dir != "" {
-		t.Errorf("empty-repo path: want (nil, \"\"), got (%p, %q)", w, dir)
-	}
-}

--- a/internal/cli/serve/serve.go
+++ b/internal/cli/serve/serve.go
@@ -225,20 +225,6 @@ type daemonState struct {
 	parseCache     *scanner.ParseCache
 	parseCacheErr  error
 
-	// androidCacheWriterOnce gates lazy construction of the resident
-	// Android findings cache writer + cache-dir path. The CLI runner
-	// pairs these so AndroidPhase can persist resource/manifest/icon
-	// rule results between runs; the daemon previously left both
-	// fields zero, which made the entire androidFindingsCacheable
-	// gate evaluate to false and forced every analyze to rerun all
-	// resource rules (~8 s on the Signal-Android corpus). One
-	// resident writer is shared across analyze calls — the async
-	// writer queues per Save, so concurrent analyze serialization is
-	// not required.
-	androidCacheWriterOnce sync.Once
-	androidCacheWriter     *scanner.AndroidCacheWriter
-	androidCacheDir        string
-
 	// analysisCacheMu guards lazy construction of the resident
 	// *cache.Cache + its file path, scoped per scan-path set. Pipeline
 	// dispatch merges per-file findings into the cache and saves it on
@@ -619,39 +605,6 @@ func (s *daemonState) closeParseCache() {
 	}
 	_ = s.parseCache.Close()
 	s.parseCache = nil
-}
-
-// androidCacheWriterFor returns the daemon's resident
-// AndroidCacheWriter and its on-disk cache directory, constructing
-// both lazily on the first call. Returns (nil, "") when repoDir is
-// empty — the AndroidPhase treats a nil writer as "caching disabled"
-// and just skips the persistence step, so the rest of the analyze
-// still runs correctly without it. workers is the worker count
-// passed to NewAndroidCacheWriter; the daemon picks a fixed small
-// value because the writer caps it to 4 internally.
-func (s *daemonState) androidCacheWriterFor(repoDir string) (*scanner.AndroidCacheWriter, string) {
-	if s == nil {
-		return nil, ""
-	}
-	s.androidCacheWriterOnce.Do(func() {
-		if repoDir == "" {
-			return
-		}
-		s.androidCacheDir = scanner.AndroidFindingsCacheDir(repoDir)
-		s.androidCacheWriter = scanner.NewAndroidCacheWriter(2)
-	})
-	return s.androidCacheWriter, s.androidCacheDir
-}
-
-// closeAndroidCacheWriter flushes queued Android cache writes and
-// releases the writer. Called from Server shutdown; safe to call
-// when no writer exists.
-func (s *daemonState) closeAndroidCacheWriter() {
-	if s == nil || s.androidCacheWriter == nil {
-		return
-	}
-	_ = s.androidCacheWriter.Close()
-	s.androidCacheWriter = nil
 }
 
 func (s *daemonState) warm() error {


### PR DESCRIPTION
## Summary

- Workaround for [#254](https://github.com/kaeawc/krit/issues/254): un-wire the daemon-side `AndroidCacheWriter` / `AndroidCacheDir` host fields. With them set (PR #285), warm post-edit analyze runs on `~/github/kotlin` collapsed from ~87,069 findings to ~62 starting on the second run.
- Removes the now-unused `androidCacheWriterFor` / `closeAndroidCacheWriter` helpers and lazy daemon state. The XML-key / Java-facts decoupling from PR #285 stays — it is safe and orthogonal to the regression.
- AndroidPhase now recomputes manifest/resource/gradle rules every daemon analyze; the ~1.5 s cost on the kotlin corpus is the next perf lever once the root cause is fixed.

## Validation criteria

- `go build ./...` clean
- `go vet ./...` clean
- `golangci-lint run ./...` → 0 issues
- `go test ./... -count=1` passes
- Daemon analyze with no AndroidCacheWriter wiring returns the same finding count as the CLI baseline (acceptance criterion 1 from #254)
- Findings remain stable across repeated daemon analyze runs (acceptance criterion 3 from #254)

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...`
- [x] `go test ./... -count=1`
- [ ] On `~/github/kotlin`: warm baseline analyze → ABI edit → 10 consecutive daemon analyzes all return ~87 k findings (acceptance criteria, validates the workaround in situ)

Closes #254 (via workaround — root-cause perf fix is tracked as the follow-up the issue calls out).