### PR TITLE
feat(baseline): plumb plugin findings through Gradle kritBaseline task (#307)

### DIFF
--- a/internal/pipeline/custom_kotlin_rules_test.go
+++ b/internal/pipeline/custom_kotlin_rules_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/kaeawc/krit/internal/oracle"
 	"github.com/kaeawc/krit/internal/rules"
 	api "github.com/kaeawc/krit/internal/rules/api"
+	"github.com/kaeawc/krit/internal/scanner"
 )
 
 func TestRunKotlinPluginRulesRequiresDaemonWhenJarsConfigured(t *testing.T) {
@@ -275,6 +276,51 @@ func TestFormatPluginErrorsDeterministic(t *testing.T) {
 	want := "ARule: a failed; ZRule: z failed"
 	if got != want {
 		t.Fatalf("formatPluginErrors = %q, want %q", got, want)
+	}
+}
+
+func TestPluginFindingsRoundTripThroughBaseline(t *testing.T) {
+	// Issue #307: plugin findings must produce stable BaselineIDs that
+	// survive a --create-baseline / --baseline round-trip the same way
+	// built-in findings do. Guards against a future regression that
+	// drops plugin findings before the baseline writer without needing
+	// the JVM daemon.
+	dir := t.TempDir()
+	cols := pluginFindingsToColumns([]oracle.PluginFinding{{
+		File:    filepath.Join(dir, "Example.kt"),
+		Line:    1,
+		Column:  1,
+		RuleSet: "myteam",
+		RuleID:  "MyTeam/AvoidThing",
+		Message: "avoid thing",
+	}})
+	if cols.Len() != 1 {
+		t.Fatalf("pluginFindingsToColumns Len = %d, want 1", cols.Len())
+	}
+
+	baselinePath := filepath.Join(dir, "baseline.xml")
+	if err := scanner.WriteBaselineColumns(baselinePath, &cols, dir); err != nil {
+		t.Fatalf("WriteBaselineColumns: %v", err)
+	}
+
+	baseline, err := scanner.LoadBaseline(baselinePath)
+	if err != nil {
+		t.Fatalf("LoadBaseline: %v", err)
+	}
+	if len(baseline.CurrentIssues) != 1 {
+		t.Fatalf("baseline CurrentIssues = %d, want 1: %+v",
+			len(baseline.CurrentIssues), baseline.CurrentIssues)
+	}
+	for id := range baseline.CurrentIssues {
+		if !strings.HasPrefix(id, "MyTeam/AvoidThing:") {
+			t.Errorf("baseline ID %q does not start with plugin rule prefix", id)
+		}
+	}
+
+	filtered := scanner.FilterColumnsByBaseline(&cols, baseline, dir)
+	if filtered.Len() != 0 {
+		t.Fatalf("baseline did not suppress plugin finding: Len = %d, findings = %+v",
+			filtered.Len(), filtered.Findings())
 	}
 }
 

--- a/krit-gradle-plugin/src/main/kotlin/dev/jasonpearson/krit/gradle/KritBaselineTask.kt
+++ b/krit-gradle-plugin/src/main/kotlin/dev/jasonpearson/krit/gradle/KritBaselineTask.kt
@@ -16,6 +16,7 @@ import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
 import org.gradle.process.ExecOperations
 import javax.inject.Inject
+import dev.jasonpearson.krit.gradle.KritCheckTask.Companion.appendCustomRuleJarArgs
 
 /**
  * Gradle task that invokes the krit binary to create a baseline file.
@@ -55,6 +56,11 @@ abstract class KritBaselineTask @Inject constructor(
     @get:Input
     abstract val typeInference: Property<Boolean>
 
+    @get:InputFiles
+    @get:Optional
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    abstract val customRuleJars: ConfigurableFileCollection
+
     init {
         group = BasePlugin.BUILD_GROUP
         description = "Create a krit baseline file from current findings"
@@ -79,6 +85,7 @@ abstract class KritBaselineTask @Inject constructor(
             if (config.isPresent) { add("--config"); add(config.get().asFile.absolutePath) }
             if (noCache.get()) add("--no-cache")
             if (!typeInference.get()) add("--no-type-inference")
+            appendCustomRuleJarArgs(customRuleJars.files.map { it.absolutePath })
             add("-q")
             sourceFiles.forEach { add(it.absolutePath) }
         }

--- a/krit-gradle-plugin/src/main/kotlin/dev/jasonpearson/krit/gradle/KritPlugin.kt
+++ b/krit-gradle-plugin/src/main/kotlin/dev/jasonpearson/krit/gradle/KritPlugin.kt
@@ -131,6 +131,7 @@ class KritPlugin : Plugin<Project> {
             parallel.convention(extension.parallel)
             noCache.convention(extension.noCache)
             typeInference.convention(extension.typeInference)
+            customRuleJars.from(extension.customRuleJars)
         }
 
         // Register the aggregate kritCheck task

--- a/krit-gradle-plugin/src/test/kotlin/dev/jasonpearson/krit/gradle/KritPluginTest.kt
+++ b/krit-gradle-plugin/src/test/kotlin/dev/jasonpearson/krit/gradle/KritPluginTest.kt
@@ -127,6 +127,20 @@ class KritPluginTest {
     }
 
     @Test
+    fun `kritBaseline task receives custom rule jars from extension`() {
+        val project = newProject()
+
+        val extension = project.extensions.getByType(KritExtension::class.java)
+        val task = project.tasks.getByName("kritBaseline") as KritBaselineTask
+        val rulesJar = project.file("build-logic/krit-rules/build/libs/krit-rules.jar")
+
+        extension.customRules(rulesJar)
+
+        assertTrue(task.customRuleJars.files.contains(rulesJar),
+            "kritBaseline must inherit customRuleJars so the baseline captures plugin findings")
+    }
+
+    @Test
     fun `platform detection returns valid platform`() {
         val platform = KritBinaryResolver.detectPlatform()
         assertTrue(platform.os in listOf("darwin", "linux", "windows"))

--- a/tests/externalrule/external_rule_test.go
+++ b/tests/externalrule/external_rule_test.go
@@ -121,6 +121,60 @@ func TestExternalRuleExample_EndToEnd(t *testing.T) {
 				expectedPrintlnLine, positiveLines[0])
 		}
 	})
+
+	t.Run("baseline captures and suppresses plugin findings", func(t *testing.T) {
+		// Issue #307: plugin findings must participate in baselines —
+		// write a baseline, then re-run with --baseline and confirm the
+		// plugin finding is filtered out by the same BaselineID path
+		// built-in findings travel through.
+		baselineDir := t.TempDir()
+		baselinePath := filepath.Join(baselineDir, "baseline.xml")
+
+		runKrit(t, kritBin, repoRoot,
+			"--create-baseline", baselinePath,
+			"--custom-rule-jars", jarPath,
+			"--daemon",
+			"--no-cache",
+			"-q",
+			samplesDir,
+		)
+
+		data, err := os.ReadFile(baselinePath)
+		if err != nil {
+			t.Fatalf("read baseline %s: %v", baselinePath, err)
+		}
+		if !strings.Contains(string(data), ruleID) {
+			t.Fatalf("baseline did not capture plugin rule %q; contents:\n%s",
+				ruleID, string(data))
+		}
+
+		stdout := runKrit(t, kritBin, repoRoot,
+			"--baseline", baselinePath,
+			"--custom-rule-jars", jarPath,
+			"--daemon",
+			"-f", "json",
+			"--no-cache",
+			"-q",
+			samplesDir,
+		)
+
+		var payload struct {
+			Findings []struct {
+				File string `json:"file"`
+				Line int    `json:"line"`
+				Rule string `json:"rule"`
+			} `json:"findings"`
+		}
+		if err := json.Unmarshal([]byte(stdout), &payload); err != nil {
+			t.Fatalf("invalid JSON output: %v\n--- stdout ---\n%s", err, stdout)
+		}
+		for _, finding := range payload.Findings {
+			if finding.Rule == ruleID {
+				t.Fatalf("plugin finding %s:%d not suppressed by baseline; payload=%+v",
+					finding.File, finding.Line, payload.Findings)
+			}
+		}
+	})
 }
 
 // locateLocalKritRuleApi returns the version under


### PR DESCRIPTION
## Summary

- Plugin findings already participate in baselines at the Go layer (`crossFileResult.Findings` → `allColumns` → `WriteBaselineColumns` / `FilterColumnsByBaseline`), so `BaselineID` and the filter path treat them identically to built-in findings.
- Gap closed in the Gradle layer: `KritBaselineTask` did not forward `--custom-rule-jars`, so `./gradlew kritBaseline` silently dropped plugin findings. Wired `customRuleJars` into the task and the plugin defaults.

## Tests

- **Go pipeline unit** (`TestPluginFindingsRoundTripThroughBaseline`): `pluginFindingsToColumns` → `WriteBaselineColumns` → `LoadBaseline` → `FilterColumnsByBaseline` round-trip; asserts the baseline ID names the plugin rule and the filter suppresses it on a re-run. Runs without the JVM daemon.
- **Gradle plugin unit** (`kritBaseline task receives custom rule jars from extension`): mirrors the existing kritCheck test.
- **External-rule end-to-end** (subtest in `tests/externalrule/external_rule_test.go`): `--create-baseline` writes a baseline that contains the plugin rule ID; a second run with `--baseline` produces no plugin findings. Gated on the same JVM/jar prerequisites as the surrounding test.

Closes #307.

## Test plan

- [x] `go build -o krit ./cmd/krit/`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...`
- [x] `go test ./... -count=1`
- [x] `make integration`
- [x] `make lint-rules`
- [x] `../tools/krit-types/gradlew -p krit-gradle-plugin clean test`