### PR TITLE
feat(cli): apply-suggestion verb for inspecting/applying selected suggested fixes (#243)

### DIFF
--- a/cmd/krit/verb_dispatch.go
+++ b/cmd/krit/verb_dispatch.go
@@ -5,6 +5,7 @@ import (
 
 	climabihash "github.com/kaeawc/krit/internal/cli/abihash"
 	climapi "github.com/kaeawc/krit/internal/cli/api"
+	climapplysuggestion "github.com/kaeawc/krit/internal/cli/applysuggestion"
 	climbisect "github.com/kaeawc/krit/internal/cli/bisect"
 	climblastradius "github.com/kaeawc/krit/internal/cli/blastradius"
 	climbreakage "github.com/kaeawc/krit/internal/cli/breakage"
@@ -79,6 +80,7 @@ const (
 	verbBisectStructure
 	verbDeltaRisk
 	verbTraces
+	verbApplySuggestion
 )
 
 var verbByName = map[string]subcommandVerb{
@@ -118,6 +120,7 @@ var verbByName = map[string]subcommandVerb{
 	"bisect-structure":   verbBisectStructure,
 	"delta-risk":         verbDeltaRisk,
 	"traces":             verbTraces,
+	"apply-suggestion":   verbApplySuggestion,
 }
 
 func classifyVerb(arg string) subcommandVerb {
@@ -222,6 +225,8 @@ func runVerbAndExitC(verb subcommandVerb, rest []string) bool {
 	switch verb {
 	case verbTraces:
 		os.Exit(climtraces.Run(rest))
+	case verbApplySuggestion:
+		os.Exit(climapplysuggestion.Run(rest))
 	}
 	return false
 }

--- a/internal/cli/applysuggestion/applysuggestion.go
+++ b/internal/cli/applysuggestion/applysuggestion.go
@@ -1,0 +1,307 @@
+// Package applysuggestion implements `krit apply-suggestion`, a CLI verb
+// that inspects and applies a single rule-emitted suggested fix from a
+// JSON findings report.
+//
+// Suggested fixes are intentionally separate from the autofix slot driven
+// by `krit --fix`: autofixes apply automatically while suggestions require
+// an explicit user/tool selection. This command provides that selection
+// surface — both for direct CLI use (`krit --format=json . > findings.json
+// && krit apply-suggestion --finding <id> --suggestion <id> findings.json`)
+// and for IDE/LSP wrappers that need a deterministic way to act on one
+// suggestion at a time.
+//
+// The command reuses the autofix application path (fixer.ApplyAllFixesColumns)
+// so cross-file edits, byte/line mode handling, overlap deduplication, and
+// ktfmt-shaped output stay consistent with `--fix`.
+package applysuggestion
+
+import (
+	"bufio"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/kaeawc/krit/internal/fixer"
+	"github.com/kaeawc/krit/internal/output"
+	"github.com/kaeawc/krit/internal/scanner"
+)
+
+func Run(args []string) int { return run(args, os.Stdin, os.Stdout, os.Stderr) }
+
+func run(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("apply-suggestion", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	fs.Usage = func() {
+		fmt.Fprintln(stderr, "usage: krit apply-suggestion [--list] [--finding ID --suggestion ID] [--dry-run] [--base DIR] [report.json|-]")
+		fs.PrintDefaults()
+	}
+	list := fs.Bool("list", false, "List findings with suggestions and their ids.")
+	dryRun := fs.Bool("dry-run", false, "Print the edits that would be applied without modifying any files.")
+	findingID := fs.String("finding", "", "Finding id (rule:file:line:column) to target. Required unless --list is set.")
+	suggestion := fs.String("suggestion", "", "Suggestion id to apply. Required unless --list is set.")
+	base := fs.String("base", "", "Base directory for resolving relative paths in the report (default: current directory).")
+	if err := fs.Parse(args); err != nil {
+		return 1
+	}
+
+	rest := fs.Args()
+	if len(rest) > 1 {
+		fmt.Fprintf(stderr, "apply-suggestion: expected at most one report path, got %d\n", len(rest))
+		return 1
+	}
+	source := ""
+	if len(rest) == 1 {
+		source = rest[0]
+	}
+
+	if !*list && (*findingID == "" || *suggestion == "") {
+		fmt.Fprintln(stderr, "apply-suggestion: --finding and --suggestion are required unless --list is given")
+		fs.Usage()
+		return 1
+	}
+
+	report, err := decodeReport(source, stdin)
+	if err != nil {
+		fmt.Fprintf(stderr, "apply-suggestion: %v\n", err)
+		return 1
+	}
+
+	if *list {
+		printSuggestionsList(stdout, report)
+		return 0
+	}
+
+	finding, ok := findFindingByID(report, *findingID)
+	if !ok {
+		writeStaleError(stderr, "finding", *findingID, listFindingIDsWithSuggestions(report))
+		return 1
+	}
+	sug, ok := findSuggestion(finding, *suggestion)
+	if !ok {
+		writeStaleError(stderr, "suggestion", *suggestion, listSuggestionIDs(finding))
+		return 1
+	}
+	if len(sug.Edits) == 0 {
+		fmt.Fprintf(stderr, "apply-suggestion: suggestion %q for finding %q is not machine-applicable (no edits)\n",
+			*suggestion, *findingID)
+		if sug.ApplicationToken != "" {
+			fmt.Fprintf(stderr, "  applicationToken: %s\n", sug.ApplicationToken)
+		}
+		return 1
+	}
+
+	baseDir, err := resolveBaseDir(*base)
+	if err != nil {
+		fmt.Fprintf(stderr, "apply-suggestion: %v\n", err)
+		return 1
+	}
+
+	edits := resolveSuggestionEdits(finding.File, sug, baseDir)
+	if *dryRun {
+		printDryRun(stdout, finding, sug, edits)
+		return 0
+	}
+
+	cols := buildFindingColumns(finding, sug, edits)
+	applied, _, errs := fixer.ApplyAllFixesColumns(&cols, "")
+	for _, e := range errs {
+		fmt.Fprintf(stderr, "apply-suggestion: %v\n", e)
+	}
+	if len(errs) > 0 {
+		return 1
+	}
+	fmt.Fprintf(stdout, "applied suggestion %q for finding %q (%d edit(s) across %s)\n",
+		sug.ID, *findingID, applied, summarizeTargets(edits))
+	return 0
+}
+
+func resolveBaseDir(explicit string) (string, error) {
+	if explicit != "" {
+		return explicit, nil
+	}
+	return os.Getwd()
+}
+
+func decodeReport(source string, stdin io.Reader) (output.JSONReport, error) {
+	var rdr io.ReadCloser
+	if source == "" || source == "-" {
+		rdr = io.NopCloser(stdin)
+	} else {
+		f, err := os.Open(source)
+		if err != nil {
+			return output.JSONReport{}, fmt.Errorf("opening %s: %w", source, err)
+		}
+		rdr = f
+	}
+	defer rdr.Close()
+	var report output.JSONReport
+	if err := json.NewDecoder(rdr).Decode(&report); err != nil {
+		return output.JSONReport{}, fmt.Errorf("decoding findings: %w", err)
+	}
+	return report, nil
+}
+
+func findFindingByID(report output.JSONReport, id string) (output.JSONFinding, bool) {
+	for _, f := range report.Findings {
+		if output.FindingID(f) == id {
+			return f, true
+		}
+	}
+	return output.JSONFinding{}, false
+}
+
+func findSuggestion(f output.JSONFinding, id string) (output.JSONSuggestedFix, bool) {
+	for _, s := range f.SuggestedFixes {
+		if s.ID == id {
+			return s, true
+		}
+	}
+	return output.JSONSuggestedFix{}, false
+}
+
+func listFindingIDsWithSuggestions(report output.JSONReport) []string {
+	out := make([]string, 0, len(report.Findings))
+	for _, f := range report.Findings {
+		if len(f.SuggestedFixes) == 0 {
+			continue
+		}
+		out = append(out, output.FindingID(f))
+	}
+	sort.Strings(out)
+	return out
+}
+
+func listSuggestionIDs(f output.JSONFinding) []string {
+	out := make([]string, 0, len(f.SuggestedFixes))
+	for _, s := range f.SuggestedFixes {
+		out = append(out, s.ID)
+	}
+	return out
+}
+
+func writeStaleError(w io.Writer, kind, id string, available []string) {
+	fmt.Fprintf(w, "apply-suggestion: %s id %q not found in report\n", kind, id)
+	if len(available) == 0 {
+		return
+	}
+	fmt.Fprintln(w, "available:")
+	for _, a := range available {
+		fmt.Fprintf(w, "  %s\n", a)
+	}
+}
+
+// resolveSuggestionEdits returns a copy of the suggestion's edits with
+// TargetFile resolved against base when the rule emitted a relative
+// path. The finding's own file is used as a fallback when an edit has
+// no target file set (mirrors fixer.collectTextFixRows).
+func resolveSuggestionEdits(findingFile string, sug output.JSONSuggestedFix, base string) []output.JSONSuggestedEdit {
+	out := make([]output.JSONSuggestedEdit, len(sug.Edits))
+	for i, e := range sug.Edits {
+		target := e.TargetFile
+		if target == "" {
+			target = findingFile
+		}
+		if !filepath.IsAbs(target) {
+			target = filepath.Join(base, target)
+		}
+		e.TargetFile = target
+		out[i] = e
+	}
+	return out
+}
+
+// buildFindingColumns materializes a one-finding-per-edit FindingColumns
+// where each row carries the suggestion edit as its autofix Fix. This
+// lets fixer.ApplyAllFixesColumns dedupe overlaps, group by file, and
+// emit ktfmt-shaped output through the same path `--fix` uses.
+func buildFindingColumns(finding output.JSONFinding, sug output.JSONSuggestedFix, edits []output.JSONSuggestedEdit) scanner.FindingColumns {
+	syn := make([]scanner.Finding, 0, len(edits))
+	for _, e := range edits {
+		syn = append(syn, scanner.Finding{
+			File:     e.TargetFile,
+			Line:     finding.Line,
+			Col:      finding.Column,
+			RuleSet:  finding.RuleSet,
+			Rule:     finding.Rule,
+			Severity: finding.Severity,
+			Message:  fmt.Sprintf("suggestion %s: %s", sug.ID, sug.Title),
+			Fix: &scanner.Fix{
+				TargetFile:  e.TargetFile,
+				StartLine:   e.StartLine,
+				EndLine:     e.EndLine,
+				StartByte:   e.StartByte,
+				EndByte:     e.EndByte,
+				ByteMode:    e.ByteMode,
+				Replacement: e.Replacement,
+			},
+		})
+	}
+	return scanner.CollectFindings(syn)
+}
+
+func printSuggestionsList(w io.Writer, report output.JSONReport) {
+	// Wrap in bufio so a large report doesn't generate a write syscall
+	// per Fprintf call (~tens of thousands on a kotlin-corpus report).
+	bw := bufio.NewWriter(w)
+	defer bw.Flush()
+	printed := false
+	for _, f := range report.Findings {
+		if len(f.SuggestedFixes) == 0 {
+			continue
+		}
+		printed = true
+		fmt.Fprintf(bw, "%s  %s\n", output.FindingID(f), f.Message)
+		for _, s := range f.SuggestedFixes {
+			machine := "informational"
+			if len(s.Edits) > 0 {
+				machine = fmt.Sprintf("%d edit(s)", len(s.Edits))
+			}
+			fmt.Fprintf(bw, "  %s  %s  [%s]\n", s.ID, s.Title, machine)
+		}
+	}
+	if !printed {
+		fmt.Fprintln(bw, "no findings carry suggested fixes")
+	}
+}
+
+func printDryRun(w io.Writer, finding output.JSONFinding, sug output.JSONSuggestedFix, edits []output.JSONSuggestedEdit) {
+	fmt.Fprintf(w, "dry-run: finding %s\n", output.FindingID(finding))
+	fmt.Fprintf(w, "  suggestion %s (%s)\n", sug.ID, sug.Title)
+	for i, e := range edits {
+		mode := "lines"
+		span := fmt.Sprintf("%d-%d", e.StartLine, e.EndLine)
+		if e.ByteMode {
+			mode = "bytes"
+			span = fmt.Sprintf("%d-%d", e.StartByte, e.EndByte)
+		}
+		fmt.Fprintf(w, "  edit %d: %s [%s %s]\n", i+1, e.TargetFile, mode, span)
+		fmt.Fprintf(w, "    replacement: %s\n", quoteReplacement(e.Replacement))
+	}
+}
+
+// quoteReplacement renders a multi-line replacement as a single-line
+// JSON string so dry-run output stays scannable. json.Marshal on a
+// string cannot fail.
+func quoteReplacement(s string) string {
+	b, _ := json.Marshal(s)
+	return string(b)
+}
+
+func summarizeTargets(edits []output.JSONSuggestedEdit) string {
+	seen := make(map[string]struct{}, len(edits))
+	out := make([]string, 0, len(edits))
+	for _, e := range edits {
+		if _, ok := seen[e.TargetFile]; ok {
+			continue
+		}
+		seen[e.TargetFile] = struct{}{}
+		out = append(out, e.TargetFile)
+	}
+	sort.Strings(out)
+	return strings.Join(out, ", ")
+}

--- a/internal/cli/applysuggestion/applysuggestion_test.go
+++ b/internal/cli/applysuggestion/applysuggestion_test.go
@@ -1,0 +1,320 @@
+package applysuggestion
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kaeawc/krit/internal/fixer"
+	"github.com/kaeawc/krit/internal/output"
+	"github.com/kaeawc/krit/internal/scanner"
+)
+
+func reportFile(t *testing.T, report output.JSONReport) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "report.json")
+	b, err := json.Marshal(report)
+	if err != nil {
+		t.Fatalf("marshal report: %v", err)
+	}
+	if err := os.WriteFile(path, b, 0o644); err != nil {
+		t.Fatalf("write report: %v", err)
+	}
+	return path
+}
+
+func TestList_printsFindingsAndSuggestions(t *testing.T) {
+	report := output.JSONReport{
+		Findings: []output.JSONFinding{
+			{
+				File:    "a.kt",
+				Line:    5,
+				Column:  3,
+				RuleSet: "style",
+				Rule:    "PreferVal",
+				Message: "use val",
+				SuggestedFixes: []output.JSONSuggestedFix{
+					{ID: "use-val", Title: "Convert to val",
+						Edits: []output.JSONSuggestedEdit{{StartLine: 5, EndLine: 5, Replacement: "val x = 1"}}},
+					{ID: "explain", Title: "Explain"},
+				},
+			},
+			{File: "b.kt", Rule: "NoSuggestions", Line: 1, Column: 1},
+		},
+	}
+	path := reportFile(t, report)
+	var stdout, stderr bytes.Buffer
+	rc := run([]string{"--list", path}, nil, &stdout, &stderr)
+	if rc != 0 {
+		t.Fatalf("rc=%d stderr=%s", rc, stderr.String())
+	}
+	out := stdout.String()
+	wantID := "PreferVal:a.kt:5:3"
+	if !strings.Contains(out, wantID) {
+		t.Errorf("output missing finding id %q: %s", wantID, out)
+	}
+	if !strings.Contains(out, "use-val") || !strings.Contains(out, "Convert to val") {
+		t.Errorf("output missing first suggestion: %s", out)
+	}
+	if !strings.Contains(out, "informational") {
+		t.Errorf("output missing informational tag for edit-less suggestion: %s", out)
+	}
+	if strings.Contains(out, "NoSuggestions") {
+		t.Errorf("findings without suggestions should be omitted from --list: %s", out)
+	}
+}
+
+func TestList_emptyReport(t *testing.T) {
+	path := reportFile(t, output.JSONReport{})
+	var stdout, stderr bytes.Buffer
+	rc := run([]string{"--list", path}, nil, &stdout, &stderr)
+	if rc != 0 {
+		t.Fatalf("rc=%d stderr=%s", rc, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "no findings carry suggested fixes") {
+		t.Errorf("expected empty-list notice, got: %s", stdout.String())
+	}
+}
+
+func TestApply_modifiesFile(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "a.kt")
+	if err := os.WriteFile(src, []byte("var x = 1\n"), 0o644); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	report := output.JSONReport{
+		Findings: []output.JSONFinding{{
+			File: "a.kt", Line: 1, Column: 1, RuleSet: "style", Rule: "PreferVal",
+			Message: "use val",
+			SuggestedFixes: []output.JSONSuggestedFix{{
+				ID: "use-val", Title: "Convert to val",
+				Edits: []output.JSONSuggestedEdit{{StartLine: 1, EndLine: 1, Replacement: "val x = 1"}},
+			}},
+		}},
+	}
+	path := reportFile(t, report)
+
+	var stdout, stderr bytes.Buffer
+	rc := run([]string{
+		"--finding", "PreferVal:a.kt:1:1",
+		"--suggestion", "use-val",
+		"--base", dir,
+		path,
+	}, nil, &stdout, &stderr)
+	if rc != 0 {
+		t.Fatalf("rc=%d stderr=%s", rc, stderr.String())
+	}
+	got, err := os.ReadFile(src)
+	if err != nil {
+		t.Fatalf("read modified source: %v", err)
+	}
+	if string(got) != "val x = 1\n" {
+		t.Errorf("file content: got %q want %q", got, "val x = 1\n")
+	}
+}
+
+func TestApply_dryRunDoesNotWrite(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "a.kt")
+	original := []byte("var x = 1\n")
+	if err := os.WriteFile(src, original, 0o644); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	report := output.JSONReport{
+		Findings: []output.JSONFinding{{
+			File: "a.kt", Line: 1, Column: 1, Rule: "PreferVal",
+			SuggestedFixes: []output.JSONSuggestedFix{{
+				ID: "use-val", Title: "Convert to val",
+				Edits: []output.JSONSuggestedEdit{{StartLine: 1, EndLine: 1, Replacement: "val x = 1"}},
+			}},
+		}},
+	}
+	path := reportFile(t, report)
+	var stdout, stderr bytes.Buffer
+	rc := run([]string{
+		"--dry-run",
+		"--finding", "PreferVal:a.kt:1:1",
+		"--suggestion", "use-val",
+		"--base", dir,
+		path,
+	}, nil, &stdout, &stderr)
+	if rc != 0 {
+		t.Fatalf("rc=%d stderr=%s", rc, stderr.String())
+	}
+	got, err := os.ReadFile(src)
+	if err != nil {
+		t.Fatalf("read source: %v", err)
+	}
+	if !bytes.Equal(got, original) {
+		t.Errorf("dry-run mutated file: got %q", got)
+	}
+	if !strings.Contains(stdout.String(), "dry-run") || !strings.Contains(stdout.String(), "val x = 1") {
+		t.Errorf("dry-run output missing details: %s", stdout.String())
+	}
+}
+
+func TestApply_staleFindingID(t *testing.T) {
+	report := output.JSONReport{
+		Findings: []output.JSONFinding{{
+			File: "a.kt", Line: 1, Column: 1, Rule: "R",
+			SuggestedFixes: []output.JSONSuggestedFix{{ID: "s1", Title: "t"}},
+		}},
+	}
+	path := reportFile(t, report)
+	var stdout, stderr bytes.Buffer
+	rc := run([]string{
+		"--finding", "R:a.kt:42:9",
+		"--suggestion", "s1",
+		path,
+	}, nil, &stdout, &stderr)
+	if rc != 1 {
+		t.Fatalf("expected exit 1 for stale finding, got %d", rc)
+	}
+	if !strings.Contains(stderr.String(), "finding id") {
+		t.Errorf("expected stale-finding error, got: %s", stderr.String())
+	}
+}
+
+func TestApply_staleSuggestionID(t *testing.T) {
+	report := output.JSONReport{
+		Findings: []output.JSONFinding{{
+			File: "a.kt", Line: 1, Column: 1, Rule: "R",
+			SuggestedFixes: []output.JSONSuggestedFix{{ID: "s1", Title: "t"}},
+		}},
+	}
+	path := reportFile(t, report)
+	var stdout, stderr bytes.Buffer
+	rc := run([]string{
+		"--finding", "R:a.kt:1:1",
+		"--suggestion", "nope",
+		path,
+	}, nil, &stdout, &stderr)
+	if rc != 1 {
+		t.Fatalf("expected exit 1 for stale suggestion, got %d", rc)
+	}
+	if !strings.Contains(stderr.String(), "suggestion id") {
+		t.Errorf("expected stale-suggestion error, got: %s", stderr.String())
+	}
+}
+
+func TestApply_informationalSuggestionRejected(t *testing.T) {
+	report := output.JSONReport{
+		Findings: []output.JSONFinding{{
+			File: "a.kt", Line: 1, Column: 1, Rule: "R",
+			SuggestedFixes: []output.JSONSuggestedFix{{
+				ID: "explain", Title: "Read the docs",
+				ApplicationToken: "help:docs",
+			}},
+		}},
+	}
+	path := reportFile(t, report)
+	var stdout, stderr bytes.Buffer
+	rc := run([]string{
+		"--finding", "R:a.kt:1:1",
+		"--suggestion", "explain",
+		path,
+	}, nil, &stdout, &stderr)
+	if rc != 1 {
+		t.Fatalf("expected exit 1 for non-machine-applicable suggestion, got %d", rc)
+	}
+	if !strings.Contains(stderr.String(), "not machine-applicable") {
+		t.Errorf("expected machine-applicability error, got: %s", stderr.String())
+	}
+}
+
+func TestApply_missingRequiredFlags(t *testing.T) {
+	path := reportFile(t, output.JSONReport{})
+	var stdout, stderr bytes.Buffer
+	rc := run([]string{path}, nil, &stdout, &stderr)
+	if rc != 1 {
+		t.Fatalf("expected exit 1 when --finding/--suggestion are missing, got %d", rc)
+	}
+}
+
+func TestApply_crossFileEdit(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "a.kt")
+	other := filepath.Join(dir, "b.kt")
+	if err := os.WriteFile(src, []byte("var x = 1\n"), 0o644); err != nil {
+		t.Fatalf("write a: %v", err)
+	}
+	if err := os.WriteFile(other, []byte("var y = 2\n"), 0o644); err != nil {
+		t.Fatalf("write b: %v", err)
+	}
+	report := output.JSONReport{
+		Findings: []output.JSONFinding{{
+			File: "a.kt", Line: 1, Column: 1, Rule: "R",
+			SuggestedFixes: []output.JSONSuggestedFix{{
+				ID: "cross", Title: "edits across files",
+				Edits: []output.JSONSuggestedEdit{
+					{StartLine: 1, EndLine: 1, Replacement: "val x = 1"},
+					{TargetFile: "b.kt", StartLine: 1, EndLine: 1, Replacement: "val y = 2"},
+				},
+			}},
+		}},
+	}
+	path := reportFile(t, report)
+	var stdout, stderr bytes.Buffer
+	rc := run([]string{
+		"--finding", "R:a.kt:1:1",
+		"--suggestion", "cross",
+		"--base", dir,
+		path,
+	}, nil, &stdout, &stderr)
+	if rc != 0 {
+		t.Fatalf("rc=%d stderr=%s", rc, stderr.String())
+	}
+	gotA, _ := os.ReadFile(src)
+	gotB, _ := os.ReadFile(other)
+	if string(gotA) != "val x = 1\n" {
+		t.Errorf("a.kt: got %q", gotA)
+	}
+	if string(gotB) != "val y = 2\n" {
+		t.Errorf("b.kt: got %q", gotB)
+	}
+}
+
+// TestFix_doesNotApplySuggestedEdits guards the mutual exclusion between
+// --fix and suggested fixes. A finding with no autofix (Fix=nil) but a
+// suggested fix carrying edits must not be touched by the
+// fixer.ApplyAllFixesColumns path that --fix drives.
+func TestFix_doesNotApplySuggestedEdits(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "a.kt")
+	original := []byte("var x = 1\n")
+	if err := os.WriteFile(src, original, 0o644); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	findings := []scanner.Finding{{
+		File:    src,
+		Line:    1,
+		Col:     1,
+		RuleSet: "style",
+		Rule:    "PreferVal",
+		Message: "use val",
+		SuggestedFixes: []scanner.SuggestedFix{{
+			ID: "use-val", Title: "Convert to val",
+			Edits: []scanner.SuggestedEdit{{StartLine: 1, EndLine: 1, Replacement: "val x = 1"}},
+		}},
+		// No Fix slot: suggested fix is not an autofix.
+	}}
+	cols := scanner.CollectFindings(findings)
+	applied, modified, errs := fixer.ApplyAllFixesColumns(&cols, "")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if applied != 0 || modified != 0 {
+		t.Fatalf("--fix should not apply suggested fixes: applied=%d modified=%d", applied, modified)
+	}
+	got, err := os.ReadFile(src)
+	if err != nil {
+		t.Fatalf("read source: %v", err)
+	}
+	if !bytes.Equal(got, original) {
+		t.Errorf("source mutated by --fix path despite no autofix: got %q", got)
+	}
+}

--- a/internal/output/finding_id.go
+++ b/internal/output/finding_id.go
@@ -1,0 +1,16 @@
+package output
+
+import "fmt"
+
+// FindingID returns the deterministic, transport-independent identifier
+// for a JSON finding. The format is "rule:file:line:column" using the
+// exact field values present in the JSON report; no normalization is
+// performed so the id round-trips through cold/warm runs that use the
+// same report.
+//
+// Used by `krit apply-suggestion` (and any future LSP/IDE flow that
+// needs to refer to a finding without round-tripping through scanner
+// internals) to look up findings by id.
+func FindingID(f JSONFinding) string {
+	return fmt.Sprintf("%s:%s:%d:%d", f.Rule, f.File, f.Line, f.Column)
+}

--- a/internal/output/finding_id_test.go
+++ b/internal/output/finding_id_test.go
@@ -1,0 +1,11 @@
+package output
+
+import "testing"
+
+func TestFindingID_deterministicShape(t *testing.T) {
+	f := JSONFinding{Rule: "R", File: "src/foo/Bar.kt", Line: 12, Column: 4}
+	want := "R:src/foo/Bar.kt:12:4"
+	if got := FindingID(f); got != want {
+		t.Errorf("FindingID: got %q want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `krit apply-suggestion` CLI verb that consumes the existing JSON
  findings report and either lists suggestion ids, previews the edits a
  chosen suggestion would apply (`--dry-run`), or applies exactly one
  suggestion in-place. Cross-file edits are supported via the existing
  fixer pipeline.
- Introduces `output.FindingID` — a deterministic `rule:file:line:column`
  identifier computed from JSON fields already in the report. Combined
  with the existing rule-defined `SuggestedFix.ID`, CLI/IDE/LSP callers
  now have a stable way to refer to one suggestion.
- Keeps `krit --fix` strictly limited to autofixes. The fixer's text-fix
  path (`VisitRowsWithTextFixes`) walks only the autofix `FixStart` pool;
  suggested fixes live in a separate pool. The new
  `TestFix_doesNotApplySuggestedEdits` test pins that mutual exclusion.

Resolves issue #243.

## Validation criteria

- [x] `go build ./...`, `go vet ./...`, `golangci-lint run ./...` clean
      on the new/edited packages.
- [x] `make lint-rules` passes.
- [x] `go test ./... -count=1` passes.
- [x] CLI smoke-test: `krit apply-suggestion --help` prints usage.

## Test plan

- [x] `--list` prints findings + suggestion ids and tags
      non-machine-applicable suggestions as informational.
- [x] `--list` on a report without suggestions emits a friendly notice.
- [x] Applying a known finding+suggestion mutates the source file.
- [x] `--dry-run` prints the intended edits without writing.
- [x] Stale `--finding` id exits 1 and lists available finding ids.
- [x] Stale `--suggestion` id exits 1 and lists available suggestion
      ids for the targeted finding.
- [x] Informational-only suggestion (no edits) is rejected with a clear
      error mentioning the `applicationToken` when present.
- [x] Missing `--finding` / `--suggestion` flags (without `--list`)
      exits 1 and prints usage.
- [x] Cross-file suggestion (edits to two distinct `TargetFile`s)
      applies both edits.
- [x] `--fix` path (no autofix, only suggested fixes) does not mutate
      any file.