### PR TITLE
feat(supply-chain): ordered suggested fixes for DependenciesInRootProject (#245)

### DIFF
--- a/internal/rules/fix_test.go
+++ b/internal/rules/fix_test.go
@@ -292,7 +292,6 @@ var knownFixableRulesWithoutPerRuleFixture = map[string]bool{
 	// TestApplyPluginTwice's "fix removes duplicate apply line" subtest.
 	"ApplyPluginTwice":                   true,
 	"BooleanPropertyNaming":              true,
-	"DependenciesInRootProject":          true,
 	"ExplicitItLambdaMultipleParameters": true,
 	"FunctionOnlyReturningConstant":      true,
 	"MissingPackageDeclaration":          true,

--- a/internal/rules/registry_supply_chain.go
+++ b/internal/rules/registry_supply_chain.go
@@ -88,7 +88,11 @@ func registerSupplyChainRules() {
 		}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			Needs: api.NeedsGradle, AndroidDeps: uint32(AndroidDepGradle), Confidence: r.Confidence(), Fix: api.FixIdiomatic, Implementation: r,
+			Needs: api.NeedsGradle, AndroidDeps: uint32(AndroidDepGradle), Confidence: r.Confidence(), Implementation: r,
+			SuggestedFixes: []api.SuggestedFix{
+				{ID: DependenciesInRootProjectMoveSuggestionID, Title: dependenciesInRootProjectMoveSuggestionTitle, Level: api.FixSemantic},
+				{ID: DependenciesInRootProjectAllowSuggestionID, Title: dependenciesInRootProjectAllowSuggestionTitle, Level: api.FixIdiomatic},
+			},
 			Check: r.check,
 		})
 	}

--- a/internal/rules/supply_chain_test.go
+++ b/internal/rules/supply_chain_test.go
@@ -422,6 +422,56 @@ func readFile(t *testing.T, path string) string {
 	return string(content)
 }
 
+// applySuggestionEdits applies the edits of the named suggested fix on the
+// given finding through the same fixer pipeline used by `krit apply-suggestion`.
+// It fails the test when the suggestion or its edits are missing or do not
+// apply cleanly.
+func applySuggestionEdits(t *testing.T, finding scanner.Finding, suggestionID string) {
+	t.Helper()
+	var sug *scanner.SuggestedFix
+	for i := range finding.SuggestedFixes {
+		if finding.SuggestedFixes[i].ID == suggestionID {
+			sug = &finding.SuggestedFixes[i]
+			break
+		}
+	}
+	if sug == nil {
+		t.Fatalf("suggestion %q not found on finding", suggestionID)
+	}
+	if len(sug.Edits) == 0 {
+		t.Fatalf("suggestion %q has no edits to apply", suggestionID)
+	}
+	edits := make([]scanner.Finding, 0, len(sug.Edits))
+	for _, edit := range sug.Edits {
+		edits = append(edits, scanner.Finding{
+			File:     finding.File,
+			Line:     finding.Line,
+			Col:      finding.Col,
+			RuleSet:  finding.RuleSet,
+			Rule:     finding.Rule,
+			Severity: finding.Severity,
+			Message:  finding.Message,
+			Fix: &scanner.Fix{
+				TargetFile:  edit.TargetFile,
+				StartLine:   edit.StartLine,
+				EndLine:     edit.EndLine,
+				StartByte:   edit.StartByte,
+				EndByte:     edit.EndByte,
+				ByteMode:    edit.ByteMode,
+				Replacement: edit.Replacement,
+			},
+		})
+	}
+	columns := scanner.CollectFindings(edits)
+	applied, _, errs := fixer.ApplyAllFixesColumns(&columns, "")
+	if len(errs) > 0 {
+		t.Fatalf("ApplyAllFixesColumns errors: %v", errs)
+	}
+	if applied != len(sug.Edits) {
+		t.Fatalf("applied fixes = %d, want %d", applied, len(sug.Edits))
+	}
+}
+
 func TestDependencySnapshotInRelease(t *testing.T) {
 	r := findGradleRule(t, "DependencySnapshotInRelease")
 
@@ -499,7 +549,31 @@ dependencies {
 func TestDependenciesInRootProject(t *testing.T) {
 	r := findGradleRule(t, "DependenciesInRootProject")
 
-	t.Run("root build dependencies trigger", func(t *testing.T) {
+	t.Run("rule advertises suggested fixes and no autofix", func(t *testing.T) {
+		if r.Fix != api.FixNone {
+			t.Fatalf("Fix = %v, want FixNone (rule must not advertise an autofix)", r.Fix)
+		}
+		if mode := r.FixMode(); mode != api.FixModeSuggested {
+			t.Fatalf("FixMode = %v, want FixModeSuggested", mode)
+		}
+		if len(r.SuggestedFixes) != 2 {
+			t.Fatalf("SuggestedFixes count = %d, want 2", len(r.SuggestedFixes))
+		}
+		wantIDs := []string{
+			rulespkg.DependenciesInRootProjectMoveSuggestionID,
+			rulespkg.DependenciesInRootProjectAllowSuggestionID,
+		}
+		for i, want := range wantIDs {
+			if got := r.SuggestedFixes[i].ID; got != want {
+				t.Errorf("SuggestedFixes[%d].ID = %q, want %q", i, got, want)
+			}
+		}
+		if err := r.ValidateFixMode(); err != nil {
+			t.Fatalf("ValidateFixMode: %v", err)
+		}
+	})
+
+	t.Run("root build dependencies emit ordered suggestions", func(t *testing.T) {
 		root := t.TempDir()
 		writeFile(t, filepath.Join(root, "settings.gradle.kts"), `pluginManagement { repositories { gradlePluginPortal() } }`)
 		buildPath := filepath.Join(root, "build.gradle.kts")
@@ -519,15 +593,31 @@ dependencies {
 		if !strings.Contains(findings[0].Message, "implementation") {
 			t.Fatalf("expected message to name implementation, got %q", findings[0].Message)
 		}
-		if findings[0].Fix == nil {
-			t.Fatal("expected finding to include config autofix")
+		if findings[0].Fix != nil {
+			t.Fatal("finding must not carry an autofix when SuggestedFixes are emitted")
 		}
-		if got, want := findings[0].Fix.TargetFile, filepath.Join(root, "krit.yml"); got != want {
-			t.Fatalf("Fix.TargetFile = %q, want %q", got, want)
+		got := findings[0].SuggestedFixes
+		if len(got) != 2 {
+			t.Fatalf("expected 2 suggested fixes, got %d", len(got))
+		}
+		if got[0].ID != rulespkg.DependenciesInRootProjectMoveSuggestionID {
+			t.Errorf("suggestion[0].ID = %q, want %q", got[0].ID, rulespkg.DependenciesInRootProjectMoveSuggestionID)
+		}
+		if len(got[0].Edits) != 0 {
+			t.Errorf("moveToOwningModule must be guidance-only (no edits), got %d", len(got[0].Edits))
+		}
+		if got[1].ID != rulespkg.DependenciesInRootProjectAllowSuggestionID {
+			t.Errorf("suggestion[1].ID = %q, want %q", got[1].ID, rulespkg.DependenciesInRootProjectAllowSuggestionID)
+		}
+		if len(got[1].Edits) != 1 {
+			t.Fatalf("addAllowedConfigurations must carry exactly 1 edit, got %d", len(got[1].Edits))
+		}
+		if want := filepath.Join(root, "krit.yml"); got[1].Edits[0].TargetFile != want {
+			t.Errorf("edit.TargetFile = %q, want %q", got[1].Edits[0].TargetFile, want)
 		}
 	})
 
-	t.Run("autofix creates root krit config allowlist", func(t *testing.T) {
+	t.Run("applying allow suggestion writes root krit config allowlist", func(t *testing.T) {
 		root := t.TempDir()
 		writeFile(t, filepath.Join(root, "settings.gradle.kts"), ``)
 		buildPath := filepath.Join(root, "build.gradle.kts")
@@ -542,15 +632,8 @@ dependencies {
 		if len(findings) != 1 {
 			t.Fatalf("expected 1 finding, got %d", len(findings))
 		}
+		applySuggestionEdits(t, findings[0], rulespkg.DependenciesInRootProjectAllowSuggestionID)
 
-		columns := scanner.CollectFindings(findings)
-		applied, _, errs := fixer.ApplyAllFixesColumns(&columns, "")
-		if len(errs) > 0 {
-			t.Fatalf("ApplyAllFixesColumns errors: %v", errs)
-		}
-		if applied != 1 {
-			t.Fatalf("applied fixes = %d, want 1", applied)
-		}
 		got := readFile(t, filepath.Join(root, "krit.yml"))
 		for _, want := range []string{"classpath", "detektPlugins", "implementation", "ksp", "testImplementation"} {
 			if !strings.Contains(got, "- "+want) {
@@ -559,7 +642,7 @@ dependencies {
 		}
 	})
 
-	t.Run("autofix preserves generated krit config header", func(t *testing.T) {
+	t.Run("applying allow suggestion preserves generated krit config header", func(t *testing.T) {
 		root := t.TempDir()
 		writeFile(t, filepath.Join(root, "settings.gradle.kts"), ``)
 		writeFile(t, filepath.Join(root, "krit.yml"), `# Generated by krit init (bubbletea TUI)
@@ -579,15 +662,8 @@ style:
 		if len(findings) != 1 {
 			t.Fatalf("expected 1 finding, got %d", len(findings))
 		}
+		applySuggestionEdits(t, findings[0], rulespkg.DependenciesInRootProjectAllowSuggestionID)
 
-		columns := scanner.CollectFindings(findings)
-		applied, _, errs := fixer.ApplyAllFixesColumns(&columns, "")
-		if len(errs) > 0 {
-			t.Fatalf("ApplyAllFixesColumns errors: %v", errs)
-		}
-		if applied != 1 {
-			t.Fatalf("applied fixes = %d, want 1", applied)
-		}
 		got := readFile(t, filepath.Join(root, "krit.yml"))
 		if !strings.HasPrefix(got, "# Generated by krit init (bubbletea TUI)\n# Profile: balanced\n\n") {
 			t.Fatalf("krit.yml header not preserved:\n%s", got)

--- a/internal/rules/supply_dependencies.go
+++ b/internal/rules/supply_dependencies.go
@@ -111,6 +111,17 @@ type DependenciesInRootProjectRule struct {
 
 func (r *DependenciesInRootProjectRule) Confidence() float64 { return 0.85 }
 
+// Suggested-fix identifiers and canonical titles for the
+// DependenciesInRootProject rule. The titles are shared between the rule's
+// registry catalog (api.Rule.SuggestedFixes) and the per-finding emit so
+// IDE quick-fix menus and the CLI list view show the same label.
+const (
+	DependenciesInRootProjectMoveSuggestionID     = "moveToOwningModule"
+	dependenciesInRootProjectMoveSuggestionTitle  = "Move dependencies into an owning module"
+	DependenciesInRootProjectAllowSuggestionID    = "addAllowedConfigurations"
+	dependenciesInRootProjectAllowSuggestionTitle = "Add configurations to allowedConfigurations in the root Krit config"
+)
+
 func (r *DependenciesInRootProjectRule) check(ctx *api.Context) {
 	path, content := ctx.GradlePath, ctx.GradleContent
 	if !isRootGradleProjectScript(path) {
@@ -128,27 +139,48 @@ func (r *DependenciesInRootProjectRule) check(ctx *api.Context) {
 			Message:    fmt.Sprintf("Root project dependencies block declares %s. Move project dependencies into an owning module or add legitimate root tooling configurations to allowedConfigurations.", strings.Join(block.configurations, ", ")),
 			Confidence: r.Confidence(),
 		}
-		finding.Fix = rootDependencyAllowedConfigurationsFix(path, r.AllowedConfigurations, block.configurations)
+		finding.SuggestedFixes = r.suggestedFixesForBlock(path, block.configurations)
 		ctx.Emit(finding)
 	}
 }
 
-func rootDependencyAllowedConfigurationsFix(gradlePath string, existingAllowed, missing []string) *scanner.Fix {
+func (r *DependenciesInRootProjectRule) suggestedFixesForBlock(gradlePath string, missing []string) []scanner.SuggestedFix {
+	joined := strings.Join(missing, ", ")
+	suggestions := []scanner.SuggestedFix{
+		{
+			ID:     DependenciesInRootProjectMoveSuggestionID,
+			Title:  dependenciesInRootProjectMoveSuggestionTitle,
+			Detail: fmt.Sprintf("Declare %s in the module that owns the code instead of the root project. Root build scripts should configure plugins and conventions; application and runtime dependencies belong to an owning module's build.gradle(.kts).", joined),
+		},
+	}
+
+	allowSuggestion := scanner.SuggestedFix{
+		ID:     DependenciesInRootProjectAllowSuggestionID,
+		Title:  dependenciesInRootProjectAllowSuggestionTitle,
+		Detail: fmt.Sprintf("Add %s to allowedConfigurations in krit.yml so the listed root-project configurations no longer trigger this rule. Use this when the root dependency block is intentional (e.g. classpath, detektPlugins, lintChecks).", joined),
+	}
+	if edit, ok := rootDependencyAllowedConfigurationsEdit(gradlePath, r.AllowedConfigurations, missing); ok {
+		allowSuggestion.Edits = []scanner.SuggestedEdit{edit}
+	}
+	return append(suggestions, allowSuggestion)
+}
+
+func rootDependencyAllowedConfigurationsEdit(gradlePath string, existingAllowed, missing []string) (scanner.SuggestedEdit, bool) {
 	targetPath, content, ok := rootKritConfigForFix(filepath.Dir(gradlePath))
 	if !ok {
-		return nil
+		return scanner.SuggestedEdit{}, false
 	}
 	replacement, ok := mergeRootDependencyAllowedConfigurations(content, existingAllowed, missing)
 	if !ok {
-		return nil
+		return scanner.SuggestedEdit{}, false
 	}
-	return &scanner.Fix{
+	return scanner.SuggestedEdit{
 		TargetFile:  targetPath,
 		ByteMode:    true,
 		StartByte:   0,
 		EndByte:     len(content),
 		Replacement: replacement,
-	}
+	}, true
 }
 
 func rootKritConfigForFix(root string) (string, []byte, bool) {


### PR DESCRIPTION
## Summary

- Converts `supply-chain/DependenciesInRootProject` from a single idiomatic autofix to two ordered, user-selectable suggested fixes — the first real built-in rule to exercise the suggestion exclusivity rule.
- Suggestions are emitted in rule-recommended order:
  1. `moveToOwningModule` — guidance-only, no edits (`FixSemantic`).
  2. `addAllowedConfigurations` — machine-applicable edit that rewrites `krit.yml` (`FixIdiomatic`); preserves the existing YAML merge logic.
- Registry declaration drops `Fix: api.FixIdiomatic` and advertises `SuggestedFixes` instead; `ValidateFixMode` enforces the rule no longer mixes autofix with suggestions.

Closes [#245](https://github.com/kaeawc/krit/issues/245).

## Validation

- `go build -o krit ./cmd/krit/`
- `go vet ./...`
- `golangci-lint run ./...` — 0 issues
- `go test ./... -count=1`
- `make integration` — 11 passed
- `make regression` — playground expectations unchanged

The new `TestDependenciesInRootProject/rule_advertises_suggested_fixes_and_no_autofix` subtest pins the catalog ordering and the FixModeSuggested exclusivity; remaining subtests assert per-finding `SuggestedFixes` shape and apply the allow-edit suggestion through the same fixer path used by `krit apply-suggestion`.

## Test plan

- [x] `TestDependenciesInRootProject` covers rule metadata, per-finding suggestion order, applying the allow-suggestion edit, krit.yml header preservation, and clean-fixture negatives.
- [x] `make integration` (CLI, LSP, MCP, dry-run fix flows).
- [x] `make regression` (playground finding counts unchanged).