### PR TITLE
fix(pipeline): carry forward cached paths in delta manifest (#254)

### DIFF
--- a/internal/cli/serve/analyze_project_abi_regression_test.go
+++ b/internal/cli/serve/analyze_project_abi_regression_test.go
@@ -1,0 +1,154 @@
+//go:build kotlin_corpus
+
+package serve
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kaeawc/krit/internal/daemon"
+)
+
+// TestAnalyzeProject_RepeatedABIEditFindingsStable_KotlinCorpus is the
+// regression repro for issue #254. With AndroidCacheWriter wired on
+// the daemon path, post-edit analyze runs on ~/github/kotlin collapse
+// from ~87k findings to ~62 starting on the second run.
+//
+// Flow:
+//  1. Spin daemon at the corpus.
+//  2. Warm baseline analyze (no edit) — record findings count.
+//  3. ABI-edit one Kotlin file (rename a public symbol).
+//  4. Analyze run 1..N, capturing findings count after each.
+//  5. Assert every post-edit run produces ≥ baselineCount-10 findings
+//     (allow tiny drift for the edited file itself; the symptom is a
+//     catastrophic collapse to ~62, not single-digit churn).
+func TestAnalyzeProject_RepeatedABIEditFindingsStable_KotlinCorpus(t *testing.T) {
+	root := os.Getenv("KRIT_KOTLIN_CORPUS")
+	if root == "" {
+		t.Skip("KRIT_KOTLIN_CORPUS not set")
+	}
+	if fi, err := os.Stat(root); err != nil || !fi.IsDir() {
+		t.Skipf("KRIT_KOTLIN_CORPUS=%q is not a directory: %v", root, err)
+	}
+
+	socket, state := startServerWith(t, root, 10*time.Second)
+
+	// Real watcher rooted at corpus — drives the dirty set that the
+	// bundle-fingerprint check uses to invalidate on ABI edits. Without
+	// this, daemon.Call(VerbAnalyzeProject) sees an empty dirty set
+	// and trusts the cached bundle even after we mutate disk.
+	w, err := startFileWatcher(context.Background(), state.root, state.workspace, nil)
+	if err != nil {
+		t.Fatalf("startFileWatcher: %v", err)
+	}
+	t.Cleanup(w.Stop)
+
+	var baseline daemon.AnalyzeProjectResult
+	if err := daemon.Call(socket, daemon.VerbAnalyzeProject,
+		daemon.AnalyzeProjectArgs{}, &baseline); err != nil {
+		t.Fatalf("warm baseline analyze: %v", err)
+	}
+	baselineCount := baseline.Stats.FindingsCount
+	t.Logf("warm baseline: %d findings", baselineCount)
+	if baselineCount < 1000 {
+		t.Fatalf("baseline findings = %d, expected ≫ 1000 (corpus misconfigured?)", baselineCount)
+	}
+
+	// Pick a Kotlin file with a top-level public class to ABI-edit.
+	target, original := pickKotlinTarget(t, root)
+	defer func() {
+		_ = os.WriteFile(target, []byte(original), 0o644)
+	}()
+
+	// Rename the symbol by injecting a fresh suffix on every run so
+	// the watcher sees a real content change.
+	abiEdit := func(suffix string) {
+		t.Helper()
+		// Append a fresh public top-level declaration. That bumps the
+		// file's ABI surface without touching existing identifiers, so
+		// the rest of the corpus still compiles structurally.
+		patched := original + "\nclass __KritAbiProbe" + suffix + "__ {}\n"
+		if err := os.WriteFile(target, []byte(patched), 0o644); err != nil {
+			t.Fatalf("write abi edit: %v", err)
+		}
+	}
+
+	const runs = 4
+	for i := 1; i <= runs; i++ {
+		abiEdit(suffix(i))
+		// Wait for the watcher to register the change.
+		deadline := time.Now().Add(3 * time.Second)
+		for time.Now().Before(deadline) && state.workspace.DirtyCount() == 0 {
+			time.Sleep(20 * time.Millisecond)
+		}
+		var got daemon.AnalyzeProjectResult
+		if err := daemon.Call(socket, daemon.VerbAnalyzeProject,
+			daemon.AnalyzeProjectArgs{}, &got); err != nil {
+			t.Fatalf("run %d analyze: %v", i, err)
+		}
+		t.Logf("run %d: %d findings (Δ vs baseline = %d, bundleHit=%v, dirty=%d)",
+			i, got.Stats.FindingsCount, got.Stats.FindingsCount-baselineCount,
+			got.Stats.FindingsBundleHit, got.Stats.DirtyFiles)
+		if got.Stats.FindingsCount < baselineCount-10 {
+			t.Fatalf("run %d findings collapsed: got %d, expected ≥ baseline-10 (%d)",
+				i, got.Stats.FindingsCount, baselineCount-10)
+		}
+	}
+}
+
+// pickKotlinTarget walks the corpus for a Kotlin file with a public
+// top-level class declaration. Returns its absolute path and original
+// content.
+func pickKotlinTarget(t *testing.T, root string) (string, string) {
+	t.Helper()
+	var picked string
+	var content string
+	stop := filepath.SkipDir
+	_ = stop
+	walkErr := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil || picked != "" {
+			return nil
+		}
+		if d.IsDir() {
+			// Skip build/test/script dirs that are unstable across runs.
+			name := d.Name()
+			if name == "build" || name == ".git" || name == ".krit" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".kt") {
+			return nil
+		}
+		// Skip generated / sample dirs.
+		if strings.Contains(path, "/build/") || strings.Contains(path, "/testData/") {
+			return nil
+		}
+		b, err := os.ReadFile(path)
+		if err != nil {
+			return nil
+		}
+		s := string(b)
+		if !strings.Contains(s, "class ") && !strings.Contains(s, "object ") {
+			return nil
+		}
+		if len(s) > 200_000 {
+			return nil
+		}
+		picked = path
+		content = s
+		return filepath.SkipAll
+	})
+	if walkErr != nil || picked == "" {
+		t.Fatalf("could not pick a Kotlin target: walkErr=%v picked=%q", walkErr, picked)
+	}
+	return picked, content
+}
+
+func suffix(i int) string {
+	return string(rune('A' + i - 1))
+}

--- a/internal/pipeline/build_manifest_data_test.go
+++ b/internal/pipeline/build_manifest_data_test.go
@@ -1,0 +1,115 @@
+package pipeline
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kaeawc/krit/internal/scanner"
+)
+
+// TestBuildManifestData_CarriesForwardCachedPaths is the regression
+// pin for issue #254. Under the parse-only-misses warm path, the
+// previous implementation only iterated parseResult.{Kotlin,Java}Files
+// and wrote a manifest that listed just the dirty files. The next
+// analyze re-read that manifest through prepopulatedSourcePaths and
+// collapsed the source set to one path — driving the entire daemon
+// pipeline into single-file dispatch and dropping ~87 k findings to
+// ~62 on ~/github/kotlin.
+//
+// The fix: any path present in host.PriorContentHashes that wasn't
+// parsed this run (and isn't dirty) gets carried into the new
+// manifest using its prior content / structural fingerprint. Cache
+// hits keep their entries, deletions still drop out.
+func TestBuildManifestData_CarriesForwardCachedPaths(t *testing.T) {
+	tmp := t.TempDir()
+	parsed := writeManifestTestFile(t, tmp, "Parsed.kt", "package demo\nclass Parsed { fun a() = 1 }\n")
+	cached := writeManifestTestFile(t, tmp, "Cached.kt", "package demo\nclass Cached { fun b() = 2 }\n")
+
+	parsedFile := &scanner.File{
+		Path:     parsed,
+		Language: scanner.LangKotlin,
+		Content:  []byte("package demo\nclass Parsed { fun a() = 1 }\n"),
+	}
+
+	args := ProjectArgs{
+		Paths:       []string{tmp},
+		KotlinPaths: []string{parsed, cached},
+	}
+	host := ProjectHostState{
+		FindingsBundleCacheRoot: tmp,
+		PriorContentHashes: map[string]string{
+			parsed: "stale-hash-recomputed-because-parsed",
+			cached: "prior-hash-for-cached",
+		},
+		PriorStructuralFPs: map[string]string{
+			parsed: "stale-fp-recomputed-because-parsed",
+			cached: "prior-fp-for-cached",
+		},
+		SourceSetDirty: []string{parsed},
+	}
+	parseResult := ParseResult{KotlinFiles: []*scanner.File{parsedFile}}
+
+	m := buildManifestData(args, host, parseResult, scanner.RunFingerprint{}, true)
+	if !m.enabled {
+		t.Fatalf("manifest disabled: %+v", m)
+	}
+	if len(m.contentHashes) != 2 {
+		t.Errorf("contentHashes len = %d, want 2 (parsed + cached). Got: %v", len(m.contentHashes), m.contentHashes)
+	}
+	if got, want := m.contentHashes[cached], "prior-hash-for-cached"; got != want {
+		t.Errorf("cached path content hash = %q, want %q (carried forward)", got, want)
+	}
+	if _, ok := m.contentHashes[parsed]; !ok {
+		t.Errorf("parsed path missing from contentHashes")
+	}
+	if got, want := m.structuralFPs[cached], "prior-fp-for-cached"; got != want {
+		t.Errorf("cached path structural fp = %q, want %q (carried forward)", got, want)
+	}
+}
+
+// TestBuildManifestData_DropsDirtyUnparsedPaths covers deletions.
+// A path that's marked dirty and isn't in parseResult is most likely
+// gone from disk (the watcher fired but ParsePhase didn't pick it up).
+// Carrying it forward would let it haunt the next manifest as if it
+// were still cache-valid.
+func TestBuildManifestData_DropsDirtyUnparsedPaths(t *testing.T) {
+	tmp := t.TempDir()
+	deleted := filepath.Join(tmp, "Gone.kt") // intentionally never written
+	survivor := writeManifestTestFile(t, tmp, "Survivor.kt", "package demo\nclass Survivor\n")
+
+	args := ProjectArgs{
+		Paths:       []string{tmp},
+		KotlinPaths: []string{deleted, survivor},
+	}
+	host := ProjectHostState{
+		FindingsBundleCacheRoot: tmp,
+		PriorContentHashes: map[string]string{
+			deleted:  "prior-hash-deleted",
+			survivor: "prior-hash-survivor",
+		},
+		PriorStructuralFPs: map[string]string{
+			deleted:  "prior-fp-deleted",
+			survivor: "prior-fp-survivor",
+		},
+		SourceSetDirty: []string{deleted},
+	}
+	parseResult := ParseResult{}
+
+	m := buildManifestData(args, host, parseResult, scanner.RunFingerprint{}, true)
+	if _, ok := m.contentHashes[deleted]; ok {
+		t.Errorf("deleted dirty path should be dropped, but contentHashes contains it: %v", m.contentHashes)
+	}
+	if _, ok := m.contentHashes[survivor]; !ok {
+		t.Errorf("non-dirty cached path should be carried forward; contentHashes=%v", m.contentHashes)
+	}
+}
+
+func writeManifestTestFile(t *testing.T, dir, name, content string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+	return path
+}

--- a/internal/pipeline/project.go
+++ b/internal/pipeline/project.go
@@ -1311,41 +1311,64 @@ type deltaManifestData struct {
 // buildManifestData prepares per-file content + structural fingerprints
 // for the delta planner. Returns the inputs whether or not the bundle
 // cache is enabled — callers gate on enabled before persisting.
+//
+// On warm runs that parse only cache misses (runProjectParsePhase's
+// CanParseOnlyCacheMisses path), parseResult.{Kotlin,Java}Files holds
+// just the dirty files. The cached-but-unparsed paths still belong in
+// the persisted manifest — otherwise the next analyze's
+// prepopulatedSourcePaths reads a manifest that knows about only the
+// last-edited file and the source set collapses to a single path
+// (issue #254). We carry those entries forward from the prior
+// manifest's ContentHashes / StructuralFPs maps, which are stable for
+// any non-dirty cached file by construction (cached == content hash
+// unchanged).
 func buildManifestData(args ProjectArgs, host ProjectHostState, parseResult ParseResult, _ scanner.RunFingerprint, bundleEnabled bool) deltaManifestData {
 	if !bundleEnabled {
 		return deltaManifestData{}
 	}
-	total := len(parseResult.KotlinFiles) + len(parseResult.JavaFiles)
+	parsedByPath := make(map[string]*scanner.File, len(parseResult.KotlinFiles)+len(parseResult.JavaFiles))
+	for _, f := range parseResult.KotlinFiles {
+		if f != nil {
+			parsedByPath[f.Path] = f
+		}
+	}
+	for _, f := range parseResult.JavaFiles {
+		if f != nil {
+			parsedByPath[f.Path] = f
+		}
+	}
+	total := len(parsedByPath) + len(host.PriorContentHashes)
 	contentHashes := make(map[string]string, total)
 	structuralFPs := make(map[string]string, total)
 	fileStats := make(map[string]scanner.FileStat, total)
 	dirty := dirtyPathSet(host.SourceSetDirty)
-	for _, f := range parseResult.KotlinFiles {
-		if f == nil {
-			continue
-		}
-		contentHashes[f.Path] = priorOrCompute(host.PriorContentHashes, dirty, f.Path, func() string {
-			return hashutil.Default().HashContent(f.Path, f.Content)
+	for path, f := range parsedByPath {
+		contentHashes[path] = priorOrCompute(host.PriorContentHashes, dirty, path, func() string {
+			return hashutil.Default().HashContent(path, f.Content)
 		})
-		structuralFPs[f.Path] = priorOrCompute(host.PriorStructuralFPs, dirty, f.Path, func() string {
+		structuralFPs[path] = priorOrCompute(host.PriorStructuralFPs, dirty, path, func() string {
 			return scanner.FileStructuralFingerprint(f)
 		})
-		if stat, ok := statForPath(f.Path); ok {
-			fileStats[f.Path] = stat
+		if stat, ok := statForPath(path); ok {
+			fileStats[path] = stat
 		}
 	}
-	for _, f := range parseResult.JavaFiles {
-		if f == nil {
+	for path, hash := range host.PriorContentHashes {
+		if _, parsed := parsedByPath[path]; parsed {
 			continue
 		}
-		contentHashes[f.Path] = priorOrCompute(host.PriorContentHashes, dirty, f.Path, func() string {
-			return hashutil.Default().HashContent(f.Path, f.Content)
-		})
-		structuralFPs[f.Path] = priorOrCompute(host.PriorStructuralFPs, dirty, f.Path, func() string {
-			return scanner.FileStructuralFingerprint(f)
-		})
-		if stat, ok := statForPath(f.Path); ok {
-			fileStats[f.Path] = stat
+		if dirty != nil && dirty[path] {
+			// Dirty AND not parsed — the file was likely deleted or
+			// became unreadable. Dropping the entry here prevents a
+			// ghost path from haunting the next manifest read.
+			continue
+		}
+		contentHashes[path] = hash
+		if fp, ok := host.PriorStructuralFPs[path]; ok {
+			structuralFPs[path] = fp
+		}
+		if stat, ok := statForPath(path); ok {
+			fileStats[path] = stat
 		}
 	}
 	return deltaManifestData{


### PR DESCRIPTION
## Summary

Root-cause fix for [#254](https://github.com/kaeawc/krit/issues/254): warm post-edit analyze runs on `~/github/kotlin` collapsed from ~87,069 findings to ~62 starting on the second run when the daemon's `AndroidCacheWriter` is wired.

The bug is in [internal/pipeline/project.go](internal/pipeline/project.go) `buildManifestData`, not the Android cache. PR #285's wiring didn't cause the bug — it exposed it by enabling the parse-only-misses warm path.

### The chain

1. Daemon analyze with `AndroidCacheWriter` wired → `allowWarmResourceSourceDelta` returns true → `RulesNeedParsedSource` returns false → `CanParseOnlyCacheMisses` returns true.
2. `runProjectParsePhase` parses only the dirty file(s); the rest stay cached.
3. `buildManifestData` then iterated only `parseResult.{Kotlin,Java}Files` and persisted a manifest with **one** `ContentHash` entry.
4. Next analyze: `prepopulatedSourcePaths` reads that manifest → `ProjectArgs.KotlinPaths` collapses to one path → warm cache check sees a one-file project → dispatch runs on one file → findings count collapses.

### The fix

Carry every prior-manifest entry forward into the new manifest unless the path was parsed this run (use `priorOrCompute`) or is dirty-and-unparsed (treated as a deletion). Cached files retain their prior content hash and structural fingerprint, which is correct by construction: cached ⇔ watcher hasn't seen a dirty signal since the last manifest, so the prior hash still matches disk.

## Validation criteria

- `make build` clean, `make test` passes
- `golangci-lint run` on touched packages → 0 issues
- New focused unit test [`internal/pipeline/build_manifest_data_test.go`](internal/pipeline/build_manifest_data_test.go) pins the carry-forward + dirty-deletion semantics
- New build-tagged corpus test [`internal/cli/serve/analyze_project_abi_regression_test.go`](internal/cli/serve/analyze_project_abi_regression_test.go) runs the full daemon + fsnotify watcher + ABI-edit loop on `~/github/kotlin` (KRIT_KOTLIN_CORPUS) and asserts the findings count stays stable across 4 consecutive ABI edits

## Verification on ~/github/kotlin

| state | findings |
| --- | --- |
| warm baseline | 87,070 |
| warm + 1kt ABI run 1 | 87,072 |
| warm + 1kt ABI run 2 | 87,072 (was 62) |
| warm + 1kt ABI run 3 | 87,072 (was 62) |
| warm + 1kt ABI run 4 | 87,072 (was 62) |

## Test plan

- [x] Reproduced the regression on the real corpus
- [x] Added a corpus-tagged regression test that fails before the fix and passes after
- [x] Added focused unit tests for `buildManifestData` (carry-forward + delete behaviors)
- [x] Full test suite passes
- [x] Lint clean on touched packages

Closes #254.