### PR TITLE
refactor(ruleslinter): drop unused ad-hoc-cache grandfathering hatch

### DIFF
--- a/internal/ruleslinter/ruleslinter.go
+++ b/internal/ruleslinter/ruleslinter.go
@@ -62,23 +62,6 @@ func (v Violation) String() string {
 	return fmt.Sprintf("%s: rule %s: %s", v.Position, label, v.Message)
 }
 
-// AdHocCacheException identifies a sync.Map declaration that pre-dates
-// the no-ad-hoc-cache gate and is allowed to exist temporarily. Each
-// entry is keyed by file basename + var/field name. Removing an entry
-// here is part of the migration of that cache to a shared facts layer
-// (typically internal/filefacts/).
-type AdHocCacheException struct {
-	File string // basename within the rules dir, e.g. "complexity.go"
-	Name string // identifier of the sync.Map var or field
-}
-
-// grandfatheredAdHocCaches lists package-level sync.Map declarations and
-// rule-struct sync.Map fields that existed before the gate landed. They
-// represent rule-local memoization that should migrate to a shared
-// per-run facts layer. The list MUST shrink over time; new entries are
-// not accepted.
-var grandfatheredAdHocCaches = map[AdHocCacheException]bool{}
-
 // adHocCacheInfraFiles holds files that contain sync.Map declarations
 // which are NOT rule-local memoization but legitimate dispatcher
 // infrastructure.
@@ -88,8 +71,7 @@ var adHocCacheInfraFiles = map[string]bool{
 
 // AnalyzeAdHocCaches scans every .go file in dir for sync.Map
 // declarations (package-level vars or struct fields) and returns one
-// violation per unknown declaration. Known cases are listed in
-// grandfatheredAdHocCaches; legitimate infrastructure files are listed
+// violation per declaration. Legitimate infrastructure files are listed
 // in adHocCacheInfraFiles. Test files are skipped.
 func AnalyzeAdHocCaches(dir string) ([]Violation, error) {
 	return walkRulesPackageDir(dir, func(name string) bool {
@@ -138,12 +120,9 @@ func walkRulesPackageDir(
 	return violations, nil
 }
 
-func scanAdHocCaches(fset *token.FileSet, file *ast.File, basename string) []Violation {
+func scanAdHocCaches(fset *token.FileSet, file *ast.File, _ string) []Violation {
 	var out []Violation
 	report := func(name string, pos token.Pos, message string) {
-		if grandfatheredAdHocCaches[AdHocCacheException{File: basename, Name: name}] {
-			return
-		}
 		out = append(out, Violation{
 			RuleID:   name,
 			Position: fset.Position(pos),

--- a/internal/ruleslinter/ruleslinter_test.go
+++ b/internal/ruleslinter/ruleslinter_test.go
@@ -33,11 +33,11 @@ func TestRulesPackageHasNoCapabilityDrift(t *testing.T) {
 	t.Fatalf("ruleslinter found %d capability-declaration violation(s):\n%s", len(violations), b.String())
 }
 
-// TestRulesPackageHasNoNewAdHocCaches is the gate against new sync.Map
-// memoization in rule files. Existing instances are listed in
-// grandfatheredAdHocCaches and shrink as caches migrate to a shared
-// per-run facts layer (internal/filefacts/). New ad-hoc caches fail
-// here.
+// TestRulesPackageHasNoNewAdHocCaches is the gate against sync.Map
+// memoization in rule files. Rule-local memoization belongs in the
+// shared per-run facts layer (internal/filefacts/); any package-level
+// sync.Map or mutex+map pair in a rule file fails here. Legitimate
+// dispatcher infrastructure is listed in adHocCacheInfraFiles.
 func TestRulesPackageHasNoNewAdHocCaches(t *testing.T) {
 	_, thisFile, _, _ := runtime.Caller(0)
 	rulesDir := filepath.Join(filepath.Dir(thisFile), "..", "rules")
@@ -241,31 +241,6 @@ var newCache sync.Map
 	}
 	if !strings.Contains(violations[0].Message, "filefacts") {
 		t.Fatalf("want filefacts hint, got %q", violations[0].Message)
-	}
-}
-
-func TestAnalyzeAdHocCaches_AcceptsGrandfathered(t *testing.T) {
-	dir := t.TempDir()
-	src := `package rules
-
-import "sync"
-
-var allowedCache sync.Map
-`
-	if err := os.WriteFile(filepath.Join(dir, "exempt_test_fixture.go"), []byte(src), 0o644); err != nil {
-		t.Fatalf("write: %v", err)
-	}
-	saved := grandfatheredAdHocCaches
-	defer func() { grandfatheredAdHocCaches = saved }()
-	grandfatheredAdHocCaches = map[AdHocCacheException]bool{
-		{File: "exempt_test_fixture.go", Name: "allowedCache"}: true,
-	}
-	violations, err := AnalyzeAdHocCaches(dir)
-	if err != nil {
-		t.Fatalf("AnalyzeAdHocCaches: %v", err)
-	}
-	if len(violations) != 0 {
-		t.Fatalf("want 0 violations, got %d: %v", len(violations), violations)
 	}
 }
 


### PR DESCRIPTION
## Summary
- `grandfatheredAdHocCaches` has been empty since the initial commit, so the `AdHocCacheException` type, the exemption check in `scanAdHocCaches`, and the `TestAnalyzeAdHocCaches_AcceptsGrandfathered` test were dead code.
- Removed all three, and rewrote the gate's doc comment and the gate-test comment to describe behavior as it actually is: no ad-hoc caches in rule files, with `adHocCacheInfraFiles` as the only exception path.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./internal/ruleslinter/...`
- [x] `golangci-lint run ./internal/ruleslinter/...`
- [x] `go test ./internal/ruleslinter/... -count=1`