### PR TITLE
feat(plugin-fix): plumb Fix.Safety so --fix-level gates plugin fixes

### DIFF
--- a/internal/pipeline/custom_kotlin_rules.go
+++ b/internal/pipeline/custom_kotlin_rules.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/kaeawc/krit/internal/oracle"
+	"github.com/kaeawc/krit/internal/rules"
 	"github.com/kaeawc/krit/internal/scanner"
 )
 
@@ -89,11 +90,18 @@ func pluginFixToScanner(fix *oracle.PluginFix) *scanner.Fix {
 	if fix == nil {
 		return nil
 	}
-	return &scanner.Fix{
+	out := &scanner.Fix{
 		StartLine:   fix.StartLine,
 		EndLine:     fix.EndLine,
 		Replacement: fix.Replacement,
 	}
+	if lvl, ok := rules.ParseFixLevel(fix.Safety); ok {
+		out.Safety = uint8(lvl)
+	} else {
+		// Unknown/missing → semantic so --fix-level still gates it.
+		out.Safety = uint8(rules.FixSemantic)
+	}
+	return out
 }
 
 func formatPluginErrors(errors map[string]string) string {

--- a/internal/pipeline/custom_kotlin_rules_test.go
+++ b/internal/pipeline/custom_kotlin_rules_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/kaeawc/krit/internal/oracle"
+	"github.com/kaeawc/krit/internal/rules"
 	api "github.com/kaeawc/krit/internal/rules/api"
 )
 
@@ -78,6 +79,138 @@ func TestPluginFindingsToColumns(t *testing.T) {
 	fix := cols.FixAt(0)
 	if fix == nil || fix.Replacement != "replacement" {
 		t.Fatalf("FixAt(0) = %#v", fix)
+	}
+}
+
+func TestPluginFixToScannerPopulatesSafety(t *testing.T) {
+	tests := []struct {
+		safety string
+		want   uint8
+	}{
+		{"cosmetic", uint8(rules.FixCosmetic)},
+		{"idiomatic", uint8(rules.FixIdiomatic)},
+		{"semantic", uint8(rules.FixSemantic)},
+		{"", uint8(rules.FixSemantic)},        // unset → conservative
+		{"unknown", uint8(rules.FixSemantic)}, // unrecognized → conservative
+	}
+	for _, tt := range tests {
+		t.Run(tt.safety, func(t *testing.T) {
+			got := pluginFixToScanner(&oracle.PluginFix{
+				StartLine:   1,
+				EndLine:     1,
+				Replacement: "x",
+				Safety:      tt.safety,
+			})
+			if got == nil {
+				t.Fatal("pluginFixToScanner = nil")
+			}
+			if got.Safety != tt.want {
+				t.Errorf("Safety = %d, want %d", got.Safety, tt.want)
+			}
+		})
+	}
+
+	if got := pluginFixToScanner(nil); got != nil {
+		t.Errorf("pluginFixToScanner(nil) = %#v, want nil", got)
+	}
+}
+
+func TestFixupGatesPluginSemanticFixUnderCosmeticLevel(t *testing.T) {
+	// Plugin rule reports a SEMANTIC fix; --fix-level cosmetic must
+	// strip it just like any built-in FixSemantic. We seed scanner.Fix
+	// the same way pluginFixToScanner does so the registry doesn't
+	// know the rule but the fix carries Safety directly.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "Example.kt")
+	original := "val foo = 1\n"
+	if err := os.WriteFile(path, []byte(original), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	cols := pluginFindingsToColumns([]oracle.PluginFinding{{
+		File:       path,
+		Line:       1,
+		Column:     1,
+		RuleSet:    "myteam",
+		RuleID:     "MyTeam/SemanticRule",
+		Severity:   "warning",
+		Message:    "semantic plugin fix",
+		Confidence: 0.9,
+		Fix: &oracle.PluginFix{
+			StartLine:   1,
+			EndLine:     1,
+			Replacement: "val bar = 1",
+			Safety:      "semantic",
+		},
+	}})
+
+	out, err := (FixupPhase{}).Run(context.Background(), FixupInput{
+		CrossFileResult: CrossFileResult{
+			DispatchResult: DispatchResult{Findings: cols},
+		},
+		Apply:       true,
+		MaxFixLevel: rules.FixCosmetic,
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if out.AppliedFixes != 0 {
+		t.Errorf("AppliedFixes = %d, want 0 (semantic plugin fix must be stripped)", out.AppliedFixes)
+	}
+	if out.StrippedByLevel != 1 {
+		t.Errorf("StrippedByLevel = %d, want 1", out.StrippedByLevel)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if string(got) != original {
+		t.Errorf("file changed: got %q, want %q", string(got), original)
+	}
+}
+
+func TestFixupAppliesPluginCosmeticFixUnderCosmeticLevel(t *testing.T) {
+	// Counterpart to the semantic-strip test: a plugin fix declared
+	// COSMETIC must survive the same --fix-level cosmetic gate even
+	// though the rule isn't in the built-in registry (where the
+	// fallback would otherwise classify it as FixSemantic).
+	dir := t.TempDir()
+	path := filepath.Join(dir, "Example.kt")
+	if err := os.WriteFile(path, []byte("val foo = 1\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	cols := pluginFindingsToColumns([]oracle.PluginFinding{{
+		File:     path,
+		Line:     1,
+		Column:   1,
+		RuleSet:  "myteam",
+		RuleID:   "MyTeam/CosmeticRule",
+		Severity: "warning",
+		Message:  "cosmetic plugin fix",
+		Fix: &oracle.PluginFix{
+			StartLine:   1,
+			EndLine:     1,
+			Replacement: "val bar = 1",
+			Safety:      "cosmetic",
+		},
+	}})
+
+	out, err := (FixupPhase{}).Run(context.Background(), FixupInput{
+		CrossFileResult: CrossFileResult{
+			DispatchResult: DispatchResult{Findings: cols},
+		},
+		Apply:       true,
+		MaxFixLevel: rules.FixCosmetic,
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if out.AppliedFixes != 1 {
+		t.Errorf("AppliedFixes = %d, want 1 (cosmetic plugin fix must apply)", out.AppliedFixes)
+	}
+	if out.StrippedByLevel != 0 {
+		t.Errorf("StrippedByLevel = %d, want 0", out.StrippedByLevel)
 	}
 }
 

--- a/internal/pipeline/fixup.go
+++ b/internal/pipeline/fixup.go
@@ -71,6 +71,11 @@ func (FixupPhase) Run(_ context.Context, in FixupInput) (FixupResult, error) {
 			}
 		}
 		strippedByLevel = columns.StripTextFixes(func(row int) bool {
+			// Per-fix Safety wins so non-registry sources (plugin rules)
+			// participate in --fix-level gating.
+			if fix := columns.FixAt(row); fix != nil && fix.Safety > 0 {
+				return rules.FixLevel(fix.Safety) > in.MaxFixLevel
+			}
 			lvl, ok := ruleLevels[columns.RuleAt(row)]
 			if !ok {
 				// Unknown or unfixable rule: default to FixSemantic (most conservative).

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -75,6 +75,10 @@ type Fix struct {
 	StartByte int
 	EndByte   int
 	ByteMode  bool // if true, use byte offsets instead of line offsets
+	// Safety is the FixLevel (1=cosmetic, 2=idiomatic, 3=semantic), or
+	// 0 when unset. Stored as uint8 to avoid a scanner→rules import
+	// cycle. The fixup phase falls back to the rule registry when 0.
+	Safety uint8
 }
 
 // Language identifies which source language a File holds. Used by the


### PR DESCRIPTION
## Summary

Closes #305.

- Add `Safety uint8` field on `scanner.Fix` (stored as `uint8` to avoid a scanner→rules import cycle; 0 means unset).
- Populate it in `pluginFixToScanner` from `PluginFix.safety` via `rules.ParseFixLevel`. Unknown/missing safety defaults to `FixSemantic` so `--fix-level cosmetic`/`idiomatic` still strips it.
- Teach `FixupPhase.Run` to prefer the per-fix `Safety` before falling back to the rule-registry lookup, so plugin rules (which are not in `api.Registry`) participate in `--fix-level` gating.

## Test plan
- [x] Unit: `TestPluginFixToScannerPopulatesSafety` covers cosmetic/idiomatic/semantic/empty/unknown → expected `Safety`.
- [x] Unit: `TestFixupGatesPluginSemanticFixUnderCosmeticLevel` — a plugin SEMANTIC fix is stripped under `--fix-level cosmetic` (acceptance criterion from #305).
- [x] Unit: `TestFixupAppliesPluginCosmeticFixUnderCosmeticLevel` — a plugin COSMETIC fix is **applied** under `--fix-level cosmetic`, proving the previous registry-only fallback would have wrongly stripped it.
- [x] Existing built-in fix-level gating (`TestFixupPhase_RespectsMaxFixLevel`, `TestFixupPhase_PreservesFindings`) unchanged.
- [x] `go build`, `go vet`, `golangci-lint run`, full `go test ./... -count=1` all pass.