### PR TITLE
feat(daemon): route --clear-matrix-cache via daemon verb

### DIFF
--- a/docs/daemon-flag-routing.md
+++ b/docs/daemon-flag-routing.md
@@ -178,6 +178,54 @@ promotion match the in-process flow. The wire addition was shared with
 `--rule-audit` / `--baseline-audit`; see "Audits that ship with the
 analysis" above for the response-shape rationale.
 
+## Cache clears
+
+### `--clear-cache` (now routed via daemon)
+
+Routes through the `clear-cache` verb (`handleClearCache` in
+`internal/cli/serve/clear_cache.go`). The daemon serialises against any
+concurrent `analyze-project` on `state.analyzeMu`, then calls
+`cacheutil.ClearAll`, removes the on-disk analysis-cache file, resets the
+parse cache, drops every resident `WorkspaceState` slot, and clears the
+manifest cache so the next analyze rebuilds from cold rather than
+resurrecting state from in-memory snapshots that no longer have a disk
+backing.
+
+When the daemon socket is unreachable (or `--no-daemon` is passed) the CLI
+falls back to `runClearCacheFlag` in-process; behaviour is equivalent for
+the on-disk caches but no resident-state invalidation happens because there
+is no resident state in a one-shot CLI invocation.
+
+### `--clear-matrix-cache` (now routed via daemon)
+
+Routes through the `clear-matrix-cache` verb (`handleClearMatrixCache` in
+`internal/cli/serve/clear_cache.go`). The daemon calls
+`scan.ClearMatrixCache`, the same function the in-process early-exit
+(`runClearMatrixCacheFlag` in `internal/cli/scan/early_exits.go:49`) uses.
+
+The matrix baseline cache lives at a host-wide path
+(`~/.cache/krit/matrix-baseline`), so multiple per-repo daemons may share
+it. We do not add a host-level lock for the following reason: the matrix
+cache is best-effort by design — `saveBaseline` swallows write errors,
+and `tryLoadBaseline` treats any missing or mismatched entry as a miss,
+which the matrix runner handles by recomputing. A clear that races a
+concurrent write from another daemon at worst causes one experiment case
+to be recomputed; it cannot corrupt durable state because the matrix
+runner re-execs `krit` for every case and never holds the cache open
+across a recompute.
+
+Inside a single daemon the clear is serialised on `state.analyzeMu` so it
+cannot race with that daemon's own `analyze-project` enumerations of the
+`cacheutil` registry.
+
+The daemon also imports `internal/cli/scan` transitively (via
+`internal/cli/serve/meta_verbs.go`'s use of `scan.RunOutputTypesTo`), so
+`scan/matrix_cache.go`'s `init()` registers the matrix cache with
+`cacheutil` in the daemon process. As a side effect, `--clear-cache`
+already wipes the matrix cache too. The standalone `--clear-matrix-cache`
+verb keeps the host-wide directory deletable without also dropping the
+daemon's resident WorkspaceState / analysis cache / parse cache.
+
 ## Adding a new flag
 
 When introducing a new CLI flag, decide which bucket it belongs in:

--- a/internal/cli/scan/daemon_delegate.go
+++ b/internal/cli/scan/daemon_delegate.go
@@ -342,9 +342,8 @@ func runDaemonSampleRule(f *scanFlags, paths []string, findingsJSON []byte) int 
 // when one is reachable. Returning true means the daemon performed
 // the clear and the caller should exit 0; false means the caller
 // falls back to in-process clear-cache (which still works when no
-// daemon is up). --clear-matrix-cache stays in-process: the matrix
-// cache lives in ~/.cache/krit and the daemon binary doesn't link
-// the registration code, so there's nothing for it to coordinate.
+// daemon is up). See tryDaemonClearMatrixCache below for the matrix-
+// baseline cache equivalent.
 func tryDaemonClearCache(f *scanFlags, repoDir string) bool {
 	if f == nil || *f.NoDaemon || !*f.ClearCache {
 		return false
@@ -366,6 +365,45 @@ func tryDaemonClearCache(f *scanFlags, repoDir string) bool {
 		fmt.Fprintln(os.Stderr, "info: Cache cleared (via daemon).")
 	} else {
 		fmt.Fprintln(os.Stderr, "info: Cache clear completed with errors (via daemon).")
+	}
+	return true
+}
+
+// tryDaemonClearMatrixCache routes --clear-matrix-cache through a
+// running daemon when one is reachable. Returning true means the
+// daemon performed the clear and the caller should exit 0; false
+// means the caller falls back to in-process ClearMatrixCache (which
+// still works when no daemon is up).
+//
+// The matrix cache lives at a host-wide path (~/.cache/krit/
+// matrix-baseline). Multiple per-repo daemons can share it, but the
+// clear itself is best-effort (matrixSave/Load tolerate missing or
+// partial entries — a wiped slot just triggers a recompute). The
+// daemon serialises against its own analyze loop on state.analyzeMu
+// to avoid intra-daemon races; cross-daemon races are tolerated by
+// the matrix runner's own miss-then-recompute design, so no extra
+// host-level lock is needed.
+func tryDaemonClearMatrixCache(f *scanFlags, repoDir string) bool {
+	if f == nil || *f.NoDaemon || !*f.ClearMatrixCache {
+		return false
+	}
+	client, ok := daemonclient.TryConnect(repoDir, *f.DaemonSocket)
+	if !ok {
+		return false
+	}
+	res, err := client.ClearMatrixCache(daemon.ClearMatrixCacheArgs{})
+	if err != nil {
+		if daemonclient.IsBinaryHashMismatch(err) {
+			fmt.Fprintf(os.Stderr, "warning: krit daemon rejected request (%v); falling back to in-process. Restart it with: krit daemon restart\n", err)
+			return false
+		}
+		fmt.Fprintf(os.Stderr, "warning: krit daemon clear-matrix-cache failed (%v); falling back to in-process\n", err)
+		return false
+	}
+	if res.Cleared {
+		fmt.Fprintln(os.Stderr, "info: Matrix baseline cache cleared (via daemon).")
+	} else {
+		fmt.Fprintln(os.Stderr, "info: Matrix baseline cache clear completed with errors (via daemon).")
 	}
 	return true
 }
@@ -440,10 +478,12 @@ func daemonAutoStartDisabled() bool {
 // --no-cache, --clear-cache, --clear-matrix-cache are also daemon-
 // routable: --no-cache rides on AnalyzeProjectArgs.NoCache (the
 // daemon nils every disk-cache pointer for this single call); the
-// two clear-* flags are handled by tryDaemonCacheClear before
-// tryDaemonDelegate runs (early-exit verbs that also drop the
-// daemon's resident WorkspaceState slots so the next analyze
-// rebuilds from cold).
+// two clear-* flags are handled by tryDaemonClearCache and
+// tryDaemonClearMatrixCache before tryDaemonDelegate runs (early-
+// exit verbs). --clear-cache also drops the daemon's resident
+// WorkspaceState slots so the next analyze rebuilds from cold;
+// --clear-matrix-cache only touches the host-wide matrix baseline
+// directory because the matrix cache has no resident counterpart.
 //
 // --create-baseline and --dry-run ARE compatible: the daemon computes
 // the baseline-ID list / fixable-file list from the same FindingColumns

--- a/internal/cli/scan/daemon_delegate_test.go
+++ b/internal/cli/scan/daemon_delegate_test.go
@@ -397,10 +397,10 @@ func TestDaemonCompatibleFlags_PerfAllowed(t *testing.T) {
 		// the right place to serve it.
 		{"--no-cache", func(f *scanFlags) { *f.NoCache = true }, true},
 		// --clear-cache and --clear-matrix-cache are early-exit
-		// verbs handled outside the analyze path (clear-cache via
-		// tryDaemonClearCache, clear-matrix-cache stays in-process),
-		// so daemonCompatibleFlags must NOT short-circuit on them
-		// the way the analyze path used to.
+		// verbs handled outside the analyze path via
+		// tryDaemonClearCache / tryDaemonClearMatrixCache, so
+		// daemonCompatibleFlags must NOT short-circuit on them the
+		// way the analyze path used to.
 		{"--clear-cache", func(f *scanFlags) { *f.ClearCache = true }, true},
 		{"--clear-matrix-cache", func(f *scanFlags) { *f.ClearMatrixCache = true }, true},
 		// --input-types and --sample-rule are daemon-served via the
@@ -472,6 +472,82 @@ func TestTryDaemonClearCache_HappyPath(t *testing.T) {
 	if !tryDaemonClearCache(f, root) {
 		t.Fatalf("expected handled=true on daemon success")
 	}
+}
+
+// TestTryDaemonClearMatrixCache_NoClearFlagNoOp pins the entry-gate
+// contract: when --clear-matrix-cache is not set,
+// tryDaemonClearMatrixCache must not even attempt a dial.
+func TestTryDaemonClearMatrixCache_NoClearFlagNoOp(t *testing.T) {
+	root := newRoot(t)
+	f := freshScanFlags(t)
+	if tryDaemonClearMatrixCache(f, root) {
+		t.Fatalf("expected handled=false when --clear-matrix-cache is unset")
+	}
+}
+
+// TestTryDaemonClearMatrixCache_NoDaemonShortCircuits guards the
+// --no-daemon flag for the matrix-clear path: even if a socket is
+// reachable and --clear-matrix-cache is set, --no-daemon falls
+// through to in-process.
+func TestTryDaemonClearMatrixCache_NoDaemonShortCircuits(t *testing.T) {
+	socketDir := startMockClearMatrixCacheDaemon(t, false)
+	root := newRoot(t)
+	linkSock(t, root, filepath.Join(socketDir, "d.sock"))
+	f := freshScanFlags(t)
+	*f.ClearMatrixCache = true
+	*f.NoDaemon = true
+	if tryDaemonClearMatrixCache(f, root) {
+		t.Fatalf("expected fall-through with --no-daemon")
+	}
+}
+
+// TestTryDaemonClearMatrixCache_HappyPath confirms the verb is
+// invoked and the CLI exits cleanly (code 0) when the daemon reports
+// success.
+func TestTryDaemonClearMatrixCache_HappyPath(t *testing.T) {
+	socketDir := startMockClearMatrixCacheDaemon(t, true)
+	root := newRoot(t)
+	linkSock(t, root, filepath.Join(socketDir, "d.sock"))
+	f := freshScanFlags(t)
+	*f.ClearMatrixCache = true
+	if !tryDaemonClearMatrixCache(f, root) {
+		t.Fatalf("expected handled=true on daemon success")
+	}
+}
+
+// startMockClearMatrixCacheDaemon stands up a minimal daemon that
+// implements just enough of clear-matrix-cache to drive
+// tryDaemonClearMatrixCache assertions.
+func startMockClearMatrixCacheDaemon(t *testing.T, cleared bool) string {
+	t.Helper()
+	socketDir, err := os.MkdirTemp("/tmp", "krit-clearmx-srv-")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(socketDir) })
+	socket := filepath.Join(socketDir, "d.sock")
+	srv := daemon.NewServer(socket)
+	srv.Register(daemon.VerbStatus, func(_ context.Context, _ json.RawMessage) (any, error) {
+		return daemon.StatusResult{Ready: true}, nil
+	})
+	srv.Register(daemon.VerbShutdown, func(_ context.Context, _ json.RawMessage) (any, error) {
+		return map[string]bool{"ok": true}, nil
+	})
+	srv.Register(daemon.VerbClearMatrixCache, func(_ context.Context, _ json.RawMessage) (any, error) {
+		return daemon.ClearMatrixCacheResult{Cleared: cleared}, nil
+	})
+	if err := srv.Start(context.Background()); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	t.Cleanup(srv.Stop)
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if daemon.Available(socket) {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	return socketDir
 }
 
 // startMockClearCacheDaemon stands up a minimal daemon that

--- a/internal/cli/scan/scan.go
+++ b/internal/cli/scan/scan.go
@@ -291,6 +291,9 @@ func Run() int {
 	if tryDaemonClearCache(f, repoDir) {
 		return 0
 	}
+	if tryDaemonClearMatrixCache(f, repoDir) {
+		return 0
+	}
 	if handled, code := tryDaemonDelegate(f, flag.Args(), repoDir); handled {
 		return code
 	}

--- a/internal/cli/serve/cache_ops_test.go
+++ b/internal/cli/serve/cache_ops_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/kaeawc/krit/internal/cli/scan"
 	"github.com/kaeawc/krit/internal/daemon"
 )
 
@@ -101,6 +102,58 @@ func TestClearCache_DropsResidentAndDiskState(t *testing.T) {
 	}
 	if !afterClear.Stats.Cold {
 		t.Errorf("post-clear analyze must be Cold; got %+v", afterClear.Stats)
+	}
+}
+
+// TestClearMatrixCache_RemovesHostWideEntries pins that the
+// clear-matrix-cache verb wipes the host-wide matrix-baseline
+// directory by routing through scan.ClearMatrixCache. Equivalence
+// with the in-process path: any file written under
+// ~/.cache/krit/matrix-baseline before the verb call is gone after.
+//
+// $HOME is redirected to t.TempDir() so the test never touches the
+// developer's real cache.
+func TestClearMatrixCache_RemovesHostWideEntries(t *testing.T) {
+	tempHome := t.TempDir()
+	t.Setenv("HOME", tempHome)
+
+	// Seed an entry under the matrix-baseline directory. Use the same
+	// helper the scan package uses so the path layout is whatever
+	// matrixCacheDir() resolves to under the redirected HOME.
+	dir := filepath.Join(tempHome, ".cache", "krit", "matrix-baseline")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	seedPath := filepath.Join(dir, "deadbeef.json")
+	if err := os.WriteFile(seedPath, []byte(`{}`), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	socket, _ := startServerForTest(t)
+	var res daemon.ClearMatrixCacheResult
+	if err := daemon.Call(socket, daemon.VerbClearMatrixCache,
+		daemon.ClearMatrixCacheArgs{}, &res); err != nil {
+		t.Fatalf("clear-matrix-cache: %v", err)
+	}
+	if !res.Cleared {
+		t.Errorf("Cleared=false, want true; got %+v", res)
+	}
+	if _, err := os.Stat(seedPath); !os.IsNotExist(err) {
+		t.Errorf("expected matrix entry removed; stat err=%v", err)
+	}
+
+	// Equivalence: in-process scan.ClearMatrixCache on an empty
+	// directory should succeed (idempotent), and the daemon-routed
+	// clear should match that no-op behaviour. Seed again, call the
+	// in-process function, confirm the entry is gone.
+	if err := os.WriteFile(seedPath, []byte(`{}`), 0o644); err != nil {
+		t.Fatalf("re-seed: %v", err)
+	}
+	if err := scan.ClearMatrixCache(); err != nil {
+		t.Fatalf("in-process ClearMatrixCache: %v", err)
+	}
+	if _, err := os.Stat(seedPath); !os.IsNotExist(err) {
+		t.Errorf("in-process clear should match daemon clear; stat err=%v", err)
 	}
 }
 

--- a/internal/cli/serve/clear_cache.go
+++ b/internal/cli/serve/clear_cache.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/kaeawc/krit/internal/cache"
 	"github.com/kaeawc/krit/internal/cacheutil"
+	"github.com/kaeawc/krit/internal/cli/scan"
 	"github.com/kaeawc/krit/internal/daemon"
 	"github.com/kaeawc/krit/internal/scanner"
 )
@@ -21,13 +22,13 @@ import (
 // resurrecting state from in-memory snapshots that no longer have a
 // disk-cache backing.
 //
-// The matrix-cache subsystem (internal/cli/scan/matrix_cache.go) only
-// auto-registers itself when the scan package is linked. The daemon
-// shim binary doesn't link scan, so the matrix cache stays a CLI-side
-// concern; --clear-matrix-cache is intentionally NOT routed through
-// the daemon. The daemon's clear-cache verb still calls ClearAll()
-// because other subsystems that DO get registered from packages the
-// daemon imports get cleared this way.
+// The matrix-cache subsystem (internal/cli/scan/matrix_cache.go)
+// auto-registers itself via init() and is linked into this package
+// transitively through internal/cli/serve/meta_verbs.go's scan
+// import, so cacheutil.ClearAll() below also wipes the host-wide
+// experiment-matrix baseline cache. handleClearMatrixCache exposes
+// the same delete as a standalone verb for --clear-matrix-cache,
+// which intentionally does NOT also drop resident WorkspaceState.
 func handleClearCache(_ context.Context, state *daemonState, raw json.RawMessage) (any, error) {
 	var args daemon.ClearCacheArgs
 	if len(raw) > 0 {
@@ -93,4 +94,47 @@ func (s *daemonState) resetParseCache() {
 	s.closeParseCache()
 	s.parseCacheOnce = sync.Once{}
 	s.parseCacheErr = nil
+}
+
+// handleClearMatrixCache implements the clear-matrix-cache verb. It
+// removes every entry under ~/.cache/krit/matrix-baseline (the
+// host-wide experiment-matrix baseline cache) by delegating to
+// scan.ClearMatrixCache, which the in-process --clear-matrix-cache
+// path uses too.
+//
+// Unlike clear-cache, this verb does NOT touch the daemon's resident
+// WorkspaceState, analysis cache, parse cache, or manifest cache:
+// the matrix cache has no resident counterpart and the experiment-
+// matrix runner re-execs the krit binary for every case, so wiping
+// the host directory is sufficient to force a recompute on the next
+// run.
+//
+// Concurrency: the matrix cache lives at a host-wide path that may
+// be shared with other per-repo daemons. The clear itself is a
+// directory scan plus per-entry os.Remove; cross-daemon races are
+// non-fatal by design because matrixSave/Load already tolerates
+// missing or partial entries (saveBaseline swallows write errors and
+// tryLoadBaseline reports any unreadable / mismatched entry as a
+// miss, which the matrix runner handles by recomputing). We still
+// take state.analyzeMu so this daemon's own clear cannot race with
+// an in-flight analyze that might enumerate the cacheutil registry
+// at an awkward moment.
+func handleClearMatrixCache(_ context.Context, state *daemonState, raw json.RawMessage) (any, error) {
+	var args daemon.ClearMatrixCacheArgs
+	if len(raw) > 0 {
+		if err := json.Unmarshal(raw, &args); err != nil {
+			return nil, fmt.Errorf("decode args: %w", err)
+		}
+	}
+	if daemonHash := daemonBinaryHash(); args.ClientBinaryHash != "" && daemonHash != "" && args.ClientBinaryHash != daemonHash {
+		return nil, fmt.Errorf("%s (daemon=%s client=%s)", daemon.ErrBinaryHashMismatchPrefix, daemonHash, args.ClientBinaryHash)
+	}
+
+	state.analyzeMu.Lock()
+	defer state.analyzeMu.Unlock()
+
+	if err := scan.ClearMatrixCache(); err != nil {
+		return daemon.ClearMatrixCacheResult{Cleared: false}, fmt.Errorf("clear matrix cache: %w", err)
+	}
+	return daemon.ClearMatrixCacheResult{Cleared: true}, nil
 }

--- a/internal/cli/serve/serve.go
+++ b/internal/cli/serve/serve.go
@@ -778,6 +778,9 @@ func registerVerbs(srv *daemon.Server, state *daemonState) {
 	srv.Register(daemon.VerbClearCache, func(ctx context.Context, raw json.RawMessage) (any, error) {
 		return handleClearCache(ctx, state, raw)
 	})
+	srv.Register(daemon.VerbClearMatrixCache, func(ctx context.Context, raw json.RawMessage) (any, error) {
+		return handleClearMatrixCache(ctx, state, raw)
+	})
 }
 
 // handleAnalyzeBuffer parses (or reuses a cached parse for) the buffer


### PR DESCRIPTION
## Summary

- Wire `--clear-matrix-cache` through the daemon by implementing
  `handleClearMatrixCache` (the protocol verb + client method already existed
  from a previous round of scaffolding) and routing the CLI flag via
  `tryDaemonClearMatrixCache` before the in-process early-exit fires.
- Update `docs/daemon-flag-routing.md` with the correct rationale: the
  daemon process *does* link the matrix-cache registration code (transitively
  through `internal/cli/serve/meta_verbs.go`'s use of
  `scan.RunOutputTypesTo`), so the PR #273 reasoning ("daemon shim doesn't
  link scan") was already stale before PR #289 landed.
- Add CLI tests (no-op, `--no-daemon` short-circuit, happy path) and a
  daemon-side equivalence test that seeds an entry under
  `~/.cache/krit/matrix-baseline` (with `$HOME` redirected), invokes the
  verb, and confirms the entry is gone — then re-seeds and shows that
  in-process `scan.ClearMatrixCache` produces the same final state.

## Rationale: why no host-level lock?

The matrix baseline cache is host-wide and may be touched by multiple
per-repo daemons. We don't add a coordination primitive:

- `saveBaseline` swallows write errors; `tryLoadBaseline` treats any missing
  or mismatched entry as a miss; the matrix runner handles a miss by
  recomputing. A clear that races a concurrent write at worst causes one
  experiment case to be recomputed.
- The matrix runner re-execs `krit` for every case, so no daemon holds the
  cache open across a recompute.
- Intra-daemon races are blocked by `state.analyzeMu` (same lock
  `handleClearCache` uses).
- `--clear-cache` already wipes the matrix cache today as a side effect of
  `cacheutil.ClearAll`, so the host-wide race surface already existed; this
  PR doesn't introduce it.

Addresses item 3 of #284. Items 1, 2, 4, and 5 remain.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...`
- [x] `go test ./... -count=1`
- [x] `make lint-rules`