### PR TITLE
test(serve): stabilize DebounceEditorSavePattern watcher test (#284)

### DIFF
--- a/internal/cli/serve/watcher_test.go
+++ b/internal/cli/serve/watcher_test.go
@@ -377,7 +377,12 @@ func TestFileWatcher_TouchPropagatesOnGradleWrite(t *testing.T) {
 }
 
 // TestFileWatcher_DebounceEditorSavePattern verifies that three rapid events
-// for the same Kotlin file coalesce into a single Invalidate call.
+// for the same Kotlin file coalesce into a single Invalidate call. Events
+// are injected directly into handle() so the debouncer is tested in
+// isolation from fsnotify's variable event-delivery timing —
+// TestFileWatcher_InvalidatesOnWrite covers the OS-roundtrip path. Driving
+// handle() directly was the fix for a CI flake where editor-save bursts
+// spread past the debounce window under load.
 func TestFileWatcher_DebounceEditorSavePattern(t *testing.T) {
 	root := t.TempDir()
 	ktPath := filepath.Join(root, "Foo.kt")
@@ -395,16 +400,12 @@ func TestFileWatcher_DebounceEditorSavePattern(t *testing.T) {
 	defer w.Stop()
 	<-w.Ready()
 
-	// Simulate three Write+Write+Chmod events within 5ms — a typical
-	// editor save burst.
+	ev := fsnotify.Event{Name: ktPath, Op: fsnotify.Write}
 	for range 3 {
-		if err := os.WriteFile(ktPath, []byte("fun a() { 1 }\n"), 0o644); err != nil {
-			t.Fatalf("rewrite: %v", err)
-		}
+		w.handle(ev)
 		time.Sleep(2 * time.Millisecond)
 	}
 
-	// Wait for the debounce window to fire (window + generous margin).
 	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
 		if state.invalidateCalls.Load() > 0 {
@@ -412,6 +413,9 @@ func TestFileWatcher_DebounceEditorSavePattern(t *testing.T) {
 		}
 		time.Sleep(5 * time.Millisecond)
 	}
+	// Settle: if a stray timer was re-armed under load, give it a full
+	// window + margin to complete before asserting the final count.
+	time.Sleep(window * 4)
 
 	if got := state.invalidateCalls.Load(); got != 1 {
 		t.Errorf("Invalidate called %d times, want 1 (debounce should coalesce burst)", got)


### PR DESCRIPTION
## Summary

Fixes the `TestFileWatcher_DebounceEditorSavePattern` flake called out as the final follow-up in [#284](https://github.com/kaeawc/krit/issues/284) — the remaining open item now that #291, #293, #295, and #319 have landed the verb routing work.

- Inject fsnotify events directly via `fileWatcher.handle()` instead of driving them through real `os.WriteFile` calls. The debouncer is what we want to test; `TestFileWatcher_InvalidatesOnWrite` already covers the OS round-trip.
- Add a `window * 4` settle after detecting the first invalidation so a stray re-armed timer is captured before asserting `== 1`.

### Why this flakes today

Under CI load, `os.WriteFile` may emit `Create + Write` events whose delivery spreads past the 20 ms debounce window, so 3 quick rewrites can fire 2 or 3 debounce timers. The test breaks at first `>0` and asserts exactly 1, leaving no slack for a late-firing second debounce. Synthesizing events removes the fsnotify timing dependency entirely.

## Validation criteria

- `go test ./internal/cli/serve/ -run TestFileWatcher_DebounceEditorSavePattern -count=500 -race` — clean (run locally, 59s).
- `go test ./internal/cli/serve/ -count=3 -race` — full package clean.
- `go build ./... && go vet ./... && golangci-lint run ./...` — all green.

## Test plan

- [x] Targeted test runs 500x under `-race` without failure
- [x] `golangci-lint run ./...` clean
- [x] `go vet ./...` clean
- [x] `go build -o krit ./cmd/krit/`