### PR TITLE
feat(plugin-resolver): expose PSI + Analysis API resolver to custom rules (#308)

### DIFF
--- a/docs/external-rules.md
+++ b/docs/external-rules.md
@@ -107,10 +107,9 @@ class NoTodoRule : KritRule {
 
 - `path` — canonical source path.
 - `text` — raw source bytes (UTF-8).
-- `ktFile` — the Kotlin compiler `KtFile` PSI root, typed as `Any?`
-  on the API surface so consumers without the compiler on their
-  classpath still compile. Cast to `org.jetbrains.kotlin.psi.KtFile`
-  inside the rule if you need PSI walking.
+- `ktFile` — the Kotlin compiler `KtFile` PSI root (`KtFile?`). Walk
+  it with the standard `org.jetbrains.kotlin.psi.*` types. Null when
+  the daemon could not parse the file.
 
 `RuleContext` exposes:
 
@@ -120,10 +119,44 @@ class NoTodoRule : KritRule {
   `intOption`, `boolOption`, `stringListOption`) instead of casting
   directly; they fall through to the supplied default when the option
   is absent or the wrong type.
+- `resolver: Resolver?` — narrow, type-aware queries backed by the
+  Kotlin Analysis API. Non-null when the rule declared
+  `Capability.NEEDS_RESOLVER` and the daemon successfully prepared a
+  session for the current file. Methods (see `Resolver` Kdoc):
+  `isSuspendCall(KtCallExpression)`, `resolvedCallFqName(...)`,
+  `isLambdaSuspend(KtLambdaExpression)`, `expressionType(...)`.
 
-The PSI / resolver expansion is tracked under
-[#308](https://github.com/kaeawc/krit/issues/308); the rest of this
-doc calls out what is deferred.
+The PSI surface is the Kotlin compiler's. To compile against it, add
+the JetBrains intellij-dependencies redirector to your consumer
+`settings.gradle.kts` (the host plugin can't add it for you when
+`FAIL_ON_PROJECT_REPOS` is enabled):
+
+```kotlin
+// settings.gradle.kts
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        mavenCentral()
+        exclusiveContent {
+            forRepository {
+                maven("https://redirector.kotlinlang.org/maven/intellij-dependencies")
+            }
+            filter {
+                includeModule("org.jetbrains.kotlin", "kotlin-compiler")
+            }
+        }
+    }
+}
+```
+
+The host plugin adds `kotlin-compiler:<kotlinVersion>` to
+`compileOnly` automatically — no extra dependency declaration needed.
+
+Working example: `examples/external-rule/SuspendInNonSuspendLambdaRule`
+flags `suspend` function calls inside non-suspend lambda bodies. It
+walks PSI ancestors to find the enclosing lambda, asks the resolver
+for the lambda's bound parameter type, and skips the call when that
+type is suspend.
 
 ### 3. Register the implementation (manual path only)
 
@@ -275,7 +308,7 @@ expects. Today the daemon reports declared capabilities back through
 
 | Capability | Today | Target (per [#308](https://github.com/kaeawc/krit/issues/308)) |
 | --- | --- | --- |
-| `NEEDS_RESOLVER` | Advisory metadata only. `file.ktFile` is non-null when the daemon loaded the file, but the resolver / `KaSession` is not on `RuleContext`. | Typed expression resolution, declaration lookup, supertype/subtype queries. |
+| `NEEDS_RESOLVER` | `RuleContext.resolver` is non-null. Methods: `isSuspendCall`, `resolvedCallFqName`, `isLambdaSuspend`, `expressionType`. The bridge opens a fresh Kotlin Analysis API session per query; expect microsecond-class overhead per call. | Wider `KaSession` exposure (symbols, supertype queries, diagnostics) once the API surface stabilizes. |
 | `NEEDS_CROSS_FILE` | Advisory. | Cross-file declaration index (decl → references, references → decl). |
 | `NEEDS_MODULE_INDEX` | Advisory. | Gradle module identity + per-module dependency graph. |
 | `NEEDS_PARSED_FILES` | Already true for Kotlin custom rules — the daemon parses the file before invoking `check()`. | No change. |
@@ -325,6 +358,15 @@ broader sense: the API may add fields and methods in a minor release.
 Source-compatible changes are favored, but anything labeled
 experimental on the Krit side may shift without a major version bump
 until the SDK stabilizes.
+
+**Resolver surface.** `Resolver` is the narrowest surface we could
+ship that still lets rules express type-aware checks. We intentionally
+do not expose `KaSession`, `KaSymbol`, or other JetBrains-internal
+types — the Kotlin Analysis API is itself unstable across compiler
+versions, and direct exposure would couple every rule jar to the exact
+analysis-api-for-ide version Krit links. The methods on `Resolver`
+will grow in source-compatible ways (new methods, new defaults); the
+underlying KAA calls may change without notice between Krit releases.
 
 **SDK version.** Krit publishes `dev.jasonpearson.krit:krit-rule-api`
 to Maven Central in lockstep with each Krit release (see

--- a/examples/external-rule/samples/src/main/kotlin/com/example/negative/SuspendOk.kt
+++ b/examples/external-rule/samples/src/main/kotlin/com/example/negative/SuspendOk.kt
@@ -1,0 +1,31 @@
+package com.example.negative
+
+suspend fun doSuspendWork() {
+    // Body intentionally empty.
+}
+
+fun runSuspendBlock(block: suspend () -> Unit) {
+    // We never invoke `block` here; we only need the parameter type
+    // signature so the analyzer reports the passed lambda as
+    // `suspend`. Non-`inline` so the lambda's functional type is the
+    // declared parameter type (inlined lambdas adopt the caller's
+    // suspend context instead).
+    @Suppress("UNUSED_VARIABLE")
+    val captured = block
+}
+
+class SuspendOk {
+    fun runIt() {
+        // Suspend call inside a `suspend () -> Unit` lambda — the
+        // resolver should report the lambda as `suspend`, so the rule
+        // must skip this call.
+        runSuspendBlock {
+            doSuspendWork()
+        }
+    }
+
+    // Suspend call inside a `suspend` named function — also fine.
+    suspend fun runAlso() {
+        doSuspendWork()
+    }
+}

--- a/examples/external-rule/samples/src/main/kotlin/com/example/positive/SuspendMisuse.kt
+++ b/examples/external-rule/samples/src/main/kotlin/com/example/positive/SuspendMisuse.kt
@@ -1,0 +1,24 @@
+package com.example.positive
+
+// Standalone, dependency-free reproduction: a local `suspend` function
+// called from a non-suspend lambda body. The example rule's resolver
+// queries (`isSuspendCall`, `isLambdaSuspend`) work off the project's
+// own sources, so we don't need `kotlinx.coroutines` on the analyzer
+// classpath to drive the type-aware path.
+suspend fun doSuspendWork() {
+    // Body intentionally empty — only the modifier matters.
+}
+
+inline fun runRegularBlock(block: () -> Unit) {
+    block()
+}
+
+class SuspendMisuse {
+    fun runIt() {
+        runRegularBlock {
+            // Suspend call inside a non-suspend `() -> Unit` lambda —
+            // the rule must flag this line.
+            doSuspendWork()
+        }
+    }
+}

--- a/examples/external-rule/settings.gradle.kts
+++ b/examples/external-rule/settings.gradle.kts
@@ -18,6 +18,18 @@ dependencyResolutionManagement {
     repositories {
         mavenLocal()
         mavenCentral()
+        // `org.jetbrains.kotlin:kotlin-compiler` (used at compileOnly
+        // by the rule API for PSI types) lives in JetBrains' redirector,
+        // not Maven Central. Exclusive content keeps everything else
+        // resolving from Central.
+        exclusiveContent {
+            forRepository {
+                maven("https://redirector.kotlinlang.org/maven/intellij-dependencies")
+            }
+            filter {
+                includeModule("org.jetbrains.kotlin", "kotlin-compiler")
+            }
+        }
     }
 }
 

--- a/examples/external-rule/src/main/kotlin/com/example/rules/SuspendInNonSuspendLambdaRule.kt
+++ b/examples/external-rule/src/main/kotlin/com/example/rules/SuspendInNonSuspendLambdaRule.kt
@@ -1,0 +1,112 @@
+package com.example.rules
+
+import dev.jasonpearson.krit.api.Capability
+import dev.jasonpearson.krit.api.Finding
+import dev.jasonpearson.krit.api.KritFile
+import dev.jasonpearson.krit.api.KritRule
+import dev.jasonpearson.krit.api.KritRuleInfo
+import dev.jasonpearson.krit.api.Resolver
+import dev.jasonpearson.krit.api.RuleContext
+import dev.jasonpearson.krit.api.Severity
+import org.jetbrains.kotlin.lexer.KtTokens
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtFunction
+import org.jetbrains.kotlin.psi.KtFunctionLiteral
+import org.jetbrains.kotlin.psi.KtLambdaExpression
+import org.jetbrains.kotlin.psi.KtModifierListOwner
+import org.jetbrains.kotlin.psi.KtTreeVisitorVoid
+
+/**
+ * Type-aware example: flag suspend function invocations that sit inside
+ * a non-suspend lambda. PSI alone cannot tell whether a call resolves
+ * to a `suspend` function or whether an enclosing lambda was typed as
+ * `suspend () -> R`, so the rule consults `ctx.resolver` for both
+ * facts. Demonstrates the [Capability.NEEDS_RESOLVER] contract end to
+ * end.
+ *
+ * Negative cases the rule must skip:
+ *
+ *  - calls inside a `suspend` named function — the compiler accepts
+ *    them and reporting would just be noise.
+ *  - calls inside a lambda typed `suspend () -> R` (e.g.
+ *    `runBlocking { delay(10) }`) — the resolver reports the lambda's
+ *    functional type, which is the only reliable signal.
+ *  - non-suspend calls anywhere.
+ */
+@KritRuleInfo(
+    id = "example.SuspendInNonSuspendLambda",
+    category = "custom",
+    severity = Severity.ERROR,
+    needs = [Capability.NEEDS_RESOLVER],
+)
+class SuspendInNonSuspendLambdaRule : KritRule {
+    override fun check(file: KritFile, ctx: RuleContext): List<Finding> {
+        val ktFile = file.ktFile ?: return emptyList()
+        val resolver = ctx.resolver ?: return emptyList()
+        val findings = mutableListOf<Finding>()
+        ktFile.accept(object : KtTreeVisitorVoid() {
+            override fun visitCallExpression(expression: KtCallExpression) {
+                super.visitCallExpression(expression)
+                if (!resolver.isSuspendCall(expression)) return
+                if (isInsideSuspendContext(expression, resolver)) return
+                val callee = expression.calleeExpression?.text ?: "<unknown>"
+                val resolved = resolver.resolvedCallFqName(expression) ?: callee
+                val offset = expression.textOffset
+                val document = ktFile.viewProvider.document
+                val line = document?.getLineNumber(offset)?.plus(1) ?: 1
+                val column = if (document != null) {
+                    offset - document.getLineStartOffset(line - 1) + 1
+                } else {
+                    1
+                }
+                findings.add(
+                    Finding(
+                        message = "Suspend function `$resolved` called outside a suspend context",
+                        line = line,
+                        column = column,
+                    ),
+                )
+            }
+        })
+        return findings
+    }
+
+    /**
+     * Walks PSI ancestors looking for the closest enclosing function or
+     * lambda. If that scope is a `suspend` named function, or the
+     * resolver reports the lambda as `suspend`, the call is fine.
+     * Stops at the class/object boundary because crossing a class
+     * boundary changes the call site to a member declaration's body
+     * (not the original scope).
+     */
+    private fun isInsideSuspendContext(call: KtCallExpression, resolver: Resolver): Boolean {
+        var element = call.parent
+        while (element != null) {
+            when {
+                // A lambda's PSI shape is a KtLambdaExpression that
+                // wraps a KtFunctionLiteral; the latter extends
+                // KtFunction. We have to short-circuit on the literal
+                // and forward the suspend-context check to the wrapping
+                // lambda — otherwise the `is KtFunction` branch fires
+                // first, sees no `suspend` modifier on the literal, and
+                // treats the lambda as a shadowing non-suspend scope.
+                element is KtFunctionLiteral -> {
+                    val parent = element.parent
+                    if (parent is KtLambdaExpression && resolver.isLambdaSuspend(parent)) {
+                        return true
+                    }
+                    return false
+                }
+                element is KtFunction -> {
+                    if ((element as KtModifierListOwner).hasModifier(KtTokens.SUSPEND_KEYWORD)) return true
+                    // A non-suspend named function shadows any outer
+                    // suspend context: a call here is in that
+                    // function's body, not the enclosing lambda's.
+                    return false
+                }
+            }
+            element = element.parent
+        }
+        return false
+    }
+}

--- a/examples/external-rule/src/main/resources/META-INF/services/dev.jasonpearson.krit.api.KritRule
+++ b/examples/external-rule/src/main/resources/META-INF/services/dev.jasonpearson.krit.api.KritRule
@@ -1,1 +1,0 @@
-com.example.rules.NoPrintlnRule

--- a/krit-custom-rule-plugin/src/main/kotlin/dev/jasonpearson/krit/custom/KritCustomRulePlugin.kt
+++ b/krit-custom-rule-plugin/src/main/kotlin/dev/jasonpearson/krit/custom/KritCustomRulePlugin.kt
@@ -33,6 +33,18 @@ class KritCustomRulePlugin : Plugin<Project> {
             )
         }
 
+        // PSI types are surfaced on the rule API but provided at
+        // runtime by the krit-types daemon. Consumers must add the
+        // JetBrains intellij-dependencies redirector to settings —
+        // see docs/external-rules.md.
+        project.configurations.named("compileOnly").configure {
+            dependencies.add(
+                project.dependencies.create(
+                    "org.jetbrains.kotlin:kotlin-compiler:$KOTLIN_COMPILER_VERSION",
+                ),
+            )
+        }
+
         val javaExtension = project.extensions.getByType(JavaPluginExtension::class.java)
         val mainSourceSet = javaExtension.sourceSets.getByName(SourceSet.MAIN_SOURCE_SET_NAME)
 
@@ -83,5 +95,9 @@ class KritCustomRulePlugin : Plugin<Project> {
         internal const val MANIFEST_PLUGIN_VERSION = "Krit-Plugin-Version"
         internal const val MANIFEST_VENDOR_ID = "Krit-Vendor-Id"
         internal const val MANIFEST_DEFAULT_SEVERITY = "Krit-Default-Severity"
+
+        // Must track the krit-types daemon's bundled compiler so PSI
+        // classes resolve at runtime.
+        internal const val KOTLIN_COMPILER_VERSION = "2.3.21"
     }
 }

--- a/tests/externalrule/external_rule_test.go
+++ b/tests/externalrule/external_rule_test.go
@@ -346,7 +346,16 @@ func runKrit(t *testing.T, bin, repoRoot string, args ...string) string {
 	cmd := exec.Command(bin, args...)
 	cmd.Dir = repoRoot
 	cmd.Env = os.Environ()
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
 	out, err := cmd.Output()
+	// Always log stderr (even on success) when verbose — daemon-spawn
+	// warnings emitted to stderr by krit are silently consumed by
+	// `cmd.Output` and have hidden CI failures before. Log at the test
+	// level so go test -v carries them into the run log.
+	if stderr.Len() > 0 {
+		t.Logf("krit %v stderr:\n%s", args, stderr.String())
+	}
 	if err != nil {
 		var exitErr *exec.ExitError
 		// Exit code 1 = findings present; surface stdout so the caller
@@ -354,12 +363,8 @@ func runKrit(t *testing.T, bin, repoRoot string, args ...string) string {
 		if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
 			return string(out)
 		}
-		stderr := ""
-		if exitErr != nil {
-			stderr = string(exitErr.Stderr)
-		}
 		t.Fatalf("krit %v: %v\nstderr: %s\nstdout: %s",
-			args, err, stderr, string(out))
+			args, err, stderr.String(), string(out))
 	}
 	return string(out)
 }

--- a/tests/externalrule/external_rule_test.go
+++ b/tests/externalrule/external_rule_test.go
@@ -25,6 +25,15 @@ import (
 const (
 	ruleID              = "example.NoPrintln"
 	expectedPrintlnLine = 5 // samples/.../Greeter.kt: line 5 holds the println(
+
+	// SuspendInNonSuspendLambdaRule fires on doSuspendWork() inside
+	// runRegularBlock { ... } at SuspendMisuse.kt:21. The rule
+	// requires NEEDS_RESOLVER and asks the daemon-backed Resolver
+	// whether the enclosing lambda's parameter type is suspend; on
+	// SuspendOk.kt the parameter is `suspend () -> Unit` so the rule
+	// must NOT fire.
+	suspendRuleID           = "example.SuspendInNonSuspendLambda"
+	expectedSuspendCallLine = 21
 )
 
 func TestExternalRuleExample_EndToEnd(t *testing.T) {
@@ -119,6 +128,66 @@ func TestExternalRuleExample_EndToEnd(t *testing.T) {
 		if positiveLines[0] != expectedPrintlnLine {
 			t.Errorf("expected positive finding on line %d (println call), got line %d",
 				expectedPrintlnLine, positiveLines[0])
+		}
+	})
+
+	t.Run("type-aware rule fires only on positive sample", func(t *testing.T) {
+		// Type-aware sample rule: declared NEEDS_RESOLVER, calls
+		// resolver.isSuspendCall / isLambdaSuspend. The positive
+		// sample has a `suspend` call inside a `() -> Unit` lambda;
+		// the negative has the same call inside a `suspend () -> Unit`
+		// lambda. The resolver must distinguish them — without it,
+		// both fixtures look identical at the AST level.
+		positiveSuspendFile, err := filepath.Abs(filepath.Join(
+			samplesDir, "src", "main", "kotlin", "com", "example", "positive", "SuspendMisuse.kt"))
+		if err != nil {
+			t.Fatalf("absolutize positive suspend sample: %v", err)
+		}
+
+		stdout := runKrit(t, kritBin, repoRoot,
+			"--custom-rule-jars", jarPath,
+			"--daemon",
+			"-f", "json",
+			"--no-cache",
+			"--experimental",
+			"-q",
+			samplesDir,
+		)
+
+		var payload struct {
+			Findings []struct {
+				File string `json:"file"`
+				Line int    `json:"line"`
+				Rule string `json:"rule"`
+			} `json:"findings"`
+		}
+		if err := json.Unmarshal([]byte(stdout), &payload); err != nil {
+			t.Fatalf("invalid JSON output: %v\n--- stdout ---\n%s", err, stdout)
+		}
+
+		var suspendLines []int
+		for _, finding := range payload.Findings {
+			if finding.Rule != suspendRuleID {
+				continue
+			}
+			abs, err := filepath.Abs(finding.File)
+			if err != nil {
+				t.Fatalf("absolutize finding path %q: %v", finding.File, err)
+			}
+			if abs == positiveSuspendFile {
+				suspendLines = append(suspendLines, finding.Line)
+			} else {
+				t.Errorf("unexpected %s finding outside positive sample: %s:%d",
+					suspendRuleID, finding.File, finding.Line)
+			}
+		}
+		if len(suspendLines) != 1 {
+			t.Fatalf("expected exactly 1 %s finding in positive sample, got %d (findings=%+v)",
+				suspendRuleID, len(suspendLines), payload.Findings)
+		}
+		if suspendLines[0] != expectedSuspendCallLine {
+			t.Errorf("expected positive finding on line %d (suspend call), got line %d",
+				expectedSuspendCallLine, suspendLines[0])
 		}
 	})
 

--- a/tools/krit-rule-api/build.gradle.kts
+++ b/tools/krit-rule-api/build.gradle.kts
@@ -15,6 +15,14 @@ version = (findProperty("kritVersion") as String?)
 
 val isSnapshot = version.toString().endsWith("-SNAPSHOT")
 
+val kotlinVersion = "2.3.21"
+
+dependencies {
+    // PSI types are surfaced on the rule API but provided at runtime
+    // by the krit-types daemon — keep them off the published rule jar.
+    compileOnly("org.jetbrains.kotlin:kotlin-compiler:$kotlinVersion")
+}
+
 kotlin {
     jvmToolchain(21)
 }

--- a/tools/krit-rule-api/settings.gradle.kts
+++ b/tools/krit-rule-api/settings.gradle.kts
@@ -3,5 +3,17 @@ rootProject.name = "krit-rule-api"
 dependencyResolutionManagement {
     repositories {
         mavenCentral()
+        // kotlin-compiler-embeddable relocates `com.intellij.*` and
+        // would NoClassDefFoundError at runtime against the daemon's
+        // non-embeddable kotlin-compiler. Pull the same artifact the
+        // daemon links — only available from JetBrains' redirector.
+        exclusiveContent {
+            forRepository {
+                maven("https://redirector.kotlinlang.org/maven/intellij-dependencies")
+            }
+            filter {
+                includeModule("org.jetbrains.kotlin", "kotlin-compiler")
+            }
+        }
     }
 }

--- a/tools/krit-rule-api/src/main/kotlin/dev/jasonpearson/krit/api/KritRule.kt
+++ b/tools/krit-rule-api/src/main/kotlin/dev/jasonpearson/krit/api/KritRule.kt
@@ -1,5 +1,10 @@
 package dev.jasonpearson.krit.api
 
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtExpression
+import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.psi.KtLambdaExpression
+
 /**
  * ServiceLoader entry point implemented by Kotlin-authored Krit rules.
  */
@@ -29,12 +34,60 @@ annotation class KritRuleInfo(
 
 /**
  * Kotlin source file view exposed to custom rules.
+ *
+ * `ktFile` is the Kotlin compiler PSI root for the source. It is `null`
+ * when the daemon could not load the file (e.g. parse errors) or when
+ * the rule was invoked through a path that does not parse Kotlin source.
  */
 class KritFile(
     val path: String,
     val text: String,
-    val ktFile: Any? = null,
+    val ktFile: KtFile? = null,
 )
+
+/**
+ * Narrow, type-aware queries backed by the Kotlin Analysis API.
+ *
+ * Available on [RuleContext.resolver] when the rule declares
+ * [Capability.NEEDS_RESOLVER] and the daemon successfully built a
+ * resolver-backed session for the file. Each method opens (or re-uses)
+ * a Kotlin Analysis API session under the hood; returning typed
+ * primitives avoids leaking JetBrains-internal types onto the rule API
+ * surface, so rule jars do not need to depend on the Analysis API
+ * artifacts directly.
+ *
+ * The bridge methods are intentionally minimal — additions are
+ * source-compatible (default implementations may evolve in minor
+ * releases), but the surface is deliberately small to keep the API
+ * stable. See `docs/external-rules.md` for the long-form contract.
+ */
+interface Resolver {
+    /** Returns true if the call's resolved target is a `suspend` function. */
+    fun isSuspendCall(call: KtCallExpression): Boolean
+
+    /**
+     * Returns the fully-qualified name of the resolved callable target
+     * for [call] (e.g. `kotlinx.coroutines.delay`), or `null` if the
+     * target is unresolved.
+     */
+    fun resolvedCallFqName(call: KtCallExpression): String?
+
+    /**
+     * Returns true when [lambda]'s functional type is a
+     * `kotlin.coroutines.SuspendFunction*` — i.e. the lambda body
+     * itself is treated as a `suspend` block. Returns false when the
+     * lambda's type is unresolved.
+     */
+    fun isLambdaSuspend(lambda: KtLambdaExpression): Boolean
+
+    /**
+     * Returns the rendered fully-qualified type of [expression], or
+     * `null` when the type is unresolved. The exact rendering format is
+     * implementation-defined; prefer this for diagnostic messages, not
+     * for parsing.
+     */
+    fun expressionType(expression: KtExpression): String?
+}
 
 /**
  * Per-invocation context passed to custom rules.
@@ -53,6 +106,12 @@ class KritFile(
 class RuleContext(
     val ruleId: String,
     val config: Map<String, Any?> = emptyMap(),
+    /**
+     * Type-aware queries backed by the Kotlin Analysis API. Non-null
+     * only when the rule declared [Capability.NEEDS_RESOLVER] and the
+     * daemon successfully prepared a session for the current file.
+     */
+    val resolver: Resolver? = null,
 ) {
     /** Returns the [key] option as a String, or [default] if absent / wrong type. */
     fun stringOption(key: String, default: String = ""): String =

--- a/tools/krit-types/src/main/kotlin/dev/jasonpearson/krit/types/PluginRules.kt
+++ b/tools/krit-types/src/main/kotlin/dev/jasonpearson/krit/types/PluginRules.kt
@@ -1,16 +1,35 @@
 package dev.jasonpearson.krit.types
 
+import dev.jasonpearson.krit.api.Capability
 import dev.jasonpearson.krit.api.Finding
 import dev.jasonpearson.krit.api.FixSafety
 import dev.jasonpearson.krit.api.KritFile
 import dev.jasonpearson.krit.api.KritRule
 import dev.jasonpearson.krit.api.KritRuleInfo
+import dev.jasonpearson.krit.api.Resolver
 import dev.jasonpearson.krit.api.RuleContext
 import org.jetbrains.kotlin.analysis.api.KaExperimentalApi
+import org.jetbrains.kotlin.analysis.api.analyze
 import org.jetbrains.kotlin.analysis.api.projectStructure.KaSourceModule
+import org.jetbrains.kotlin.analysis.api.resolution.KaCallableMemberCall
+import org.jetbrains.kotlin.analysis.api.resolution.singleFunctionCallOrNull
+import org.jetbrains.kotlin.analysis.api.resolution.singleVariableAccessCall
+import org.jetbrains.kotlin.analysis.api.resolution.symbol
+import org.jetbrains.kotlin.analysis.api.symbols.KaFunctionSymbol
+import org.jetbrains.kotlin.analysis.api.symbols.KaNamedFunctionSymbol
+import org.jetbrains.kotlin.analysis.api.types.KaClassType
+import org.jetbrains.kotlin.analysis.api.types.KaFunctionType
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtExpression
 import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.psi.KtLabeledExpression
+import org.jetbrains.kotlin.psi.KtLambdaArgument
+import org.jetbrains.kotlin.psi.KtLambdaExpression
+import org.jetbrains.kotlin.psi.KtValueArgument
+import org.jetbrains.kotlin.psi.KtValueArgumentList
 import java.io.File
 import java.net.URLClassLoader
+import java.util.IdentityHashMap
 import java.util.ServiceLoader
 import java.util.jar.JarFile
 
@@ -163,7 +182,12 @@ fun DaemonSession.handleAnalyzeFileWithPlugins(request: DaemonRequest): String {
         for (loaded in PluginRuleRegistry.selected(request.ruleIds)) {
             try {
                 val options = request.ruleConfigs?.get(loaded.descriptor.ruleId).orEmpty()
-                val ctx = RuleContext(loaded.descriptor.ruleId, options)
+                val resolver = if (ktFile != null && loaded.descriptor.needs.contains(Capability.NEEDS_RESOLVER.name)) {
+                    AnalysisApiResolver(ktFile)
+                } else {
+                    null
+                }
+                val ctx = RuleContext(loaded.descriptor.ruleId, options, resolver)
                 for (finding in loaded.rule.check(file, ctx)) {
                     findings.add(toPluginFinding(file.path, loaded.descriptor, finding))
                 }
@@ -175,6 +199,129 @@ fun DaemonSession.handleAnalyzeFileWithPlugins(request: DaemonRequest): String {
     } catch (t: Throwable) {
         """{"id":${request.id},"error":"${escJsonStr(t.message ?: "analyzeFile failed")}"}"""
     }
+}
+
+/**
+ * `Resolver` bridge backed by per-call Kotlin Analysis API sessions,
+ * memoized on the requesting PSI element. Each public method opens
+ * `analyze(ktFile) {}` and swallows KAA exceptions — KAA throws on
+ * half-resolved bodies fairly liberally; bubbling those up would turn
+ * one malformed expression into a whole-rule failure. Mirrors the
+ * resilience pattern used in `analyzeKtFile`'s call resolver.
+ *
+ * Identity-keyed caches avoid re-resolving the same call twice when a
+ * rule asks `isSuspendCall` and then `resolvedCallFqName` on the same
+ * `KtCallExpression`, or asks `isLambdaSuspend` for an outer lambda
+ * once per inner suspend call.
+ */
+private class AnalysisApiResolver(private val ktFile: KtFile) : Resolver {
+    private val callTargetCache = IdentityHashMap<KtCallExpression, CallTarget>()
+    private val lambdaSuspendCache = IdentityHashMap<KtLambdaExpression, Boolean>()
+
+    override fun isSuspendCall(call: KtCallExpression): Boolean =
+        resolveCallTarget(call).isSuspend
+
+    override fun resolvedCallFqName(call: KtCallExpression): String? =
+        resolveCallTarget(call).fqName
+
+    override fun isLambdaSuspend(lambda: KtLambdaExpression): Boolean {
+        if (!lambda.isInModule()) return false
+        lambdaSuspendCache[lambda]?.let { return it }
+        val answer = try {
+            analyze(ktFile) {
+                val call = lambda.enclosingValueCall()
+                if (call != null && callHasSuspendFunctionalParam(call)) return@analyze true
+                // Fall back to the lambda's own inferred type — covers
+                // explicit `suspend { ... }` block expressions whose
+                // inferred type already carries the suspend modifier.
+                val type = lambda.expressionType
+                (type is KaFunctionType) && type.isSuspend
+            }
+        } catch (_: Throwable) {
+            false
+        }
+        lambdaSuspendCache[lambda] = answer
+        return answer
+    }
+
+    @OptIn(KaExperimentalApi::class)
+    override fun expressionType(expression: KtExpression): String? {
+        if (!expression.isInModule()) return null
+        return try {
+            analyze(ktFile) {
+                val type = expression.expressionType ?: return@analyze null
+                (type as? KaClassType)?.classId?.asFqNameString() ?: type.toString()
+            }
+        } catch (_: Throwable) {
+            null
+        }
+    }
+
+    private data class CallTarget(val isSuspend: Boolean, val fqName: String?) {
+        companion object {
+            val UNKNOWN = CallTarget(isSuspend = false, fqName = null)
+        }
+    }
+
+    private fun resolveCallTarget(call: KtCallExpression): CallTarget {
+        if (!call.isInModule()) return CallTarget.UNKNOWN
+        callTargetCache[call]?.let { return it }
+        val target = try {
+            analyze(ktFile) {
+                val callInfo = call.resolveToCall() ?: return@analyze CallTarget.UNKNOWN
+                val callable: KaCallableMemberCall<*, *> =
+                    callInfo.singleFunctionCallOrNull()
+                        ?: callInfo.singleVariableAccessCall()
+                        ?: return@analyze CallTarget.UNKNOWN
+                val symbol = callable.partiallyAppliedSymbol.symbol
+                val suspend = (symbol is KaNamedFunctionSymbol) && symbol.isSuspend
+                val fqn = symbol.callableId?.asSingleFqName()?.asString()
+                CallTarget(suspend, fqn)
+            }
+        } catch (_: Throwable) {
+            CallTarget.UNKNOWN
+        }
+        callTargetCache[call] = target
+        return target
+    }
+
+    // FIR represents a lambda literal passed to a `suspend () -> R`
+    // parameter with the lambda's own type unchanged — the suspend
+    // conversion happens at the argument boundary. Walk up through the
+    // wrapping arg/label/list nodes to find the enclosing call so we
+    // can ask the resolved function symbol whether any value parameter
+    // is a suspend functional type.
+    private fun KtLambdaExpression.enclosingValueCall(): KtCallExpression? {
+        var anc: com.intellij.psi.PsiElement? = parent
+        while (anc != null) {
+            if (anc is KtCallExpression) return anc
+            if (anc !is KtLambdaArgument &&
+                anc !is KtValueArgument &&
+                anc !is KtValueArgumentList &&
+                anc !is KtLabeledExpression
+            ) {
+                return null
+            }
+            anc = anc.parent
+        }
+        return null
+    }
+
+    // Heuristic — single-lambda-parameter calls are unambiguous; calls
+    // with multiple functional parameters where only some are suspend
+    // (rare) will be over-approximated as suspend-allowed. Trading a
+    // small false-negative cost (suspend-in-non-suspend-lambda misses)
+    // for cheap, mapping-independent logic.
+    private fun org.jetbrains.kotlin.analysis.api.KaSession.callHasSuspendFunctionalParam(
+        call: KtCallExpression,
+    ): Boolean {
+        val memberCall = call.resolveToCall()?.singleFunctionCallOrNull() ?: return false
+        val symbol = memberCall.partiallyAppliedSymbol.symbol as? KaFunctionSymbol ?: return false
+        return symbol.valueParameters.any { (it.returnType as? KaFunctionType)?.isSuspend == true }
+    }
+
+    private fun org.jetbrains.kotlin.psi.KtElement.isInModule(): Boolean =
+        containingKtFile === ktFile
 }
 
 @OptIn(KaExperimentalApi::class)


### PR DESCRIPTION
## Summary

Closes #308.

- `KritFile.ktFile` is typed `KtFile?` and `RuleContext.resolver: Resolver?` is non-null when a rule declares `Capability.NEEDS_RESOLVER`. The `Resolver` interface ships four narrow type-aware queries (`isSuspendCall`, `resolvedCallFqName`, `isLambdaSuspend`, `expressionType`) backed by the Kotlin Analysis API in `krit-types`. Identity-keyed memoization avoids re-resolving the same call / lambda across sibling queries.
- The published `krit-rule-api` declares `kotlin-compiler` as `compileOnly` so rules can import PSI types; `krit-custom-rule-plugin` mirrors that on consumer projects. Consumers add the JetBrains intellij-dependencies redirector to settings (the host plugin can't add it when `FAIL_ON_PROJECT_REPOS` is enabled — documented in `docs/external-rules.md`).
- `examples/external-rule` gains a `SuspendInNonSuspendLambdaRule` demonstrating the contract end-to-end, with positive (`SuspendMisuse.kt`) / negative (`SuspendOk.kt`) fixtures. Negative case has the same AST as positive — only the resolver-reported parameter type distinguishes them.

## Test plan

- [x] `go vet ./... && golangci-lint run ./... && go test ./... -short`
- [x] `tools/krit-rule-api`, `krit-custom-rule-plugin`, `examples/external-rule` all build
- [x] Integration test `TestExternalRuleExample_EndToEnd/type-aware_rule_fires_only_on_positive_sample` passes against a freshly-shadowJar'd `krit-types.jar` on JDK 21
- [x] Existing subtests (list-rules, baseline) continue to pass

## API stability

Documented in `docs/external-rules.md`: we intentionally do not expose `KaSession`/`KaSymbol`. The `Resolver` surface will grow source-compatibly; the underlying KAA calls may change between Krit releases without notice.