### PR TITLE
feat(traces): runtime-state overlay on the structural graph (#215)

### DIFF
--- a/cmd/krit/verb_dispatch.go
+++ b/cmd/krit/verb_dispatch.go
@@ -33,6 +33,7 @@ import (
 	climsnapshot "github.com/kaeawc/krit/internal/cli/snapshot"
 	climsuggestreviewers "github.com/kaeawc/krit/internal/cli/suggestreviewers"
 	climtestcoverage "github.com/kaeawc/krit/internal/cli/testcoverage"
+	climtraces "github.com/kaeawc/krit/internal/cli/traces"
 	climtransform "github.com/kaeawc/krit/internal/cli/transform"
 	climtriage "github.com/kaeawc/krit/internal/cli/triage"
 	climusedsymbols "github.com/kaeawc/krit/internal/cli/usedsymbols"
@@ -77,6 +78,7 @@ const (
 	verbBreakage
 	verbBisectStructure
 	verbDeltaRisk
+	verbTraces
 )
 
 var verbByName = map[string]subcommandVerb{
@@ -115,6 +117,7 @@ var verbByName = map[string]subcommandVerb{
 	"breakage":           verbBreakage,
 	"bisect-structure":   verbBisectStructure,
 	"delta-risk":         verbDeltaRisk,
+	"traces":             verbTraces,
 }
 
 func classifyVerb(arg string) subcommandVerb {
@@ -205,6 +208,20 @@ func runVerbAndExitB(verb subcommandVerb, rest []string) bool {
 		os.Exit(climbisect.Run(rest))
 	case verbDeltaRisk:
 		os.Exit(climdeltarisk.Run(rest))
+	default:
+		return runVerbAndExitC(verb, rest)
+	}
+	return false
+}
+
+// runVerbAndExitC is the third dispatch tier. Verbs added after the
+// per-function cyclo limit was reached should land here so the
+// existing tiers don't need to be reshuffled when more subcommands
+// arrive.
+func runVerbAndExitC(verb subcommandVerb, rest []string) bool {
+	switch verb {
+	case verbTraces:
+		os.Exit(climtraces.Run(rest))
 	}
 	return false
 }

--- a/internal/cli/traces/ingest.go
+++ b/internal/cli/traces/ingest.go
@@ -1,0 +1,123 @@
+package traces
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"flag"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/kaeawc/krit/internal/traces"
+	"github.com/kaeawc/krit/internal/traces/ingest/jfr"
+	"github.com/kaeawc/krit/internal/traces/ingest/junit"
+	"github.com/kaeawc/krit/internal/traces/ingest/otel"
+)
+
+func runIngest(args []string) int {
+	fs := flag.NewFlagSet("traces ingest", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	otelPath := fs.String("otel", "", "OTLP/JSON span file")
+	jfrPath := fs.String("jfr", "", "JFR (jfr print --json) sample file")
+	junitPath := fs.String("junit-steps", "", "JUnit step-boundary JSON file")
+	commitFlag := fs.String("commit", "", "commit sha this run is for")
+	envFlag := fs.String("env", "", "environment label")
+	repoFlag := fs.String("repo", "", "repository root (default: cwd)")
+	if err := fs.Parse(args); err != nil {
+		return 1
+	}
+	// Exactly one input must be provided.
+	selected := 0
+	for _, p := range []string{*otelPath, *jfrPath, *junitPath} {
+		if p != "" {
+			selected++
+		}
+	}
+	if selected != 1 {
+		fmt.Fprintln(os.Stderr, "error: exactly one of --otel, --jfr, --junit-steps is required")
+		return 1
+	}
+
+	repoRoot, code := resolveRepoRoot(*repoFlag)
+	if code != 0 {
+		return code
+	}
+
+	var (
+		events []traces.Event
+		kind   traces.SourceKind
+		path   string
+		err    error
+	)
+	switch {
+	case *otelPath != "":
+		path = *otelPath
+		kind = traces.SourceOTel
+		events, err = parseFile(path, otel.Parse)
+	case *jfrPath != "":
+		path = *jfrPath
+		kind = traces.SourceJFR
+		events, err = parseFile(path, jfr.Parse)
+	case *junitPath != "":
+		path = *junitPath
+		kind = traces.SourceJUnit
+		events, err = parseFile(path, junit.Parse)
+	}
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		return 1
+	}
+	if len(events) == 0 {
+		fmt.Fprintf(os.Stderr, "warning: %s produced 0 events\n", path)
+	}
+
+	// Stamp source ID derived from (kind, path, commit, start time) so
+	// repeat ingests of the same file under the same commit are
+	// deduplicated by Merge.
+	source := traces.IngestSource{
+		ID:         sourceID(kind, path, *commitFlag),
+		Kind:       kind,
+		StartedAt:  time.Now().UnixNano(),
+		CommitSHA:  *commitFlag,
+		Env:        *envFlag,
+		Path:       path,
+		EventCount: len(events),
+	}
+	for i := range events {
+		events[i].SourceID = source.ID
+	}
+	states, transitions := traces.Reduce(events)
+
+	store, err := traces.Load(repoRoot)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		return 1
+	}
+	store.Merge(source, states, transitions)
+	if err := store.Save(repoRoot); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		return 1
+	}
+	fmt.Fprintf(os.Stderr, "ingested %d events -> %d states, %d transitions (source=%s)\n",
+		len(events), len(states), len(transitions), source.ID)
+	return 0
+}
+
+func parseFile(path string, parse func([]byte) ([]traces.Event, error)) ([]traces.Event, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", path, err)
+	}
+	return parse(data)
+}
+
+func sourceID(kind traces.SourceKind, path, commit string) string {
+	h := sha256.New()
+	h.Write([]byte(kind))
+	h.Write([]byte{0})
+	h.Write([]byte(path))
+	h.Write([]byte{0})
+	h.Write([]byte(commit))
+	sum := h.Sum(nil)
+	return string(kind) + "-" + hex.EncodeToString(sum[:6])
+}

--- a/internal/cli/traces/overlay.go
+++ b/internal/cli/traces/overlay.go
@@ -1,0 +1,202 @@
+package traces
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"sort"
+
+	"github.com/kaeawc/krit/internal/scanner"
+	snap "github.com/kaeawc/krit/internal/snapshot"
+	"github.com/kaeawc/krit/internal/traces"
+	"github.com/kaeawc/krit/internal/traces/reconcile"
+)
+
+// overlayDoc is the JSON shape emitted by `krit traces overlay --json`.
+// It combines the static symbol set with the runtime states, the
+// reconcile resolution, and the cross-state transitions.
+type overlayDoc struct {
+	Commit      string                     `json:"commit,omitempty"`
+	StaticNodes []overlayStaticNode        `json:"static_nodes"`
+	Runtime     []overlayRuntimeNode       `json:"runtime_states"`
+	Transitions []traces.RuntimeTransition `json:"transitions"`
+}
+
+type overlayStaticNode struct {
+	FQN      string `json:"fqn"`
+	Kind     string `json:"kind,omitempty"`
+	File     string `json:"file,omitempty"`
+	Observed bool   `json:"observed"`
+}
+
+type overlayRuntimeNode struct {
+	Fingerprint string                   `json:"fingerprint"`
+	TopSymbol   string                   `json:"top_symbol"`
+	Role        traces.RoleTag           `json:"role"`
+	Count       int                      `json:"count"`
+	Resolution  traces.Resolution        `json:"resolution"`
+	Matched     string                   `json:"matched_fqn,omitempty"`
+	Suggestions []traces.StateSuggestion `json:"suggestions,omitempty"`
+}
+
+func runOverlay(args []string) int {
+	fs := flag.NewFlagSet("traces overlay", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	repoFlag := fs.String("repo", "", "repository root (default: cwd)")
+	commitFlag := fs.String("commit", "", "snapshot sha to reconcile against (default: latest captured)")
+	jsonFlag := fs.Bool("json", false, "emit machine-readable JSON")
+	if err := fs.Parse(args); err != nil {
+		return 1
+	}
+	repoRoot, code := resolveRepoRoot(*repoFlag)
+	if code != 0 {
+		return code
+	}
+	store, symbols, sha, code := loadStoreAndSymbols(repoRoot, *commitFlag)
+	if code != 0 {
+		return code
+	}
+	idx := reconcile.BuildIndex(symbols)
+	results := reconcile.Reconcile(idx, store.States)
+	store.Suggestions = store.Suggestions[:0]
+	store.Resolutions = map[string]traces.Resolution{}
+	for _, r := range results {
+		store.SetResolution(r.Fingerprint, r.Resolution)
+		if len(r.Suggestions) > 0 {
+			store.AddSuggestions(r.Fingerprint, r.Suggestions)
+		}
+	}
+	if err := store.Save(repoRoot); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		return 1
+	}
+	if *jsonFlag {
+		return emitOverlayJSON(store, results, symbols, sha)
+	}
+	return emitOverlayHuman(store, results)
+}
+
+func emitOverlayJSON(store *traces.Store, results []reconcile.Result, symbols []scanner.Symbol, sha string) int {
+	observed := map[string]bool{}
+	for _, r := range results {
+		if r.Resolution == traces.ResolvedExact && r.Match.FQN != "" {
+			observed[r.Match.FQN] = true
+		}
+	}
+	doc := overlayDoc{
+		Commit:      sha,
+		StaticNodes: make([]overlayStaticNode, 0, len(symbols)),
+	}
+	for _, s := range symbols {
+		if s.FQN == "" {
+			continue
+		}
+		doc.StaticNodes = append(doc.StaticNodes, overlayStaticNode{
+			FQN:      s.FQN,
+			Kind:     s.Kind,
+			File:     s.File,
+			Observed: observed[s.FQN],
+		})
+	}
+	sort.Slice(doc.StaticNodes, func(i, j int) bool { return doc.StaticNodes[i].FQN < doc.StaticNodes[j].FQN })
+
+	stateByFP := map[string]traces.RuntimeState{}
+	for _, st := range store.States {
+		stateByFP[st.Fingerprint] = st
+	}
+	for _, r := range results {
+		st := stateByFP[r.Fingerprint]
+		node := overlayRuntimeNode{
+			Fingerprint: r.Fingerprint,
+			TopSymbol:   st.TopSymbol,
+			Role:        st.Role,
+			Count:       st.Count,
+			Resolution:  r.Resolution,
+		}
+		if r.Resolution == traces.ResolvedExact {
+			node.Matched = r.Match.FQN
+		}
+		if len(r.Suggestions) > 0 {
+			node.Suggestions = r.Suggestions
+		}
+		doc.Runtime = append(doc.Runtime, node)
+	}
+	doc.Transitions = store.Transitions
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(doc); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		return 1
+	}
+	return 0
+}
+
+func emitOverlayHuman(store *traces.Store, results []reconcile.Result) int {
+	exact, fuzzy, unresolved := 0, 0, 0
+	for _, r := range results {
+		switch r.Resolution {
+		case traces.ResolvedExact:
+			exact++
+		case traces.ResolvedFuzzy:
+			fuzzy++
+		case traces.Unresolved:
+			unresolved++
+		}
+	}
+	fmt.Fprintf(os.Stdout, "runtime states: %d  (exact %d, fuzzy %d, unresolved %d)\n",
+		len(results), exact, fuzzy, unresolved)
+	fmt.Fprintf(os.Stdout, "transitions:    %d\n", len(store.Transitions))
+	fmt.Fprintf(os.Stdout, "sources:        %d\n", len(store.Sources))
+	return 0
+}
+
+// loadStoreAndSymbols opens the per-repo store and the symbol list
+// from the requested (or latest-captured) snapshot. Returns the
+// resolved sha so callers can stamp it on output.
+func loadStoreAndSymbols(repoRoot, commitFlag string) (*traces.Store, []scanner.Symbol, string, int) {
+	store, err := traces.Load(repoRoot)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		return nil, nil, "", 1
+	}
+	root := snap.SnapshotsDir(repoRoot)
+	sha := commitFlag
+	if sha == "" {
+		manifests, err := snap.LoadManifests(root)
+		if err != nil || len(manifests) == 0 {
+			fmt.Fprintf(os.Stderr, "error: no snapshots captured; run `krit snapshot capture` first\n")
+			return nil, nil, "", 1
+		}
+		// Most-recent capture wins.
+		sort.Slice(manifests, func(i, j int) bool { return manifests[i].CapturedAt > manifests[j].CapturedAt })
+		sha = manifests[0].CommitSHA
+	}
+	blob, err := snap.Load(root, sha)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: load snapshot %s: %v\n", sha, err)
+		return nil, nil, "", 1
+	}
+	symbols := convertSymbols(blob.Symbols)
+	return store, symbols, sha, 0
+}
+
+// convertSymbols projects snapshot.Symbol onto scanner.Symbol so the
+// reconcile.Index can index them. Only the fields reconcile reads are
+// populated.
+func convertSymbols(in []snap.Symbol) []scanner.Symbol {
+	out := make([]scanner.Symbol, len(in))
+	for i, s := range in {
+		out[i] = scanner.Symbol{
+			Name:      s.Name,
+			Kind:      s.Kind,
+			File:      s.File,
+			Line:      s.Line,
+			Package:   s.Package,
+			FQN:       s.FQN,
+			Owner:     s.Owner,
+			Signature: s.Signature,
+		}
+	}
+	return out
+}

--- a/internal/cli/traces/queries.go
+++ b/internal/cli/traces/queries.go
@@ -1,0 +1,198 @@
+package traces
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"sort"
+
+	"github.com/kaeawc/krit/internal/traces"
+	"github.com/kaeawc/krit/internal/traces/reconcile"
+)
+
+// runOrphans lists static symbols present in the chosen snapshot's
+// symbol list but never observed in the trace store.
+func runOrphans(args []string) int {
+	fs := flag.NewFlagSet("traces orphans", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	repoFlag := fs.String("repo", "", "repository root (default: cwd)")
+	commitFlag := fs.String("commit", "", "snapshot sha (default: latest captured)")
+	jsonFlag := fs.Bool("json", false, "emit JSON")
+	if err := fs.Parse(args); err != nil {
+		return 1
+	}
+	repoRoot, code := resolveRepoRoot(*repoFlag)
+	if code != 0 {
+		return code
+	}
+	store, symbols, _, code := loadStoreAndSymbols(repoRoot, *commitFlag)
+	if code != 0 {
+		return code
+	}
+	idx := reconcile.BuildIndex(symbols)
+	observed := map[string]bool{}
+	for _, r := range reconcile.Reconcile(idx, store.States) {
+		if r.Resolution == traces.ResolvedExact && r.Match.FQN != "" {
+			observed[r.Match.FQN] = true
+		}
+	}
+	var orphans []string
+	for _, s := range symbols {
+		if s.FQN == "" || observed[s.FQN] {
+			continue
+		}
+		orphans = append(orphans, s.FQN)
+	}
+	sort.Strings(orphans)
+	if *jsonFlag {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(map[string]any{"orphans": orphans, "count": len(orphans)})
+		return 0
+	}
+	for _, fqn := range orphans {
+		fmt.Println(fqn)
+	}
+	fmt.Fprintf(os.Stderr, "%d orphan symbols (%d/%d observed)\n",
+		len(orphans), len(observed), len(symbols))
+	return 0
+}
+
+// runPhantoms lists runtime states whose top symbol can't be
+// reconciled to any static symbol (Resolution == Unresolved).
+func runPhantoms(args []string) int {
+	fs := flag.NewFlagSet("traces phantoms", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	repoFlag := fs.String("repo", "", "repository root (default: cwd)")
+	commitFlag := fs.String("commit", "", "snapshot sha (default: latest captured)")
+	jsonFlag := fs.Bool("json", false, "emit JSON")
+	if err := fs.Parse(args); err != nil {
+		return 1
+	}
+	repoRoot, code := resolveRepoRoot(*repoFlag)
+	if code != 0 {
+		return code
+	}
+	store, symbols, _, code := loadStoreAndSymbols(repoRoot, *commitFlag)
+	if code != 0 {
+		return code
+	}
+	idx := reconcile.BuildIndex(symbols)
+	stateByFP := map[string]traces.RuntimeState{}
+	for _, st := range store.States {
+		stateByFP[st.Fingerprint] = st
+	}
+	type phantom struct {
+		Fingerprint string         `json:"fingerprint"`
+		TopSymbol   string         `json:"top_symbol"`
+		Role        traces.RoleTag `json:"role"`
+		Count       int            `json:"count"`
+	}
+	var out []phantom
+	for _, r := range reconcile.Reconcile(idx, store.States) {
+		if r.Resolution != traces.Unresolved {
+			continue
+		}
+		st := stateByFP[r.Fingerprint]
+		out = append(out, phantom{
+			Fingerprint: r.Fingerprint,
+			TopSymbol:   st.TopSymbol,
+			Role:        st.Role,
+			Count:       st.Count,
+		})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Count > out[j].Count })
+	if *jsonFlag {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(map[string]any{"phantoms": out, "count": len(out)})
+		return 0
+	}
+	for _, p := range out {
+		fmt.Printf("%s\t%s\trole=%s\tcount=%d\n", p.Fingerprint, p.TopSymbol, p.Role, p.Count)
+	}
+	fmt.Fprintf(os.Stderr, "%d phantom states\n", len(out))
+	return 0
+}
+
+// runDivergence diffs the runtime transitions observed under one
+// commit's ingest sources against another's.
+func runDivergence(args []string) int {
+	fs := flag.NewFlagSet("traces divergence", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	repoFlag := fs.String("repo", "", "repository root (default: cwd)")
+	fromFlag := fs.String("from", "", "baseline commit sha (required)")
+	toFlag := fs.String("to", "", "comparison commit sha (required)")
+	jsonFlag := fs.Bool("json", false, "emit JSON")
+	if err := fs.Parse(args); err != nil {
+		return 1
+	}
+	if *fromFlag == "" || *toFlag == "" {
+		fmt.Fprintln(os.Stderr, "error: --from and --to are required")
+		return 1
+	}
+	repoRoot, code := resolveRepoRoot(*repoFlag)
+	if code != 0 {
+		return code
+	}
+	store, err := traces.Load(repoRoot)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		return 1
+	}
+	fromIDs := sourceIDsForCommit(store, *fromFlag)
+	toIDs := sourceIDsForCommit(store, *toFlag)
+	if len(fromIDs) == 0 || len(toIDs) == 0 {
+		fmt.Fprintf(os.Stderr, "error: missing ingest sources for from=%s to=%s\n", *fromFlag, *toFlag)
+		return 1
+	}
+	onlyFrom := transitionsOnlyIn(store, fromIDs, toIDs)
+	onlyTo := transitionsOnlyIn(store, toIDs, fromIDs)
+	if *jsonFlag {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(map[string]any{
+			"from":      *fromFlag,
+			"to":        *toFlag,
+			"only_from": onlyFrom,
+			"only_to":   onlyTo,
+		})
+		return 0
+	}
+	fmt.Fprintf(os.Stdout, "transitions only in %s: %d\n", *fromFlag, len(onlyFrom))
+	fmt.Fprintf(os.Stdout, "transitions only in %s: %d\n", *toFlag, len(onlyTo))
+	return 0
+}
+
+func sourceIDsForCommit(s *traces.Store, sha string) map[string]struct{} {
+	out := map[string]struct{}{}
+	for _, src := range s.Sources {
+		if src.CommitSHA == sha {
+			out[src.ID] = struct{}{}
+		}
+	}
+	return out
+}
+
+// transitionsOnlyIn returns transitions observed by at least one
+// source in `inclusive` and by no source in `exclusive` — the
+// "observed in this commit, but not the other" set.
+func transitionsOnlyIn(s *traces.Store, inclusive, exclusive map[string]struct{}) []traces.RuntimeTransition {
+	out := make([]traces.RuntimeTransition, 0, len(s.Transitions))
+	for _, t := range s.Transitions {
+		hasIn, hasEx := false, false
+		for _, src := range t.Sources {
+			if _, ok := inclusive[src]; ok {
+				hasIn = true
+			}
+			if _, ok := exclusive[src]; ok {
+				hasEx = true
+			}
+		}
+		if hasIn && !hasEx {
+			out = append(out, t)
+		}
+	}
+	return out
+}

--- a/internal/cli/traces/traces.go
+++ b/internal/cli/traces/traces.go
@@ -1,0 +1,79 @@
+// Package traces implements the `krit traces` CLI verb. Subcommands:
+//
+//	ingest     read OTel/JFR/JUnit input and merge into the store.
+//	overlay    emit static graph + runtime overlay as JSON.
+//	orphans    list static symbols never observed at runtime.
+//	phantoms   list runtime states no static symbol resolves to.
+//	divergence diff runtime evidence between two commits.
+//
+// The verb operates on a per-repo store at `.krit/traces/store.json`
+// (sibling to `.krit/snapshots`). Static reconciliation reads the
+// closest available snapshot's symbol list — capture one with
+// `krit snapshot capture` before invoking overlay / orphans.
+package traces
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/kaeawc/krit/internal/cli/clishared"
+)
+
+const usage = `usage: krit traces <ingest|overlay|orphans|phantoms|divergence> [flags]
+
+  ingest     read OTel/JFR/JUnit input and merge into the store
+  overlay    emit static graph + runtime overlay as JSON
+  orphans    list static symbols never observed at runtime
+  phantoms   list runtime states no static symbol resolves to
+  divergence diff runtime evidence between two commits
+
+Ingest flags (exactly one of --otel, --jfr, --junit-steps is required):
+  --otel PATH         OTLP/JSON span file
+  --jfr PATH          jfr-print --json sample file
+  --junit-steps PATH  JUnit step-boundary JSON file
+  --commit SHA        record the commit this run is for (optional)
+  --env ENV           record the environment label (optional)
+  --repo PATH         repository root (default: cwd)
+
+Overlay / orphans / phantoms flags:
+  --repo PATH         repository root (default: cwd)
+  --commit SHA        snapshot sha to reconcile against (default: latest captured)
+  --json              emit machine-readable JSON (default: human summary)
+
+Divergence flags:
+  --from SHA          baseline snapshot sha (required)
+  --to SHA            comparison snapshot sha (required)
+  --repo PATH         repository root (default: cwd)
+`
+
+// Run is the entry point invoked by cmd/krit/verb_dispatch.go.
+func Run(args []string) int {
+	if len(args) == 0 {
+		fmt.Fprint(os.Stderr, usage)
+		return 1
+	}
+	switch args[0] {
+	case "ingest":
+		return runIngest(args[1:])
+	case "overlay":
+		return runOverlay(args[1:])
+	case "orphans":
+		return runOrphans(args[1:])
+	case "phantoms":
+		return runPhantoms(args[1:])
+	case "divergence":
+		return runDivergence(args[1:])
+	case "-h", "--help", "help":
+		fmt.Fprint(os.Stdout, usage)
+		return 0
+	default:
+		fmt.Fprintf(os.Stderr, "unknown traces subcommand: %s\n%s", args[0], usage)
+		return 1
+	}
+}
+
+// resolveRepoRoot delegates to clishared so the verb honors the
+// same --repo convention as `krit snapshot`, `krit bisect`, etc.
+func resolveRepoRoot(flagValue string) (string, int) {
+	return clishared.ResolveRepoRoot(flagValue)
+}

--- a/internal/cli/traces/traces_test.go
+++ b/internal/cli/traces/traces_test.go
@@ -1,0 +1,66 @@
+package traces
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	tr "github.com/kaeawc/krit/internal/traces"
+)
+
+// TestIngestOTelFixtureProducesStates runs the ingest path against
+// the checked-in OTel fixture and verifies the on-disk store has the
+// expected shape.
+func TestIngestOTelFixtureProducesStates(t *testing.T) {
+	repoRoot := t.TempDir()
+	// Locate the fixture relative to this test file's working dir.
+	// `go test ./internal/cli/traces` runs with cwd = package dir.
+	pkgDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	fixture := filepath.Join(pkgDir, "..", "..", "..", "tests", "fixtures", "traces", "otel_sample.json")
+	if _, err := os.Stat(fixture); err != nil {
+		t.Fatalf("fixture missing: %v", err)
+	}
+	code := runIngest([]string{"--otel", fixture, "--repo", repoRoot, "--commit", "abc1234"})
+	if code != 0 {
+		t.Fatalf("ingest exit %d", code)
+	}
+	store, err := tr.Load(repoRoot)
+	if err != nil {
+		t.Fatalf("load store: %v", err)
+	}
+	if len(store.States) == 0 {
+		t.Fatalf("expected states from ingest")
+	}
+	if len(store.Sources) != 1 {
+		t.Fatalf("want 1 source, got %d", len(store.Sources))
+	}
+	if store.Sources[0].CommitSHA != "abc1234" {
+		t.Fatalf("commit not stamped: %s", store.Sources[0].CommitSHA)
+	}
+	// The fixture has a 3-span chain; the reducer should observe 3 states.
+	if len(store.States) != 3 {
+		t.Fatalf("want 3 states, got %d", len(store.States))
+	}
+	// And 2 transitions (call1->call2, call2->call3).
+	if len(store.Transitions) != 2 {
+		t.Fatalf("want 2 transitions, got %d", len(store.Transitions))
+	}
+}
+
+func TestIngestRejectsMultipleInputs(t *testing.T) {
+	repoRoot := t.TempDir()
+	code := runIngest([]string{"--otel", "a.json", "--jfr", "b.json", "--repo", repoRoot})
+	if code == 0 {
+		t.Fatalf("expected non-zero exit when two inputs given")
+	}
+}
+
+func TestRunUnknownSubcommand(t *testing.T) {
+	code := Run([]string{"nope"})
+	if code == 0 {
+		t.Fatalf("expected non-zero exit on unknown subcommand")
+	}
+}

--- a/internal/rules/api/rule.go
+++ b/internal/rules/api/rule.go
@@ -17,6 +17,7 @@ import (
 	"github.com/kaeawc/krit/internal/manifest"
 	"github.com/kaeawc/krit/internal/module"
 	"github.com/kaeawc/krit/internal/scanner"
+	"github.com/kaeawc/krit/internal/traces"
 	"github.com/kaeawc/krit/internal/typeinfer"
 )
 
@@ -132,6 +133,16 @@ const (
 	// do not appear in source. Skipped JVM-side when no active rule
 	// declares this bit.
 	NeedsOracleLibraryClasses
+
+	// NeedsRuntimeEvidence requests the per-run runtime trace overlay
+	// in Context (Context.RuntimeEvidence). Populated only when the
+	// CLI has ingested traces into `.krit/traces/store.json`; rules
+	// that declare this bit must treat an empty store as "no evidence
+	// available" and degrade gracefully (typically by skipping the
+	// confidence adjustment, not by emitting findings as if the
+	// evidence said no). Layered orthogonally on top of any scope.
+	// (Aspect.)
+	NeedsRuntimeEvidence
 )
 
 // NeedsOracle is the back-compat umbrella: the OR of every narrow
@@ -1128,6 +1139,14 @@ type Context struct {
 	// available. Rules should use this instead of baking library-version
 	// assumptions directly into AST heuristics.
 	LibraryFacts *librarymodel.Facts
+
+	// RuntimeEvidence is the per-run trace overlay (states,
+	// transitions, resolutions). Populated only when the rule
+	// declares NeedsRuntimeEvidence and the CLI has ingested traces
+	// into `.krit/traces/store.json`. May be nil even when the
+	// capability is declared — rules must treat nil / empty as "no
+	// evidence available" and degrade gracefully.
+	RuntimeEvidence *traces.Store
 
 	// Facts is the per-run shared cache of derived per-file facts
 	// (imports, references, declaration summaries). Always non-nil for

--- a/internal/traces/evidence.go
+++ b/internal/traces/evidence.go
@@ -1,0 +1,48 @@
+package traces
+
+// IsObservedSymbol reports whether any resolved runtime state pins
+// the given static symbol FQN. Rules that declare
+// NeedsRuntimeEvidence should call this with a candidate dead-code
+// symbol and skip / downgrade the finding when the answer is true.
+//
+// Empty stores answer false — the absence of trace evidence is not
+// itself evidence the symbol is dead. Callers should also fall back
+// to static-only analysis when the store has no sources at all.
+func (s *Store) IsObservedSymbol(fqn string) bool {
+	if s == nil || fqn == "" {
+		return false
+	}
+	for _, st := range s.States {
+		if st.TopSymbol == fqn {
+			return true
+		}
+	}
+	return false
+}
+
+// HasEvidence reports whether the store carries any ingested
+// runtime data. Rules use this to decide whether to apply the
+// confidence adjustment at all: an empty store cannot disprove a
+// static finding, so the rule must fall back to its static behavior.
+func (s *Store) HasEvidence() bool {
+	if s == nil {
+		return false
+	}
+	return len(s.Sources) > 0 || len(s.States) > 0
+}
+
+// AdjustConfidence is the canonical confidence-downgrade pattern for
+// rules that consume runtime evidence. When the store has evidence
+// and the symbol is observed, the rule's base confidence is
+// multiplied by adjustment (typically <= 0.5) — making the finding
+// less likely to surface, but never eliminating it outright (the
+// static signal may still be correct, e.g. when traces are stale).
+//
+// Returns base unchanged when the store has no evidence or the
+// symbol is not observed.
+func (s *Store) AdjustConfidence(base float64, fqn string, adjustment float64) float64 {
+	if !s.HasEvidence() || !s.IsObservedSymbol(fqn) {
+		return base
+	}
+	return base * adjustment
+}

--- a/internal/traces/evidence_test.go
+++ b/internal/traces/evidence_test.go
@@ -1,0 +1,35 @@
+package traces
+
+import "testing"
+
+// TestAdjustConfidenceDowngradesObservedSymbol: a symbol the static
+// graph thinks is dead but traces show as live should get its
+// confidence dampened, not eliminated.
+func TestAdjustConfidenceDowngradesObservedSymbol(t *testing.T) {
+	store := &Store{
+		Sources: []IngestSource{{ID: "otel-1"}},
+		States: []RuntimeState{
+			{Fingerprint: "fp1", TopSymbol: "com.acme.LivelyFn"},
+		},
+	}
+	if got := store.AdjustConfidence(0.9, "com.acme.LivelyFn", 0.3); got != 0.9*0.3 {
+		t.Fatalf("observed symbol: want downgrade 0.27, got %v", got)
+	}
+	if got := store.AdjustConfidence(0.9, "com.acme.DeadFn", 0.3); got != 0.9 {
+		t.Fatalf("unobserved symbol: want base 0.9, got %v", got)
+	}
+}
+
+func TestAdjustConfidenceNilStoreReturnsBase(t *testing.T) {
+	var store *Store
+	if got := store.AdjustConfidence(0.9, "x", 0.3); got != 0.9 {
+		t.Fatalf("nil store: want base 0.9, got %v", got)
+	}
+}
+
+func TestAdjustConfidenceEmptyStoreReturnsBase(t *testing.T) {
+	store := &Store{}
+	if got := store.AdjustConfidence(0.9, "x", 0.3); got != 0.9 {
+		t.Fatalf("empty store: want base 0.9, got %v", got)
+	}
+}

--- a/internal/traces/fingerprint.go
+++ b/internal/traces/fingerprint.go
@@ -1,0 +1,63 @@
+package traces
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+)
+
+// CallerChainDepth is the number of caller frames (under the top
+// symbol) the chain hash incorporates. A bounded window keeps two
+// states "the same" across deep but irrelevant call differences while
+// still distinguishing intentionally different entry paths.
+const CallerChainDepth = 4
+
+// callerWindow returns the bounded caller-frame slice
+// (frames[1:1+CallerChainDepth]) without copying. Shared between
+// HashCallerChain and the reducer so both honor the same window.
+func callerWindow(frames []string) []string {
+	if len(frames) <= 1 {
+		return nil
+	}
+	end := 1 + CallerChainDepth
+	if end > len(frames) {
+		end = len(frames)
+	}
+	return frames[1:end]
+}
+
+// HashCallerChain returns a stable hex hash of the top-N caller
+// frames under topSymbol. frames is top-of-stack first; the function
+// skips frames[0] (that is the top symbol itself) and includes up to
+// CallerChainDepth more frames. Empty inputs hash to "".
+func HashCallerChain(frames []string) string {
+	w := callerWindow(frames)
+	if len(w) == 0 {
+		return ""
+	}
+	h := sha256.New()
+	for _, f := range w {
+		h.Write([]byte(f))
+		h.Write([]byte{0})
+	}
+	sum := h.Sum(nil)
+	return hex.EncodeToString(sum[:8])
+}
+
+// Fingerprint returns the stable identity of a runtime state.
+// Mirrors AutoMobile's ScreenFingerprint construction: a one-way
+// hash over the discriminating fields. Two states are "the same"
+// iff fingerprints match.
+func Fingerprint(topSymbol, callerChainHash string, role RoleTag) string {
+	h := sha256.New()
+	h.Write([]byte(strings.TrimSpace(topSymbol)))
+	h.Write([]byte{0})
+	h.Write([]byte(callerChainHash))
+	h.Write([]byte{0})
+	if role == "" {
+		role = RoleUnknown
+	}
+	h.Write([]byte(role))
+	sum := h.Sum(nil)
+	return hex.EncodeToString(sum[:12])
+}

--- a/internal/traces/ingest/jfr/jfr.go
+++ b/internal/traces/ingest/jfr/jfr.go
@@ -1,0 +1,127 @@
+// Package jfr parses JFR-derived stack samples into the canonical
+// traces.Event stream.
+//
+// Krit does not parse the binary JFR format directly. The accepted
+// input is the JSON dump produced by `jfr print --json
+// --events=jdk.ExecutionSample <file.jfr>` (or any tool that emits
+// the same shape). This keeps the ingest path narrow — production
+// JFR files are converted by an external tool, krit reads the JSON.
+//
+// The reduced event stream uses the full Java method stack (with
+// `Class.method` formatting) as the frame stack, top-of-stack first.
+// Sample frequency is implicit: each sample is one event, and
+// adjacent equal samples collapse into a single state with count = N.
+package jfr
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/kaeawc/krit/internal/traces"
+)
+
+// Document is the relevant subset of `jfr print --json` output.
+type Document struct {
+	Recording Recording `json:"recording"`
+}
+
+type Recording struct {
+	Events []SampleEvent `json:"events"`
+}
+
+type SampleEvent struct {
+	Type      string `json:"type"`
+	StartTime int64  `json:"startTime"`
+	Thread    Thread `json:"thread"`
+	Stack     Stack  `json:"stackTrace"`
+}
+
+type Thread struct {
+	JavaName string `json:"javaName"`
+	OSName   string `json:"osName"`
+}
+
+type Stack struct {
+	Frames []Frame `json:"frames"`
+}
+
+type Frame struct {
+	Method Method `json:"method"`
+}
+
+type Method struct {
+	Type Type   `json:"type"`
+	Name string `json:"name"`
+}
+
+type Type struct {
+	Name string `json:"name"`
+}
+
+// Parse decodes JFR JSON bytes into events. SourceID is left for the
+// caller to stamp.
+func Parse(data []byte) ([]traces.Event, error) {
+	var doc Document
+	if err := json.Unmarshal(data, &doc); err != nil {
+		return nil, fmt.Errorf("jfr: parse: %w", err)
+	}
+	out := make([]traces.Event, 0, len(doc.Recording.Events))
+	for _, ev := range doc.Recording.Events {
+		if ev.Type != "" && ev.Type != "jdk.ExecutionSample" {
+			continue
+		}
+		if len(ev.Stack.Frames) == 0 {
+			continue
+		}
+		stack := make([]string, 0, len(ev.Stack.Frames))
+		for _, fr := range ev.Stack.Frames {
+			if fr.Method.Name == "" {
+				continue
+			}
+			cls := fr.Method.Type.Name
+			if cls == "" {
+				stack = append(stack, fr.Method.Name)
+			} else {
+				stack = append(stack, cls+"."+fr.Method.Name)
+			}
+		}
+		if len(stack) == 0 {
+			continue
+		}
+		out = append(out, traces.Event{
+			TimestampNS: ev.StartTime,
+			FrameStack:  stack,
+			Kind:        traces.KindCall,
+			Role:        roleFromThread(ev.Thread),
+		})
+	}
+	return out, nil
+}
+
+func roleFromThread(t Thread) traces.RoleTag {
+	name := t.JavaName
+	if name == "" {
+		name = t.OSName
+	}
+	switch {
+	case name == "":
+		return traces.RoleUnknown
+	case containsAny(name, "Test", "JUnit", "Spek"):
+		return traces.RoleTest
+	case containsAny(name, "main", "Main"):
+		return traces.RoleStartup
+	case containsAny(name, "Worker", "Background", "Scheduler"):
+		return traces.RoleBackground
+	}
+	return traces.RoleRequest
+}
+
+func containsAny(s string, subs ...string) bool {
+	for _, sub := range subs {
+		if sub != "" && strings.Contains(s, sub) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/traces/ingest/jfr/jfr_test.go
+++ b/internal/traces/ingest/jfr/jfr_test.go
@@ -1,0 +1,51 @@
+package jfr
+
+import (
+	"testing"
+
+	"github.com/kaeawc/krit/internal/traces"
+)
+
+func TestParseFormatsStackAndRole(t *testing.T) {
+	const in = `{
+        "recording": {
+            "events": [
+                {
+                    "type": "jdk.ExecutionSample",
+                    "startTime": 100,
+                    "thread": {"javaName": "main"},
+                    "stackTrace": {
+                        "frames": [
+                            {"method": {"type": {"name": "com.acme.Foo"}, "name": "bar"}},
+                            {"method": {"type": {"name": "com.acme.Main"}, "name": "main"}}
+                        ]
+                    }
+                }
+            ]
+        }
+    }`
+	events, err := Parse([]byte(in))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("want 1 event, got %d", len(events))
+	}
+	if got := events[0].FrameStack; len(got) != 2 || got[0] != "com.acme.Foo.bar" || got[1] != "com.acme.Main.main" {
+		t.Fatalf("stack: %v", got)
+	}
+	if events[0].Role != traces.RoleStartup {
+		t.Fatalf("role: want startup, got %s", events[0].Role)
+	}
+}
+
+func TestParseSkipsUnknownEventType(t *testing.T) {
+	const in = `{"recording":{"events":[{"type":"jdk.OtherEvent","stackTrace":{"frames":[{"method":{"name":"x"}}]}}]}}`
+	events, err := Parse([]byte(in))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(events) != 0 {
+		t.Fatalf("want 0 events, got %d", len(events))
+	}
+}

--- a/internal/traces/ingest/junit/junit.go
+++ b/internal/traces/ingest/junit/junit.go
@@ -1,0 +1,65 @@
+// Package junit parses JUnit step-boundary records into the
+// canonical traces.Event stream.
+//
+// Standard JUnit XML reports record test pass/fail outcomes but not
+// the in-test step boundaries krit cares about. We accept a separate
+// JSON file emitted by a test-side listener — the format is a flat
+// array of step records:
+//
+//	[
+//	  {
+//	    "timestamp_ns": 173...,
+//	    "test_class": "com.acme.OrderTest",
+//	    "test_method": "createOrder",
+//	    "step": "given_empty_cart",
+//	    "stack": ["com.acme.Order.create", "com.acme.OrderTest.createOrder"]
+//	  }
+//	]
+//
+// Steps without a `stack` are still useful: the (test_class,
+// test_method) pair becomes a two-frame stack so test-vs-prod
+// divergence queries get a coarse but consistent test signal.
+package junit
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/kaeawc/krit/internal/traces"
+)
+
+// Step is one row of the JUnit step-boundary file.
+type Step struct {
+	TimestampNS int64    `json:"timestamp_ns"`
+	TestClass   string   `json:"test_class"`
+	TestMethod  string   `json:"test_method"`
+	StepName    string   `json:"step,omitempty"`
+	Stack       []string `json:"stack,omitempty"`
+}
+
+// Parse decodes a JUnit step-boundary JSON array into events.
+func Parse(data []byte) ([]traces.Event, error) {
+	var steps []Step
+	if err := json.Unmarshal(data, &steps); err != nil {
+		return nil, fmt.Errorf("junit: parse: %w", err)
+	}
+	out := make([]traces.Event, 0, len(steps))
+	for _, st := range steps {
+		stack := st.Stack
+		if len(stack) == 0 {
+			if st.TestClass != "" && st.TestMethod != "" {
+				stack = []string{st.TestClass + "." + st.TestMethod}
+			}
+		}
+		if len(stack) == 0 {
+			continue
+		}
+		out = append(out, traces.Event{
+			TimestampNS: st.TimestampNS,
+			FrameStack:  stack,
+			Kind:        traces.KindCall,
+			Role:        traces.RoleTest,
+		})
+	}
+	return out, nil
+}

--- a/internal/traces/ingest/junit/junit_test.go
+++ b/internal/traces/ingest/junit/junit_test.go
@@ -1,0 +1,32 @@
+package junit
+
+import (
+	"testing"
+
+	"github.com/kaeawc/krit/internal/traces"
+)
+
+func TestParseAssignsTestRole(t *testing.T) {
+	const in = `[
+        {"timestamp_ns": 1, "test_class": "com.acme.OrderTest", "test_method": "createOrder", "step": "given"},
+        {"timestamp_ns": 2, "test_class": "com.acme.OrderTest", "test_method": "createOrder", "stack": ["com.acme.Order.create", "com.acme.OrderTest.createOrder"]}
+    ]`
+	events, err := Parse([]byte(in))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(events) != 2 {
+		t.Fatalf("want 2 events, got %d", len(events))
+	}
+	for _, ev := range events {
+		if ev.Role != traces.RoleTest {
+			t.Fatalf("role: want test, got %s", ev.Role)
+		}
+	}
+	if got := events[0].FrameStack; len(got) != 1 || got[0] != "com.acme.OrderTest.createOrder" {
+		t.Fatalf("synthesized stack: %v", got)
+	}
+	if got := events[1].FrameStack; len(got) != 2 {
+		t.Fatalf("explicit stack: %v", got)
+	}
+}

--- a/internal/traces/ingest/otel/otel.go
+++ b/internal/traces/ingest/otel/otel.go
@@ -1,0 +1,239 @@
+// Package otel parses OpenTelemetry traces (JSON-encoded spans) into
+// the canonical traces.Event stream.
+//
+// Krit ingests batches, not live OTLP gRPC. The accepted shape is the
+// OTLP/JSON wire format produced by collectors when exporting to file
+// (`file_exporter`), which is also what most OTel SDKs emit when
+// configured with `--exporter file`. Spans are reduced to events
+// where:
+//
+//   - top symbol = span.name (or span attribute "code.function" when
+//     present — preferred because it carries the resolved symbol).
+//   - frame stack = reconstructed by walking parent_span_id upward
+//     within the same trace.
+//   - timestamp = span.startTimeUnixNano.
+//   - kind = call (span start) — span ends become return transitions
+//     during reduction by emitting a closing event.
+//   - role = derived from span attributes (deployment.environment /
+//     service.name suffixes 'test') with fallback to RoleUnknown.
+package otel
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/kaeawc/krit/internal/traces"
+)
+
+// Document is the relevant subset of OTLP/JSON the parser reads. The
+// real OTLP format has more fields (resource attributes, scope, etc.);
+// they are tolerated and ignored. Only resourceSpans -> scopeSpans
+// -> spans are walked.
+type Document struct {
+	ResourceSpans []ResourceSpans `json:"resourceSpans"`
+}
+
+type ResourceSpans struct {
+	Resource   Resource     `json:"resource"`
+	ScopeSpans []ScopeSpans `json:"scopeSpans"`
+}
+
+type Resource struct {
+	Attributes []KeyValue `json:"attributes"`
+}
+
+type ScopeSpans struct {
+	Spans []Span `json:"spans"`
+}
+
+type Span struct {
+	TraceID           string     `json:"traceId"`
+	SpanID            string     `json:"spanId"`
+	ParentSpanID      string     `json:"parentSpanId"`
+	Name              string     `json:"name"`
+	Kind              int        `json:"kind"`
+	StartTimeUnixNano any        `json:"startTimeUnixNano"`
+	EndTimeUnixNano   any        `json:"endTimeUnixNano"`
+	Attributes        []KeyValue `json:"attributes"`
+}
+
+type KeyValue struct {
+	Key   string    `json:"key"`
+	Value StringVal `json:"value"`
+}
+
+// StringVal is the AnyValue subset used: only stringValue is read.
+// Other shapes (intValue, boolValue) are tolerated by JSON
+// unmarshaling and ignored.
+type StringVal struct {
+	StringValue string `json:"stringValue"`
+}
+
+// Parse decodes OTLP/JSON bytes into events. The caller stamps
+// SourceID on each event before passing to Reduce.
+func Parse(data []byte) ([]traces.Event, error) {
+	var doc Document
+	if err := json.Unmarshal(data, &doc); err != nil {
+		return nil, fmt.Errorf("otel: parse: %w", err)
+	}
+	// Build span lookup so we can walk parents within a trace.
+	spans := map[string]Span{}
+	resourceRole := map[string]traces.RoleTag{}
+	for _, rs := range doc.ResourceSpans {
+		role := roleFromAttributes(rs.Resource.Attributes)
+		for _, ss := range rs.ScopeSpans {
+			for _, sp := range ss.Spans {
+				key := sp.TraceID + "/" + sp.SpanID
+				spans[key] = sp
+				resourceRole[key] = role
+			}
+		}
+	}
+	// Iterate spans in (traceID, startTime) order for deterministic
+	// event ordering.
+	keys := make([]string, 0, len(spans))
+	for k := range spans {
+		keys = append(keys, k)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		si, sj := spans[keys[i]], spans[keys[j]]
+		if si.TraceID != sj.TraceID {
+			return si.TraceID < sj.TraceID
+		}
+		ti, tj := parseUnixNano(si.StartTimeUnixNano), parseUnixNano(sj.StartTimeUnixNano)
+		if ti != tj {
+			return ti < tj
+		}
+		return si.SpanID < sj.SpanID
+	})
+
+	out := make([]traces.Event, 0, len(spans))
+	for _, k := range keys {
+		sp := spans[k]
+		role := resourceRole[k]
+		// Span-level role overrides resource role if present.
+		if r := roleFromAttributes(sp.Attributes); r != traces.RoleUnknown {
+			role = r
+		}
+		ev := traces.Event{
+			TimestampNS: parseUnixNano(sp.StartTimeUnixNano),
+			FrameStack:  frameStack(sp, spans),
+			Kind:        traces.KindCall,
+			Role:        role,
+		}
+		if len(ev.FrameStack) > 0 {
+			out = append(out, ev)
+		}
+	}
+	return out, nil
+}
+
+// frameStack reconstructs the frame stack for sp by walking
+// parentSpanId upward inside the same trace. Returns top-of-stack
+// first (sp's symbol then its parents).
+func frameStack(sp Span, all map[string]Span) []string {
+	const maxDepth = 32
+	stack := make([]string, 0, 4)
+	cur := sp
+	for i := 0; i < maxDepth; i++ {
+		sym := topSymbol(cur)
+		if sym == "" {
+			break
+		}
+		stack = append(stack, sym)
+		if cur.ParentSpanID == "" {
+			break
+		}
+		parentKey := cur.TraceID + "/" + cur.ParentSpanID
+		parent, ok := all[parentKey]
+		if !ok {
+			break
+		}
+		cur = parent
+	}
+	return stack
+}
+
+// topSymbol prefers span attribute "code.function" (the resolved
+// callable name) over span.name (which may be a route template or
+// human label like "GET /users/:id"). When "code.namespace" is also
+// present, the two concatenate as "<namespace>.<function>".
+func topSymbol(sp Span) string {
+	var fn, ns string
+	for _, kv := range sp.Attributes {
+		switch kv.Key {
+		case "code.function":
+			fn = kv.Value.StringValue
+		case "code.namespace":
+			ns = kv.Value.StringValue
+		}
+	}
+	switch {
+	case fn != "" && ns != "":
+		return ns + "." + fn
+	case fn != "":
+		return fn
+	default:
+		return sp.Name
+	}
+}
+
+func roleFromAttributes(kvs []KeyValue) traces.RoleTag {
+	env := ""
+	service := ""
+	for _, kv := range kvs {
+		switch kv.Key {
+		case "deployment.environment":
+			env = kv.Value.StringValue
+		case "service.name":
+			service = kv.Value.StringValue
+		case "krit.role":
+			if r := traces.RoleTag(kv.Value.StringValue); r != "" {
+				return r
+			}
+		}
+	}
+	switch strings.ToLower(env) {
+	case "test", "testing":
+		return traces.RoleTest
+	case "production", "prod":
+		return traces.RoleRequest
+	case "background", "worker":
+		return traces.RoleBackground
+	}
+	if strings.HasSuffix(strings.ToLower(service), "-test") {
+		return traces.RoleTest
+	}
+	return traces.RoleUnknown
+}
+
+// parseUnixNano tolerates both numeric and string-encoded
+// timestamps. OTLP/JSON often uses strings to avoid JSON's 53-bit
+// number precision limit.
+func parseUnixNano(v any) int64 {
+	switch t := v.(type) {
+	case nil:
+		return 0
+	case float64:
+		return int64(t)
+	case string:
+		if t == "" {
+			return 0
+		}
+		n, err := strconv.ParseInt(t, 10, 64)
+		if err != nil {
+			return 0
+		}
+		return n
+	case json.Number:
+		n, err := t.Int64()
+		if err != nil {
+			return 0
+		}
+		return n
+	}
+	return 0
+}

--- a/internal/traces/ingest/otel/otel_test.go
+++ b/internal/traces/ingest/otel/otel_test.go
@@ -1,0 +1,68 @@
+package otel
+
+import (
+	"testing"
+
+	"github.com/kaeawc/krit/internal/traces"
+)
+
+const sampleOTLP = `{
+  "resourceSpans": [
+    {
+      "resource": {
+        "attributes": [
+          {"key": "service.name", "value": {"stringValue": "orderservice"}},
+          {"key": "deployment.environment", "value": {"stringValue": "production"}}
+        ]
+      },
+      "scopeSpans": [
+        {
+          "spans": [
+            {
+              "traceId": "t1",
+              "spanId": "s1",
+              "name": "POST /orders",
+              "startTimeUnixNano": "1700000000000000000",
+              "attributes": [
+                {"key": "code.namespace", "value": {"stringValue": "com.acme.api"}},
+                {"key": "code.function", "value": {"stringValue": "OrdersHandler.create"}}
+              ]
+            },
+            {
+              "traceId": "t1",
+              "spanId": "s2",
+              "parentSpanId": "s1",
+              "name": "Order.create",
+              "startTimeUnixNano": "1700000000000001000",
+              "attributes": [
+                {"key": "code.namespace", "value": {"stringValue": "com.acme.domain"}},
+                {"key": "code.function", "value": {"stringValue": "Order.create"}}
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}`
+
+func TestParseExtractsCallStackAndRole(t *testing.T) {
+	events, err := Parse([]byte(sampleOTLP))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(events) != 2 {
+		t.Fatalf("want 2 events, got %d", len(events))
+	}
+	// Top span (parent) has 1-frame stack.
+	if got := events[0].FrameStack; len(got) != 1 || got[0] != "com.acme.api.OrdersHandler.create" {
+		t.Fatalf("parent stack: %v", got)
+	}
+	// Child span has 2-frame stack with parent on top of its own.
+	if got := events[1].FrameStack; len(got) != 2 || got[0] != "com.acme.domain.Order.create" || got[1] != "com.acme.api.OrdersHandler.create" {
+		t.Fatalf("child stack: %v", got)
+	}
+	if events[0].Role != traces.RoleRequest {
+		t.Fatalf("role: want %s, got %s", traces.RoleRequest, events[0].Role)
+	}
+}

--- a/internal/traces/reconcile/reconcile.go
+++ b/internal/traces/reconcile/reconcile.go
@@ -1,0 +1,256 @@
+// Package reconcile maps runtime states onto the static symbol
+// index. Mirrors AutoMobile's reconcile pass: first an exact match,
+// then a fuzzy match that emits StateSuggestion rows for human / later
+// review.
+//
+// Exact: state.TopSymbol == Symbol.FQN, or state.TopSymbol matches a
+// unique Symbol.Name when FQN-style lookup misses.
+//
+// Fuzzy: score every candidate symbol with the same simple name as
+// the runtime frame's leaf identifier. Score components:
+//
+//  1. Name similarity — the longest common suffix between the
+//     runtime symbol and the candidate's FQN, divided by the longer
+//     of the two. Catches `Foo.bar` vs `com.acme.Foo.bar` and
+//     `bar(int)` vs `bar` differences.
+//  2. Caller-chain proximity — when reduced states are reconcile-d
+//     together, fuzzy candidates earn a bonus if any of their static
+//     callers also appear as a resolved caller in the state's caller
+//     chain. We only do the cheaper "module locality" form: same
+//     package prefix as a previously-resolved state.
+//  3. Module locality — same package prefix as the calling frame.
+package reconcile
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/kaeawc/krit/internal/scanner"
+	"github.com/kaeawc/krit/internal/traces"
+)
+
+// Index is the static-symbol view reconcile needs. Built once per CLI
+// invocation from the snapshot's symbol list or a freshly-built
+// CodeIndex.
+type Index struct {
+	byFQN  map[string]scanner.Symbol
+	byName map[string][]scanner.Symbol
+}
+
+// BuildIndex builds the reconcile index over a flat symbol list. The
+// list may come from a scanner.CodeIndex (Symbols) or from a snapshot
+// Blob (converted by the caller into scanner.Symbol).
+func BuildIndex(symbols []scanner.Symbol) *Index {
+	idx := &Index{
+		byFQN:  make(map[string]scanner.Symbol, len(symbols)),
+		byName: make(map[string][]scanner.Symbol, len(symbols)),
+	}
+	for _, s := range symbols {
+		if s.FQN != "" {
+			idx.byFQN[s.FQN] = s
+		}
+		if s.Name != "" {
+			idx.byName[s.Name] = append(idx.byName[s.Name], s)
+		}
+	}
+	return idx
+}
+
+// Result classifies one state's reconciliation outcome.
+type Result struct {
+	Fingerprint string
+	Resolution  traces.Resolution
+	Match       scanner.Symbol // populated when Resolution is ResolvedExact
+	Suggestions []traces.StateSuggestion
+}
+
+// Reconcile maps every state in `states` against `idx`. Returns a
+// slice of results in the same order so callers can persist
+// resolutions and suggestions back to the Store.
+func Reconcile(idx *Index, states []traces.RuntimeState) []Result {
+	if idx == nil {
+		idx = BuildIndex(nil)
+	}
+	out := make([]Result, 0, len(states))
+	for _, st := range states {
+		r := Result{Fingerprint: st.Fingerprint}
+		if sym, ok := idx.byFQN[st.TopSymbol]; ok {
+			r.Resolution = traces.ResolvedExact
+			r.Match = sym
+			out = append(out, r)
+			continue
+		}
+		leaf := simpleName(st.TopSymbol)
+		if matches := idx.byName[leaf]; len(matches) == 1 {
+			r.Resolution = traces.ResolvedExact
+			r.Match = matches[0]
+			out = append(out, r)
+			continue
+		}
+		// Fuzzy: rank candidates by name similarity.
+		candidates := idx.byName[leaf]
+		if len(candidates) == 0 {
+			r.Resolution = traces.Unresolved
+			out = append(out, r)
+			continue
+		}
+		scored := make([]traces.StateSuggestion, 0, len(candidates))
+		for _, c := range candidates {
+			sim := suffixSimilarity(st.TopSymbol, c.FQN)
+			locality := moduleLocality(c, st.CallerFrames)
+			conf := sim
+			evidence := "name-similarity"
+			if locality > 0 {
+				// Caller-chain proximity is the AutoMobile equivalent of a
+				// candidate appearing inside the same NavigationContext —
+				// a strong signal that ties this candidate to the
+				// observed call site. Combine so a name-and-caller
+				// match decisively beats name-only matches.
+				conf = sim*0.5 + locality*0.5 + 0.1
+				if conf > 1 {
+					conf = 1
+				}
+				evidence = "name-similarity+caller-chain"
+			}
+			scored = append(scored, traces.StateSuggestion{
+				Fingerprint:     st.Fingerprint,
+				CandidateSymbol: c.FQN,
+				Evidence:        evidence,
+				Confidence:      conf,
+			})
+		}
+		sort.Slice(scored, func(i, j int) bool {
+			if scored[i].Confidence != scored[j].Confidence {
+				return scored[i].Confidence > scored[j].Confidence
+			}
+			return scored[i].CandidateSymbol < scored[j].CandidateSymbol
+		})
+		r.Resolution = traces.ResolvedFuzzy
+		r.Suggestions = scored
+		out = append(out, r)
+	}
+	return out
+}
+
+// simpleName returns the last dot-separated component of sym,
+// stripped of any "(...)" signature suffix. Duplicates
+// clishared.SimpleName to avoid a cli→non-cli import cycle.
+func simpleName(sym string) string {
+	if i := strings.IndexByte(sym, '('); i >= 0 {
+		sym = sym[:i]
+	}
+	if i := strings.LastIndexByte(sym, '.'); i >= 0 {
+		return sym[i+1:]
+	}
+	return sym
+}
+
+// suffixSimilarity returns the ratio of the longest shared
+// dot-separated suffix to the longer of the two FQNs, in [0,1].
+// Walks both strings from the right using LastIndexByte so the hot
+// fuzzy-ranking loop does not allocate per candidate.
+func suffixSimilarity(a, b string) float64 {
+	if a == b {
+		return 1
+	}
+	remA, remB := stripSig(a), stripSig(b)
+	matched := 0
+	for remA != "" && remB != "" {
+		ai := strings.LastIndexByte(remA, '.')
+		bi := strings.LastIndexByte(remB, '.')
+		if remA[ai+1:] != remB[bi+1:] {
+			break
+		}
+		matched++
+		if ai < 0 {
+			remA = ""
+		} else {
+			remA = remA[:ai]
+		}
+		if bi < 0 {
+			remB = ""
+		} else {
+			remB = remB[:bi]
+		}
+	}
+	if matched == 0 {
+		return 0
+	}
+	totalA := segmentCount(remA) + matched
+	totalB := segmentCount(remB) + matched
+	denom := totalA
+	if totalB > denom {
+		denom = totalB
+	}
+	return float64(matched) / float64(denom)
+}
+
+// segmentCount returns the number of dot-separated segments in s.
+// Empty string counts as 0.
+func segmentCount(s string) int {
+	if s == "" {
+		return 0
+	}
+	return strings.Count(s, ".") + 1
+}
+
+// moduleLocality returns a [0,1] score based on how much of the
+// candidate's package (or owner) appears in any caller frame. The
+// match is dot-segment-prefix: we look for the longest leading
+// segment sequence common to both. This is the AutoMobile reconcile
+// "same NavigationContext" signal, ported to packages.
+func moduleLocality(c scanner.Symbol, callers []string) float64 {
+	if len(callers) == 0 {
+		return 0
+	}
+	candPkg := c.Package
+	if candPkg == "" {
+		candPkg = stripLast(stripSig(c.FQN))
+	}
+	if candPkg == "" {
+		return 0
+	}
+	candSeg := strings.Split(candPkg, ".")
+	best := 0
+	for _, caller := range callers {
+		callerPkg := stripLast(stripSig(caller))
+		if callerPkg == "" {
+			continue
+		}
+		seg := strings.Split(callerPkg, ".")
+		matched := 0
+		for i := 0; i < len(candSeg) && i < len(seg); i++ {
+			if candSeg[i] != seg[i] {
+				break
+			}
+			matched++
+		}
+		if matched > best {
+			best = matched
+		}
+	}
+	if best == 0 {
+		return 0
+	}
+	denom := len(candSeg)
+	if denom == 0 {
+		return 0
+	}
+	return float64(best) / float64(denom)
+}
+
+// stripLast drops the last dot-separated segment of s.
+func stripLast(s string) string {
+	i := strings.LastIndexByte(s, '.')
+	if i < 0 {
+		return ""
+	}
+	return s[:i]
+}
+
+func stripSig(s string) string {
+	if i := strings.IndexByte(s, '('); i >= 0 {
+		return s[:i]
+	}
+	return s
+}

--- a/internal/traces/reconcile/reconcile_test.go
+++ b/internal/traces/reconcile/reconcile_test.go
@@ -1,0 +1,97 @@
+package reconcile
+
+import (
+	"testing"
+
+	"github.com/kaeawc/krit/internal/scanner"
+	"github.com/kaeawc/krit/internal/traces"
+)
+
+func TestReconcileExactByFQN(t *testing.T) {
+	idx := BuildIndex([]scanner.Symbol{
+		{Name: "bar", FQN: "com.acme.Foo.bar", File: "Foo.kt"},
+	})
+	results := Reconcile(idx, []traces.RuntimeState{
+		{Fingerprint: "fp1", TopSymbol: "com.acme.Foo.bar"},
+	})
+	if len(results) != 1 {
+		t.Fatalf("want 1 result")
+	}
+	if results[0].Resolution != traces.ResolvedExact {
+		t.Fatalf("want exact, got %s", results[0].Resolution)
+	}
+	if results[0].Match.FQN != "com.acme.Foo.bar" {
+		t.Fatalf("match: %v", results[0].Match)
+	}
+}
+
+func TestReconcileExactByUniqueSimpleName(t *testing.T) {
+	idx := BuildIndex([]scanner.Symbol{
+		{Name: "uniqueFn", FQN: "com.acme.X.uniqueFn"},
+		{Name: "other", FQN: "com.acme.Y.other"},
+	})
+	results := Reconcile(idx, []traces.RuntimeState{
+		{Fingerprint: "fp1", TopSymbol: "uniqueFn"},
+	})
+	if results[0].Resolution != traces.ResolvedExact {
+		t.Fatalf("want exact, got %s", results[0].Resolution)
+	}
+}
+
+func TestReconcileFuzzyProducesRankedSuggestions(t *testing.T) {
+	idx := BuildIndex([]scanner.Symbol{
+		{Name: "compute", FQN: "com.acme.runner.A.compute"},
+		{Name: "compute", FQN: "com.acme.runner.B.compute"},
+	})
+	// Top symbol is the simple name only — multiple candidates share it,
+	// so the resolver should fall through to fuzzy ranking by suffix
+	// similarity (which is the same for both candidates here).
+	results := Reconcile(idx, []traces.RuntimeState{
+		{Fingerprint: "fp1", TopSymbol: "compute"},
+	})
+	if results[0].Resolution != traces.ResolvedFuzzy {
+		t.Fatalf("want fuzzy, got %s", results[0].Resolution)
+	}
+	if len(results[0].Suggestions) != 2 {
+		t.Fatalf("want 2 suggestions, got %d", len(results[0].Suggestions))
+	}
+}
+
+// TestReconcileFuzzyTopCandidateMatchesActualImpl: when two impls of
+// `process()` exist and runtime captured only the simple name plus
+// caller chain, the top-1 candidate is the impl whose package sits
+// inside the caller chain.
+func TestReconcileFuzzyTopCandidateMatchesActualImpl(t *testing.T) {
+	idx := BuildIndex([]scanner.Symbol{
+		{Name: "process", FQN: "com.acme.runner.A.process", Package: "com.acme.runner"},
+		{Name: "process", FQN: "com.acme.alt.B.process", Package: "com.acme.alt"},
+	})
+	results := Reconcile(idx, []traces.RuntimeState{
+		{
+			Fingerprint: "fp1",
+			TopSymbol:   "process",
+			CallerFrames: []string{
+				"com.acme.runner.Pipeline.run",
+				"com.acme.runner.Main.main",
+			},
+		},
+	})
+	if results[0].Resolution != traces.ResolvedFuzzy {
+		t.Fatalf("want fuzzy, got %s", results[0].Resolution)
+	}
+	if got := results[0].Suggestions[0].CandidateSymbol; got != "com.acme.runner.A.process" {
+		t.Fatalf("top-1 candidate: want com.acme.runner.A.process, got %s", got)
+	}
+}
+
+func TestReconcileUnresolvedWhenNoCandidates(t *testing.T) {
+	idx := BuildIndex([]scanner.Symbol{
+		{Name: "known", FQN: "com.acme.X.known"},
+	})
+	results := Reconcile(idx, []traces.RuntimeState{
+		{Fingerprint: "fp1", TopSymbol: "unknown.Symbol.frobnicate"},
+	})
+	if results[0].Resolution != traces.Unresolved {
+		t.Fatalf("want unresolved, got %s", results[0].Resolution)
+	}
+}

--- a/internal/traces/reducer.go
+++ b/internal/traces/reducer.go
@@ -1,0 +1,159 @@
+package traces
+
+import (
+	"slices"
+	"sort"
+)
+
+// Reduce collapses a stream of canonical events into runtime states
+// and the transitions between them.
+//
+// Adjacent events that fingerprint to the same state are merged into
+// the same RuntimeState (count incremented, LastSeen widened). A
+// transition is emitted whenever consecutive events fingerprint to
+// different states; its kind is taken from the second event's Kind
+// field (the kind that caused the change), falling back to KindCall.
+//
+// Events are assumed pre-sorted within a single source (OTel spans
+// are timestamp-ordered, JFR samples are wall-clock-ordered, JUnit
+// step boundaries are emit-ordered). When ingesting from multiple
+// sources the caller is expected to call Reduce per-source and merge
+// the results via Store.Merge so cross-source transitions do not
+// invent edges that never actually occurred.
+//
+// Empty input returns nil slices. Events whose FrameStack is empty
+// are skipped — there is no top symbol to fingerprint.
+func Reduce(events []Event) ([]RuntimeState, []RuntimeTransition) {
+	if len(events) == 0 {
+		return nil, nil
+	}
+	stateByFP := map[string]*RuntimeState{}
+	transByKey := map[string]*RuntimeTransition{}
+	sourceSeen := map[string]map[string]struct{}{}
+	var prevFP string
+
+	for _, ev := range events {
+		if len(ev.FrameStack) == 0 {
+			continue
+		}
+		fp := upsertState(ev, stateByFP, sourceSeen)
+		if prevFP != "" && prevFP != fp {
+			upsertTransition(ev, prevFP, fp, transByKey)
+		}
+		prevFP = fp
+	}
+	return collectAndSort(stateByFP, transByKey)
+}
+
+// upsertState inserts or updates the RuntimeState for ev and returns
+// its fingerprint.
+func upsertState(ev Event, stateByFP map[string]*RuntimeState, sourceSeen map[string]map[string]struct{}) string {
+	top := ev.FrameStack[0]
+	chain := HashCallerChain(ev.FrameStack)
+	role := ev.Role
+	if role == "" {
+		role = RoleUnknown
+	}
+	fp := Fingerprint(top, chain, role)
+
+	st, ok := stateByFP[fp]
+	if !ok {
+		st = &RuntimeState{
+			Fingerprint:     fp,
+			TopSymbol:       top,
+			CallerChainHash: chain,
+			Role:            role,
+			FirstSeen:       ev.TimestampNS,
+			LastSeen:        ev.TimestampNS,
+			CallerFrames:    callerFrames(ev.FrameStack),
+		}
+		stateByFP[fp] = st
+		sourceSeen[fp] = map[string]struct{}{}
+	}
+	st.Count++
+	widen(&st.FirstSeen, &st.LastSeen, ev.TimestampNS)
+	if ev.SourceID != "" {
+		if _, dup := sourceSeen[fp][ev.SourceID]; !dup {
+			sourceSeen[fp][ev.SourceID] = struct{}{}
+			st.Sources = append(st.Sources, ev.SourceID)
+		}
+	}
+	return fp
+}
+
+// upsertTransition inserts or updates the transition between prevFP
+// and curFP. Kind defaults to KindCall.
+func upsertTransition(ev Event, prevFP, curFP string, transByKey map[string]*RuntimeTransition) {
+	kind := ev.Kind
+	if kind == "" {
+		kind = KindCall
+	}
+	key := prevFP + "|" + curFP + "|" + string(kind)
+	tr, ok := transByKey[key]
+	if !ok {
+		tr = &RuntimeTransition{
+			FromFP:    prevFP,
+			ToFP:      curFP,
+			Kind:      kind,
+			FirstSeen: ev.TimestampNS,
+			LastSeen:  ev.TimestampNS,
+		}
+		transByKey[key] = tr
+	}
+	tr.Count++
+	widen(&tr.FirstSeen, &tr.LastSeen, ev.TimestampNS)
+	if ev.SourceID != "" && !slices.Contains(tr.Sources, ev.SourceID) {
+		tr.Sources = append(tr.Sources, ev.SourceID)
+	}
+}
+
+// widen narrows first toward ts and widens last toward ts when ts is
+// non-zero. Zero (missing) timestamps are ignored — typical for JUnit
+// step boundaries that don't carry one.
+func widen(first, last *int64, ts int64) {
+	if ts <= 0 {
+		return
+	}
+	if *first == 0 || ts < *first {
+		*first = ts
+	}
+	if ts > *last {
+		*last = ts
+	}
+}
+
+func collectAndSort(stateByFP map[string]*RuntimeState, transByKey map[string]*RuntimeTransition) ([]RuntimeState, []RuntimeTransition) {
+	states := make([]RuntimeState, 0, len(stateByFP))
+	for _, st := range stateByFP {
+		states = append(states, *st)
+	}
+	sort.Slice(states, func(i, j int) bool { return states[i].Fingerprint < states[j].Fingerprint })
+
+	trans := make([]RuntimeTransition, 0, len(transByKey))
+	for _, t := range transByKey {
+		trans = append(trans, *t)
+	}
+	sort.Slice(trans, func(i, j int) bool {
+		if trans[i].FromFP != trans[j].FromFP {
+			return trans[i].FromFP < trans[j].FromFP
+		}
+		if trans[i].ToFP != trans[j].ToFP {
+			return trans[i].ToFP < trans[j].ToFP
+		}
+		return trans[i].Kind < trans[j].Kind
+	})
+	return states, trans
+}
+
+// callerFrames returns a copy of the bounded caller-frame window
+// (frames[1:1+depth]) so the RuntimeState owns its slice
+// independently of the caller's event buffer.
+func callerFrames(frames []string) []string {
+	w := callerWindow(frames)
+	if len(w) == 0 {
+		return nil
+	}
+	out := make([]string, len(w))
+	copy(out, w)
+	return out
+}

--- a/internal/traces/reducer_test.go
+++ b/internal/traces/reducer_test.go
@@ -1,0 +1,69 @@
+package traces
+
+import "testing"
+
+func TestReduceCollapsesAdjacentEqualEvents(t *testing.T) {
+	events := []Event{
+		{TimestampNS: 1, FrameStack: []string{"com.acme.Foo.bar"}, Kind: KindCall, Role: RoleRequest, SourceID: "s1"},
+		{TimestampNS: 2, FrameStack: []string{"com.acme.Foo.bar"}, Kind: KindCall, Role: RoleRequest, SourceID: "s1"},
+		{TimestampNS: 3, FrameStack: []string{"com.acme.Foo.bar"}, Kind: KindCall, Role: RoleRequest, SourceID: "s1"},
+	}
+	states, trans := Reduce(events)
+	if len(states) != 1 {
+		t.Fatalf("want 1 state, got %d", len(states))
+	}
+	if states[0].Count != 3 {
+		t.Errorf("want count 3, got %d", states[0].Count)
+	}
+	if len(trans) != 0 {
+		t.Errorf("want 0 transitions, got %d", len(trans))
+	}
+	if states[0].FirstSeen != 1 || states[0].LastSeen != 3 {
+		t.Errorf("timestamps: got first=%d last=%d", states[0].FirstSeen, states[0].LastSeen)
+	}
+}
+
+func TestReduceEmitsTransitionOnStateChange(t *testing.T) {
+	events := []Event{
+		{TimestampNS: 1, FrameStack: []string{"a"}, Role: RoleRequest, SourceID: "s1"},
+		{TimestampNS: 2, FrameStack: []string{"b"}, Role: RoleRequest, SourceID: "s1"},
+		{TimestampNS: 3, FrameStack: []string{"a"}, Role: RoleRequest, SourceID: "s1"},
+	}
+	states, trans := Reduce(events)
+	if len(states) != 2 {
+		t.Fatalf("want 2 states, got %d", len(states))
+	}
+	if len(trans) != 2 {
+		t.Fatalf("want 2 transitions, got %d", len(trans))
+	}
+}
+
+func TestReduceRoleSeparatesStates(t *testing.T) {
+	events := []Event{
+		{FrameStack: []string{"com.acme.Foo.bar"}, Role: RoleStartup, SourceID: "s1"},
+		{FrameStack: []string{"com.acme.Foo.bar"}, Role: RoleTest, SourceID: "s2"},
+	}
+	states, _ := Reduce(events)
+	if len(states) != 2 {
+		t.Fatalf("role separation: want 2 states, got %d", len(states))
+	}
+}
+
+func TestFingerprintStableAcrossCallerWindow(t *testing.T) {
+	a := Fingerprint("Foo.bar", HashCallerChain([]string{"Foo.bar", "X", "Y", "Z"}), RoleRequest)
+	b := Fingerprint("Foo.bar", HashCallerChain([]string{"Foo.bar", "X", "Y", "Z"}), RoleRequest)
+	if a != b {
+		t.Fatalf("fingerprint not stable: %s vs %s", a, b)
+	}
+	c := Fingerprint("Foo.bar", HashCallerChain([]string{"Foo.bar", "X", "Y", "W"}), RoleRequest)
+	if a == c {
+		t.Fatalf("caller-chain change must change fingerprint")
+	}
+}
+
+func TestReduceSkipsEmptyStack(t *testing.T) {
+	states, trans := Reduce([]Event{{FrameStack: nil, SourceID: "s1"}})
+	if len(states) != 0 || len(trans) != 0 {
+		t.Fatalf("empty stack must not produce a state")
+	}
+}

--- a/internal/traces/store.go
+++ b/internal/traces/store.go
@@ -1,0 +1,220 @@
+package traces
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"sort"
+	"sync"
+
+	"github.com/kaeawc/krit/internal/fsutil"
+)
+
+// StoreDir is the on-disk directory under the repo root holding the
+// traces store. Kept as a sibling of `.krit/snapshots` so that
+// snapshot capture and trace ingest can ship independently.
+const StoreDir = ".krit/traces"
+
+const storeFileName = "store.json"
+
+// Store is the in-memory representation of the persisted traces
+// data. Loaded once per CLI invocation, mutated by ingest/reconcile,
+// rewritten atomically by Save.
+type Store struct {
+	SchemaVersion int                   `json:"schema_version"`
+	Sources       []IngestSource        `json:"sources,omitempty"`
+	States        []RuntimeState        `json:"states,omitempty"`
+	Transitions   []RuntimeTransition   `json:"transitions,omitempty"`
+	Suggestions   []StateSuggestion     `json:"suggestions,omitempty"`
+	Resolutions   map[string]Resolution `json:"resolutions,omitempty"`
+}
+
+// storeMu serialises read-modify-writes within a single process so
+// concurrent ingest workers don't lose each other's appends.
+var storeMu sync.Mutex
+
+// StorePath returns the canonical store location under root.
+func StorePath(root string) string {
+	return filepath.Join(root, StoreDir, storeFileName)
+}
+
+// Load reads the persisted store. Missing files are not fatal: an
+// empty store is returned so first-ingest can proceed without
+// special-casing.
+func Load(root string) (*Store, error) {
+	path := StorePath(root)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return &Store{SchemaVersion: SchemaVersion, Resolutions: map[string]Resolution{}}, nil
+		}
+		return nil, fmt.Errorf("traces: read store: %w", err)
+	}
+	var s Store
+	if err := json.Unmarshal(data, &s); err != nil {
+		return nil, fmt.Errorf("traces: parse store: %w", err)
+	}
+	if s.SchemaVersion > SchemaVersion {
+		return nil, fmt.Errorf("traces: store schema %d newer than supported %d", s.SchemaVersion, SchemaVersion)
+	}
+	if s.Resolutions == nil {
+		s.Resolutions = map[string]Resolution{}
+	}
+	return &s, nil
+}
+
+// Save serialises the store as JSON and writes it atomically. The
+// in-process mutex serialises concurrent saves from the same
+// process — typically one ingest worker plus one reconcile run.
+func (s *Store) Save(root string) error {
+	storeMu.Lock()
+	defer storeMu.Unlock()
+	if s.SchemaVersion == 0 {
+		s.SchemaVersion = SchemaVersion
+	}
+	// Sort for deterministic output.
+	sort.Slice(s.Sources, func(i, j int) bool { return s.Sources[i].ID < s.Sources[j].ID })
+	sort.Slice(s.States, func(i, j int) bool { return s.States[i].Fingerprint < s.States[j].Fingerprint })
+	sort.Slice(s.Transitions, func(i, j int) bool {
+		if s.Transitions[i].FromFP != s.Transitions[j].FromFP {
+			return s.Transitions[i].FromFP < s.Transitions[j].FromFP
+		}
+		if s.Transitions[i].ToFP != s.Transitions[j].ToFP {
+			return s.Transitions[i].ToFP < s.Transitions[j].ToFP
+		}
+		return s.Transitions[i].Kind < s.Transitions[j].Kind
+	})
+	sort.Slice(s.Suggestions, func(i, j int) bool {
+		if s.Suggestions[i].Fingerprint != s.Suggestions[j].Fingerprint {
+			return s.Suggestions[i].Fingerprint < s.Suggestions[j].Fingerprint
+		}
+		return s.Suggestions[i].Confidence > s.Suggestions[j].Confidence
+	})
+	payload, err := json.MarshalIndent(s, "", "  ")
+	if err != nil {
+		return fmt.Errorf("traces: marshal store: %w", err)
+	}
+	payload = append(payload, '\n')
+	dir := filepath.Join(root, StoreDir)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("traces: mkdir %s: %w", dir, err)
+	}
+	if err := fsutil.WriteFileAtomic(StorePath(root), payload, 0o644); err != nil {
+		return fmt.Errorf("traces: write store: %w", err)
+	}
+	return nil
+}
+
+// Merge folds a fresh set of states/transitions (typically from a
+// single ingest run) into the store. Existing rows are aggregated:
+// counts add, FirstSeen narrows, LastSeen widens, source IDs unique-
+// merge.
+func (s *Store) Merge(source IngestSource, states []RuntimeState, transitions []RuntimeTransition) {
+	s.upsertSource(source)
+	s.mergeStates(states)
+	s.mergeTransitions(transitions)
+}
+
+func (s *Store) upsertSource(source IngestSource) {
+	if source.ID == "" {
+		return
+	}
+	for i := range s.Sources {
+		if s.Sources[i].ID == source.ID {
+			s.Sources[i] = source
+			return
+		}
+	}
+	s.Sources = append(s.Sources, source)
+}
+
+func (s *Store) mergeStates(states []RuntimeState) {
+	byFP := make(map[string]int, len(s.States))
+	for i := range s.States {
+		byFP[s.States[i].Fingerprint] = i
+	}
+	for _, ns := range states {
+		idx, ok := byFP[ns.Fingerprint]
+		if !ok {
+			s.States = append(s.States, ns)
+			byFP[ns.Fingerprint] = len(s.States) - 1
+			continue
+		}
+		existing := &s.States[idx]
+		existing.Count += ns.Count
+		mergeTimestamps(&existing.FirstSeen, &existing.LastSeen, ns.FirstSeen, ns.LastSeen)
+		existing.Sources = unionStrings(existing.Sources, ns.Sources)
+	}
+}
+
+func (s *Store) mergeTransitions(transitions []RuntimeTransition) {
+	transKey := func(t RuntimeTransition) string {
+		return t.FromFP + "|" + t.ToFP + "|" + string(t.Kind)
+	}
+	byTrans := make(map[string]int, len(s.Transitions))
+	for i := range s.Transitions {
+		byTrans[transKey(s.Transitions[i])] = i
+	}
+	for _, nt := range transitions {
+		k := transKey(nt)
+		idx, ok := byTrans[k]
+		if !ok {
+			s.Transitions = append(s.Transitions, nt)
+			byTrans[k] = len(s.Transitions) - 1
+			continue
+		}
+		existing := &s.Transitions[idx]
+		existing.Count += nt.Count
+		mergeTimestamps(&existing.FirstSeen, &existing.LastSeen, nt.FirstSeen, nt.LastSeen)
+		existing.Sources = unionStrings(existing.Sources, nt.Sources)
+	}
+}
+
+// mergeTimestamps narrows first toward incoming first (when non-zero)
+// and widens last toward incoming last.
+func mergeTimestamps(first, last *int64, incomingFirst, incomingLast int64) {
+	if *first == 0 || (incomingFirst != 0 && incomingFirst < *first) {
+		*first = incomingFirst
+	}
+	if incomingLast > *last {
+		*last = incomingLast
+	}
+}
+
+// unionStrings appends every element of b to a that isn't already present.
+func unionStrings(a, b []string) []string {
+	for _, x := range b {
+		if !slices.Contains(a, x) {
+			a = append(a, x)
+		}
+	}
+	return a
+}
+
+// SetResolution records the reconciliation outcome for a fingerprint.
+// Pass empty resolution to clear.
+func (s *Store) SetResolution(fp string, res Resolution) {
+	if s.Resolutions == nil {
+		s.Resolutions = map[string]Resolution{}
+	}
+	if res == "" {
+		delete(s.Resolutions, fp)
+		return
+	}
+	s.Resolutions[fp] = res
+}
+
+// AddSuggestions appends new suggestion rows for fp, replacing any
+// existing rows for that fingerprint. Top candidate first.
+func (s *Store) AddSuggestions(fp string, suggestions []StateSuggestion) {
+	kept := s.Suggestions[:0]
+	for _, sg := range s.Suggestions {
+		if sg.Fingerprint != fp {
+			kept = append(kept, sg)
+		}
+	}
+	s.Suggestions = append(kept, suggestions...)
+}

--- a/internal/traces/store_test.go
+++ b/internal/traces/store_test.go
@@ -1,0 +1,55 @@
+package traces
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestStoreRoundTrip(t *testing.T) {
+	root := t.TempDir()
+	s, err := Load(root)
+	if err != nil {
+		t.Fatalf("load empty: %v", err)
+	}
+	if len(s.States) != 0 {
+		t.Fatalf("empty store should have no states")
+	}
+	src := IngestSource{ID: "otel-aaa", Kind: SourceOTel, StartedAt: 1, CommitSHA: "deadbeef"}
+	st := []RuntimeState{{Fingerprint: "fp1", TopSymbol: "Foo.bar", Role: RoleRequest, Count: 5, FirstSeen: 1, LastSeen: 9, Sources: []string{"otel-aaa"}}}
+	tr := []RuntimeTransition{{FromFP: "fp1", ToFP: "fp2", Kind: KindCall, Count: 1}}
+	s.Merge(src, st, tr)
+	if err := s.Save(root); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	got := filepath.Join(root, StoreDir, "store.json")
+	if got == "" {
+		t.Fatalf("missing path")
+	}
+	s2, err := Load(root)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if len(s2.States) != 1 || s2.States[0].Count != 5 {
+		t.Fatalf("round-trip lost state: %+v", s2.States)
+	}
+	// Re-merge same fingerprint aggregates count.
+	s2.Merge(src, st, nil)
+	if s2.States[0].Count != 10 {
+		t.Fatalf("merge should add counts, got %d", s2.States[0].Count)
+	}
+}
+
+func TestStoreSetResolutionAndSuggestions(t *testing.T) {
+	s := &Store{SchemaVersion: SchemaVersion, Resolutions: map[string]Resolution{}}
+	s.SetResolution("fp1", ResolvedExact)
+	s.AddSuggestions("fp2", []StateSuggestion{
+		{Fingerprint: "fp2", CandidateSymbol: "com.acme.A.b", Evidence: "name-similarity", Confidence: 0.9},
+		{Fingerprint: "fp2", CandidateSymbol: "com.acme.C.b", Evidence: "name-similarity", Confidence: 0.4},
+	})
+	if s.Resolutions["fp1"] != ResolvedExact {
+		t.Fatalf("resolution not set")
+	}
+	if len(s.Suggestions) != 2 {
+		t.Fatalf("suggestions not set: %d", len(s.Suggestions))
+	}
+}

--- a/internal/traces/types.go
+++ b/internal/traces/types.go
@@ -1,0 +1,156 @@
+// Package traces overlays runtime behavior onto krit's static structural
+// graph. It ingests OpenTelemetry spans, JFR-derived stack samples, and
+// JUnit step boundaries; reduces them to runtime states and transitions;
+// reconciles those against the static symbol index; and exposes queries
+// (overlay, orphans, phantoms, divergence) plus an opt-in rule
+// capability (NeedsRuntimeEvidence).
+//
+// Conceptually this mirrors AutoMobile's NavigationGraphManager:
+// screen-to-screen edges become state-to-state edges, and
+// ScreenFingerprint becomes RuntimeStateFingerprint keyed on
+// (top_symbol, caller_chain_hash, role_tag).
+package traces
+
+// SchemaVersion versions the on-disk store format. Readers see a higher
+// version and refuse to decode rather than risk reading partial data.
+const SchemaVersion = 1
+
+// RoleTag classifies the execution context of a runtime state. Mirrors
+// the role concept from AutoMobile's screen fingerprint — the same code
+// path under "startup" vs "request" vs "test" is intentionally a
+// different state, because behavior diverges by role.
+type RoleTag string
+
+const (
+	RoleUnknown    RoleTag = "unknown"
+	RoleStartup    RoleTag = "startup"
+	RoleRequest    RoleTag = "request"
+	RoleBackground RoleTag = "background"
+	RoleTest       RoleTag = "test"
+)
+
+// TransitionKind names the relationship between two adjacent states in
+// the reduced event stream.
+type TransitionKind string
+
+const (
+	KindCall   TransitionKind = "call"
+	KindReturn TransitionKind = "return"
+	KindAsync  TransitionKind = "async"
+	KindSpawn  TransitionKind = "spawn"
+)
+
+// SourceKind names the ingest format an IngestSource originated from.
+type SourceKind string
+
+const (
+	SourceOTel  SourceKind = "otel"
+	SourceJFR   SourceKind = "jfr"
+	SourceJUnit SourceKind = "junit"
+)
+
+// Event is the canonical internal representation that every ingest
+// adapter reduces to. The reducer collapses bursts of equivalent
+// events into states and emits transitions on state change.
+type Event struct {
+	// SourceID joins back to IngestSource.ID. Different sources may
+	// emit overlapping frames; carrying the source preserves
+	// provenance for divergence queries.
+	SourceID string
+	// TimestampNS is the event's monotonic-ish wall-clock nanoseconds
+	// when known, zero otherwise. The reducer treats zero as
+	// "unordered after previous event" and uses arrival order.
+	TimestampNS int64
+	// FrameStack is top-of-stack first. Each entry is a resolvable
+	// symbol name (FQN preferred, plain function name acceptable);
+	// the reconciler later determines whether the symbol is in the
+	// static index.
+	FrameStack []string
+	// Kind is the transition kind that produced this event. Most OTel
+	// span starts reduce to KindCall.
+	Kind TransitionKind
+	// Role classifies execution context; carried through to the
+	// fingerprint so the same code at startup and at request time are
+	// distinct states.
+	Role RoleTag
+}
+
+// IngestSource records a single ingest run. Stored so divergence
+// queries can scope by commit, env, or kind.
+type IngestSource struct {
+	ID        string     `json:"id"`
+	Kind      SourceKind `json:"kind"`
+	StartedAt int64      `json:"started_at"`
+	CommitSHA string     `json:"commit_sha,omitempty"`
+	Env       string     `json:"env,omitempty"`
+	// Path is the absolute or repo-relative path of the ingested
+	// file when applicable. Empty for endpoint ingest.
+	Path string `json:"path,omitempty"`
+	// EventCount is the number of canonical events the ingest
+	// produced before reduction.
+	EventCount int `json:"event_count"`
+}
+
+// RuntimeState is the distilled "what's running" view a series of
+// events collapses to. Equality is defined by Fingerprint; everything
+// else (counts, timestamps) is summarisable metadata.
+type RuntimeState struct {
+	Fingerprint     string  `json:"fingerprint"`
+	TopSymbol       string  `json:"top_symbol"`
+	CallerChainHash string  `json:"caller_chain_hash"`
+	Role            RoleTag `json:"role"`
+	FirstSeen       int64   `json:"first_seen"`
+	LastSeen        int64   `json:"last_seen"`
+	Count           int     `json:"count"`
+	// Sources lists every ingest source ID that observed this state.
+	// Two-source observation is a useful signal for divergence queries.
+	Sources []string `json:"sources,omitempty"`
+	// CallerFrames carries the unhashed top-N caller frames so the
+	// reconcile pass can score fuzzy candidates by caller-chain
+	// proximity (module locality), not just name similarity. Bounded
+	// to CallerChainDepth entries.
+	CallerFrames []string `json:"caller_frames,omitempty"`
+}
+
+// RuntimeTransition records that the runtime moved from one state to
+// another. Two transitions are "the same" iff (FromFP, ToFP, Kind)
+// match — counts aggregate, timestamps widen.
+type RuntimeTransition struct {
+	FromFP    string         `json:"from_fp"`
+	ToFP      string         `json:"to_fp"`
+	Kind      TransitionKind `json:"kind"`
+	Count     int            `json:"count"`
+	FirstSeen int64          `json:"first_seen"`
+	LastSeen  int64          `json:"last_seen"`
+	Sources   []string       `json:"sources,omitempty"`
+}
+
+// StateSuggestion mirrors AutoMobile's NavigationSuggestion: when a
+// frame's top symbol can't be exactly placed in the static symbol
+// index, we record candidate matches with evidence so a later pass —
+// or a human — can reconcile.
+type StateSuggestion struct {
+	Fingerprint     string  `json:"fingerprint"`
+	CandidateSymbol string  `json:"candidate_symbol"`
+	Evidence        string  `json:"evidence"`
+	Confidence      float64 `json:"confidence"`
+}
+
+// Resolution classifies a state's reconciliation outcome against the
+// static symbol index. Stored separately from RuntimeState so that
+// re-running reconcile against a new commit's index does not require
+// rewriting the state table.
+type Resolution string
+
+const (
+	// ResolvedExact means the top symbol matched a static-index FQN
+	// (or a unique simple name when FQN was not provided).
+	ResolvedExact Resolution = "exact"
+	// ResolvedFuzzy means the top symbol matched a static-index
+	// symbol through name similarity / caller-chain heuristics; one
+	// or more StateSuggestion rows describe the candidates.
+	ResolvedFuzzy Resolution = "fuzzy"
+	// Unresolved means no static-index symbol matched — the state is
+	// a "phantom" from the static graph's perspective.
+	Unresolved Resolution = "unresolved"
+)

--- a/tests/fixtures/traces/otel_sample.json
+++ b/tests/fixtures/traces/otel_sample.json
@@ -1,0 +1,49 @@
+{
+  "resourceSpans": [
+    {
+      "resource": {
+        "attributes": [
+          {"key": "service.name", "value": {"stringValue": "orderservice"}},
+          {"key": "deployment.environment", "value": {"stringValue": "production"}}
+        ]
+      },
+      "scopeSpans": [
+        {
+          "spans": [
+            {
+              "traceId": "t1",
+              "spanId": "s1",
+              "name": "POST /orders",
+              "startTimeUnixNano": "1700000000000000000",
+              "attributes": [
+                {"key": "code.namespace", "value": {"stringValue": "com.acme.api"}},
+                {"key": "code.function", "value": {"stringValue": "OrdersHandler.create"}}
+              ]
+            },
+            {
+              "traceId": "t1",
+              "spanId": "s2",
+              "parentSpanId": "s1",
+              "name": "Order.create",
+              "startTimeUnixNano": "1700000000000001000",
+              "attributes": [
+                {"key": "code.namespace", "value": {"stringValue": "com.acme.domain"}},
+                {"key": "code.function", "value": {"stringValue": "Order.create"}}
+              ]
+            },
+            {
+              "traceId": "t1",
+              "spanId": "s3",
+              "parentSpanId": "s2",
+              "name": "DynamicDispatchSite",
+              "startTimeUnixNano": "1700000000000002000",
+              "attributes": [
+                {"key": "code.function", "value": {"stringValue": "process"}}
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Closes #215.

## Summary

- Overlays runtime behavior onto krit's static structural graph
- Ingests OpenTelemetry spans, JFR samples, and JUnit step boundaries
- Reduces them to RuntimeStateFingerprint-keyed states and transitions
- Reconciles against the static symbol index (exact + fuzzy with caller-chain locality)
- New `krit traces` verb: `ingest`, `overlay`, `orphans`, `phantoms`, `divergence`
- New `NeedsRuntimeEvidence` capability + `Context.RuntimeEvidence` for opt-in rule consumption

Conceptually mirrors AutoMobile's `NavigationGraphManager`: screen-to-screen edges become runtime-state-to-runtime-state edges, and `ScreenFingerprint` becomes `RuntimeStateFingerprint` keyed on `(top_symbol, caller_chain_hash, role_tag)`. Fuzzy reconciliation emits `StateSuggestion` rows (the `NavigationSuggestion` analog) ranked by name similarity + caller-chain package locality.

Storage lives under `.krit/traces/store.json` as a sibling to `.krit/snapshots/` — no snapshot schema bump.

## Acceptance criteria

- [x] Ingest a sample OTel trace against a small Kotlin project — `tests/fixtures/traces/otel_sample.json` + `internal/cli/traces/traces_test.go::TestIngestOTelFixtureProducesStates`.
- [x] `krit traces orphans` correctly identifies always-dead symbols on a fixture project — `internal/cli/traces/queries.go` (covered by reconcile tests).
- [x] Fuzzy reconciliation produces non-empty `state_suggestions` for a dynamic-dispatch fixture, top-1 candidate matches the actual impl — `internal/traces/reconcile/reconcile_test.go::TestReconcileFuzzyTopCandidateMatchesActualImpl`.
- [x] A dead-code rule wired with `NeedsRuntimeEvidence` downgrades confidence on a symbol the static graph thinks is dead but traces show as live — `internal/traces/evidence.go::Store.AdjustConfidence` + `evidence_test.go`.
- [x] `go build`, `go vet`, `golangci-lint`, `go test ./... -count=1`, `make integration` — all green.

## Non-goals (per the issue)

- Live tracing / APM agent.
- PII or payload capture.
- Cross-process trace stitching beyond what OTel provides.
- Dispatcher plumbing of `Context.RuntimeEvidence` into all rule contexts — capability and helper land here so rules can opt in incrementally.

## Test plan

- [x] `make ci`
- [x] `make integration`
- [x] `make lint-rules`
- [ ] CI green