### PR TITLE
feat(release): lazy-download krit-types.jar for installed binaries (#300)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,11 +119,43 @@ jobs:
           retention-days: 1
           if-no-files-found: error
 
+  # Build the JVM sidecar (krit-types shaded jar) once and stage it for
+  # the release funnel. The Go CLI auto-downloads this asset on first
+  # use of --daemon / --custom-rule-jars; see internal/oracle.EnsureJar.
+  build-krit-types:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with: { fetch-depth: 0 }
+      - uses: actions/setup-java@3a4f6e1af504cf6a31855fa4c52c5c265c3b610f # v4.7.1
+        with:
+          distribution: temurin
+          java-version: '21'
+      - uses: gradle/actions/setup-gradle@94baf225fe0a508e581a564467443d0e2379123b # v4.3.0
+      - name: Build krit-types shaded jar
+        working-directory: tools/krit-types
+        run: ./gradlew --no-daemon shadowJar
+      - name: Stage jar with release-tagged name
+        shell: bash
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          mkdir staged
+          cp tools/krit-types/build/libs/krit-types.jar "staged/krit-types-${TAG}.jar"
+          ls -la staged/
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4.6.2
+        with:
+          name: dist-krit-types
+          path: staged/
+          retention-days: 1
+          if-no-files-found: error
+
   # Funnel: gather every matrix runner's archives, generate one combined
   # checksums.txt covering all platforms, sign it, create the GitHub
   # release, and push the brew cask + scoop manifest to their tap repos.
   release:
-    needs: build
+    needs: [build, build-krit-types]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -150,6 +182,7 @@ jobs:
           mkdir -p dist
           cp staging/*.tar.gz staging/*.zip dist/ 2>/dev/null || true
           cp staging/*.sbom.json dist/ 2>/dev/null || true
+          cp staging/*.jar dist/ 2>/dev/null || true
           ls -la dist/
 
       - name: Generate combined checksums.txt
@@ -158,7 +191,7 @@ jobs:
           set -euo pipefail
           cd dist
           : > checksums.txt
-          for f in *.tar.gz *.zip; do
+          for f in *.tar.gz *.zip *.jar; do
             [ -f "$f" ] || continue
             sha256sum "$f" >> checksums.txt
           done
@@ -189,7 +222,7 @@ jobs:
             --repo "$GITHUB_REPOSITORY" \
             --title "$TAG" \
             --generate-notes \
-            $(ls *.tar.gz *.zip *.sbom.json checksums.txt checksums.txt.sig 2>/dev/null)
+            $(ls *.tar.gz *.zip *.jar *.sbom.json checksums.txt checksums.txt.sig 2>/dev/null)
 
       - name: Publish Homebrew cask
         env:

--- a/cmd/krit/main.go
+++ b/cmd/krit/main.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/kaeawc/krit/internal/cli/scan"
 	"github.com/kaeawc/krit/internal/cli/serve"
+	"github.com/kaeawc/krit/internal/oracle"
 )
 
 // version is set by goreleaser via ldflags: -X main.version=...
@@ -13,6 +14,7 @@ var version = "dev"
 func main() {
 	scan.Version = version
 	serve.Version = version
+	oracle.Version = version
 	if dispatchSubcommand() {
 		scan.BaselineAuditVerb = true
 	}

--- a/internal/cli/scan/early_exits.go
+++ b/internal/cli/scan/early_exits.go
@@ -1,13 +1,13 @@
 package scan
 
 import (
+	"context"
 	"embed"
 	"encoding/json"
 	"fmt"
 	"io"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"strings"
 
 	"github.com/kaeawc/krit/internal/cache"
@@ -195,20 +195,10 @@ func runDoctorFlag(doctorFlag bool, version string) {
 	} else {
 		fmt.Println("  cwebp: not found (optional — needed for --fix-binary WebP)")
 	}
-	jarPaths := []string{
-		"tools/krit-types/build/libs/krit-types.jar",
-		filepath.Join(os.Getenv("HOME"), ".krit", "krit-types.jar"),
-	}
-	jarFound := false
-	for _, p := range jarPaths {
-		if _, err := os.Stat(p); err == nil {
-			fmt.Printf("  krit-types: %s\n", p)
-			jarFound = true
-			break
-		}
-	}
-	if !jarFound {
-		fmt.Println("  krit-types: not found (optional — needed for type oracle)")
+	if p := oracle.FindJar(nil); p != "" {
+		fmt.Printf("  krit-types: %s\n", p)
+	} else {
+		fmt.Println("  krit-types: not found (optional — auto-downloaded on first use of --daemon / --custom-rule-jars in tagged releases)")
 	}
 	fmt.Println()
 	fmt.Println("  Everything looks good!")
@@ -477,9 +467,9 @@ type RunOutputTypesOpts struct {
 // terminate. The on-disk write happens at opts.OutputPath, which the
 // caller is responsible for absolutising when crossing CWD boundaries.
 func RunOutputTypesTo(errOut io.Writer, opts RunOutputTypesOpts) int {
-	jarPath := oracle.FindJar(opts.Paths)
-	if jarPath == "" {
-		fmt.Fprintf(errOut, "error: krit-types.jar not found. Build it with: cd tools/krit-types && ./gradlew shadowJar\n")
+	jarPath, err := oracle.EnsureJar(context.Background(), opts.Paths, opts.Verbose)
+	if err != nil {
+		fmt.Fprintf(errOut, "error: %v\n", err)
 		return 2
 	}
 	sourceDirs := oracle.FindSourceDirs(opts.Paths)
@@ -490,7 +480,6 @@ func RunOutputTypesTo(errOut io.Writer, opts RunOutputTypesOpts) int {
 	if opts.Verbose {
 		fmt.Fprintf(errOut, "verbose: Found %d source directories\n", len(sourceDirs))
 	}
-	var err error
 	// --output-types is a standalone oracle dump: no rules are loaded so
 	// there's no rule-classification filter to apply. Pass "" for the
 	// filter list path; both call paths handle that as "no filter".

--- a/internal/oracle/invoke.go
+++ b/internal/oracle/invoke.go
@@ -54,12 +54,38 @@ func invokeGraceExitFrom(r env.Reader) time.Duration {
 	return 15 * time.Second
 }
 
-// FindJar locates the krit-types shadow JAR by checking:
-// 1. Next to the krit binary (tools/krit-types/build/libs/krit-types.jar)
-// 2. In the project being scanned (.krit/krit-types.jar)
-// 3. Relative to the krit binary's directory
+// FindJar locates the krit-types shadow JAR. Checked in order:
+//  1. $KRIT_TYPES_JAR env override (when the file exists)
+//  2. Installed jars under ~/.krit/jars/ — version-pinned then unversioned
+//  3. ~/.krit/krit-types.jar (legacy, pre-#300 install location)
+//  4. Next to the krit binary or under exe-dir/tools/krit-types/build/libs/
+//  5. In the project being scanned (.krit/krit-types.jar or
+//     tools/krit-types/build/libs/krit-types.jar)
+//  6. Under the current working directory's tools/krit-types/build/libs/
+//
+// Returns "" when no jar is found. Use EnsureJar instead when the caller
+// should auto-download a missing jar for the current krit release.
 func FindJar(scanPaths []string) string {
+	if v := strings.TrimSpace(os.Getenv("KRIT_TYPES_JAR")); v != "" {
+		if _, err := os.Stat(v); err == nil {
+			return v
+		}
+	}
+
 	candidates := []string{}
+
+	// Installed locations under ~/.krit. krit binary releases download
+	// the matching jar here on first use; see EnsureJar.
+	if home, err := os.UserHomeDir(); err == nil && home != "" {
+		jarsDir := filepath.Join(home, ".krit", "jars")
+		if tag := versionTag(); tag != "" {
+			candidates = append(candidates, filepath.Join(jarsDir, "krit-types-"+tag+".jar"))
+		}
+		candidates = append(candidates,
+			filepath.Join(jarsDir, "krit-types.jar"),
+			filepath.Join(home, ".krit", "krit-types.jar"),
+		)
+	}
 
 	// Check relative to the krit binary
 	exe, err := os.Executable()
@@ -403,11 +429,12 @@ func runOracleProcessMeasured(
 
 // InvokeDaemon finds the JAR and source directories, then starts a long-lived
 // krit-types daemon process. The caller is responsible for calling Close() on
-// the returned Daemon.
+// the returned Daemon. Missing jars are auto-downloaded for tagged releases;
+// see EnsureJar.
 func InvokeDaemon(scanPaths []string, verbose bool) (*Daemon, error) {
-	jarPath := FindJar(scanPaths)
-	if jarPath == "" {
-		return nil, fmt.Errorf("krit-types.jar not found. Build it with: cd tools/krit-types && ./gradlew shadowJar")
+	jarPath, err := EnsureJar(context.Background(), scanPaths, verbose)
+	if err != nil {
+		return nil, err
 	}
 
 	sourceDirs := FindSourceDirs(scanPaths)
@@ -426,10 +453,11 @@ func InvokeDaemon(scanPaths []string, verbose bool) (*Daemon, error) {
 // connects to an existing persistent daemon or starts a new one. The daemon
 // survives across krit invocations and is reused via PID file + TCP port.
 // The caller is responsible for calling Close() on the returned Daemon.
+// Missing jars are auto-downloaded for tagged releases; see EnsureJar.
 func InvokePersistentDaemon(scanPaths []string, verbose bool) (*Daemon, error) {
-	jarPath := FindJar(scanPaths)
-	if jarPath == "" {
-		return nil, fmt.Errorf("krit-types.jar not found. Build it with: cd tools/krit-types && ./gradlew shadowJar")
+	jarPath, err := EnsureJar(context.Background(), scanPaths, verbose)
+	if err != nil {
+		return nil, err
 	}
 
 	sourceDirs := FindSourceDirs(scanPaths)

--- a/internal/oracle/invoke_test.go
+++ b/internal/oracle/invoke_test.go
@@ -16,8 +16,22 @@ import (
 // FindJar tests
 // ---------------------------------------------------------------------------
 
+// isolateJarLookup repoints HOME and clears KRIT_TYPES_JAR / oracle.Version so
+// the test sees only fixtures it explicitly creates. Returns the isolated
+// fake-home directory.
+func isolateJarLookup(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("KRIT_TYPES_JAR", "")
+	prev := Version
+	Version = ""
+	t.Cleanup(func() { Version = prev })
+	return home
+}
+
 func TestFindJar_NoJarReturnsEmpty(t *testing.T) {
-	// Use a temp dir with no jar files; FindJar should return empty string.
+	isolateJarLookup(t)
 	tmp := t.TempDir()
 	result := FindJar([]string{tmp})
 	if result != "" {
@@ -26,6 +40,7 @@ func TestFindJar_NoJarReturnsEmpty(t *testing.T) {
 }
 
 func TestFindJar_FindsJarInProjectDir(t *testing.T) {
+	isolateJarLookup(t)
 	tmp := t.TempDir()
 	kritDir := filepath.Join(tmp, ".krit")
 	if err := os.MkdirAll(kritDir, 0755); err != nil {
@@ -42,6 +57,47 @@ func TestFindJar_FindsJarInProjectDir(t *testing.T) {
 	}
 	if filepath.Base(result) != "krit-types.jar" {
 		t.Errorf("expected filename krit-types.jar, got %q", filepath.Base(result))
+	}
+}
+
+func TestFindJar_EnvOverride(t *testing.T) {
+	isolateJarLookup(t)
+	tmp := t.TempDir()
+	jarPath := filepath.Join(tmp, "custom-types.jar")
+	if err := os.WriteFile(jarPath, []byte("fake"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("KRIT_TYPES_JAR", jarPath)
+	if got := FindJar(nil); got != jarPath {
+		t.Errorf("KRIT_TYPES_JAR override: got %q, want %q", got, jarPath)
+	}
+}
+
+func TestFindJar_EnvOverrideMissingFileFallsThrough(t *testing.T) {
+	isolateJarLookup(t)
+	t.Setenv("KRIT_TYPES_JAR", "/nonexistent/path/to/krit-types.jar")
+	if got := FindJar(nil); got != "" {
+		t.Errorf("expected fall-through when env path missing, got %q", got)
+	}
+}
+
+func TestFindJar_VersionPinnedInstall(t *testing.T) {
+	home := isolateJarLookup(t)
+	Version = "1.2.3"
+	jarsDir := filepath.Join(home, ".krit", "jars")
+	if err := os.MkdirAll(jarsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	pinned := filepath.Join(jarsDir, "krit-types-v1.2.3.jar")
+	unversioned := filepath.Join(jarsDir, "krit-types.jar")
+	if err := os.WriteFile(pinned, []byte("pin"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(unversioned, []byte("unpinned"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := FindJar(nil); got != pinned {
+		t.Errorf("expected version-pinned jar to win: got %q, want %q", got, pinned)
 	}
 }
 

--- a/internal/oracle/jar_install.go
+++ b/internal/oracle/jar_install.go
@@ -1,0 +1,130 @@
+package oracle
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/kaeawc/krit/internal/fsutil"
+)
+
+// Version is the krit CLI semantic version, set by cmd/krit/main.go from the
+// same goreleaser ldflag that drives scan.Version and serve.Version. EnsureJar
+// uses it to pick the matching krit-types-<version>.jar release asset and the
+// per-version cache file under ~/.krit/jars/.
+//
+// Empty or "dev" disables auto-download: developer builds compile the jar
+// in-tree via `cd tools/krit-types && ./gradlew shadowJar`.
+var Version = ""
+
+// jarDownloadTimeout caps a single jar download. The shaded jar is ~50 MB,
+// well within reach over a slow connection in 5 minutes.
+const jarDownloadTimeout = 5 * time.Minute
+
+var ensureJarMu sync.Mutex
+
+// EnsureJar returns the krit-types jar path, downloading the matching release
+// asset under ~/.krit/jars/krit-types-<version>.jar when no jar is found
+// locally and the krit binary is a tagged release.
+//
+// Returns an actionable error when no jar is locatable and auto-download is
+// not available (dev builds, missing HOME, or no network).
+func EnsureJar(ctx context.Context, scanPaths []string, verbose bool) (string, error) {
+	if path := FindJar(scanPaths); path != "" {
+		return path, nil
+	}
+
+	ensureJarMu.Lock()
+	defer ensureJarMu.Unlock()
+	// Re-check under the lock: a concurrent EnsureJar may have downloaded.
+	if path := FindJar(scanPaths); path != "" {
+		return path, nil
+	}
+
+	target, err := installedJarPath()
+	if err != nil {
+		return "", missingJarError(err)
+	}
+	url := jarReleaseURL()
+	if url == "" {
+		return "", missingJarError(errors.New("dev build; auto-download is disabled"))
+	}
+	if verbose {
+		reporter().Verbosef("verbose: downloading krit-types.jar from %s\n", url)
+	}
+	if err := downloadJar(ctx, url, target); err != nil {
+		return "", fmt.Errorf("download krit-types.jar from %s: %w", url, err)
+	}
+	return target, nil
+}
+
+// versionTag normalises the package-level Version into a release tag form
+// ("vX.Y.Z"). Returns "" when Version is unset or a dev build.
+func versionTag() string {
+	v := strings.TrimSpace(Version)
+	if v == "" || v == "dev" {
+		return ""
+	}
+	if !strings.HasPrefix(v, "v") {
+		return "v" + v
+	}
+	return v
+}
+
+func installedJarPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return "", errors.New("no HOME directory; cannot install jar under ~/.krit/jars")
+	}
+	tag := versionTag()
+	if tag == "" {
+		return filepath.Join(home, ".krit", "jars", "krit-types.jar"), nil
+	}
+	return filepath.Join(home, ".krit", "jars", "krit-types-"+tag+".jar"), nil
+}
+
+func jarReleaseURL() string {
+	tag := versionTag()
+	if tag == "" {
+		return ""
+	}
+	return "https://github.com/kaeawc/krit/releases/download/" + tag + "/krit-types-" + tag + ".jar"
+}
+
+func downloadJar(ctx context.Context, url, target string) error {
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		return err
+	}
+	dlCtx, cancel := context.WithTimeout(ctx, jarDownloadTimeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(dlCtx, http.MethodGet, url, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("http %d", resp.StatusCode)
+	}
+	return fsutil.WriteFileAtomicStream(target, 0o644, func(w io.Writer) error {
+		_, copyErr := io.Copy(w, resp.Body)
+		return copyErr
+	})
+}
+
+// missingJarError builds the helpful error users see when no jar is found and
+// auto-download cannot fill the gap. Keeps the install / env-var / dev-build
+// options visible together.
+func missingJarError(reason error) error {
+	return fmt.Errorf("krit-types.jar not found (%w). Install via 'brew install krit' to enable auto-download, set KRIT_TYPES_JAR to an existing jar, or build with: cd tools/krit-types && ./gradlew shadowJar", reason)
+}

--- a/internal/oracle/jar_install_test.go
+++ b/internal/oracle/jar_install_test.go
@@ -1,0 +1,44 @@
+package oracle
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestEnsureJar_DevBuildReturnsHelpfulError(t *testing.T) {
+	isolateJarLookup(t)
+	// Version stays "" → versionTag() returns "" → no release URL → error.
+	_, err := EnsureJar(context.Background(), nil, false)
+	if err == nil {
+		t.Fatal("expected error for dev build with no jar")
+	}
+	msg := err.Error()
+	for _, want := range []string{"krit-types.jar not found", "KRIT_TYPES_JAR", "./gradlew shadowJar"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("error message missing %q: %s", want, msg)
+		}
+	}
+}
+
+func TestJarReleaseURL_NormalisesVersion(t *testing.T) {
+	prev := Version
+	t.Cleanup(func() { Version = prev })
+
+	Version = "1.2.3"
+	if got, want := jarReleaseURL(), "https://github.com/kaeawc/krit/releases/download/v1.2.3/krit-types-v1.2.3.jar"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+	Version = "v1.2.3"
+	if got, want := jarReleaseURL(), "https://github.com/kaeawc/krit/releases/download/v1.2.3/krit-types-v1.2.3.jar"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+	Version = "dev"
+	if got := jarReleaseURL(); got != "" {
+		t.Errorf("dev build should not have a release URL, got %q", got)
+	}
+	Version = ""
+	if got := jarReleaseURL(); got != "" {
+		t.Errorf("empty version should not have a release URL, got %q", got)
+	}
+}

--- a/internal/pipeline/custom_kotlin_rules.go
+++ b/internal/pipeline/custom_kotlin_rules.go
@@ -19,7 +19,7 @@ func runKotlinPluginRulesAndMerge(ctx context.Context, args ProjectArgs, host Pr
 		daemon = host.OracleDaemon
 	}
 	if daemon == nil {
-		return fmt.Errorf("kotlin custom rules require the krit-types daemon; pass --daemon and ensure tools/krit-types/build/libs/krit-types.jar exists")
+		return fmt.Errorf("kotlin custom rules require the krit-types daemon; pass --daemon. Released krit binaries auto-download the matching krit-types.jar into ~/.krit/jars/ on first use; for dev builds run: cd tools/krit-types && ./gradlew shadowJar (or set KRIT_TYPES_JAR to an existing jar)")
 	}
 
 	list, err := daemon.ListPlugins(args.CustomRuleJars)


### PR DESCRIPTION
## Summary

Closes #300.

Installed krit binaries (brew / scoop / winget / tarball) had no way to find the JVM sidecar, so `--daemon` and `--custom-rule-jars` errored on any clean machine. This PR ships the jar as a release asset and teaches the Go CLI to lazy-download it on first use.

- `.github/workflows/release.yml` — new `build-krit-types` job runs `./gradlew shadowJar`, uploads `krit-types-<tag>.jar`. The release funnel adds `*.jar` to dist/, checksums, and `gh release create`.
- `internal/oracle/invoke.go` `FindJar` — checks `$KRIT_TYPES_JAR`, then `~/.krit/jars/krit-types-<version>.jar` (version-pinned), then unversioned and legacy paths, before falling back to the existing exe-dir / project / cwd discovery.
- `internal/oracle/jar_install.go` (new) `EnsureJar(ctx, scanPaths, verbose)` — calls `FindJar` and, on miss, downloads the matching release asset from `https://github.com/kaeawc/krit/releases/download/v<version>/krit-types-v<version>.jar` into `~/.krit/jars/`. Uses `fsutil.WriteFileAtomicStream` for atomic writes; serialises concurrent callers with double-checked locking. Dev builds (`Version="dev"`) return an actionable error mentioning the env var, install path, and `./gradlew shadowJar` fallback.
- `internal/pipeline/custom_kotlin_rules.go:22` — error message updated to point at the install path and `KRIT_TYPES_JAR`.
- `internal/cli/scan/early_exits.go` — `RunOutputTypesTo` and `doctor` switched to the new discovery / download helpers.
- `cmd/krit/main.go` — sets `oracle.Version` alongside `scan.Version` / `serve.Version`.

Took the lazy-download alternative path from the issue ("publish it as a release asset and have the CLI fetch it on first use") rather than bundling the ~50 MB jar in every Homebrew/Scoop/Winget download. No manifest changes needed.

## Test plan

- [x] `go build -o krit ./cmd/krit/`
- [x] `go vet ./...`
- [x] `golangci-lint run ./internal/oracle/... ./internal/cli/scan/... ./internal/pipeline/... ./cmd/krit/...`
- [x] `go test ./... -count=1` (full suite green)
- [x] New unit tests cover: `$KRIT_TYPES_JAR` override, env-path-missing fall-through, version-pinned install wins over unversioned, `EnsureJar` dev-build error message, `jarReleaseURL` version normalisation.
- [ ] Validate on next tag: `gh release view v<tag>` shows `krit-types-v<tag>.jar` with a checksum.
- [ ] Validate end-to-end after release: `brew install krit && krit --custom-rule-jars sample.jar .` downloads the jar and runs custom rules without a local source tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)