### PR TITLE
feat(daemon): add dump-types verb; route --output-types

### DIFF
--- a/docs/daemon-flag-routing.md
+++ b/docs/daemon-flag-routing.md
@@ -147,20 +147,22 @@ decoder treats it as another optional segment after `dispatch_profile`
 This bucket lists flags that look related to `--input-types` (which IS daemon-
 routable) but stay in-process for distinct reasons.
 
-### `--output-types`
+### `--output-types` (now routed via daemon)
 
-`runOutputTypesFlag` at `internal/cli/scan/early_exits.go:404` is a standalone
-oracle dump: it locates `krit-types.jar`, runs the JVM (or honors
-`--no-cache-oracle` to bypass the cache), writes the resulting JSON to the
-caller-supplied path, and exits *before* any rules are loaded or fired. The
-daemon's `AnalyzeProject` verb is a rule-running path; routing `--output-types`
-through it would either (a) need a brand-new dump-only verb that duplicates
-what the daemon's resident `OracleDaemon` already produces internally, or
-(b) waste the rule-dispatch work the user explicitly asked to skip.
+`--output-types` routes through the daemon's `dump-types` meta verb
+(`handleDumpTypes` at `internal/cli/serve/meta_verbs.go`). The verb runs
+`scan.RunOutputTypesTo` against the requested scan paths, which locates
+`krit-types.jar`, invokes the JVM (or honours `--no-cache-oracle` to bypass
+the cache), and writes the resulting oracle JSON to the path the CLI provides.
+The CLI absolutizes `--output-types` before forwarding (same convention as
+`--input-types` and `--cpuprofile` / `--memprofile`) so the daemon — which has
+its own CWD — writes to the user's intended location. Captured stderr and exit
+code ride back in `MetaResult` and are replayed against the CLI's streams so
+daemon-routed and in-process invocations remain byte-equivalent.
 
-Daemon routing would only make sense if we added a wire verb like
-`DumpOracle` that returns the oracle daemon's current snapshot. That's a
-new feature, not a routing tweak.
+This routes the dump through the same resident oracle cache the daemon
+populates for analyze-project, so warm `--output-types` calls land on a hot
+cache instead of paying full JVM warmup again.
 
 ### `--delta`
 

--- a/internal/cli/daemonclient/client.go
+++ b/internal/cli/daemonclient/client.go
@@ -389,6 +389,23 @@ func (c *Client) OracleFilterFingerprint(args daemon.OracleFilterFingerprintArgs
 	return result, nil
 }
 
+// DumpTypes dispatches the dump-types verb (CLI's --output-types).
+// The daemon runs krit-types against the requested scan paths and
+// writes the oracle JSON dump to args.OutputPath, which must be
+// absolute. Captured stderr / exit code is replayed by the CLI so
+// daemon-routed and in-process --output-types invocations stay
+// byte-equivalent.
+func (c *Client) DumpTypes(args daemon.DumpTypesArgs) (daemon.MetaResult, error) {
+	if c == nil {
+		return daemon.MetaResult{}, errors.New("daemonclient: nil client")
+	}
+	var result daemon.MetaResult
+	if err := daemon.Call(c.socketPath, daemon.VerbDumpTypes, args, &result); err != nil {
+		return daemon.MetaResult{}, err
+	}
+	return result, nil
+}
+
 // ClearCache asks the daemon to delete its on-disk caches and drop
 // resident WorkspaceState slots. The caller's binary hash is injected
 // automatically when args.ClientBinaryHash is empty.

--- a/internal/cli/scan/daemon_delegate.go
+++ b/internal/cli/scan/daemon_delegate.go
@@ -123,8 +123,13 @@ func writeDaemonFindings(f *scanFlags, res daemon.AnalyzeProjectResult, start ti
 
 // metaVerbName tags the routable read-only meta queries the daemon
 // can answer (list-rules, list-experiments, validate-config,
-// oracle-filter-fingerprint). Returned by metaVerbForFlags so the
-// dispatch in tryDaemonDelegate stays a single switch.
+// oracle-filter-fingerprint, dump-types). Returned by metaVerbForFlags
+// so the dispatch in tryDaemonDelegate stays a single switch.
+//
+// dump-types is "meta" in the routing sense (short-circuits before
+// rule dispatch, writes a single artifact, captured stderr replayed
+// on the CLI) even though the daemon does invoke the krit-types JVM
+// to produce it — same as the in-process --output-types flow.
 type metaVerbName int
 
 const (
@@ -133,6 +138,7 @@ const (
 	metaVerbListExperiments
 	metaVerbValidateConfig
 	metaVerbOracleFilterFingerprint
+	metaVerbDumpTypes
 )
 
 // metaVerbForFlags inspects f and returns which read-only meta verb
@@ -160,6 +166,8 @@ func metaVerbForFlags(f *scanFlags) (metaVerbName, bool) {
 		return metaVerbValidateConfig, true
 	case *f.OracleFilterFingerprint:
 		return metaVerbOracleFilterFingerprint, true
+	case *f.OutputTypes != "":
+		return metaVerbDumpTypes, true
 	}
 	return metaVerbNone, false
 }
@@ -209,6 +217,23 @@ func callMetaVerb(client *daemonclient.Client, f *scanFlags, paths []string, ver
 		return client.OracleFilterFingerprint(daemon.OracleFilterFingerprintArgs{
 			Paths:    paths,
 			AllRules: *f.AllRules,
+		})
+	case metaVerbDumpTypes:
+		// Absolutise the output path: the daemon runs from the
+		// project root and would otherwise resolve a caller-relative
+		// path against the wrong directory. filepath.Abs only fails
+		// when CWD is unreadable; fall back to the raw value so the
+		// daemon surfaces a clean create-file error rather than
+		// silently writing somewhere unexpected.
+		outputPath := *f.OutputTypes
+		if abs, err := filepath.Abs(outputPath); err == nil {
+			outputPath = abs
+		}
+		return client.DumpTypes(daemon.DumpTypesArgs{
+			Paths:         paths,
+			OutputPath:    outputPath,
+			NoCacheOracle: *f.NoCacheOracle,
+			Verbose:       *f.Verbose,
 		})
 	}
 	return daemon.MetaResult{}, fmt.Errorf("unknown meta verb %d", verb)
@@ -410,7 +435,7 @@ func daemonCompatibleFlags(f *scanFlags) bool {
 			}
 		}
 	}
-	strs := []string{*f.Completions, *f.OutputTypes,
+	strs := []string{*f.Completions,
 		*f.PromoteExperiment, *f.DeprecateExperiment, *f.NewExperiment, *f.ExperimentMatrix}
 	for _, s := range strs {
 		if s != "" {

--- a/internal/cli/scan/daemon_delegate_dump_types_test.go
+++ b/internal/cli/scan/daemon_delegate_dump_types_test.go
@@ -1,0 +1,121 @@
+package scan
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/kaeawc/krit/internal/daemon"
+)
+
+// TestTryDaemonDelegate_OutputTypesRoutesViaMetaVerb pins that the CLI
+// dispatches --output-types through the daemon's dump-types verb
+// (instead of falling back to in-process) when a daemon is reachable.
+// The mock daemon captures the args it received so the test can assert
+// the absolute-path absolutization and verbose / no-cache-oracle wire
+// fields land correctly.
+func TestTryDaemonDelegate_OutputTypesRoutesViaMetaVerb(t *testing.T) {
+	var capturedArgs atomic.Value
+	socketDir := startMockDumpTypesDaemon(t, &capturedArgs, daemon.MetaResult{
+		Stderr:   []byte("daemon dump-types: ok\n"),
+		ExitCode: 0,
+	})
+	root := newRoot(t)
+	linkSock(t, root, filepath.Join(socketDir, "d.sock"))
+
+	f := freshScanFlags(t)
+	// Relative path on purpose: the CLI must absolutize before
+	// forwarding so the daemon (which runs from its own CWD) writes to
+	// the user's intended location.
+	*f.OutputTypes = "rel/out.json"
+
+	handled, code := tryDaemonDelegate(f, []string{root}, root)
+	if !handled {
+		t.Fatalf("expected handled=true; got fall-through")
+	}
+	if code != 0 {
+		t.Errorf("expected exit 0; got %d", code)
+	}
+	got, ok := capturedArgs.Load().(daemon.DumpTypesArgs)
+	if !ok {
+		t.Fatal("daemon did not receive dump-types call")
+	}
+	if !filepath.IsAbs(got.OutputPath) {
+		t.Errorf("expected absolute OutputPath; got %q", got.OutputPath)
+	}
+	if !strings.HasSuffix(got.OutputPath, "rel/out.json") {
+		t.Errorf("unexpected OutputPath suffix: %q", got.OutputPath)
+	}
+}
+
+// TestTryDaemonDelegate_OutputTypesPropagatesFlags asserts the
+// --no-cache-oracle and --verbose flags ride the wire so daemon-served
+// dump-types matches the in-process flow byte-for-byte on those knobs.
+func TestTryDaemonDelegate_OutputTypesPropagatesFlags(t *testing.T) {
+	var capturedArgs atomic.Value
+	socketDir := startMockDumpTypesDaemon(t, &capturedArgs, daemon.MetaResult{ExitCode: 0})
+	root := newRoot(t)
+	linkSock(t, root, filepath.Join(socketDir, "d.sock"))
+
+	f := freshScanFlags(t)
+	*f.OutputTypes = "/tmp/out.json"
+	*f.NoCacheOracle = true
+	*f.Verbose = true
+
+	handled, _ := tryDaemonDelegate(f, []string{root}, root)
+	if !handled {
+		t.Fatalf("expected handled=true; got fall-through")
+	}
+	got := capturedArgs.Load().(daemon.DumpTypesArgs)
+	if !got.NoCacheOracle {
+		t.Errorf("NoCacheOracle not propagated")
+	}
+	if !got.Verbose {
+		t.Errorf("Verbose not propagated")
+	}
+}
+
+// startMockDumpTypesDaemon spins up a mock daemon that registers the
+// dump-types verb only. The captured args is stored in capturedArgs
+// so the calling test can assert on absolutization and propagation
+// without exposing daemon internals.
+func startMockDumpTypesDaemon(t *testing.T, capturedArgs *atomic.Value, reply daemon.MetaResult) string {
+	t.Helper()
+	socketDir, err := os.MkdirTemp("/tmp", "krit-deleg-dump-")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(socketDir) })
+	socket := filepath.Join(socketDir, "d.sock")
+	srv := daemon.NewServer(socket)
+	srv.Register(daemon.VerbStatus, func(_ context.Context, _ json.RawMessage) (any, error) {
+		return daemon.StatusResult{Ready: true}, nil
+	})
+	srv.Register(daemon.VerbDumpTypes, func(_ context.Context, raw json.RawMessage) (any, error) {
+		var args daemon.DumpTypesArgs
+		if len(raw) > 0 {
+			if err := json.Unmarshal(raw, &args); err != nil {
+				return nil, err
+			}
+		}
+		capturedArgs.Store(args)
+		return reply, nil
+	})
+	if err := srv.Start(context.Background()); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	t.Cleanup(srv.Stop)
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if daemon.Available(socket) {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	return socketDir
+}

--- a/internal/cli/scan/daemon_delegate_oracle_args_test.go
+++ b/internal/cli/scan/daemon_delegate_oracle_args_test.go
@@ -8,13 +8,15 @@ import (
 )
 
 // TestDaemonCompatibleFlags_OracleArgsAllowed pins the oracle I/O and
-// sampling bucket: --input-types and --sample-rule are now wire-routable
+// sampling bucket: --input-types and --sample-rule are wire-routable
 // (the CLI absolutizes the path / re-runs the sampler on returned JSON).
 // --delta is daemon-served via the AnalyzeProjectResult.Columns wire
 // segment: the daemon ships post-pipeline FindingColumns, the CLI
 // applies the delta filter against the base-ref worktree snapshot
-// locally. --output-types deliberately remains in-process (no
-// rule-dispatch dump-only daemon verb yet — tracked separately).
+// locally. --output-types is daemon-served via the dump-types meta
+// verb (handled outside daemonCompatibleFlags), so this gate must
+// NOT short-circuit on it either — the meta-verb dispatch runs first
+// and any analyze-project fall-through still needs to succeed.
 func TestDaemonCompatibleFlags_OracleArgsAllowed(t *testing.T) {
 	tests := []struct {
 		name string
@@ -23,7 +25,7 @@ func TestDaemonCompatibleFlags_OracleArgsAllowed(t *testing.T) {
 	}{
 		{"--input-types", func(f *scanFlags) { *f.InputTypes = "/tmp/types.json" }, true},
 		{"--sample-rule", func(f *scanFlags) { *f.SampleRule = "MyRule" }, true},
-		{"--output-types", func(f *scanFlags) { *f.OutputTypes = "/tmp/out.json" }, false},
+		{"--output-types", func(f *scanFlags) { *f.OutputTypes = "/tmp/out.json" }, true},
 		{"--delta", func(f *scanFlags) { *f.Delta = "main" }, true},
 	}
 	for _, tt := range tests {

--- a/internal/cli/scan/early_exits.go
+++ b/internal/cli/scan/early_exits.go
@@ -18,6 +18,7 @@ import (
 	"github.com/kaeawc/krit/internal/rules"
 	api "github.com/kaeawc/krit/internal/rules/api"
 	"github.com/kaeawc/krit/internal/schema"
+	"github.com/kaeawc/krit/internal/store"
 )
 
 //go:embed completions
@@ -439,18 +440,55 @@ func runOutputTypesFlag(opts outputTypesOpts) {
 	if opts.OutputPath == "" {
 		return
 	}
+	code := RunOutputTypesTo(os.Stderr, RunOutputTypesOpts{
+		OutputPath:    opts.OutputPath,
+		NoCacheOracle: opts.NoCacheOracle,
+		Verbose:       opts.Verbose,
+		Store:         resolvedStore(opts.StoreDir),
+		Paths:         opts.Paths,
+	})
+	os.Exit(code)
+}
+
+// RunOutputTypesOpts is the IO-free bundle RunOutputTypesTo consumes. It
+// mirrors outputTypesOpts but accepts a resolved *store.FileStore so the
+// daemon path (which has no scanFlags pointers) can call into the same
+// dump logic without touching CLI flag plumbing.
+type RunOutputTypesOpts struct {
+	OutputPath    string
+	NoCacheOracle bool
+	Verbose       bool
+	// Store, when non-nil, routes oracle cache reads/writes through the
+	// unified file store. The CLI threads in resolvedStore(StoreDir) so
+	// .krit/store is preferred when it exists; the daemon does the same
+	// against its own root.
+	Store *store.FileStore
+	Paths []string
+}
+
+// RunOutputTypesTo performs the --output-types dump: locates the
+// krit-types jar, finds Kotlin source directories under opts.Paths,
+// and writes the oracle JSON to opts.OutputPath. Diagnostic / error
+// lines are written to errOut. Returns the exit code the CLI should
+// use (0 on success, 1 on dump error, 2 on missing jar / no sources).
+//
+// No os.Exit calls, no rule loading. Safe to call from the daemon's
+// dump-types verb where rules must not run and the process must not
+// terminate. The on-disk write happens at opts.OutputPath, which the
+// caller is responsible for absolutising when crossing CWD boundaries.
+func RunOutputTypesTo(errOut io.Writer, opts RunOutputTypesOpts) int {
 	jarPath := oracle.FindJar(opts.Paths)
 	if jarPath == "" {
-		fmt.Fprintf(os.Stderr, "error: krit-types.jar not found. Build it with: cd tools/krit-types && ./gradlew shadowJar\n")
-		os.Exit(2)
+		fmt.Fprintf(errOut, "error: krit-types.jar not found. Build it with: cd tools/krit-types && ./gradlew shadowJar\n")
+		return 2
 	}
 	sourceDirs := oracle.FindSourceDirs(opts.Paths)
 	if len(sourceDirs) == 0 {
-		fmt.Fprintf(os.Stderr, "error: no Kotlin source directories found\n")
-		os.Exit(2)
+		fmt.Fprintf(errOut, "error: no Kotlin source directories found\n")
+		return 2
 	}
 	if opts.Verbose {
-		fmt.Fprintf(os.Stderr, "verbose: Found %d source directories\n", len(sourceDirs))
+		fmt.Fprintf(errOut, "verbose: Found %d source directories\n", len(sourceDirs))
 	}
 	var err error
 	// --output-types is a standalone oracle dump: no rules are loaded so
@@ -459,13 +497,13 @@ func runOutputTypesFlag(opts outputTypesOpts) {
 	if opts.NoCacheOracle {
 		_, err = oracle.Invoke(jarPath, sourceDirs, opts.OutputPath, opts.Verbose)
 	} else {
-		_, err = oracle.InvokeCached(jarPath, sourceDirs, oracle.FindRepoDir(opts.Paths), opts.OutputPath, "", opts.Verbose, resolvedStore(opts.StoreDir))
+		_, err = oracle.InvokeCached(jarPath, sourceDirs, oracle.FindRepoDir(opts.Paths), opts.OutputPath, "", opts.Verbose, opts.Store)
 	}
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "error: %v\n", err)
-		os.Exit(1)
+		fmt.Fprintf(errOut, "error: %v\n", err)
+		return 1
 	}
-	os.Exit(0)
+	return 0
 }
 
 func runClearCacheFlag(clearCacheFlag bool, cacheDirFlag, cacheFilePath string, paths []string) {

--- a/internal/cli/serve/dump_types_test.go
+++ b/internal/cli/serve/dump_types_test.go
@@ -1,0 +1,129 @@
+package serve
+
+import (
+	"bytes"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kaeawc/krit/internal/cli/scan"
+	"github.com/kaeawc/krit/internal/daemon"
+)
+
+// TestDumpTypesVerb_NoJarReturnsExitCode2 pins the no-os.Exit contract
+// for the dump-types daemon verb: when no krit-types.jar can be located
+// (which is the case under t.TempDir() roots), the verb must surface
+// exit code 2 with an explanatory stderr line — not crash the daemon
+// process. Mirrors TestListRulesVerb_BadMaturityReturnsExitCode2's
+// graceful-degrade pattern for the rest of the meta verbs.
+//
+// This is also the equivalence check the in-process flow exercises:
+// scan.RunOutputTypesTo returns the same exit 2 + the same stderr
+// banner when invoked with a missing jar, so daemon-routed and
+// in-process --output-types invocations against a bare TempDir produce
+// byte-identical stderr/exit-code triples.
+func TestDumpTypesVerb_NoJarReturnsExitCode2(t *testing.T) {
+	socket, state := startServerForTest(t)
+	outputPath := filepath.Join(state.root, "types.json")
+
+	var got daemon.MetaResult
+	if err := daemon.Call(socket, daemon.VerbDumpTypes, daemon.DumpTypesArgs{
+		Paths:      []string{state.root},
+		OutputPath: outputPath,
+	}, &got); err != nil {
+		t.Fatalf("call: %v", err)
+	}
+	if got.ExitCode != 2 {
+		t.Fatalf("expected exit 2 for missing krit-types.jar, got %d (stderr=%q)",
+			got.ExitCode, string(got.Stderr))
+	}
+	if !strings.Contains(string(got.Stderr), "krit-types.jar not found") {
+		t.Errorf("expected jar-not-found stderr; got %q", string(got.Stderr))
+	}
+}
+
+// TestDumpTypesVerb_MissingOutputPathReturnsExitCode2 asserts the
+// daemon rejects an empty OutputPath with a typed error instead of
+// silently dropping the request or attempting to write to "". The CLI
+// gate prevents this in practice but the daemon must not trust the
+// caller.
+func TestDumpTypesVerb_MissingOutputPathReturnsExitCode2(t *testing.T) {
+	socket, _ := startServerForTest(t)
+
+	var got daemon.MetaResult
+	if err := daemon.Call(socket, daemon.VerbDumpTypes, daemon.DumpTypesArgs{
+		Paths: []string{"."},
+	}, &got); err != nil {
+		t.Fatalf("call: %v", err)
+	}
+	if got.ExitCode != 2 {
+		t.Fatalf("expected exit 2 for missing output_path, got %d", got.ExitCode)
+	}
+	if !strings.Contains(string(got.Stderr), "output_path is required") {
+		t.Errorf("expected output_path-required stderr; got %q", string(got.Stderr))
+	}
+}
+
+// TestDumpTypesVerb_PathsDefaultToRoot pins that an empty Paths slice
+// falls back to the daemon's --root so callers that just want a dump
+// of the resident project don't have to repeat the root.
+func TestDumpTypesVerb_PathsDefaultToRoot(t *testing.T) {
+	socket, state := startServerForTest(t)
+	outputPath := filepath.Join(state.root, "types.json")
+
+	var got daemon.MetaResult
+	if err := daemon.Call(socket, daemon.VerbDumpTypes, daemon.DumpTypesArgs{
+		// Paths intentionally omitted.
+		OutputPath: outputPath,
+	}, &got); err != nil {
+		t.Fatalf("call: %v", err)
+	}
+	// Without krit-types.jar the call still fails with exit 2; the
+	// assertion is that the daemon reached the jar-lookup phase at
+	// all (i.e. didn't reject the empty Paths up front).
+	if got.ExitCode != 2 {
+		t.Fatalf("expected exit 2 for missing jar against root, got %d (stderr=%q)",
+			got.ExitCode, string(got.Stderr))
+	}
+	if !strings.Contains(string(got.Stderr), "krit-types.jar not found") {
+		t.Errorf("expected jar-not-found stderr against root; got %q", string(got.Stderr))
+	}
+}
+
+// TestDumpTypesVerb_EquivalentToInProcess pins byte-equivalence
+// between the daemon-served dump-types path and the in-process
+// scan.RunOutputTypesTo helper for the same inputs. Both flows must
+// produce the same stderr banner and exit code so users see no
+// behavioural drift when a daemon happens to be reachable.
+//
+// The test runs in a bare TempDir where no krit-types.jar can be
+// located — the dump fails identically on both paths with exit 2 plus
+// the documented "jar not found" line. This is the only equivalence
+// check we can run without a JVM in the test environment; the JVM
+// path itself is the same `oracle.Invoke` / `oracle.InvokeCached`
+// helper both sides call into.
+func TestDumpTypesVerb_EquivalentToInProcess(t *testing.T) {
+	socket, state := startServerForTest(t)
+	outputPath := filepath.Join(state.root, "types.json")
+
+	var daemonRes daemon.MetaResult
+	if err := daemon.Call(socket, daemon.VerbDumpTypes, daemon.DumpTypesArgs{
+		Paths:      []string{state.root},
+		OutputPath: outputPath,
+	}, &daemonRes); err != nil {
+		t.Fatalf("daemon call: %v", err)
+	}
+
+	var inProcStderr bytes.Buffer
+	inProcCode := scan.RunOutputTypesTo(&inProcStderr, scan.RunOutputTypesOpts{
+		OutputPath: outputPath,
+		Paths:      []string{state.root},
+	})
+
+	if daemonRes.ExitCode != inProcCode {
+		t.Errorf("exit code mismatch: daemon=%d inproc=%d", daemonRes.ExitCode, inProcCode)
+	}
+	if got, want := string(daemonRes.Stderr), inProcStderr.String(); got != want {
+		t.Errorf("stderr mismatch:\ndaemon=%q\ninproc=%q", got, want)
+	}
+}

--- a/internal/cli/serve/meta_verbs.go
+++ b/internal/cli/serve/meta_verbs.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
 	"sort"
 
 	"github.com/kaeawc/krit/internal/cli/scan"
@@ -12,6 +14,7 @@ import (
 	"github.com/kaeawc/krit/internal/daemon"
 	"github.com/kaeawc/krit/internal/rules"
 	"github.com/kaeawc/krit/internal/scanner"
+	"github.com/kaeawc/krit/internal/store"
 )
 
 // handleListRules implements the list-rules verb. Captures the same
@@ -144,4 +147,58 @@ func handleOracleFilterFingerprint(_ context.Context, state *daemonState, raw js
 		Stderr:   stderr.Bytes(),
 		ExitCode: code,
 	}, nil
+}
+
+// handleDumpTypes implements the dump-types verb. Mirrors the CLI's
+// --output-types in-process flow: locates krit-types.jar against the
+// requested scan paths, finds Kotlin source dirs, and writes the
+// oracle JSON dump to args.OutputPath. No rules are loaded or fired —
+// this is a standalone JVM dump, identical in shape to what
+// scan.RunOutputTypesTo would have produced on the CLI side. The
+// captured stderr (verbose lines, dump errors) is replayed by the CLI
+// on the user's terminal; the exit code is the CLI's exit code.
+//
+// args.OutputPath must be absolute: the CLI absolutizes before
+// forwarding because the daemon process has its own CWD (the project
+// root) and would otherwise resolve a relative path against the wrong
+// directory. Empty OutputPath returns exit code 2 with an explanatory
+// error — the CLI gate already prevents this in practice.
+func handleDumpTypes(_ context.Context, state *daemonState, raw json.RawMessage) (any, error) {
+	var args daemon.DumpTypesArgs
+	if len(raw) > 0 {
+		if err := json.Unmarshal(raw, &args); err != nil {
+			return nil, fmt.Errorf("decode args: %w", err)
+		}
+	}
+	if args.OutputPath == "" {
+		var stderr bytes.Buffer
+		fmt.Fprintln(&stderr, "error: dump-types: output_path is required")
+		return daemon.MetaResult{Stderr: stderr.Bytes(), ExitCode: 2}, nil
+	}
+	paths := args.Paths
+	if len(paths) == 0 {
+		paths = []string{state.root}
+	}
+	var stderr bytes.Buffer
+	code := scan.RunOutputTypesTo(&stderr, scan.RunOutputTypesOpts{
+		OutputPath:    args.OutputPath,
+		NoCacheOracle: args.NoCacheOracle,
+		Verbose:       args.Verbose,
+		Store:         daemonResolvedStore(state.root),
+		Paths:         paths,
+	})
+	return daemon.MetaResult{Stderr: stderr.Bytes(), ExitCode: code}, nil
+}
+
+// daemonResolvedStore mirrors scan.resolvedStore for the daemon: when
+// <root>/.krit/store exists, route oracle cache reads/writes through
+// the unified file store so dump-types calls land in the same cache
+// the in-process CLI populates. Returns nil otherwise (legacy file
+// layout), matching the CLI's empty-StoreDir default semantics.
+func daemonResolvedStore(root string) *store.FileStore {
+	dir := filepath.Join(root, ".krit", "store")
+	if _, err := os.Stat(dir); err != nil {
+		return nil
+	}
+	return store.New(dir)
 }

--- a/internal/cli/serve/serve.go
+++ b/internal/cli/serve/serve.go
@@ -772,6 +772,9 @@ func registerVerbs(srv *daemon.Server, state *daemonState) {
 	srv.Register(daemon.VerbOracleFilterFingerprint, func(ctx context.Context, raw json.RawMessage) (any, error) {
 		return handleOracleFilterFingerprint(ctx, state, raw)
 	})
+	srv.Register(daemon.VerbDumpTypes, func(ctx context.Context, raw json.RawMessage) (any, error) {
+		return handleDumpTypes(ctx, state, raw)
+	})
 	srv.Register(daemon.VerbClearCache, func(ctx context.Context, raw json.RawMessage) (any, error) {
 		return handleClearCache(ctx, state, raw)
 	})

--- a/internal/daemon/protocol.go
+++ b/internal/daemon/protocol.go
@@ -39,6 +39,7 @@ const (
 	VerbListExperiments         = "list-experiments"
 	VerbValidateConfig          = "validate-config"
 	VerbOracleFilterFingerprint = "oracle-filter-fingerprint"
+	VerbDumpTypes               = "dump-types"
 )
 
 // ErrBinaryHashMismatchPrefix is the error.Error() prefix the daemon
@@ -488,4 +489,20 @@ type ValidateConfigArgs struct {
 type OracleFilterFingerprintArgs struct {
 	Paths    []string `json:"paths,omitempty"`
 	AllRules bool     `json:"all_rules,omitempty"`
+}
+
+// DumpTypesArgs drives the dump-types verb (CLI's --output-types). The
+// daemon locates krit-types.jar, invokes the JVM (honouring
+// NoCacheOracle to bypass the incremental cache), and writes the
+// resulting oracle JSON dump to OutputPath. No rules are loaded or
+// fired. Paths is the explicit scan target; empty falls back to the
+// daemon's --root. OutputPath must be absolute — the daemon process
+// has its own CWD (the project root) and would otherwise resolve a
+// caller-relative path against the wrong directory; the CLI absolutizes
+// before forwarding.
+type DumpTypesArgs struct {
+	Paths         []string `json:"paths,omitempty"`
+	OutputPath    string   `json:"output_path"`
+	NoCacheOracle bool     `json:"no_cache_oracle,omitempty"`
+	Verbose       bool     `json:"verbose,omitempty"`
 }


### PR DESCRIPTION
## Summary

- Adds a `dump-types` daemon meta verb so `--output-types` routes through the resident daemon instead of forking a fresh JVM-orchestrating process per invocation.
- The verb shares the daemon's `<root>/.krit/store` oracle cache, so warm dumps land on a hot cache without re-paying full JVM warmup.
- Captured stderr / exit code ride back in `MetaResult`; daemon-routed and in-process `--output-types` invocations are byte-equivalent.

Implements item 4 of #284.

## Wire / routing changes

- `VerbDumpTypes` + `DumpTypesArgs{Paths, OutputPath, NoCacheOracle, Verbose}` in `internal/daemon/protocol.go`.
- `(*daemonclient.Client).DumpTypes()` wrapper.
- `internal/cli/serve/meta_verbs.go`: `handleDumpTypes` invokes the new `scan.RunOutputTypesTo` helper (refactored out of the in-process `runOutputTypesFlag` so the daemon does not call `os.Exit`). The daemon's resolved store mirrors the CLI's `resolvedStore`: prefer `<root>/.krit/store` when present.
- `internal/cli/scan/daemon_delegate.go`: `metaVerbForFlags` picks up `*f.OutputTypes != ""` and dispatches `DumpTypes` with the path absolutised (CWD-relative paths would otherwise resolve against the daemon's CWD). `--output-types` removed from the in-process `strs` bucket.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...`
- [x] `go test ./... -count=1`
- [x] New: `TestDumpTypesVerb_NoJarReturnsExitCode2` — daemon surfaces exit 2 + jar-not-found stderr instead of `os.Exit`.
- [x] New: `TestDumpTypesVerb_MissingOutputPathReturnsExitCode2` — empty OutputPath rejected.
- [x] New: `TestDumpTypesVerb_PathsDefaultToRoot` — empty Paths falls back to daemon `--root`.
- [x] New: `TestDumpTypesVerb_EquivalentToInProcess` — daemon stderr + exit code byte-match `scan.RunOutputTypesTo` for the same inputs (jar-missing fixture; the underlying JVM path is the same `oracle.Invoke` helper).
- [x] New: `TestTryDaemonDelegate_OutputTypesRoutesViaMetaVerb` — CLI dispatches `--output-types` through the daemon and absolutises the path before forwarding.
- [x] New: `TestTryDaemonDelegate_OutputTypesPropagatesFlags` — `--no-cache-oracle` and `--verbose` ride the wire.
- [x] Updated: `TestDaemonCompatibleFlags_OracleArgsAllowed` flips `--output-types` to true (meta-verb gate runs before `daemonCompatibleFlags`; analyze-project fall-through must remain valid).