### PR TITLE
ci(release): nightly tag generator + prerelease auto-marking

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -23,7 +23,7 @@ jobs:
           fetch-depth: 0
           # Default GITHUB_TOKEN won't trigger downstream workflows on tag
           # push — use a PAT with workflow scope so release.yml fires.
-          token: ${{ secrets.NIGHTLY_TAG_TOKEN }}
+          token: ${{ secrets.KRIT_NIGHTLY_TAG_TOKEN }}
 
       - name: Compute next nightly tag
         id: compute

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,89 @@
+name: Nightly
+on:
+  schedule:
+    # 06:00 UTC daily. Picks up everything merged the previous US workday
+    # while keeping the release artifacts ready before EU morning.
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+    inputs:
+      force:
+        description: 'Tag even if no commits since last nightly'
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          # Default GITHUB_TOKEN won't trigger downstream workflows on tag
+          # push — use a PAT with workflow scope so release.yml fires.
+          token: ${{ secrets.NIGHTLY_TAG_TOKEN }}
+
+      - name: Compute next nightly tag
+        id: compute
+        env:
+          FORCE: ${{ inputs.force }}
+        run: |
+          set -euo pipefail
+
+          # Latest stable tag = vX.Y.Z with no prerelease suffix.
+          latest_stable=$(git tag --list 'v*' --sort=-v:refname \
+            | grep -Ev '-' \
+            | head -1)
+          if [ -z "$latest_stable" ]; then
+            echo "No stable tag found; defaulting base to v0.0.0" >&2
+            latest_stable="v0.0.0"
+          fi
+          echo "Latest stable: $latest_stable"
+
+          # Bump minor: vA.B.C -> vA.(B+1).0
+          ver="${latest_stable#v}"
+          major="${ver%%.*}"
+          rest="${ver#*.}"
+          minor="${rest%%.*}"
+          next_minor=$((minor + 1))
+          base="v${major}.${next_minor}.0"
+
+          date_stamp=$(date -u +%Y%m%d)
+          tag="${base}-nightly.${date_stamp}"
+
+          # If a nightly with today's stamp already exists, append a -N suffix.
+          if git rev-parse -q --verify "refs/tags/${tag}" >/dev/null; then
+            n=2
+            while git rev-parse -q --verify "refs/tags/${tag}.${n}" >/dev/null; do
+              n=$((n + 1))
+            done
+            tag="${tag}.${n}"
+          fi
+          echo "Next tag: $tag"
+
+          # Skip if no new commits since the most recent nightly (unless forced).
+          last_nightly=$(git tag --list 'v*-nightly.*' --sort=-creatordate | head -1)
+          if [ -n "$last_nightly" ] && [ "$FORCE" != "true" ]; then
+            if [ "$(git rev-list --count "${last_nightly}..HEAD")" -eq 0 ]; then
+              echo "No commits since $last_nightly; skipping." >&2
+              echo "skip=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          fi
+
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+
+      - name: Push tag
+        if: steps.compute.outputs.skip != 'true'
+        env:
+          TAG: ${{ steps.compute.outputs.tag }}
+        run: |
+          set -euo pipefail
+          git config user.name "krit-nightly[bot]"
+          git config user.email "krit-nightly@users.noreply.github.com"
+          git tag -a "$TAG" -m "Nightly $TAG"
+          git push origin "$TAG"
+          echo "Pushed $TAG — release.yml will pick it up."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -217,11 +217,19 @@ jobs:
         run: |
           set -euo pipefail
           cd dist
+          # Any tag with a SemVer prerelease suffix (e.g. v1.5.0-nightly.20260516,
+          # v1.5.0-beta.1, v1.5.0-rc1) is marked as a GitHub prerelease so it
+          # doesn't show up under the "Latest" badge.
+          prerelease_flag=""
+          case "$TAG" in
+            *-*) prerelease_flag="--prerelease" ;;
+          esac
           # shellcheck disable=SC2046
           gh release create "$TAG" \
             --repo "$GITHUB_REPOSITORY" \
             --title "$TAG" \
             --generate-notes \
+            $prerelease_flag \
             $(ls *.tar.gz *.zip *.jar *.sbom.json checksums.txt checksums.txt.sig 2>/dev/null)
 
       - name: Publish Homebrew cask


### PR DESCRIPTION
## Summary
- New `nightly.yml` workflow cuts `vX.(Y+1).0-nightly.YYYYMMDD` tags from a daily cron (06:00 UTC) and manual dispatch. Skips when no commits have landed since the last nightly; appends `.N` if a same-day nightly already exists.
- `release.yml` now marks any tag with a SemVer prerelease suffix (`-nightly.*`, `-beta.*`, `-rc*`) as a GitHub **prerelease**, keeping the "Latest" badge on stable releases only.
- First slice of the multi-track release plan. Follow-ups (separate PRs): publish-vscode, publish-intellij-plugin, publish-gradle-plugin.

## Setup required before merge takes effect
- Add repo secret `NIGHTLY_TAG_TOKEN` — fine-grained PAT with `Contents: write` + `Workflows: write` (or a GitHub App token). The default `GITHUB_TOKEN` does not trigger downstream workflows on tag push, so without this the nightly tag would be created but `release.yml` would not fire.

## Test plan
- [ ] Provision `NIGHTLY_TAG_TOKEN` repo secret
- [ ] `gh workflow run nightly.yml -f force=true` and confirm tag `v0.3.0-nightly.YYYYMMDD` is created
- [ ] Confirm `release.yml` fires on the pushed tag and produces artifacts
- [ ] Verify the resulting GitHub release is marked as **Pre-release** (no "Latest" badge)
- [ ] Re-run without `force=true` on the same day and confirm it skips