### PR TITLE
feat(custom-rules): auto-pass --daemon from Gradle plugin and lock hard-error

### DIFF
--- a/internal/pipeline/custom_kotlin_rules_test.go
+++ b/internal/pipeline/custom_kotlin_rules_test.go
@@ -4,11 +4,46 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/kaeawc/krit/internal/oracle"
 	api "github.com/kaeawc/krit/internal/rules/api"
 )
+
+func TestRunKotlinPluginRulesRequiresDaemonWhenJarsConfigured(t *testing.T) {
+	args := ProjectArgs{CustomRuleJars: []string{"/tmp/does-not-exist.jar"}}
+	indexResult := IndexResult{}
+	crossFile := &CrossFileResult{}
+
+	err := runKotlinPluginRulesAndMerge(context.Background(), args, ProjectHostState{}, indexResult, crossFile, false)
+	if err == nil {
+		t.Fatal("expected error when CustomRuleJars set without daemon, got nil")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "krit-types daemon") {
+		t.Errorf("error should name the failing daemon: %q", msg)
+	}
+	if !strings.Contains(msg, "--daemon") {
+		t.Errorf("error should suggest --daemon flag: %q", msg)
+	}
+	if !strings.Contains(msg, "KRIT_TYPES_JAR") {
+		t.Errorf("error should point at KRIT_TYPES_JAR recovery path: %q", msg)
+	}
+}
+
+func TestRunKotlinPluginRulesNoOpWhenNoJars(t *testing.T) {
+	if err := runKotlinPluginRulesAndMerge(context.Background(), ProjectArgs{}, ProjectHostState{}, IndexResult{}, &CrossFileResult{}, false); err != nil {
+		t.Fatalf("unexpected error with empty jars: %v", err)
+	}
+}
+
+func TestRunKotlinPluginRulesNoOpWhenBundleHit(t *testing.T) {
+	args := ProjectArgs{CustomRuleJars: []string{"/tmp/does-not-exist.jar"}}
+	if err := runKotlinPluginRulesAndMerge(context.Background(), args, ProjectHostState{}, IndexResult{}, &CrossFileResult{}, true); err != nil {
+		t.Fatalf("unexpected error on bundle hit: %v", err)
+	}
+}
 
 func TestPluginFindingsToColumns(t *testing.T) {
 	cols := pluginFindingsToColumns([]oracle.PluginFinding{{

--- a/krit-gradle-plugin/src/main/kotlin/dev/jasonpearson/krit/gradle/KritCheckTask.kt
+++ b/krit-gradle-plugin/src/main/kotlin/dev/jasonpearson/krit/gradle/KritCheckTask.kt
@@ -220,10 +220,17 @@ abstract class KritCheckTask @Inject constructor(
     }
 
     private fun MutableList<String>.addCustomRuleJarArgs() {
-        val jars = customRuleJars.files
-        if (jars.isNotEmpty()) {
+        appendCustomRuleJarArgs(customRuleJars.files.map { it.absolutePath })
+    }
+
+    companion object {
+        // Forces --daemon on when jars are present: the CLI hard-errors otherwise
+        // (see internal/pipeline/custom_kotlin_rules.go).
+        internal fun MutableList<String>.appendCustomRuleJarArgs(jarPaths: Collection<String>) {
+            if (jarPaths.isEmpty()) return
             add("--custom-rule-jars")
-            add(jars.joinToString(",") { it.absolutePath })
+            add(jarPaths.joinToString(","))
+            if ("--daemon" !in this) add("--daemon")
         }
     }
 }

--- a/krit-gradle-plugin/src/test/kotlin/dev/jasonpearson/krit/gradle/KritPluginTest.kt
+++ b/krit-gradle-plugin/src/test/kotlin/dev/jasonpearson/krit/gradle/KritPluginTest.kt
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import java.io.File
+import dev.jasonpearson.krit.gradle.KritCheckTask.Companion.appendCustomRuleJarArgs
 
 class KritPluginTest {
 
@@ -299,5 +300,33 @@ class KritPluginTest {
         // Without Android plugin, no variant-specific tasks
         assertEquals(null, project.tasks.findByName("kritCheckDebug"))
         assertEquals(null, project.tasks.findByName("kritCheckRelease"))
+    }
+
+    // --- Custom rule jars + --daemon auto-pass ---
+
+    @Test
+    fun `appendCustomRuleJarArgs is a no-op when jar list is empty`() {
+        val args = mutableListOf<String>()
+        args.appendCustomRuleJarArgs(emptyList())
+        assertTrue(args.isEmpty(), "empty jar list should not mutate args, was: $args")
+    }
+
+    @Test
+    fun `appendCustomRuleJarArgs adds --daemon automatically when jars present`() {
+        val args = mutableListOf("--format=sarif")
+        args.appendCustomRuleJarArgs(listOf("/jars/a.jar", "/jars/b.jar"))
+        val index = args.indexOf("--custom-rule-jars")
+        assertTrue(index >= 0, "expected --custom-rule-jars, was: $args")
+        assertEquals("/jars/a.jar,/jars/b.jar", args[index + 1])
+        assertTrue("--daemon" in args,
+            "expected --daemon to be auto-passed when custom-rule jars configured, was: $args")
+    }
+
+    @Test
+    fun `appendCustomRuleJarArgs does not duplicate --daemon when already present`() {
+        val args = mutableListOf("--daemon", "--format=sarif")
+        args.appendCustomRuleJarArgs(listOf("/jars/a.jar"))
+        assertEquals(1, args.count { it == "--daemon" },
+            "--daemon should not be duplicated, was: $args")
     }
 }


### PR DESCRIPTION
## Summary
- The pipeline already hard-errors at `internal/pipeline/custom_kotlin_rules.go:21` when `CustomRuleJars` is configured but the krit-types daemon is unavailable. This PR locks that behavior with a regression test and makes the Gradle path "just work".
- `KritCheckTask` now auto-appends `--daemon` to the CLI args when `customRules()` is non-empty, so consumers wiring custom rules through `dev.jasonpearson.krit` no longer have to remember the flag.
- Adds three Gradle plugin tests covering empty jars (no-op), auto-pass behavior, and idempotency.

Closes #302.

## Test plan
- [x] `go test ./internal/pipeline/ -count=1`
- [x] `go vet ./... && golangci-lint run ./...`
- [x] `go test ./... -count=1`
- [x] `gradle test --rerun-tasks` in `krit-gradle-plugin/`