### PR TITLE
refactor(scanner): plumb context.Context through parse/scan/git paths

### DIFF
--- a/internal/arch/abihash_test.go
+++ b/internal/arch/abihash_test.go
@@ -1,6 +1,7 @@
 package arch
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -15,7 +16,7 @@ func parseSource(t *testing.T, src string) *scanner.File {
 	if err := os.WriteFile(path, []byte(src), 0o644); err != nil {
 		t.Fatalf("write: %v", err)
 	}
-	f, err := scanner.ParseFile(path)
+	f, err := scanner.ParseFile(context.Background(), path)
 	if err != nil {
 		t.Fatalf("parse: %v", err)
 	}

--- a/internal/cli/abihash/abihash.go
+++ b/internal/cli/abihash/abihash.go
@@ -1,6 +1,7 @@
 package abihash
 
 import (
+	"context"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -130,13 +131,13 @@ func resolveAbiHashTarget(target string) ([]*scanner.File, error) {
 		if err != nil {
 			return nil, fmt.Errorf("collecting %s: %w", target, err)
 		}
-		files, _ := scanner.ScanFiles(paths, runtime.NumCPU())
+		files, _ := scanner.ScanFiles(context.Background(), paths, runtime.NumCPU())
 		return files, nil
 	}
 	if !strings.HasSuffix(target, ".kt") {
 		return nil, fmt.Errorf("expected a .kt file or directory, got %s", target)
 	}
-	f, err := scanner.ParseFile(target)
+	f, err := scanner.ParseFile(context.Background(), target)
 	if err != nil {
 		return nil, fmt.Errorf("parsing %s: %w", target, err)
 	}

--- a/internal/cli/blastradius/blastradius.go
+++ b/internal/cli/blastradius/blastradius.go
@@ -92,7 +92,7 @@ func Analyze(root, base string) (Report, error) {
 	if err != nil {
 		return Report{}, err
 	}
-	files, errs := scanner.ScanFiles(paths, runtime.NumCPU())
+	files, errs := scanner.ScanFiles(context.Background(), paths, runtime.NumCPU())
 	if len(errs) > 0 {
 		return Report{}, errs[0]
 	}

--- a/internal/cli/clishared/helpers.go
+++ b/internal/cli/clishared/helpers.go
@@ -3,6 +3,7 @@
 package clishared
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -147,7 +148,7 @@ func ScanModuleKotlinFiles(mod *module.Module) []*scanner.File {
 	}
 	files := make([]*scanner.File, 0, len(ktFiles))
 	for _, path := range ktFiles {
-		f, err := scanner.ParseFile(path)
+		f, err := scanner.ParseFile(context.Background(), path)
 		if err != nil {
 			continue
 		}

--- a/internal/cli/digraph/digraph.go
+++ b/internal/cli/digraph/digraph.go
@@ -1,6 +1,7 @@
 package digraph
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"os"
@@ -43,7 +44,7 @@ func Run(args []string) int {
 		fmt.Fprintf(os.Stderr, "error: collect files: %v\n", err)
 		return 1
 	}
-	parsed, errs := scanner.ScanFiles(files, runtime.NumCPU())
+	parsed, errs := scanner.ScanFiles(context.Background(), files, runtime.NumCPU())
 	if len(errs) > 0 {
 		fmt.Fprintf(os.Stderr, "error: parse: %v\n", errs[0])
 		return 1

--- a/internal/cli/editorconfigdrift/editorconfigdrift.go
+++ b/internal/cli/editorconfigdrift/editorconfigdrift.go
@@ -1,6 +1,7 @@
 package editorconfigdrift
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"sort"
@@ -26,7 +27,7 @@ func Run(args []string) int {
 
 	summary := newSummary()
 	for _, path := range files {
-		file, err := scanner.ParseFile(path)
+		file, err := scanner.ParseFile(context.Background(), path)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "editorconfig-drift: parsing %s: %v\n", path, err)
 			continue

--- a/internal/cli/gen/gen.go
+++ b/internal/cli/gen/gen.go
@@ -1,6 +1,7 @@
 package gen
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"io"
@@ -103,7 +104,7 @@ func BuildModuleReadmeSummary(root, modulePath string) (ModuleReadmeSummary, err
 	if err != nil {
 		return ModuleReadmeSummary{}, fmt.Errorf("collecting Kotlin files: %w", err)
 	}
-	parsed, parseErrs := scanner.ScanFiles(kotlinPaths, runtime.NumCPU())
+	parsed, parseErrs := scanner.ScanFiles(context.Background(), kotlinPaths, runtime.NumCPU())
 	if len(parseErrs) > 0 {
 		return ModuleReadmeSummary{}, fmt.Errorf("parsing Kotlin files: %w", parseErrs[0])
 	}

--- a/internal/cli/gen/walkthrough.go
+++ b/internal/cli/gen/walkthrough.go
@@ -1,6 +1,7 @@
 package gen
 
 import (
+	"context"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -77,11 +78,11 @@ func BuildWalkthrough(root string, limit int) (Walkthrough, error) {
 	if err != nil {
 		return Walkthrough{}, fmt.Errorf("collecting Java files: %w", err)
 	}
-	kotlinFiles, parseErrs := scanner.ScanFiles(kotlinPaths, runtime.NumCPU())
+	kotlinFiles, parseErrs := scanner.ScanFiles(context.Background(), kotlinPaths, runtime.NumCPU())
 	if len(parseErrs) > 0 {
 		return Walkthrough{}, fmt.Errorf("parsing Kotlin files: %w", parseErrs[0])
 	}
-	javaFiles, javaErrs := scanner.ScanJavaFiles(javaPaths, runtime.NumCPU())
+	javaFiles, javaErrs := scanner.ScanJavaFiles(context.Background(), javaPaths, runtime.NumCPU())
 	if len(javaErrs) > 0 {
 		return Walkthrough{}, fmt.Errorf("parsing Java files: %w", javaErrs[0])
 	}

--- a/internal/cli/graphexport/graph.go
+++ b/internal/cli/graphexport/graph.go
@@ -1,6 +1,7 @@
 package graphexport
 
 import (
+	"context"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -134,7 +135,7 @@ func renderPackageGraph(root, format string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("collecting Kotlin files: %w", err)
 	}
-	files, parseErrs := scanner.ScanFiles(paths, runtime.NumCPU())
+	files, parseErrs := scanner.ScanFiles(context.Background(), paths, runtime.NumCPU())
 	if len(parseErrs) > 0 {
 		return "", fmt.Errorf("parsing Kotlin files: %w", parseErrs[0])
 	}

--- a/internal/cli/impact/impact.go
+++ b/internal/cli/impact/impact.go
@@ -245,7 +245,7 @@ func relPath(root, p string) string {
 
 // changedFQNsFromFile returns the FQNs declared in a single Kotlin file.
 func changedFQNsFromFile(path string) ([]string, error) {
-	f, err := scanner.ParseFile(path)
+	f, err := scanner.ParseFile(context.Background(), path)
 	if err != nil {
 		return nil, fmt.Errorf("parsing %s: %w", path, err)
 	}
@@ -315,6 +315,6 @@ func scanProjectKotlinFiles(root string) ([]*scanner.File, error) {
 	if err != nil {
 		return nil, fmt.Errorf("collecting Kotlin files: %w", err)
 	}
-	files, _ := scanner.ScanFiles(paths, runtime.NumCPU())
+	files, _ := scanner.ScanFiles(context.Background(), paths, runtime.NumCPU())
 	return files, nil
 }

--- a/internal/cli/impact/impact_test.go
+++ b/internal/cli/impact/impact_test.go
@@ -1,6 +1,7 @@
 package impact
 
 import (
+	"context"
 	"errors"
 	"os"
 	"path/filepath"
@@ -57,7 +58,7 @@ class Unrelated { fun nothing() = 0 }
 	if err != nil {
 		t.Fatalf("collect: %v", err)
 	}
-	files, _ := scanner.ScanFiles(paths, runtime.NumCPU())
+	files, _ := scanner.ScanFiles(context.Background(), paths, runtime.NumCPU())
 	idx := scanner.BuildIndex(files, runtime.NumCPU())
 
 	hits := computeImpact(idx, []string{"com.acme.core.UserRepository.load"})

--- a/internal/cli/rename/rename.go
+++ b/internal/cli/rename/rename.go
@@ -1,6 +1,7 @@
 package rename
 
 import (
+	"context"
 	"errors"
 	"flag"
 	"fmt"
@@ -124,7 +125,7 @@ func buildRenamePlan(paths []string, workers int, target krename.Target) (krenam
 	if err != nil {
 		return krename.Plan{}, err
 	}
-	parsedFiles, scanErrs := scanner.ScanFiles(kotlinPaths, workers)
+	parsedFiles, scanErrs := scanner.ScanFiles(context.Background(), kotlinPaths, workers)
 	if err := joinErrors(scanErrs); err != nil {
 		return krename.Plan{}, err
 	}
@@ -133,7 +134,7 @@ func buildRenamePlan(paths []string, workers int, target krename.Target) (krenam
 	if err != nil {
 		return krename.Plan{}, err
 	}
-	parsedJavaFiles, javaErrs := scanner.ScanJavaFiles(javaPaths, workers)
+	parsedJavaFiles, javaErrs := scanner.ScanJavaFiles(context.Background(), javaPaths, workers)
 	if err := joinErrors(javaErrs); err != nil {
 		return krename.Plan{}, err
 	}

--- a/internal/cli/riskmap/riskmap.go
+++ b/internal/cli/riskmap/riskmap.go
@@ -78,7 +78,7 @@ func Analyze(root, since string) (Report, error) {
 	if err != nil {
 		return Report{}, err
 	}
-	files, errs := scanner.ScanFiles(paths, 1)
+	files, errs := scanner.ScanFiles(context.Background(), paths, 1)
 	if len(errs) > 0 {
 		return Report{}, errs[0]
 	}

--- a/internal/cli/scorecard/scorecard.go
+++ b/internal/cli/scorecard/scorecard.go
@@ -1,6 +1,7 @@
 package scorecard
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"io"
@@ -72,7 +73,7 @@ func Build(paths []string, configPath string) ([]Row, error) {
 	if err != nil {
 		return nil, fmt.Errorf("collecting Kotlin files: %w", err)
 	}
-	files, parseErrs := scanner.ScanFiles(kotlinPaths, runtime.NumCPU())
+	files, parseErrs := scanner.ScanFiles(context.Background(), kotlinPaths, runtime.NumCPU())
 	if len(parseErrs) > 0 {
 		return nil, fmt.Errorf("parsing Kotlin files: %w", parseErrs[0])
 	}

--- a/internal/cli/selecttests/selecttests.go
+++ b/internal/cli/selecttests/selecttests.go
@@ -137,7 +137,7 @@ func scanKotlinFiles(root string) ([]*scanner.File, error) {
 		if !strings.HasSuffix(path, ".kt") {
 			return nil
 		}
-		file, err := scanner.ParseFile(path)
+		file, err := scanner.ParseFile(context.Background(), path)
 		if err == nil {
 			out = append(out, file)
 		}

--- a/internal/cli/selecttests/selecttests_test.go
+++ b/internal/cli/selecttests/selecttests_test.go
@@ -1,6 +1,7 @@
 package selecttests
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -71,7 +72,7 @@ func parseFixture(t *testing.T, root string, files map[string]string) []*scanner
 		if err := os.WriteFile(path, []byte(content), 0644); err != nil {
 			t.Fatal(err)
 		}
-		file, err := scanner.ParseFile(path)
+		file, err := scanner.ParseFile(context.Background(), path)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/cli/serve/serve.go
+++ b/internal/cli/serve/serve.go
@@ -865,13 +865,13 @@ func resolveAbiHashTargetForDaemon(state *daemonState, target string) ([]*scanne
 		if err != nil {
 			return nil, fmt.Errorf("collecting %s: %w", target, err)
 		}
-		files, _ := scanner.ScanFiles(paths, runtime.NumCPU())
+		files, _ := scanner.ScanFiles(context.Background(), paths, runtime.NumCPU())
 		return files, nil
 	}
 	if !strings.HasSuffix(path, ".kt") {
 		return nil, fmt.Errorf("expected a .kt file or directory, got %s", target)
 	}
-	f, err := scanner.ParseFile(path)
+	f, err := scanner.ParseFile(context.Background(), path)
 	if err != nil {
 		return nil, fmt.Errorf("parsing %s: %w", target, err)
 	}

--- a/internal/cli/suggestreviewers/suggestreviewers.go
+++ b/internal/cli/suggestreviewers/suggestreviewers.go
@@ -284,7 +284,7 @@ func changedFqnsFromFiles(root string, changedRel []string) []string {
 		if err != nil || info.IsDir() {
 			continue
 		}
-		f, err := scanner.ParseFile(full)
+		f, err := scanner.ParseFile(context.Background(), full)
 		if err != nil {
 			continue
 		}
@@ -304,7 +304,7 @@ func buildIndex(root string) *scanner.CodeIndex {
 	if err != nil {
 		return nil
 	}
-	files, _ := scanner.ScanFiles(paths, runtime.NumCPU())
+	files, _ := scanner.ScanFiles(context.Background(), paths, runtime.NumCPU())
 	return scanner.BuildIndex(files, runtime.NumCPU())
 }
 

--- a/internal/cli/testcoverage/testcoverage.go
+++ b/internal/cli/testcoverage/testcoverage.go
@@ -1,6 +1,7 @@
 package testcoverage
 
 import (
+	"context"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -197,7 +198,7 @@ func scanKotlinFiles(root string) ([]*scanner.File, error) {
 		if !strings.HasSuffix(path, ".kt") {
 			return nil
 		}
-		file, err := scanner.ParseFile(path)
+		file, err := scanner.ParseFile(context.Background(), path)
 		if err == nil {
 			out = append(out, file)
 		}

--- a/internal/cli/testcoverage/testcoverage_test.go
+++ b/internal/cli/testcoverage/testcoverage_test.go
@@ -1,6 +1,7 @@
 package testcoverage
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -92,7 +93,7 @@ func parseFixture(t *testing.T, root string, files map[string]string) []*scanner
 		if err := os.WriteFile(path, []byte(content), 0644); err != nil {
 			t.Fatal(err)
 		}
-		file, err := scanner.ParseFile(path)
+		file, err := scanner.ParseFile(context.Background(), path)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/cli/usedsymbols/usedsymbols.go
+++ b/internal/cli/usedsymbols/usedsymbols.go
@@ -1,6 +1,7 @@
 package usedsymbols
 
 import (
+	"context"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -99,7 +100,7 @@ func runUsedSymbolsFile(path string, asJSON bool) int {
 		fmt.Fprintf(os.Stderr, "expected a .kt file or :module path, got %s\n", path)
 		return 1
 	}
-	f, err := scanner.ParseFile(path)
+	f, err := scanner.ParseFile(context.Background(), path)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "parsing %s: %v\n", path, err)
 		return 1

--- a/internal/deadcode/project.go
+++ b/internal/deadcode/project.go
@@ -1,6 +1,7 @@
 package deadcode
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -98,12 +99,12 @@ func buildProjectIndex(scanRoot string, paths []string, workers int) (*module.Gr
 	if err != nil {
 		return nil, nil, nil, err
 	}
-	files, _ := scanner.ScanFiles(ktPaths, workers)
+	files, _ := scanner.ScanFiles(context.Background(), ktPaths, workers)
 	javaPaths, err := scanner.CollectJavaFiles(paths, nil)
 	if err != nil {
 		return nil, nil, nil, err
 	}
-	javaFiles, _ := scanner.ScanJavaFiles(javaPaths, workers)
+	javaFiles, _ := scanner.ScanJavaFiles(context.Background(), javaPaths, workers)
 	idx := scanner.BuildIndex(files, workers, javaFiles...)
 
 	allFiles := make([]*scanner.File, 0, len(files)+len(javaFiles))

--- a/internal/di/export_test.go
+++ b/internal/di/export_test.go
@@ -2,6 +2,7 @@ package di
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -62,7 +63,7 @@ func parseDIFile(t *testing.T, content string) *scanner.File {
 	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
 		t.Fatal(err)
 	}
-	file, err := scanner.ParseFile(path)
+	file, err := scanner.ParseFile(context.Background(), path)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/di/graph_test.go
+++ b/internal/di/graph_test.go
@@ -1,6 +1,7 @@
 package di
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -47,7 +48,7 @@ class Api @Inject constructor()`)
 	if err != nil {
 		t.Fatalf("CollectKotlinFiles: %v", err)
 	}
-	files, errs := scanner.ScanFiles(paths, 2)
+	files, errs := scanner.ScanFiles(context.Background(), paths, 2)
 	if len(errs) > 0 {
 		t.Fatalf("ScanFiles returned errors: %v", errs)
 	}

--- a/internal/filefacts/filefacts_test.go
+++ b/internal/filefacts/filefacts_test.go
@@ -1,6 +1,7 @@
 package filefacts
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -30,7 +31,7 @@ func parseSample(t *testing.T) *scanner.File {
 	if err := os.WriteFile(path, []byte(sampleKotlin), 0o644); err != nil {
 		t.Fatalf("write: %v", err)
 	}
-	file, err := scanner.ParseFile(path)
+	file, err := scanner.ParseFile(context.Background(), path)
 	if err != nil {
 		t.Fatalf("ParseFile: %v", err)
 	}

--- a/internal/harvest/harvest.go
+++ b/internal/harvest/harvest.go
@@ -1,6 +1,7 @@
 package harvest
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -62,7 +63,7 @@ func ExtractFixture(target Target, ruleName string) (Result, error) {
 		return Result{}, fmt.Errorf("rule %s requires module-aware analysis and cannot be harvested from a single source file yet", ruleName)
 	}
 
-	file, err := scanner.ParseFile(target.Path)
+	file, err := scanner.ParseFile(context.Background(), target.Path)
 	if err != nil {
 		return Result{}, err
 	}

--- a/internal/javafacts/source_test.go
+++ b/internal/javafacts/source_test.go
@@ -1,6 +1,7 @@
 package javafacts
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -228,7 +229,7 @@ func parseJavaSource(t *testing.T, name, src string) *scanner.File {
 	if err := os.WriteFile(path, []byte(src), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	file, err := scanner.ParseJavaFile(path)
+	file, err := scanner.ParseJavaFile(context.Background(), path)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/lsp/go_to_test_action.go
+++ b/internal/lsp/go_to_test_action.go
@@ -1,6 +1,7 @@
 package lsp
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"path/filepath"
@@ -61,7 +62,7 @@ func buildWorkspaceCodeIndex(root string) (*scanner.CodeIndex, error) {
 	}
 	files := make([]*scanner.File, 0, len(paths))
 	for _, path := range paths {
-		file, err := scanner.ParseFile(path)
+		file, err := scanner.ParseFile(context.Background(), path)
 		if err != nil {
 			continue
 		}

--- a/internal/lsp/indexer.go
+++ b/internal/lsp/indexer.go
@@ -20,7 +20,7 @@ func (SourceWorkspaceIndexer) BuildWorkspaceIndex(ctx context.Context, root stri
 	if root == "" {
 		return oracle.BuildIndex(nil), nil
 	}
-	kotlin, java, err := scanner.CollectKotlinAndJavaFiles([]string{root}, nil)
+	kotlin, java, err := scanner.CollectKotlinAndJavaFiles(ctx, []string{root}, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -28,7 +28,7 @@ func (SourceWorkspaceIndexer) BuildWorkspaceIndex(ctx context.Context, root stri
 	if progress != nil {
 		progress(0, total)
 	}
-	kotlinFiles, errs := scanner.ScanFiles(kotlin, runtime.NumCPU())
+	kotlinFiles, errs := scanner.ScanFiles(ctx, kotlin, runtime.NumCPU())
 	if len(errs) > 0 {
 		return nil, errs[0]
 	}
@@ -38,7 +38,7 @@ func (SourceWorkspaceIndexer) BuildWorkspaceIndex(ctx context.Context, root stri
 	if progress != nil {
 		progress(len(kotlinFiles), total)
 	}
-	javaFiles, errs := scanner.ScanJavaFiles(java, runtime.NumCPU())
+	javaFiles, errs := scanner.ScanJavaFiles(ctx, java, runtime.NumCPU())
 	if len(errs) > 0 {
 		return nil, errs[0]
 	}

--- a/internal/mcp/tool_analyze.go
+++ b/internal/mcp/tool_analyze.go
@@ -1,6 +1,7 @@
 package mcp
 
 import (
+	"context"
 	"encoding/json"
 	"os"
 	"sort"
@@ -113,7 +114,7 @@ func (s *Server) analyzeProject(args analyzeArgs) ToolResult {
 		return errorResult("no Kotlin files found in the specified paths")
 	}
 
-	files, _ := scanner.ScanFiles(ktFiles, 4)
+	files, _ := scanner.ScanFiles(context.Background(), ktFiles, 4)
 
 	type fileResult struct {
 		File     string `json:"file"`
@@ -355,7 +356,7 @@ func (s *Server) analyzeImpact(args analyzeArgs) ToolResult {
 		if len(ktFiles) == 0 {
 			return errorResult("no Kotlin files found in the specified paths")
 		}
-		files, _ := scanner.ScanFiles(ktFiles, 4)
+		files, _ := scanner.ScanFiles(context.Background(), ktFiles, 4)
 		collector := scanner.NewFindingCollector(len(files) * 8)
 		for _, f := range files {
 			cols, _ := s.analyzer.Dispatcher.RunColumnsWithStats(f)

--- a/internal/mcp/tool_structure.go
+++ b/internal/mcp/tool_structure.go
@@ -1,6 +1,7 @@
 package mcp
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"os"
@@ -212,7 +213,7 @@ func (s *Server) structureBreadth(args structureArgs) ToolResult {
 		return errorResult("no Kotlin files found in the specified paths")
 	}
 
-	files, _ := scanner.ScanFiles(ktFiles, 4)
+	files, _ := scanner.ScanFiles(context.Background(), ktFiles, 4)
 
 	threshold := args.Threshold
 	if threshold <= 0 {
@@ -262,7 +263,7 @@ func (s *Server) structurePkgDrift(args structureArgs) ToolResult {
 		return errorResult("no Kotlin files found in the specified paths")
 	}
 
-	files, _ := scanner.ScanFiles(ktFiles, 4)
+	files, _ := scanner.ScanFiles(context.Background(), ktFiles, 4)
 
 	type driftJSON struct {
 		File            string `json:"file"`
@@ -322,9 +323,9 @@ func buildIndexForPaths(paths []string) (*scanner.CodeIndex, error) {
 	if len(ktFiles) == 0 {
 		return nil, errors.New("no Kotlin files found in the specified paths")
 	}
-	files, _ := scanner.ScanFiles(ktFiles, 4)
+	files, _ := scanner.ScanFiles(context.Background(), ktFiles, 4)
 	javaPaths, _ := scanner.CollectJavaFiles(paths, nil)
-	javaFiles, _ := scanner.ScanFiles(javaPaths, 4)
+	javaFiles, _ := scanner.ScanFiles(context.Background(), javaPaths, 4)
 	return scanner.BuildIndex(files, 4, javaFiles...), nil
 }
 

--- a/internal/migration/analyze.go
+++ b/internal/migration/analyze.go
@@ -1,6 +1,7 @@
 package migration
 
 import (
+	"context"
 	"path/filepath"
 	"runtime"
 	"sort"
@@ -43,15 +44,15 @@ func Analyze(opts Options) (Report, error) {
 	if root == "" {
 		root = "."
 	}
-	kotlinPaths, javaPaths, err := scanner.CollectKotlinAndJavaFiles([]string{root}, nil)
+	kotlinPaths, javaPaths, err := scanner.CollectKotlinAndJavaFiles(context.Background(), []string{root}, nil)
 	if err != nil {
 		return Report{}, err
 	}
-	kotlinFiles, errs := scanner.ScanFiles(kotlinPaths, runtime.NumCPU())
+	kotlinFiles, errs := scanner.ScanFiles(context.Background(), kotlinPaths, runtime.NumCPU())
 	if len(errs) > 0 {
 		return Report{}, errs[0]
 	}
-	javaFiles, errs := scanner.ScanJavaFiles(javaPaths, runtime.NumCPU())
+	javaFiles, errs := scanner.ScanJavaFiles(context.Background(), javaPaths, runtime.NumCPU())
 	if len(errs) > 0 {
 		return Report{}, errs[0]
 	}

--- a/internal/module/permodule_test.go
+++ b/internal/module/permodule_test.go
@@ -1,6 +1,7 @@
 package module
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -61,13 +62,13 @@ func TestBuildPerModuleIndex_AssignsFilesToModules(t *testing.T) {
 	allPaths := []string{appFile, libFile, rootFile}
 	var allFiles []*scanner.File
 	for _, p := range allPaths {
-		f, err := scanner.ParseFile(p)
+		f, err := scanner.ParseFile(context.Background(), p)
 		if err != nil {
 			t.Fatalf("ParseFile(%s): %v", p, err)
 		}
 		allFiles = append(allFiles, f)
 	}
-	javaParsed, err := scanner.ParseJavaFile(libJavaFile)
+	javaParsed, err := scanner.ParseJavaFile(context.Background(), libJavaFile)
 	if err != nil {
 		t.Fatalf("ParseJavaFile(%s): %v", libJavaFile, err)
 	}

--- a/internal/oracle/oracle_test.go
+++ b/internal/oracle/oracle_test.go
@@ -1,6 +1,7 @@
 package oracle
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -440,7 +441,7 @@ func TestFlatRangeLookups(t *testing.T) {
 	if err := os.WriteFile(path, []byte("fun main() { foo() }\n"), 0644); err != nil {
 		t.Fatal(err)
 	}
-	file, err := scanner.ParseKotlinFileCached(path, nil)
+	file, err := scanner.ParseKotlinFileCached(context.Background(), path, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/pipeline/android_resource_source_cache_test.go
+++ b/internal/pipeline/android_resource_source_cache_test.go
@@ -56,7 +56,7 @@ func parseKotlinForTest(t *testing.T, path, content string) *scanner.File {
 	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
 		t.Fatalf("write kt: %v", err)
 	}
-	f, err := scanner.ParseFile(path)
+	f, err := scanner.ParseFile(context.Background(), path)
 	if err != nil {
 		t.Fatalf("ParseFile %s: %v", path, err)
 	}

--- a/internal/pipeline/code_index_cache_test.go
+++ b/internal/pipeline/code_index_cache_test.go
@@ -39,7 +39,7 @@ func TestCrossFilePhase_CodeIndexCache_BuildsOnceAcrossRuns(t *testing.T) {
 	if err := os.WriteFile(src, []byte("package test\n\nclass Sample\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	parsed, err := scanner.ParseFile(src)
+	parsed, err := scanner.ParseFile(context.Background(), src)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -93,8 +93,8 @@ func TestCodeIndexFingerprint_StableAndDistinct(t *testing.T) {
 	if err := os.WriteFile(b, []byte("package x\nclass B\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	pa, _ := scanner.ParseFile(a)
-	pb, _ := scanner.ParseFile(b)
+	pa, _ := scanner.ParseFile(context.Background(), a)
+	pb, _ := scanner.ParseFile(context.Background(), b)
 
 	fp1 := codeIndexFingerprint([]*scanner.File{pa, pb}, nil)
 	fp2 := codeIndexFingerprint([]*scanner.File{pb, pa}, nil)

--- a/internal/pipeline/crossfile_concurrent_test.go
+++ b/internal/pipeline/crossfile_concurrent_test.go
@@ -89,7 +89,7 @@ func writeParsedJavaFile(t *testing.T, code string, name string) *scanner.File {
 	if err := os.WriteFile(path, []byte(code), 0644); err != nil {
 		t.Fatalf("write: %v", err)
 	}
-	file, err := scanner.ParseJavaFile(path)
+	file, err := scanner.ParseJavaFile(context.Background(), path)
 	if err != nil {
 		t.Fatalf("parse: %v", err)
 	}

--- a/internal/pipeline/crossfile_test.go
+++ b/internal/pipeline/crossfile_test.go
@@ -28,7 +28,7 @@ func parsedKotlinFile(t *testing.T, content string) *scanner.File {
 	if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	f, err := scanner.ParseFile(p)
+	f, err := scanner.ParseFile(context.Background(), p)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -44,7 +44,7 @@ func parsedJavaFile(t *testing.T, content string) *scanner.File {
 	if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	f, err := scanner.ParseJavaFile(p)
+	f, err := scanner.ParseJavaFile(context.Background(), p)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -221,7 +221,7 @@ func TestCrossFilePhase_SuppressionPassesThrough_WhenNoIndex(t *testing.T) {
 	if err := os.WriteFile(p, []byte("class A\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	f, err := scanner.ParseFile(p)
+	f, err := scanner.ParseFile(context.Background(), p)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -302,7 +302,7 @@ func TestCrossFilePhase_ExcludeGlobSuppressesCrossFileFinding(t *testing.T) {
 	if err := os.WriteFile(p, []byte("class T\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	f, err := scanner.ParseFile(p)
+	f, err := scanner.ParseFile(context.Background(), p)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/pipeline/delta_planner_test.go
+++ b/internal/pipeline/delta_planner_test.go
@@ -26,7 +26,7 @@ func TestFileStructuralFingerprint_BodyEditStable(t *testing.T) {
 	if err := os.WriteFile(path, v1, 0o644); err != nil {
 		t.Fatal(err)
 	}
-	f1, err := scanner.ParseFile(path)
+	f1, err := scanner.ParseFile(context.Background(), path)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -34,7 +34,7 @@ func TestFileStructuralFingerprint_BodyEditStable(t *testing.T) {
 	if err := os.WriteFile(path, v2, 0o644); err != nil {
 		t.Fatal(err)
 	}
-	f2, err := scanner.ParseFile(path)
+	f2, err := scanner.ParseFile(context.Background(), path)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -61,12 +61,12 @@ func TestFileStructuralFingerprint_DeclarationChangeMoves(t *testing.T) {
 	if err := os.WriteFile(path, v1, 0o644); err != nil {
 		t.Fatal(err)
 	}
-	f1, _ := scanner.ParseFile(path)
+	f1, _ := scanner.ParseFile(context.Background(), path)
 
 	if err := os.WriteFile(path, v2, 0o644); err != nil {
 		t.Fatal(err)
 	}
-	f2, _ := scanner.ParseFile(path)
+	f2, _ := scanner.ParseFile(context.Background(), path)
 
 	fp1 := scanner.FileStructuralFingerprint(f1)
 	fp2 := scanner.FileStructuralFingerprint(f2)

--- a/internal/pipeline/dispatch_test.go
+++ b/internal/pipeline/dispatch_test.go
@@ -22,7 +22,7 @@ func writeKotlin(t *testing.T, dir, name, code string) *scanner.File {
 	if err := os.WriteFile(path, []byte(code), 0644); err != nil {
 		t.Fatalf("WriteFile(%s): %v", path, err)
 	}
-	file, err := scanner.ParseFile(path)
+	file, err := scanner.ParseFile(context.Background(), path)
 	if err != nil {
 		t.Fatalf("ParseFile(%s): %v", path, err)
 	}
@@ -35,7 +35,7 @@ func writeJava(t *testing.T, dir, name, code string) *scanner.File {
 	if err := os.WriteFile(path, []byte(code), 0644); err != nil {
 		t.Fatalf("WriteFile(%s): %v", path, err)
 	}
-	file, err := scanner.ParseJavaFile(path)
+	file, err := scanner.ParseJavaFile(context.Background(), path)
 	if err != nil {
 		t.Fatalf("ParseJavaFile(%s): %v", path, err)
 	}

--- a/internal/pipeline/exprresolve_test.go
+++ b/internal/pipeline/exprresolve_test.go
@@ -1,6 +1,7 @@
 package pipeline
 
 import (
+	"context"
 	"errors"
 	"os"
 	"path/filepath"
@@ -179,7 +180,7 @@ func parseTestFile(t *testing.T, source string) *scanner.File {
 	if err := os.WriteFile(path, []byte(source), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	f, err := scanner.ParseFile(path)
+	f, err := scanner.ParseFile(context.Background(), path)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/pipeline/index.go
+++ b/internal/pipeline/index.go
@@ -681,7 +681,7 @@ func (p IndexPhase) Run(ctx context.Context, in IndexInput) (IndexResult, error)
 	})
 
 	if in.BuildCodeIndex {
-		p.runCodeIndexBuild(in, &result)
+		p.runCodeIndexBuild(ctx, in, &result)
 	}
 
 	if in.BuildModuleIndex {
@@ -1096,7 +1096,7 @@ func loadFilesForOracleFilter(paths []string) []*scanner.File {
 // index. Tracker labels ("javaIndexing", "codeIndexBuild", inner
 // "indexBuild") stay under the caller-supplied "crossFileAnalysis"
 // parent so rule execution siblings can continue to nest under it.
-func (p IndexPhase) runCodeIndexBuild(in IndexInput, result *IndexResult) {
+func (p IndexPhase) runCodeIndexBuild(ctx context.Context, in IndexInput, result *IndexResult) {
 	if in.CrossFileParentTracker == nil {
 		return
 	}
@@ -1129,7 +1129,7 @@ func (p IndexPhase) runCodeIndexBuild(in IndexInput, result *IndexResult) {
 		if len(javaFilePaths) > 0 {
 			crossWorkers = phaseWorkerCount("crossFileAnalysis", in.CrossFileJobsFlag, len(parsedFiles)+len(javaFilePaths))
 			var javaErrs []error
-			parsedJavaFiles, javaErrs = scanner.ScanJavaFilesCachedForIndex(javaFilePaths, crossWorkers, in.ParseCache, javaPerf)
+			parsedJavaFiles, javaErrs = scanner.ScanJavaFilesCachedForIndex(ctx, javaFilePaths, crossWorkers, in.ParseCache, javaPerf)
 			if len(javaErrs) > 0 && in.Verbose {
 				in.logf("verbose: Java file parsing: %d errors\n", len(javaErrs))
 			}

--- a/internal/pipeline/index_test.go
+++ b/internal/pipeline/index_test.go
@@ -77,7 +77,7 @@ func TestIndexPhase_Run_BuildsResolver_WhenRuleNeedsIt(t *testing.T) {
 	if err := os.WriteFile(kt, []byte("class A { val x: Int = 1 }\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	file, err := scanner.ParseFile(kt)
+	file, err := scanner.ParseFile(context.Background(), kt)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -243,7 +243,7 @@ func TestIndexPhase_Run_JavaIndexingChildTimings(t *testing.T) {
 	if err := os.WriteFile(java, []byte("package a;\npublic class B { A a; }\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	kotlinFile, err := scanner.ParseFile(kt)
+	kotlinFile, err := scanner.ParseFile(context.Background(), kt)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -309,7 +309,7 @@ func TestIndexPhase_Run_ReusesCollectedCrossFileJavaPaths(t *testing.T) {
 	if err := os.WriteFile(java, []byte("package a;\npublic class B { A a; }\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	kotlinFile, err := scanner.ParseFile(kt)
+	kotlinFile, err := scanner.ParseFile(context.Background(), kt)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/pipeline/oracle_filter_cache_test.go
+++ b/internal/pipeline/oracle_filter_cache_test.go
@@ -1,6 +1,7 @@
 package pipeline
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -23,8 +24,8 @@ func TestOracleFilterFingerprint_StableAndDistinct(t *testing.T) {
 	if err := os.WriteFile(b, []byte("package x\nclass B\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	pa, _ := scanner.ParseFile(a)
-	pb, _ := scanner.ParseFile(b)
+	pa, _ := scanner.ParseFile(context.Background(), a)
+	pb, _ := scanner.ParseFile(context.Background(), b)
 
 	r1 := api.FakeRule("R1")
 	r2 := api.FakeRule("R2")

--- a/internal/pipeline/parse.go
+++ b/internal/pipeline/parse.go
@@ -72,7 +72,7 @@ func (p ParsePhase) Run(ctx context.Context, in ParseInput) (ParseResult, error)
 	)
 	parseStart := time.Now()
 	_ = in.trackSerial("parse", func() error {
-		kotlinFiles, parseErrs, residentHits = scanWithResident(kotlinPaths, workers, in.ParseCache, in.ResidentFiles, scanner.ScanFilesCached)
+		kotlinFiles, parseErrs, residentHits = scanWithResident(ctx, kotlinPaths, workers, in.ParseCache, in.ResidentFiles, scanner.ScanFilesCached)
 		return nil
 	})
 	in.logf("verbose: Parsed %d files in %v (%d errors, %d workers, %d resident hits)\n",
@@ -131,7 +131,7 @@ func (p ParsePhase) Run(ctx context.Context, in ParseInput) (ParseResult, error)
 			parseErrs = append(parseErrs, javaErr)
 		} else if len(javaPaths) > 0 {
 			var javaParseErrs []error
-			javaFiles, javaParseErrs, _ = scanWithResident(javaPaths, workers, in.ParseCache, in.ResidentFiles, scanner.ScanJavaFilesCached)
+			javaFiles, javaParseErrs, _ = scanWithResident(ctx, javaPaths, workers, in.ParseCache, in.ResidentFiles, scanner.ScanJavaFilesCached)
 			parseErrs = append(parseErrs, javaParseErrs...)
 			if !in.IncludeGenerated {
 				javaFiles, _ = filterGeneratedSourceFilesWithAllowlist(javaFiles, in.IncludeGeneratedAllowlist)
@@ -273,14 +273,15 @@ func NeedsJavaBeforeDispatch(rules []*api.Rule) bool {
 // just forwards every path to scan, matching the pre-#254 behavior.
 // Errors from scan are returned unchanged.
 func scanWithResident(
+	ctx context.Context,
 	paths []string,
 	workers int,
 	pc *scanner.ParseCache,
 	cache ResidentFileCache,
-	scan func([]string, int, *scanner.ParseCache) ([]*scanner.File, []error),
+	scan func(context.Context, []string, int, *scanner.ParseCache) ([]*scanner.File, []error),
 ) ([]*scanner.File, []error, int) {
 	if cache == nil || len(paths) == 0 {
-		files, errs := scan(paths, workers, pc)
+		files, errs := scan(ctx, paths, workers, pc)
 		return files, errs, 0
 	}
 	hits := make([]*scanner.File, 0, len(paths))
@@ -292,7 +293,7 @@ func scanWithResident(
 		}
 		misses = append(misses, p)
 	}
-	freshFiles, errs := scan(misses, workers, pc)
+	freshFiles, errs := scan(ctx, misses, workers, pc)
 	for _, f := range freshFiles {
 		if f == nil {
 			continue

--- a/internal/pipeline/parse_test.go
+++ b/internal/pipeline/parse_test.go
@@ -494,7 +494,7 @@ func TestParsePhase_Run_ResidentCache(t *testing.T) {
 	writeKt(t, coldPath, "class Cold {}\n")
 
 	// Pre-parse Hot.kt so we can hand a real *scanner.File to the cache.
-	hotFile, err := scanner.ParseFile(hotPath)
+	hotFile, err := scanner.ParseFile(context.Background(), hotPath)
 	if err != nil {
 		t.Fatalf("pre-parse Hot.kt: %v", err)
 	}

--- a/internal/pipeline/resolver_cache_test.go
+++ b/internal/pipeline/resolver_cache_test.go
@@ -40,7 +40,7 @@ func TestIndexPhase_ResolverCache_BuildsOnceAcrossRuns(t *testing.T) {
 	if err := os.WriteFile(src, []byte("package test\n\nclass Sample\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	parsed, err := scanner.ParseFile(src)
+	parsed, err := scanner.ParseFile(context.Background(), src)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -90,7 +90,7 @@ func TestIndexPhase_ResolverCache_RebuildsOnContentChange(t *testing.T) {
 	if err := os.WriteFile(src, []byte("package test\nclass A\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	parsed1, err := scanner.ParseFile(src)
+	parsed1, err := scanner.ParseFile(context.Background(), src)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -120,7 +120,7 @@ func TestIndexPhase_ResolverCache_RebuildsOnContentChange(t *testing.T) {
 	if err := os.WriteFile(src, []byte("package test\nclass B\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	parsed2, err := scanner.ParseFile(src)
+	parsed2, err := scanner.ParseFile(context.Background(), src)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -143,8 +143,8 @@ func TestResolverFingerprint_StableAndDistinct(t *testing.T) {
 	if err := os.WriteFile(b, []byte("package x\nclass B\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	pa, _ := scanner.ParseFile(a)
-	pb, _ := scanner.ParseFile(b)
+	pa, _ := scanner.ParseFile(context.Background(), a)
+	pb, _ := scanner.ParseFile(context.Background(), b)
 
 	fp1 := resolverFingerprint([]*scanner.File{pa, pb})
 	fp2 := resolverFingerprint([]*scanner.File{pb, pa})

--- a/internal/pipeline/type_index_cache_test.go
+++ b/internal/pipeline/type_index_cache_test.go
@@ -22,7 +22,7 @@ func TestIndexPhase_TypeIndexCacheDir_HitsOnSecondRun(t *testing.T) {
 	if err := os.WriteFile(src, []byte("package test\n\nclass Sample\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	parsed, err := scanner.ParseFile(src)
+	parsed, err := scanner.ParseFile(context.Background(), src)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/rename/apply_test.go
+++ b/internal/rename/apply_test.go
@@ -1,6 +1,7 @@
 package rename
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -137,7 +138,7 @@ func TestApply_JavaCrossPackageRename(t *testing.T) {
 		"    public OldName useIt() { return new OldName(); }\n"+
 		"}\n")
 
-	files, errs := scanner.ScanJavaFiles([]string{declPath, usePath}, 1)
+	files, errs := scanner.ScanJavaFiles(context.Background(), []string{declPath, usePath}, 1)
 	for _, e := range errs {
 		if e != nil {
 			t.Fatalf("scan: %v", e)
@@ -505,7 +506,7 @@ func TestBuildPlan_NoConflictsWhenDestinationFree(t *testing.T) {
 
 func buildKotlinPlan(t *testing.T, paths []string, fromFQN, toFQN string) Plan {
 	t.Helper()
-	files, errs := scanner.ScanFiles(paths, 1)
+	files, errs := scanner.ScanFiles(context.Background(), paths, 1)
 	for _, e := range errs {
 		if e != nil {
 			t.Fatalf("scan: %v", e)

--- a/internal/rules/android_base_test.go
+++ b/internal/rules/android_base_test.go
@@ -1,6 +1,7 @@
 package rules_test
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -255,7 +256,7 @@ class MyTest {
 	if err := os.WriteFile(path, []byte(code), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	file, err := scanner.ParseFile(path)
+	file, err := scanner.ParseFile(context.Background(), path)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/rules/android_correctness_checks_test.go
+++ b/internal/rules/android_correctness_checks_test.go
@@ -1,6 +1,7 @@
 package rules_test
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -382,7 +383,7 @@ func runWrongViewCastOnJava(t *testing.T, code string, idx *android.ResourceInde
 	if err := os.WriteFile(path, []byte(code), 0644); err != nil {
 		t.Fatal(err)
 	}
-	file, err := scanner.ParseJavaFile(path)
+	file, err := scanner.ParseJavaFile(context.Background(), path)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/rules/android_requires_api_test.go
+++ b/internal/rules/android_requires_api_test.go
@@ -1,6 +1,7 @@
 package rules
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -36,7 +37,7 @@ func runRequiresApi(t *testing.T, source string, minSdk int) []scanner.Finding {
 	if err := os.WriteFile(path, []byte(source), 0o600); err != nil {
 		t.Fatalf("write source: %v", err)
 	}
-	file, err := scanner.ParseFile(path)
+	file, err := scanner.ParseFile(context.Background(), path)
 	if err != nil {
 		t.Fatalf("parse failed: %v", err)
 	}

--- a/internal/rules/android_security_test.go
+++ b/internal/rules/android_security_test.go
@@ -1,6 +1,7 @@
 package rules_test
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -229,9 +230,9 @@ android {
 	var file *scanner.File
 	var err error
 	if strings.HasSuffix(fileName, ".java") {
-		file, err = scanner.ParseJavaFile(path)
+		file, err = scanner.ParseJavaFile(context.Background(), path)
 	} else {
-		file, err = scanner.ParseFile(path)
+		file, err = scanner.ParseFile(context.Background(), path)
 	}
 	if err != nil {
 		t.Fatal(err)
@@ -2666,7 +2667,7 @@ func runJavaRuleByName(t *testing.T, ruleName string, code string) []scanner.Fin
 	if err := os.WriteFile(path, []byte(code), 0644); err != nil {
 		t.Fatal(err)
 	}
-	file, err := scanner.ParseJavaFile(path)
+	file, err := scanner.ParseJavaFile(context.Background(), path)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/rules/api/evidence/evidence_test.go
+++ b/internal/rules/api/evidence/evidence_test.go
@@ -1,6 +1,7 @@
 package evidence
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -95,7 +96,7 @@ func parseKotlin(t *testing.T, code string) *scanner.File {
 	if err := os.WriteFile(path, []byte(code), 0644); err != nil {
 		t.Fatal(err)
 	}
-	file, err := scanner.ParseFile(path)
+	file, err := scanner.ParseFile(context.Background(), path)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/rules/api/exprresolve_test.go
+++ b/internal/rules/api/exprresolve_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"errors"
 	"os"
 	"path/filepath"
@@ -247,7 +248,7 @@ func parseTestFile(t *testing.T, source string) *scanner.File {
 	if err := os.WriteFile(path, []byte(source), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	f, err := scanner.ParseFile(path)
+	f, err := scanner.ParseFile(context.Background(), path)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/rules/assert_inline_test.go
+++ b/internal/rules/assert_inline_test.go
@@ -1,6 +1,7 @@
 package rules_test
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -39,7 +40,7 @@ func inlineKotlin(t *testing.T, src string) *scanner.File {
 	if err := os.WriteFile(path, []byte(src), 0644); err != nil {
 		t.Fatalf("write inline source: %v", err)
 	}
-	f, err := scanner.ParseFile(path)
+	f, err := scanner.ParseFile(context.Background(), path)
 	if err != nil {
 		t.Fatalf("parse inline source: %v", err)
 	}

--- a/internal/rules/benchmark_test.go
+++ b/internal/rules/benchmark_test.go
@@ -1,6 +1,7 @@
 package rules_test
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -19,7 +20,7 @@ func parseFixtureB(b *testing.B, relPath string) *scanner.File {
 	if _, err := os.Stat(abs); err != nil {
 		b.Skipf("fixture not found: %s", abs)
 	}
-	f, err := scanner.ParseFile(abs)
+	f, err := scanner.ParseFile(context.Background(), abs)
 	if err != nil {
 		b.Fatalf("ParseFile(%s): %v", abs, err)
 	}

--- a/internal/rules/comments_test.go
+++ b/internal/rules/comments_test.go
@@ -1,6 +1,7 @@
 package rules_test
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -746,7 +747,7 @@ func runCommentsCrossFileFixture(t *testing.T, ruleName string, files map[string
 		if err := os.WriteFile(path, []byte(content), 0644); err != nil {
 			t.Fatal(err)
 		}
-		file, err := scanner.ParseFile(path)
+		file, err := scanner.ParseFile(context.Background(), path)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/rules/complexity_test.go
+++ b/internal/rules/complexity_test.go
@@ -1,6 +1,7 @@
 package rules_test
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -1496,7 +1497,7 @@ func parseBenchmarkFile(b *testing.B, code string) *scanner.File {
 	if err := os.WriteFile(path, []byte(code), 0o644); err != nil {
 		b.Fatalf("write benchmark file: %v", err)
 	}
-	file, err := scanner.ParseFile(path)
+	file, err := scanner.ParseFile(context.Background(), path)
 	if err != nil {
 		b.Fatalf("ParseFile(%s): %v", path, err)
 	}

--- a/internal/rules/database_room_version_internal_test.go
+++ b/internal/rules/database_room_version_internal_test.go
@@ -1,6 +1,7 @@
 package rules
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -15,7 +16,7 @@ func writeAndParseKotlin(t *testing.T, dir, name, content string) *scanner.File 
 	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
 		t.Fatalf("WriteFile(%s): %v", path, err)
 	}
-	file, err := scanner.ParseFile(path)
+	file, err := scanner.ParseFile(context.Background(), path)
 	if err != nil {
 		t.Fatalf("ParseFile(%s): %v", path, err)
 	}

--- a/internal/rules/database_test.go
+++ b/internal/rules/database_test.go
@@ -1,6 +1,7 @@
 package rules_test
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -226,7 +227,7 @@ func TestRoomConflictStrategyReplaceOnFk(t *testing.T) {
 	negativePath := filepath.Join(root, "negative", "database", "RoomConflictStrategyReplaceOnFk.kt")
 
 	t.Run("positive fixture triggers", func(t *testing.T) {
-		file, err := scanner.ParseFile(positivePath)
+		file, err := scanner.ParseFile(context.Background(), positivePath)
 		if err != nil {
 			t.Fatalf("ParseFile(%s): %v", positivePath, err)
 		}
@@ -240,7 +241,7 @@ func TestRoomConflictStrategyReplaceOnFk(t *testing.T) {
 	})
 
 	t.Run("negative fixture is clean", func(t *testing.T) {
-		file, err := scanner.ParseFile(negativePath)
+		file, err := scanner.ParseFile(context.Background(), negativePath)
 		if err != nil {
 			t.Fatalf("ParseFile(%s): %v", negativePath, err)
 		}
@@ -297,7 +298,7 @@ func TestRoomEntityChangedMigrationMissing(t *testing.T) {
 	negativePath := filepath.Join(root, "negative", "database", "RoomEntityChangedMigrationMissing.kt")
 
 	t.Run("positive fixture triggers", func(t *testing.T) {
-		file, err := scanner.ParseFile(positivePath)
+		file, err := scanner.ParseFile(context.Background(), positivePath)
 		if err != nil {
 			t.Fatalf("ParseFile(%s): %v", positivePath, err)
 		}
@@ -311,7 +312,7 @@ func TestRoomEntityChangedMigrationMissing(t *testing.T) {
 	})
 
 	t.Run("negative fixture is clean", func(t *testing.T) {
-		file, err := scanner.ParseFile(negativePath)
+		file, err := scanner.ParseFile(context.Background(), negativePath)
 		if err != nil {
 			t.Fatalf("ParseFile(%s): %v", negativePath, err)
 		}
@@ -390,7 +391,7 @@ func TestRoomRelationWithoutIndex(t *testing.T) {
 	negativePath := filepath.Join(root, "negative", "database", "RoomRelationWithoutIndex.kt")
 
 	t.Run("positive fixture triggers", func(t *testing.T) {
-		file, err := scanner.ParseFile(positivePath)
+		file, err := scanner.ParseFile(context.Background(), positivePath)
 		if err != nil {
 			t.Fatalf("ParseFile(%s): %v", positivePath, err)
 		}
@@ -404,7 +405,7 @@ func TestRoomRelationWithoutIndex(t *testing.T) {
 	})
 
 	t.Run("negative fixture is clean", func(t *testing.T) {
-		file, err := scanner.ParseFile(negativePath)
+		file, err := scanner.ParseFile(context.Background(), negativePath)
 		if err != nil {
 			t.Fatalf("ParseFile(%s): %v", negativePath, err)
 		}
@@ -859,7 +860,7 @@ fun open(context: Context): AppDb =
 	if err := os.WriteFile(path, []byte(src), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	file, err := scanner.ParseFile(path)
+	file, err := scanner.ParseFile(context.Background(), path)
 	if err != nil {
 		t.Fatalf("ParseFile: %v", err)
 	}
@@ -1146,7 +1147,7 @@ func TestRoomFlowQueryWithoutDistinct_Fixtures(t *testing.T) {
 	root := fixtureRoot(t)
 
 	t.Run("positive fixture flags caller missing distinctUntilChanged", func(t *testing.T) {
-		file, err := scanner.ParseFile(filepath.Join(root, "positive", "database", "RoomFlowQueryWithoutDistinct.kt"))
+		file, err := scanner.ParseFile(context.Background(), filepath.Join(root, "positive", "database", "RoomFlowQueryWithoutDistinct.kt"))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1161,7 +1162,7 @@ func TestRoomFlowQueryWithoutDistinct_Fixtures(t *testing.T) {
 	})
 
 	t.Run("negative fixture is clean", func(t *testing.T) {
-		file, err := scanner.ParseFile(filepath.Join(root, "negative", "database", "RoomFlowQueryWithoutDistinct.kt"))
+		file, err := scanner.ParseFile(context.Background(), filepath.Join(root, "negative", "database", "RoomFlowQueryWithoutDistinct.kt"))
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/rules/deadcode_module_test.go
+++ b/internal/rules/deadcode_module_test.go
@@ -1,6 +1,7 @@
 package rules
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -20,7 +21,7 @@ func writeAndParse(t *testing.T, dir, name, content string) *scanner.File {
 	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	f, err := scanner.ParseFile(path)
+	f, err := scanner.ParseFile(context.Background(), path)
 	if err != nil {
 		t.Fatalf("ParseFile(%s): %v", path, err)
 	}
@@ -36,7 +37,7 @@ func writeAndParseJava(t *testing.T, dir, name, content string) *scanner.File {
 	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	f, err := scanner.ParseJavaFile(path)
+	f, err := scanner.ParseJavaFile(context.Background(), path)
 	if err != nil {
 		t.Fatalf("ParseJavaFile(%s): %v", path, err)
 	}

--- a/internal/rules/di_hygiene_test.go
+++ b/internal/rules/di_hygiene_test.go
@@ -1,6 +1,7 @@
 package rules_test
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -21,7 +22,7 @@ func TestBindsInsteadOfProvides(t *testing.T) {
 	negativePath := filepath.Join(root, "negative", "di-hygiene", "BindsInsteadOfProvides.kt")
 
 	t.Run("positive fixture triggers", func(t *testing.T) {
-		file, err := scanner.ParseFile(positivePath)
+		file, err := scanner.ParseFile(context.Background(), positivePath)
 		if err != nil {
 			t.Fatalf("ParseFile(%s): %v", positivePath, err)
 		}
@@ -35,7 +36,7 @@ func TestBindsInsteadOfProvides(t *testing.T) {
 	})
 
 	t.Run("negative fixture is clean", func(t *testing.T) {
-		file, err := scanner.ParseFile(negativePath)
+		file, err := scanner.ParseFile(context.Background(), negativePath)
 		if err != nil {
 			t.Fatalf("ParseFile(%s): %v", negativePath, err)
 		}
@@ -57,7 +58,7 @@ func TestBindsReturnTypeMatchesParam(t *testing.T) {
 	negativePath := filepath.Join(root, "negative", "di-hygiene", "BindsReturnTypeMatchesParam.kt")
 
 	t.Run("positive fixture triggers", func(t *testing.T) {
-		file, err := scanner.ParseFile(positivePath)
+		file, err := scanner.ParseFile(context.Background(), positivePath)
 		if err != nil {
 			t.Fatalf("ParseFile(%s): %v", positivePath, err)
 		}
@@ -71,7 +72,7 @@ func TestBindsReturnTypeMatchesParam(t *testing.T) {
 	})
 
 	t.Run("negative fixture is clean", func(t *testing.T) {
-		file, err := scanner.ParseFile(negativePath)
+		file, err := scanner.ParseFile(context.Background(), negativePath)
 		if err != nil {
 			t.Fatalf("ParseFile(%s): %v", negativePath, err)
 		}
@@ -96,7 +97,7 @@ func TestComponentMissingModule(t *testing.T) {
 	negativePath := filepath.Join(root, "negative", "di-hygiene", "ComponentMissingModule.kt")
 
 	t.Run("positive fixture triggers", func(t *testing.T) {
-		file, err := scanner.ParseFile(positivePath)
+		file, err := scanner.ParseFile(context.Background(), positivePath)
 		if err != nil {
 			t.Fatalf("ParseFile(%s): %v", positivePath, err)
 		}
@@ -110,7 +111,7 @@ func TestComponentMissingModule(t *testing.T) {
 	})
 
 	t.Run("negative fixture is clean", func(t *testing.T) {
-		file, err := scanner.ParseFile(negativePath)
+		file, err := scanner.ParseFile(context.Background(), negativePath)
 		if err != nil {
 			t.Fatalf("ParseFile(%s): %v", negativePath, err)
 		}
@@ -132,7 +133,7 @@ func TestBindsMismatchedArity(t *testing.T) {
 	negativePath := filepath.Join(root, "negative", "di-hygiene", "BindsMismatchedArity.kt")
 
 	t.Run("positive fixture triggers", func(t *testing.T) {
-		file, err := scanner.ParseFile(positivePath)
+		file, err := scanner.ParseFile(context.Background(), positivePath)
 		if err != nil {
 			t.Fatalf("ParseFile(%s): %v", positivePath, err)
 		}
@@ -143,7 +144,7 @@ func TestBindsMismatchedArity(t *testing.T) {
 	})
 
 	t.Run("negative fixture is clean", func(t *testing.T) {
-		file, err := scanner.ParseFile(negativePath)
+		file, err := scanner.ParseFile(context.Background(), negativePath)
 		if err != nil {
 			t.Fatalf("ParseFile(%s): %v", negativePath, err)
 		}
@@ -165,7 +166,7 @@ func TestAnvilContributesBindingWithoutScope(t *testing.T) {
 	negativePath := filepath.Join(root, "negative", "di-hygiene", "AnvilContributesBindingWithoutScope.kt")
 
 	t.Run("positive fixture triggers", func(t *testing.T) {
-		file, err := scanner.ParseFile(positivePath)
+		file, err := scanner.ParseFile(context.Background(), positivePath)
 		if err != nil {
 			t.Fatalf("ParseFile(%s): %v", positivePath, err)
 		}
@@ -176,7 +177,7 @@ func TestAnvilContributesBindingWithoutScope(t *testing.T) {
 	})
 
 	t.Run("negative fixture is clean", func(t *testing.T) {
-		file, err := scanner.ParseFile(negativePath)
+		file, err := scanner.ParseFile(context.Background(), negativePath)
 		if err != nil {
 			t.Fatalf("ParseFile(%s): %v", negativePath, err)
 		}
@@ -217,7 +218,7 @@ func TestAnvilMergeComponentEmptyScope(t *testing.T) {
 	negativePath := filepath.Join(root, "negative", "di-hygiene", "AnvilMergeComponentEmptyScope.kt")
 
 	t.Run("positive fixture triggers", func(t *testing.T) {
-		file, err := scanner.ParseFile(positivePath)
+		file, err := scanner.ParseFile(context.Background(), positivePath)
 		if err != nil {
 			t.Fatalf("ParseFile(%s): %v", positivePath, err)
 		}
@@ -232,7 +233,7 @@ func TestAnvilMergeComponentEmptyScope(t *testing.T) {
 	})
 
 	t.Run("negative fixture is clean", func(t *testing.T) {
-		file, err := scanner.ParseFile(negativePath)
+		file, err := scanner.ParseFile(context.Background(), negativePath)
 		if err != nil {
 			t.Fatalf("ParseFile(%s): %v", negativePath, err)
 		}
@@ -324,7 +325,7 @@ func TestDeadBindings(t *testing.T) {
 	negativePath := filepath.Join(root, "negative", "di-hygiene", "DeadBindings.kt")
 
 	t.Run("positive fixture triggers", func(t *testing.T) {
-		file, err := scanner.ParseFile(positivePath)
+		file, err := scanner.ParseFile(context.Background(), positivePath)
 		if err != nil {
 			t.Fatalf("ParseFile(%s): %v", positivePath, err)
 		}
@@ -338,7 +339,7 @@ func TestDeadBindings(t *testing.T) {
 	})
 
 	t.Run("negative fixture is clean", func(t *testing.T) {
-		file, err := scanner.ParseFile(negativePath)
+		file, err := scanner.ParseFile(context.Background(), negativePath)
 		if err != nil {
 			t.Fatalf("ParseFile(%s): %v", negativePath, err)
 		}
@@ -391,7 +392,7 @@ func TestHiltInstallInMismatch(t *testing.T) {
 	negativePath := filepath.Join(root, "negative", "di-hygiene", "HiltInstallInMismatch.kt")
 
 	t.Run("positive fixture triggers", func(t *testing.T) {
-		file, err := scanner.ParseFile(positivePath)
+		file, err := scanner.ParseFile(context.Background(), positivePath)
 		if err != nil {
 			t.Fatalf("ParseFile(%s): %v", positivePath, err)
 		}
@@ -405,7 +406,7 @@ func TestHiltInstallInMismatch(t *testing.T) {
 	})
 
 	t.Run("negative fixture is clean", func(t *testing.T) {
-		file, err := scanner.ParseFile(negativePath)
+		file, err := scanner.ParseFile(context.Background(), negativePath)
 		if err != nil {
 			t.Fatalf("ParseFile(%s): %v", negativePath, err)
 		}
@@ -430,7 +431,7 @@ func TestSubcomponentNotInstalled(t *testing.T) {
 	negativePath := filepath.Join(root, "negative", "di-hygiene", "SubcomponentNotInstalled.kt")
 
 	t.Run("positive fixture triggers", func(t *testing.T) {
-		file, err := scanner.ParseFile(positivePath)
+		file, err := scanner.ParseFile(context.Background(), positivePath)
 		if err != nil {
 			t.Fatalf("ParseFile(%s): %v", positivePath, err)
 		}
@@ -444,7 +445,7 @@ func TestSubcomponentNotInstalled(t *testing.T) {
 	})
 
 	t.Run("negative fixture is clean", func(t *testing.T) {
-		file, err := scanner.ParseFile(negativePath)
+		file, err := scanner.ParseFile(context.Background(), negativePath)
 		if err != nil {
 			t.Fatalf("ParseFile(%s): %v", negativePath, err)
 		}
@@ -496,7 +497,7 @@ func TestIntoMapDuplicateKey(t *testing.T) {
 	negativePath := filepath.Join(root, "negative", "di-hygiene", "IntoMapDuplicateKey.kt")
 
 	t.Run("positive fixture triggers", func(t *testing.T) {
-		file, err := scanner.ParseFile(positivePath)
+		file, err := scanner.ParseFile(context.Background(), positivePath)
 		if err != nil {
 			t.Fatalf("ParseFile(%s): %v", positivePath, err)
 		}
@@ -507,7 +508,7 @@ func TestIntoMapDuplicateKey(t *testing.T) {
 	})
 
 	t.Run("negative fixture is clean", func(t *testing.T) {
-		file, err := scanner.ParseFile(negativePath)
+		file, err := scanner.ParseFile(context.Background(), negativePath)
 		if err != nil {
 			t.Fatalf("ParseFile(%s): %v", negativePath, err)
 		}
@@ -573,7 +574,7 @@ func TestIntoSetDuplicateType(t *testing.T) {
 	negativePath := filepath.Join(root, "negative", "di-hygiene", "IntoSetDuplicateType.kt")
 
 	t.Run("positive fixture triggers", func(t *testing.T) {
-		file, err := scanner.ParseFile(positivePath)
+		file, err := scanner.ParseFile(context.Background(), positivePath)
 		if err != nil {
 			t.Fatalf("ParseFile(%s): %v", positivePath, err)
 		}
@@ -584,7 +585,7 @@ func TestIntoSetDuplicateType(t *testing.T) {
 	})
 
 	t.Run("negative fixture is clean", func(t *testing.T) {
-		file, err := scanner.ParseFile(negativePath)
+		file, err := scanner.ParseFile(context.Background(), negativePath)
 		if err != nil {
 			t.Fatalf("ParseFile(%s): %v", negativePath, err)
 		}
@@ -606,7 +607,7 @@ func TestProviderInsteadOfLazy(t *testing.T) {
 	negativePath := filepath.Join(root, "negative", "di-hygiene", "ProviderInsteadOfLazy.kt")
 
 	t.Run("positive fixture triggers", func(t *testing.T) {
-		file, err := scanner.ParseFile(positivePath)
+		file, err := scanner.ParseFile(context.Background(), positivePath)
 		if err != nil {
 			t.Fatalf("ParseFile(%s): %v", positivePath, err)
 		}
@@ -620,7 +621,7 @@ func TestProviderInsteadOfLazy(t *testing.T) {
 	})
 
 	t.Run("negative fixture is clean", func(t *testing.T) {
-		file, err := scanner.ParseFile(negativePath)
+		file, err := scanner.ParseFile(context.Background(), negativePath)
 		if err != nil {
 			t.Fatalf("ParseFile(%s): %v", negativePath, err)
 		}
@@ -642,7 +643,7 @@ func TestLazyInsteadOfDirect(t *testing.T) {
 	negativePath := filepath.Join(root, "negative", "di-hygiene", "LazyInsteadOfDirect.kt")
 
 	t.Run("positive fixture triggers", func(t *testing.T) {
-		file, err := scanner.ParseFile(positivePath)
+		file, err := scanner.ParseFile(context.Background(), positivePath)
 		if err != nil {
 			t.Fatalf("ParseFile(%s): %v", positivePath, err)
 		}
@@ -653,7 +654,7 @@ func TestLazyInsteadOfDirect(t *testing.T) {
 	})
 
 	t.Run("negative fixture is clean", func(t *testing.T) {
-		file, err := scanner.ParseFile(negativePath)
+		file, err := scanner.ParseFile(context.Background(), negativePath)
 		if err != nil {
 			t.Fatalf("ParseFile(%s): %v", negativePath, err)
 		}
@@ -675,7 +676,7 @@ func TestHiltSingletonWithActivityDep(t *testing.T) {
 	negativePath := filepath.Join(root, "negative", "di-hygiene", "HiltSingletonWithActivityDep.kt")
 
 	t.Run("positive fixture triggers", func(t *testing.T) {
-		file, err := scanner.ParseFile(positivePath)
+		file, err := scanner.ParseFile(context.Background(), positivePath)
 		if err != nil {
 			t.Fatalf("ParseFile(%s): %v", positivePath, err)
 		}
@@ -689,7 +690,7 @@ func TestHiltSingletonWithActivityDep(t *testing.T) {
 	})
 
 	t.Run("negative fixture is clean", func(t *testing.T) {
-		file, err := scanner.ParseFile(negativePath)
+		file, err := scanner.ParseFile(context.Background(), negativePath)
 		if err != nil {
 			t.Fatalf("ParseFile(%s): %v", negativePath, err)
 		}
@@ -711,7 +712,7 @@ func TestInjectOnAbstractClass(t *testing.T) {
 	negativePath := filepath.Join(root, "negative", "di-hygiene", "InjectOnAbstractClass.kt")
 
 	t.Run("positive fixture triggers", func(t *testing.T) {
-		file, err := scanner.ParseFile(positivePath)
+		file, err := scanner.ParseFile(context.Background(), positivePath)
 		if err != nil {
 			t.Fatalf("ParseFile(%s): %v", positivePath, err)
 		}
@@ -725,7 +726,7 @@ func TestInjectOnAbstractClass(t *testing.T) {
 	})
 
 	t.Run("negative fixture is clean", func(t *testing.T) {
-		file, err := scanner.ParseFile(negativePath)
+		file, err := scanner.ParseFile(context.Background(), negativePath)
 		if err != nil {
 			t.Fatalf("ParseFile(%s): %v", negativePath, err)
 		}
@@ -747,7 +748,7 @@ func TestSingletonOnMutableClass(t *testing.T) {
 	negativePath := filepath.Join(root, "negative", "di-hygiene", "SingletonOnMutableClass.kt")
 
 	t.Run("positive fixture triggers", func(t *testing.T) {
-		file, err := scanner.ParseFile(positivePath)
+		file, err := scanner.ParseFile(context.Background(), positivePath)
 		if err != nil {
 			t.Fatalf("ParseFile(%s): %v", positivePath, err)
 		}
@@ -758,7 +759,7 @@ func TestSingletonOnMutableClass(t *testing.T) {
 	})
 
 	t.Run("negative fixture is clean", func(t *testing.T) {
-		file, err := scanner.ParseFile(negativePath)
+		file, err := scanner.ParseFile(context.Background(), negativePath)
 		if err != nil {
 			t.Fatalf("ParseFile(%s): %v", negativePath, err)
 		}
@@ -780,7 +781,7 @@ func TestMetroFactoryDeclarationShape(t *testing.T) {
 	negativePath := filepath.Join(root, "negative", "di-hygiene", "MetroFactoryDeclarationShape.kt")
 
 	t.Run("positive fixture triggers", func(t *testing.T) {
-		file, err := scanner.ParseFile(positivePath)
+		file, err := scanner.ParseFile(context.Background(), positivePath)
 		if err != nil {
 			t.Fatalf("ParseFile(%s): %v", positivePath, err)
 		}
@@ -791,7 +792,7 @@ func TestMetroFactoryDeclarationShape(t *testing.T) {
 	})
 
 	t.Run("negative fixture is clean", func(t *testing.T) {
-		file, err := scanner.ParseFile(negativePath)
+		file, err := scanner.ParseFile(context.Background(), negativePath)
 		if err != nil {
 			t.Fatalf("ParseFile(%s): %v", negativePath, err)
 		}
@@ -813,7 +814,7 @@ func TestScopeOnParameterizedClass(t *testing.T) {
 	negativePath := filepath.Join(root, "negative", "di-hygiene", "ScopeOnParameterizedClass.kt")
 
 	t.Run("positive fixture triggers", func(t *testing.T) {
-		file, err := scanner.ParseFile(positivePath)
+		file, err := scanner.ParseFile(context.Background(), positivePath)
 		if err != nil {
 			t.Fatalf("ParseFile(%s): %v", positivePath, err)
 		}
@@ -827,7 +828,7 @@ func TestScopeOnParameterizedClass(t *testing.T) {
 	})
 
 	t.Run("negative fixture is clean", func(t *testing.T) {
-		file, err := scanner.ParseFile(negativePath)
+		file, err := scanner.ParseFile(context.Background(), negativePath)
 		if err != nil {
 			t.Fatalf("ParseFile(%s): %v", negativePath, err)
 		}
@@ -849,7 +850,7 @@ func TestMissingJvmSuppressWildcards(t *testing.T) {
 	negativePath := filepath.Join(root, "negative", "di-hygiene", "MissingJvmSuppressWildcards.kt")
 
 	t.Run("positive fixture triggers", func(t *testing.T) {
-		file, err := scanner.ParseFile(positivePath)
+		file, err := scanner.ParseFile(context.Background(), positivePath)
 		if err != nil {
 			t.Fatalf("ParseFile(%s): %v", positivePath, err)
 		}
@@ -860,7 +861,7 @@ func TestMissingJvmSuppressWildcards(t *testing.T) {
 	})
 
 	t.Run("negative fixture is clean", func(t *testing.T) {
-		file, err := scanner.ParseFile(negativePath)
+		file, err := scanner.ParseFile(context.Background(), negativePath)
 		if err != nil {
 			t.Fatalf("ParseFile(%s): %v", negativePath, err)
 		}
@@ -882,7 +883,7 @@ func TestModuleWithNonStaticProvides(t *testing.T) {
 	negativePath := filepath.Join(root, "negative", "di-hygiene", "ModuleWithNonStaticProvides.kt")
 
 	t.Run("positive fixture triggers", func(t *testing.T) {
-		file, err := scanner.ParseFile(positivePath)
+		file, err := scanner.ParseFile(context.Background(), positivePath)
 		if err != nil {
 			t.Fatalf("ParseFile(%s): %v", positivePath, err)
 		}
@@ -896,7 +897,7 @@ func TestModuleWithNonStaticProvides(t *testing.T) {
 	})
 
 	t.Run("negative fixture is clean", func(t *testing.T) {
-		file, err := scanner.ParseFile(negativePath)
+		file, err := scanner.ParseFile(context.Background(), negativePath)
 		if err != nil {
 			t.Fatalf("ParseFile(%s): %v", negativePath, err)
 		}
@@ -918,7 +919,7 @@ func TestIntoMapMissingKey(t *testing.T) {
 	negativePath := filepath.Join(root, "negative", "di-hygiene", "IntoMapMissingKey.kt")
 
 	t.Run("positive fixture triggers", func(t *testing.T) {
-		file, err := scanner.ParseFile(positivePath)
+		file, err := scanner.ParseFile(context.Background(), positivePath)
 		if err != nil {
 			t.Fatalf("ParseFile(%s): %v", positivePath, err)
 		}
@@ -932,7 +933,7 @@ func TestIntoMapMissingKey(t *testing.T) {
 	})
 
 	t.Run("negative fixture is clean", func(t *testing.T) {
-		file, err := scanner.ParseFile(negativePath)
+		file, err := scanner.ParseFile(context.Background(), negativePath)
 		if err != nil {
 			t.Fatalf("ParseFile(%s): %v", negativePath, err)
 		}
@@ -954,7 +955,7 @@ func TestIntoSetOnNonSetReturn(t *testing.T) {
 	negativePath := filepath.Join(root, "negative", "di-hygiene", "IntoSetOnNonSetReturn.kt")
 
 	t.Run("positive fixture triggers", func(t *testing.T) {
-		file, err := scanner.ParseFile(positivePath)
+		file, err := scanner.ParseFile(context.Background(), positivePath)
 		if err != nil {
 			t.Fatalf("ParseFile(%s): %v", positivePath, err)
 		}
@@ -968,7 +969,7 @@ func TestIntoSetOnNonSetReturn(t *testing.T) {
 	})
 
 	t.Run("negative fixture is clean", func(t *testing.T) {
-		file, err := scanner.ParseFile(negativePath)
+		file, err := scanner.ParseFile(context.Background(), negativePath)
 		if err != nil {
 			t.Fatalf("ParseFile(%s): %v", negativePath, err)
 		}
@@ -990,7 +991,7 @@ func TestHiltEntryPointOnNonInterface(t *testing.T) {
 	negativePath := filepath.Join(root, "negative", "di-hygiene", "HiltEntryPointOnNonInterface.kt")
 
 	t.Run("positive fixture triggers", func(t *testing.T) {
-		file, err := scanner.ParseFile(positivePath)
+		file, err := scanner.ParseFile(context.Background(), positivePath)
 		if err != nil {
 			t.Fatalf("ParseFile(%s): %v", positivePath, err)
 		}
@@ -1001,7 +1002,7 @@ func TestHiltEntryPointOnNonInterface(t *testing.T) {
 	})
 
 	t.Run("negative fixture is clean", func(t *testing.T) {
-		file, err := scanner.ParseFile(negativePath)
+		file, err := scanner.ParseFile(context.Background(), negativePath)
 		if err != nil {
 			t.Fatalf("ParseFile(%s): %v", negativePath, err)
 		}
@@ -1025,7 +1026,7 @@ func parseKotlinFiles(t *testing.T, filesAndContents ...string) []*scanner.File 
 		if err := os.WriteFile(path, []byte(filesAndContents[i+1]), 0o644); err != nil {
 			t.Fatalf("WriteFile(%s): %v", path, err)
 		}
-		file, err := scanner.ParseFile(path)
+		file, err := scanner.ParseFile(context.Background(), path)
 		if err != nil {
 			t.Fatalf("ParseFile(%s): %v", path, err)
 		}

--- a/internal/rules/dispatch_test.go
+++ b/internal/rules/dispatch_test.go
@@ -1,6 +1,7 @@
 package rules
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -16,7 +17,7 @@ func TestDispatcher_DefersCrossFileAndModuleAwareRules(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	file, err := scanner.ParseFile(path)
+	file, err := scanner.ParseFile(context.Background(), path)
 	if err != nil {
 		t.Fatalf("ParseFile: %v", err)
 	}
@@ -61,7 +62,7 @@ func TestDispatcher_RunWithStats_TracksRuleBuckets(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	file, err := scanner.ParseFile(path)
+	file, err := scanner.ParseFile(context.Background(), path)
 	if err != nil {
 		t.Fatalf("ParseFile: %v", err)
 	}
@@ -100,7 +101,7 @@ func TestDispatcher_RunWithStats_TracksLineRuleInvocations(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	file, err := scanner.ParseFile(path)
+	file, err := scanner.ParseFile(context.Background(), path)
 	if err != nil {
 		t.Fatalf("ParseFile: %v", err)
 	}
@@ -147,7 +148,7 @@ func TestDispatcher_FlatDispatchRuleRunsOnFlatTree(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	file, err := scanner.ParseFile(path)
+	file, err := scanner.ParseFile(context.Background(), path)
 	if err != nil {
 		t.Fatalf("ParseFile: %v", err)
 	}
@@ -196,7 +197,7 @@ fun live() {
 		t.Fatal(err)
 	}
 
-	file, err := scanner.ParseFile(path)
+	file, err := scanner.ParseFile(context.Background(), path)
 	if err != nil {
 		t.Fatalf("ParseFile: %v", err)
 	}
@@ -255,7 +256,7 @@ fun second() = 2
 		t.Fatal(err)
 	}
 
-	file, err := scanner.ParseFile(path)
+	file, err := scanner.ParseFile(context.Background(), path)
 	if err != nil {
 		t.Fatalf("ParseFile: %v", err)
 	}
@@ -315,7 +316,7 @@ func TestDispatcher_ConfidenceProviderOverridesDefault(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	file, err := scanner.ParseFile(path)
+	file, err := scanner.ParseFile(context.Background(), path)
 	if err != nil {
 		t.Fatalf("ParseFile: %v", err)
 	}
@@ -347,7 +348,7 @@ func TestDispatcher_ExplicitFindingConfidenceBeatsRuleDefault(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	file, err := scanner.ParseFile(path)
+	file, err := scanner.ParseFile(context.Background(), path)
 	if err != nil {
 		t.Fatalf("ParseFile: %v", err)
 	}

--- a/internal/rules/dispatcher_test.go
+++ b/internal/rules/dispatcher_test.go
@@ -1,6 +1,7 @@
 package rules
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -23,7 +24,7 @@ func writeKotlinFile(t *testing.T, code string, name string) *scanner.File {
 	if err := os.WriteFile(path, []byte(code), 0644); err != nil {
 		t.Fatalf("write: %v", err)
 	}
-	file, err := scanner.ParseFile(path)
+	file, err := scanner.ParseFile(context.Background(), path)
 	if err != nil {
 		t.Fatalf("parse: %v", err)
 	}
@@ -37,7 +38,7 @@ func writeJavaFile(t *testing.T, code string, name string) *scanner.File {
 	if err := os.WriteFile(path, []byte(code), 0644); err != nil {
 		t.Fatalf("write: %v", err)
 	}
-	file, err := scanner.ParseJavaFile(path)
+	file, err := scanner.ParseJavaFile(context.Background(), path)
 	if err != nil {
 		t.Fatalf("parse: %v", err)
 	}

--- a/internal/rules/edge_test.go
+++ b/internal/rules/edge_test.go
@@ -1,6 +1,7 @@
 package rules_test
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -20,7 +21,7 @@ func parseInline(t *testing.T, code string) *scanner.File {
 	if err := os.WriteFile(path, []byte(code), 0644); err != nil {
 		t.Fatal(err)
 	}
-	f, err := scanner.ParseFile(path)
+	f, err := scanner.ParseFile(context.Background(), path)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -40,7 +41,7 @@ func runRuleByNameOnJava(t *testing.T, ruleName string, code string) []scanner.F
 	if err := os.WriteFile(path, []byte(code), 0644); err != nil {
 		t.Fatal(err)
 	}
-	file, err := scanner.ParseJavaFile(path)
+	file, err := scanner.ParseJavaFile(context.Background(), path)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -56,7 +57,7 @@ func runRuleByNameOnJavaPath(t *testing.T, ruleName, filename, code string) []sc
 	if err := os.WriteFile(path, []byte(code), 0644); err != nil {
 		t.Fatal(err)
 	}
-	file, err := scanner.ParseJavaFile(path)
+	file, err := scanner.ParseJavaFile(context.Background(), path)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -76,7 +77,7 @@ func runRuleByNameOnJavaWithSemanticCalls(t *testing.T, ruleName string, code st
 	if err := os.WriteFile(path, []byte(code), 0644); err != nil {
 		t.Fatal(err)
 	}
-	file, err := scanner.ParseJavaFile(path)
+	file, err := scanner.ParseJavaFile(context.Background(), path)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -126,7 +127,7 @@ func parseJavaFixture(t *testing.T, path string) *scanner.File {
 	if _, err := os.Stat(path); err != nil {
 		t.Fatal(err)
 	}
-	file, err := scanner.ParseJavaFile(path)
+	file, err := scanner.ParseJavaFile(context.Background(), path)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -906,7 +907,7 @@ func parseInlineWithName(t *testing.T, filename string, code string) *scanner.Fi
 	if err := os.WriteFile(path, []byte(code), 0644); err != nil {
 		t.Fatal(err)
 	}
-	f, err := scanner.ParseFile(path)
+	f, err := scanner.ParseFile(context.Background(), path)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/rules/excludes_test.go
+++ b/internal/rules/excludes_test.go
@@ -1,6 +1,7 @@
 package rules_test
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -60,7 +61,7 @@ fun check(x: Boolean) {
 		t.Fatal(err)
 	}
 
-	file, err := scanner.ParseFile(testPath)
+	file, err := scanner.ParseFile(context.Background(), testPath)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -118,7 +119,7 @@ fun check(x: Boolean) {
 		t.Fatal(err)
 	}
 
-	file, err := scanner.ParseFile(mainPath)
+	file, err := scanner.ParseFile(context.Background(), mainPath)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -165,7 +166,7 @@ fun check(x: Boolean) {
 		t.Fatal(err)
 	}
 
-	file, err := scanner.ParseFile(specPath)
+	file, err := scanner.ParseFile(context.Background(), specPath)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/rules/fix_test.go
+++ b/internal/rules/fix_test.go
@@ -1,6 +1,7 @@
 package rules_test
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"sort"
@@ -273,9 +274,9 @@ func fixableFixtureRuleName(name string) string {
 
 func parseFixableSourceFixture(path string) (*scanner.File, error) {
 	if strings.HasSuffix(path, ".java") {
-		return scanner.ParseJavaFile(path)
+		return scanner.ParseJavaFile(context.Background(), path)
 	}
-	return scanner.ParseFile(path)
+	return scanner.ParseFile(context.Background(), path)
 }
 
 func truncate(s string, max int) string {

--- a/internal/rules/flat_helpers_test.go
+++ b/internal/rules/flat_helpers_test.go
@@ -1,6 +1,7 @@
 package rules
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -18,7 +19,7 @@ class Config {
 `), 0644); err != nil {
 		t.Fatal(err)
 	}
-	file, err := scanner.ParseJavaFile(path)
+	file, err := scanner.ParseJavaFile(context.Background(), path)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/rules/hardcoded_gcp_service_account_test.go
+++ b/internal/rules/hardcoded_gcp_service_account_test.go
@@ -1,6 +1,7 @@
 package rules_test
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -21,7 +22,7 @@ func runRuleByNameOnPath(t *testing.T, ruleName, filename, code string) []scanne
 		t.Fatal(err)
 	}
 
-	file, err := scanner.ParseFile(path)
+	file, err := scanner.ParseFile(context.Background(), path)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/rules/hotspot_test.go
+++ b/internal/rules/hotspot_test.go
@@ -1,6 +1,7 @@
 package rules
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -25,7 +26,7 @@ class AppCoordinator
 		t.Fatal(err)
 	}
 
-	file, err := scanner.ParseFile(path)
+	file, err := scanner.ParseFile(context.Background(), path)
 	if err != nil {
 		t.Fatalf("ParseFile: %v", err)
 	}
@@ -60,7 +61,7 @@ class FeatureModule
 		t.Fatal(err)
 	}
 
-	file, err := scanner.ParseFile(path)
+	file, err := scanner.ParseFile(context.Background(), path)
 	if err != nil {
 		t.Fatalf("ParseFile: %v", err)
 	}

--- a/internal/rules/licensing_test.go
+++ b/internal/rules/licensing_test.go
@@ -1,6 +1,7 @@
 package rules_test
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -449,7 +450,7 @@ func TestSpdxIdentifierMismatchWithProject(t *testing.T) {
 		defer restoreDefaults()
 
 		loadFixtureRuleConfig(t, filepath.Join(positiveDir, "krit.yml"))
-		file, err := scanner.ParseFile(filepath.Join(positiveDir, "Mismatch.kt"))
+		file, err := scanner.ParseFile(context.Background(), filepath.Join(positiveDir, "Mismatch.kt"))
 		if err != nil {
 			t.Fatalf("ParseFile: %v", err)
 		}
@@ -467,7 +468,7 @@ func TestSpdxIdentifierMismatchWithProject(t *testing.T) {
 		defer restoreDefaults()
 
 		loadFixtureRuleConfig(t, filepath.Join(negativeDir, "krit.yml"))
-		file, err := scanner.ParseFile(filepath.Join(negativeDir, "Match.kt"))
+		file, err := scanner.ParseFile(context.Background(), filepath.Join(negativeDir, "Match.kt"))
 		if err != nil {
 			t.Fatalf("ParseFile: %v", err)
 		}

--- a/internal/rules/naming_test.go
+++ b/internal/rules/naming_test.go
@@ -1,6 +1,7 @@
 package rules_test
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -1869,7 +1870,7 @@ func BenchmarkNoNameShadowing_LargeFile(b *testing.B) {
 	if err := os.WriteFile(path, []byte(src.String()), 0o644); err != nil {
 		b.Fatal(err)
 	}
-	file, err := scanner.ParseFile(path)
+	file, err := scanner.ParseFile(context.Background(), path)
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/internal/rules/performance_test.go
+++ b/internal/rules/performance_test.go
@@ -1,6 +1,7 @@
 package rules_test
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -267,7 +268,7 @@ func BenchmarkUnnecessaryTemporaryInstantiation_NoMatch(b *testing.B) {
 	if err := os.WriteFile(path, []byte(src.String()), 0644); err != nil {
 		b.Fatal(err)
 	}
-	file, err := scanner.ParseFile(path)
+	file, err := scanner.ParseFile(context.Background(), path)
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/internal/rules/potentialbugs_misc_test.go
+++ b/internal/rules/potentialbugs_misc_test.go
@@ -1,6 +1,7 @@
 package rules_test
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -21,7 +22,7 @@ func benchmarkRuleByName(b *testing.B, ruleName string, code string) {
 	if err := os.WriteFile(path, []byte(code), 0o644); err != nil {
 		b.Fatal(err)
 	}
-	file, err := scanner.ParseFile(path)
+	file, err := scanner.ParseFile(context.Background(), path)
 	if err != nil {
 		b.Fatalf("ParseFile(%s): %v", path, err)
 	}

--- a/internal/rules/potentialbugs_nullsafety_test.go
+++ b/internal/rules/potentialbugs_nullsafety_test.go
@@ -1,6 +1,7 @@
 package rules_test
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -309,7 +310,7 @@ fun process(record: Any) {
 			if err := os.WriteFile(path, []byte(code), 0644); err != nil {
 				t.Fatal(err)
 			}
-			file, err := scanner.ParseFile(path)
+			file, err := scanner.ParseFile(context.Background(), path)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/rules/precompile_fixtures_test.go
+++ b/internal/rules/precompile_fixtures_test.go
@@ -1,6 +1,7 @@
 package rules_test
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"sort"
@@ -94,7 +95,7 @@ func walkPrecompileFixtures(t *testing.T, kind string, fn func(t *testing.T, rul
 			name := strings.TrimSuffix(fx.Name(), ".kt")
 			t.Run(kind+"/"+ruleID+"/"+name, func(t *testing.T) {
 				t.Parallel()
-				file, err := scanner.ParseFile(path)
+				file, err := scanner.ParseFile(context.Background(), path)
 				if err != nil {
 					t.Fatalf("parse %s: %v", path, err)
 				}

--- a/internal/rules/release_engineering_test.go
+++ b/internal/rules/release_engineering_test.go
@@ -1,6 +1,7 @@
 package rules_test
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -38,7 +39,7 @@ fun logOnlyInDebug() {
 }
 `)
 
-		file, err := scanner.ParseFile(sourcePath)
+		file, err := scanner.ParseFile(context.Background(), sourcePath)
 		if err != nil {
 			t.Fatalf("ParseFile(%s): %v", sourcePath, err)
 		}
@@ -70,7 +71,7 @@ fun logOnlyInDebug() {
 }
 `)
 
-		file, err := scanner.ParseFile(sourcePath)
+		file, err := scanner.ParseFile(context.Background(), sourcePath)
 		if err != nil {
 			t.Fatalf("ParseFile(%s): %v", sourcePath, err)
 		}
@@ -92,7 +93,7 @@ func TestBuildConfigDebugInverted(t *testing.T) {
 	negativePath := filepath.Join(root, "negative", "release-engineering", "BuildConfigDebugInverted.kt")
 
 	t.Run("positive fixture triggers", func(t *testing.T) {
-		file, err := scanner.ParseFile(positivePath)
+		file, err := scanner.ParseFile(context.Background(), positivePath)
 		if err != nil {
 			t.Fatalf("ParseFile(%s): %v", positivePath, err)
 		}
@@ -103,7 +104,7 @@ func TestBuildConfigDebugInverted(t *testing.T) {
 	})
 
 	t.Run("negative fixture is clean", func(t *testing.T) {
-		file, err := scanner.ParseFile(negativePath)
+		file, err := scanner.ParseFile(context.Background(), negativePath)
 		if err != nil {
 			t.Fatalf("ParseFile(%s): %v", negativePath, err)
 		}
@@ -125,7 +126,7 @@ func TestAllProjectsBlock(t *testing.T) {
 	negativePath := filepath.Join(root, "negative", "release-engineering", "all-projects-block", "build.gradle.kts")
 
 	t.Run("positive fixture triggers", func(t *testing.T) {
-		file, err := scanner.ParseFile(positivePath)
+		file, err := scanner.ParseFile(context.Background(), positivePath)
 		if err != nil {
 			t.Fatalf("ParseFile(%s): %v", positivePath, err)
 		}
@@ -136,7 +137,7 @@ func TestAllProjectsBlock(t *testing.T) {
 	})
 
 	t.Run("negative fixture is clean", func(t *testing.T) {
-		file, err := scanner.ParseFile(negativePath)
+		file, err := scanner.ParseFile(context.Background(), negativePath)
 		if err != nil {
 			t.Fatalf("ParseFile(%s): %v", negativePath, err)
 		}
@@ -158,7 +159,7 @@ func TestHardcodedEnvironmentName(t *testing.T) {
 	negativePath := filepath.Join(root, "negative", "release-engineering", "HardcodedEnvironmentName.kt")
 
 	t.Run("positive fixture triggers", func(t *testing.T) {
-		file, err := scanner.ParseFile(positivePath)
+		file, err := scanner.ParseFile(context.Background(), positivePath)
 		if err != nil {
 			t.Fatalf("ParseFile(%s): %v", positivePath, err)
 		}
@@ -169,7 +170,7 @@ func TestHardcodedEnvironmentName(t *testing.T) {
 	})
 
 	t.Run("negative fixture is clean", func(t *testing.T) {
-		file, err := scanner.ParseFile(negativePath)
+		file, err := scanner.ParseFile(context.Background(), negativePath)
 		if err != nil {
 			t.Fatalf("ParseFile(%s): %v", negativePath, err)
 		}
@@ -383,7 +384,7 @@ func runVisibleForTestingCallerRule(t *testing.T, files map[string]string) []sca
 	for rel, content := range files {
 		path := filepath.Join(root, filepath.FromSlash(rel))
 		writeModuleFile(t, path, content)
-		file, err := scanner.ParseFile(path)
+		file, err := scanner.ParseFile(context.Background(), path)
 		if err != nil {
 			t.Fatalf("ParseFile(%s): %v", path, err)
 		}
@@ -635,7 +636,7 @@ func runTimberTreeNotPlantedRule(t *testing.T, files map[string]string, fakeTarg
 	for rel, content := range files {
 		path := filepath.Join(root, filepath.FromSlash(rel))
 		writeModuleFile(t, path, content)
-		file, err := scanner.ParseFile(path)
+		file, err := scanner.ParseFile(context.Background(), path)
 		if err != nil {
 			t.Fatalf("ParseFile(%s): %v", path, err)
 		}
@@ -820,7 +821,7 @@ func runOpenForTestingCallerRule(t *testing.T, files map[string]string) []scanne
 	for rel, content := range files {
 		path := filepath.Join(root, filepath.FromSlash(rel))
 		writeModuleFile(t, path, content)
-		file, err := scanner.ParseFile(path)
+		file, err := scanner.ParseFile(context.Background(), path)
 		if err != nil {
 			t.Fatalf("ParseFile(%s): %v", path, err)
 		}
@@ -904,14 +905,14 @@ func runTestFixtureAccessedFromProductionRule(t *testing.T, registered *api.Rule
 		}
 		switch {
 		case strings.HasSuffix(path, ".kt"), strings.HasSuffix(path, ".kts"):
-			file, parseErr := scanner.ParseFile(path)
+			file, parseErr := scanner.ParseFile(context.Background(), path)
 			if parseErr != nil {
 				return parseErr
 			}
 			kotlinFiles = append(kotlinFiles, file)
 			parsedFiles = append(parsedFiles, file)
 		case strings.HasSuffix(path, ".java"):
-			file, parseErr := scanner.ParseJavaFile(path)
+			file, parseErr := scanner.ParseJavaFile(context.Background(), path)
 			if parseErr != nil {
 				return parseErr
 			}
@@ -955,7 +956,7 @@ func TestCommentedOutCodeBlock(t *testing.T) {
 	negativePath := filepath.Join(root, "negative", "release-engineering", "CommentedOutCodeBlock.kt")
 
 	t.Run("positive fixture triggers", func(t *testing.T) {
-		file, err := scanner.ParseFile(positivePath)
+		file, err := scanner.ParseFile(context.Background(), positivePath)
 		if err != nil {
 			t.Fatalf("ParseFile(%s): %v", positivePath, err)
 		}
@@ -966,7 +967,7 @@ func TestCommentedOutCodeBlock(t *testing.T) {
 	})
 
 	t.Run("negative fixture is clean", func(t *testing.T) {
-		file, err := scanner.ParseFile(negativePath)
+		file, err := scanner.ParseFile(context.Background(), negativePath)
 		if err != nil {
 			t.Fatalf("ParseFile(%s): %v", negativePath, err)
 		}
@@ -988,7 +989,7 @@ func TestGradleBuildContainsTodo(t *testing.T) {
 	negativePath := filepath.Join(root, "negative", "release-engineering", "gradle-build-contains-todo", "build.gradle.kts")
 
 	t.Run("positive fixture triggers", func(t *testing.T) {
-		file, err := scanner.ParseFile(positivePath)
+		file, err := scanner.ParseFile(context.Background(), positivePath)
 		if err != nil {
 			t.Fatalf("ParseFile(%s): %v", positivePath, err)
 		}
@@ -999,7 +1000,7 @@ func TestGradleBuildContainsTodo(t *testing.T) {
 	})
 
 	t.Run("negative fixture is clean", func(t *testing.T) {
-		file, err := scanner.ParseFile(negativePath)
+		file, err := scanner.ParseFile(context.Background(), negativePath)
 		if err != nil {
 			t.Fatalf("ParseFile(%s): %v", negativePath, err)
 		}
@@ -1136,7 +1137,7 @@ func TestCommentedOutImport(t *testing.T) {
 	root := fixtureRoot(t)
 
 	t.Run("positive fixture triggers", func(t *testing.T) {
-		file, err := scanner.ParseFile(filepath.Join(root, "positive", "release-engineering", "CommentedOutImport.kt"))
+		file, err := scanner.ParseFile(context.Background(), filepath.Join(root, "positive", "release-engineering", "CommentedOutImport.kt"))
 		if err != nil {
 			t.Fatalf("ParseFile: %v", err)
 		}
@@ -1147,7 +1148,7 @@ func TestCommentedOutImport(t *testing.T) {
 	})
 
 	t.Run("negative fixture is clean", func(t *testing.T) {
-		file, err := scanner.ParseFile(filepath.Join(root, "negative", "release-engineering", "CommentedOutImport.kt"))
+		file, err := scanner.ParseFile(context.Background(), filepath.Join(root, "negative", "release-engineering", "CommentedOutImport.kt"))
 		if err != nil {
 			t.Fatalf("ParseFile: %v", err)
 		}
@@ -1167,7 +1168,7 @@ func TestDebugToastInProduction(t *testing.T) {
 	root := fixtureRoot(t)
 
 	t.Run("positive fixture triggers", func(t *testing.T) {
-		file, err := scanner.ParseFile(filepath.Join(root, "positive", "release-engineering", "DebugToastInProduction.kt"))
+		file, err := scanner.ParseFile(context.Background(), filepath.Join(root, "positive", "release-engineering", "DebugToastInProduction.kt"))
 		if err != nil {
 			t.Fatalf("ParseFile: %v", err)
 		}
@@ -1178,7 +1179,7 @@ func TestDebugToastInProduction(t *testing.T) {
 	})
 
 	t.Run("negative fixture is clean", func(t *testing.T) {
-		file, err := scanner.ParseFile(filepath.Join(root, "negative", "release-engineering", "DebugToastInProduction.kt"))
+		file, err := scanner.ParseFile(context.Background(), filepath.Join(root, "negative", "release-engineering", "DebugToastInProduction.kt"))
 		if err != nil {
 			t.Fatalf("ParseFile: %v", err)
 		}
@@ -1198,7 +1199,7 @@ func TestMergeConflictMarkerLeftover(t *testing.T) {
 	root := fixtureRoot(t)
 
 	t.Run("positive fixture triggers", func(t *testing.T) {
-		file, err := scanner.ParseFile(filepath.Join(root, "positive", "release-engineering", "MergeConflictMarkerLeftover.kt"))
+		file, err := scanner.ParseFile(context.Background(), filepath.Join(root, "positive", "release-engineering", "MergeConflictMarkerLeftover.kt"))
 		if err != nil {
 			t.Fatalf("ParseFile: %v", err)
 		}
@@ -1209,7 +1210,7 @@ func TestMergeConflictMarkerLeftover(t *testing.T) {
 	})
 
 	t.Run("negative fixture is clean", func(t *testing.T) {
-		file, err := scanner.ParseFile(filepath.Join(root, "negative", "release-engineering", "MergeConflictMarkerLeftover.kt"))
+		file, err := scanner.ParseFile(context.Background(), filepath.Join(root, "negative", "release-engineering", "MergeConflictMarkerLeftover.kt"))
 		if err != nil {
 			t.Fatalf("ParseFile: %v", err)
 		}
@@ -1283,7 +1284,7 @@ func TestPrintlnInProduction(t *testing.T) {
 	root := fixtureRoot(t)
 
 	t.Run("positive fixture triggers", func(t *testing.T) {
-		file, err := scanner.ParseFile(filepath.Join(root, "positive", "release-engineering", "PrintlnInProduction.kt"))
+		file, err := scanner.ParseFile(context.Background(), filepath.Join(root, "positive", "release-engineering", "PrintlnInProduction.kt"))
 		if err != nil {
 			t.Fatalf("ParseFile: %v", err)
 		}
@@ -1294,7 +1295,7 @@ func TestPrintlnInProduction(t *testing.T) {
 	})
 
 	t.Run("negative fixture is clean", func(t *testing.T) {
-		file, err := scanner.ParseFile(filepath.Join(root, "negative", "release-engineering", "PrintlnInProduction.kt"))
+		file, err := scanner.ParseFile(context.Background(), filepath.Join(root, "negative", "release-engineering", "PrintlnInProduction.kt"))
 		if err != nil {
 			t.Fatalf("ParseFile: %v", err)
 		}
@@ -1500,7 +1501,7 @@ func TestPrintStackTraceInProduction(t *testing.T) {
 	root := fixtureRoot(t)
 
 	t.Run("positive fixture triggers", func(t *testing.T) {
-		file, err := scanner.ParseFile(filepath.Join(root, "positive", "release-engineering", "PrintStackTraceInProduction.kt"))
+		file, err := scanner.ParseFile(context.Background(), filepath.Join(root, "positive", "release-engineering", "PrintStackTraceInProduction.kt"))
 		if err != nil {
 			t.Fatalf("ParseFile: %v", err)
 		}
@@ -1511,7 +1512,7 @@ func TestPrintStackTraceInProduction(t *testing.T) {
 	})
 
 	t.Run("negative fixture is clean", func(t *testing.T) {
-		file, err := scanner.ParseFile(filepath.Join(root, "negative", "release-engineering", "PrintStackTraceInProduction.kt"))
+		file, err := scanner.ParseFile(context.Background(), filepath.Join(root, "negative", "release-engineering", "PrintStackTraceInProduction.kt"))
 		if err != nil {
 			t.Fatalf("ParseFile: %v", err)
 		}
@@ -1615,7 +1616,7 @@ func TestHardcodedLocalhostUrl(t *testing.T) {
 	root := fixtureRoot(t)
 
 	t.Run("positive fixture triggers", func(t *testing.T) {
-		file, err := scanner.ParseFile(filepath.Join(root, "positive", "release-engineering", "HardcodedLocalhostUrl.kt"))
+		file, err := scanner.ParseFile(context.Background(), filepath.Join(root, "positive", "release-engineering", "HardcodedLocalhostUrl.kt"))
 		if err != nil {
 			t.Fatalf("ParseFile: %v", err)
 		}
@@ -1626,7 +1627,7 @@ func TestHardcodedLocalhostUrl(t *testing.T) {
 	})
 
 	t.Run("negative fixture is clean", func(t *testing.T) {
-		file, err := scanner.ParseFile(filepath.Join(root, "negative", "release-engineering", "HardcodedLocalhostUrl.kt"))
+		file, err := scanner.ParseFile(context.Background(), filepath.Join(root, "negative", "release-engineering", "HardcodedLocalhostUrl.kt"))
 		if err != nil {
 			t.Fatalf("ParseFile: %v", err)
 		}
@@ -1670,7 +1671,7 @@ func TestTestOnlyImportInProduction(t *testing.T) {
 	root := fixtureRoot(t)
 
 	t.Run("positive fixture triggers", func(t *testing.T) {
-		file, err := scanner.ParseFile(filepath.Join(root, "positive", "release-engineering", "TestOnlyImportInProduction.kt"))
+		file, err := scanner.ParseFile(context.Background(), filepath.Join(root, "positive", "release-engineering", "TestOnlyImportInProduction.kt"))
 		if err != nil {
 			t.Fatalf("ParseFile: %v", err)
 		}
@@ -1681,7 +1682,7 @@ func TestTestOnlyImportInProduction(t *testing.T) {
 	})
 
 	t.Run("negative fixture is clean", func(t *testing.T) {
-		file, err := scanner.ParseFile(filepath.Join(root, "negative", "release-engineering", "TestOnlyImportInProduction.kt"))
+		file, err := scanner.ParseFile(context.Background(), filepath.Join(root, "negative", "release-engineering", "TestOnlyImportInProduction.kt"))
 		if err != nil {
 			t.Fatalf("ParseFile: %v", err)
 		}
@@ -1840,7 +1841,7 @@ func TestNonAsciiIdentifier(t *testing.T) {
 	root := fixtureRoot(t)
 
 	t.Run("positive fixture triggers", func(t *testing.T) {
-		file, err := scanner.ParseFile(filepath.Join(root, "positive", "release-engineering", "NonAsciiIdentifier.kt"))
+		file, err := scanner.ParseFile(context.Background(), filepath.Join(root, "positive", "release-engineering", "NonAsciiIdentifier.kt"))
 		if err != nil {
 			t.Fatalf("ParseFile: %v", err)
 		}
@@ -1851,7 +1852,7 @@ func TestNonAsciiIdentifier(t *testing.T) {
 	})
 
 	t.Run("negative fixture is clean", func(t *testing.T) {
-		file, err := scanner.ParseFile(filepath.Join(root, "negative", "release-engineering", "NonAsciiIdentifier.kt"))
+		file, err := scanner.ParseFile(context.Background(), filepath.Join(root, "negative", "release-engineering", "NonAsciiIdentifier.kt"))
 		if err != nil {
 			t.Fatalf("ParseFile: %v", err)
 		}
@@ -1871,7 +1872,7 @@ func TestHardcodedLogTag(t *testing.T) {
 	root := fixtureRoot(t)
 
 	t.Run("positive fixture triggers", func(t *testing.T) {
-		file, err := scanner.ParseFile(filepath.Join(root, "positive", "release-engineering", "HardcodedLogTag.kt"))
+		file, err := scanner.ParseFile(context.Background(), filepath.Join(root, "positive", "release-engineering", "HardcodedLogTag.kt"))
 		if err != nil {
 			t.Fatalf("ParseFile: %v", err)
 		}
@@ -1882,7 +1883,7 @@ func TestHardcodedLogTag(t *testing.T) {
 	})
 
 	t.Run("negative fixture is clean", func(t *testing.T) {
-		file, err := scanner.ParseFile(filepath.Join(root, "negative", "release-engineering", "HardcodedLogTag.kt"))
+		file, err := scanner.ParseFile(context.Background(), filepath.Join(root, "negative", "release-engineering", "HardcodedLogTag.kt"))
 		if err != nil {
 			t.Fatalf("ParseFile: %v", err)
 		}

--- a/internal/rules/resource_cost_test.go
+++ b/internal/rules/resource_cost_test.go
@@ -1,6 +1,7 @@
 package rules_test
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -28,7 +29,7 @@ func parseJavaInline(t *testing.T, code string) *scanner.File {
 	if err := os.WriteFile(path, []byte(code), 0644); err != nil {
 		t.Fatal(err)
 	}
-	file, err := scanner.ParseJavaFile(path)
+	file, err := scanner.ParseJavaFile(context.Background(), path)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -103,7 +104,7 @@ func TestDatabaseQueryOnMainThread_Fixtures(t *testing.T) {
 	root := fixtureRoot(t)
 
 	t.Run("positive fixture includes SQLite Room and SQLDelight", func(t *testing.T) {
-		file, err := scanner.ParseFile(filepath.Join(root, "positive", "resource-cost", "DatabaseQueryOnMainThread.kt"))
+		file, err := scanner.ParseFile(context.Background(), filepath.Join(root, "positive", "resource-cost", "DatabaseQueryOnMainThread.kt"))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -114,7 +115,7 @@ func TestDatabaseQueryOnMainThread_Fixtures(t *testing.T) {
 	})
 
 	t.Run("negative fixture keeps repository wrappers clean", func(t *testing.T) {
-		file, err := scanner.ParseFile(filepath.Join(root, "negative", "resource-cost", "DatabaseQueryOnMainThread.kt"))
+		file, err := scanner.ParseFile(context.Background(), filepath.Join(root, "negative", "resource-cost", "DatabaseQueryOnMainThread.kt"))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -129,7 +130,7 @@ func TestRoomLoadsAllWhereFirstUsed_Fixtures(t *testing.T) {
 	root := fixtureRoot(t)
 
 	t.Run("positive fixture requires Room DAO evidence", func(t *testing.T) {
-		file, err := scanner.ParseFile(filepath.Join(root, "positive", "resource-cost", "RoomLoadsAllWhereFirstUsed.kt"))
+		file, err := scanner.ParseFile(context.Background(), filepath.Join(root, "positive", "resource-cost", "RoomLoadsAllWhereFirstUsed.kt"))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -144,7 +145,7 @@ func TestRoomLoadsAllWhereFirstUsed_Fixtures(t *testing.T) {
 	})
 
 	t.Run("negative fixture ignores limited Room queries and plain collections", func(t *testing.T) {
-		file, err := scanner.ParseFile(filepath.Join(root, "negative", "resource-cost", "RoomLoadsAllWhereFirstUsed.kt"))
+		file, err := scanner.ParseFile(context.Background(), filepath.Join(root, "negative", "resource-cost", "RoomLoadsAllWhereFirstUsed.kt"))
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/rules/rules_test.go
+++ b/internal/rules/rules_test.go
@@ -1,6 +1,7 @@
 package rules_test
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -134,7 +135,7 @@ func TestPositiveFixtures(t *testing.T) {
 		count++
 		t.Run("positive/"+ruleName, func(t *testing.T) {
 			t.Parallel()
-			file, err := scanner.ParseFile(path)
+			file, err := scanner.ParseFile(context.Background(), path)
 			if err != nil {
 				t.Fatalf("failed to parse %s: %v", path, err)
 			}
@@ -188,7 +189,7 @@ func TestNegativeFixtures(t *testing.T) {
 		count++
 		t.Run("negative/"+ruleName, func(t *testing.T) {
 			t.Parallel()
-			file, err := scanner.ParseFile(path)
+			file, err := scanner.ParseFile(context.Background(), path)
 			if err != nil {
 				t.Fatalf("failed to parse %s: %v", path, err)
 			}

--- a/internal/rules/ruletest/ruletest.go
+++ b/internal/rules/ruletest/ruletest.go
@@ -32,6 +32,7 @@
 package ruletest
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -193,7 +194,7 @@ func writeAndParseKotlin(t *testing.T, src string) *scanner.File {
 	if err := os.WriteFile(path, []byte(src), 0o644); err != nil {
 		t.Fatalf("ruletest: write Kotlin temp file: %v", err)
 	}
-	file, err := scanner.ParseFile(path)
+	file, err := scanner.ParseFile(context.Background(), path)
 	if err != nil {
 		t.Fatalf("ruletest: parse Kotlin: %v", err)
 	}
@@ -206,7 +207,7 @@ func writeAndParseJava(t *testing.T, src string) *scanner.File {
 	if err := os.WriteFile(path, []byte(src), 0o644); err != nil {
 		t.Fatalf("ruletest: write Java temp file: %v", err)
 	}
-	file, err := scanner.ParseJavaFile(path)
+	file, err := scanner.ParseJavaFile(context.Background(), path)
 	if err != nil {
 		t.Fatalf("ruletest: parse Java: %v", err)
 	}

--- a/internal/rules/semantics/semantics_test.go
+++ b/internal/rules/semantics/semantics_test.go
@@ -1,6 +1,7 @@
 package semantics
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -215,7 +216,7 @@ func parseKotlin(t *testing.T, content string) *scanner.File {
 	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
 		t.Fatalf("write fixture: %v", err)
 	}
-	file, err := scanner.ParseFile(path)
+	file, err := scanner.ParseFile(context.Background(), path)
 	if err != nil {
 		t.Fatalf("ParseFile: %v", err)
 	}

--- a/internal/rules/style_braces_test.go
+++ b/internal/rules/style_braces_test.go
@@ -1,6 +1,7 @@
 package rules
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"sort"
@@ -19,7 +20,7 @@ func parseBracesInline(t *testing.T, code string) *scanner.File {
 	if err := os.WriteFile(path, []byte(code), 0644); err != nil {
 		t.Fatal(err)
 	}
-	f, err := scanner.ParseFile(path)
+	f, err := scanner.ParseFile(context.Background(), path)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -35,7 +36,7 @@ func parseBracesPath(t *testing.T, name, code string) *scanner.File {
 	if err := os.WriteFile(path, []byte(code), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	f, err := scanner.ParseFile(path)
+	f, err := scanner.ParseFile(context.Background(), path)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/rules/style_expressions_internal_test.go
+++ b/internal/rules/style_expressions_internal_test.go
@@ -1,6 +1,7 @@
 package rules
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -15,7 +16,7 @@ func parseStyleExpressionsInline(t *testing.T, code string) *scanner.File {
 	if err := os.WriteFile(path, []byte(code), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	file, err := scanner.ParseFile(path)
+	file, err := scanner.ParseFile(context.Background(), path)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/rules/style_expressions_test.go
+++ b/internal/rules/style_expressions_test.go
@@ -1,6 +1,7 @@
 package rules_test
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -570,7 +571,7 @@ func BenchmarkVarCouldBeValSharedScope(b *testing.B) {
 	if err := os.WriteFile(path, []byte(src.String()), 0644); err != nil {
 		b.Fatal(err)
 	}
-	file, err := scanner.ParseFile(path)
+	file, err := scanner.ParseFile(context.Background(), path)
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/internal/rules/style_format_internal_test.go
+++ b/internal/rules/style_format_internal_test.go
@@ -1,6 +1,7 @@
 package rules
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -56,7 +57,7 @@ func parseInlineKt(t *testing.T, code string) *scanner.File {
 	if err := os.WriteFile(path, []byte(code), 0644); err != nil {
 		t.Fatal(err)
 	}
-	f, err := scanner.ParseFile(path)
+	f, err := scanner.ParseFile(context.Background(), path)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/rules/supply_catalog_buildsrc_mismatch.go
+++ b/internal/rules/supply_catalog_buildsrc_mismatch.go
@@ -2,6 +2,7 @@ package rules
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -239,7 +240,7 @@ func buildSrcDirs(rootDir string) []string {
 }
 
 func (r *VersionCatalogBuildSrcMismatchRule) scanKotlin(ctx *api.Context, catalogPath, path string, coords map[string]catalogCoord) {
-	file, err := scanner.ParseFile(path)
+	file, err := scanner.ParseFile(context.Background(), path)
 	if err != nil || file == nil || file.FlatTree == nil {
 		return
 	}

--- a/internal/rules/testing_quality_test.go
+++ b/internal/rules/testing_quality_test.go
@@ -1,6 +1,7 @@
 package rules_test
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -2438,7 +2439,7 @@ class GeneratedTestTemplate {
 	if err := os.WriteFile(path, []byte(code), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	file, err := scanner.ParseFile(path)
+	file, err := scanner.ParseFile(context.Background(), path)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/rules/untested_public_api_test.go
+++ b/internal/rules/untested_public_api_test.go
@@ -1,6 +1,7 @@
 package rules
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -86,7 +87,7 @@ func runUntestedPublicAPIFixture(t *testing.T, files map[string]string) []scanne
 		if err := os.WriteFile(path, []byte(content), 0644); err != nil {
 			t.Fatal(err)
 		}
-		file, err := scanner.ParseFile(path)
+		file, err := scanner.ParseFile(context.Background(), path)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/scanner/benchmark_test.go
+++ b/internal/scanner/benchmark_test.go
@@ -1,6 +1,7 @@
 package scanner
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -16,9 +17,9 @@ func helperParseFixture(b *testing.B, relPath string) *File {
 	if err != nil {
 		b.Fatalf("cannot resolve path %s: %v", relPath, err)
 	}
-	f, err := ParseFile(abs)
+	f, err := ParseFile(context.Background(), abs)
 	if err != nil {
-		b.Fatalf("ParseFile(%s): %v", abs, err)
+		b.Fatalf("ParseFile(context.Background(), %s): %v", abs, err)
 	}
 	return f
 }
@@ -34,7 +35,7 @@ func BenchmarkParseFile(b *testing.B) {
 	}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, err := ParseFile(path)
+		_, err := ParseFile(context.Background(), path)
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -51,7 +52,7 @@ func BenchmarkParseFile_Large(b *testing.B) {
 	}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, err := ParseFile(path)
+		_, err := ParseFile(context.Background(), path)
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -84,7 +85,7 @@ func BenchmarkParseFile_Inline(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, err := ParseFile(tmpFile)
+		_, err := ParseFile(context.Background(), tmpFile)
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -105,7 +106,7 @@ func BenchmarkParseFile_WithPool(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, err := ParseFile(path)
+		_, err := ParseFile(context.Background(), path)
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -131,9 +132,9 @@ fun shared%d(): Int = %d
 		if err := os.WriteFile(path, []byte(content), 0644); err != nil {
 			b.Fatalf("write %s: %v", path, err)
 		}
-		file, err := ParseFile(path)
+		file, err := ParseFile(context.Background(), path)
 		if err != nil {
-			b.Fatalf("ParseFile(%s): %v", path, err)
+			b.Fatalf("ParseFile(context.Background(), %s): %v", path, err)
 		}
 		files = append(files, file)
 	}
@@ -217,9 +218,9 @@ func benchParseIdentifiers(b *testing.B) (*File, []uint32) {
 		b.Fatal(err)
 	}
 
-	f, err := ParseFile(tmpFile)
+	f, err := ParseFile(context.Background(), tmpFile)
 	if err != nil {
-		b.Fatalf("ParseFile(%s): %v", tmpFile, err)
+		b.Fatalf("ParseFile(context.Background(), %s): %v", tmpFile, err)
 	}
 
 	var identifiers []uint32
@@ -281,9 +282,9 @@ func BenchmarkFlatHasModifier(b *testing.B) {
 		b.Fatal(err)
 	}
 
-	f, err := ParseFile(tmpFile)
+	f, err := ParseFile(context.Background(), tmpFile)
 	if err != nil {
-		b.Fatalf("ParseFile(%s): %v", tmpFile, err)
+		b.Fatalf("ParseFile(context.Background(), %s): %v", tmpFile, err)
 	}
 
 	var decls []uint32
@@ -356,9 +357,9 @@ func BenchmarkNodeTextVsZeroCopy(b *testing.B) {
 		b.Fatal(err)
 	}
 
-	f, err := ParseFile(tmpFile)
+	f, err := ParseFile(context.Background(), tmpFile)
 	if err != nil {
-		b.Fatalf("ParseFile(%s): %v", tmpFile, err)
+		b.Fatalf("ParseFile(context.Background(), %s): %v", tmpFile, err)
 	}
 
 	var allNodes []uint32

--- a/internal/scanner/dependents_test.go
+++ b/internal/scanner/dependents_test.go
@@ -1,6 +1,7 @@
 package scanner
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -17,7 +18,7 @@ func writeAndParseKotlin(t *testing.T, dir, name, content string) *File {
 	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
 		t.Fatalf("write: %v", err)
 	}
-	f, err := ParseFile(path)
+	f, err := ParseFile(context.Background(), path)
 	if err != nil {
 		t.Fatalf("parse %s: %v", path, err)
 	}
@@ -126,7 +127,7 @@ func TestDependentsIndex_DropsNonKotlin(t *testing.T) {
 	if err := os.WriteFile(javaPath, []byte("package x; class Foo {}\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	jf, err := ParseJavaFile(javaPath)
+	jf, err := ParseJavaFile(context.Background(), javaPath)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/scanner/flat_test.go
+++ b/internal/scanner/flat_test.go
@@ -1,6 +1,7 @@
 package scanner
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -225,7 +226,7 @@ func TestParseFile_PopulatesFlatTree(t *testing.T) {
 		t.Fatalf("failed to write temp file: %v", err)
 	}
 
-	file, err := ParseFile(path)
+	file, err := ParseFile(context.Background(), path)
 	if err != nil {
 		t.Fatalf("ParseFile returned error: %v", err)
 	}

--- a/internal/scanner/index_cache_test.go
+++ b/internal/scanner/index_cache_test.go
@@ -1,6 +1,7 @@
 package scanner
 
 import (
+	"context"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -302,11 +303,11 @@ func TestCrossFileOverlayCacheSmallEditAvoidsPayloadRewrite(t *testing.T) {
 	if err := os.WriteFile(bPath, []byte("class B\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	aFile, err := ParseFile(aPath)
+	aFile, err := ParseFile(context.Background(), aPath)
 	if err != nil {
 		t.Fatal(err)
 	}
-	bFile, err := ParseFile(bPath)
+	bFile, err := ParseFile(context.Background(), bPath)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -327,7 +328,7 @@ func TestCrossFileOverlayCacheSmallEditAvoidsPayloadRewrite(t *testing.T) {
 	if err := os.WriteFile(bPath, []byte("class C\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	bChanged, err := ParseFile(bPath)
+	bChanged, err := ParseFile(context.Background(), bPath)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/scanner/index_test.go
+++ b/internal/scanner/index_test.go
@@ -350,7 +350,7 @@ public final class Widget {
 `), 0o644); err != nil {
 		t.Fatalf("write java: %v", err)
 	}
-	file, err := ParseJavaFile(path)
+	file, err := ParseJavaFile(context.Background(), path)
 	if err != nil {
 		t.Fatalf("ParseJavaFile: %v", err)
 	}
@@ -415,11 +415,11 @@ public class JavaHelper {
 fun use(helper: JavaHelper) = helper.label()
 `)
 
-	kt, err := ParseFile(kotlinPath)
+	kt, err := ParseFile(context.Background(), kotlinPath)
 	if err != nil {
 		t.Fatalf("ParseFile: %v", err)
 	}
-	javaFile, err := ParseJavaFile(javaPath)
+	javaFile, err := ParseJavaFile(context.Background(), javaPath)
 	if err != nil {
 		t.Fatalf("ParseJavaFile: %v", err)
 	}
@@ -447,11 +447,11 @@ func TestBuildIndex_JavaFilesAppearInIndexFiles(t *testing.T) {
 		t.Fatalf("write java: %v", err)
 	}
 	kotlinPath := writeTempKt(t, dir, "UseJava.kt", "package com.example\n")
-	kt, err := ParseFile(kotlinPath)
+	kt, err := ParseFile(context.Background(), kotlinPath)
 	if err != nil {
 		t.Fatalf("ParseFile: %v", err)
 	}
-	javaFile, err := ParseJavaFile(javaPath)
+	javaFile, err := ParseJavaFile(context.Background(), javaPath)
 	if err != nil {
 		t.Fatalf("ParseJavaFile: %v", err)
 	}
@@ -488,7 +488,7 @@ class UseJava {
 `), 0o644); err != nil {
 		t.Fatalf("write java: %v", err)
 	}
-	file, err := ParseJavaFile(path)
+	file, err := ParseJavaFile(context.Background(), path)
 	if err != nil {
 		t.Fatalf("ParseJavaFile: %v", err)
 	}
@@ -524,11 +524,11 @@ class UseKotlin {
 `), 0o644); err != nil {
 		t.Fatalf("write java: %v", err)
 	}
-	kt, err := ParseFile(kotlinPath)
+	kt, err := ParseFile(context.Background(), kotlinPath)
 	if err != nil {
 		t.Fatalf("ParseFile: %v", err)
 	}
-	javaFile, err := ParseJavaFile(javaPath)
+	javaFile, err := ParseJavaFile(context.Background(), javaPath)
 	if err != nil {
 		t.Fatalf("ParseJavaFile: %v", err)
 	}
@@ -574,15 +574,15 @@ class UseKotlin {
 `), 0o644); err != nil {
 		t.Fatalf("write java: %v", err)
 	}
-	imported, err := ParseFile(importedPath)
+	imported, err := ParseFile(context.Background(), importedPath)
 	if err != nil {
 		t.Fatalf("ParseFile imported: %v", err)
 	}
-	local, err := ParseFile(localPath)
+	local, err := ParseFile(context.Background(), localPath)
 	if err != nil {
 		t.Fatalf("ParseFile local: %v", err)
 	}
-	javaFile, err := ParseJavaFile(javaPath)
+	javaFile, err := ParseJavaFile(context.Background(), javaPath)
 	if err != nil {
 		t.Fatalf("ParseJavaFile: %v", err)
 	}
@@ -614,11 +614,11 @@ import com.example.api.JavaApi
 
 fun call(api: JavaApi) = api.label()
 `)
-	javaFile, err := ParseJavaFile(javaPath)
+	javaFile, err := ParseJavaFile(context.Background(), javaPath)
 	if err != nil {
 		t.Fatalf("ParseJavaFile: %v", err)
 	}
-	kt, err := ParseFile(kotlinPath)
+	kt, err := ParseFile(context.Background(), kotlinPath)
 	if err != nil {
 		t.Fatalf("ParseFile: %v", err)
 	}
@@ -652,7 +652,7 @@ class UseKotlin {
 `), 0o644); err != nil {
 		t.Fatalf("write java: %v", err)
 	}
-	file, err := ParseJavaFile(path)
+	file, err := ParseJavaFile(context.Background(), path)
 	if err != nil {
 		t.Fatalf("ParseJavaFile: %v", err)
 	}
@@ -766,11 +766,11 @@ class SharedClass {}
 fun caller() { sharedFunction() }
 `)
 
-	f1, err := ParseFile(file1)
+	f1, err := ParseFile(context.Background(), file1)
 	if err != nil {
 		t.Fatalf("ParseFile file1: %v", err)
 	}
-	f2, err := ParseFile(file2)
+	f2, err := ParseFile(context.Background(), file2)
 	if err != nil {
 		t.Fatalf("ParseFile file2: %v", err)
 	}
@@ -840,11 +840,11 @@ fun caller() {
 }
 `)
 
-	f1, err := ParseFile(file1)
+	f1, err := ParseFile(context.Background(), file1)
 	if err != nil {
 		t.Fatalf("ParseFile file1: %v", err)
 	}
-	f2, err := ParseFile(file2)
+	f2, err := ParseFile(context.Background(), file2)
 	if err != nil {
 		t.Fatalf("ParseFile file2: %v", err)
 	}
@@ -927,15 +927,15 @@ fun caller() { sharedFunction() }
 fun anotherCaller() { sharedFunction() }
 `)
 
-	f1, err := ParseFile(file1)
+	f1, err := ParseFile(context.Background(), file1)
 	if err != nil {
 		t.Fatalf("ParseFile file1: %v", err)
 	}
-	f2, err := ParseFile(file2)
+	f2, err := ParseFile(context.Background(), file2)
 	if err != nil {
 		t.Fatalf("ParseFile file2: %v", err)
 	}
-	f3, err := ParseFile(file3)
+	f3, err := ParseFile(context.Background(), file3)
 	if err != nil {
 		t.Fatalf("ParseFile file3: %v", err)
 	}
@@ -979,11 +979,11 @@ fun localOnly() {}
 fun caller() { sharedFunction() }
 `)
 
-	f1, err := ParseFile(file1)
+	f1, err := ParseFile(context.Background(), file1)
 	if err != nil {
 		t.Fatalf("ParseFile file1: %v", err)
 	}
-	f2, err := ParseFile(file2)
+	f2, err := ParseFile(context.Background(), file2)
 	if err != nil {
 		t.Fatalf("ParseFile file2: %v", err)
 	}
@@ -1017,11 +1017,11 @@ class SharedClass {}
 fun caller() { sharedFunction() }
 `)
 
-	f1, err := ParseFile(file1)
+	f1, err := ParseFile(context.Background(), file1)
 	if err != nil {
 		t.Fatalf("ParseFile file1: %v", err)
 	}
-	f2, err := ParseFile(file2)
+	f2, err := ParseFile(context.Background(), file2)
 	if err != nil {
 		t.Fatalf("ParseFile file2: %v", err)
 	}
@@ -1054,8 +1054,8 @@ fun targetFunc() {}
 // targetFunc is documented here
 fun caller() { targetFunc() }
 `)
-	file1, _ := ParseFile(f1)
-	file2, _ := ParseFile(f2)
+	file1, _ := ParseFile(context.Background(), f1)
+	file2, _ := ParseFile(context.Background(), f2)
 	idx := BuildIndex([]*File{file1, file2}, 1)
 
 	// Should be referenced outside file (in actual code, not just comments)
@@ -1070,7 +1070,7 @@ func TestCountNonCommentRefsInFile(t *testing.T) {
 fun myFunc() {}
 fun caller() { myFunc() }
 `)
-	file1, _ := ParseFile(f1)
+	file1, _ := ParseFile(context.Background(), f1)
 	idx := BuildIndex([]*File{file1}, 1)
 
 	count := idx.CountNonCommentRefsInFile("myFunc", f1)

--- a/internal/scanner/parse_cache_java_test.go
+++ b/internal/scanner/parse_cache_java_test.go
@@ -1,6 +1,7 @@
 package scanner
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -47,7 +48,7 @@ func TestParseCache_Java_RoundTrip(t *testing.T) {
 	src := largeJavaSource()
 	path := writeJava(t, repo, "Round.java", src)
 
-	miss, err := ParseJavaFileCached(path, pc)
+	miss, err := ParseJavaFileCached(context.Background(), path, pc)
 	if err != nil {
 		t.Fatalf("parse (miss): %v", err)
 	}
@@ -55,7 +56,7 @@ func TestParseCache_Java_RoundTrip(t *testing.T) {
 		t.Fatal("expected FlatTree on miss")
 	}
 
-	hit, err := ParseJavaFileCached(path, pc)
+	hit, err := ParseJavaFileCached(context.Background(), path, pc)
 	if err != nil {
 		t.Fatalf("parse (hit): %v", err)
 	}
@@ -81,7 +82,7 @@ func TestParseJavaFileCachedForIndex_RecordsMissPerfAndPrecomputesRefs(t *testin
 	path := writeJava(t, repo, "Foo.java", src)
 
 	stats := &JavaIndexPerf{}
-	file, err := ParseJavaFileCachedForIndex(path, nil, stats)
+	file, err := ParseJavaFileCachedForIndex(context.Background(), path, nil, stats)
 	if err != nil {
 		t.Fatalf("parse index java: %v", err)
 	}
@@ -125,7 +126,7 @@ func TestParseJavaFileCachedForIndex_RecordsCacheHitPerf(t *testing.T) {
 
 	src := largeJavaSource()
 	path := writeJava(t, repo, "Hit.java", src)
-	seed, err := ParseJavaFileCached(path, nil)
+	seed, err := ParseJavaFileCached(context.Background(), path, nil)
 	if err != nil {
 		t.Fatalf("seed parse: %v", err)
 	}
@@ -134,7 +135,7 @@ func TestParseJavaFileCachedForIndex_RecordsCacheHitPerf(t *testing.T) {
 	}
 
 	stats := &JavaIndexPerf{}
-	hit, err := ParseJavaFileCachedForIndex(path, pc, stats)
+	hit, err := ParseJavaFileCachedForIndex(context.Background(), path, pc, stats)
 	if err != nil {
 		t.Fatalf("parse index java hit: %v", err)
 	}
@@ -179,7 +180,7 @@ func TestParseCache_Java_CrossLanguageIsolation(t *testing.T) {
 	// on either axis.
 	src := largeJavaSource()
 	path := writeJava(t, repo, "Iso.java", src)
-	if _, err := ParseJavaFileCached(path, pc); err != nil {
+	if _, err := ParseJavaFileCached(context.Background(), path, pc); err != nil {
 		t.Fatalf("seed java: %v", err)
 	}
 	// Kotlin Load on the same bytes must miss — the Kotlin shard never
@@ -200,7 +201,7 @@ func TestParseCache_Java_GrammarVersionMismatch(t *testing.T) {
 		t.Fatalf("NewParseCache: %v", err)
 	}
 	src := largeJavaSource()
-	if _, err := ParseJavaFileCached(writeJava(t, repo, "GV.java", src), pc); err != nil {
+	if _, err := ParseJavaFileCached(context.Background(), writeJava(t, repo, "GV.java", src), pc); err != nil {
 		t.Fatalf("seed parse: %v", err)
 	}
 
@@ -232,7 +233,7 @@ func TestParseCache_Java_ContentChangeMisses(t *testing.T) {
 		t.Fatalf("NewParseCache: %v", err)
 	}
 	src := largeJavaSource()
-	if _, err := ParseJavaFileCached(writeJava(t, repo, "CC.java", src), pc); err != nil {
+	if _, err := ParseJavaFileCached(context.Background(), writeJava(t, repo, "CC.java", src), pc); err != nil {
 		t.Fatalf("seed parse: %v", err)
 	}
 
@@ -256,7 +257,7 @@ func TestParseCache_Java_SmallFileSkipsCache(t *testing.T) {
 		t.Fatalf("test assumes tiny source < threshold, got %d", len(tiny))
 	}
 	path := writeJava(t, repo, "Tiny.java", tiny)
-	if _, err := ParseJavaFileCached(path, pc); err != nil {
+	if _, err := ParseJavaFileCached(context.Background(), path, pc); err != nil {
 		t.Fatalf("parse: %v", err)
 	}
 	entries := filepath.Join(pc.JavaDir(), "entries")
@@ -279,7 +280,7 @@ func TestParseCache_Java_ConcurrentWritesSameHash(t *testing.T) {
 	}
 	src := largeJavaSource()
 	path := writeJava(t, repo, "Conc.java", src)
-	seed, err := ParseJavaFileCached(path, nil)
+	seed, err := ParseJavaFileCached(context.Background(), path, nil)
 	if err != nil {
 		t.Fatalf("seed parse: %v", err)
 	}
@@ -326,10 +327,10 @@ func TestParseCache_ClearRemovesBothLanguages(t *testing.T) {
 	// Seed one entry per language.
 	ktSrc := largeSource()
 	jSrc := largeJavaSource()
-	if _, err := ParseKotlinFileCached(writeKotlin(t, repo, "K.kt", ktSrc), pc); err != nil {
+	if _, err := ParseKotlinFileCached(context.Background(), writeKotlin(t, repo, "K.kt", ktSrc), pc); err != nil {
 		t.Fatalf("kotlin seed: %v", err)
 	}
-	if _, err := ParseJavaFileCached(writeJava(t, repo, "J.java", jSrc), pc); err != nil {
+	if _, err := ParseJavaFileCached(context.Background(), writeJava(t, repo, "J.java", jSrc), pc); err != nil {
 		t.Fatalf("java seed: %v", err)
 	}
 	if err := pc.Clear(); err != nil {
@@ -367,7 +368,7 @@ func TestScanJavaFilesCachedForIndex_ParallelPerfAggregation(t *testing.T) {
 	}
 
 	stats := &JavaIndexPerf{}
-	files, errs := ScanJavaFilesCachedForIndex(paths, 4, nil, stats)
+	files, errs := ScanJavaFilesCachedForIndex(context.Background(), paths, 4, nil, stats)
 	for _, err := range errs {
 		if err != nil {
 			t.Fatalf("unexpected parse error: %v", err)

--- a/internal/scanner/parse_cache_test.go
+++ b/internal/scanner/parse_cache_test.go
@@ -1,6 +1,7 @@
 package scanner
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -76,7 +77,7 @@ func TestParseCache_RoundTrip(t *testing.T) {
 	src := largeSource()
 	path := writeKotlin(t, repo, "Round.kt", src)
 
-	miss, err := ParseKotlinFileCached(path, pc)
+	miss, err := ParseKotlinFileCached(context.Background(), path, pc)
 	if err != nil {
 		t.Fatalf("parse (miss): %v", err)
 	}
@@ -84,7 +85,7 @@ func TestParseCache_RoundTrip(t *testing.T) {
 		t.Fatal("expected FlatTree on miss")
 	}
 
-	hit, err := ParseKotlinFileCached(path, pc)
+	hit, err := ParseKotlinFileCached(context.Background(), path, pc)
 	if err != nil {
 		t.Fatalf("parse (hit): %v", err)
 	}
@@ -120,7 +121,7 @@ func TestParseCache_HitAfterRestart(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewParseCache run1: %v", err)
 	}
-	f1, err := ParseKotlinFileCached(path, pc1)
+	f1, err := ParseKotlinFileCached(context.Background(), path, pc1)
 	if err != nil {
 		t.Fatalf("parse run1: %v", err)
 	}
@@ -164,10 +165,10 @@ func TestParseCache_AsyncSaveFlushVisibleAfterRestart(t *testing.T) {
 	ktPath := writeKotlin(t, repo, "Async.kt", largeSource())
 	javaPath := writeJava(t, repo, "Async.java", largeJavaSource())
 
-	if _, err := ParseKotlinFileCached(ktPath, pc); err != nil {
+	if _, err := ParseKotlinFileCached(context.Background(), ktPath, pc); err != nil {
 		t.Fatalf("parse kotlin: %v", err)
 	}
-	if _, err := ParseJavaFileCached(javaPath, pc); err != nil {
+	if _, err := ParseJavaFileCached(context.Background(), javaPath, pc); err != nil {
 		t.Fatalf("parse java: %v", err)
 	}
 	if err := pc.Close(); err != nil {
@@ -206,7 +207,7 @@ func TestParseCache_HasWritesExcludesReadHits(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewParseCache: %v", err)
 	}
-	if _, err := ParseKotlinFileCached(path, pc); err != nil {
+	if _, err := ParseKotlinFileCached(context.Background(), path, pc); err != nil {
 		t.Fatalf("parse prime: %v", err)
 	}
 	if !pc.HasWrites() {
@@ -245,7 +246,7 @@ func TestParseCache_AsyncConcurrentWritesSamePack(t *testing.T) {
 
 	src := largeSource()
 	path := writeKotlin(t, repo, "AsyncSamePack.kt", src)
-	seed, err := ParseKotlinFileCached(path, nil)
+	seed, err := ParseKotlinFileCached(context.Background(), path, nil)
 	if err != nil {
 		t.Fatalf("seed parse: %v", err)
 	}
@@ -285,7 +286,7 @@ func TestParseCache_AddPerfEntriesRecordsFlushPendingWrite(t *testing.T) {
 
 	src := largeSource()
 	path := writeKotlin(t, repo, "FlushPending.kt", src)
-	seed, err := ParseKotlinFileCached(path, nil)
+	seed, err := ParseKotlinFileCached(context.Background(), path, nil)
 	if err != nil {
 		t.Fatalf("seed parse: %v", err)
 	}
@@ -319,7 +320,7 @@ func TestParseCache_SkipsUnchangedPackRewrite(t *testing.T) {
 	repo := t.TempDir()
 	src := largeSource()
 	path := writeKotlin(t, repo, "Unchanged.kt", src)
-	seed, err := ParseKotlinFileCached(path, nil)
+	seed, err := ParseKotlinFileCached(context.Background(), path, nil)
 	if err != nil {
 		t.Fatalf("seed parse: %v", err)
 	}
@@ -370,7 +371,7 @@ func TestParseCache_GrammarVersionMismatch(t *testing.T) {
 		t.Fatalf("NewParseCache: %v", err)
 	}
 	src := largeSource()
-	if _, err := ParseKotlinFileCached(writeKotlin(t, repo, "GV.kt", src), pc); err != nil {
+	if _, err := ParseKotlinFileCached(context.Background(), writeKotlin(t, repo, "GV.kt", src), pc); err != nil {
 		t.Fatalf("seed parse: %v", err)
 	}
 
@@ -405,7 +406,7 @@ func TestParseCache_ContentChangeMisses(t *testing.T) {
 		t.Fatalf("NewParseCache: %v", err)
 	}
 	src := largeSource()
-	if _, err := ParseKotlinFileCached(writeKotlin(t, repo, "CC.kt", src), pc); err != nil {
+	if _, err := ParseKotlinFileCached(context.Background(), writeKotlin(t, repo, "CC.kt", src), pc); err != nil {
 		t.Fatalf("seed parse: %v", err)
 	}
 
@@ -425,7 +426,7 @@ func TestParseCache_CorruptEntryTreatedAsMiss(t *testing.T) {
 		t.Fatalf("NewParseCache: %v", err)
 	}
 	src := largeSource()
-	if _, err := ParseKotlinFileCached(writeKotlin(t, repo, "Bad.kt", src), pc); err != nil {
+	if _, err := ParseKotlinFileCached(context.Background(), writeKotlin(t, repo, "Bad.kt", src), pc); err != nil {
 		t.Fatalf("seed parse: %v", err)
 	}
 	hash := hashutil.HashHex([]byte(src))
@@ -450,7 +451,7 @@ func TestParseCache_SmallFileSkipsCache(t *testing.T) {
 		t.Fatalf("test assumes tiny source < threshold, got %d", len(tiny))
 	}
 	path := writeKotlin(t, repo, "Tiny.kt", tiny)
-	if _, err := ParseKotlinFileCached(path, pc); err != nil {
+	if _, err := ParseKotlinFileCached(context.Background(), path, pc); err != nil {
 		t.Fatalf("parse: %v", err)
 	}
 	entries := filepath.Join(pc.Dir(), "entries")
@@ -475,7 +476,7 @@ func TestParseCache_ConcurrentWritesSameHash(t *testing.T) {
 	src := largeSource()
 	path := writeKotlin(t, repo, "Conc.kt", src)
 	// Seed so we have a real FlatTree to write.
-	seed, err := ParseKotlinFileCached(path, nil)
+	seed, err := ParseKotlinFileCached(context.Background(), path, nil)
 	if err != nil {
 		t.Fatalf("seed parse: %v", err)
 	}
@@ -529,7 +530,7 @@ func measureEntrySize(t *testing.T, src string) int64 {
 		t.Fatalf("measure NewParseCacheWithCap: %v", err)
 	}
 	p := writeKotlin(t, repo, "M.kt", src)
-	if _, err := ParseKotlinFileCached(p, pc); err != nil {
+	if _, err := ParseKotlinFileCached(context.Background(), p, pc); err != nil {
 		t.Fatalf("measure parse: %v", err)
 	}
 	return pc.Stats().Bytes
@@ -560,15 +561,15 @@ func TestParseCache_LRUEvictsUnderCap(t *testing.T) {
 	pathB := writeKotlin(t, repo, "B.kt", srcB)
 	pathC := writeKotlin(t, repo, "C.kt", srcC)
 
-	if _, err := ParseKotlinFileCached(pathA, pc); err != nil {
+	if _, err := ParseKotlinFileCached(context.Background(), pathA, pc); err != nil {
 		t.Fatalf("parse A: %v", err)
 	}
 	time.Sleep(5 * time.Millisecond)
-	if _, err := ParseKotlinFileCached(pathB, pc); err != nil {
+	if _, err := ParseKotlinFileCached(context.Background(), pathB, pc); err != nil {
 		t.Fatalf("parse B: %v", err)
 	}
 	time.Sleep(5 * time.Millisecond)
-	if _, err := ParseKotlinFileCached(pathC, pc); err != nil {
+	if _, err := ParseKotlinFileCached(context.Background(), pathC, pc); err != nil {
 		t.Fatalf("parse C: %v", err)
 	}
 
@@ -625,11 +626,11 @@ func TestParseCache_LRUHotEntrySurvivesEviction(t *testing.T) {
 	pathB := writeKotlin(t, repo, "B.kt", srcB)
 	pathC := writeKotlin(t, repo, "C.kt", srcC)
 
-	if _, err := ParseKotlinFileCached(pathA, pc); err != nil {
+	if _, err := ParseKotlinFileCached(context.Background(), pathA, pc); err != nil {
 		t.Fatalf("parse A: %v", err)
 	}
 	time.Sleep(5 * time.Millisecond)
-	if _, err := ParseKotlinFileCached(pathB, pc); err != nil {
+	if _, err := ParseKotlinFileCached(context.Background(), pathB, pc); err != nil {
 		t.Fatalf("parse B: %v", err)
 	}
 	time.Sleep(5 * time.Millisecond)
@@ -640,7 +641,7 @@ func TestParseCache_LRUHotEntrySurvivesEviction(t *testing.T) {
 	}
 	time.Sleep(5 * time.Millisecond)
 
-	if _, err := ParseKotlinFileCached(pathC, pc); err != nil {
+	if _, err := ParseKotlinFileCached(context.Background(), pathC, pc); err != nil {
 		t.Fatalf("parse C: %v", err)
 	}
 	pc.Evict()
@@ -664,7 +665,7 @@ func TestParseCache_UnlimitedCapNeverEvicts(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		src := largeSource() + "\n// variant " + strconv.Itoa(i) + "\n"
 		path := writeKotlin(t, repo, "V"+strconv.Itoa(i)+".kt", src)
-		if _, err := ParseKotlinFileCached(path, pc); err != nil {
+		if _, err := ParseKotlinFileCached(context.Background(), path, pc); err != nil {
 			t.Fatalf("parse v%d: %v", i, err)
 		}
 	}
@@ -681,7 +682,7 @@ func TestClearParseCache_Removes(t *testing.T) {
 		t.Fatalf("NewParseCache: %v", err)
 	}
 	src := largeSource()
-	if _, err := ParseKotlinFileCached(writeKotlin(t, repo, "Clr.kt", src), pc); err != nil {
+	if _, err := ParseKotlinFileCached(context.Background(), writeKotlin(t, repo, "Clr.kt", src), pc); err != nil {
 		t.Fatalf("seed parse: %v", err)
 	}
 	if err := ClearParseCache(repo); err != nil {

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -670,6 +670,9 @@ func scanFilesParallel(ctx context.Context, paths []string, workers int, parse f
 			}
 
 			for _, input := range inputs {
+				if ctx.Err() != nil {
+					return
+				}
 				f, err := parse(ctx, input.path)
 				if err != nil {
 					local.errs = append(local.errs, indexedError{index: input.index, err: err})

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -185,16 +185,17 @@ func (f *File) LineOffset(lineIdx int) int {
 	return len(f.Content)
 }
 
-// ParseFile parses a Kotlin file and returns the AST.
-func ParseFile(path string) (*File, error) {
-	return ParseKotlinFileCached(path, nil)
+// ParseFile parses a Kotlin file and returns the AST. The ctx is forwarded
+// to the tree-sitter parser so callers can cancel a long-running parse.
+func ParseFile(ctx context.Context, path string) (*File, error) {
+	return ParseKotlinFileCached(ctx, path, nil)
 }
 
 // ParseKotlinFileCached parses a Kotlin file, consulting the parse cache
 // first when pc is non-nil. On a cache hit the tree-sitter parse and
 // flattenTree walk are both skipped. A nil pc behaves exactly like
-// ParseFile.
-func ParseKotlinFileCached(path string, pc *ParseCache) (*File, error) {
+// ParseFile. The ctx is forwarded to the tree-sitter parser.
+func ParseKotlinFileCached(ctx context.Context, path string, pc *ParseCache) (*File, error) {
 	content, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
@@ -206,7 +207,7 @@ func ParseKotlinFileCached(path string, pc *ParseCache) (*File, error) {
 
 	parser := GetKotlinParser()
 	defer PutKotlinParser(parser)
-	tree, err := parser.ParseCtx(context.Background(), nil, content)
+	tree, err := parser.ParseCtx(ctx, nil, content)
 	if err != nil {
 		return nil, err
 	}
@@ -267,8 +268,8 @@ func collectKotlinJavaFile(path string, _ []string, _ *fileignore.Matcher, seenK
 	}
 }
 
-func collectKotlinJavaFromGit(dir string, excludes []string, matcher *fileignore.Matcher, seenKt, seenJv map[string]bool, kotlin, java *[]string) bool {
-	files, ok := gitLsKotlinJava(dir)
+func collectKotlinJavaFromGit(ctx context.Context, dir string, excludes []string, matcher *fileignore.Matcher, seenKt, seenJv map[string]bool, kotlin, java *[]string) bool {
+	files, ok := gitLsKotlinJava(ctx, dir)
 	if !ok {
 		return false
 	}
@@ -309,7 +310,7 @@ func collectKotlinJavaByWalk(dir string, excludes []string, matcher *fileignore.
 // CollectKotlinAndJavaFiles walks the tree once and returns Kotlin and Java
 // files separately. Equivalent to calling CollectKotlinFiles and CollectJavaFiles
 // but does a single filesystem traversal.
-func CollectKotlinAndJavaFiles(paths []string, excludes []string) (kotlin []string, java []string, err error) {
+func CollectKotlinAndJavaFiles(ctx context.Context, paths []string, excludes []string) (kotlin []string, java []string, err error) {
 	seenKt := make(map[string]bool)
 	seenJv := make(map[string]bool)
 	ignoreMatchers := make(map[string]*fileignore.Matcher)
@@ -329,7 +330,7 @@ func CollectKotlinAndJavaFiles(paths []string, excludes []string) (kotlin []stri
 			collectKotlinJavaFile(p, excludes, matcher, seenKt, seenJv, &kotlin, &java)
 			continue
 		}
-		if collectKotlinJavaFromGit(p, excludes, matcher, seenKt, seenJv, &kotlin, &java) {
+		if collectKotlinJavaFromGit(ctx, p, excludes, matcher, seenKt, seenJv, &kotlin, &java) {
 			continue
 		}
 		if walkErr := collectKotlinJavaByWalk(p, excludes, matcher, seenKt, seenJv, &kotlin, &java); walkErr != nil {
@@ -340,23 +341,24 @@ func CollectKotlinAndJavaFiles(paths []string, excludes []string) (kotlin []stri
 }
 
 // ScanFiles parses all files in parallel and returns parsed File objects.
-func ScanFiles(paths []string, workers int) ([]*File, []error) {
-	return scanFilesParallel(paths, workers, ParseFile)
+// The ctx is forwarded to each per-file parse.
+func ScanFiles(ctx context.Context, paths []string, workers int) ([]*File, []error) {
+	return scanFilesParallel(ctx, paths, workers, ParseFile)
 }
 
 // ScanFilesCached is like ScanFiles but routes every file through
 // ParseKotlinFileCached so the on-disk parse cache is consulted (and
 // populated) on each file. A nil pc is a no-op cache.
-func ScanFilesCached(paths []string, workers int, pc *ParseCache) ([]*File, []error) {
-	return scanFilesParallel(paths, workers, func(p string) (*File, error) {
-		return ParseKotlinFileCached(p, pc)
+func ScanFilesCached(ctx context.Context, paths []string, workers int, pc *ParseCache) ([]*File, []error) {
+	return scanFilesParallel(ctx, paths, workers, func(c context.Context, p string) (*File, error) {
+		return ParseKotlinFileCached(c, p, pc)
 	})
 }
 
 // gitLsKotlinJava returns Kotlin (.kt/.kts) and Java (.java) paths
 // tracked by the git repo rooted at dir.
-func gitLsKotlinJava(dir string) ([]string, bool) {
-	return GitLsFilesByExt(dir, []string{".kt", ".kts", ".java"})
+func gitLsKotlinJava(ctx context.Context, dir string) ([]string, bool) {
+	return GitLsFilesByExt(ctx, dir, []string{".kt", ".kts", ".java"})
 }
 
 // GitLsFilesByExt returns paths tracked by the git repo rooted at dir
@@ -367,7 +369,7 @@ func gitLsKotlinJava(dir string) ([]string, bool) {
 // is unavailable, or when ls-files exits non-zero — callers fall back to
 // a manual walk. ls-files reports paths relative to the repo top, so we
 // require dir to be the top to keep caller path-joining sound.
-func GitLsFilesByExt(dir string, extensions []string) ([]string, bool) {
+func GitLsFilesByExt(ctx context.Context, dir string, extensions []string) ([]string, bool) {
 	if len(extensions) == 0 {
 		return nil, false
 	}
@@ -382,7 +384,7 @@ func GitLsFilesByExt(dir string, extensions []string) ([]string, bool) {
 	for _, ext := range extensions {
 		args = append(args, "*"+ext)
 	}
-	cmd := exec.CommandContext(context.Background(), gitBin, args...)
+	cmd := exec.CommandContext(ctx, gitBin, args...)
 	stdout, err := cmd.Output()
 	if err != nil {
 		return nil, false
@@ -478,24 +480,25 @@ func collectSourceFiles(paths []string, excludes []string, isSourceFile func(str
 	return files, nil
 }
 
-// ParseJavaFile parses a Java file and returns a File with its AST.
-func ParseJavaFile(path string) (*File, error) {
-	return ParseJavaFileCached(path, nil)
+// ParseJavaFile parses a Java file and returns a File with its AST. The
+// ctx is forwarded to the tree-sitter parser.
+func ParseJavaFile(ctx context.Context, path string) (*File, error) {
+	return ParseJavaFileCached(ctx, path, nil)
 }
 
 // ParseJavaFileCached parses a Java file, consulting the parse cache
 // first when pc is non-nil. On a cache hit the tree-sitter parse and
 // flattenTree walk are both skipped. A nil pc behaves exactly like an
-// uncached parse.
-func ParseJavaFileCached(path string, pc *ParseCache) (*File, error) {
-	return parseJavaFileCached(path, pc, javaParseOptions{buildLines: true})
+// uncached parse. The ctx is forwarded to the tree-sitter parser.
+func ParseJavaFileCached(ctx context.Context, path string, pc *ParseCache) (*File, error) {
+	return parseJavaFileCached(ctx, path, pc, javaParseOptions{buildLines: true})
 }
 
 // ParseJavaFileCachedForIndex is a reference-indexing-only Java parse path.
 // It skips line splitting and, on parse-cache misses, precomputes Java
 // references so index construction can reuse the same flattened tree walk.
-func ParseJavaFileCachedForIndex(path string, pc *ParseCache, stats *JavaIndexPerf) (*File, error) {
-	return parseJavaFileCached(path, pc, javaParseOptions{
+func ParseJavaFileCachedForIndex(ctx context.Context, path string, pc *ParseCache, stats *JavaIndexPerf) (*File, error) {
+	return parseJavaFileCached(ctx, path, pc, javaParseOptions{
 		buildLines:                 false,
 		precomputeReferencesOnMiss: true,
 		perf:                       stats,
@@ -508,7 +511,7 @@ type javaParseOptions struct {
 	perf                       *JavaIndexPerf
 }
 
-func parseJavaFileCached(path string, pc *ParseCache, opts javaParseOptions) (*File, error) {
+func parseJavaFileCached(ctx context.Context, path string, pc *ParseCache, opts javaParseOptions) (*File, error) {
 	readStart := time.Now()
 	content, err := os.ReadFile(path)
 	if opts.perf != nil {
@@ -538,7 +541,7 @@ func parseJavaFileCached(path string, pc *ParseCache, opts javaParseOptions) (*F
 	parser.SetLanguage(java.GetLanguage())
 	defer parser.Close()
 	parseStart := time.Now()
-	tree, err := parser.ParseCtx(context.Background(), nil, content)
+	tree, err := parser.ParseCtx(ctx, nil, content)
 	if opts.perf != nil {
 		opts.perf.TreeSitterParseNs.Add(time.Since(parseStart).Nanoseconds())
 	}
@@ -601,23 +604,23 @@ func newJavaFileFromFlatTreeWithOptions(path string, content []byte, tree *FlatT
 }
 
 // ScanJavaFiles parses all Java files in parallel (for reference indexing only).
-func ScanJavaFiles(paths []string, workers int) ([]*File, []error) {
-	return scanFilesParallel(paths, workers, ParseJavaFile)
+func ScanJavaFiles(ctx context.Context, paths []string, workers int) ([]*File, []error) {
+	return scanFilesParallel(ctx, paths, workers, ParseJavaFile)
 }
 
 // ScanJavaFilesCached is like ScanJavaFiles but routes every file through
 // ParseJavaFileCached so the on-disk parse cache is consulted (and
 // populated) on each file. A nil pc is a no-op cache.
-func ScanJavaFilesCached(paths []string, workers int, pc *ParseCache) ([]*File, []error) {
-	return scanFilesParallel(paths, workers, func(p string) (*File, error) {
-		return ParseJavaFileCached(p, pc)
+func ScanJavaFilesCached(ctx context.Context, paths []string, workers int, pc *ParseCache) ([]*File, []error) {
+	return scanFilesParallel(ctx, paths, workers, func(c context.Context, p string) (*File, error) {
+		return ParseJavaFileCached(c, p, pc)
 	})
 }
 
 // ScanJavaFilesCachedForIndex parses Java files for cross-file indexing.
-func ScanJavaFilesCachedForIndex(paths []string, workers int, pc *ParseCache, stats *JavaIndexPerf) ([]*File, []error) {
-	return scanFilesParallel(paths, workers, func(p string) (*File, error) {
-		return ParseJavaFileCachedForIndex(p, pc, stats)
+func ScanJavaFilesCachedForIndex(ctx context.Context, paths []string, workers int, pc *ParseCache, stats *JavaIndexPerf) ([]*File, []error) {
+	return scanFilesParallel(ctx, paths, workers, func(c context.Context, p string) (*File, error) {
+		return ParseJavaFileCachedForIndex(c, p, pc, stats)
 	})
 }
 
@@ -641,7 +644,7 @@ type scanBatchResult struct {
 	errs  []indexedError
 }
 
-func scanFilesParallel(paths []string, workers int, parse func(string) (*File, error)) ([]*File, []error) {
+func scanFilesParallel(ctx context.Context, paths []string, workers int, parse func(context.Context, string) (*File, error)) ([]*File, []error) {
 	if len(paths) == 0 {
 		return nil, nil
 	}
@@ -667,7 +670,7 @@ func scanFilesParallel(paths []string, workers int, parse func(string) (*File, e
 			}
 
 			for _, input := range inputs {
-				f, err := parse(input.path)
+				f, err := parse(ctx, input.path)
 				if err != nil {
 					local.errs = append(local.errs, indexedError{index: input.index, err: err})
 					continue

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -132,7 +132,7 @@ func TestParseFile_ValidKotlinFile(t *testing.T) {
 		t.Fatalf("failed to write temp file: %v", err)
 	}
 
-	f, err := ParseFile(path)
+	f, err := ParseFile(context.Background(), path)
 	if err != nil {
 		t.Fatalf("ParseFile returned error: %v", err)
 	}
@@ -161,11 +161,11 @@ func TestParseFile_InternsPath(t *testing.T) {
 	firstPath := strings.Clone(path)
 	secondPath := string([]byte(path))
 
-	first, err := ParseFile(firstPath)
+	first, err := ParseFile(context.Background(), firstPath)
 	if err != nil {
 		t.Fatalf("ParseFile returned error: %v", err)
 	}
-	second, err := ParseFile(secondPath)
+	second, err := ParseFile(context.Background(), secondPath)
 	if err != nil {
 		t.Fatalf("ParseFile returned error: %v", err)
 	}
@@ -176,7 +176,7 @@ func TestParseFile_InternsPath(t *testing.T) {
 }
 
 func TestParseFile_NonexistentFile(t *testing.T) {
-	_, err := ParseFile("/nonexistent/path/Foo.kt")
+	_, err := ParseFile(context.Background(), "/nonexistent/path/Foo.kt")
 	if err == nil {
 		t.Fatal("expected error for nonexistent file")
 	}
@@ -539,7 +539,7 @@ func TestParseFile_MalformedKotlin(t *testing.T) {
 	os.WriteFile(path, []byte("package test\nfun broken( { class }}} if while\n"), 0644)
 
 	// Tree-sitter is error-recovering — it should parse without returning an error
-	file, err := ParseFile(path)
+	file, err := ParseFile(context.Background(), path)
 	if err != nil {
 		t.Fatalf("expected no error (tree-sitter recovers), got: %v", err)
 	}
@@ -776,7 +776,7 @@ func TestScanFiles_PreservesInputOrder(t *testing.T) {
 		t.Fatalf("failed to write second file: %v", err)
 	}
 
-	files, errs := ScanFiles([]string{secondPath, missingPath, firstPath}, 2)
+	files, errs := ScanFiles(context.Background(), []string{secondPath, missingPath, firstPath}, 2)
 	if len(files) != 2 {
 		t.Fatalf("expected 2 parsed files, got %d", len(files))
 	}

--- a/internal/scanner/stats_test.go
+++ b/internal/scanner/stats_test.go
@@ -1,6 +1,7 @@
 package scanner
 
 import (
+	"context"
 	"sync"
 	"testing"
 )
@@ -20,7 +21,7 @@ func TestParseCache_StatsCounters(t *testing.T) {
 	path := writeKotlin(t, repo, "S.kt", src)
 
 	// First parse: miss (no cached entry), writes an entry.
-	if _, err := ParseKotlinFileCached(path, pc); err != nil {
+	if _, err := ParseKotlinFileCached(context.Background(), path, pc); err != nil {
 		t.Fatalf("parse 1: %v", err)
 	}
 	// Second load: should be a hit.
@@ -62,7 +63,7 @@ func TestParseCache_StatsRaceClean(t *testing.T) {
 	src := largeSource()
 
 	// Seed one entry so Load can both hit and miss.
-	if _, err := ParseKotlinFileCached(writeKotlin(t, repo, "A.kt", src), pc); err != nil {
+	if _, err := ParseKotlinFileCached(context.Background(), writeKotlin(t, repo, "A.kt", src), pc); err != nil {
 		t.Fatalf("seed parse: %v", err)
 	}
 

--- a/internal/snapshot/capture.go
+++ b/internal/snapshot/capture.go
@@ -78,8 +78,8 @@ func Capture(opts CaptureOptions) (*Result, error) {
 	}
 
 	ktPaths, javaPaths, fileToModule := collectSources(graph, root)
-	ktFiles, _ := scanner.ScanFilesCached(ktPaths, workers, nil)
-	javaFiles, _ := scanner.ScanJavaFilesCached(javaPaths, workers, nil)
+	ktFiles, _ := scanner.ScanFilesCached(context.Background(), ktPaths, workers, nil)
+	javaFiles, _ := scanner.ScanJavaFilesCached(context.Background(), javaPaths, workers, nil)
 
 	idx := scanner.BuildIndex(ktFiles, workers, javaFiles...)
 
@@ -143,7 +143,7 @@ func collectSources(graph *module.Graph, repoRoot string) (kotlin, java []string
 			if len(roots) == 0 {
 				roots = []string{filepath.Join(mod.Dir, "src", "main", "kotlin"), filepath.Join(mod.Dir, "src", "main", "java")}
 			}
-			ktForMod, jvForMod, _ := scanner.CollectKotlinAndJavaFiles(roots, nil)
+			ktForMod, jvForMod, _ := scanner.CollectKotlinAndJavaFiles(context.Background(), roots, nil)
 			for _, p := range ktForMod {
 				if !seenKt[p] {
 					seenKt[p] = true
@@ -162,7 +162,7 @@ func collectSources(graph *module.Graph, repoRoot string) (kotlin, java []string
 	}
 
 	if len(kotlin) == 0 && len(java) == 0 {
-		ktForRoot, jvForRoot, _ := scanner.CollectKotlinAndJavaFiles([]string{repoRoot}, nil)
+		ktForRoot, jvForRoot, _ := scanner.CollectKotlinAndJavaFiles(context.Background(), []string{repoRoot}, nil)
 		for _, p := range ktForRoot {
 			if !seenKt[p] {
 				seenKt[p] = true

--- a/internal/typeinfer/benchmark_test.go
+++ b/internal/typeinfer/benchmark_test.go
@@ -1,6 +1,7 @@
 package typeinfer
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -19,7 +20,7 @@ func parseFixtureTI(b *testing.B, relPath string) *scanner.File {
 	if _, err := os.Stat(abs); err != nil {
 		b.Skipf("fixture not found: %s", abs)
 	}
-	f, err := scanner.ParseFile(abs)
+	f, err := scanner.ParseFile(context.Background(), abs)
 	if err != nil {
 		b.Fatalf("ParseFile(%s): %v", abs, err)
 	}
@@ -70,7 +71,7 @@ func BenchmarkIndexFileParallel_HeavyDeclarations(b *testing.B) {
 	if err := os.WriteFile(path, []byte(sb.String()), 0o644); err != nil {
 		b.Fatal(err)
 	}
-	file, err := scanner.ParseFile(path)
+	file, err := scanner.ParseFile(context.Background(), path)
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -116,7 +117,7 @@ func BenchmarkIndexFileParallel_HeavyImportsAndDeclarations(b *testing.B) {
 	if err := os.WriteFile(path, []byte(sb.String()), 0o644); err != nil {
 		b.Fatal(err)
 	}
-	file, err := scanner.ParseFile(path)
+	file, err := scanner.ParseFile(context.Background(), path)
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -150,7 +151,7 @@ func BenchmarkIndexFilesParallel(b *testing.B) {
 		if e.IsDir() || filepath.Ext(e.Name()) != ".kt" {
 			continue
 		}
-		f, err := scanner.ParseFile(filepath.Join(fixtureDir, e.Name()))
+		f, err := scanner.ParseFile(context.Background(), filepath.Join(fixtureDir, e.Name()))
 		if err != nil {
 			continue
 		}

--- a/internal/typeinfer/crossfile_test.go
+++ b/internal/typeinfer/crossfile_test.go
@@ -1,6 +1,7 @@
 package typeinfer
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -15,7 +16,7 @@ func parseTempFile(t *testing.T, dir, name, src string) *scanner.File {
 	if err := os.WriteFile(p, []byte(src), 0644); err != nil {
 		t.Fatal(err)
 	}
-	f, err := scanner.ParseFile(p)
+	f, err := scanner.ParseFile(context.Background(), p)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/typeinfer/index_cache_test.go
+++ b/internal/typeinfer/index_cache_test.go
@@ -1,6 +1,7 @@
 package typeinfer
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -15,7 +16,7 @@ func TestIndexFilesParallelCachedWithTrackerReusesUnchangedFiles(t *testing.T) {
 	if err := os.WriteFile(aPath, []byte("package demo\nclass A { val name: String = \"a\" }\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	file, err := scanner.ParseFile(aPath)
+	file, err := scanner.ParseFile(context.Background(), aPath)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -50,11 +51,11 @@ func TestIndexFilesParallelCachedInvalidatesChangedFileOnly(t *testing.T) {
 	if err := os.WriteFile(bPath, []byte("class B\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	aFile, err := scanner.ParseFile(aPath)
+	aFile, err := scanner.ParseFile(context.Background(), aPath)
 	if err != nil {
 		t.Fatal(err)
 	}
-	bFile, err := scanner.ParseFile(bPath)
+	bFile, err := scanner.ParseFile(context.Background(), bPath)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -65,7 +66,7 @@ func TestIndexFilesParallelCachedInvalidatesChangedFileOnly(t *testing.T) {
 	if err := os.WriteFile(bPath, []byte("class C\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	bChanged, err := scanner.ParseFile(bPath)
+	bChanged, err := scanner.ParseFile(context.Background(), bPath)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/typeinfer/resolver_test.go
+++ b/internal/typeinfer/resolver_test.go
@@ -1,6 +1,7 @@
 package typeinfer
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -16,7 +17,7 @@ func parseTestFile(t *testing.T, src string) *scanner.File {
 	if err := os.WriteFile(tmpFile, []byte(src), 0644); err != nil {
 		t.Fatal(err)
 	}
-	f, err := scanner.ParseFile(tmpFile)
+	f, err := scanner.ParseFile(context.Background(), tmpFile)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/usedsymbols/usedsymbols_test.go
+++ b/internal/usedsymbols/usedsymbols_test.go
@@ -1,6 +1,7 @@
 package usedsymbols
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -15,7 +16,7 @@ func parseSource(t *testing.T, src string) *scanner.File {
 	if err := os.WriteFile(path, []byte(src), 0644); err != nil {
 		t.Fatalf("write: %v", err)
 	}
-	f, err := scanner.ParseFile(path)
+	f, err := scanner.ParseFile(context.Background(), path)
 	if err != nil {
 		t.Fatalf("parse: %v", err)
 	}

--- a/tests/corpus/parse_corpus_bench_test.go
+++ b/tests/corpus/parse_corpus_bench_test.go
@@ -13,6 +13,7 @@
 package corpus_test
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -50,7 +51,7 @@ func BenchmarkParseKotlinCorpus(b *testing.B) {
 	var parseErrors int
 	for i := 0; i < b.N; i++ {
 		for _, p := range paths {
-			f, err := scanner.ParseFile(p)
+			f, err := scanner.ParseFile(context.Background(), p)
 			if err != nil {
 				// Real corpora occasionally contain test fixtures
 				// the parser intentionally rejects. Don't fail

--- a/tests/parity/fir_parity_test.go
+++ b/tests/parity/fir_parity_test.go
@@ -2,6 +2,7 @@ package parity_test
 
 import (
 	"archive/zip"
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -327,7 +328,7 @@ func rewritePackage(source, packageName string) string {
 
 func runGoRule(t *testing.T, root, ruleName, fixture string) []scanner.Finding {
 	t.Helper()
-	file, err := scanner.ParseFile(filepath.Join(root, fixture))
+	file, err := scanner.ParseFile(context.Background(), filepath.Join(root, fixture))
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## Summary
- Public scanner entry points now take `ctx context.Context` as the first parameter and forward it to `tree-sitter parser.ParseCtx` and `exec.CommandContext` for `git ls-files`. Previously these paths hardcoded `context.Background()` inside scanner.
- Affected functions: `ParseFile`, `ParseKotlinFileCached`, `ParseJavaFile{,Cached,CachedForIndex}`, `ScanFiles{,Cached}`, `ScanJavaFiles{,Cached,CachedForIndex}`, `CollectKotlinAndJavaFiles`, `GitLsFilesByExt`.
- The pipeline parse phase, `IndexPhase.runCodeIndexBuild`, and the LSP `BuildWorkspaceIndex` now thread their existing ctx end-to-end. CLI/MCP leaf callers pass `context.Background()` where no upstream ctx exists.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...`
- [x] `make lint-rules`
- [x] `go test ./... -count=1` (all packages pass)