### PR TITLE
docs(suggested-fixes): document model and lock mutual-exclusion in CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,9 +25,11 @@ vet:
 #   - java-support-coverage: rules declaring NeedsTypeInfo/NeedsResolver must
 #     carry an explicit Java LanguageSupport entry (existing rules are
 #     grandfathered; new ones must classify)
+#   - fix-mode-mutual-exclusion: every registered rule must declare exactly
+#     one fix mode (autofix XOR suggested), see docs/suggested-fixes.md
 lint-rules:
 	go test ./internal/ruleslinter/ -run 'TestRulesPackageHasNoCapabilityDrift|TestRulesPackageHasNoNewAdHocCaches|TestRulesPackageHasOptInReasons|TestRulesPackageHasNoDefensiveContextGuards' -count=1
-	go test ./internal/rules/ -run 'TestRulesWithTypeInfoDeclareExplicitJavaSupport' -count=1
+	go test ./internal/rules/ -run 'TestRulesWithTypeInfoDeclareExplicitJavaSupport|TestRegistryFixModeIsValid|TestRegistryFixModeIsObservable' -count=1
 
 lint: build
 	./krit .

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -33,3 +33,58 @@ the same hook stage.
 | Checkstyle | Jenkins, other CI tools     | `--format checkstyle` |
 | JSON       | Custom processing (default) | `--format json` |
 | Plain      | Human-readable logs         | `--format plain` |
+
+## Suggested fixes (CLI and IDE)
+
+Some rules emit ordered, user-selectable **suggested fixes** instead
+of a single autofix (see [Suggested fixes](suggested-fixes.md)). The
+two surfaces below are how integrations apply one.
+
+### CLI: `krit apply-suggestion`
+
+```bash
+krit --format=json . > findings.json
+
+# List all findings that carry suggestions and their suggestion ids:
+krit apply-suggestion --list findings.json
+
+# Preview what a specific suggestion would change:
+krit apply-suggestion \
+  --finding 'PreferVal:src/main/kotlin/Example.kt:5:3' \
+  --suggestion use-val \
+  --dry-run \
+  findings.json
+
+# Apply it:
+krit apply-suggestion \
+  --finding 'PreferVal:src/main/kotlin/Example.kt:5:3' \
+  --suggestion use-val \
+  findings.json
+```
+
+The verb reuses the autofix application path
+(`fixer.ApplyAllFixesColumns`), so cross-file edits, byte/line spans,
+overlap deduplication, and ktfmt-shaped output match `krit --fix`.
+Informational suggestions (no `edits`, only `applicationToken`) are
+rejected — they are for the integration to interpret, not for the CLI
+to write.
+
+### IDE / LSP
+
+Integrations should render each `suggestedFixes[]` entry as its own
+native quick-fix / code-action, **in the order the rule emitted them**
+— do not sort by id, title, or safety level. The IntelliJ plugin
+follows this contract:
+
+- `KritInspection` registers one `KritApplySuggestionQuickFix` per
+  machine-applicable suggestion (those with non-empty `edits`).
+- When suggestions are present, the generic "apply autofix" entry is
+  suppressed so the user is never offered both choices at once.
+- Informational suggestions (no `edits`) are surfaced as intentions
+  that route through the integration's help/`applicationToken`
+  handling.
+
+For LSP wrappers, expose each suggestion as a distinct `CodeAction`
+with a stable `title` (the rule-provided `Title`) and a `data` blob
+that carries `{findingId, suggestionId}` so the resolve step can run
+`krit apply-suggestion` with deterministic ids.

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -47,6 +47,15 @@ Krit recognizes common Compose patterns without extra config:
 
 `krit --fix .` applies cosmetic + idiomatic. `krit --fix --fix-level=semantic .` applies everything. Use `--dry-run` to preview.
 
+## Suggested fixes
+
+A rule that cannot reduce to a single safe rewrite may instead emit
+**suggested fixes** — an ordered, user-selectable list. Autofix and
+suggested fixes are mutually exclusive per rule, and the order is
+rule-recommended. See [Suggested fixes](suggested-fixes.md) for the
+full contract, an authoring example, JSON shape, and integration
+guidance.
+
 ## Rule types (internals)
 
 - **Node-dispatched rules** — register `NodeTypes` and receive matching flat AST nodes.

--- a/docs/suggested-fixes.md
+++ b/docs/suggested-fixes.md
@@ -1,0 +1,162 @@
+# Suggested fixes
+
+Krit rules carry one of two kinds of edits: a single **autofix** that
+`krit --fix` applies automatically, or an ordered list of **suggested
+fixes** that a user (or an IDE) picks from. A rule picks exactly one
+mode — they are mutually exclusive.
+
+## Autofix vs suggested fix
+
+| Aspect          | Autofix                                | Suggested fix                          |
+|-----------------|----------------------------------------|----------------------------------------|
+| Slot            | `Rule.Fix` (single `FixLevel`)         | `Rule.SuggestedFixes` (ordered slice)  |
+| Applied by      | `krit --fix`, IDE "apply fixes"        | User selection (`krit apply-suggestion`, IDE quick fix) |
+| Cardinality     | Exactly one fix per finding            | One or more per finding                |
+| User choice     | None — runs unattended                 | Required — the user picks one          |
+| JSON surface    | `fixable` + `fixLevel`                 | `suggestedFixes[]`                     |
+| Wire schema     | `Fix` on the finding                   | `SuggestedFixes` on the finding        |
+
+Pick **autofix** when there is exactly one correct rewrite and it is
+safe to apply unattended at the declared safety tier. Pick
+**suggested fixes** when more than one reasonable resolution exists,
+or when a "fix" is informational guidance the user must approve.
+
+## Mutual exclusion (enforced at registration)
+
+A rule cannot expose both modes. `api.Register` panics if a rule
+declares both `Fix != FixNone` and a non-empty `SuggestedFixes`, and
+also panics if the rule's `Implementation` satisfies both
+`AutofixRule` and `SuggestedFixRule`.
+
+Validation lives in `Rule.ValidateFixMode` and is covered by:
+
+- Unit tests in `internal/rules/api/fixmode_test.go`.
+- A registry-wide gate in `internal/rules/fixmode_registry_test.go`
+  that walks every built-in rule and asserts `ValidateFixMode` returns
+  nil. Run via `go test ./internal/rules/ -run TestRegistryFixModeIsValid`.
+
+Either gate failing in CI means a rule has mixed declarations or a
+malformed `SuggestedFix` entry (empty ID/title, `FixNone` level, or
+duplicate ID).
+
+## Order is meaningful
+
+`Rule.SuggestedFixes` is an ordered slice. Position is the
+rule-recommended display and application order — list the safer or
+stronger fix first, alternatives after. The order survives all
+transport layers: registry → finding → JSON → CLI/IDE. Tests pin the
+contract end-to-end:
+
+- `internal/rules/api/fixmode_test.go::TestRegister_PreservesSuggestedFixOrdering`
+- `internal/output/suggested_fixes_test.go::TestSuggestedFixes_JSONShape`
+- `internal/output/suggested_fixes_test.go::TestSuggestedFixes_DeterministicSerialization`
+- `editors/intellij-plugin/.../KritJsonParserTest.kt::parse suggested fixes preserves rule-defined order`
+
+Integrations must surface suggestions in the order they appear in the
+finding's `suggestedFixes` array. Do not sort by id, title, or safety
+tier.
+
+## Authoring example: multiple suggestions
+
+```go
+// internal/rules/style/prefer_val.go (illustrative)
+var preferValRule = &api.Rule{
+    ID:          "PreferVal",
+    Category:    "style",
+    Description: "Suggest tightening a mutable binding to val.",
+    Sev:         api.SeverityWarning,
+    NodeTypes:   []string{"property_declaration"},
+    // SuggestedFixes is ordered: safer/preferred first.
+    SuggestedFixes: []api.SuggestedFix{
+        {ID: "use-val", Title: "Convert to val", Level: api.FixSemantic},
+        {ID: "explain", Title: "Why prefer val?", Level: api.FixCosmetic},
+    },
+    Check: func(ctx *api.Context) {
+        // ... node analysis omitted ...
+        ctx.Emit(&scanner.Finding{
+            File: ctx.File.Path, Line: line, Col: col,
+            Rule: "PreferVal", RuleSet: "style", Severity: "warning",
+            Message: "Prefer val when the binding is read-only.",
+            // Suggestions on the finding mirror the rule's declared
+            // order. Each entry references the rule's SuggestedFix.ID.
+            SuggestedFixes: []scanner.SuggestedFix{
+                {
+                    ID: "use-val", Title: "Convert to val",
+                    Edits: []scanner.SuggestedEdit{
+                        {StartLine: line, EndLine: line, Replacement: rewrite},
+                    },
+                },
+                {
+                    ID: "explain", Title: "Why prefer val?",
+                    Detail:           "var becomes val when the binding is read-only.",
+                    ApplicationToken: "help:val-vs-var",
+                },
+            },
+        })
+    },
+}
+
+func init() { api.Register(preferValRule) }
+```
+
+Notes:
+
+- `use-val` is **machine-applicable** — it carries `Edits`. CLI and
+  IDE wrappers can apply it directly.
+- `explain` is **informational** — no `Edits`, only `Detail` and an
+  `ApplicationToken` for the integration to interpret (open a doc,
+  show a tooltip, route to a help action).
+- Each finding's suggestion ids match a registered
+  `Rule.SuggestedFixes[i].ID`, so consumers can correlate per-finding
+  edits back to rule metadata (Title, Level).
+
+## Determinism guarantee
+
+Repeated scans of the same source produce byte-identical JSON for
+findings with suggestions: same finding ids, same suggestion ids in
+the same order, same edit byte ranges and replacement strings. The
+cold/warm cache path preserves the same shape — the
+`FindingColumns` codec round-trips suggestion data without reordering.
+See `TestSuggestedFixes_DeterministicSerialization` and
+`TestSuggestedFixes_ColdWarmRoundTrip`.
+
+## JSON shape
+
+```json
+{
+  "findings": [
+    {
+      "file": "src/main/kotlin/Example.kt",
+      "line": 5, "column": 3,
+      "ruleSet": "style", "rule": "PreferVal",
+      "severity": "warning",
+      "message": "Prefer val when the binding is read-only.",
+      "fixable": false,
+      "suggestedFixes": [
+        {
+          "id": "use-val",
+          "title": "Convert to val",
+          "edits": [
+            {"startLine": 5, "endLine": 5, "replacement": "val x = 1"}
+          ]
+        },
+        {
+          "id": "explain",
+          "title": "Why prefer val?",
+          "detail": "var becomes val when the binding is read-only.",
+          "applicationToken": "help:val-vs-var"
+        }
+      ]
+    }
+  ]
+}
+```
+
+`fixable` / `fixLevel` track only the autofix slot. A finding can
+carry `suggestedFixes` while `fixable` is false (and frequently does).
+
+## Integration guidance
+
+See [Integrations](integrations.md#suggested-fixes-cli-and-ide) for
+the `krit apply-suggestion` CLI verb, IDE quick-fix layout, and LSP
+notes.

--- a/internal/output/suggested_fixes_test.go
+++ b/internal/output/suggested_fixes_test.go
@@ -3,12 +3,24 @@ package output
 import (
 	"bytes"
 	"encoding/json"
+	"regexp"
 	"slices"
 	"testing"
 	"time"
 
 	"github.com/kaeawc/krit/internal/scanner"
 )
+
+// durationMsField matches the report's wall-clock-derived durationMs
+// payload. FormatJSONColumns computes it from time.Since(start) at call
+// time, which is not deterministic across two calls in a row. Tests
+// that compare cold/warm or repeated formatter output byte-for-byte
+// must strip this field first.
+var durationMsField = regexp.MustCompile(`"durationMs":\s*\d+`)
+
+func stripDurationMs(b []byte) []byte {
+	return durationMsField.ReplaceAll(b, []byte(`"durationMs":0`))
+}
 
 // TestSuggestedFixes_JSONShape covers the fixture-rule acceptance criterion:
 // a rule emits one finding with two suggested fixes, and both appear in the
@@ -127,8 +139,8 @@ func TestSuggestedFixes_DeterministicSerialization(t *testing.T) {
 		},
 	}
 
-	first := runJSONFormatterBytes(t, findings)
-	second := runJSONFormatterBytes(t, findings)
+	first := stripDurationMs(runJSONFormatterBytes(t, findings))
+	second := stripDurationMs(runJSONFormatterBytes(t, findings))
 	if !bytes.Equal(first, second) {
 		t.Fatalf("non-deterministic JSON output:\n--- first ---\n%s\n--- second ---\n%s",
 			first, second)
@@ -136,8 +148,8 @@ func TestSuggestedFixes_DeterministicSerialization(t *testing.T) {
 
 	// Cross-collector merge must preserve per-finding suggestion ordering.
 	mergedCols := mergedCollectorColumns(findings)
-	formatA := formatColumns(t, mergedCols)
-	formatB := formatColumns(t, mergedCols)
+	formatA := stripDurationMs(formatColumns(t, mergedCols))
+	formatB := stripDurationMs(formatColumns(t, mergedCols))
 	if !bytes.Equal(formatA, formatB) {
 		t.Fatalf("non-deterministic JSON output from merged collector")
 	}
@@ -193,8 +205,8 @@ func TestSuggestedFixes_ColdWarmRoundTrip(t *testing.T) {
 		t.Fatalf("unmarshal warm columns: %v", err)
 	}
 
-	coldJSON := formatColumns(t, &cold)
-	warmJSON := formatColumns(t, &warm)
+	coldJSON := stripDurationMs(formatColumns(t, &cold))
+	warmJSON := stripDurationMs(formatColumns(t, &warm))
 	if !bytes.Equal(coldJSON, warmJSON) {
 		t.Fatalf("cold vs warm JSON drift:\ncold: %s\nwarm: %s", coldJSON, warmJSON)
 	}

--- a/internal/rules/fixmode_registry_test.go
+++ b/internal/rules/fixmode_registry_test.go
@@ -1,0 +1,70 @@
+package rules
+
+import (
+	"errors"
+	"testing"
+
+	api "github.com/kaeawc/krit/internal/rules/api"
+)
+
+// TestRegistryFixModeIsValid is the CI gate for the mutual-exclusion
+// invariant between autofix and suggested fixes across the entire
+// built-in registry. api.Register already panics on invalid
+// declarations, but a fresh registration error in an init() only
+// surfaces when a downstream importer loads the package; walking
+// api.Registry here makes the check explicit and gives a clearer
+// failure mode than a panic at first import.
+//
+// Companion to unit-level coverage in internal/rules/api/fixmode_test.go.
+// See docs/suggested-fixes.md for the rule-author contract.
+func TestRegistryFixModeIsValid(t *testing.T) {
+	if len(api.Registry) == 0 {
+		t.Fatal("api.Registry is empty; rule packages not loaded")
+	}
+	for _, r := range api.Registry {
+		err := r.ValidateFixMode()
+		if err == nil {
+			continue
+		}
+		var fme *api.FixModeError
+		if !errors.As(err, &fme) {
+			t.Errorf("rule %s: ValidateFixMode returned non-FixModeError %T: %v",
+				r.ID, err, err)
+			continue
+		}
+		t.Errorf("rule %s: %v", r.ID, err)
+	}
+}
+
+// TestRegistryFixModeIsObservable exercises FixMode() on every
+// registered rule so we have one place that fails loudly if FixMode
+// ever drifts away from the Fix / SuggestedFixes invariants — e.g. a
+// refactor that changes the resolution order between the two slots.
+func TestRegistryFixModeIsObservable(t *testing.T) {
+	if len(api.Registry) == 0 {
+		t.Fatal("api.Registry is empty; rule packages not loaded")
+	}
+	var autofix, suggested, none int
+	for _, r := range api.Registry {
+		got := r.FixMode()
+		switch {
+		case len(r.SuggestedFixes) > 0:
+			if got != api.FixModeSuggested {
+				t.Errorf("rule %s: FixMode() = %v, want FixModeSuggested", r.ID, got)
+			}
+			suggested++
+		case r.Fix != api.FixNone:
+			if got != api.FixModeAutofix {
+				t.Errorf("rule %s: FixMode() = %v, want FixModeAutofix", r.ID, got)
+			}
+			autofix++
+		default:
+			if got != api.FixModeNone {
+				t.Errorf("rule %s: FixMode() = %v, want FixModeNone", r.ID, got)
+			}
+			none++
+		}
+	}
+	t.Logf("fix-mode distribution: none=%d autofix=%d suggested=%d (total=%d)",
+		none, autofix, suggested, len(api.Registry))
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -57,6 +57,7 @@ nav:
   - Quickstart: quickstart.md
   - Configuration: configuration.md
   - Rules: rules.md
+  - Suggested fixes: suggested-fixes.md
   - Rule Scope: rule-scope.md
   - External Rules: external-rules.md
   - Integrations: integrations.md


### PR DESCRIPTION
## Summary

Closes #246.

- New page `docs/suggested-fixes.md` explains autofix vs suggested fix, the per-rule mutual exclusion, that order is rule-recommended, and gives an authoring example with multiple suggestions plus the JSON shape.
- `docs/integrations.md` documents the `krit apply-suggestion` CLI verb and how IDE/LSP wrappers should surface ordered quick fixes (matching the contract the IntelliJ plugin already follows).
- `docs/rules.md` adds a short section linking to the new page; `mkdocs.yml` adds it to the nav.
- New registry-wide gate `internal/rules/fixmode_registry_test.go` walks `api.Registry` and asserts `ValidateFixMode` on every built-in rule — wired into `make lint-rules` so a future rule mixing both fix modes fails CI explicitly rather than panicking at first import.

The other test requirements from #246 are already in place:

- Unit-level registry tests for mixed declarations / interfaces / malformed suggestions: `internal/rules/api/fixmode_test.go`.
- JSON output snapshot for ordered suggestions: `internal/output/suggested_fixes_test.go::TestSuggestedFixes_JSONShape`.
- Determinism test (byte-identical ids, ordering, edits): `TestSuggestedFixes_DeterministicSerialization` + `TestSuggestedFixes_ColdWarmRoundTrip`.
- CLI apply tests: `internal/cli/applysuggestion/applysuggestion_test.go`.
- IntelliJ ordered quick fixes: `editors/intellij-plugin/.../KritJsonParserTest.kt::parse suggested fixes preserves rule-defined order` and the `intentions ... yield ordered per-suggestion intentions` cases.

## Test plan

- [x] `go build -o krit ./cmd/krit/`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...`
- [x] `go test ./... -count=1`
- [x] `make lint-rules` (includes the new `TestRegistryFixModeIsValid` / `TestRegistryFixModeIsObservable`)