### PR TITLE
feat(intellij): expose ordered suggested fixes as native quick fixes

### DIFF
--- a/editors/intellij-plugin/src/main/kotlin/dev/jasonpearson/krit/intellij/KritExternalAnnotator.kt
+++ b/editors/intellij-plugin/src/main/kotlin/dev/jasonpearson/krit/intellij/KritExternalAnnotator.kt
@@ -29,11 +29,10 @@ class KritExternalAnnotator : ExternalAnnotator<PsiFile, List<KritFinding>>() {
         for (finding in annotationResult.orEmpty()) {
             val annotation = holder.newAnnotation(highlightSeverity(finding), finding.displayMessage)
                 .range(KritRanges.rangeFor(file, finding))
-            if (finding.fixable) {
-                annotation.withFix(KritApplyFixesIntention(finding.fixLevel))
+            for (intention in KritIntentions.forFinding(finding)) {
+                annotation.withFix(intention)
             }
-            annotation
-                .create()
+            annotation.create()
         }
     }
 
@@ -46,20 +45,49 @@ class KritExternalAnnotator : ExternalAnnotator<PsiFile, List<KritFinding>>() {
     }
 }
 
+object KritIntentions {
+    // Suggestions and the autofix slot are mutually exclusive per finding:
+    // when a rule emits suggestions the user picks one explicitly, so the
+    // catch-all "apply auto-fixes" entry would conflict.
+    fun forFinding(finding: KritFinding): List<IntentionAction> {
+        val applicable = finding.suggestedFixes.filter { it.edits.isNotEmpty() }
+        if (applicable.isNotEmpty()) {
+            return applicable.map { KritApplySuggestionIntention(finding.findingId, it) }
+        }
+        if (finding.fixable) {
+            return listOf(KritApplyFixesIntention(finding.fixLevel))
+        }
+        return emptyList()
+    }
+}
+
 class KritApplyFixesIntention(private val fixLevel: String?) : IntentionAction {
-    override fun getText(): String = "Apply Krit ${normalizedFixLevel()} auto-fixes"
+    override fun getText(): String = KritFixLabels.applyFixesTitle(fixLevel)
 
     override fun getFamilyName(): String = text
 
     override fun isAvailable(project: Project, editor: Editor?, file: PsiFile?): Boolean = true
 
     override fun invoke(project: Project, editor: Editor?, file: PsiFile?) {
-        project.service<KritProjectService>().applyFixes(normalizedFixLevel())
+        project.service<KritProjectService>().applyFixes(KritFixLabels.normalizeFixLevel(fixLevel))
     }
 
     override fun startInWriteAction(): Boolean = false
+}
 
-    private fun normalizedFixLevel(): String {
-        return fixLevel.orEmpty().ifBlank { "idiomatic" }
+class KritApplySuggestionIntention(
+    private val findingId: String,
+    private val suggestion: KritSuggestedFix,
+) : IntentionAction {
+    override fun getText(): String = KritFixLabels.suggestionTitle(suggestion)
+
+    override fun getFamilyName(): String = KritFixLabels.SUGGESTION_FAMILY_NAME
+
+    override fun isAvailable(project: Project, editor: Editor?, file: PsiFile?): Boolean = true
+
+    override fun invoke(project: Project, editor: Editor?, file: PsiFile?) {
+        project.service<KritProjectService>().applySuggestion(findingId, suggestion.id)
     }
+
+    override fun startInWriteAction(): Boolean = false
 }

--- a/editors/intellij-plugin/src/main/kotlin/dev/jasonpearson/krit/intellij/KritFinding.kt
+++ b/editors/intellij-plugin/src/main/kotlin/dev/jasonpearson/krit/intellij/KritFinding.kt
@@ -10,10 +10,32 @@ data class KritFinding(
     val message: String,
     val fixable: Boolean = false,
     val fixLevel: String? = null,
+    val suggestedFixes: List<KritSuggestedFix> = emptyList(),
 ) {
     val displayMessage: String
         get() = "Krit ${ruleSet}/${rule}: ${message}"
+
+    val findingId: String
+        get() = "${rule}:${file}:${line}:${column}"
 }
+
+data class KritSuggestedFix(
+    val id: String = "",
+    val title: String = "",
+    val detail: String = "",
+    val edits: List<KritSuggestedEdit> = emptyList(),
+    val applicationToken: String = "",
+)
+
+data class KritSuggestedEdit(
+    val targetFile: String = "",
+    val startLine: Int = 0,
+    val endLine: Int = 0,
+    val startByte: Int = 0,
+    val endByte: Int = 0,
+    val byteMode: Boolean = false,
+    val replacement: String = "",
+)
 
 data class KritReport(
     val findings: List<KritFinding> = emptyList(),

--- a/editors/intellij-plugin/src/main/kotlin/dev/jasonpearson/krit/intellij/KritFixLabels.kt
+++ b/editors/intellij-plugin/src/main/kotlin/dev/jasonpearson/krit/intellij/KritFixLabels.kt
@@ -1,0 +1,18 @@
+package dev.jasonpearson.krit.intellij
+
+object KritFixLabels {
+    private const val DEFAULT_FIX_LEVEL = "idiomatic"
+
+    fun normalizeFixLevel(fixLevel: String?): String =
+        fixLevel.orEmpty().ifBlank { DEFAULT_FIX_LEVEL }
+
+    fun applyFixesTitle(fixLevel: String?): String =
+        "Apply Krit ${normalizeFixLevel(fixLevel)} auto-fixes"
+
+    fun suggestionTitle(suggestion: KritSuggestedFix): String {
+        val title = suggestion.title.ifBlank { suggestion.id }
+        return "Krit suggestion: $title"
+    }
+
+    const val SUGGESTION_FAMILY_NAME = "Krit suggested fix"
+}

--- a/editors/intellij-plugin/src/main/kotlin/dev/jasonpearson/krit/intellij/KritInspection.kt
+++ b/editors/intellij-plugin/src/main/kotlin/dev/jasonpearson/krit/intellij/KritInspection.kt
@@ -2,8 +2,8 @@ package dev.jasonpearson.krit.intellij
 
 import com.intellij.codeInspection.LocalInspectionTool
 import com.intellij.codeInspection.LocalQuickFix
-import com.intellij.codeInspection.ProblemHighlightType
 import com.intellij.codeInspection.ProblemDescriptor
+import com.intellij.codeInspection.ProblemHighlightType
 import com.intellij.codeInspection.ProblemsHolder
 import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
@@ -51,6 +51,12 @@ class KritInspection : LocalInspectionTool() {
     }
 
     private fun quickFixes(finding: KritFinding): Array<LocalQuickFix> {
+        val applicable = finding.suggestedFixes.filter { it.edits.isNotEmpty() }
+        if (applicable.isNotEmpty()) {
+            return applicable
+                .map { KritApplySuggestionQuickFix(finding.findingId, it) }
+                .toTypedArray()
+        }
         if (!finding.fixable) {
             return emptyArray()
         }
@@ -59,13 +65,22 @@ class KritInspection : LocalInspectionTool() {
 }
 
 class KritApplyFixesQuickFix(private val fixLevel: String?) : LocalQuickFix {
-    override fun getFamilyName(): String = "Apply Krit ${normalizedFixLevel()} auto-fixes"
+    override fun getFamilyName(): String = KritFixLabels.applyFixesTitle(fixLevel)
 
     override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
-        project.service<KritProjectService>().applyFixes(normalizedFixLevel())
+        project.service<KritProjectService>().applyFixes(KritFixLabels.normalizeFixLevel(fixLevel))
     }
+}
 
-    private fun normalizedFixLevel(): String {
-        return fixLevel.orEmpty().ifBlank { "idiomatic" }
+class KritApplySuggestionQuickFix(
+    private val findingId: String,
+    private val suggestion: KritSuggestedFix,
+) : LocalQuickFix {
+    override fun getName(): String = KritFixLabels.suggestionTitle(suggestion)
+
+    override fun getFamilyName(): String = KritFixLabels.SUGGESTION_FAMILY_NAME
+
+    override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
+        project.service<KritProjectService>().applySuggestion(findingId, suggestion.id)
     }
 }

--- a/editors/intellij-plugin/src/main/kotlin/dev/jasonpearson/krit/intellij/KritJsonParser.kt
+++ b/editors/intellij-plugin/src/main/kotlin/dev/jasonpearson/krit/intellij/KritJsonParser.kt
@@ -10,11 +10,46 @@ object KritJsonParser {
         if (json.isBlank()) {
             return KritReport()
         }
-        return try {
+        // Gson uses reflective field assignment, so Kotlin default values do
+        // not apply to missing JSON fields — reference-typed fields land as
+        // null even though their declared type is non-null. Normalize after
+        // parse so the rest of the plugin sees a well-typed model.
+        val raw = try {
             gson.fromJson(json, KritReport::class.java) ?: KritReport()
         } catch (_: JsonSyntaxException) {
             KritReport()
         }
+        return normalize(raw)
     }
-}
 
+    private fun normalize(report: KritReport): KritReport {
+        val findings = report.findings.orNull().map { finding ->
+            finding.copy(
+                suggestedFixes = finding.suggestedFixes.orNull().map { normalizeSuggestion(it) },
+            )
+        }
+        return report.copy(findings = findings)
+    }
+
+    private fun normalizeSuggestion(suggestion: KritSuggestedFix): KritSuggestedFix {
+        return suggestion.copy(
+            id = suggestion.id.orNull(),
+            title = suggestion.title.orNull(),
+            detail = suggestion.detail.orNull(),
+            applicationToken = suggestion.applicationToken.orNull(),
+            edits = suggestion.edits.orNull().map { normalizeEdit(it) },
+        )
+    }
+
+    private fun normalizeEdit(edit: KritSuggestedEdit): KritSuggestedEdit {
+        return edit.copy(
+            targetFile = edit.targetFile.orNull(),
+            replacement = edit.replacement.orNull(),
+        )
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun <T> List<T>.orNull(): List<T> = (this as List<T>?) ?: emptyList()
+
+    private fun String.orNull(): String = (this as String?) ?: ""
+}

--- a/editors/intellij-plugin/src/main/kotlin/dev/jasonpearson/krit/intellij/KritProjectService.kt
+++ b/editors/intellij-plugin/src/main/kotlin/dev/jasonpearson/krit/intellij/KritProjectService.kt
@@ -40,6 +40,9 @@ class KritProjectService(private val project: Project) : Disposable {
     @Volatile
     private var findingsByFile: Map<String, List<KritFinding>> = emptyMap()
 
+    @Volatile
+    private var lastReportJson: String = ""
+
     init {
         EditorFactory.getInstance().eventMulticaster.addDocumentListener(documentListener, this)
         scheduleScan(0)
@@ -57,12 +60,30 @@ class KritProjectService(private val project: Project) : Disposable {
             }
             try {
                 if (KritRunner.fixProject(project, fixLevel)) {
-                    val report = KritRunner.analyzeProject(project)
-                    findingsByFile = report.findings.groupBy { canonicalPath(it.file, project.basePath) }
-                    restartHighlighting()
+                    refreshFindings()
                 }
             } catch (t: Throwable) {
                 log.warn("krit fix runner failed", t)
+            } finally {
+                running.set(false)
+                scheduleRequestedRerun()
+            }
+        }
+    }
+
+    fun applySuggestion(findingId: String, suggestionId: String) {
+        val cachedReport = lastReportJson
+        executor.execute {
+            if (project.isDisposed || !running.compareAndSet(false, true)) {
+                rerunAfterCurrent.set(true)
+                return@execute
+            }
+            try {
+                if (KritRunner.applySuggestion(project, findingId, suggestionId, cachedReport)) {
+                    refreshFindings()
+                }
+            } catch (t: Throwable) {
+                log.warn("krit apply-suggestion runner failed", t)
             } finally {
                 running.set(false)
                 scheduleRequestedRerun()
@@ -76,15 +97,20 @@ class KritProjectService(private val project: Project) : Disposable {
             return
         }
         try {
-            val report = KritRunner.analyzeProject(project)
-            findingsByFile = report.findings.groupBy { canonicalPath(it.file, project.basePath) }
-            restartHighlighting()
+            refreshFindings()
         } catch (t: Throwable) {
             log.warn("krit project runner failed", t)
         } finally {
             running.set(false)
             scheduleRequestedRerun()
         }
+    }
+
+    private fun refreshFindings() {
+        val result = KritRunner.analyzeProject(project)
+        findingsByFile = result.report.findings.groupBy { canonicalPath(it.file, project.basePath) }
+        lastReportJson = result.rawJson
+        restartHighlighting()
     }
 
     private fun scheduleScan(delayMs: Long) {

--- a/editors/intellij-plugin/src/main/kotlin/dev/jasonpearson/krit/intellij/KritRunner.kt
+++ b/editors/intellij-plugin/src/main/kotlin/dev/jasonpearson/krit/intellij/KritRunner.kt
@@ -8,40 +8,35 @@ import java.util.concurrent.TimeUnit
 object KritRunner {
     private val log = Logger.getInstance(KritRunner::class.java)
 
-    fun analyzeProject(project: Project): KritReport {
-        val projectDir = project.baseDir() ?: return KritReport()
+    data class AnalyzeResult(val report: KritReport, val rawJson: String) {
+        companion object {
+            val EMPTY = AnalyzeResult(KritReport(), "")
+        }
+    }
+
+    fun analyzeProject(project: Project): AnalyzeResult {
+        val projectDir = project.baseDir() ?: return AnalyzeResult.EMPTY
         val output = File.createTempFile("krit-intellij-", ".json")
-        val command = mutableListOf(
-            kritBinary(),
-            "--format=json",
-            "-o",
-            output.absolutePath,
-            "-q",
-            projectDir.absolutePath,
-        )
         return try {
-            val process = ProcessBuilder(command)
-                .directory(projectDir)
-                .redirectError(ProcessBuilder.Redirect.PIPE)
-                .start()
-
-            if (!process.waitFor(120, TimeUnit.SECONDS)) {
-                process.destroyForcibly()
-                log.warn("krit project analysis timed out for ${projectDir.path}")
-                return KritReport()
+            val command = listOf(
+                kritBinary(),
+                "--format=json",
+                "-o",
+                output.absolutePath,
+                "-q",
+                projectDir.absolutePath,
+            )
+            // krit exits non-zero when it reports findings; trust the output
+            // file as long as it exists rather than the exit code.
+            val ok = runKrit(projectDir, command, ANALYZE_TIMEOUT_SECONDS, "project analysis") { exit, _ ->
+                exit == 0 || output.isFile
             }
-
-            val stderr = process.errorStream.bufferedReader().readText()
-            val exit = process.exitValue()
-            if (exit != 0 && !output.isFile) {
-                log.warn("krit failed for ${projectDir.path} with exit $exit: $stderr")
-                return KritReport()
-            }
-
-            KritJsonParser.parse(output.readText())
+            if (!ok) return AnalyzeResult.EMPTY
+            val raw = output.readText()
+            AnalyzeResult(KritJsonParser.parse(raw), raw)
         } catch (t: Throwable) {
             log.warn("krit project analysis failed for ${projectDir.path}", t)
-            KritReport()
+            AnalyzeResult.EMPTY
         } finally {
             output.delete()
         }
@@ -49,36 +44,80 @@ object KritRunner {
 
     fun fixProject(project: Project, fixLevel: String?): Boolean {
         val projectDir = project.baseDir() ?: return false
-        val level = fixLevel.orEmpty().ifBlank { "idiomatic" }
+        val level = KritFixLabels.normalizeFixLevel(fixLevel)
+        val command = listOf(
+            kritBinary(),
+            "--fix",
+            "--fix-level",
+            level,
+            "-q",
+            projectDir.absolutePath,
+        )
+        return runKrit(projectDir, command, FIX_TIMEOUT_SECONDS, "fix") { exit, _ -> exit == 0 }
+    }
+
+    fun applySuggestion(
+        project: Project,
+        findingId: String,
+        suggestionId: String,
+        reportJson: String,
+    ): Boolean {
+        val projectDir = project.baseDir() ?: return false
+        if (reportJson.isBlank()) {
+            log.warn("krit apply-suggestion skipped: no cached report for ${projectDir.path}")
+            return false
+        }
+        val reportFile = File.createTempFile("krit-intellij-suggest-", ".json")
         return try {
+            reportFile.writeText(reportJson)
             val command = listOf(
                 kritBinary(),
-                "--fix",
-                "--fix-level",
-                level,
-                "-q",
+                "apply-suggestion",
+                "--finding",
+                findingId,
+                "--suggestion",
+                suggestionId,
+                "--base",
                 projectDir.absolutePath,
+                reportFile.absolutePath,
             )
+            runKrit(projectDir, command, APPLY_SUGGESTION_TIMEOUT_SECONDS, "apply-suggestion") { exit, _ ->
+                exit == 0
+            }
+        } finally {
+            reportFile.delete()
+        }
+    }
+
+    private fun runKrit(
+        projectDir: File,
+        command: List<String>,
+        timeoutSeconds: Long,
+        label: String,
+        isSuccess: (exit: Int, stderr: String) -> Boolean,
+    ): Boolean {
+        return try {
             val process = ProcessBuilder(command)
                 .directory(projectDir)
                 .redirectError(ProcessBuilder.Redirect.PIPE)
+                .redirectOutput(ProcessBuilder.Redirect.PIPE)
                 .start()
 
-            if (!process.waitFor(120, TimeUnit.SECONDS)) {
+            if (!process.waitFor(timeoutSeconds, TimeUnit.SECONDS)) {
                 process.destroyForcibly()
-                log.warn("krit fix timed out for ${projectDir.path}")
+                log.warn("krit $label timed out for ${projectDir.path}")
                 return false
             }
 
             val stderr = process.errorStream.bufferedReader().readText()
             val exit = process.exitValue()
-            if (exit != 0) {
-                log.warn("krit fix failed for ${projectDir.path} with exit $exit: $stderr")
+            if (!isSuccess(exit, stderr)) {
+                log.warn("krit $label failed for ${projectDir.path} with exit $exit: $stderr")
                 return false
             }
             true
         } catch (t: Throwable) {
-            log.warn("krit fix failed for ${projectDir.path}", t)
+            log.warn("krit $label failed for ${projectDir.path}", t)
             false
         }
     }
@@ -93,4 +132,8 @@ object KritRunner {
         val base = basePath ?: return null
         return File(base)
     }
+
+    private const val ANALYZE_TIMEOUT_SECONDS = 120L
+    private const val FIX_TIMEOUT_SECONDS = 120L
+    private const val APPLY_SUGGESTION_TIMEOUT_SECONDS = 60L
 }

--- a/editors/intellij-plugin/src/test/kotlin/dev/jasonpearson/krit/intellij/KritJsonParserTest.kt
+++ b/editors/intellij-plugin/src/test/kotlin/dev/jasonpearson/krit/intellij/KritJsonParserTest.kt
@@ -3,6 +3,7 @@ package dev.jasonpearson.krit.intellij
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
 class KritJsonParserTest {
@@ -51,6 +52,187 @@ class KritJsonParserTest {
         )
 
         assertFalse(report.findings.single().fixable)
+    }
+
+    @Test
+    fun `parse suggested fixes preserves rule-defined order`() {
+        val report = KritJsonParser.parse(
+            """
+            {
+              "findings": [
+                {
+                  "file": "/repo/Example.kt",
+                  "line": 5,
+                  "column": 3,
+                  "ruleSet": "style",
+                  "rule": "Suggester",
+                  "severity": "warning",
+                  "message": "pick one",
+                  "fixable": false,
+                  "suggestedFixes": [
+                    {
+                      "id": "use-val",
+                      "title": "Convert to val",
+                      "edits": [
+                        {"startLine":5,"endLine":5,"replacement":"val x = 1"}
+                      ]
+                    },
+                    {
+                      "id": "explain",
+                      "title": "Explain the warning",
+                      "detail": "var becomes val when read-only.",
+                      "applicationToken": "help:val-vs-var"
+                    }
+                  ]
+                }
+              ]
+            }
+            """.trimIndent(),
+        )
+
+        val finding = report.findings.single()
+        assertFalse(finding.fixable)
+        assertEquals(2, finding.suggestedFixes.size)
+        assertEquals("use-val", finding.suggestedFixes[0].id)
+        assertEquals("Convert to val", finding.suggestedFixes[0].title)
+        val firstEdit = finding.suggestedFixes[0].edits.single()
+        assertEquals("val x = 1", firstEdit.replacement)
+        assertEquals(5, firstEdit.startLine)
+
+        assertEquals("explain", finding.suggestedFixes[1].id)
+        assertEquals("var becomes val when read-only.", finding.suggestedFixes[1].detail)
+        assertEquals("help:val-vs-var", finding.suggestedFixes[1].applicationToken)
+        assertTrue(finding.suggestedFixes[1].edits.isEmpty())
+
+        assertEquals("Suggester:/repo/Example.kt:5:3", finding.findingId)
+    }
+
+    @Test
+    fun `suggestions absent defaults to empty list`() {
+        val report = KritJsonParser.parse(
+            """
+            {"findings":[{"file":"A.kt","line":1,"column":1,"ruleSet":"x","rule":"R","severity":"warning","message":"m"}]}
+            """.trimIndent(),
+        )
+
+        val finding = report.findings.single()
+        assertNotNull(finding.suggestedFixes)
+        assertTrue(finding.suggestedFixes.isEmpty())
+    }
+
+    @Test
+    fun `intentions for finding with suggestions yield ordered per-suggestion intentions and skip autofix`() {
+        val finding = KritFinding(
+            file = "/repo/A.kt",
+            line = 1,
+            column = 1,
+            ruleSet = "style",
+            rule = "R",
+            severity = "warning",
+            message = "m",
+            fixable = true,
+            fixLevel = "idiomatic",
+            suggestedFixes = listOf(
+                KritSuggestedFix(
+                    id = "a",
+                    title = "Apply A",
+                    edits = listOf(KritSuggestedEdit(startLine = 1, endLine = 1, replacement = "A")),
+                ),
+                KritSuggestedFix(
+                    id = "b",
+                    title = "Apply B",
+                    edits = listOf(KritSuggestedEdit(startLine = 1, endLine = 1, replacement = "B")),
+                ),
+            ),
+        )
+
+        val actions = KritIntentions.forFinding(finding)
+        assertEquals(2, actions.size)
+        actions.forEach { assertTrue(it is KritApplySuggestionIntention) }
+        assertEquals("Krit suggestion: Apply A", actions[0].text)
+        assertEquals("Krit suggestion: Apply B", actions[1].text)
+    }
+
+    @Test
+    fun `intentions for finding without suggestions fall back to autofix when fixable`() {
+        val finding = KritFinding(
+            file = "/repo/A.kt",
+            line = 1,
+            column = 1,
+            ruleSet = "style",
+            rule = "R",
+            severity = "warning",
+            message = "m",
+            fixable = true,
+            fixLevel = "cosmetic",
+        )
+
+        val actions = KritIntentions.forFinding(finding)
+        assertEquals(1, actions.size)
+        assertTrue(actions.single() is KritApplyFixesIntention)
+        assertEquals("Apply Krit cosmetic auto-fixes", actions.single().text)
+    }
+
+    @Test
+    fun `intentions filter out suggestions without machine-applicable edits`() {
+        val finding = KritFinding(
+            file = "/repo/A.kt",
+            line = 1,
+            column = 1,
+            ruleSet = "style",
+            rule = "R",
+            severity = "warning",
+            message = "m",
+            suggestedFixes = listOf(
+                KritSuggestedFix(id = "explain", title = "Explain", applicationToken = "help:x"),
+                KritSuggestedFix(
+                    id = "use-val",
+                    title = "Convert to val",
+                    edits = listOf(KritSuggestedEdit(startLine = 1, endLine = 1, replacement = "val x")),
+                ),
+            ),
+        )
+
+        val actions = KritIntentions.forFinding(finding)
+        assertEquals(1, actions.size)
+        assertEquals("Krit suggestion: Convert to val", actions.single().text)
+    }
+
+    @Test
+    fun `intentions fall back to autofix when all suggestions are informational`() {
+        val finding = KritFinding(
+            file = "/repo/A.kt",
+            line = 1,
+            column = 1,
+            ruleSet = "style",
+            rule = "R",
+            severity = "warning",
+            message = "m",
+            fixable = true,
+            fixLevel = "idiomatic",
+            suggestedFixes = listOf(
+                KritSuggestedFix(id = "explain", title = "Explain", applicationToken = "help:x"),
+            ),
+        )
+
+        val actions = KritIntentions.forFinding(finding)
+        assertEquals(1, actions.size)
+        assertTrue(actions.single() is KritApplyFixesIntention)
+    }
+
+    @Test
+    fun `intentions for non-fixable finding with no suggestions are empty`() {
+        val finding = KritFinding(
+            file = "/repo/A.kt",
+            line = 1,
+            column = 1,
+            ruleSet = "style",
+            rule = "R",
+            severity = "warning",
+            message = "m",
+        )
+
+        assertTrue(KritIntentions.forFinding(finding).isEmpty())
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Parse `suggestedFixes` (and their ordered edits / metadata) from the Krit project-scan JSON in the IntelliJ plugin and register one native `IntentionAction` / `LocalQuickFix` per suggestion, in the order the rule emitted them.
- Suppress the catch-all auto-fix entry when a finding carries machine-applicable suggestions so a single diagnostic offers only one of {auto-fix, suggestion choice}, per the issue's requirement to keep the two paths separate.
- Apply a chosen suggestion by shelling out to `krit apply-suggestion --finding ID --suggestion ID --base PROJECT report.json` against the JSON cached from the most recent project scan, then re-running the scan to refresh highlighting. Continuous 5-second scan behavior and open-file filtering are unchanged.

## Validation

- `editors/intellij-plugin` `gradle test` passes (parser preserves rule-defined order; quick fixes filter out informational suggestions; autofix fallback when no suggestions; XOR semantics covered).
- `scripts/ide-plugin/validate.sh` (`test buildPlugin verifyPlugin`) reports **Compatible** against both K2-capable builds (IU-253.33514.17 and IU-261.24374.151).

## Test plan

- [x] Plugin unit tests cover the parser, ordering, empty-edits filtering, and the XOR-with-autofix decision.
- [x] Plugin verifier passes against IU-253 and IU-261.
- [ ] Manual: open a project where a rule emits a finding with two suggestions; confirm both appear as ordered quick fixes and selecting one applies just that suggestion.

Closes #244