### PR TITLE
feat(transport): ordered suggested fixes separate from autofix slot (#242)

### DIFF
--- a/internal/output/json.go
+++ b/internal/output/json.go
@@ -47,6 +47,33 @@ type JSONFinding struct {
 	FixLevel   string  `json:"fixLevel,omitempty"`
 	Confidence float64 `json:"confidence,omitempty"`
 	Effort     string  `json:"effort,omitempty"`
+	// SuggestedFixes carries non-autofix, ordered recommendations from the
+	// rule. It is intentionally additive: presence here does NOT change the
+	// fixable / fixLevel semantics, which remain tied to the rule's single
+	// autofix slot. Order mirrors the order the rule emitted them.
+	SuggestedFixes []JSONSuggestedFix `json:"suggestedFixes,omitempty"`
+}
+
+// JSONSuggestedFix is one suggested fix attached to a finding. It is
+// distinct from the autofix slot (`fixable` / `fixLevel`): a finding may
+// carry suggestions without being autofixable.
+type JSONSuggestedFix struct {
+	ID               string              `json:"id"`
+	Title            string              `json:"title"`
+	Detail           string              `json:"detail,omitempty"`
+	Edits            []JSONSuggestedEdit `json:"edits,omitempty"`
+	ApplicationToken string              `json:"applicationToken,omitempty"`
+}
+
+// JSONSuggestedEdit is one text edit inside a JSONSuggestedFix.
+type JSONSuggestedEdit struct {
+	TargetFile  string `json:"targetFile,omitempty"`
+	StartLine   int    `json:"startLine,omitempty"`
+	EndLine     int    `json:"endLine,omitempty"`
+	StartByte   int    `json:"startByte,omitempty"`
+	EndByte     int    `json:"endByte,omitempty"`
+	ByteMode    bool   `json:"byteMode,omitempty"`
+	Replacement string `json:"replacement"`
 }
 
 // JSONSummary summarizes findings.
@@ -388,6 +415,7 @@ func buildJSONFindings(columns *scanner.FindingColumns, fixLevels, efforts map[s
 			*fixableCount = *fixableCount + 1
 		}
 		finding.Effort = efforts[rule]
+		finding.SuggestedFixes = buildSuggestedFixes(&cols, row)
 		byRuleSet[ruleSet]++
 		byRule[rule]++
 
@@ -405,4 +433,39 @@ func buildJSONFindings(columns *scanner.FindingColumns, fixLevels, efforts map[s
 	}
 	buf = append(buf, ']')
 	return json.RawMessage(buf)
+}
+
+// buildSuggestedFixes copies the suggested-fix payload for one row out of
+// the columnar pool into the per-finding JSON shape. Order is preserved
+// because SuggestedFixesAt walks the pool slice in the same order the rule
+// appended.
+func buildSuggestedFixes(cols *scanner.FindingColumns, row int) []JSONSuggestedFix {
+	src := cols.SuggestedFixesAt(row)
+	if len(src) == 0 {
+		return nil
+	}
+	out := make([]JSONSuggestedFix, len(src))
+	for i, fix := range src {
+		out[i] = JSONSuggestedFix{
+			ID:               fix.ID,
+			Title:            fix.Title,
+			Detail:           fix.Detail,
+			ApplicationToken: fix.ApplicationToken,
+		}
+		if len(fix.Edits) > 0 {
+			out[i].Edits = make([]JSONSuggestedEdit, len(fix.Edits))
+			for j, edit := range fix.Edits {
+				out[i].Edits[j] = JSONSuggestedEdit{
+					TargetFile:  edit.TargetFile,
+					StartLine:   edit.StartLine,
+					EndLine:     edit.EndLine,
+					StartByte:   edit.StartByte,
+					EndByte:     edit.EndByte,
+					ByteMode:    edit.ByteMode,
+					Replacement: edit.Replacement,
+				}
+			}
+		}
+	}
+	return out
 }

--- a/internal/output/json_finding_encoder.go
+++ b/internal/output/json_finding_encoder.go
@@ -1,6 +1,7 @@
 package output
 
 import (
+	"encoding/json"
 	"strconv"
 	"unicode/utf8"
 )
@@ -69,6 +70,16 @@ func appendFindingJSON(dst []byte, f JSONFinding) []byte {
 	if f.Effort != "" {
 		dst = append(dst, `,"effort":`...)
 		dst = appendJSONString(dst, f.Effort)
+	}
+
+	if len(f.SuggestedFixes) > 0 {
+		// json.Marshal on JSONSuggestedFix slices cannot fail (no channels,
+		// unsupported types, or custom marshalers in the type graph), so the
+		// error path is unreachable. Field ordering must match the
+		// JSONFinding declaration to stay byte-identical to json.Marshal(f).
+		raw, _ := json.Marshal(f.SuggestedFixes)
+		dst = append(dst, `,"suggestedFixes":`...)
+		dst = append(dst, raw...)
 	}
 
 	dst = append(dst, '}')

--- a/internal/output/suggested_fixes_test.go
+++ b/internal/output/suggested_fixes_test.go
@@ -1,0 +1,297 @@
+package output
+
+import (
+	"bytes"
+	"encoding/json"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/kaeawc/krit/internal/scanner"
+)
+
+// TestSuggestedFixes_JSONShape covers the fixture-rule acceptance criterion:
+// a rule emits one finding with two suggested fixes, and both appear in the
+// JSON output in rule-defined order. Also verifies that the autofix metadata
+// (`fixable` / `fixLevel`) is independent of suggestions — a finding can
+// carry suggestions without being autofixable.
+func TestSuggestedFixes_JSONShape(t *testing.T) {
+	findings := []scanner.Finding{
+		{
+			File:     "a.kt",
+			Line:     5,
+			Col:      3,
+			Severity: "warning",
+			RuleSet:  "style",
+			Rule:     "FixtureSuggester",
+			Message:  "two suggestions please",
+			SuggestedFixes: []scanner.SuggestedFix{
+				{
+					ID:    "use-val",
+					Title: "Convert to val",
+					Edits: []scanner.SuggestedEdit{
+						{StartLine: 5, EndLine: 5, Replacement: "val x = 1"},
+					},
+				},
+				{
+					ID:               "explain",
+					Title:            "Explain the warning",
+					Detail:           "var becomes val when the binding is read-only.",
+					ApplicationToken: "help:val-vs-var",
+				},
+			},
+		},
+	}
+
+	report := runJSONFormatter(t, findings)
+	if len(report.Findings) != 1 {
+		t.Fatalf("want 1 finding, got %d", len(report.Findings))
+	}
+	got := report.Findings[0]
+
+	// Suggestions are orthogonal to the autofix slot.
+	if got.Fixable {
+		t.Errorf("suggestions must not make a finding fixable: got fixable=true")
+	}
+	if got.FixLevel != "" {
+		t.Errorf("suggestions must not populate fixLevel: got %q", got.FixLevel)
+	}
+
+	if len(got.SuggestedFixes) != 2 {
+		t.Fatalf("want 2 suggested fixes, got %d", len(got.SuggestedFixes))
+	}
+
+	// Rule-defined order is preserved.
+	if got.SuggestedFixes[0].ID != "use-val" {
+		t.Errorf("suggestion 0 id: got %q want %q", got.SuggestedFixes[0].ID, "use-val")
+	}
+	if got.SuggestedFixes[1].ID != "explain" {
+		t.Errorf("suggestion 1 id: got %q want %q", got.SuggestedFixes[1].ID, "explain")
+	}
+	if got.SuggestedFixes[0].Title != "Convert to val" {
+		t.Errorf("suggestion 0 title: got %q", got.SuggestedFixes[0].Title)
+	}
+	if len(got.SuggestedFixes[0].Edits) != 1 {
+		t.Fatalf("suggestion 0 edits: got %d", len(got.SuggestedFixes[0].Edits))
+	}
+	if got.SuggestedFixes[0].Edits[0].Replacement != "val x = 1" {
+		t.Errorf("edit replacement: got %q", got.SuggestedFixes[0].Edits[0].Replacement)
+	}
+	if got.SuggestedFixes[1].Detail != "var becomes val when the binding is read-only." {
+		t.Errorf("suggestion 1 detail: got %q", got.SuggestedFixes[1].Detail)
+	}
+	if got.SuggestedFixes[1].ApplicationToken != "help:val-vs-var" {
+		t.Errorf("suggestion 1 application token: got %q", got.SuggestedFixes[1].ApplicationToken)
+	}
+	if len(got.SuggestedFixes[1].Edits) != 0 {
+		t.Errorf("suggestion 1 should be non-machine-applicable: got %d edits",
+			len(got.SuggestedFixes[1].Edits))
+	}
+}
+
+// TestSuggestedFixes_DeterministicSerialization formats the same finding set
+// twice and verifies the byte output is identical. This is the cold vs. warm
+// determinism guarantee — the merge / sort / format pipeline must not depend
+// on Go map iteration order or pool growth ordering for findings with
+// multiple suggestions.
+func TestSuggestedFixes_DeterministicSerialization(t *testing.T) {
+	findings := []scanner.Finding{
+		{
+			File:    "b.kt",
+			Line:    1,
+			Col:     1,
+			RuleSet: "style",
+			Rule:    "R2",
+			Message: "two",
+			SuggestedFixes: []scanner.SuggestedFix{
+				{ID: "b-1", Title: "B1"},
+				{ID: "b-2", Title: "B2"},
+				{ID: "b-3", Title: "B3"},
+			},
+			Severity: "warning",
+		},
+		{
+			File:    "a.kt",
+			Line:    1,
+			Col:     1,
+			RuleSet: "style",
+			Rule:    "R1",
+			Message: "one",
+			SuggestedFixes: []scanner.SuggestedFix{
+				{ID: "a-1", Title: "A1", Edits: []scanner.SuggestedEdit{
+					{StartLine: 1, EndLine: 1, Replacement: "x"},
+				}},
+				{ID: "a-2", Title: "A2"},
+			},
+			Severity: "warning",
+		},
+	}
+
+	first := runJSONFormatterBytes(t, findings)
+	second := runJSONFormatterBytes(t, findings)
+	if !bytes.Equal(first, second) {
+		t.Fatalf("non-deterministic JSON output:\n--- first ---\n%s\n--- second ---\n%s",
+			first, second)
+	}
+
+	// Cross-collector merge must preserve per-finding suggestion ordering.
+	mergedCols := mergedCollectorColumns(findings)
+	formatA := formatColumns(t, mergedCols)
+	formatB := formatColumns(t, mergedCols)
+	if !bytes.Equal(formatA, formatB) {
+		t.Fatalf("non-deterministic JSON output from merged collector")
+	}
+
+	var report JSONReport
+	if err := json.Unmarshal(first, &report); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if len(report.Findings) != 2 {
+		t.Fatalf("want 2 findings, got %d", len(report.Findings))
+	}
+	// a.kt sorts before b.kt — verify suggestion order inside each finding.
+	if report.Findings[0].File != "a.kt" {
+		t.Fatalf("expected a.kt first, got %q", report.Findings[0].File)
+	}
+	if ids := suggestionIDs(report.Findings[0]); !slices.Equal(ids, []string{"a-1", "a-2"}) {
+		t.Errorf("a.kt suggestion order: %v", ids)
+	}
+	if ids := suggestionIDs(report.Findings[1]); !slices.Equal(ids, []string{"b-1", "b-2", "b-3"}) {
+		t.Errorf("b.kt suggestion order: %v", ids)
+	}
+}
+
+// TestSuggestedFixes_ColdWarmRoundTrip exercises the FindingColumns cache
+// codec: serialize to JSON and back, then format from the rehydrated columns.
+// The resulting output must equal the cold-run output byte-for-byte.
+func TestSuggestedFixes_ColdWarmRoundTrip(t *testing.T) {
+	findings := []scanner.Finding{
+		{
+			File:     "a.kt",
+			Line:     2,
+			Col:      4,
+			Severity: "warning",
+			RuleSet:  "style",
+			Rule:     "Cold",
+			Message:  "cached",
+			SuggestedFixes: []scanner.SuggestedFix{
+				{ID: "s1", Title: "First"},
+				{ID: "s2", Title: "Second", Edits: []scanner.SuggestedEdit{
+					{StartByte: 10, EndByte: 12, ByteMode: true, Replacement: "ok"},
+				}},
+			},
+		},
+	}
+
+	cold := scanner.CollectFindings(findings)
+	encoded, err := json.Marshal(&cold)
+	if err != nil {
+		t.Fatalf("marshal cold columns: %v", err)
+	}
+	var warm scanner.FindingColumns
+	if err := json.Unmarshal(encoded, &warm); err != nil {
+		t.Fatalf("unmarshal warm columns: %v", err)
+	}
+
+	coldJSON := formatColumns(t, &cold)
+	warmJSON := formatColumns(t, &warm)
+	if !bytes.Equal(coldJSON, warmJSON) {
+		t.Fatalf("cold vs warm JSON drift:\ncold: %s\nwarm: %s", coldJSON, warmJSON)
+	}
+
+	got := warm.SuggestedFixesAt(0)
+	if len(got) != 2 {
+		t.Fatalf("warm row should carry 2 suggestions, got %d", len(got))
+	}
+	if got[0].ID != "s1" || got[1].ID != "s2" {
+		t.Errorf("warm suggestion order: %q,%q want s1,s2", got[0].ID, got[1].ID)
+	}
+	if !got[1].Edits[0].ByteMode {
+		t.Errorf("warm suggestion 2 edit ByteMode lost")
+	}
+}
+
+// TestAppendFindingJSON_MatchesJSONMarshal_WithSuggestedFixes pins the
+// byte-identical contract for the hand-rolled encoder when a finding has
+// suggested fixes attached. The contract is broader than this case but the
+// hand-rolled path uses json.Marshal for the suggestions slice; this guards
+// against accidental field-order drift in JSONFinding.
+func TestAppendFindingJSON_MatchesJSONMarshal_WithSuggestedFixes(t *testing.T) {
+	f := JSONFinding{
+		File: "A.kt", Line: 1, Column: 1,
+		RuleSet: "style", Rule: "R", Severity: "warning",
+		Message: "m", Confidence: 0.75,
+		SuggestedFixes: []JSONSuggestedFix{
+			{
+				ID:    "s1",
+				Title: "Title 1",
+				Edits: []JSONSuggestedEdit{
+					{StartLine: 1, EndLine: 2, Replacement: "x"},
+				},
+			},
+			{
+				ID:               "s2",
+				Title:            "Title 2",
+				Detail:           "detail text",
+				ApplicationToken: "tok",
+			},
+		},
+	}
+	want, err := json.Marshal(f)
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+	got := appendFindingJSON(nil, f)
+	if !bytes.Equal(got, want) {
+		t.Fatalf("byte mismatch:\n got: %s\nwant: %s", got, want)
+	}
+}
+
+func runJSONFormatter(t *testing.T, findings []scanner.Finding) JSONReport {
+	t.Helper()
+	body := runJSONFormatterBytes(t, findings)
+	var report JSONReport
+	if err := json.Unmarshal(body, &report); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	return report
+}
+
+func runJSONFormatterBytes(t *testing.T, findings []scanner.Finding) []byte {
+	t.Helper()
+	cols := scanner.CollectFindings(findings)
+	return formatColumns(t, &cols)
+}
+
+func formatColumns(t *testing.T, cols *scanner.FindingColumns) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	err := FormatJSONColumns(&buf, cols, "test-version", 1, 1, time.Unix(0, 0),
+		nil, nil, nil, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("FormatJSONColumns: %v", err)
+	}
+	return buf.Bytes()
+}
+
+func mergedCollectorColumns(findings []scanner.Finding) *scanner.FindingColumns {
+	workerA := scanner.NewFindingCollector(0)
+	workerB := scanner.NewFindingCollector(0)
+	for i, f := range findings {
+		if i%2 == 0 {
+			workerA.Append(f)
+		} else {
+			workerB.Append(f)
+		}
+	}
+	merged := scanner.MergeCollectors(nil, workerA, workerB)
+	return merged.Columns()
+}
+
+func suggestionIDs(f JSONFinding) []string {
+	out := make([]string, len(f.SuggestedFixes))
+	for i, s := range f.SuggestedFixes {
+		out[i] = s.ID
+	}
+	return out
+}

--- a/internal/scanner/findings.go
+++ b/internal/scanner/findings.go
@@ -23,12 +23,13 @@ var findingRowOrderPool = sync.Pool{
 // FindingColumns stores finding rows in mostly-scalar parallel slices.
 // String-heavy fields are interned into side tables so the hot row data stays flat.
 type FindingColumns struct {
-	Files         []string
-	RuleSets      []string
-	Rules         []string
-	Messages      []string
-	FixPool       []Fix
-	BinaryFixPool []BinaryFix
+	Files            []string
+	RuleSets         []string
+	Rules            []string
+	Messages         []string
+	FixPool          []Fix
+	BinaryFixPool    []BinaryFix
+	SuggestedFixPool []SuggestedFix
 
 	FileIdx        []uint32
 	Line           []uint32
@@ -42,7 +43,14 @@ type FindingColumns struct {
 	Confidence     []uint8
 	FixStart       []uint32
 	BinaryFixStart []uint32
-	N              int
+	// SuggestedFixStart is the 1-based start index into SuggestedFixPool for
+	// the suggestions attached to a row. 0 means no suggestions.
+	SuggestedFixStart []uint32
+	// SuggestedFixCount is the number of suggestions attached to a row,
+	// stored in pool insertion order. Capped to math.MaxUint16; rules that
+	// emit more share the cap.
+	SuggestedFixCount []uint16
+	N                 int
 
 	fileLexRanks    []uint32
 	ruleSetLexRanks []uint16
@@ -71,18 +79,20 @@ type FindingCollector struct {
 func NewFindingCollector(capacity int) *FindingCollector {
 	return &FindingCollector{
 		columns: FindingColumns{
-			FileIdx:        make([]uint32, 0, capacity),
-			Line:           make([]uint32, 0, capacity),
-			Col:            make([]uint16, 0, capacity),
-			StartByte:      make([]uint32, 0, capacity),
-			EndByte:        make([]uint32, 0, capacity),
-			RuleSetIdx:     make([]uint16, 0, capacity),
-			RuleIdx:        make([]uint16, 0, capacity),
-			SeverityID:     make([]uint8, 0, capacity),
-			MessageIdx:     make([]uint32, 0, capacity),
-			Confidence:     make([]uint8, 0, capacity),
-			FixStart:       make([]uint32, 0, capacity),
-			BinaryFixStart: make([]uint32, 0, capacity),
+			FileIdx:           make([]uint32, 0, capacity),
+			Line:              make([]uint32, 0, capacity),
+			Col:               make([]uint16, 0, capacity),
+			StartByte:         make([]uint32, 0, capacity),
+			EndByte:           make([]uint32, 0, capacity),
+			RuleSetIdx:        make([]uint16, 0, capacity),
+			RuleIdx:           make([]uint16, 0, capacity),
+			SeverityID:        make([]uint8, 0, capacity),
+			MessageIdx:        make([]uint32, 0, capacity),
+			Confidence:        make([]uint8, 0, capacity),
+			FixStart:          make([]uint32, 0, capacity),
+			BinaryFixStart:    make([]uint32, 0, capacity),
+			SuggestedFixStart: make([]uint32, 0, capacity),
+			SuggestedFixCount: make([]uint16, 0, capacity),
 		},
 		fileIdx:    make(map[string]uint32),
 		ruleSetIdx: make(map[string]uint16),
@@ -115,6 +125,9 @@ func (c *FindingCollector) Append(f Finding) {
 	c.columns.Confidence = append(c.columns.Confidence, confidenceToByte(f.Confidence))
 	c.columns.FixStart = append(c.columns.FixStart, c.appendFix(f.Fix))
 	c.columns.BinaryFixStart = append(c.columns.BinaryFixStart, c.appendBinaryFix(f.BinaryFix))
+	start, count := c.appendSuggestedFixes(f.SuggestedFixes)
+	c.columns.SuggestedFixStart = append(c.columns.SuggestedFixStart, start)
+	c.columns.SuggestedFixCount = append(c.columns.SuggestedFixCount, count)
 	c.columns.N++
 }
 
@@ -143,6 +156,9 @@ func (c *FindingCollector) AppendRow(columns *FindingColumns, row int) {
 	c.columns.Confidence = append(c.columns.Confidence, columns.Confidence[row])
 	c.columns.FixStart = append(c.columns.FixStart, c.appendExistingFix(columns, row))
 	c.columns.BinaryFixStart = append(c.columns.BinaryFixStart, c.appendExistingBinaryFix(columns, row))
+	start, count := c.appendExistingSuggestedFixes(columns, row)
+	c.columns.SuggestedFixStart = append(c.columns.SuggestedFixStart, start)
+	c.columns.SuggestedFixCount = append(c.columns.SuggestedFixCount, count)
 	c.columns.N++
 }
 
@@ -179,6 +195,12 @@ func (c *FindingCollector) AppendColumns(columns *FindingColumns) {
 			c.columns.BinaryFixPool = append(c.columns.BinaryFixPool, cloneBinaryFix(fix))
 		}
 	}
+	suggestedFixOffset := len(c.columns.SuggestedFixPool)
+	if len(columns.SuggestedFixPool) > 0 {
+		for _, fix := range columns.SuggestedFixPool {
+			c.columns.SuggestedFixPool = append(c.columns.SuggestedFixPool, cloneSuggestedFix(fix))
+		}
+	}
 
 	for i := 0; i < columns.Len(); i++ {
 		c.columns.FileIdx = append(c.columns.FileIdx, fileIdx[columns.FileIdx[i]])
@@ -203,6 +225,20 @@ func (c *FindingCollector) AppendColumns(columns *FindingColumns) {
 			binaryFixStart += uint32(binaryFixOffset)
 		}
 		c.columns.BinaryFixStart = append(c.columns.BinaryFixStart, binaryFixStart)
+
+		suggestedStart := uint32(0)
+		suggestedCount := uint16(0)
+		if i < len(columns.SuggestedFixStart) {
+			suggestedStart = columns.SuggestedFixStart[i]
+		}
+		if i < len(columns.SuggestedFixCount) {
+			suggestedCount = columns.SuggestedFixCount[i]
+		}
+		if suggestedStart > 0 {
+			suggestedStart += uint32(suggestedFixOffset)
+		}
+		c.columns.SuggestedFixStart = append(c.columns.SuggestedFixStart, suggestedStart)
+		c.columns.SuggestedFixCount = append(c.columns.SuggestedFixCount, suggestedCount)
 		c.columns.N++
 	}
 }
@@ -253,24 +289,26 @@ func (c *FindingColumns) Clone() FindingColumns {
 	}
 
 	clone := FindingColumns{
-		Files:          append([]string(nil), c.Files...),
-		RuleSets:       append([]string(nil), c.RuleSets...),
-		Rules:          append([]string(nil), c.Rules...),
-		Messages:       append([]string(nil), c.Messages...),
-		FileIdx:        append([]uint32(nil), c.FileIdx...),
-		Line:           append([]uint32(nil), c.Line...),
-		Col:            append([]uint16(nil), c.Col...),
-		StartByte:      append([]uint32(nil), c.StartByte...),
-		EndByte:        append([]uint32(nil), c.EndByte...),
-		RuleSetIdx:     append([]uint16(nil), c.RuleSetIdx...),
-		RuleIdx:        append([]uint16(nil), c.RuleIdx...),
-		SeverityID:     append([]uint8(nil), c.SeverityID...),
-		MessageIdx:     append([]uint32(nil), c.MessageIdx...),
-		Confidence:     append([]uint8(nil), c.Confidence...),
-		FixStart:       append([]uint32(nil), c.FixStart...),
-		BinaryFixStart: append([]uint32(nil), c.BinaryFixStart...),
-		N:              c.N,
-		fileLexRanks:   append([]uint32(nil), c.fileLexRanks...),
+		Files:             append([]string(nil), c.Files...),
+		RuleSets:          append([]string(nil), c.RuleSets...),
+		Rules:             append([]string(nil), c.Rules...),
+		Messages:          append([]string(nil), c.Messages...),
+		FileIdx:           append([]uint32(nil), c.FileIdx...),
+		Line:              append([]uint32(nil), c.Line...),
+		Col:               append([]uint16(nil), c.Col...),
+		StartByte:         append([]uint32(nil), c.StartByte...),
+		EndByte:           append([]uint32(nil), c.EndByte...),
+		RuleSetIdx:        append([]uint16(nil), c.RuleSetIdx...),
+		RuleIdx:           append([]uint16(nil), c.RuleIdx...),
+		SeverityID:        append([]uint8(nil), c.SeverityID...),
+		MessageIdx:        append([]uint32(nil), c.MessageIdx...),
+		Confidence:        append([]uint8(nil), c.Confidence...),
+		FixStart:          append([]uint32(nil), c.FixStart...),
+		BinaryFixStart:    append([]uint32(nil), c.BinaryFixStart...),
+		SuggestedFixStart: append([]uint32(nil), c.SuggestedFixStart...),
+		SuggestedFixCount: append([]uint16(nil), c.SuggestedFixCount...),
+		N:                 c.N,
+		fileLexRanks:      append([]uint32(nil), c.fileLexRanks...),
 		ruleSetLexRanks: append([]uint16(nil),
 			c.ruleSetLexRanks...),
 		ruleLexRanks: append([]uint16(nil), c.ruleLexRanks...),
@@ -282,6 +320,12 @@ func (c *FindingColumns) Clone() FindingColumns {
 		clone.BinaryFixPool = make([]BinaryFix, len(c.BinaryFixPool))
 		for i, fix := range c.BinaryFixPool {
 			clone.BinaryFixPool[i] = cloneBinaryFix(fix)
+		}
+	}
+	if len(c.SuggestedFixPool) > 0 {
+		clone.SuggestedFixPool = make([]SuggestedFix, len(c.SuggestedFixPool))
+		for i, fix := range c.SuggestedFixPool {
+			clone.SuggestedFixPool[i] = cloneSuggestedFix(fix)
 		}
 	}
 	return clone
@@ -352,6 +396,37 @@ func (c *FindingColumns) FixAt(i int) *Fix {
 		return &fix
 	}
 	return nil
+}
+
+// HasSuggestedFixes reports whether row i carries any suggestions.
+// Independent of HasFix / HasBinaryFix.
+func (c *FindingColumns) HasSuggestedFixes(i int) bool {
+	if c == nil || i < 0 || i >= len(c.SuggestedFixStart) {
+		return false
+	}
+	return c.SuggestedFixStart[i] > 0 && c.suggestedFixCountAt(i) > 0
+}
+
+func (c *FindingColumns) suggestedFixCountAt(i int) uint16 {
+	if i < 0 || i >= len(c.SuggestedFixCount) {
+		return 0
+	}
+	return c.SuggestedFixCount[i]
+}
+
+// SuggestedFixesAt returns a defensive copy of row i's suggestions in
+// rule-emitted order, or nil when none are present.
+func (c *FindingColumns) SuggestedFixesAt(i int) []SuggestedFix {
+	if !c.HasSuggestedFixes(i) {
+		return nil
+	}
+	start := int(c.SuggestedFixStart[i]) - 1
+	end := start + int(c.suggestedFixCountAt(i))
+	out := make([]SuggestedFix, 0, end-start)
+	for idx := start; idx < end; idx++ {
+		out = append(out, cloneSuggestedFix(c.SuggestedFixPool[idx]))
+	}
+	return out
 }
 
 // BinaryFixAt returns a cloned binary fix for row i, or nil when absent.
@@ -436,6 +511,7 @@ func (c *FindingColumns) Finding(i int) Finding {
 	}
 	finding.Fix = c.FixAt(i)
 	finding.BinaryFix = c.BinaryFixAt(i)
+	finding.SuggestedFixes = c.SuggestedFixesAt(i)
 	return finding
 }
 
@@ -576,6 +652,8 @@ func (c *FindingColumns) SortByFileLine() {
 		swapSlice(c.Confidence, i, j)
 		swapSlice(c.FixStart, i, j)
 		swapSlice(c.BinaryFixStart, i, j)
+		swapSlice(c.SuggestedFixStart, i, j)
+		swapSlice(c.SuggestedFixCount, i, j)
 	})
 }
 
@@ -737,6 +815,40 @@ func (c *FindingCollector) appendExistingBinaryFix(columns *FindingColumns, row 
 	}
 	c.columns.BinaryFixPool = append(c.columns.BinaryFixPool, cloneBinaryFix(columns.BinaryFixPool[ref-1]))
 	return uint32(len(c.columns.BinaryFixPool))
+}
+
+func (c *FindingCollector) appendSuggestedFixes(fixes []SuggestedFix) (uint32, uint16) {
+	if len(fixes) == 0 {
+		return 0, 0
+	}
+	start := uint32(len(c.columns.SuggestedFixPool)) + 1
+	count := len(fixes)
+	if count > math.MaxUint16 {
+		count = math.MaxUint16
+	}
+	for i := 0; i < count; i++ {
+		c.columns.SuggestedFixPool = append(c.columns.SuggestedFixPool, cloneSuggestedFix(fixes[i]))
+	}
+	return start, uint16(count)
+}
+
+func (c *FindingCollector) appendExistingSuggestedFixes(columns *FindingColumns, row int) (uint32, uint16) {
+	if row < 0 || row >= len(columns.SuggestedFixStart) {
+		return 0, 0
+	}
+	ref := columns.SuggestedFixStart[row]
+	if ref == 0 || row >= len(columns.SuggestedFixCount) {
+		return 0, 0
+	}
+	count := columns.SuggestedFixCount[row]
+	if count == 0 {
+		return 0, 0
+	}
+	start := uint32(len(c.columns.SuggestedFixPool)) + 1
+	for i := uint16(0); i < count; i++ {
+		c.columns.SuggestedFixPool = append(c.columns.SuggestedFixPool, cloneSuggestedFix(columns.SuggestedFixPool[int(ref-1)+int(i)]))
+	}
+	return start, count
 }
 
 func severityToID(severity string) uint8 {

--- a/internal/scanner/findings_json.go
+++ b/internal/scanner/findings_json.go
@@ -6,49 +6,55 @@ import (
 )
 
 type findingColumnsJSON struct {
-	Files          []string    `json:"files,omitempty"`
-	RuleSets       []string    `json:"ruleSets,omitempty"`
-	Rules          []string    `json:"rules,omitempty"`
-	Messages       []string    `json:"messages,omitempty"`
-	FixPool        []Fix       `json:"fixPool,omitempty"`
-	BinaryFixPool  []BinaryFix `json:"binaryFixPool,omitempty"`
-	FileIdx        []uint32    `json:"fileIdx,omitempty"`
-	Line           []uint32    `json:"line,omitempty"`
-	Col            []uint16    `json:"col,omitempty"`
-	StartByte      []uint32    `json:"startByte,omitempty"`
-	EndByte        []uint32    `json:"endByte,omitempty"`
-	RuleSetIdx     []uint16    `json:"ruleSetIdx,omitempty"`
-	RuleIdx        []uint16    `json:"ruleIdx,omitempty"`
-	SeverityID     []uint8     `json:"severityID,omitempty"`
-	MessageIdx     []uint32    `json:"messageIdx,omitempty"`
-	Confidence     []uint8     `json:"confidence,omitempty"`
-	FixStart       []uint32    `json:"fixStart,omitempty"`
-	BinaryFixStart []uint32    `json:"binaryFixStart,omitempty"`
-	N              int         `json:"n,omitempty"`
+	Files             []string       `json:"files,omitempty"`
+	RuleSets          []string       `json:"ruleSets,omitempty"`
+	Rules             []string       `json:"rules,omitempty"`
+	Messages          []string       `json:"messages,omitempty"`
+	FixPool           []Fix          `json:"fixPool,omitempty"`
+	BinaryFixPool     []BinaryFix    `json:"binaryFixPool,omitempty"`
+	SuggestedFixPool  []SuggestedFix `json:"suggestedFixPool,omitempty"`
+	FileIdx           []uint32       `json:"fileIdx,omitempty"`
+	Line              []uint32       `json:"line,omitempty"`
+	Col               []uint16       `json:"col,omitempty"`
+	StartByte         []uint32       `json:"startByte,omitempty"`
+	EndByte           []uint32       `json:"endByte,omitempty"`
+	RuleSetIdx        []uint16       `json:"ruleSetIdx,omitempty"`
+	RuleIdx           []uint16       `json:"ruleIdx,omitempty"`
+	SeverityID        []uint8        `json:"severityID,omitempty"`
+	MessageIdx        []uint32       `json:"messageIdx,omitempty"`
+	Confidence        []uint8        `json:"confidence,omitempty"`
+	FixStart          []uint32       `json:"fixStart,omitempty"`
+	BinaryFixStart    []uint32       `json:"binaryFixStart,omitempty"`
+	SuggestedFixStart []uint32       `json:"suggestedFixStart,omitempty"`
+	SuggestedFixCount []uint16       `json:"suggestedFixCount,omitempty"`
+	N                 int            `json:"n,omitempty"`
 }
 
 // MarshalJSON persists finding columns with a stable lowercase schema rather
 // than exposing Go field names directly.
 func (c FindingColumns) MarshalJSON() ([]byte, error) {
 	return json.Marshal(findingColumnsJSON{
-		Files:          c.Files,
-		RuleSets:       c.RuleSets,
-		Rules:          c.Rules,
-		Messages:       c.Messages,
-		FixPool:        c.FixPool,
-		BinaryFixPool:  c.BinaryFixPool,
-		FileIdx:        c.FileIdx,
-		Line:           c.Line,
-		Col:            c.Col,
-		StartByte:      omitZeroUint32Column(c.StartByte),
-		EndByte:        omitZeroUint32Column(c.EndByte),
-		RuleSetIdx:     c.RuleSetIdx,
-		RuleIdx:        c.RuleIdx,
-		SeverityID:     c.SeverityID,
-		MessageIdx:     c.MessageIdx,
-		Confidence:     c.Confidence,
-		FixStart:       c.FixStart,
-		BinaryFixStart: c.BinaryFixStart,
+		Files:             c.Files,
+		RuleSets:          c.RuleSets,
+		Rules:             c.Rules,
+		Messages:          c.Messages,
+		FixPool:           c.FixPool,
+		BinaryFixPool:     c.BinaryFixPool,
+		SuggestedFixPool:  c.SuggestedFixPool,
+		FileIdx:           c.FileIdx,
+		Line:              c.Line,
+		Col:               c.Col,
+		StartByte:         omitZeroUint32Column(c.StartByte),
+		EndByte:           omitZeroUint32Column(c.EndByte),
+		RuleSetIdx:        c.RuleSetIdx,
+		RuleIdx:           c.RuleIdx,
+		SeverityID:        c.SeverityID,
+		MessageIdx:        c.MessageIdx,
+		Confidence:        c.Confidence,
+		FixStart:          c.FixStart,
+		BinaryFixStart:    c.BinaryFixStart,
+		SuggestedFixStart: omitZeroUint32Column(c.SuggestedFixStart),
+		SuggestedFixCount: omitZeroUint16Column(c.SuggestedFixCount),
 	})
 }
 
@@ -92,29 +98,37 @@ func (c *FindingColumns) UnmarshalJSON(data []byte) error {
 	}
 
 	*c = FindingColumns{
-		Files:          append([]string(nil), payload.Files...),
-		RuleSets:       append([]string(nil), payload.RuleSets...),
-		Rules:          append([]string(nil), payload.Rules...),
-		Messages:       append([]string(nil), payload.Messages...),
-		FixPool:        append([]Fix(nil), payload.FixPool...),
-		FileIdx:        append([]uint32(nil), payload.FileIdx...),
-		Line:           append([]uint32(nil), payload.Line...),
-		Col:            append([]uint16(nil), payload.Col...),
-		StartByte:      normalizeOptionalUint32Column(payload.StartByte, rowCount),
-		EndByte:        normalizeOptionalUint32Column(payload.EndByte, rowCount),
-		RuleSetIdx:     append([]uint16(nil), payload.RuleSetIdx...),
-		RuleIdx:        append([]uint16(nil), payload.RuleIdx...),
-		SeverityID:     append([]uint8(nil), payload.SeverityID...),
-		MessageIdx:     append([]uint32(nil), payload.MessageIdx...),
-		Confidence:     append([]uint8(nil), payload.Confidence...),
-		FixStart:       append([]uint32(nil), payload.FixStart...),
-		BinaryFixStart: append([]uint32(nil), payload.BinaryFixStart...),
-		N:              rowCount,
+		Files:             append([]string(nil), payload.Files...),
+		RuleSets:          append([]string(nil), payload.RuleSets...),
+		Rules:             append([]string(nil), payload.Rules...),
+		Messages:          append([]string(nil), payload.Messages...),
+		FixPool:           append([]Fix(nil), payload.FixPool...),
+		FileIdx:           append([]uint32(nil), payload.FileIdx...),
+		Line:              append([]uint32(nil), payload.Line...),
+		Col:               append([]uint16(nil), payload.Col...),
+		StartByte:         normalizeOptionalUint32Column(payload.StartByte, rowCount),
+		EndByte:           normalizeOptionalUint32Column(payload.EndByte, rowCount),
+		RuleSetIdx:        append([]uint16(nil), payload.RuleSetIdx...),
+		RuleIdx:           append([]uint16(nil), payload.RuleIdx...),
+		SeverityID:        append([]uint8(nil), payload.SeverityID...),
+		MessageIdx:        append([]uint32(nil), payload.MessageIdx...),
+		Confidence:        append([]uint8(nil), payload.Confidence...),
+		FixStart:          append([]uint32(nil), payload.FixStart...),
+		BinaryFixStart:    append([]uint32(nil), payload.BinaryFixStart...),
+		SuggestedFixStart: normalizeOptionalUint32Column(payload.SuggestedFixStart, rowCount),
+		SuggestedFixCount: normalizeOptionalUint16Column(payload.SuggestedFixCount, rowCount),
+		N:                 rowCount,
 	}
 	if len(payload.BinaryFixPool) > 0 {
 		c.BinaryFixPool = make([]BinaryFix, len(payload.BinaryFixPool))
 		for i, fix := range payload.BinaryFixPool {
 			c.BinaryFixPool[i] = cloneBinaryFix(fix)
+		}
+	}
+	if len(payload.SuggestedFixPool) > 0 {
+		c.SuggestedFixPool = make([]SuggestedFix, len(payload.SuggestedFixPool))
+		for i, fix := range payload.SuggestedFixPool {
+			c.SuggestedFixPool[i] = cloneSuggestedFix(fix)
 		}
 	}
 	return nil
@@ -127,7 +141,23 @@ func normalizeOptionalUint32Column(values []uint32, rowCount int) []uint32 {
 	return make([]uint32, rowCount)
 }
 
+func normalizeOptionalUint16Column(values []uint16, rowCount int) []uint16 {
+	if len(values) == rowCount {
+		return append([]uint16(nil), values...)
+	}
+	return make([]uint16, rowCount)
+}
+
 func omitZeroUint32Column(values []uint32) []uint32 {
+	for _, value := range values {
+		if value != 0 {
+			return values
+		}
+	}
+	return nil
+}
+
+func omitZeroUint16Column(values []uint16) []uint16 {
 	for _, value := range values {
 		if value != 0 {
 			return values
@@ -167,8 +197,31 @@ func validateFindingColumnsIndexes(payload *findingColumnsJSON) error {
 			return fmt.Errorf("scanner: invalid binaryFixStart at row %d", row)
 		}
 	}
+	if err := validateSuggestedFixRanges(payload); err != nil {
+		return err
+	}
 	if payload.N < 0 {
 		return fmt.Errorf("scanner: invalid FindingColumns row count")
+	}
+	return nil
+}
+
+func validateSuggestedFixRanges(payload *findingColumnsJSON) error {
+	if len(payload.SuggestedFixStart) == 0 || len(payload.SuggestedFixCount) == 0 {
+		return nil
+	}
+	if len(payload.SuggestedFixStart) != len(payload.SuggestedFixCount) {
+		return fmt.Errorf("scanner: suggestedFixStart and suggestedFixCount length mismatch")
+	}
+	poolLen := uint32(len(payload.SuggestedFixPool))
+	for row, ref := range payload.SuggestedFixStart {
+		if ref == 0 {
+			continue
+		}
+		count := uint32(payload.SuggestedFixCount[row])
+		if count == 0 || ref-1+count > poolLen {
+			return fmt.Errorf("scanner: invalid suggestedFix range at row %d", row)
+		}
 	}
 	return nil
 }

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -43,18 +43,23 @@ func PutKotlinParser(p *sitter.Parser) {
 // columnar accessors; construct Finding only at serialization or emit
 // boundaries.
 type Finding struct {
-	File       string
-	Line       int
-	Col        int
-	StartByte  int
-	EndByte    int
-	RuleSet    string
-	Rule       string
-	Severity   string
-	Message    string
-	Fix        *Fix       // nil if no auto-fix available
-	BinaryFix  *BinaryFix // nil if no binary fix available
-	Confidence float64    // 0.0-1.0, 0 means not set
+	File      string
+	Line      int
+	Col       int
+	StartByte int
+	EndByte   int
+	RuleSet   string
+	Rule      string
+	Severity  string
+	Message   string
+	Fix       *Fix       // nil if no auto-fix available
+	BinaryFix *BinaryFix // nil if no binary fix available
+	// SuggestedFixes carries ordered, non-autofix suggestions in the
+	// rule-defined order. Presence here is informational and does NOT
+	// imply the finding is autofixable — that semantic stays tied to
+	// Fix / BinaryFix. See suggested_fix.go for details.
+	SuggestedFixes []SuggestedFix
+	Confidence     float64 // 0.0-1.0, 0 means not set
 }
 
 // Fix describes an auto-fix for a finding.

--- a/internal/scanner/suggested_fix.go
+++ b/internal/scanner/suggested_fix.go
@@ -1,0 +1,38 @@
+package scanner
+
+// SuggestedFix is an ordered, rule-emitted suggestion attached to a Finding.
+// Distinct from Fix / BinaryFix: the autofix slot drives the `fixable` and
+// `fixLevel` JSON fields and is bound by the rule's declared FixLevel safety
+// tier, whereas suggestions are advisory and may be machine-applicable
+// (non-empty Edits), application-resolved (non-empty ApplicationToken), or
+// purely informational.
+type SuggestedFix struct {
+	ID               string
+	Title            string
+	Detail           string
+	Edits            []SuggestedEdit
+	ApplicationToken string
+}
+
+// SuggestedEdit mirrors Fix's line/byte-mode replacement shape so consumers
+// can apply suggestions through the same code path as autofixes.
+type SuggestedEdit struct {
+	TargetFile  string
+	StartLine   int
+	EndLine     int
+	Replacement string
+	StartByte   int
+	EndByte     int
+	ByteMode    bool
+}
+
+func cloneSuggestedFix(fix SuggestedFix) SuggestedFix {
+	if len(fix.Edits) > 0 {
+		edits := make([]SuggestedEdit, len(fix.Edits))
+		copy(edits, fix.Edits)
+		fix.Edits = edits
+	} else {
+		fix.Edits = nil
+	}
+	return fix
+}


### PR DESCRIPTION
## Summary

Closes #242. Extends Krit's finding transport so a single finding can carry multiple ordered suggested fixes without implying that the finding is autofixable.

- `scanner.Finding` gains a `SuggestedFixes []SuggestedFix` field; `FindingColumns` gains a `SuggestedFixPool` plus per-row `SuggestedFixStart` / `SuggestedFixCount` columns wired through `Append` / `AppendRow` / `AppendColumns` / `Clone` / `SortByFileLine` and the JSON cache codec (cold/warm round-trip preserved).
- `output.JSONFinding` gains a `suggestedFixes` array (omitempty). The hand-rolled `appendFindingJSON` encoder stays byte-identical to `json.Marshal` by delegating the rare suggestions slice to the reflect path under a length guard.
- `fixable` and `fixLevel` semantics remain bound to the autofix slot only — suggestions never set them.
- Each `SuggestedFix` has a stable `ID`, user-facing `Title`, optional `Detail`, ordered `Edits`, and/or an `ApplicationToken` for non-machine-applicable cases.

## Validation criteria

- New tests in [internal/output/suggested_fixes_test.go](internal/output/suggested_fixes_test.go) cover:
  - **Fixture-rule acceptance**: a single finding emits two `SuggestedFix` entries; both appear in JSON in rule-defined order; `fixable` / `fixLevel` stay zero.
  - **Determinism**: same finding set serialized twice produces byte-identical JSON, including after merging two worker collectors (mirrors phase-boundary merge ordering).
  - **Cold/warm round-trip**: `FindingColumns` → JSON → `FindingColumns` → JSON yields the same bytes; the rehydrated columns preserve suggestion order and `ByteMode` edits.
  - **Encoder byte-match**: `appendFindingJSON` output equals `json.Marshal(JSONFinding{...})` when `SuggestedFixes` is populated.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...`
- [x] `go test ./... -count=1`
- [x] `make integration` (11/11 pass; SARIF, LSP/MCP, playground analysis unaffected by additive JSON field)