### PR TITLE
feat(daemon): route --fix, --fix-binary, --remove-dead-code via daemon (#284)

### DIFF
--- a/docs/daemon-flag-routing.md
+++ b/docs/daemon-flag-routing.md
@@ -132,8 +132,9 @@ larger change than wiring a flag through.
 `--baseline-audit` and `--rule-audit` are **now routed via daemon**. The
 daemon emits an optional `columns` segment in the analyze-project response
 when `AnalyzeProjectArgs.IncludeColumns` is true (the CLI sets it whenever
-`--baseline-audit`, `--rule-audit`, or `--delta` is present). The CLI
-deserialises the segment into a `*scanner.FindingColumns` and replays
+`--baseline-audit`, `--rule-audit`, `--delta`, `--fix`, `--fix-binary`,
+or `--remove-dead-code` is present). The CLI deserialises the segment
+into a `*scanner.FindingColumns` and replays
 `RunBaselineAuditColumns` (`internal/cli/scan/baseline_audit.go:34`) /
 `RunRuleAuditColumns` (`internal/cli/scan/rule_audit.go:75`) locally,
 producing the same audit output the in-process flow does. The non-audit
@@ -141,6 +142,45 @@ common path stays on the original `{findings,stats[,dispatch_profile]}`
 envelope: the `columns` field is `omitempty` and the fast-scan response
 decoder treats it as another optional segment after `dispatch_profile`
 (see `scanOptionalColumns` in `internal/daemon/response_scan.go`).
+
+## Fixes that ship with the analysis
+
+`--fix`, `--fix-binary`, and `--remove-dead-code` are **now routed via
+daemon**. The same `columns` wire segment used by `--rule-audit` /
+`--baseline-audit` / `--delta` carries the post-pipeline
+`FindingColumns` — which serialise `FixPool` / `BinaryFixPool`
+alongside the finding rows (see `internal/scanner/findings_json.go`)
+— so no new fix-payload schema was required. The CLI flips
+`IncludeColumns=true` in `buildDaemonAnalyzeArgs` whenever any of the
+three flags is set.
+
+The daemon-side pipeline never invokes `FixupPhase` apply because
+`args.Fix` / `args.FixBinary` are not forwarded across the wire —
+`runFixupPhase` (`internal/pipeline/project.go`) short-circuits when
+none of `Fix`, `FixBinary`, `DryRun` is set, returning the raw
+`CrossFileResult` unchanged. CLI-side replay:
+
+- `runDaemonFix` (`internal/cli/scan/daemon_fix.go`) decodes the
+  columns, runs `pipeline.FixupPhase{}` locally with
+  `Apply=*f.Fix && !*f.DryRun`, `ApplyBinary=*f.FixBinary`, and the
+  resolved `MaxFixLevel`, then replays the same
+  `info: Applied N fix(es)…` / `info: %d binary fix(es) applied.`
+  lines `runner.printFixupResult` emits in-process. The same short-
+  circuit conditions (`--output==""`, `--format=json`, `--report==""`,
+  `--fix`) drive an early return with exit code 0 / 1; otherwise the
+  daemon-routed flow re-renders the post-strip columns through
+  `pipeline.OutputPhase` locally so the findings emit matches the
+  in-process flow.
+
+- `runDaemonRemoveDeadCode` decodes the columns and calls
+  `RunDeadCodeRemovalColumns(cols, format, *f.DryRun, *f.FixSuffix)`
+  — the same entry point the in-process `applyBaselinesAndDiff` uses.
+
+This preserves the "daemon never writes user files" invariant: every
+`os.WriteFile`, `os.Rename`, and `cwebp` / `optipng` subprocess
+launched by `fixer.ApplyAllFixesColumns` /
+`fixer.ApplyBinaryFixesBatchColumns` runs with the CLI's CWD and
+permissions, not the daemon's.
 
 ## Oracle I/O & sampling
 

--- a/internal/cli/scan/daemon_delegate.go
+++ b/internal/cli/scan/daemon_delegate.go
@@ -118,8 +118,24 @@ func dispatchDaemonShortCircuits(f *scanFlags, paths []string, res daemon.Analyz
 		return true, runDaemonRuleAudit(f, paths, res.Columns)
 	case *f.BaselineAudit:
 		return true, runDaemonBaselineAudit(f, paths, res.Columns)
+	case *f.RemoveDeadCode:
+		// --remove-dead-code mirrors the in-process
+		// applyBaselinesAndDiff short-circuit: take the daemon-
+		// shipped columns, run BuildPlanColumns + Apply locally so
+		// the daemon never edits user source, and emit the
+		// dry-run / apply report.
+		return true, runDaemonRemoveDeadCode(f, paths, res.Columns)
 	case *f.Delta != "":
 		return true, runDaemonDelta(f, paths, res.Columns)
+	case *f.Fix || *f.FixBinary:
+		// --fix / --fix-binary mirror the in-process runFixup path:
+		// the daemon ships post-pipeline FindingColumns (no fixes
+		// applied daemon-side because args.Fix/FixBinary are not on
+		// the wire), and the CLI replays
+		// fixer.ApplyAllFixesColumns /
+		// fixer.ApplyBinaryFixesBatchColumns locally with the
+		// user's --fix-level cap.
+		return runDaemonFix(f, paths, res)
 	}
 	return false, 0
 }
@@ -501,21 +517,24 @@ func daemonAutoStartDisabled() bool {
 // add filesystem side-effects to a long-lived service); only the
 // current-tree scan and the delta diff step are daemon-routable.
 //
-// --fix, --fix-binary, and --remove-dead-code stay in-process. Each
-// would need a separate fix-payload-over-the-wire design where the
-// daemon serialises text edits / binary operations and the CLI replays
-// them; the existing fix application code path is intertwined with
-// per-rule context that doesn't currently survive serialisation. Land
-// those in follow-up PRs once a payload schema exists.
+// --fix, --fix-binary, and --remove-dead-code are now daemon-
+// compatible too. No new wire schema was required: the daemon already
+// ships the post-pipeline FindingColumns (FixPool / BinaryFixPool
+// included) under AnalyzeProjectResult.Columns when
+// AnalyzeProjectArgs.IncludeColumns is true, and the daemon-side
+// pipeline never invokes FixupPhase apply because args.Fix /
+// args.FixBinary are not forwarded across the wire. The CLI replays
+// fixer.ApplyAllFixesColumns / fixer.ApplyBinaryFixesBatchColumns /
+// RunDeadCodeRemovalColumns against the deserialised columns locally
+// (see runDaemonFix / runDaemonRemoveDeadCode), preserving the
+// "daemon never writes user files" invariant — every os.WriteFile
+// / os.Rename still happens with the CLI's CWD and permissions.
 func daemonCompatibleFlags(f *scanFlags) bool {
-	mutating := []bool{*f.Fix, *f.RemoveDeadCode, *f.FixBinary}
 	meta := []bool{*f.Init, *f.Doctor, *f.Version, *f.List, *f.ValidateConfig, *f.GenerateSchema,
 		*f.OracleFilterFingerprint, *f.ListExperiments}
-	for _, group := range [][]bool{mutating, meta} {
-		for _, on := range group {
-			if on {
-				return false
-			}
+	for _, on := range meta {
+		if on {
+			return false
 		}
 	}
 	strs := []string{*f.Completions,
@@ -565,11 +584,12 @@ func buildDaemonAnalyzeArgs(f *scanFlags, paths []string) daemon.AnalyzeProjectA
 	if *f.CreateBaseline != "" {
 		baselinePath = ""
 	}
-	// --rule-audit / --baseline-audit / --delta need the post-pipeline
-	// FindingColumns shipped back so the CLI can run the audit or
-	// delta filter locally. The daemon ships the columns alongside
-	// the normal findings JSON only when IncludeColumns is true so
-	// non-audit / non-delta scans stay on the original
+	// --rule-audit / --baseline-audit / --delta / --fix / --fix-binary
+	// / --remove-dead-code need the post-pipeline FindingColumns
+	// shipped back so the CLI can run the audit / delta filter / fix
+	// application locally. The daemon ships the columns alongside the
+	// normal findings JSON only when IncludeColumns is true so non-
+	// column-consuming scans stay on the original
 	// {findings,stats[,dispatch_profile]} wire shape.
 	//
 	// Also force JSON format when --rule-audit's caller picked a
@@ -577,7 +597,8 @@ func buildDaemonAnalyzeArgs(f *scanFlags, paths []string) daemon.AnalyzeProjectA
 	// directly and discards the findings JSON, but the daemon still
 	// streams it. --baseline-audit / --delta tolerate any format on
 	// the daemon side because the bytes are discarded the same way.
-	includeColumns := *f.RuleAudit || *f.BaselineAudit || *f.Delta != ""
+	includeColumns := *f.RuleAudit || *f.BaselineAudit || *f.Delta != "" ||
+		*f.Fix || *f.FixBinary || *f.RemoveDeadCode
 	return daemon.AnalyzeProjectArgs{
 		Paths:            paths,
 		Format:           format,

--- a/internal/cli/scan/daemon_delegate_test.go
+++ b/internal/cli/scan/daemon_delegate_test.go
@@ -110,12 +110,18 @@ func TestTryDaemonDelegate_HashMismatchFallsBack(t *testing.T) {
 	}
 }
 
-// TestTryDaemonDelegate_FlagBlocksDelegation exercises the
-// compatibility filter: `--fix` (and friends) must not be silently
-// dispatched through the daemon since the daemon doesn't perform
-// file rewrites.
-func TestTryDaemonDelegate_FlagBlocksDelegation(t *testing.T) {
-	socketDir := startMockDaemon(t, mockBehavior{})
+// TestTryDaemonDelegate_FixRoutesViaDaemon confirms `--fix` now
+// delegates to the daemon: the daemon ships FindingColumns under
+// the optional "columns" wire segment and the CLI replays
+// fixer.ApplyAllFixesColumns locally so the "daemon never writes
+// user files" invariant holds. The mock daemon returns empty
+// columns, so the CLI's runDaemonFix short-circuits with an
+// "info: No auto-fixable issues found." line; the assertion here
+// is on the routing (handled=true), not the message.
+func TestTryDaemonDelegate_FixRoutesViaDaemon(t *testing.T) {
+	socketDir := startMockDaemon(t, mockBehavior{
+		columns: `{"n":0}`,
+	})
 	root := newRoot(t)
 	linkSock(t, root, filepath.Join(socketDir, "d.sock"))
 
@@ -123,8 +129,8 @@ func TestTryDaemonDelegate_FlagBlocksDelegation(t *testing.T) {
 	*f.Fix = true
 
 	handled, _ := tryDaemonDelegate(f, []string{root}, root)
-	if handled {
-		t.Fatalf("expected fall-through with --fix; got handled=true")
+	if !handled {
+		t.Fatalf("expected handled=true with --fix routed through daemon; got fall-through")
 	}
 }
 
@@ -201,6 +207,11 @@ type mockBehavior struct {
 	rejectHash    bool
 	findings      string
 	findingsCount int
+	// columns, when non-empty, populates AnalyzeProjectResult.Columns
+	// so callers can exercise the daemon-routed --fix / --rule-audit /
+	// --baseline-audit / --delta / --remove-dead-code paths that
+	// consume the optional FindingColumns wire segment.
+	columns string
 }
 
 // startMockDaemon spins up a minimal server with status, shutdown,
@@ -236,10 +247,14 @@ func startMockDaemon(t *testing.T, b mockBehavior) string {
 		if findings == "" {
 			findings = `{"rules":[],"line":[]}`
 		}
-		return daemon.AnalyzeProjectResult{
+		result := daemon.AnalyzeProjectResult{
 			Findings: json.RawMessage(findings),
 			Stats:    daemon.AnalyzeProjectStats{FindingsCount: b.findingsCount},
-		}, nil
+		}
+		if b.columns != "" {
+			result.Columns = json.RawMessage(b.columns)
+		}
+		return result, nil
 	})
 	if err := srv.Start(context.Background()); err != nil {
 		t.Fatalf("start: %v", err)
@@ -389,9 +404,17 @@ func TestDaemonCompatibleFlags_PerfAllowed(t *testing.T) {
 		{"--profile-dispatch", func(f *scanFlags) { *f.ProfileDispatch = true }, true},
 		{"--cpuprofile", func(f *scanFlags) { *f.CPUProfile = "/tmp/cpu.pprof" }, true},
 		{"--memprofile", func(f *scanFlags) { *f.MemProfile = "/tmp/mem.pprof" }, true},
-		{"--fix", func(f *scanFlags) { *f.Fix = true }, false},
-		{"--fix-binary", func(f *scanFlags) { *f.FixBinary = true }, false},
-		{"--remove-dead-code", func(f *scanFlags) { *f.RemoveDeadCode = true }, false},
+		// --fix, --fix-binary, --remove-dead-code are daemon-served:
+		// the daemon ships FindingColumns on the wire under the
+		// optional "columns" segment (no fixes applied daemon-side
+		// because args.Fix / args.FixBinary are not forwarded across
+		// the wire), and the CLI replays fixer.ApplyAllFixesColumns /
+		// fixer.ApplyBinaryFixesBatchColumns / RunDeadCodeRemovalColumns
+		// locally, preserving the "daemon never writes user files"
+		// invariant.
+		{"--fix", func(f *scanFlags) { *f.Fix = true }, true},
+		{"--fix-binary", func(f *scanFlags) { *f.FixBinary = true }, true},
+		{"--remove-dead-code", func(f *scanFlags) { *f.RemoveDeadCode = true }, true},
 		// --no-cache rides on AnalyzeProjectArgs.NoCache; daemon
 		// nils its on-disk cache pointers for the call but stays
 		// the right place to serve it.
@@ -586,11 +609,12 @@ func startMockClearCacheDaemon(t *testing.T, cleared bool) string {
 }
 
 // TestBuildDaemonAnalyzeArgs_ForwardsIncludeColumns confirms each
-// column-consuming flag (--rule-audit, --baseline-audit, --delta)
-// flips AnalyzeProjectArgs.IncludeColumns to true so the daemon
-// emits the post-pipeline FindingColumns under the optional
-// "columns" wire segment. Other flag sets keep it false to preserve
-// the original {findings,stats[,dispatch_profile]} envelope.
+// column-consuming flag (--rule-audit, --baseline-audit, --delta,
+// --fix, --fix-binary, --remove-dead-code) flips
+// AnalyzeProjectArgs.IncludeColumns to true so the daemon emits the
+// post-pipeline FindingColumns under the optional "columns" wire
+// segment. Other flag sets keep it false to preserve the original
+// {findings,stats[,dispatch_profile]} envelope.
 func TestBuildDaemonAnalyzeArgs_ForwardsIncludeColumns(t *testing.T) {
 	tests := []struct {
 		name string
@@ -602,6 +626,9 @@ func TestBuildDaemonAnalyzeArgs_ForwardsIncludeColumns(t *testing.T) {
 		{"--baseline-audit", func(f *scanFlags) { *f.BaselineAudit = true }, true},
 		{"--delta", func(f *scanFlags) { *f.Delta = "main" }, true},
 		{"--rule-audit and --delta", func(f *scanFlags) { *f.RuleAudit = true; *f.Delta = "main" }, true},
+		{"--fix", func(f *scanFlags) { *f.Fix = true }, true},
+		{"--fix-binary", func(f *scanFlags) { *f.FixBinary = true }, true},
+		{"--remove-dead-code", func(f *scanFlags) { *f.RemoveDeadCode = true }, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/cli/scan/daemon_fix.go
+++ b/internal/cli/scan/daemon_fix.go
@@ -1,0 +1,85 @@
+package scan
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/kaeawc/krit/internal/daemon"
+	"github.com/kaeawc/krit/internal/pipeline"
+)
+
+// runDaemonFix replays --fix / --fix-binary against the daemon-shipped
+// FindingColumns. The daemon never applies fixes (FixupPhase short-
+// circuits daemon-side because args.Fix / args.FixBinary are not
+// forwarded across the wire), so the CLI runs pipeline.FixupPhase
+// locally against the deserialised columns. This preserves the
+// "daemon never writes user files" invariant while still letting the
+// scan itself benefit from daemon-resident state (parse cache,
+// resolver, oracle, cross-file indexes).
+//
+// Always returns handled=true: the daemon-routed --fix path emits its
+// own findings (via the in-process FixupPhase + emitDaemonFilteredColumns
+// re-render) rather than streaming the daemon's pre-strip findings
+// bytes through writeDaemonFindings. Falling through would double-
+// write the findings.
+func runDaemonFix(f *scanFlags, paths []string, res daemon.AnalyzeProjectResult) (handled bool, code int) {
+	cols, err := decodeDaemonColumns(res.Columns)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: --fix via daemon: %v\n", err)
+		return true, 2
+	}
+	maxFixLevel, ok := resolveMaxFixLevel(f)
+	if !ok {
+		return true, 2
+	}
+	preCount := cols.Len()
+	start := time.Now()
+	fixRes, _ := (pipeline.FixupPhase{}).Run(context.Background(), pipeline.FixupInput{
+		CrossFileResult: pipeline.CrossFileResult{
+			DispatchResult: pipeline.DispatchResult{
+				Findings: *cols,
+			},
+		},
+		Apply:        *f.Fix && !*f.DryRun,
+		ApplyBinary:  *f.FixBinary,
+		Suffix:       *f.FixSuffix,
+		MaxFixLevel:  maxFixLevel,
+		DryRunBinary: *f.DryRun,
+		CountOnly:    *f.DryRun,
+	})
+
+	printFixupResult(f, fixRes, start)
+	printBinaryFixResult(f, fixRes)
+
+	if *f.Output == "" && resolveEffectiveFormat(f) == "json" && *f.Report == "" && *f.Fix {
+		if preCount-fixRes.FixableCount > 0 {
+			if !*f.Quiet {
+				fmt.Fprintf(os.Stderr, "info: %d unfixable issue(s) remain.\n", preCount-fixRes.FixableCount)
+			}
+			return true, 1
+		}
+		return true, 0
+	}
+	// Non-short-circuit: re-render post-strip columns through
+	// OutputPhase locally so the findings sink matches the in-process
+	// flow byte-for-byte. The daemon's pre-strip findings JSON is
+	// discarded — mirrors how --delta uses emitDaemonFilteredColumns.
+	return true, emitDaemonFilteredColumns(f, paths, &fixRes.Findings, resolveBasePath(*f.BasePath, paths))
+}
+
+// runDaemonRemoveDeadCode replays --remove-dead-code against the
+// daemon-shipped columns. The daemon does not own the disk write —
+// dead-code removal mutates user source via fixer.ApplyAllFixesColumns,
+// so the CLI runs it locally. The format / dry-run / suffix knobs
+// mirror the in-process RunDeadCodeRemovalColumns invocation.
+func runDaemonRemoveDeadCode(f *scanFlags, _ []string, raw json.RawMessage) int {
+	cols, err := decodeDaemonColumns(raw)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: --remove-dead-code via daemon: %v\n", err)
+		return 2
+	}
+	return RunDeadCodeRemovalColumns(cols, resolveEffectiveFormat(f), *f.DryRun, *f.FixSuffix)
+}

--- a/internal/cli/scan/daemon_fix_test.go
+++ b/internal/cli/scan/daemon_fix_test.go
@@ -1,0 +1,229 @@
+package scan
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kaeawc/krit/internal/daemon"
+	"github.com/kaeawc/krit/internal/scanner"
+)
+
+// TestRunDaemonFix_AppliesTextFixLocally proves the daemon-routed
+// --fix path preserves the "daemon never writes user files"
+// invariant while still applying the fix the daemon computed. The
+// daemon ships FindingColumns under AnalyzeProjectResult.Columns;
+// runDaemonFix decodes them, runs pipeline.FixupPhase locally with
+// Apply=true, and the on-disk source file ends up rewritten by the
+// CLI's process — not the daemon's.
+func TestRunDaemonFix_AppliesTextFixLocally(t *testing.T) {
+	dir := t.TempDir()
+	sourcePath := filepath.Join(dir, "fix.kt")
+	original := "foo()\n"
+	if err := os.WriteFile(sourcePath, []byte(original), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cols := scanner.CollectFindings([]scanner.Finding{{
+		File:     sourcePath,
+		Line:     1,
+		Col:      1,
+		RuleSet:  "test",
+		Rule:     "TestRule",
+		Severity: "warning",
+		Message:  "swap foo for bar",
+		Fix: &scanner.Fix{
+			ByteMode:    true,
+			StartByte:   0,
+			EndByte:     3,
+			Replacement: "bar",
+		},
+	}})
+	columnsJSON, err := json.Marshal(cols)
+	if err != nil {
+		t.Fatalf("marshal columns: %v", err)
+	}
+
+	f := freshScanFlags(t)
+	*f.Fix = true
+	*f.FixLevel = "semantic"
+
+	res := daemon.AnalyzeProjectResult{
+		Findings: json.RawMessage(`{"rules":[],"line":[]}`),
+		Columns:  json.RawMessage(columnsJSON),
+	}
+	handled, code := runDaemonFix(f, []string{dir}, res)
+	if !handled {
+		t.Fatalf("expected handled=true; got false")
+	}
+	if code != 0 {
+		t.Errorf("expected exit 0; got %d", code)
+	}
+	got, err := os.ReadFile(sourcePath)
+	if err != nil {
+		t.Fatalf("read source: %v", err)
+	}
+	if string(got) != "bar()\n" {
+		t.Errorf("file content = %q, want %q", string(got), "bar()\n")
+	}
+}
+
+// TestRunDaemonFix_DryRunDoesNotWrite confirms the daemon-routed
+// --fix --dry-run path mirrors the in-process CountOnly mode: the
+// FixupPhase runs the MaxFixLevel filter and fixable counts, but
+// the on-disk file is untouched.
+func TestRunDaemonFix_DryRunDoesNotWrite(t *testing.T) {
+	dir := t.TempDir()
+	sourcePath := filepath.Join(dir, "fix.kt")
+	original := "foo()\n"
+	if err := os.WriteFile(sourcePath, []byte(original), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cols := scanner.CollectFindings([]scanner.Finding{{
+		File:     sourcePath,
+		Line:     1,
+		Col:      1,
+		RuleSet:  "test",
+		Rule:     "TestRule",
+		Severity: "warning",
+		Message:  "swap foo for bar",
+		Fix: &scanner.Fix{
+			ByteMode:    true,
+			StartByte:   0,
+			EndByte:     3,
+			Replacement: "bar",
+		},
+	}})
+	columnsJSON, err := json.Marshal(cols)
+	if err != nil {
+		t.Fatalf("marshal columns: %v", err)
+	}
+
+	f := freshScanFlags(t)
+	*f.Fix = true
+	*f.DryRun = true
+	*f.FixLevel = "semantic"
+
+	res := daemon.AnalyzeProjectResult{
+		Findings: json.RawMessage(`{"rules":[],"line":[]}`),
+		Columns:  json.RawMessage(columnsJSON),
+	}
+	if _, code := runDaemonFix(f, []string{dir}, res); code != 0 && code != 1 {
+		t.Errorf("expected exit 0 or 1; got %d", code)
+	}
+	got, err := os.ReadFile(sourcePath)
+	if err != nil {
+		t.Fatalf("read source: %v", err)
+	}
+	if string(got) != original {
+		t.Errorf("--dry-run rewrote file: got %q, want %q", string(got), original)
+	}
+}
+
+// TestRunDaemonFix_MaxFixLevelStripsBeforeApply proves the CLI-side
+// MaxFixLevel filter runs against the daemon-shipped columns: a fix
+// from a rule above the requested level is dropped, so the file
+// stays unchanged even though --fix is set.
+func TestRunDaemonFix_MaxFixLevelStripsBeforeApply(t *testing.T) {
+	dir := t.TempDir()
+	sourcePath := filepath.Join(dir, "fix.kt")
+	original := "foo()\n"
+	if err := os.WriteFile(sourcePath, []byte(original), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cols := scanner.CollectFindings([]scanner.Finding{{
+		File:     sourcePath,
+		Line:     1,
+		Col:      1,
+		RuleSet:  "test",
+		Rule:     "UnknownRuleAboveCosmetic",
+		Severity: "warning",
+		Message:  "would swap foo for bar",
+		Fix: &scanner.Fix{
+			ByteMode:    true,
+			StartByte:   0,
+			EndByte:     3,
+			Replacement: "bar",
+		},
+	}})
+	columnsJSON, err := json.Marshal(cols)
+	if err != nil {
+		t.Fatalf("marshal columns: %v", err)
+	}
+
+	f := freshScanFlags(t)
+	*f.Fix = true
+	*f.FixLevel = "cosmetic" // unknown rules default to FixSemantic, > cosmetic → stripped
+
+	res := daemon.AnalyzeProjectResult{
+		Findings: json.RawMessage(`{"rules":[],"line":[]}`),
+		Columns:  json.RawMessage(columnsJSON),
+	}
+	if _, code := runDaemonFix(f, []string{dir}, res); code != 0 && code != 1 {
+		t.Errorf("expected exit 0 or 1; got %d", code)
+	}
+	got, err := os.ReadFile(sourcePath)
+	if err != nil {
+		t.Fatalf("read source: %v", err)
+	}
+	if string(got) != original {
+		t.Errorf("MaxFixLevel filter failed to strip; file rewritten to %q", string(got))
+	}
+}
+
+// TestRunDaemonRemoveDeadCode_DryRunReportsPlan exercises the
+// daemon-routed --remove-dead-code dry-run path: the CLI replays
+// RunDeadCodeRemovalColumns against the daemon-shipped columns and
+// produces the standard report without rewriting disk.
+func TestRunDaemonRemoveDeadCode_DryRunReportsPlan(t *testing.T) {
+	dir := t.TempDir()
+	sourcePath := filepath.Join(dir, "dead.kt")
+	original := "fun dead() {}\n"
+	if err := os.WriteFile(sourcePath, []byte(original), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cols := scanner.CollectFindings(nil)
+	columnsJSON, err := json.Marshal(cols)
+	if err != nil {
+		t.Fatalf("marshal columns: %v", err)
+	}
+
+	f := freshScanFlags(t)
+	*f.RemoveDeadCode = true
+	*f.DryRun = true
+
+	if code := runDaemonRemoveDeadCode(f, []string{dir}, json.RawMessage(columnsJSON)); code != 0 {
+		t.Errorf("expected exit 0 on empty dry-run; got %d", code)
+	}
+	got, err := os.ReadFile(sourcePath)
+	if err != nil {
+		t.Fatalf("read source: %v", err)
+	}
+	if string(got) != original {
+		t.Errorf("--dry-run rewrote file: got %q, want %q", string(got), original)
+	}
+}
+
+// TestRunDaemonFix_MissingColumnsErrors proves runDaemonFix surfaces
+// a typed error when the daemon ships an empty columns payload (the
+// CLI only sets IncludeColumns when the fix flags require it, so an
+// empty columns segment means a daemon-side bug worth surfacing).
+func TestRunDaemonFix_MissingColumnsErrors(t *testing.T) {
+	f := freshScanFlags(t)
+	*f.Fix = true
+
+	res := daemon.AnalyzeProjectResult{
+		Findings: json.RawMessage(`{"rules":[],"line":[]}`),
+	}
+	handled, code := runDaemonFix(f, []string{t.TempDir()}, res)
+	if !handled {
+		t.Fatalf("expected handled=true on column decode error")
+	}
+	if code != 2 {
+		t.Errorf("expected exit 2 on decode error; got %d", code)
+	}
+}

--- a/internal/cli/scan/runner_output.go
+++ b/internal/cli/scan/runner_output.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/kaeawc/krit/internal/pipeline"
 	"github.com/kaeawc/krit/internal/rules"
+	"github.com/kaeawc/krit/internal/scanner"
 )
 
 func (r *runner) printVerboseBanner() {
@@ -33,44 +34,59 @@ func (r *runner) printVerboseBanner() {
 }
 
 func (r *runner) printFixupResult(fixRes pipeline.FixupResult) {
+	printFixupResult(r.f, fixRes, r.start)
+}
+
+func (r *runner) printBinaryFixResult(fixRes pipeline.FixupResult) {
+	printBinaryFixResult(r.f, fixRes)
+}
+
+// printFixupResult is the runner-independent fixup reporter. The
+// daemon-routed --fix path uses it too so the user-visible info /
+// dry-run / applied lines stay byte-identical regardless of which
+// path executed the scan.
+func printFixupResult(f *scanFlags, fixRes pipeline.FixupResult, start time.Time) {
 	fixableCount := fixRes.FixableCount
 	strippedByLevel := fixRes.StrippedByLevel
 	if fixableCount == 0 {
-		if !*r.f.Quiet {
+		if !*f.Quiet {
 			if strippedByLevel > 0 {
 				fmt.Fprintf(os.Stderr, "info: No auto-fixable issues at level %s. %d fix(es) available at higher levels (use --fix-level=semantic).\n",
-					*r.f.FixLevel, strippedByLevel)
+					*f.FixLevel, strippedByLevel)
 			} else {
 				fmt.Fprintln(os.Stderr, "info: No auto-fixable issues found.")
 			}
 		}
 		return
 	}
-	if *r.f.DryRun {
-		r.printDryRunFixResult(fixableCount)
+	if *f.DryRun {
+		printDryRunFixResult(f, &fixRes.Findings, fixableCount)
 	} else {
-		r.printAppliedFixResult(fixRes)
+		printAppliedFixResult(f, fixRes, start)
 	}
 }
 
-func (r *runner) printDryRunFixResult(fixableCount int) {
+// printDryRunFixResult prints one file per line (the files with at
+// least one available text fix) plus the summary line. Iterates the
+// post-strip columns so the file list reflects the MaxFixLevel cap.
+func printDryRunFixResult(f *scanFlags, cols *scanner.FindingColumns, fixableCount int) {
 	seen := make(map[string]bool)
-	for row := 0; row < r.allColumns.Len(); row++ {
-		if !r.allColumns.HasFix(row) {
+	for row := 0; row < cols.Len(); row++ {
+		if !cols.HasFix(row) {
 			continue
 		}
-		file := r.allColumns.FileAt(row)
+		file := cols.FileAt(row)
 		if !seen[file] {
 			seen[file] = true
 			fmt.Println(file)
 		}
 	}
-	if !*r.f.Quiet {
+	if !*f.Quiet {
 		fmt.Fprintf(os.Stderr, "info: %d fix(es) available across %d file(s).\n", fixableCount, len(seen))
 	}
 }
 
-func (r *runner) printAppliedFixResult(fixRes pipeline.FixupResult) {
+func printAppliedFixResult(f *scanFlags, fixRes pipeline.FixupResult, start time.Time) {
 	binarySet := make(map[error]bool, len(fixRes.BinaryErrors))
 	for _, e := range fixRes.BinaryErrors {
 		binarySet[e] = true
@@ -81,26 +97,26 @@ func (r *runner) printAppliedFixResult(fixRes pipeline.FixupResult) {
 		}
 		fmt.Fprintf(os.Stderr, "error: %v\n", e)
 	}
-	if !*r.f.Quiet {
+	if !*f.Quiet {
 		suffix := "in place"
-		if *r.f.FixSuffix != "" {
-			suffix = "with suffix '" + *r.f.FixSuffix + "'"
+		if *f.FixSuffix != "" {
+			suffix = "with suffix '" + *f.FixSuffix + "'"
 		}
 		fmt.Fprintf(os.Stderr, "info: Applied %d fix(es) across %d file(s) %s in %v.\n",
-			fixRes.TextApplied, len(fixRes.ModifiedFiles), suffix, time.Since(r.start).Round(time.Millisecond))
+			fixRes.TextApplied, len(fixRes.ModifiedFiles), suffix, time.Since(start).Round(time.Millisecond))
 	}
 }
 
-func (r *runner) printBinaryFixResult(fixRes pipeline.FixupResult) {
-	if !*r.f.FixBinary {
+func printBinaryFixResult(f *scanFlags, fixRes pipeline.FixupResult) {
+	if !*f.FixBinary {
 		return
 	}
 	for _, e := range fixRes.BinaryErrors {
 		fmt.Fprintf(os.Stderr, "error: binary fix: %v\n", e)
 	}
-	if fixRes.BinaryApplied > 0 && !*r.f.Quiet {
+	if fixRes.BinaryApplied > 0 && !*f.Quiet {
 		mode := "applied"
-		if *r.f.DryRun {
+		if *f.DryRun {
 			mode = "available"
 		}
 		fmt.Fprintf(os.Stderr, "info: %d binary fix(es) %s.\n", fixRes.BinaryApplied, mode)


### PR DESCRIPTION
## Summary

Resolves item #2 from [#284](https://github.com/kaeawc/krit/issues/284): `--fix`, `--fix-binary`, and `--remove-dead-code` now route through the krit daemon. Previously these stayed in-process because the issue assumed a new wire schema for serialised text edits / binary file ops would be needed.

It turns out **no new wire schema was required**: the daemon already serialises the post-pipeline `scanner.FindingColumns` (including `FixPool` and `BinaryFixPool`) under `AnalyzeProjectResult.Columns` — the same segment `--rule-audit` / `--baseline-audit` / `--delta` already use. The CLI just flips `IncludeColumns=true` when any fix flag is passed, decodes the columns, and replays `pipeline.FixupPhase` / `RunDeadCodeRemovalColumns` locally.

- **\"Daemon never writes user files\" invariant preserved** — `args.Fix` / `args.FixBinary` are not forwarded across the wire, so daemon-side `runFixupPhase` short-circuits and ships unmodified columns. Every `os.WriteFile`, `os.Rename`, and `cwebp` / `optipng` subprocess runs in the CLI's process with the CLI's CWD and permissions.
- **Output byte-identical** — `printFixupResult` / `printDryRunFixResult` / `printAppliedFixResult` / `printBinaryFixResult` are lifted from the runner to package-level helpers so the daemon-routed path emits the same `info: Applied N fix(es)…` lines as the in-process path. Same short-circuit conditions (`--output==\"\"`, `--format=json`, `--report==\"\"`, `--fix`) drive the early return with exit code 0/1.
- **MaxFixLevel filter runs CLI-side** during the local `FixupPhase.Run` invocation, so `--fix-level=cosmetic` correctly strips semantic fixes before apply.

## Validation criteria

- [x] `go build -o krit ./cmd/krit/`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...` (0 issues)
- [x] `go test ./... -count=1` (all packages pass)
- [x] `make integration` (11/11 pass — includes daemon-routed fix dry-runs across kotlin-webservice and android-app playgrounds)
- [x] `make regression` (playground finding counts within expected ranges)
- [x] New focused tests:
  - `TestRunDaemonFix_AppliesTextFixLocally` — proves daemon-routed `--fix` rewrites the user file via CLI process
  - `TestRunDaemonFix_DryRunDoesNotWrite` — confirms `--fix --dry-run` runs CountOnly without touching disk
  - `TestRunDaemonFix_MaxFixLevelStripsBeforeApply` — proves CLI-side level filter strips fixes from above-cap rules
  - `TestRunDaemonRemoveDeadCode_DryRunReportsPlan` — exercises the daemon-routed dead-code report
  - `TestRunDaemonFix_MissingColumnsErrors` — surfaces decoder errors when daemon omits the columns segment
- [x] Existing `TestDaemonCompatibleFlags_PerfAllowed` / `TestBuildDaemonAnalyzeArgs_ForwardsIncludeColumns` table tests extended; the pre-existing `TestTryDaemonDelegate_FlagBlocksDelegation` was renamed and inverted to `TestTryDaemonDelegate_FixRoutesViaDaemon`.

## Test plan

- [x] Unit tests pass
- [x] Integration tests pass
- [x] Regression check passes
- [x] Docs updated (`docs/daemon-flag-routing.md`)
- [x] `daemon-flag-routing.md` \"Fixes that ship with the analysis\" section documents the rationale and CLI-side replay flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)