### PR TITLE
feat(config): per-plugin-rule config in krit.yml (#306)

### DIFF
--- a/docs/external-rules.md
+++ b/docs/external-rules.md
@@ -112,8 +112,16 @@ class NoTodoRule : KritRule {
   classpath still compile. Cast to `org.jetbrains.kotlin.psi.KtFile`
   inside the rule if you need PSI walking.
 
-`RuleContext` currently exposes only the active `ruleId`. The PSI /
-resolver expansion is tracked under
+`RuleContext` exposes:
+
+- `ruleId` — the active rule's `@KritRuleInfo.id`.
+- `config: Map<String, Any?>` — the per-rule `options` map from the
+  consumer's `krit.yml`. Use the typed accessors (`stringOption`,
+  `intOption`, `boolOption`, `stringListOption`) instead of casting
+  directly; they fall through to the supplied default when the option
+  is absent or the wrong type.
+
+The PSI / resolver expansion is tracked under
 [#308](https://github.com/kaeawc/krit/issues/308); the rest of this
 doc calls out what is deferred.
 
@@ -216,6 +224,46 @@ krit --custom-rule-jars my-rules/build/libs/my-rules-0.1.0-krit-rules.jar src/
 `--custom-rule-jars` keeps Krit on the in-process path (the
 daemon-eligibility gate routes around it), so first runs do not need
 the prebuilt `krit-types` daemon on disk.
+
+## Per-rule configuration (`pluginRules`)
+
+The consumer's `krit.yml` controls plugin rules through a dedicated
+top-level `pluginRules` section, keyed by `@KritRuleInfo.id`:
+
+```yaml
+pluginRules:
+  acme.NoTodo:
+    active: false           # silence a noisy rule without removing the jar
+  acme.MaxLineLength:
+    options:
+      maxLineLength: 100    # forwarded as RuleContext.config["maxLineLength"]
+      ignoredFiles:
+        - 'generated/**'
+```
+
+Each entry accepts two keys:
+
+| Key | Type | Behavior |
+| --- | --- | --- |
+| `active` | bool | When `false`, Krit skips the rule before sending the RPC — zero findings, zero work. Omit to use the rule's default activation. |
+| `options` | map | Free-form key/value pairs exposed verbatim to the rule via `RuleContext.config`. Values come through with their YAML types (string, int, bool, list). |
+
+Inside the rule, read options through the typed helpers so a missing
+or wrong-typed value falls back to your default:
+
+```kotlin
+override fun check(file: KritFile, ctx: RuleContext): List<Finding> {
+    val max = ctx.intOption("maxLineLength", default = 120)
+    val ignored = ctx.stringListOption("ignoredFiles")
+    // ...
+}
+```
+
+`krit --validate-config` validates the `pluginRules` shape (object,
+allowed keys `active` / `options`, correct types) so typos surface
+before analysis runs. The rule IDs themselves are *not* validated
+against the loaded jars — IDs are owned by user-supplied plugins and
+may not be known to the binary at config-load time.
 
 ## Capability semantics
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -424,6 +424,53 @@ func (c *Config) Oracle() OracleConfig {
 	}
 }
 
+// PluginRulesKey is the top-level `krit.yml` section that configures
+// Kotlin plugin-jar rules loaded via --custom-rule-jars. Shape:
+//
+//	pluginRules:
+//	  acme.NoTodo:
+//	    active: false
+//	    options:
+//	      maxLineLength: 100
+const PluginRulesKey = "pluginRules"
+
+// IsPluginRuleActive returns the configured active flag for a plugin
+// rule loaded from a custom-rule jar. Returns nil if not specified,
+// in which case the daemon's default activation wins.
+func (c *Config) IsPluginRuleActive(ruleID string) *bool {
+	if c == nil || c.data == nil || ruleID == "" {
+		return nil
+	}
+	m, ok := lookupMap(c.data, PluginRulesKey, ruleID)
+	if !ok {
+		return nil
+	}
+	v, ok := m["active"]
+	if !ok {
+		return nil
+	}
+	b, ok := toBool(v)
+	if !ok {
+		return nil
+	}
+	return &b
+}
+
+// PluginRuleOptions returns the configured `options` map for a plugin
+// rule loaded from a custom-rule jar. Returns nil if no options are
+// declared. The returned map is the caller's to read but must not be
+// mutated.
+func (c *Config) PluginRuleOptions(ruleID string) map[string]interface{} {
+	if c == nil || c.data == nil || ruleID == "" {
+		return nil
+	}
+	m, ok := lookupMap(c.data, PluginRulesKey, ruleID, "options")
+	if !ok {
+		return nil
+	}
+	return m
+}
+
 func (c *Config) TestSourcePaths() []string {
 	return c.GetTopLevelList("testSourcePaths")
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -124,6 +124,70 @@ func TestMergeMaps(t *testing.T) {
 	}
 }
 
+func TestPluginRulesAccessors(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "plugins.yml")
+	content := `
+pluginRules:
+  acme.NoTodo:
+    active: false
+    options:
+      maxLineLength: 120
+      ignored:
+        - 'TODO'
+        - 'FIXME'
+  acme.OptInOnly:
+    active: true
+  acme.NoOptions: {}
+`
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := LoadConfig(path)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+
+	if got := cfg.IsPluginRuleActive("acme.NoTodo"); got == nil || *got {
+		t.Errorf("acme.NoTodo active = %v, want false", got)
+	}
+	if got := cfg.IsPluginRuleActive("acme.OptInOnly"); got == nil || !*got {
+		t.Errorf("acme.OptInOnly active = %v, want true", got)
+	}
+	if got := cfg.IsPluginRuleActive("acme.Unmentioned"); got != nil {
+		t.Errorf("unmentioned rule active = %v, want nil", *got)
+	}
+	if got := cfg.IsPluginRuleActive("acme.NoOptions"); got != nil {
+		t.Errorf("acme.NoOptions active = %v, want nil (no active key)", *got)
+	}
+
+	opts := cfg.PluginRuleOptions("acme.NoTodo")
+	if opts == nil {
+		t.Fatal("expected non-nil options for acme.NoTodo")
+	}
+	if opts["maxLineLength"] != 120 {
+		t.Errorf("maxLineLength = %v, want 120", opts["maxLineLength"])
+	}
+	ignored, ok := opts["ignored"].([]interface{})
+	if !ok {
+		t.Fatalf("ignored type = %T, want []interface{}", opts["ignored"])
+	}
+	if len(ignored) != 2 {
+		t.Fatalf("ignored len = %d, want 2", len(ignored))
+	}
+
+	if got := cfg.PluginRuleOptions("acme.OptInOnly"); got != nil {
+		t.Errorf("OptInOnly options = %v, want nil", got)
+	}
+	if got := cfg.PluginRuleOptions(""); got != nil {
+		t.Errorf("empty ruleID options = %v, want nil", got)
+	}
+	var nilCfg *Config
+	if got := nilCfg.IsPluginRuleActive("x"); got != nil {
+		t.Errorf("nil config active = %v, want nil", got)
+	}
+}
+
 func TestLoadConfigExplicitPath(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "custom.yml")

--- a/internal/oracle/daemon.go
+++ b/internal/oracle/daemon.go
@@ -243,7 +243,10 @@ func (d *Daemon) ListPlugins(jars []string) (ListPluginsResult, error) {
 }
 
 // AnalyzePluginFile runs selected Kotlin custom rules against one source file.
-func (d *Daemon) AnalyzePluginFile(jars []string, path string, source []byte, ruleIDs []string) (AnalyzePluginFileResult, error) {
+// ruleConfigs maps each rule ID to its configured `options` map; an empty
+// or nil map is omitted from the request so the daemon's RuleContext.config
+// stays empty for those rules.
+func (d *Daemon) AnalyzePluginFile(jars []string, path string, source []byte, ruleIDs []string, ruleConfigs map[string]map[string]interface{}) (AnalyzePluginFileResult, error) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
@@ -252,6 +255,9 @@ func (d *Daemon) AnalyzePluginFile(jars []string, path string, source []byte, ru
 		"path":    path,
 		"source":  string(source),
 		"ruleIds": ruleIDs,
+	}
+	if len(ruleConfigs) > 0 {
+		params["ruleConfigs"] = ruleConfigs
 	}
 	result, err := d.sendResult("analyzeFile", params)
 	if err != nil {

--- a/internal/pipeline/custom_kotlin_rules.go
+++ b/internal/pipeline/custom_kotlin_rules.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/kaeawc/krit/internal/config"
 	"github.com/kaeawc/krit/internal/oracle"
 	"github.com/kaeawc/krit/internal/rules"
 	"github.com/kaeawc/krit/internal/scanner"
@@ -27,12 +28,7 @@ func runKotlinPluginRulesAndMerge(ctx context.Context, args ProjectArgs, host Pr
 	if err != nil {
 		return fmt.Errorf("list Kotlin custom rules: %w", err)
 	}
-	ruleIDs := make([]string, 0, len(list.Rules))
-	for _, rule := range list.Rules {
-		if rule.RuleID != "" {
-			ruleIDs = append(ruleIDs, rule.RuleID)
-		}
-	}
+	ruleIDs, ruleOptions := selectPluginRules(list.Rules, args.Config)
 	if len(ruleIDs) == 0 {
 		return nil
 	}
@@ -48,7 +44,7 @@ func runKotlinPluginRulesAndMerge(ctx context.Context, args ProjectArgs, host Pr
 			return ctx.Err()
 		default:
 		}
-		result, err := daemon.AnalyzePluginFile(args.CustomRuleJars, file.Path, file.Content, ruleIDs)
+		result, err := daemon.AnalyzePluginFile(args.CustomRuleJars, file.Path, file.Content, ruleIDs, ruleOptions)
 		if err != nil {
 			return fmt.Errorf("run Kotlin custom rules on %s: %w", file.Path, err)
 		}
@@ -61,6 +57,28 @@ func runKotlinPluginRulesAndMerge(ctx context.Context, args ProjectArgs, host Pr
 	}
 	crossFileResult.Findings = *collector.Columns()
 	return nil
+}
+
+// selectPluginRules picks which jar-loaded rules to dispatch and collects
+// each rule's configured options from `pluginRules:` in krit.yml. A rule
+// is skipped when the user explicitly set `active: false`; the absence of
+// any pluginRules entry preserves the daemon's default activation.
+func selectPluginRules(loaded []oracle.PluginRuleDescriptor, cfg *config.Config) ([]string, map[string]map[string]interface{}) {
+	ruleIDs := make([]string, 0, len(loaded))
+	options := map[string]map[string]interface{}{}
+	for _, rule := range loaded {
+		if rule.RuleID == "" {
+			continue
+		}
+		if active := cfg.IsPluginRuleActive(rule.RuleID); active != nil && !*active {
+			continue
+		}
+		ruleIDs = append(ruleIDs, rule.RuleID)
+		if opts := cfg.PluginRuleOptions(rule.RuleID); len(opts) > 0 {
+			options[rule.RuleID] = opts
+		}
+	}
+	return ruleIDs, options
 }
 
 func pluginFindingsToColumns(findings []oracle.PluginFinding) scanner.FindingColumns {

--- a/internal/pipeline/custom_kotlin_rules_test.go
+++ b/internal/pipeline/custom_kotlin_rules_test.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
+	"github.com/kaeawc/krit/internal/config"
 	"github.com/kaeawc/krit/internal/oracle"
 	"github.com/kaeawc/krit/internal/rules"
 	api "github.com/kaeawc/krit/internal/rules/api"
@@ -211,6 +213,57 @@ func TestFixupAppliesPluginCosmeticFixUnderCosmeticLevel(t *testing.T) {
 	}
 	if out.StrippedByLevel != 0 {
 		t.Errorf("StrippedByLevel = %d, want 0", out.StrippedByLevel)
+	}
+}
+
+func TestSelectPluginRulesSkipsDisabledAndCollectsOptions(t *testing.T) {
+	loaded := []oracle.PluginRuleDescriptor{
+		{RuleID: "acme.NoTodo"},
+		{RuleID: "acme.NoFixme"},
+		{RuleID: "acme.OptInOnly"},
+		{RuleID: ""}, // dropped: empty IDs come from malformed jars
+	}
+	cfg := config.NewConfigFromData(map[string]interface{}{
+		"pluginRules": map[string]interface{}{
+			"acme.NoTodo": map[string]interface{}{
+				"active": false,
+			},
+			"acme.NoFixme": map[string]interface{}{
+				"options": map[string]interface{}{
+					"maxLineLength": 100,
+				},
+			},
+			"acme.OptInOnly": map[string]interface{}{
+				"active": true,
+			},
+		},
+	})
+
+	ids, opts := selectPluginRules(loaded, cfg)
+
+	wantIDs := []string{"acme.NoFixme", "acme.OptInOnly"}
+	if !reflect.DeepEqual(ids, wantIDs) {
+		t.Fatalf("ruleIDs = %v, want %v", ids, wantIDs)
+	}
+	wantOpts := map[string]map[string]interface{}{
+		"acme.NoFixme": {"maxLineLength": 100},
+	}
+	if !reflect.DeepEqual(opts, wantOpts) {
+		t.Fatalf("ruleOptions = %v, want %v", opts, wantOpts)
+	}
+}
+
+func TestSelectPluginRulesNilConfigKeepsEveryRuleWithoutOptions(t *testing.T) {
+	loaded := []oracle.PluginRuleDescriptor{
+		{RuleID: "acme.A"},
+		{RuleID: "acme.B"},
+	}
+	ids, opts := selectPluginRules(loaded, nil)
+	if !reflect.DeepEqual(ids, []string{"acme.A", "acme.B"}) {
+		t.Fatalf("ruleIDs = %v, want passthrough", ids)
+	}
+	if len(opts) != 0 {
+		t.Fatalf("ruleOptions = %v, want empty", opts)
 	}
 }
 

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/kaeawc/krit/internal/config"
 	"github.com/kaeawc/krit/internal/jsonschema"
 	"github.com/kaeawc/krit/internal/rules"
 	api "github.com/kaeawc/krit/internal/rules/api"
@@ -216,6 +217,9 @@ func GenerateSchema(metas []RuleMeta) *jsonschema.Schema {
 	}).AdditionalPropertiesFalse().WithRequired("id", "pattern", "message")
 	props["customRules"] = jsonschema.Array(customRulesItem, "Config-defined pattern rules registered at runtime.")
 
+	props[config.PluginRulesKey] = jsonschema.Object(map[string]*jsonschema.Schema{}).
+		WithDescription("Per-plugin-rule configuration for rules loaded from --custom-rule-jars. Keyed by rule ID (matching @KritRuleInfo.id); each entry takes {active: bool, options: {...}}.")
+
 	for _, setName := range sortedKeys(bySet) {
 		setMetas := bySet[setName]
 		ruleProps := map[string]*jsonschema.Schema{
@@ -305,7 +309,14 @@ func sortedKeys(m map[string][]RuleMeta) []string {
 
 // KnownRuleSets returns the set of known ruleset names from the registry.
 func KnownRuleSets() map[string]bool {
-	sets := map[string]bool{"config": true, "module_template": true, "slos": true, "testSourcePaths": true, "testSourcePathsOverride": true}
+	sets := map[string]bool{
+		"config":                  true,
+		"module_template":         true,
+		"slos":                    true,
+		"testSourcePaths":         true,
+		"testSourcePathsOverride": true,
+		config.PluginRulesKey:     true,
+	}
 	for _, r := range api.Registry {
 		sets[r.Category] = true
 	}

--- a/internal/schema/schema_test.go
+++ b/internal/schema/schema_test.go
@@ -64,6 +64,87 @@ func TestGenerateSchema_HasConfigurableRules(t *testing.T) {
 	}
 }
 
+func TestGenerateSchema_HasPluginRules(t *testing.T) {
+	schema := GenerateSchema(CollectRuleMeta())
+	pluginRules, ok := schema.Properties["pluginRules"]
+	if !ok {
+		t.Fatal("schema missing pluginRules section")
+	}
+	if pluginRules.Type != "object" {
+		t.Fatalf("pluginRules.type = %q, want object", pluginRules.Type)
+	}
+	if pluginRules.Description == "" {
+		t.Error("pluginRules missing description")
+	}
+}
+
+func TestValidateConfig_PluginRulesAcceptsActiveAndOptions(t *testing.T) {
+	cfg := config.NewConfig()
+	cfg.Data()["pluginRules"] = map[string]interface{}{
+		"acme.NoTodo": map[string]interface{}{
+			"active": false,
+			"options": map[string]interface{}{
+				"maxLineLength": 100,
+			},
+		},
+	}
+	for _, e := range ValidateConfig(cfg) {
+		if e.Level == "error" {
+			t.Errorf("unexpected error: %s", e)
+		}
+	}
+}
+
+func TestValidateConfig_PluginRulesRejectsUnknownKey(t *testing.T) {
+	cfg := config.NewConfig()
+	cfg.Data()["pluginRules"] = map[string]interface{}{
+		"acme.NoTodo": map[string]interface{}{
+			"bogus": true,
+		},
+	}
+	found := false
+	for _, e := range ValidateConfig(cfg) {
+		if e.Path == "pluginRules.acme.NoTodo.bogus" && e.Level == "error" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected error for unknown plugin-rule key 'bogus'")
+	}
+}
+
+func TestValidateConfig_PluginRulesRejectsBadActiveType(t *testing.T) {
+	cfg := config.NewConfig()
+	cfg.Data()["pluginRules"] = map[string]interface{}{
+		"acme.NoTodo": map[string]interface{}{
+			"active": "yes",
+		},
+	}
+	found := false
+	for _, e := range ValidateConfig(cfg) {
+		if e.Path == "pluginRules.acme.NoTodo.active" && e.Level == "error" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected type error for non-bool active")
+	}
+}
+
+func TestValidateConfig_PluginRulesRejectsScalarSection(t *testing.T) {
+	cfg := config.NewConfig()
+	cfg.Data()["pluginRules"] = "nope"
+	found := false
+	for _, e := range ValidateConfig(cfg) {
+		if e.Path == "pluginRules" && e.Level == "error" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected error for scalar pluginRules")
+	}
+}
+
 func TestGenerateSchema_HasModuleTemplate(t *testing.T) {
 	schema := GenerateSchema(CollectRuleMeta())
 	moduleTemplate, ok := schema.Properties["module_template"]

--- a/internal/schema/validate.go
+++ b/internal/schema/validate.go
@@ -77,6 +77,10 @@ func ValidateConfig(cfg *config.Config) []ValidationError {
 			}
 			continue
 		}
+		if key == config.PluginRulesKey {
+			errs = append(errs, validatePluginRules(val)...)
+			continue
+		}
 
 		setMap, ok := val.(map[string]interface{})
 		if !ok {
@@ -174,6 +178,69 @@ func validateSLOs(raw interface{}) []ValidationError {
 				errs = append(errs, ValidationError{
 					Path:    fieldPath,
 					Message: fmt.Sprintf("unknown config key '%s'", key),
+					Level:   "error",
+				})
+			}
+		}
+	}
+	return errs
+}
+
+// validatePluginRules checks the top-level pluginRules section.
+// Shape: pluginRules: { <ruleID>: { active: bool, options: { ... } } }.
+// Rule IDs are accepted as-is — they belong to user-supplied jars and
+// the validator has no registry to check them against.
+func validatePluginRules(raw interface{}) []ValidationError {
+	section, ok := raw.(map[string]interface{})
+	if !ok {
+		return []ValidationError{{
+			Path:    config.PluginRulesKey,
+			Message: fmt.Sprintf("expected object, got %T", raw),
+			Level:   "error",
+		}}
+	}
+	var errs []ValidationError
+	ruleIDs := make([]string, 0, len(section))
+	for id := range section {
+		ruleIDs = append(ruleIDs, id)
+	}
+	sort.Strings(ruleIDs)
+	for _, ruleID := range ruleIDs {
+		ruleVal := section[ruleID]
+		path := config.PluginRulesKey + "." + ruleID
+		ruleMap, ok := ruleVal.(map[string]interface{})
+		if !ok {
+			errs = append(errs, ValidationError{
+				Path:    path,
+				Message: fmt.Sprintf("expected object, got %T", ruleVal),
+				Level:   "error",
+			})
+			continue
+		}
+		keys := make([]string, 0, len(ruleMap))
+		for k := range ruleMap {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, key := range keys {
+			fieldPath := path + "." + key
+			switch key {
+			case "active":
+				if err := checkType(fieldPath, ruleMap[key], OptionTypeBool); err != nil {
+					errs = append(errs, *err)
+				}
+			case "options":
+				if _, ok := ruleMap[key].(map[string]interface{}); !ok {
+					errs = append(errs, ValidationError{
+						Path:    fieldPath,
+						Message: fmt.Sprintf("expected object, got %T", ruleMap[key]),
+						Level:   "error",
+					})
+				}
+			default:
+				errs = append(errs, ValidationError{
+					Path:    fieldPath,
+					Message: fmt.Sprintf("unknown config key '%s' (allowed: active, options)", key),
 					Level:   "error",
 				})
 			}

--- a/schemas/krit-config.schema.json
+++ b/schemas/krit-config.schema.json
@@ -2296,7 +2296,7 @@
           }
         },
         "LogConditional": {
-          "description": "Unconditional logging calls [precision: type-aware] [noisiness: normal] [capabilities: oracle:call-targets, resolver]",
+          "description": "Unconditional logging calls [precision: type-aware] [noisiness: normal] [capabilities: resolver]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -7153,7 +7153,7 @@
           }
         },
         "WithContextInSuspendFunctionNoop": {
-          "description": "Detects nested withContext calls using the same dispatcher as the parent, which is redundant. [precision: type-aware] [noisiness: normal] [capabilities: oracle:call-targets, resolver]",
+          "description": "Detects nested withContext calls using the same dispatcher as the parent, which is redundant. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -10795,6 +10795,10 @@
           "default": true
         }
       }
+    },
+    "pluginRules": {
+      "description": "Per-plugin-rule configuration for rules loaded from --custom-rule-jars. Keyed by rule ID (matching @KritRuleInfo.id); each entry takes {active: bool, options: {...}}.",
+      "type": "object"
     },
     "potential-bugs": {
       "description": "Configuration for the potential-bugs ruleset.",

--- a/tools/krit-rule-api/src/main/kotlin/dev/jasonpearson/krit/api/KritRule.kt
+++ b/tools/krit-rule-api/src/main/kotlin/dev/jasonpearson/krit/api/KritRule.kt
@@ -38,10 +38,55 @@ class KritFile(
 
 /**
  * Per-invocation context passed to custom rules.
+ *
+ * `config` is the per-rule options map from the consumer's `krit.yml`:
+ *
+ *   pluginRules:
+ *     acme.NoTodo:
+ *       options:
+ *         maxLineLength: 100
+ *
+ * Values come straight from the YAML parser, so use the typed accessors
+ * (`intOption`, `boolOption`, `stringOption`, `stringListOption`) rather
+ * than casting. The map is empty when the user did not configure the rule.
  */
 class RuleContext(
     val ruleId: String,
-)
+    val config: Map<String, Any?> = emptyMap(),
+) {
+    /** Returns the [key] option as a String, or [default] if absent / wrong type. */
+    fun stringOption(key: String, default: String = ""): String =
+        (config[key] as? String) ?: default
+
+    /** Returns the [key] option as a Boolean, or [default] if absent / wrong type. */
+    fun boolOption(key: String, default: Boolean = false): Boolean =
+        (config[key] as? Boolean) ?: default
+
+    /**
+     * Returns the [key] option as an Int, or [default] if absent or
+     * not parseable as a 32-bit integer. Accepts numeric YAML values
+     * (Int, Long, Double) and decimal string literals.
+     */
+    fun intOption(key: String, default: Int = 0): Int {
+        return when (val v = config[key]) {
+            is Int -> v
+            is Long -> v.toInt()
+            is Double -> v.toInt()
+            is String -> v.toIntOrNull() ?: default
+            else -> default
+        }
+    }
+
+    /**
+     * Returns the [key] option as a list of strings, dropping any
+     * non-string entries. Returns an empty list when the option is
+     * absent or not a list.
+     */
+    fun stringListOption(key: String): List<String> {
+        val raw = config[key] as? List<*> ?: return emptyList()
+        return raw.mapNotNull { it as? String }
+    }
+}
 
 /**
  * A finding emitted by a custom Kotlin rule.

--- a/tools/krit-types/src/main/kotlin/dev/jasonpearson/krit/types/Main.kt
+++ b/tools/krit-types/src/main/kotlin/dev/jasonpearson/krit/types/Main.kt
@@ -654,7 +654,12 @@ data class DaemonRequest(
     val pluginJars: List<String>? = null,
     val ruleIds: List<String>? = null,
     val path: String? = null,
-    val source: String? = null
+    val source: String? = null,
+    // ruleConfigs maps a plugin rule's @KritRuleInfo.id to its
+    // configured `options` map from krit.yml's pluginRules section.
+    // Null when the request omitted the field; an absent key inside
+    // means no options were configured for that rule.
+    val ruleConfigs: Map<String, Map<String, Any?>>? = null
 )
 
 /** 1-based line/col tuple used in resolveExpressionTypes requests. */
@@ -688,7 +693,8 @@ fun parseRequest(json: String): DaemonRequest {
     val ruleIds = extractJsonStringArray(json, "ruleIds")
     val path = extractJsonString(json, "path")
     val source = extractJsonString(json, "source")
-    return DaemonRequest(id, method, files, timings, callFilter, declarationProfile, expressionPositions, jarPath, fqn, pluginJars, ruleIds, path, source)
+    val ruleConfigs = extractJsonNestedObjectMap(json, "ruleConfigs")
+    return DaemonRequest(id, method, files, timings, callFilter, declarationProfile, expressionPositions, jarPath, fqn, pluginJars, ruleIds, path, source, ruleConfigs)
 }
 
 /**
@@ -849,6 +855,142 @@ fun extractJsonStringArrayMap(json: String, key: String): Map<String, List<Strin
         }
     }
     return null
+}
+
+/**
+ * Parses a two-level JSON object: { "<outer>": { "<inner>": <value>, ... }, ... }
+ * where inner values are arbitrary JSON (string / number / boolean / null /
+ * array / object). Used for the analyzeFile `ruleConfigs` payload:
+ *
+ *   "ruleConfigs": {
+ *       "acme.NoTodo": { "maxLineLength": 100, "ignored": ["X"] }
+ *   }
+ *
+ * Returns null when the key is absent or the shape mismatches; callers treat
+ * that as "no per-rule options."
+ */
+@Suppress("ReturnCount")
+fun extractJsonNestedObjectMap(json: String, key: String): Map<String, Map<String, Any?>>? {
+    val keyPattern = """"$key""""
+    val keyIdx = json.indexOf(keyPattern)
+    if (keyIdx < 0) return null
+    var i = json.indexOf(':', keyIdx)
+    if (i < 0) return null
+    i = skipJsonWhitespace(json, i + 1)
+    if (i >= json.length || json[i] != '{') return null
+    i++
+
+    val out = linkedMapOf<String, Map<String, Any?>>()
+    while (i < json.length) {
+        i = skipJsonWhitespace(json, i)
+        if (i < json.length && json[i] == '}') return out
+        val keyResult = parseJsonStringLiteral(json, i) ?: return null
+        val outerKey = keyResult.first
+        i = skipJsonWhitespace(json, keyResult.second)
+        if (i >= json.length || json[i] != ':') return null
+        i = skipJsonWhitespace(json, i + 1)
+        val innerResult = parseJsonObjectLiteral(json, i) ?: return null
+        out[outerKey] = innerResult.first
+        i = skipJsonWhitespace(json, innerResult.second)
+        when {
+            i < json.length && json[i] == ',' -> i++
+            i < json.length && json[i] == '}' -> return out
+            else -> return null
+        }
+    }
+    return null
+}
+
+@Suppress("ReturnCount")
+private fun parseJsonObjectLiteral(json: String, start: Int): Pair<Map<String, Any?>, Int>? {
+    var i = skipJsonWhitespace(json, start)
+    if (i >= json.length || json[i] != '{') return null
+    i++
+    val out = linkedMapOf<String, Any?>()
+    while (i < json.length) {
+        i = skipJsonWhitespace(json, i)
+        if (i < json.length && json[i] == '}') return out to i + 1
+        val keyResult = parseJsonStringLiteral(json, i) ?: return null
+        val key = keyResult.first
+        i = skipJsonWhitespace(json, keyResult.second)
+        if (i >= json.length || json[i] != ':') return null
+        i = skipJsonWhitespace(json, i + 1)
+        val valueResult = parseJsonValue(json, i) ?: return null
+        out[key] = valueResult.first
+        i = skipJsonWhitespace(json, valueResult.second)
+        when {
+            i < json.length && json[i] == ',' -> i++
+            i < json.length && json[i] == '}' -> return out to i + 1
+            else -> return null
+        }
+    }
+    return null
+}
+
+@Suppress("ReturnCount")
+private fun parseJsonValue(json: String, start: Int): Pair<Any?, Int>? {
+    val i = skipJsonWhitespace(json, start)
+    if (i >= json.length) return null
+    return when (val c = json[i]) {
+        '"' -> parseJsonStringLiteral(json, i)
+        '{' -> parseJsonObjectLiteral(json, i)
+        '[' -> parseJsonAnyArrayLiteral(json, i)
+        't' -> if (json.startsWith("true", i)) (true as Any) to i + 4 else null
+        'f' -> if (json.startsWith("false", i)) (false as Any) to i + 5 else null
+        'n' -> if (json.startsWith("null", i)) (null as Any?) to i + 4 else null
+        else -> {
+            if (c == '-' || c.isDigit()) parseJsonNumber(json, i) else null
+        }
+    }
+}
+
+@Suppress("ReturnCount")
+private fun parseJsonAnyArrayLiteral(json: String, start: Int): Pair<List<Any?>, Int>? {
+    var i = skipJsonWhitespace(json, start)
+    if (i >= json.length || json[i] != '[') return null
+    i++
+    val out = mutableListOf<Any?>()
+    while (i < json.length) {
+        i = skipJsonWhitespace(json, i)
+        if (i < json.length && json[i] == ']') return out to i + 1
+        val v = parseJsonValue(json, i) ?: return null
+        out.add(v.first)
+        i = skipJsonWhitespace(json, v.second)
+        when {
+            i < json.length && json[i] == ',' -> i++
+            i < json.length && json[i] == ']' -> return out to i + 1
+            else -> return null
+        }
+    }
+    return null
+}
+
+@Suppress("ReturnCount")
+private fun parseJsonNumber(json: String, start: Int): Pair<Any, Int>? {
+    var i = start
+    if (i < json.length && json[i] == '-') i++
+    val numStart = i
+    while (i < json.length && json[i].isDigit()) i++
+    var isFloat = false
+    if (i < json.length && json[i] == '.') {
+        isFloat = true
+        i++
+        while (i < json.length && json[i].isDigit()) i++
+    }
+    if (i < json.length && (json[i] == 'e' || json[i] == 'E')) {
+        isFloat = true
+        i++
+        if (i < json.length && (json[i] == '+' || json[i] == '-')) i++
+        while (i < json.length && json[i].isDigit()) i++
+    }
+    if (i == numStart) return null
+    val literal = json.substring(start, i)
+    val parsed: Any = if (isFloat) {
+        literal.toDoubleOrNull() ?: return null
+    } else {
+        literal.toLongOrNull() ?: literal.toDoubleOrNull() ?: return null
+    }
+    return parsed to i
 }
 
 fun skipJsonWhitespace(json: String, start: Int): Int {

--- a/tools/krit-types/src/main/kotlin/dev/jasonpearson/krit/types/PluginRules.kt
+++ b/tools/krit-types/src/main/kotlin/dev/jasonpearson/krit/types/PluginRules.kt
@@ -162,7 +162,8 @@ fun DaemonSession.handleAnalyzeFileWithPlugins(request: DaemonRequest): String {
         val errors = linkedMapOf<String, String>()
         for (loaded in PluginRuleRegistry.selected(request.ruleIds)) {
             try {
-                val ctx = RuleContext(loaded.descriptor.ruleId)
+                val options = request.ruleConfigs?.get(loaded.descriptor.ruleId).orEmpty()
+                val ctx = RuleContext(loaded.descriptor.ruleId, options)
                 for (finding in loaded.rule.check(file, ctx)) {
                     findings.add(toPluginFinding(file.path, loaded.descriptor, finding))
                 }

--- a/tools/krit-types/src/test/kotlin/dev/jasonpearson/krit/types/PluginRulesRequestTest.kt
+++ b/tools/krit-types/src/test/kotlin/dev/jasonpearson/krit/types/PluginRulesRequestTest.kt
@@ -1,0 +1,47 @@
+package dev.jasonpearson.krit.types
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class PluginRulesRequestTest {
+    @Test
+    fun parsesRuleConfigsForAnalyzeFile() {
+        val json = """{"id":7,"method":"analyzeFile","params":{"jars":["/tmp/x.jar"],"path":"X.kt","source":"","ruleIds":["acme.NoTodo"],"ruleConfigs":{"acme.NoTodo":{"maxLineLength":120,"strict":true,"label":"prod","ignored":["TODO","FIXME"]}}}}"""
+
+        val request = parseRequest(json)
+        val configs = request.ruleConfigs ?: error("ruleConfigs must not be null")
+
+        val rule = configs["acme.NoTodo"] ?: error("missing acme.NoTodo entry")
+        assertEquals(120L, rule["maxLineLength"])
+        assertEquals(true, rule["strict"])
+        assertEquals("prod", rule["label"])
+        assertEquals(listOf("TODO", "FIXME"), rule["ignored"])
+    }
+
+    @Test
+    fun parseRequestLeavesRuleConfigsNullWhenAbsent() {
+        val json = """{"id":3,"method":"analyzeFile","params":{"jars":["/tmp/x.jar"],"path":"X.kt","source":"","ruleIds":[]}}"""
+
+        val request = parseRequest(json)
+
+        assertNull(request.ruleConfigs)
+    }
+
+    @Test
+    fun extractJsonNestedObjectMapHandlesNumbersAndBooleansAndNull() {
+        val json = """{"outer":{"a":{"n":-1,"f":1.5,"b":false,"z":null},"b":{"s":"hi"}}}"""
+
+        val map = extractJsonNestedObjectMap(json, "outer") ?: error("must parse")
+        val a = map["a"] ?: error("missing a")
+        assertEquals(-1L, a["n"])
+        assertEquals(1.5, a["f"])
+        assertEquals(false, a["b"])
+        assertTrue(a.containsKey("z"))
+        assertNull(a["z"])
+
+        val b = map["b"] ?: error("missing b")
+        assertEquals("hi", b["s"])
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a top-level `pluginRules:` section to `krit.yml` so consumers can disable a noisy Kotlin plugin rule or pass per-rule options without removing the jar.
- Disabled rules are filtered before the `analyzeFile` RPC (zero findings, zero per-file work). Options flow through a new `ruleConfigs` RPC payload to `RuleContext.config` on the Kotlin SDK side, with typed `stringOption` / `intOption` / `boolOption` / `stringListOption` accessors.
- Schema and validator wire the new section in; `make schema` reflects it; docs/external-rules.md grew a "Per-rule configuration" section.

Closes #306.

```yaml
pluginRules:
  acme.NoTodo:
    active: false           # silence without removing the jar
  acme.MaxLineLength:
    options:
      maxLineLength: 100    # forwarded to RuleContext.config
      ignoredFiles:
        - 'generated/**'
```

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...`
- [x] `make lint-rules`
- [x] `go test ./... -count=1` (full suite, all packages green)
- [x] `tools/krit-types ./gradlew compileKotlin compileTestKotlin`
- [x] `tools/krit-types ./gradlew test --tests PluginRulesRequestTest`
- [x] New unit tests cover: config accessors (active/options), pluginRules filtering in `selectPluginRules`, schema generation, validator paths (good/unknown key/bad type/scalar), and the daemon-side JSON parsing of `ruleConfigs`.