### PR TITLE
feat(daemon): add Linux fanotify watcher backend with auto-detect

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,36 @@ jobs:
       - name: Integration tests
         run: make integration
 
+  # fanotify exercises the Linux-only watcher backend that needs
+  # CAP_SYS_ADMIN (fanotify_mark) and CAP_DAC_READ_SEARCH
+  # (open_by_handle_at). These tests live behind the
+  # fanotify_integration build tag so `go test ./...` on a developer
+  # laptop stays quiet. The runner is already Linux; we just need to
+  # invoke `go test` under sudo so the test process holds the
+  # required capabilities. /tmp on GHA runners is ext4, which
+  # exports file handles, so FAN_MARK_FILESYSTEM is supported
+  # without the Dockerfile.fanotify tmpfs gymnastics local devs need.
+  fanotify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+      - name: Show kernel + filesystem context
+        run: |
+          uname -a
+          echo "fs of \$TMPDIR (/tmp):"
+          stat -f -c '%T' /tmp || true
+      - name: Run fanotify integration tests
+        # -E preserves the Go env (GOCACHE, GOMODCACHE, etc.) set by
+        # setup-go; PATH is re-exported because sudo strips it by
+        # default even with -E on many distros.
+        run: |
+          sudo -E env "PATH=$PATH" "HOME=$HOME" \
+            go test -tags fanotify_integration -count=1 -v \
+            ./internal/cli/serve/ -run TestFanotify
+
   intellij-plugin:
     runs-on: ubuntu-latest
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to Krit will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- Linux fanotify watcher backend for the daemon: filesystem-wide kernel mark
+  with FAN_REPORT_DFID_NAME + open_by_handle_at path resolution.
+  Auto-selected on Linux when `CAP_SYS_ADMIN` + `CAP_DAC_READ_SEARCH` are
+  available (`setcap cap_sys_admin,cap_dac_read_search+ep $(command -v krit)`),
+  fsnotify otherwise. Skips the per-directory inotify walk on huge repos.
+- `--watch-backend` flag on `krit serve`: `auto` (default), `fsnotify`, or
+  `fanotify`.
+- `docs/perf.md`: catalog of every performance-tuning option, with when to
+  use each and what you give up.
+- `make test-fanotify` Docker target + CI job to exercise the fanotify
+  path on platforms / users without the required capabilities.
+
+### Changed
+- `krit daemon: ready` startup line now reports the resolved watcher
+  backend (`watcher=fsnotify` / `watcher=fanotify` / `watcher=off`).
+
 ## [0.2.0] - 2026-05-11
 
 ### Added

--- a/Dockerfile.fanotify
+++ b/Dockerfile.fanotify
@@ -1,0 +1,32 @@
+# Dockerfile.fanotify — Linux test harness for the fanotify watcher
+# backend. macOS / Windows developers can't exercise fanotify locally
+# because the syscall is Linux-only; this image gives the test suite
+# a kernel that supports FAN_REPORT_DFID_NAME (Linux 5.17+, which
+# Docker Desktop's VM provides out of the box).
+#
+# Usage:
+#   make test-fanotify
+#
+# The container must run with CAP_SYS_ADMIN and an unconfined
+# apparmor profile so fanotify_init / fanotify_mark / open_by_handle_at
+# don't fail with EPERM. The Makefile target sets both.
+
+FROM golang:1.25-bookworm
+
+# fanotify_init with FAN_REPORT_DFID_NAME requires Linux 5.17+ and
+# CAP_SYS_ADMIN; open_by_handle_at additionally needs the kernel to
+# expose /proc/self/fd. Bookworm's base image is fine — we just need
+# Go and a writable workspace.
+WORKDIR /src
+
+# Copy go.mod + go.sum first so dependency download caches across
+# source-only changes.
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+
+# The default entrypoint runs the fanotify-tagged tests. Override
+# with `docker run ... go test ./...` to exercise the full suite
+# from within the same container.
+CMD ["go", "test", "-tags", "fanotify_integration", "-count=1", "-v", "./internal/cli/serve/"]

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test vet lint lint-rules fix schema clean bench integration playground ci regression daemon-verify all install install-completions watch
+.PHONY: build test vet lint lint-rules fix schema clean bench integration playground ci regression daemon-verify test-fanotify all install install-completions watch
 
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
 LDFLAGS = -s -w -X main.version=$(VERSION)
@@ -64,6 +64,27 @@ daemon-verify:
 	go test ./internal/daemon/ -run 'TestCompare|TestDiff' -count=1
 
 ci: build vet test integration regression daemon-verify
+
+# test-fanotify exercises the Linux-only fanotify watcher backend
+# inside a Docker container with CAP_SYS_ADMIN. macOS / Windows
+# developers can't run fanotify locally — this target gives them a
+# kernel that supports FAN_REPORT_DFID_NAME (Linux 5.17+). The
+# --security-opt unconfined arg is needed so the apparmor profile
+# Docker Desktop ships doesn't block fanotify_init.
+#
+# --tmpfs /tmp is critical: Docker's default /tmp is on overlayfs,
+# which doesn't implement the kernel's file-handle export hooks, so
+# FAN_MARK_FILESYSTEM fails with EOPNOTSUPP. tmpfs does export
+# handles, so t.TempDir() (which uses /tmp) lands on a filesystem
+# fanotify can actually mark.
+test-fanotify:
+	docker build -f Dockerfile.fanotify -t krit-fanotify-test .
+	docker run --rm \
+		--cap-add=SYS_ADMIN \
+		--cap-add=DAC_READ_SEARCH \
+		--security-opt apparmor=unconfined \
+		--tmpfs /tmp:exec \
+		krit-fanotify-test
 
 DESTDIR ?=
 

--- a/docs/perf.md
+++ b/docs/perf.md
@@ -1,0 +1,259 @@
+# Performance Tuning
+
+Krit aims to be fast out of the box. This page lists the knobs available for
+people who need to push further — large monorepos, CI tight on wall-clock, or
+laptops on battery. Each option lists what it changes, when it's worth using,
+and what you give up.
+
+If you're unsure where to start, the daemon plus `--diff` covers the vast
+majority of "make my CI faster" asks.
+
+## The single biggest win: run the daemon
+
+Cold `krit .` reparses every file, rebuilds the cross-file index, and warms
+type inference from scratch. That's fine for one-off runs, but in IDEs, pre-
+commit hooks, and CI it adds up.
+
+```bash
+krit serve --root . &       # long-lived process per project root
+krit --daemon .             # uses the running daemon
+```
+
+Subsequent calls reuse the warm parse tree, cross-file index, resolver, and
+library facts. On a 50k-file Kotlin/Android repo this typically takes
+analyze-project from ~3s cold to ~50–150ms warm.
+
+The daemon also keeps an LSP and MCP server in the same process, so editors
+and AI agents share the warm state.
+
+See `--no-daemon` to force the cold path explicitly.
+
+## Filesystem watching
+
+When the daemon is running, it watches the project tree for edits and
+invalidates exactly the cache slots that need rebuilding. Two backends:
+
+| Backend | Platforms | Setup | Best for |
+|---|---|---|---|
+| `fsnotify` (default) | macOS, Linux, Windows | None | All users |
+| `fanotify` | Linux 5.17+ | `setcap` (see below) | Repos with >50k directories |
+
+Default behavior (`--watch-backend auto`):
+
+- On Linux, probe fanotify. If `CAP_SYS_ADMIN` + `CAP_DAC_READ_SEARCH` are
+  available, use it. Otherwise silently fall back to fsnotify.
+- On every other platform, fsnotify.
+
+The daemon prints which backend resolved on its `krit daemon: ready` line.
+
+### Enabling fanotify
+
+fanotify uses a single filesystem-wide kernel mark instead of one inotify
+watch per directory. On repos with tens of thousands of directories this
+avoids hitting the per-user inotify watch limit and skips the recursive walk
+to register every dir.
+
+It requires two Linux capabilities the krit binary doesn't have by default.
+Grant them once:
+
+```bash
+sudo setcap cap_sys_admin,cap_dac_read_search+ep "$(command -v krit)"
+```
+
+Then restart the daemon. The `krit daemon: ready (..., watcher=fanotify)`
+line confirms it took effect. If you ever re-install or upgrade krit, rerun
+the `setcap` command — capabilities don't survive a binary swap.
+
+To force one backend or the other:
+
+```bash
+krit serve --watch-backend fsnotify    # skip the fanotify probe
+krit serve --watch-backend fanotify    # require fanotify; warn on fallback
+```
+
+The explicit `fanotify` value logs a warning on fallback (the user asked for
+it, so a silent fsnotify swap would hide misconfigured caps). Use `auto` if
+you're fine with whichever the system supports.
+
+### When fanotify probably isn't worth it
+
+- Repos under ~10k files. The inotify cost is negligible.
+- Networked / virtual filesystems (NFS, sshfs, virtio-fs). Many don't export
+  file handles, which fanotify needs.
+- CI runners that recreate the worktree per job. The daemon doesn't live
+  long enough to amortize anything.
+
+## Memory limits
+
+### `--max-parse-bytes N`
+
+```bash
+krit serve --max-parse-bytes 2147483648    # 2 GiB cap on resident parse trees
+```
+
+Caps the bytes held by the resident parse-cache. Over the cap, the watcher's
+LRU evicts least-recently-used entries. Reclaimed via `runtime.GC()` after
+each eviction batch.
+
+Default `0` = unbounded. Set this if you've seen the daemon's RSS grow
+without bound on huge repos, or if you're sharing a laptop with other heavy
+processes.
+
+### `--parse-cache-cap-mb N`
+
+Caps the **on-disk** parse-cache size (default 1024 MB; `0` = use config or
+default; negative = unlimited). Independent of `--max-parse-bytes` — that
+one bounds RAM, this one bounds disk.
+
+### `--idle-timeout DURATION`
+
+```bash
+krit serve --idle-timeout 10m      # default 30m, 0 disables
+```
+
+Daemon auto-shuts down after this much time without a request. The next call
+spins it back up with `krit --daemon`. Useful on laptops to avoid keeping a
+warm JVM-attached process alive overnight.
+
+## Limit the work per scan
+
+### `--diff REF` / `--delta REF`
+
+```bash
+krit --diff origin/main .          # findings on lines changed since main
+krit --delta origin/main .         # findings *newly introduced* since main
+```
+
+The best perf knob for PR/CI runs. Krit still analyses changed files but
+skips reporting on untouched ones. Combine with `--daemon` for compounding
+wins.
+
+### `--max-cost TIER`
+
+```bash
+krit --max-cost ast .              # ast or below: trivial + line + ast
+krit --max-cost crossfile .        # ast + crossfile
+krit --max-cost oracle .           # everything except FIR
+```
+
+Rules are tagged by cost class. `--max-cost` excludes everything above the
+given tier. Useful for pre-commit hooks (fast tiers only) or smoke checks
+during development.
+
+Tiers, cheapest to most expensive: `trivial` < `line` < `ast` < `crossfile`
+< `oracle` < `fir`.
+
+### `--j N`
+
+```bash
+krit -j 4 .                        # parallel job count
+```
+
+Defaults to `runtime.NumCPU()`. Lower it if you're sharing the machine; raise
+it if you have headroom and Krit is CPU-bound.
+
+## Disable subsystems for speed
+
+These reduce precision in exchange for time. Off by default; flip when you
+need the throughput more than the accuracy.
+
+### `--no-type-inference`
+
+Skips source-level type inference. Rules that depend on resolved types
+either degrade to AST-only matching or skip entirely. Saves ~10–30% on a
+typical Kotlin scan but suppresses some findings.
+
+### `--no-type-oracle`
+
+Skips the JVM-backed Kotlin Analysis API oracle entirely. Strictly faster
+than `--no-cache-oracle`. Loses precision on rules tagged `NeedsOracle` —
+they're skipped instead of running with degraded data.
+
+### `--no-fir`
+
+Disables the FIR checker pass (separate krit-fir JVM subprocess). FIR is
+opt-in to begin with; use this to override a config that turned it on.
+
+### `--no-fir-daemon`
+
+Forces one-shot mode for the FIR checker — no persistent daemon. Useful for
+hermetic CI runners that won't tolerate stray processes.
+
+## On-disk caches
+
+All caches live under `.krit/` and are safe to delete. Disabling them mostly
+helps debug stale-cache symptoms; the perf cost of an enabled cache is
+near-zero on a warm run.
+
+| Flag | What it disables |
+|---|---|
+| `--no-cache` | Incremental analysis cache (findings reuse) |
+| `--no-parse-cache` | Tree-sitter parse-tree cache |
+| `--no-resource-cache` | Android values-XML ResourceIndex cache |
+| `--no-cross-file-cache` | Cross-file index cache |
+| `--no-cache-oracle` | Incremental oracle cache (forces full JVM run) |
+| `--no-matrix-cache` | Experiment-matrix baseline cache |
+| `--clear-cache` | Delete all caches and exit |
+| `--clear-matrix-cache` | Delete the experiment-matrix baseline cache and exit |
+| `--cache-dir PATH` | Override incremental cache directory |
+| `--store-dir PATH` | Use the unified store-backed cache |
+
+## Profiling
+
+When something's slow and you want a fact instead of a theory:
+
+```bash
+krit --perf .                              # wall-clock timing in output
+krit --perf-rules .                        # plus per-rule ranking (stderr table)
+krit --profile-dispatch .                  # per-file dispatch distribution
+krit --cpuprofile cpu.prof .               # standard pprof CPU profile
+krit --memprofile mem.prof .               # heap profile
+```
+
+Then:
+
+```bash
+go tool pprof -http=:8080 cpu.prof
+go tool pprof -http=:8080 mem.prof
+```
+
+In daemon mode `--cpuprofile` and `--memprofile` profile the daemon process,
+not the short-lived CLI. Pair with `--no-daemon` if you want to profile a
+single in-process run instead.
+
+## Configuration-level perf
+
+Most flags above have config-file equivalents. See `docs/configuration.md`
+for the schema. The most useful for CI tuning:
+
+- `excludes:` — global glob excludes prune files before they reach the
+  dispatcher
+- `rules.<RuleName>.excludes:` — per-rule excludes for noisy spots
+- `strict: true` — drops `NoisinessNoisy` rules globally
+
+## Recommended setups
+
+**Pre-commit hook:** `krit --diff HEAD --max-cost ast --no-fir .`
+
+**PR CI:** `krit --diff origin/main --daemon .`
+
+**Full repo daily lint:** `krit --daemon .` (or no daemon if the runner is
+ephemeral)
+
+**Laptop dev daemon (battery-aware):** `krit serve --idle-timeout 10m
+--max-parse-bytes 2147483648`
+
+**Power-user setup on Linux:** `setcap` as above, then `krit serve` (auto
+picks fanotify).
+
+## When to file a perf issue
+
+If a warm-daemon `analyze-project` takes more than ~300ms on a repo under
+50k files, that's likely a bug. Attach:
+
+- `krit --perf-rules` output
+- `krit --version`
+- Daemon's first line on startup (`krit daemon: ready ...`)
+- A reproducer if possible (or repo size + ratios)
+
+File against [kaeawc/krit](https://github.com/kaeawc/krit/issues).

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/smacker/go-tree-sitter v0.0.0-20240827094217-dd81d9e9be82
 	github.com/zeebo/xxh3 v1.1.0
 	golang.org/x/sync v0.20.0
+	golang.org/x/sys v0.43.0
 	golang.org/x/text v0.37.0
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -40,5 +41,4 @@ require (
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/stretchr/testify v1.10.0 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
-	golang.org/x/sys v0.43.0 // indirect
 )

--- a/internal/cli/serve/serve.go
+++ b/internal/cli/serve/serve.go
@@ -105,6 +105,14 @@ func Run(args []string) int {
 	idleFlag := fs.Duration("idle-timeout", 30*time.Minute, "Auto-shutdown after no request for this duration; 0 disables")
 	maxParseBytesFlag := fs.Int64("max-parse-bytes", 0, "Cap on resident parsed-file bytes; over the cap, LRU entries are evicted. 0 disables")
 	noWatcherFlag := fs.Bool("no-watcher", false, "Disable filesystem watching for cache invalidation")
+	// auto probes fanotify (Linux 5.17+, needs CAP_SYS_ADMIN +
+	// CAP_DAC_READ_SEARCH) and falls back to fsnotify silently
+	// elsewhere. Users on platforms without fanotify, or without the
+	// caps, see no behaviour change; users who run `setcap
+	// cap_sys_admin,cap_dac_read_search+ep /path/to/krit` once
+	// transparently get the faster backend on the next daemon start.
+	// See docs/perf.md for the trade-offs.
+	watchBackendFlag := fs.String("watch-backend", "auto", "Filesystem-watch backend: auto (default; fanotify if available, else fsnotify), fsnotify, or fanotify")
 	// --strict-verify reruns every analyze in-process from cold caches
 	// and fails the response on row-level divergence vs the daemon's
 	// resident path. Doubles per-request CPU; intended for alpha and
@@ -155,15 +163,31 @@ func Run(args []string) int {
 		return 1
 	}
 
+	resolvedBackend := ""
 	if !*noWatcherFlag {
-		if w, err := startFileWatcher(ctx, root, state.workspace, srv.Reporter, withConfigChangeCallback(state.InvalidateConfig)); err != nil {
+		backendKind, ok := parseWatcherBackendKind(*watchBackendFlag)
+		if !ok {
+			fmt.Fprintf(os.Stderr, "krit serve: unknown --watch-backend %q; using auto\n", *watchBackendFlag)
+		}
+		watcherOpts := []watcherOption{
+			withConfigChangeCallback(state.InvalidateConfig),
+			withBackendKind(backendKind),
+		}
+		if w, err := startFileWatcher(ctx, root, state.workspace, srv.Reporter, watcherOpts...); err != nil {
 			fmt.Fprintf(os.Stderr, "krit serve: filesystem watcher disabled: %v\n", err)
 		} else {
 			defer w.Stop()
+			resolvedBackend = w.BackendKind().String()
 		}
 	}
-	fmt.Printf("krit daemon: ready (%d files, %d modules, warm in %.1fs)\n",
-		state.fileCount(), state.moduleCount(), state.warmDuration.Seconds())
+	watcherLine := ""
+	if resolvedBackend != "" {
+		watcherLine = fmt.Sprintf(", watcher=%s", resolvedBackend)
+	} else if *noWatcherFlag {
+		watcherLine = ", watcher=off"
+	}
+	fmt.Printf("krit daemon: ready (%d files, %d modules, warm in %.1fs%s)\n",
+		state.fileCount(), state.moduleCount(), state.warmDuration.Seconds(), watcherLine)
 	srv.Wait()
 	return 0
 }

--- a/internal/cli/serve/watcher.go
+++ b/internal/cli/serve/watcher.go
@@ -8,8 +8,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/fsnotify/fsnotify"
-
 	"github.com/kaeawc/krit/internal/config"
 	"github.com/kaeawc/krit/internal/diag"
 	"github.com/kaeawc/krit/internal/pipeline"
@@ -54,10 +52,14 @@ const defaultDebounceWindow = 50 * time.Millisecond
 // WorkspaceState catches. Errors are logged via a Reporter and never
 // crash the daemon.
 type fileWatcher struct {
-	w        *fsnotify.Watcher
+	w        watcherBackend
 	root     string
 	state    watcherState
 	reporter *diag.Reporter
+	// backendKind records which backend implementation w wraps. Pure
+	// diagnostic — used by the daemon's status verb so operators can
+	// confirm the configured backend is active.
+	backendKind watcherBackendKind
 	// onConfigChange fires when the watcher observes an edit to a
 	// krit.yml / .krit.yml file. Daemon callers wire this to
 	// daemonState.InvalidateConfig so the next analyze-project verb
@@ -103,12 +105,7 @@ func startFileWatcher(ctx context.Context, root string, state *pipeline.Workspac
 }
 
 func startFileWatcherWithState(ctx context.Context, root string, state watcherState, reporter *diag.Reporter, opts ...watcherOption) (*fileWatcher, error) {
-	w, err := fsnotify.NewWatcher()
-	if err != nil {
-		return nil, err
-	}
 	fw := &fileWatcher{
-		w:              w,
 		root:           root,
 		state:          state,
 		reporter:       reporter,
@@ -117,21 +114,36 @@ func startFileWatcherWithState(ctx context.Context, root string, state watcherSt
 		debounce:       make(map[string]*time.Timer),
 		debounceGen:    make(map[string]uint64),
 		debounceWindow: defaultDebounceWindow,
+		backendKind:    kindAuto,
 	}
 	for _, opt := range opts {
 		opt(fw)
 	}
+	w, resolved, err := newWatcherBackend(fw.backendKind, root, reporter)
+	if err != nil {
+		return nil, err
+	}
+	fw.w = w
+	fw.backendKind = resolved
 	// Add the root synchronously so files written directly under it
 	// are caught from t=0. The recursive descent runs in a goroutine —
 	// on a 60k-file repo a sync walk costs multiple seconds, which is
-	// the daemon's first-call latency budget.
-	if err := w.Add(root); err != nil {
-		_ = w.Close()
+	// the daemon's first-call latency budget. For fanotify the first
+	// Add marks the containing filesystem; subsequent Adds during the
+	// recursive walk are no-ops handled inside the backend.
+	if err := fw.w.Add(root); err != nil {
+		_ = fw.w.Close()
 		return nil, err
 	}
 	go fw.populate()
 	go fw.run(ctx)
 	return fw, nil
+}
+
+// withBackendKind selects the watcherBackend implementation. Defaults
+// to kindFsnotify; serve.go wires this from --watch-backend.
+func withBackendKind(k watcherBackendKind) watcherOption {
+	return func(fw *fileWatcher) { fw.backendKind = k }
 }
 
 // populate walks the project tree and registers each directory with
@@ -149,6 +161,13 @@ func (fw *fileWatcher) populate() {
 // walk has finished. Tests that exercise pre-existing subtrees can
 // wait on it; production callers don't need to.
 func (fw *fileWatcher) Ready() <-chan struct{} { return fw.ready }
+
+// BackendKind returns the watcher backend that was actually
+// resolved by the dispatcher. For kindAuto callers this is the
+// only way to tell whether fanotify or fsnotify is live — serve.go
+// logs it at startup so users see whether their setcap setup
+// took effect.
+func (fw *fileWatcher) BackendKind() watcherBackendKind { return fw.backendKind }
 
 // watcherOption tunes startFileWatcher. Variadic so callers without a
 // daemonState (e.g. unit tests of the watcher itself) don't need to
@@ -170,7 +189,9 @@ func withDebounceWindow(d time.Duration) watcherOption {
 // Stop releases the watcher. Safe to call multiple times.
 func (fw *fileWatcher) Stop() {
 	fw.closeOnce.Do(func() {
-		_ = fw.w.Close()
+		if fw.w != nil {
+			_ = fw.w.Close()
+		}
 		<-fw.done
 	})
 }
@@ -179,16 +200,18 @@ func (fw *fileWatcher) Stop() {
 // cancelled.
 func (fw *fileWatcher) run(ctx context.Context) {
 	defer close(fw.done)
+	events := fw.w.Events()
+	errs := fw.w.Errors()
 	for {
 		select {
 		case <-ctx.Done():
 			return
-		case event, ok := <-fw.w.Events:
+		case event, ok := <-events:
 			if !ok {
 				return
 			}
 			fw.handle(event)
-		case err, ok := <-fw.w.Errors:
+		case err, ok := <-errs:
 			if !ok {
 				return
 			}
@@ -197,17 +220,18 @@ func (fw *fileWatcher) run(ctx context.Context) {
 	}
 }
 
-// handle dispatches a single fsnotify event. Newly created
+// handle dispatches a single normalized backendEvent. Newly created
 // directories get a fresh watch so additions in subtrees don't slip
-// past; .kt/.kts file events invalidate the per-file parse cache and
-// the cross-file CodeIndex; Gradle / version-catalog edits also
-// invalidate the cached LibraryFacts since they describe the
+// past (fsnotify only — fanotify's filesystem mark catches them
+// automatically); .kt/.kts file events invalidate the per-file parse
+// cache and the cross-file CodeIndex; Gradle / version-catalog edits
+// also invalidate the cached LibraryFacts since they describe the
 // project's dependency closure.
-func (fw *fileWatcher) handle(ev fsnotify.Event) {
-	if ev.Op&fsnotify.Create != 0 {
-		if info, err := os.Stat(ev.Name); err == nil && info.IsDir() {
-			if err := fw.addRecursive(ev.Name); err != nil {
-				fw.warn("watch new dir %s: %v\n", ev.Name, err)
+func (fw *fileWatcher) handle(ev backendEvent) {
+	if ev.Op&opCreate != 0 {
+		if info, err := os.Stat(ev.Path); err == nil && info.IsDir() {
+			if err := fw.addRecursive(ev.Path); err != nil {
+				fw.warn("watch new dir %s: %v\n", ev.Path, err)
 			}
 			return
 		}
@@ -225,7 +249,7 @@ func (fw *fileWatcher) handle(ev fsnotify.Event) {
 	// Drop Chmod entirely: content-changing edits always also emit
 	// Write, Create, Remove, or Rename (modern editors' atomic-save
 	// dance is rename+create, never bare chmod).
-	relevant := ev.Op & (fsnotify.Write | fsnotify.Create | fsnotify.Remove | fsnotify.Rename)
+	relevant := ev.Op & (opWrite | opCreate | opRemove | opRename)
 	if relevant == 0 {
 		return
 	}
@@ -233,56 +257,56 @@ func (fw *fileWatcher) handle(ev fsnotify.Event) {
 	// isKotlinPath because of its extension, but it drives library
 	// facts, not the per-file parse cache.
 	switch {
-	case isKritConfigPath(ev.Name):
+	case isKritConfigPath(ev.Path):
 		// krit.yml / .krit.yml drives rule selection. The cached
 		// config on the daemon is now stale; the next analyze-project
 		// call rebuilds.
 		if fw.onConfigChange != nil {
 			fw.onConfigChange()
 		}
-		fw.state.Touch(ev.Name)
-	case isLibraryConfigPath(ev.Name):
+		fw.state.Touch(ev.Path)
+	case isLibraryConfigPath(ev.Path):
 		fw.state.InvalidateLibraryFacts()
 		fw.state.InvalidateCodeIndex()
 		fw.state.InvalidateDependents()
 		// Touch the path so daemon verbs reporting "files changed
 		// since last analyze" see Gradle/version-catalog edits.
-		fw.state.Touch(ev.Name)
+		fw.state.Touch(ev.Path)
 		// Gradle files contribute to the bundle manifest's
 		// FileStats sweep, so any change invalidates the
 		// stats-clean memo just like a .kt edit.
 		fw.state.BumpSourceMTimeVersion()
-	case isKotlinPath(ev.Name):
+	case isKotlinPath(ev.Path):
 		// Editors emit Write+Write+Chmod on a single logical save.
 		// Coalesce within debounceWindow so only one Invalidate+Touch
 		// fires per burst — the dirty-set's map semantics already dedup
 		// Touch, but Invalidate and CodeIndex drops are not free.
-		fw.scheduleKotlinInvalidate(ev.Name)
-	case isJavaPath(ev.Name):
+		fw.scheduleKotlinInvalidate(ev.Path)
+	case isJavaPath(ev.Path):
 		// .java edits invalidate the daemon-resident
 		// javafacts.SourceIndex cache. Kotlin and Java live on
 		// separate version counters so a Kotlin edit doesn't
 		// needlessly invalidate the Java source index (which is
 		// expensive to rebuild: ~100 ms of content hashing).
-		fw.state.Invalidate(ev.Name)
+		fw.state.Invalidate(ev.Path)
 		fw.state.InvalidateCodeIndex()
 		fw.state.InvalidateDependents()
 		fw.state.InvalidateResolver()
 		fw.state.InvalidateOracleFilter()
-		fw.state.Touch(ev.Name)
+		fw.state.Touch(ev.Path)
 		fw.state.BumpSourceMTimeVersion()
 		fw.state.BumpJavaSourceVersion()
-	case isXMLPath(ev.Name):
+	case isXMLPath(ev.Path):
 		// .xml edits (layouts/manifests/navigation) contribute to
 		// CodeIndex reference data, so drop the same downstream
 		// slots a .kt/.java edit drops AND rotate the dedicated
 		// XML version counter. Kotlin/Java edits don't move XML
 		// hashes so the counter stays independent — same shape
 		// as the .java case above.
-		fw.state.Invalidate(ev.Name)
+		fw.state.Invalidate(ev.Path)
 		fw.state.InvalidateCodeIndex()
 		fw.state.InvalidateDependents()
-		fw.state.Touch(ev.Name)
+		fw.state.Touch(ev.Path)
 		fw.state.BumpSourceMTimeVersion()
 		fw.state.BumpXMLFilesVersion()
 	}

--- a/internal/cli/serve/watcher_backend.go
+++ b/internal/cli/serve/watcher_backend.go
@@ -1,0 +1,99 @@
+package serve
+
+// watcherBackend abstracts the OS-level filesystem-watching primitive
+// the daemon uses. The default backend wraps fsnotify (inotify on
+// Linux, kqueue on macOS, ReadDirectoryChangesW on Windows); a Linux-
+// only fanotify backend (filesystem-wide marks + FID resolution) is
+// available behind a build tag and selected via --watch-backend.
+//
+// All backends emit the same backendEvent stream. Path classification
+// and debouncing live in fileWatcher; backends only normalize
+// platform events into a uniform shape.
+type watcherBackend interface {
+	// Add registers a watch on path. For directory-based backends
+	// (fsnotify) this watches just that directory and is called
+	// repeatedly during the recursive descent. For filesystem-wide
+	// backends (fanotify) the first Add marks the containing
+	// filesystem and subsequent calls are no-ops — path filtering
+	// happens in the event loop.
+	Add(path string) error
+	// Close releases the backend's resources. After Close, both
+	// Events and Errors are eventually closed by the backend.
+	Close() error
+	// Events streams normalized change notifications. Backends should
+	// drop or coalesce events they consider noise (e.g. fanotify
+	// FAN_OPEN) before forwarding.
+	Events() <-chan backendEvent
+	// Errors streams non-fatal backend errors. The watcher logs them
+	// via diag.Reporter but does not terminate on receipt.
+	Errors() <-chan error
+}
+
+// backendOp is a bitmask of change kinds a backend observed. The set
+// is the union of what fsnotify and fanotify can report; backends
+// translate native ops into these values. Chmod is included for
+// fidelity with fsnotify but the watcher drops Chmod-only events as
+// documented in fileWatcher.handle.
+type backendOp uint32
+
+const (
+	opCreate backendOp = 1 << iota
+	opWrite
+	opRemove
+	opRename
+	opChmod
+)
+
+// backendEvent is a single normalized change notification. Path is
+// absolute and cleaned by the backend.
+type backendEvent struct {
+	Path string
+	Op   backendOp
+}
+
+// watcherBackendKind selects which backend to construct.
+//
+//   - kindAuto (default): try fanotify on Linux and fall back to
+//     fsnotify silently when caps are missing. The right choice for
+//     almost every user — power users who set up CAP_SYS_ADMIN +
+//     CAP_DAC_READ_SEARCH (see docs/perf.md) transparently get the
+//     fanotify path; everyone else stays on fsnotify with no warning.
+//   - kindFsnotify: force fsnotify. Skips the fanotify probe entirely.
+//   - kindFanotify: force fanotify. The dispatcher still falls back if
+//     init fails, but logs a Warn so misconfigured caps are visible.
+type watcherBackendKind int
+
+const (
+	kindAuto watcherBackendKind = iota
+	kindFsnotify
+	kindFanotify
+)
+
+// String renders the kind for diagnostics and the --watch-backend
+// flag's help text.
+func (k watcherBackendKind) String() string {
+	switch k {
+	case kindAuto:
+		return "auto"
+	case kindFanotify:
+		return "fanotify"
+	default:
+		return "fsnotify"
+	}
+}
+
+// parseWatcherBackendKind maps the CLI flag value to a kind. Unknown
+// strings collapse to kindAuto so a typo in startup args doesn't fail
+// the daemon — the warning is logged at construction time.
+func parseWatcherBackendKind(s string) (watcherBackendKind, bool) {
+	switch s {
+	case "", "auto":
+		return kindAuto, true
+	case "fsnotify":
+		return kindFsnotify, true
+	case "fanotify":
+		return kindFanotify, true
+	default:
+		return kindAuto, false
+	}
+}

--- a/internal/cli/serve/watcher_dispatch.go
+++ b/internal/cli/serve/watcher_dispatch.go
@@ -1,0 +1,41 @@
+package serve
+
+import "github.com/kaeawc/krit/internal/diag"
+
+// newWatcherBackend constructs the watcherBackend named by kind and
+// returns the kind that was actually resolved (callers log this so
+// users can see whether auto-detect picked fanotify or fsnotify).
+//
+// Resolution rules:
+//
+//   - kindAuto: probe fanotify first. On Linux with CAP_SYS_ADMIN +
+//     CAP_DAC_READ_SEARCH this succeeds and we get the kernel-side-
+//     filtered backend. Everywhere else (Linux without caps, darwin,
+//     windows) fanotify init returns errFanotifyUnsupported and we
+//     fall back to fsnotify silently — auto is the default for
+//     most users so we don't want a per-startup warning.
+//   - kindFsnotify: skip the fanotify probe entirely.
+//   - kindFanotify: try fanotify; if init fails, warn loudly through
+//     the reporter and fall back to fsnotify. The user explicitly
+//     asked for fanotify, so a quiet fallback would hide a real
+//     misconfiguration.
+//
+// Defaulting to a working backend on every failure path keeps the
+// daemon safe against startup-arg typos, missing caps, and platform
+// mismatch all at once.
+func newWatcherBackend(kind watcherBackendKind, root string, reporter *diag.Reporter) (watcherBackend, watcherBackendKind, error) {
+	if kind == kindAuto || kind == kindFanotify {
+		b, err := newFanotifyBackend(root)
+		if err == nil {
+			return b, kindFanotify, nil
+		}
+		if kind == kindFanotify && reporter != nil {
+			reporter.Warnf("watch backend fanotify unavailable (%v); falling back to fsnotify", err)
+		}
+	}
+	b, err := newFsnotifyBackend()
+	if err != nil {
+		return nil, kindFsnotify, err
+	}
+	return b, kindFsnotify, nil
+}

--- a/internal/cli/serve/watcher_fanotify_linux.go
+++ b/internal/cli/serve/watcher_fanotify_linux.go
@@ -93,7 +93,7 @@ func newFanotifyBackend(root string) (watcherBackend, error) {
 	if err := unix.FanotifyMark(fd, markFlags, mask, unix.AT_FDCWD, rootAbs); err != nil {
 		_ = unix.Close(fd)
 		if errors.Is(err, syscall.EINVAL) || errors.Is(err, syscall.ENOSYS) || errors.Is(err, syscall.EPERM) {
-			return nil, fmt.Errorf("%w: %v", errFanotifyUnsupported, err)
+			return nil, fmt.Errorf("%w: %w", errFanotifyUnsupported, err)
 		}
 		return nil, fmt.Errorf("fanotify_mark %s: %w", rootAbs, err)
 	}
@@ -443,4 +443,3 @@ func opFromFanotifyMask(mask uint64) backendOp {
 	}
 	return op
 }
-

--- a/internal/cli/serve/watcher_fanotify_linux.go
+++ b/internal/cli/serve/watcher_fanotify_linux.go
@@ -1,0 +1,446 @@
+//go:build linux
+
+package serve
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+// errFanotifyUnsupported is returned when the kernel rejects
+// fanotify_init with the flags this backend needs. The dispatcher
+// logs and falls back to fsnotify.
+var errFanotifyUnsupported = errors.New("fanotify backend unsupported by this kernel")
+
+// fanotifyBackend marks the filesystem containing root with a single
+// FAN_MARK_FILESYSTEM mark and reports file-level CREATE / MODIFY /
+// DELETE / MOVE events as backendEvents whose Path is rooted at
+// rootAbs. The kernel sees every event on the filesystem (this is
+// the efficiency win versus the per-directory inotify watches that
+// fsnotify uses); the backend filters down to events whose resolved
+// path is under root.
+//
+// Event reporting relies on FAN_REPORT_DFID_NAME (Linux 5.17+): each
+// event arrives without an fd and instead carries the parent
+// directory's file_handle plus the entry name. We resolve via
+// open_by_handle_at + readlink /proc/self/fd/N. Falls back with
+// errFanotifyUnsupported on older kernels so the dispatcher can use
+// fsnotify.
+//
+// Threading model: the read goroutine owns fd + mountFd. Close
+// signals via the self-pipe wakeFd so the blocking poll returns
+// promptly without depending on the kernel to wake threads sleeping
+// on a closed fd (it doesn't, reliably).
+type fanotifyBackend struct {
+	fd      int
+	mountFd int
+	rootAbs string
+	// rootPrefix is rootAbs + filepath.Separator, precomputed once
+	// so underRoot's hot-path filter doesn't call filepath.Clean on
+	// every event. Paths from resolveDFIDName are already cleaned
+	// via filepath.Join, so a HasPrefix is the only check needed.
+	rootPrefix string
+
+	// wakeFd[0] is the read end the goroutine polls; wakeFd[1] is the
+	// write end Close() pings to break out of poll(). Non-blocking on
+	// both ends so a stuck reader / writer can never deadlock teardown.
+	wakeFd [2]int
+
+	events chan backendEvent
+	errors chan error
+
+	closeOnce sync.Once
+	closed    atomic.Bool
+	done      chan struct{}
+}
+
+// newFanotifyBackend initializes fanotify with FAN_REPORT_DFID_NAME +
+// FAN_NONBLOCK, marks the filesystem containing root, and starts the
+// read goroutine. Returns errFanotifyUnsupported if the kernel doesn't
+// understand the report flags or refuses the mark with EPERM (which
+// happens without CAP_SYS_ADMIN).
+func newFanotifyBackend(root string) (watcherBackend, error) {
+	rootAbs, err := filepath.Abs(root)
+	if err != nil {
+		return nil, fmt.Errorf("fanotify: resolve root: %w", err)
+	}
+	rootAbs = filepath.Clean(rootAbs)
+
+	initFlags := uint(unix.FAN_CLASS_NOTIF | unix.FAN_REPORT_DFID_NAME | unix.FAN_NONBLOCK | unix.FAN_CLOEXEC)
+	fd, err := unix.FanotifyInit(initFlags, uint(unix.O_RDONLY|unix.O_CLOEXEC|unix.O_LARGEFILE))
+	if err != nil {
+		if errors.Is(err, syscall.EINVAL) || errors.Is(err, syscall.ENOSYS) {
+			return nil, errFanotifyUnsupported
+		}
+		if errors.Is(err, syscall.EPERM) {
+			return nil, fmt.Errorf("%w: need CAP_SYS_ADMIN", errFanotifyUnsupported)
+		}
+		return nil, fmt.Errorf("fanotify_init: %w", err)
+	}
+
+	mask := uint64(unix.FAN_CREATE | unix.FAN_MODIFY | unix.FAN_DELETE |
+		unix.FAN_MOVED_FROM | unix.FAN_MOVED_TO | unix.FAN_ONDIR)
+	markFlags := uint(unix.FAN_MARK_ADD | unix.FAN_MARK_FILESYSTEM)
+	if err := unix.FanotifyMark(fd, markFlags, mask, unix.AT_FDCWD, rootAbs); err != nil {
+		_ = unix.Close(fd)
+		if errors.Is(err, syscall.EINVAL) || errors.Is(err, syscall.ENOSYS) || errors.Is(err, syscall.EPERM) {
+			return nil, fmt.Errorf("%w: %v", errFanotifyUnsupported, err)
+		}
+		return nil, fmt.Errorf("fanotify_mark %s: %w", rootAbs, err)
+	}
+
+	// mountFd is the "anchor" handle for open_by_handle_at. Any fd on
+	// the same mount works; the root dir is the obvious choice. We
+	// open as a real RDONLY directory rather than O_PATH because
+	// some kernels reject O_PATH fds as the mount_fd argument with
+	// EBADF.
+	mountFd, err := unix.Open(rootAbs, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC, 0)
+	if err != nil {
+		_ = unix.Close(fd)
+		return nil, fmt.Errorf("fanotify: open root %s: %w", rootAbs, err)
+	}
+
+	wake := [2]int{}
+	if err := unix.Pipe2(wake[:], unix.O_NONBLOCK|unix.O_CLOEXEC); err != nil {
+		_ = unix.Close(fd)
+		_ = unix.Close(mountFd)
+		return nil, fmt.Errorf("fanotify: self-pipe: %w", err)
+	}
+
+	b := &fanotifyBackend{
+		fd:         fd,
+		mountFd:    mountFd,
+		rootAbs:    rootAbs,
+		rootPrefix: rootAbs + string(filepath.Separator),
+		wakeFd:     wake,
+		// 64 is sized for burst tolerance: editors like JetBrains
+		// and VS Code can emit ~30 events in a single save dance.
+		// fsnotify uses 16; fanotify needs more headroom because
+		// FAN_MARK_FILESYSTEM also sees mount-wide noise that the
+		// underRoot filter drops, but only after the kernel has
+		// already delivered it to userspace.
+		events: make(chan backendEvent, 64),
+		errors: make(chan error, 4),
+		done:   make(chan struct{}),
+	}
+	go b.read()
+	return b, nil
+}
+
+// Add is a no-op for fanotify: the filesystem mark already covers
+// every directory under the root. Returning nil keeps the recursive-
+// walk caller in fileWatcher happy without special-casing the
+// backend kind in the watcher core.
+func (b *fanotifyBackend) Add(string) error { return nil }
+
+func (b *fanotifyBackend) Close() error {
+	var ret error
+	b.closeOnce.Do(func() {
+		b.closed.Store(true)
+		// Wake the poll() loop so the goroutine can exit before we
+		// close the fanotify fd. A single byte is enough — the read
+		// loop just needs to know to re-check closed.
+		_, _ = unix.Write(b.wakeFd[1], []byte{0})
+		<-b.done
+		if err := unix.Close(b.fd); err != nil {
+			ret = err
+		}
+		_ = unix.Close(b.mountFd)
+		_ = unix.Close(b.wakeFd[0])
+		_ = unix.Close(b.wakeFd[1])
+	})
+	return ret
+}
+
+func (b *fanotifyBackend) Events() <-chan backendEvent { return b.events }
+func (b *fanotifyBackend) Errors() <-chan error        { return b.errors }
+
+// read is the goroutine that drains the fanotify fd. It blocks in
+// poll() until either the fanotify fd has data or the self-pipe is
+// pinged by Close(). When data is available we read as much as the
+// kernel will give us and parse a stream of fanotify_event_metadata
+// records.
+func (b *fanotifyBackend) read() {
+	defer close(b.done)
+	defer close(b.events)
+	defer close(b.errors)
+
+	buf := make([]byte, 16*1024)
+	pfds := []unix.PollFd{
+		{Fd: int32(b.fd), Events: unix.POLLIN},
+		{Fd: int32(b.wakeFd[0]), Events: unix.POLLIN},
+	}
+	for {
+		if b.closed.Load() {
+			return
+		}
+		// -1 timeout = block until ready. We don't need a periodic
+		// wakeup because Close() pings the self-pipe.
+		if _, err := unix.Poll(pfds, -1); err != nil {
+			if errors.Is(err, syscall.EINTR) {
+				continue
+			}
+			b.errors <- fmt.Errorf("fanotify poll: %w", err)
+			return
+		}
+		if pfds[1].Revents&unix.POLLIN != 0 || b.closed.Load() {
+			// Drain the pipe so a future Close() write doesn't fill
+			// the kernel buffer — defensive; one byte usually.
+			var sink [16]byte
+			for {
+				if _, err := unix.Read(b.wakeFd[0], sink[:]); err != nil {
+					break
+				}
+			}
+			return
+		}
+		if pfds[0].Revents&unix.POLLIN == 0 {
+			continue
+		}
+		n, err := unix.Read(b.fd, buf)
+		if err != nil {
+			if errors.Is(err, syscall.EAGAIN) || errors.Is(err, syscall.EWOULDBLOCK) {
+				continue
+			}
+			if errors.Is(err, syscall.EBADF) {
+				return
+			}
+			b.errors <- fmt.Errorf("fanotify read: %w", err)
+			continue
+		}
+		if n <= 0 {
+			continue
+		}
+		b.parseBatch(buf[:n])
+	}
+}
+
+// fanotify_event_metadata layout (matches FAN_EVENT_METADATA_LEN = 24):
+//
+//	__u32 event_len;     // 0..4   total bytes including info records
+//	__u8  vers;          // 4
+//	__u8  reserved;      // 5
+//	__u16 metadata_len;  // 6..8
+//	__u64 mask;          // 8..16  aligned
+//	__s32 fd;            // 16..20 FAN_NOFD with FAN_REPORT_*
+//	__s32 pid;           // 20..24
+const fanMetaSize = 24
+
+// parseBatch walks one buffer worth of fanotify events. Each record
+// is event_len bytes; bad lengths or truncated records break us out
+// of the buffer to avoid feeding garbage to open_by_handle_at.
+//
+// FAN_Q_OVERFLOW is checked first because the kernel emits it with
+// fd=FAN_NOFD and no info records — passing it through handleEvent
+// would silently drop it. Surfacing through diag() turns a class of
+// missed-event bugs into a visible diagnostic; the watcher's mtime
+// sweep (see fileWatcher.sweepOnce equivalents) is the recovery
+// mechanism.
+func (b *fanotifyBackend) parseBatch(buf []byte) {
+	for len(buf) >= fanMetaSize {
+		eventLen := binary.LittleEndian.Uint32(buf[0:4])
+		if eventLen < fanMetaSize || int(eventLen) > len(buf) {
+			return
+		}
+		metaLen := binary.LittleEndian.Uint16(buf[6:8])
+		mask := binary.LittleEndian.Uint64(buf[8:16])
+		if mask&unix.FAN_Q_OVERFLOW != 0 {
+			b.diag("event queue overflow — kernel dropped events; some cache invalidations may be missed")
+			buf = buf[eventLen:]
+			continue
+		}
+		if metaLen < fanMetaSize || uint32(metaLen) > eventLen {
+			buf = buf[eventLen:]
+			continue
+		}
+		info := buf[metaLen:eventLen]
+		b.handleEvent(mask, info)
+		buf = buf[eventLen:]
+	}
+}
+
+// fanotify_event_info_header is 4 bytes:
+//
+//	__u8  info_type;  // FAN_EVENT_INFO_TYPE_*
+//	__u8  pad;
+//	__u16 len;        // total bytes including header
+const fanInfoHeaderSize = 4
+
+// handleEvent extracts the DFID_NAME info record from one event's
+// trailing bytes, resolves it to an absolute path under rootAbs, and
+// pushes a backendEvent. Events without a usable DFID_NAME record
+// are dropped — they're either FID-only (older kernel report
+// shape) or events on the mount root itself, neither of which the
+// daemon cares about.
+func (b *fanotifyBackend) handleEvent(mask uint64, info []byte) {
+	sawDFID := false
+	for len(info) >= fanInfoHeaderSize {
+		infoType := info[0]
+		recLen := binary.LittleEndian.Uint16(info[2:4])
+		if recLen < fanInfoHeaderSize || int(recLen) > len(info) {
+			return
+		}
+		rec := info[:recLen]
+		info = info[recLen:]
+		if infoType != unix.FAN_EVENT_INFO_TYPE_DFID_NAME &&
+			infoType != unix.FAN_EVENT_INFO_TYPE_NEW_DFID_NAME &&
+			infoType != unix.FAN_EVENT_INFO_TYPE_OLD_DFID_NAME {
+			b.diag("info_type %d skipped (len=%d)", infoType, recLen)
+			continue
+		}
+		sawDFID = true
+		path, ok := b.resolveDFIDName(rec)
+		if !ok {
+			continue
+		}
+		if !b.underRoot(path) {
+			b.diag("event outside root: %s", path)
+			continue
+		}
+		b.events <- backendEvent{Path: path, Op: opFromFanotifyMask(mask)}
+	}
+	if !sawDFID {
+		b.diag("event mask=0x%x had no DFID_NAME record (len=%d)", mask, len(info))
+	}
+}
+
+// diag emits a non-fatal diagnostic to the errors channel. Used
+// when an event arrives in a shape the parser can't make sense of —
+// surfaces unparseable events to the integration test rather than
+// silently dropping them. Drops if the errors channel is full so a
+// flood can't deadlock the read goroutine.
+func (b *fanotifyBackend) diag(format string, args ...any) {
+	select {
+	case b.errors <- fmt.Errorf("fanotify: "+format, args...):
+	default:
+	}
+}
+
+// resolveDFIDName parses a FAN_EVENT_INFO_TYPE_DFID_NAME record and
+// resolves the contained directory file_handle + name to an absolute
+// path via open_by_handle_at + /proc/self/fd readlink.
+//
+// Record layout after the 4-byte header:
+//
+//	__kernel_fsid_t fsid;        // 8 bytes (two int32)
+//	struct file_handle {
+//	    __u32 handle_bytes;
+//	    int   handle_type;
+//	    unsigned char f_handle[handle_bytes];
+//	}
+//	char name[];                 // null-terminated, padded to align
+func (b *fanotifyBackend) resolveDFIDName(rec []byte) (string, bool) {
+	const fsidSize = 8
+	if len(rec) < fanInfoHeaderSize+fsidSize+8 {
+		return "", false
+	}
+	off := fanInfoHeaderSize + fsidSize
+	handleBytes := binary.LittleEndian.Uint32(rec[off : off+4])
+	handleType := int32(binary.LittleEndian.Uint32(rec[off+4 : off+8]))
+	off += 8
+	if off+int(handleBytes) > len(rec) {
+		return "", false
+	}
+	// NewFileHandle copies handle bytes into its own buffer, so we
+	// pass the slice directly — no need for an intermediate copy.
+	handleData := rec[off : off+int(handleBytes)]
+	off += int(handleBytes)
+
+	// Name follows the handle data, null-terminated.
+	name := ""
+	if off < len(rec) {
+		end := off
+		for end < len(rec) && rec[end] != 0 {
+			end++
+		}
+		name = string(rec[off:end])
+	}
+
+	fh := unix.NewFileHandle(handleType, handleData)
+	dirFd, err := unix.OpenByHandleAt(b.mountFd, fh, unix.O_PATH|unix.O_CLOEXEC)
+	if err != nil {
+		// ESTALE: the directory was unlinked between event emission
+		// and resolution. EACCES / EPERM happen in containers with
+		// stricter security — both are recoverable: drop the event,
+		// next analyze rehashes from disk anyway.
+		b.diag("open_by_handle_at: %v (handle_bytes=%d type=%d name=%q)", err, handleBytes, handleType, name)
+		return "", false
+	}
+	defer unix.Close(dirFd)
+
+	dirPath, err := readlinkFd(dirFd)
+	if err != nil || dirPath == "" {
+		return "", false
+	}
+	if name == "" || name == "." {
+		return filepath.Clean(dirPath), true
+	}
+	return filepath.Join(dirPath, name), true
+}
+
+// readlinkFd reads /proc/self/fd/<fd> to recover the canonical path
+// of an open directory fd. We grow the buffer until the kernel
+// reports it isn't truncated. A bare PATH_MAX-sized buffer would do
+// in practice but the slight cost of one Readlink retry on the rare
+// long-path case beats a hard-coded ceiling.
+func readlinkFd(fd int) (string, error) {
+	link := "/proc/self/fd/" + strconv.Itoa(fd)
+	buf := make([]byte, 256)
+	for {
+		n, err := unix.Readlink(link, buf)
+		if err != nil {
+			return "", err
+		}
+		if n < len(buf) {
+			return string(buf[:n]), nil
+		}
+		buf = make([]byte, len(buf)*2)
+	}
+}
+
+// underRoot reports whether path is inside the watched root. Because
+// FAN_MARK_FILESYSTEM gives us every event on the mount, the backend
+// must filter — otherwise editing an unrelated file on the same
+// volume would invalidate Krit's caches. Paths reaching this
+// function are already cleaned (resolveDFIDName uses filepath.Join /
+// filepath.Clean), so the hot path skips a redundant Clean.
+func (b *fanotifyBackend) underRoot(path string) bool {
+	if path == b.rootAbs {
+		return true
+	}
+	return strings.HasPrefix(path, b.rootPrefix)
+}
+
+// opFromFanotifyMask translates the FAN_* mask into our backendOp
+// bitmask. The watcher's handle() treats Create and Write
+// interchangeably for invalidation, but keeping the distinction lets
+// the new-directory addRecursive branch fire correctly on FAN_CREATE
+// for a fresh directory. Even though fanotify's filesystem mark
+// already covers the new directory, the watcher's existing code
+// path stays uniform.
+func opFromFanotifyMask(mask uint64) backendOp {
+	var op backendOp
+	if mask&unix.FAN_CREATE != 0 || mask&unix.FAN_MOVED_TO != 0 {
+		op |= opCreate
+	}
+	if mask&unix.FAN_MODIFY != 0 {
+		op |= opWrite
+	}
+	if mask&unix.FAN_DELETE != 0 || mask&unix.FAN_MOVED_FROM != 0 {
+		op |= opRemove
+	}
+	if mask&(unix.FAN_MOVED_FROM|unix.FAN_MOVED_TO) != 0 {
+		op |= opRename
+	}
+	return op
+}
+

--- a/internal/cli/serve/watcher_fanotify_linux_test.go
+++ b/internal/cli/serve/watcher_fanotify_linux_test.go
@@ -1,0 +1,136 @@
+//go:build linux && fanotify_integration
+
+package serve
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// fanotify_integration is a build tag set only by the Docker test
+// harness (see Dockerfile.fanotify). The test needs CAP_SYS_ADMIN
+// plus a recent kernel — neither is available in the normal `go
+// test ./...` path, so the tag keeps `make test` quiet on developer
+// laptops while letting CI / docker-run pick it up explicitly.
+//
+// The test exercises the real fanotify backend end-to-end: mark the
+// filesystem, fsync a new .kt file, assert the backend reports its
+// path. Path resolution via open_by_handle_at is exercised
+// implicitly — without it the backendEvent.Path would be empty.
+
+func TestFanotifyBackend_CreateAndModify(t *testing.T) {
+	root := t.TempDir()
+	b, err := newFanotifyBackend(root)
+	if err != nil {
+		t.Skipf("fanotify backend unavailable: %v", err)
+	}
+	defer b.Close()
+
+	path := filepath.Join(root, "Foo.kt")
+	// Briefly let the mark settle. The kernel marks the filesystem
+	// synchronously inside FanotifyMark, but the read goroutine
+	// hasn't necessarily entered poll() yet; 10 ms is enough.
+	time.Sleep(10 * time.Millisecond)
+	if err := os.WriteFile(path, []byte("package x\n"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	got := drainPath(t, b.Events(), path, 2*time.Second)
+	if got.Path != path {
+		t.Fatalf("Path: got %q, want %q", got.Path, path)
+	}
+	if got.Op&(opCreate|opWrite) == 0 {
+		t.Fatalf("Op: got %d, want opCreate or opWrite bit", got.Op)
+	}
+}
+
+func TestFanotifyBackend_FiltersOutsideRoot(t *testing.T) {
+	root := t.TempDir()
+	other := t.TempDir()
+	b, err := newFanotifyBackend(root)
+	if err != nil {
+		t.Skipf("fanotify backend unavailable: %v", err)
+	}
+	defer b.Close()
+
+	time.Sleep(10 * time.Millisecond)
+	// Editing a file outside the watched root must not produce an
+	// event. fanotify's filesystem-wide mark sees it; the backend's
+	// underRoot filter drops it.
+	if err := os.WriteFile(filepath.Join(other, "noise.kt"), []byte("noise"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	// Then a file inside root we *do* expect.
+	want := filepath.Join(root, "Signal.kt")
+	if err := os.WriteFile(want, []byte("signal"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	got := drainPath(t, b.Events(), want, 2*time.Second)
+	if got.Path != want {
+		t.Fatalf("Path: got %q, want %q", got.Path, want)
+	}
+}
+
+// TestFanotifyBackend_AnyEventDelivery is a smoke test that gates
+// on the kernel's ability to deliver fanotify events at all,
+// regardless of path resolution. If this fails the more specific
+// tests above are guaranteed to fail too — debug this first.
+//
+// Reaches into the backend's raw byte stream by replacing the
+// resolved channel with one that admits the unfiltered backendEvent
+// emitted from handleEvent. If the test times out, the issue is
+// either (a) the kernel isn't delivering events on the mount, or
+// (b) open_by_handle_at is failing — see errors channel.
+func TestFanotifyBackend_AnyEventDelivery(t *testing.T) {
+	root := t.TempDir()
+	b, err := newFanotifyBackend(root)
+	if err != nil {
+		t.Skipf("fanotify backend unavailable: %v", err)
+	}
+	fb := b.(*fanotifyBackend)
+	defer fb.Close()
+
+	time.Sleep(20 * time.Millisecond)
+	path := filepath.Join(root, "Probe.kt")
+	if err := os.WriteFile(path, []byte("x"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	deadline := time.NewTimer(2 * time.Second)
+	defer deadline.Stop()
+	for {
+		select {
+		case ev := <-fb.Events():
+			t.Logf("event: path=%q op=%d", ev.Path, ev.Op)
+			return
+		case err := <-fb.Errors():
+			t.Logf("error: %v", err)
+		case <-deadline.C:
+			t.Fatalf("no events at all after 2s")
+		}
+	}
+}
+
+// drainPath consumes events from ch until one matches target's path
+// or the deadline elapses. Lets the test ignore unrelated events
+// the kernel might emit on the same mount (cache invalidations,
+// directory mtime bumps, etc.) without flaking.
+func drainPath(t *testing.T, ch <-chan backendEvent, target string, deadline time.Duration) backendEvent {
+	t.Helper()
+	timer := time.NewTimer(deadline)
+	defer timer.Stop()
+	for {
+		select {
+		case ev := <-ch:
+			if ev.Path == target {
+				return ev
+			}
+		case <-timer.C:
+			t.Fatalf("timeout waiting for event on %s", target)
+			return backendEvent{}
+		}
+	}
+}

--- a/internal/cli/serve/watcher_fanotify_other.go
+++ b/internal/cli/serve/watcher_fanotify_other.go
@@ -1,0 +1,17 @@
+//go:build !linux
+
+package serve
+
+import "errors"
+
+// errFanotifyUnsupported is returned on non-Linux platforms when the
+// caller requests the fanotify backend. The dispatcher logs and
+// falls back to fsnotify, so this is a soft failure.
+var errFanotifyUnsupported = errors.New("fanotify backend is Linux-only")
+
+// newFanotifyBackend stubs the linux-only implementation. On darwin/
+// windows/etc this always errors so the dispatcher falls back to
+// fsnotify; the error is emitted via diag.Reporter.Warnf at startup.
+func newFanotifyBackend(string) (watcherBackend, error) {
+	return nil, errFanotifyUnsupported
+}

--- a/internal/cli/serve/watcher_fsnotify.go
+++ b/internal/cli/serve/watcher_fsnotify.go
@@ -1,0 +1,102 @@
+package serve
+
+import (
+	"github.com/fsnotify/fsnotify"
+)
+
+// fsnotifyBackend adapts *fsnotify.Watcher to watcherBackend. The
+// translation is mechanical — fsnotify already gives us a per-
+// directory model with a unified Op bitmask, so the adapter just
+// renames ops and forwards events through a buffered channel sized
+// to fsnotify's own buffer (10 events) so we don't add a stall point.
+type fsnotifyBackend struct {
+	w      *fsnotify.Watcher
+	events chan backendEvent
+	errors chan error
+	done   chan struct{}
+}
+
+// newFsnotifyBackend wraps a fresh fsnotify.Watcher and starts the
+// translation goroutine. Returns the bare error from fsnotify on
+// platforms without inotify/kqueue.
+func newFsnotifyBackend() (watcherBackend, error) {
+	w, err := fsnotify.NewWatcher()
+	if err != nil {
+		return nil, err
+	}
+	b := &fsnotifyBackend{
+		w:      w,
+		events: make(chan backendEvent, 16),
+		errors: make(chan error, 4),
+		done:   make(chan struct{}),
+	}
+	go b.translate()
+	return b, nil
+}
+
+func (b *fsnotifyBackend) Add(path string) error { return b.w.Add(path) }
+
+func (b *fsnotifyBackend) Close() error {
+	err := b.w.Close()
+	<-b.done
+	return err
+}
+
+func (b *fsnotifyBackend) Events() <-chan backendEvent { return b.events }
+func (b *fsnotifyBackend) Errors() <-chan error        { return b.errors }
+
+// translate forwards fsnotify events through our normalized channel,
+// converting the fsnotify.Op bitmask to backendOp. The goroutine
+// exits when fsnotify closes both its Events and Errors channels —
+// fsnotify.Watcher.Close() guarantees this ordering.
+func (b *fsnotifyBackend) translate() {
+	defer close(b.done)
+	defer close(b.events)
+	defer close(b.errors)
+	for {
+		select {
+		case ev, ok := <-b.w.Events:
+			if !ok {
+				// Drain errors before exiting so the daemon doesn't
+				// lose a final teardown diagnostic.
+				for err := range b.w.Errors {
+					b.errors <- err
+				}
+				return
+			}
+			b.events <- backendEvent{Path: ev.Name, Op: fsnotifyOp(ev.Op)}
+		case err, ok := <-b.w.Errors:
+			if !ok {
+				for ev := range b.w.Events {
+					b.events <- backendEvent{Path: ev.Name, Op: fsnotifyOp(ev.Op)}
+				}
+				return
+			}
+			b.errors <- err
+		}
+	}
+}
+
+// fsnotifyOp translates an fsnotify.Op bitmask to backendOp. The two
+// ops have the same shape (bitmask, multi-flag) so this is a direct
+// mapping. Any future fsnotify ops not listed here are dropped — the
+// watcher doesn't care about them today.
+func fsnotifyOp(op fsnotify.Op) backendOp {
+	var out backendOp
+	if op&fsnotify.Create != 0 {
+		out |= opCreate
+	}
+	if op&fsnotify.Write != 0 {
+		out |= opWrite
+	}
+	if op&fsnotify.Remove != 0 {
+		out |= opRemove
+	}
+	if op&fsnotify.Rename != 0 {
+		out |= opRename
+	}
+	if op&fsnotify.Chmod != 0 {
+		out |= opChmod
+	}
+	return out
+}

--- a/internal/cli/serve/watcher_test.go
+++ b/internal/cli/serve/watcher_test.go
@@ -8,15 +8,17 @@ import (
 	"testing"
 	"time"
 
-	"github.com/fsnotify/fsnotify"
-
 	"github.com/kaeawc/krit/internal/librarymodel"
 	"github.com/kaeawc/krit/internal/pipeline"
 	"github.com/kaeawc/krit/internal/scanner"
 )
 
-func fsnotifyEventChmod(path string) fsnotify.Event {
-	return fsnotify.Event{Name: path, Op: fsnotify.Chmod}
+// chmodEvent constructs a normalized backendEvent with only the Chmod
+// bit set. Used by tests covering the dropped-on-purpose Chmod path —
+// fsnotify on macOS emits spurious chmods that the watcher must
+// ignore so unrelated cache slots don't churn.
+func chmodEvent(path string) backendEvent {
+	return backendEvent{Path: path, Op: opChmod}
 }
 
 // countingState is a watcherState fake that counts Invalidate calls
@@ -398,7 +400,7 @@ func TestFileWatcher_DebounceEditorSavePattern(t *testing.T) {
 	defer w.Stop()
 	<-w.Ready()
 
-	ev := fsnotify.Event{Name: ktPath, Op: fsnotify.Write}
+	ev := backendEvent{Path: ktPath, Op: opWrite}
 	for range 3 {
 		w.handle(ev)
 	}
@@ -523,8 +525,8 @@ func TestFileWatcher_IgnoresChmodOnlyEvents(t *testing.T) {
 	// Inject a Chmod-only event directly through handle() — going
 	// through os.Chmod would also trigger a Stat() that on some
 	// platforms emits Write, defeating the test's purpose.
-	w.handle(fsnotifyEventChmod(gradlePath))
-	w.handle(fsnotifyEventChmod(ktPath))
+	w.handle(chmodEvent(gradlePath))
+	w.handle(chmodEvent(ktPath))
 	time.Sleep(20 * time.Millisecond)
 
 	if got := state.libraryFactsInvalidations.Load(); got != 0 {


### PR DESCRIPTION
## Summary

- Adds a `watcherBackend` interface in front of the daemon's file watcher and a Linux fanotify implementation (`FAN_MARK_FILESYSTEM` + `FAN_REPORT_DFID_NAME` + `open_by_handle_at`) alongside the existing fsnotify path. One kernel-side filesystem mark replaces the per-directory inotify walk — meaningful for repos with tens of thousands of directories.
- New `--watch-backend` flag with `auto` (default), `fsnotify`, `fanotify`. `auto` probes fanotify on Linux and falls back silently to fsnotify when `CAP_SYS_ADMIN` + `CAP_DAC_READ_SEARCH` are missing. Explicit `--watch-backend fanotify` warns on fallback so misconfigured caps are visible.
- `krit daemon: ready` line now reports the resolved backend (`watcher=fsnotify` / `watcher=fanotify` / `watcher=off`).
- `Dockerfile.fanotify` + `make test-fanotify` give non-Linux developers a privileged container to exercise the syscall path.
- New `fanotify` CI job runs the `fanotify_integration`-tagged tests under sudo on `ubuntu-latest`.
- `docs/perf.md` catalogues the full perf-tuning surface: daemon mode, watch backends (with the `setcap` one-liner), memory caps, cost tiers, caches, profiling.

Closes #209.

## How users adopt fanotify

```bash
sudo setcap cap_sys_admin,cap_dac_read_search+ep "$(command -v krit)"
```

Then restart the daemon — `krit daemon: ready (..., watcher=fanotify)` confirms it took effect. No flag changes needed; `auto` picks it up.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `golangci-lint run ./...` clean on macOS
- [x] `go test ./... -count=1` green on macOS
- [x] `make test-fanotify` green in Docker locally (3 fanotify integration tests pass)
- [x] New `fanotify` CI job exercises the syscall path on `ubuntu-latest` under sudo
- [ ] Verify CI passes end-to-end after push