### PR TITLE
chore: gitignore .claude/scheduled_tasks.lock

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"773f6be7-fffd-4b1e-997f-d24ff8bf012d","pid":36465,"procStart":"Fri May 15 02:34:41 2026","acquiredAt":1778820250523}

--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,9 @@ android-lint-checks/
 # Claude sub-agent worktrees (isolated per-task copies)
 .claude/worktrees/
 
+# Claude scheduled-tasks runtime lock (per-machine state, not source)
+.claude/scheduled_tasks.lock
+
 # Claire agent scratch directory (worktrees, per-task state)
 .claire/
 


### PR DESCRIPTION
## Summary
- Adds `.claude/scheduled_tasks.lock` to `.gitignore` and untracks the previously-committed file. It's per-machine runtime state for the scheduled-tasks MCP, not source.

## Test plan
- [x] `git status` clean after ignore