### PR TITLE
fix(watcher): close Stop() race in scheduleKotlinInvalidate (#284)

### DIFF
--- a/internal/cli/serve/watcher.go
+++ b/internal/cli/serve/watcher.go
@@ -80,8 +80,17 @@ type fileWatcher struct {
 	// emit on a single logical save. Each path gets its own sliding timer;
 	// events within debounceWindow of each other are collapsed into one
 	// Invalidate+Touch call.
+	//
+	// debounceGen is a per-path generation counter that guards against the
+	// time.Timer.Stop() race: when a timer's callback goroutine has already
+	// been scheduled but hasn't acquired debounceMu yet, Stop() returns
+	// false and the callback will still run. Without a guard, both the
+	// stale callback and the freshly-installed timer fire Invalidate. Each
+	// scheduleKotlinInvalidate bumps the gen and the callback no-ops if
+	// its captured gen no longer matches.
 	debounceMu     sync.Mutex
 	debounce       map[string]*time.Timer
+	debounceGen    map[string]uint64
 	debounceWindow time.Duration
 }
 
@@ -106,6 +115,7 @@ func startFileWatcherWithState(ctx context.Context, root string, state watcherSt
 		done:           make(chan struct{}),
 		ready:          make(chan struct{}),
 		debounce:       make(map[string]*time.Timer),
+		debounceGen:    make(map[string]uint64),
 		debounceWindow: defaultDebounceWindow,
 	}
 	for _, opt := range opts {
@@ -286,9 +296,16 @@ func (fw *fileWatcher) scheduleKotlinInvalidate(path string) {
 	if t, ok := fw.debounce[path]; ok {
 		t.Stop()
 	}
+	fw.debounceGen[path]++
+	gen := fw.debounceGen[path]
 	fw.debounce[path] = time.AfterFunc(fw.debounceWindow, func() {
 		fw.debounceMu.Lock()
+		if fw.debounceGen[path] != gen {
+			fw.debounceMu.Unlock()
+			return
+		}
 		delete(fw.debounce, path)
+		delete(fw.debounceGen, path)
 		fw.debounceMu.Unlock()
 		fw.state.Invalidate(path)
 		fw.state.InvalidateCodeIndex()

--- a/internal/cli/serve/watcher_test.go
+++ b/internal/cli/serve/watcher_test.go
@@ -380,9 +380,7 @@ func TestFileWatcher_TouchPropagatesOnGradleWrite(t *testing.T) {
 // for the same Kotlin file coalesce into a single Invalidate call. Events
 // are injected directly into handle() so the debouncer is tested in
 // isolation from fsnotify's variable event-delivery timing —
-// TestFileWatcher_InvalidatesOnWrite covers the OS-roundtrip path. Driving
-// handle() directly was the fix for a CI flake where editor-save bursts
-// spread past the debounce window under load.
+// TestFileWatcher_InvalidatesOnWrite covers the OS-roundtrip path.
 func TestFileWatcher_DebounceEditorSavePattern(t *testing.T) {
 	root := t.TempDir()
 	ktPath := filepath.Join(root, "Foo.kt")
@@ -391,7 +389,7 @@ func TestFileWatcher_DebounceEditorSavePattern(t *testing.T) {
 	}
 
 	state := &countingState{}
-	const window = 20 * time.Millisecond
+	const window = 100 * time.Millisecond
 	w, err := startFileWatcherWithState(context.Background(), root, state, nil,
 		withDebounceWindow(window))
 	if err != nil {
@@ -403,7 +401,6 @@ func TestFileWatcher_DebounceEditorSavePattern(t *testing.T) {
 	ev := fsnotify.Event{Name: ktPath, Op: fsnotify.Write}
 	for range 3 {
 		w.handle(ev)
-		time.Sleep(2 * time.Millisecond)
 	}
 
 	deadline := time.Now().Add(2 * time.Second)
@@ -415,10 +412,47 @@ func TestFileWatcher_DebounceEditorSavePattern(t *testing.T) {
 	}
 	// Settle: if a stray timer was re-armed under load, give it a full
 	// window + margin to complete before asserting the final count.
-	time.Sleep(window * 4)
+	time.Sleep(window * 2)
 
 	if got := state.invalidateCalls.Load(); got != 1 {
 		t.Errorf("Invalidate called %d times, want 1 (debounce should coalesce burst)", got)
+	}
+}
+
+// TestFileWatcher_DebounceGenerationGuard forces the Stop()-race scenario:
+// the test holds debounceMu past the window so the scheduled timer fires
+// and its callback parks at the lock, then bumps debounceGen[path] while
+// holding the lock to simulate the relevant half of a second
+// scheduleKotlinInvalidate. The parked callback must observe the gen
+// mismatch and skip Invalidate. Removing the gen check in watcher.go must
+// fail this test — it drives the real callback path.
+func TestFileWatcher_DebounceGenerationGuard(t *testing.T) {
+	root := t.TempDir()
+	ktPath := filepath.Join(root, "Foo.kt")
+	if err := os.WriteFile(ktPath, []byte("fun a() {}\n"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	state := &countingState{}
+	const window = 10 * time.Millisecond
+	w, err := startFileWatcherWithState(context.Background(), root, state, nil,
+		withDebounceWindow(window))
+	if err != nil {
+		t.Fatalf("startFileWatcher: %v", err)
+	}
+	defer w.Stop()
+	<-w.Ready()
+
+	w.scheduleKotlinInvalidate(ktPath)
+	w.debounceMu.Lock()
+	time.Sleep(window * 3)
+	w.debounceGen[ktPath]++
+	w.debounceMu.Unlock()
+
+	time.Sleep(window * 6)
+
+	if got := state.invalidateCalls.Load(); got != 0 {
+		t.Errorf("Invalidate called %d times, want 0 (stale callback should observe gen bump and no-op)", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

Addresses section 5 of #284 — the `TestFileWatcher_DebounceEditorSavePattern` flake on `main`.

Diagnosis: when `time.Timer.Stop()` returns false because the callback goroutine has already been scheduled (but hasn't yet acquired `debounceMu`), the stale callback runs *in addition to* the newly-installed timer. Result: two `Invalidate` calls for one editor-save burst, which is exactly what the test asserts against.

Fix: per-path generation counter. `scheduleKotlinInvalidate` bumps the gen under the lock; each callback re-checks the gen on lock acquisition and no-ops on mismatch.

Test tightening:
- `TestFileWatcher_DebounceEditorSavePattern`: removed 2ms inter-event sleeps (left an 18ms safety margin against the 20ms window — CI GC pauses easily exceed that), bumped the window to 100ms.
- New `TestFileWatcher_DebounceGenerationGuard`: deterministically reproduces the `Stop()` race by holding `debounceMu` past the window so the timer callback parks at the lock, then bumping the gen. Verified locally: removing the gen check causes this test to fail 5/5; with the fix it passes 5/5 under `-race`.

Sections 1–4 of #284 are already complete per `docs/daemon-flag-routing.md` (PRs #272, #279, #282, #283, #331). This finishes off the tracking issue.

## Test plan
- [x] `go build -o krit ./cmd/krit/`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...` (0 issues)
- [x] `go test ./... -count=1` (full suite passes)
- [x] `go test -race -count=20 -run TestFileWatcher_Debounce ./internal/cli/serve/` (passes 40/40)
- [x] Verified regression test fails without the fix (5/5 fails)