### PR TITLE
refactor(ctx): finish ctx plumbing for ParseCtx callers + cancellation surfacing

### DIFF
--- a/internal/android/manifest.go
+++ b/internal/android/manifest.go
@@ -2,6 +2,7 @@
 package android
 
 import (
+	"context"
 	"encoding/xml"
 	"fmt"
 	"os"
@@ -165,7 +166,7 @@ func ParseManifestBytes(data []byte) (*Manifest, error) {
 	if err := xml.Unmarshal(data, &m); err != nil {
 		return nil, fmt.Errorf("parsing manifest XML: %w", err)
 	}
-	root, err := ParseXMLAST(data)
+	root, err := ParseXMLAST(context.Background(), data)
 	if err != nil {
 		return nil, fmt.Errorf("parsing manifest tree-sitter AST: %w", err)
 	}

--- a/internal/android/resources.go
+++ b/internal/android/resources.go
@@ -774,7 +774,7 @@ func (idx *ResourceIndex) scanDrawableDir(dir string, maxWorkers int) {
 }
 
 func (idx *ResourceIndex) parseDrawableSelectorBytes(path, resName string, data []byte) {
-	root, err := ParseXMLAST(data)
+	root, err := ParseXMLAST(context.Background(), data)
 	if err != nil || root == nil || root.Tag != "selector" {
 		return
 	}
@@ -804,7 +804,7 @@ func (idx *ResourceIndex) parseDrawableSelectorBytes(path, resName string, data 
 }
 
 func parseLayoutBytes(data []byte) (*Layout, error) {
-	rootNode, err := ParseXMLAST(data)
+	rootNode, err := ParseXMLAST(context.Background(), data)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/android/xml_parse_cache_test.go
+++ b/internal/android/xml_parse_cache_test.go
@@ -53,7 +53,7 @@ func TestXMLParseCache_RoundTrip(t *testing.T) {
 	data := largeManifest()
 
 	// Cold parse populates the cache.
-	freshRoot, err := ParseXMLAST(data)
+	freshRoot, err := ParseXMLAST(t.Context(), data)
 	if err != nil {
 		t.Fatalf("fresh ParseXMLAST: %v", err)
 	}
@@ -65,7 +65,7 @@ func TestXMLParseCache_RoundTrip(t *testing.T) {
 	}
 
 	// Warm parse should hit.
-	cachedRoot, err := ParseXMLAST(data)
+	cachedRoot, err := ParseXMLAST(t.Context(), data)
 	if err != nil {
 		t.Fatalf("warm ParseXMLAST: %v", err)
 	}
@@ -116,10 +116,10 @@ func TestXMLParseCache_SkipsSmallFiles(t *testing.T) {
 	SetActiveXMLParseCache(pc)
 
 	small := []byte(`<root><a/></root>`)
-	if _, err := ParseXMLAST(small); err != nil {
+	if _, err := ParseXMLAST(t.Context(), small); err != nil {
 		t.Fatalf("ParseXMLAST: %v", err)
 	}
-	if _, err := ParseXMLAST(small); err != nil {
+	if _, err := ParseXMLAST(t.Context(), small); err != nil {
 		t.Fatalf("ParseXMLAST: %v", err)
 	}
 
@@ -208,7 +208,7 @@ func TestXMLParseCache_GrammarMismatchForcesMiss(t *testing.T) {
 	SetActiveXMLParseCache(pc)
 
 	data := largeManifest()
-	if _, err := ParseXMLAST(data); err != nil {
+	if _, err := ParseXMLAST(t.Context(), data); err != nil {
 		t.Fatalf("ParseXMLAST: %v", err)
 	}
 	if err := pc.Close(); err != nil {
@@ -296,7 +296,7 @@ func TestXMLParseCache_ClearViaRegistry(t *testing.T) {
 	SetActiveXMLParseCache(pc)
 
 	data := largeManifest()
-	if _, err := ParseXMLAST(data); err != nil {
+	if _, err := ParseXMLAST(t.Context(), data); err != nil {
 		t.Fatalf("ParseXMLAST: %v", err)
 	}
 	if err := pc.Close(); err != nil {

--- a/internal/android/xmlast.go
+++ b/internal/android/xmlast.go
@@ -69,7 +69,7 @@ func (n *XMLNode) ChildrenByTag(tag string) []*XMLNode {
 	return out
 }
 
-func ParseXMLAST(data []byte) (*XMLNode, error) {
+func ParseXMLAST(ctx context.Context, data []byte) (*XMLNode, error) {
 	pc := activeXMLParseCache.Load()
 	if cached, ok := pc.Load(data); ok {
 		return cached, nil
@@ -78,7 +78,7 @@ func ParseXMLAST(data []byte) (*XMLNode, error) {
 	parser := xmlParserPool.Get().(*sitter.Parser)
 	defer xmlParserPool.Put(parser)
 
-	tree, err := parser.ParseCtx(context.Background(), nil, data)
+	tree, err := parser.ParseCtx(ctx, nil, data)
 	if err != nil {
 		return nil, fmt.Errorf("parse xml: %w", err)
 	}

--- a/internal/android/xmlast_test.go
+++ b/internal/android/xmlast_test.go
@@ -10,7 +10,7 @@ func TestParseXMLAST_ManifestFixture(t *testing.T) {
     </application>
 </manifest>`)
 
-	root, err := ParseXMLAST(data)
+	root, err := ParseXMLAST(t.Context(), data)
 	if err != nil {
 		t.Fatalf("ParseXMLAST failed: %v", err)
 	}
@@ -48,7 +48,7 @@ func TestParseXMLAST_ManifestFixture(t *testing.T) {
 }
 
 func TestParseXMLAST_EmptyInput(t *testing.T) {
-	_, err := ParseXMLAST([]byte{})
+	_, err := ParseXMLAST(t.Context(), []byte{})
 	if err == nil {
 		t.Fatal("expected error for empty input")
 	}
@@ -62,7 +62,7 @@ func TestParseXMLAST_ChildrenByTag(t *testing.T) {
   <other name="x"/>
 </root>`)
 
-	root, err := ParseXMLAST(data)
+	root, err := ParseXMLAST(t.Context(), data)
 	if err != nil {
 		t.Fatalf("ParseXMLAST failed: %v", err)
 	}
@@ -85,7 +85,7 @@ func TestParseXMLAST_ChildrenByTag(t *testing.T) {
 
 func TestParseXMLAST_MissingAttr(t *testing.T) {
 	data := []byte(`<root attr="val"/>`)
-	root, err := ParseXMLAST(data)
+	root, err := ParseXMLAST(t.Context(), data)
 	if err != nil {
 		t.Fatalf("ParseXMLAST failed: %v", err)
 	}
@@ -96,7 +96,7 @@ func TestParseXMLAST_MissingAttr(t *testing.T) {
 
 func TestParseXMLAST_ChildByTag_NotFound(t *testing.T) {
 	data := []byte(`<root><child/></root>`)
-	root, err := ParseXMLAST(data)
+	root, err := ParseXMLAST(t.Context(), data)
 	if err != nil {
 		t.Fatalf("ParseXMLAST failed: %v", err)
 	}
@@ -114,7 +114,7 @@ func TestParseXMLAST_NestedElements(t *testing.T) {
   </b>
 </a>`)
 
-	root, err := ParseXMLAST(data)
+	root, err := ParseXMLAST(t.Context(), data)
 	if err != nil {
 		t.Fatalf("ParseXMLAST failed: %v", err)
 	}
@@ -141,7 +141,7 @@ func TestParseXMLAST_NestedElements(t *testing.T) {
 func TestParseXMLAST_TextContent(t *testing.T) {
 	data := []byte(`<root><message>Hello World</message></root>`)
 
-	root, err := ParseXMLAST(data)
+	root, err := ParseXMLAST(t.Context(), data)
 	if err != nil {
 		t.Fatalf("ParseXMLAST failed: %v", err)
 	}

--- a/internal/cli/abihash/abihash.go
+++ b/internal/cli/abihash/abihash.go
@@ -111,7 +111,7 @@ func resolveAbiHashTarget(target string) ([]*scanner.File, error) {
 		if err != nil {
 			return nil, err
 		}
-		graph, err := module.DiscoverModules(root)
+		graph, err := module.DiscoverModules(context.Background(), root)
 		if err != nil {
 			return nil, fmt.Errorf("discovering modules: %w", err)
 		}

--- a/internal/cli/api/api.go
+++ b/internal/cli/api/api.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"os"
@@ -19,7 +20,7 @@ func resolveModuleSurface(modulePath string) ([]arch.APIEntry, error) {
 	if err != nil {
 		return nil, err
 	}
-	graph, err := module.DiscoverModules(scanRoot)
+	graph, err := module.DiscoverModules(context.Background(), scanRoot)
 	if err != nil {
 		return nil, fmt.Errorf("discovering modules: %w", err)
 	}

--- a/internal/cli/applysuggestion/applysuggestion.go
+++ b/internal/cli/applysuggestion/applysuggestion.go
@@ -17,6 +17,7 @@ package applysuggestion
 
 import (
 	"bufio"
+	"context"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -108,7 +109,7 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	}
 
 	cols := buildFindingColumns(finding, sug, edits)
-	applied, _, errs := fixer.ApplyAllFixesColumns(&cols, "")
+	applied, _, errs := fixer.ApplyAllFixesColumns(context.Background(), &cols, "")
 	for _, e := range errs {
 		fmt.Fprintf(stderr, "apply-suggestion: %v\n", e)
 	}

--- a/internal/cli/applysuggestion/applysuggestion_test.go
+++ b/internal/cli/applysuggestion/applysuggestion_test.go
@@ -303,7 +303,7 @@ func TestFix_doesNotApplySuggestedEdits(t *testing.T) {
 		// No Fix slot: suggested fix is not an autofix.
 	}}
 	cols := scanner.CollectFindings(findings)
-	applied, modified, errs := fixer.ApplyAllFixesColumns(&cols, "")
+	applied, modified, errs := fixer.ApplyAllFixesColumns(t.Context(), &cols, "")
 	if len(errs) > 0 {
 		t.Fatalf("unexpected errors: %v", errs)
 	}

--- a/internal/cli/blastradius/blastradius.go
+++ b/internal/cli/blastradius/blastradius.go
@@ -97,7 +97,7 @@ func Analyze(root, base string) (Report, error) {
 		return Report{}, errs[0]
 	}
 	index := scanner.BuildIndex(files, runtime.NumCPU())
-	graph, _ := module.DiscoverModules(root)
+	graph, _ := module.DiscoverModules(context.Background(), root)
 	if graph == nil {
 		graph = module.NewModuleGraph(root)
 	}

--- a/internal/cli/digraph/digraph.go
+++ b/internal/cli/digraph/digraph.go
@@ -34,7 +34,7 @@ func Run(args []string) int {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		return 1
 	}
-	moduleGraph, err := module.DiscoverModules(root)
+	moduleGraph, err := module.DiscoverModules(context.Background(), root)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: discover modules: %v\n", err)
 		return 1

--- a/internal/cli/gen/gen.go
+++ b/internal/cli/gen/gen.go
@@ -86,7 +86,7 @@ type TestFileSummary struct {
 }
 
 func BuildModuleReadmeSummary(root, modulePath string) (ModuleReadmeSummary, error) {
-	graph, err := module.DiscoverModules(root)
+	graph, err := module.DiscoverModules(context.Background(), root)
 	if err != nil {
 		return ModuleReadmeSummary{}, fmt.Errorf("discovering modules: %w", err)
 	}

--- a/internal/cli/graphexport/graph.go
+++ b/internal/cli/graphexport/graph.go
@@ -86,7 +86,7 @@ type moduleInfo struct {
 }
 
 func renderGraph(root, format string) (string, error) {
-	graph, err := module.DiscoverModules(root)
+	graph, err := module.DiscoverModules(context.Background(), root)
 	if err != nil {
 		return "", fmt.Errorf("discovering modules: %w", err)
 	}

--- a/internal/cli/impact/impact.go
+++ b/internal/cli/impact/impact.go
@@ -108,7 +108,7 @@ func Run(args []string) int {
 	idx := scanner.BuildIndex(files, runtime.NumCPU())
 
 	hits := computeImpact(idx, changed)
-	graph, _ := module.DiscoverModules(root)
+	graph, _ := module.DiscoverModules(context.Background(), root)
 	return emitImpact(*jsonFlag, root, changed, hits, graph)
 }
 

--- a/internal/cli/scan/remove_dead_code.go
+++ b/internal/cli/scan/remove_dead_code.go
@@ -1,6 +1,7 @@
 package scan
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -27,7 +28,7 @@ func RunDeadCodeRemovalColumns(columns *scanner.FindingColumns, format string, d
 		})
 	}
 
-	result := plan.Apply(suffix)
+	result := plan.Apply(context.Background(), suffix)
 	appliedSummary := summary
 	appliedSummary.Declarations = result.Declarations
 	appliedSummary.Files = result.Files

--- a/internal/cli/scan/slo.go
+++ b/internal/cli/scan/slo.go
@@ -1,6 +1,7 @@
 package scan
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -50,7 +51,7 @@ func discoverSLOGraph(paths []string) *module.Graph {
 	if err == nil && !info.IsDir() {
 		root = filepath.Dir(root)
 	}
-	graph, err := module.DiscoverModules(root)
+	graph, err := module.DiscoverModules(context.Background(), root)
 	if err != nil {
 		return nil
 	}

--- a/internal/cli/scorecard/scorecard.go
+++ b/internal/cli/scorecard/scorecard.go
@@ -59,7 +59,7 @@ func Build(paths []string, configPath string) ([]Row, error) {
 	if err != nil {
 		return nil, err
 	}
-	graph, err := module.DiscoverModules(root)
+	graph, err := module.DiscoverModules(context.Background(), root)
 	if err != nil {
 		return nil, fmt.Errorf("discovering modules: %w", err)
 	}

--- a/internal/cli/serve/serve.go
+++ b/internal/cli/serve/serve.go
@@ -655,7 +655,7 @@ func (s *daemonState) closeAndroidCacheWriter() {
 }
 
 func (s *daemonState) warm() error {
-	graph, err := module.DiscoverModules(s.root)
+	graph, err := module.DiscoverModules(context.Background(), s.root)
 	if err != nil {
 		return fmt.Errorf("discovering modules: %w", err)
 	}

--- a/internal/cli/transform/transform.go
+++ b/internal/cli/transform/transform.go
@@ -1,6 +1,7 @@
 package transform
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -29,7 +30,7 @@ func Run(args []string) int {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		return 1
 	}
-	result, err := codemod.Run(root, recipe, opts.apply)
+	result, err := codemod.Run(context.Background(), root, recipe, opts.apply)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		return 1

--- a/internal/cli/usedsymbols/usedsymbols.go
+++ b/internal/cli/usedsymbols/usedsymbols.go
@@ -52,7 +52,7 @@ func runUsedSymbolsModule(modulePath string, asJSON bool) int {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		return 1
 	}
-	graph, err := module.DiscoverModules(root)
+	graph, err := module.DiscoverModules(context.Background(), root)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "discovering modules: %v\n", err)
 		return 1

--- a/internal/codemod/engine.go
+++ b/internal/codemod/engine.go
@@ -29,7 +29,7 @@ type Result struct {
 	Edits         []Edit
 }
 
-func Run(root string, recipe Recipe, apply bool) (Result, error) {
+func Run(ctx context.Context, root string, recipe Recipe, apply bool) (Result, error) {
 	paths, err := sourceFiles(root, recipe.Language)
 	if err != nil {
 		return Result{}, err
@@ -37,7 +37,7 @@ func Run(root string, recipe Recipe, apply bool) (Result, error) {
 	var all []Edit
 	matchedFiles := make(map[string]bool)
 	for _, path := range paths {
-		edits, err := EditsForFile(path, recipe)
+		edits, err := EditsForFile(ctx, path, recipe)
 		if err != nil {
 			return Result{}, err
 		}
@@ -58,7 +58,7 @@ func Run(root string, recipe Recipe, apply bool) (Result, error) {
 	return result, nil
 }
 
-func EditsForFile(path string, recipe Recipe) ([]Edit, error) {
+func EditsForFile(ctx context.Context, path string, recipe Recipe) ([]Edit, error) {
 	content, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
@@ -74,7 +74,7 @@ func EditsForFile(path string, recipe Recipe) ([]Edit, error) {
 	defer query.Close()
 	parser := sitter.NewParser()
 	parser.SetLanguage(lang)
-	tree, err := parser.ParseCtx(context.Background(), nil, content)
+	tree, err := parser.ParseCtx(ctx, nil, content)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/codemod/engine_test.go
+++ b/internal/codemod/engine_test.go
@@ -28,14 +28,14 @@ fun log() {
 		Match:       `((simple_identifier) @match (#eq? @match "Timber"))`,
 		Replacement: "logger",
 	}
-	dry, err := Run(root, recipe, false)
+	dry, err := Run(t.Context(), root, recipe, false)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if dry.Matches != 1 || dry.EditsApplied != 0 {
 		t.Fatalf("dry run = %+v, want one unapplied match", dry)
 	}
-	applied, err := Run(root, recipe, true)
+	applied, err := Run(t.Context(), root, recipe, true)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/deadcode/project.go
+++ b/internal/deadcode/project.go
@@ -90,7 +90,7 @@ func AnalyzeProject(scanRoot string, opts ProjectOptions) ([]ProjectFinding, err
 }
 
 func buildProjectIndex(scanRoot string, paths []string, workers int) (*module.Graph, *scanner.CodeIndex, map[string]*scanner.File, error) {
-	graph, _ := module.DiscoverModules(scanRoot)
+	graph, _ := module.DiscoverModules(context.Background(), scanRoot)
 	if graph != nil {
 		_ = module.ParseAllDependencies(graph)
 	}

--- a/internal/deadcode/removal.go
+++ b/internal/deadcode/removal.go
@@ -1,6 +1,7 @@
 package deadcode
 
 import (
+	"context"
 	"fmt"
 	"regexp"
 	"sort"
@@ -170,12 +171,12 @@ func (p Plan) Summary() Summary {
 }
 
 // Apply runs the plan through the shared fix engine.
-func (p Plan) Apply(suffix string) ApplyResult {
+func (p Plan) Apply(ctx context.Context, suffix string) ApplyResult {
 	if p.candidateColumns.Len() == 0 {
 		return ApplyResult{}
 	}
 
-	declarations, files, errors := fixer.ApplyAllFixesColumns(&p.candidateColumns, suffix)
+	declarations, files, errors := fixer.ApplyAllFixesColumns(ctx, &p.candidateColumns, suffix)
 	return ApplyResult{
 		Declarations: declarations,
 		Files:        files,

--- a/internal/deadcode/removal_test.go
+++ b/internal/deadcode/removal_test.go
@@ -133,7 +133,7 @@ func TestApplyUsesSharedFixEngine(t *testing.T) {
 		},
 	})
 
-	result := plan.Apply("")
+	result := plan.Apply(t.Context(), "")
 	if len(result.Errors) > 0 {
 		t.Fatalf("unexpected apply errors: %v", result.Errors)
 	}
@@ -187,7 +187,7 @@ func TestBuildPlanColumnsApplyKeepsColumnarFixState(t *testing.T) {
 		t.Fatalf("expected 1 candidate, got %d", len(plan.Candidates))
 	}
 
-	result := plan.Apply("")
+	result := plan.Apply(t.Context(), "")
 	if len(result.Errors) > 0 {
 		t.Fatalf("unexpected apply errors: %v", result.Errors)
 	}

--- a/internal/di/graph_test.go
+++ b/internal/di/graph_test.go
@@ -36,7 +36,7 @@ class Router @Inject constructor(
 @Singleton
 class Api @Inject constructor()`)
 
-	moduleGraph, err := module.DiscoverModules(root)
+	moduleGraph, err := module.DiscoverModules(t.Context(), root)
 	if err != nil {
 		t.Fatalf("DiscoverModules: %v", err)
 	}

--- a/internal/fixer/benchmark_test.go
+++ b/internal/fixer/benchmark_test.go
@@ -41,7 +41,7 @@ func BenchmarkApplyFixes_ByteMode_Single(b *testing.B) {
 				ByteMode:    true,
 			}),
 		}
-		_, err := ApplyFixes(path, findings, ".fixed")
+		_, err := ApplyFixes(b.Context(), path, findings, ".fixed")
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -59,7 +59,7 @@ func BenchmarkApplyFixes_ByteMode_Multiple(b *testing.B) {
 			benchFinding(path, &scanner.Fix{StartByte: 34, EndByte: 39, Replacement: "w = 40", ByteMode: true}),
 			benchFinding(path, &scanner.Fix{StartByte: 44, EndByte: 49, Replacement: "v = 50", ByteMode: true}),
 		}
-		_, err := ApplyFixes(path, findings, ".fixed")
+		_, err := ApplyFixes(b.Context(), path, findings, ".fixed")
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -77,7 +77,7 @@ func BenchmarkApplyFixes_LineMode_Single(b *testing.B) {
 				Replacement: "val x = 42",
 			}),
 		}
-		_, err := ApplyFixes(path, findings, ".fixed")
+		_, err := ApplyFixes(b.Context(), path, findings, ".fixed")
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -95,7 +95,7 @@ func BenchmarkApplyFixes_LineMode_Multiple(b *testing.B) {
 			benchFinding(path, &scanner.Fix{StartLine: 4, EndLine: 4, Replacement: "val d = 40"}),
 			benchFinding(path, &scanner.Fix{StartLine: 5, EndLine: 5, Replacement: "val e = 50"}),
 		}
-		_, err := ApplyFixes(path, findings, ".fixed")
+		_, err := ApplyFixes(b.Context(), path, findings, ".fixed")
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -107,7 +107,7 @@ func BenchmarkValidateFixResult(b *testing.B) {
 	fixed := []byte("fun main() {\n    println(\"world\")\n}\n")
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_ = ValidateFixResult("test.kt", original, fixed)
+		_ = ValidateFixResult(b.Context(), "test.kt", original, fixed)
 	}
 }
 

--- a/internal/fixer/fixer.go
+++ b/internal/fixer/fixer.go
@@ -41,13 +41,13 @@ func splitTextFixRowsByMode(fixes []textFixRow) (byteFixes, lineFixes []textFixR
 
 // ValidateFixResult checks whether the given content (for a .kt file) still parses
 // without additional errors compared to the original. This is opt-in validation.
-func ValidateFixResult(path string, original, fixed []byte) error {
+func ValidateFixResult(ctx context.Context, path string, original, fixed []byte) error {
 	if !strings.HasSuffix(path, ".kt") && !strings.HasSuffix(path, ".kts") {
 		return nil // only validate Kotlin files
 	}
 
-	origErrors := countParseErrors(original)
-	fixedErrors := countParseErrors(fixed)
+	origErrors := countParseErrors(ctx, original)
+	fixedErrors := countParseErrors(ctx, fixed)
 
 	if fixedErrors > origErrors {
 		return fmt.Errorf("fix produced %d parse errors (original had %d)", fixedErrors, origErrors)
@@ -56,10 +56,10 @@ func ValidateFixResult(path string, original, fixed []byte) error {
 }
 
 // countParseErrors parses content as Kotlin and counts ERROR nodes in the flat tree.
-func countParseErrors(content []byte) int {
+func countParseErrors(ctx context.Context, content []byte) int {
 	parser := scanner.GetKotlinParser()
 	defer scanner.PutKotlinParser(parser)
-	tree, err := parser.ParseCtx(context.Background(), nil, content)
+	tree, err := parser.ParseCtx(ctx, nil, content)
 	if err != nil {
 		return 1 // treat parse failure as one error
 	}
@@ -86,7 +86,7 @@ type FixResult struct {
 // ApplyAllFixesColumns applies text fixes from columnar findings across all files.
 // It reconstructs only rows that carry text fixes, preserving the existing file-level
 // fixer behavior without materializing the entire finding set.
-func ApplyAllFixesColumns(columns *scanner.FindingColumns, suffix string) (totalFixes int, filesModified int, errors []error) {
+func ApplyAllFixesColumns(ctx context.Context, columns *scanner.FindingColumns, suffix string) (totalFixes int, filesModified int, errors []error) {
 	if columns == nil || columns.Len() == 0 {
 		return 0, 0, nil
 	}
@@ -105,7 +105,7 @@ func ApplyAllFixesColumns(columns *scanner.FindingColumns, suffix string) (total
 	// of CI log diff noise — see #27.
 	for _, path := range iterutil.SortedKeys(byFile) {
 		rows := byFile[path]
-		res, err := applyFixesDetailedColumns(path, columns, rows, suffix, false)
+		res, err := applyFixesDetailedColumns(ctx, path, columns, rows, suffix, false)
 		if err != nil {
 			errors = append(errors, fmt.Errorf("%s: %w", path, err))
 			continue
@@ -118,7 +118,7 @@ func ApplyAllFixesColumns(columns *scanner.FindingColumns, suffix string) (total
 	return
 }
 
-func applyFixesDetailedColumns(path string, columns *scanner.FindingColumns, rows []int, suffix string, validate bool) (FixResult, error) {
+func applyFixesDetailedColumns(ctx context.Context, path string, columns *scanner.FindingColumns, rows []int, suffix string, validate bool) (FixResult, error) {
 	if columns == nil || len(rows) == 0 {
 		return FixResult{}, nil
 	}
@@ -167,7 +167,7 @@ func applyFixesDetailedColumns(path string, columns *scanner.FindingColumns, row
 	}
 
 	if validate {
-		if err := ValidateFixResult(path, content, []byte(result)); err != nil {
+		if err := ValidateFixResult(ctx, path, content, []byte(result)); err != nil {
 			return FixResult{DroppedFixes: droppedFixes}, fmt.Errorf("fix validation failed for %s: %w", path, err)
 		}
 	}

--- a/internal/fixer/fixer_determinism_test.go
+++ b/internal/fixer/fixer_determinism_test.go
@@ -47,7 +47,7 @@ func TestApplyAllFixesColumns_StableErrorOrder(t *testing.T) {
 	// 200 iterations to amplify any scheduler-driven non-determinism.
 	for i := 0; i < 200; i++ {
 		columns := scanner.CollectFindings(findings)
-		_, _, errs := ApplyAllFixesColumns(&columns, "")
+		_, _, errs := ApplyAllFixesColumns(t.Context(), &columns, "")
 		if len(errs) != len(want) {
 			t.Fatalf("iter %d: got %d errors, want %d", i, len(errs), len(want))
 		}

--- a/internal/fixer/fixer_logger_test.go
+++ b/internal/fixer/fixer_logger_test.go
@@ -34,7 +34,7 @@ func TestApplyFixesDroppedOverlapLogsViaPkgLog(t *testing.T) {
 		}),
 	}
 
-	if _, err := ApplyFixesDetailed(path, findings, "", false); err != nil {
+	if _, err := ApplyFixesDetailed(t.Context(), path, findings, "", false); err != nil {
 		t.Fatalf("ApplyFixesDetailed: %v", err)
 	}
 

--- a/internal/fixer/fixer_test.go
+++ b/internal/fixer/fixer_test.go
@@ -1,6 +1,7 @@
 package fixer
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -31,16 +32,16 @@ func readFile(t *testing.T, path string) string {
 // shims that preserve the old API shape by routing through the columnar
 // fixer entry point. They exist so the test suite can continue to exercise
 // per-file fix application without a wholesale rewrite.
-func ApplyFixes(path string, findings []scanner.Finding, suffix string) (int, error) {
-	return ApplyFixesWithValidation(path, findings, suffix, false)
+func ApplyFixes(ctx context.Context, path string, findings []scanner.Finding, suffix string) (int, error) {
+	return ApplyFixesWithValidation(ctx, path, findings, suffix, false)
 }
 
-func ApplyFixesWithValidation(path string, findings []scanner.Finding, suffix string, validate bool) (int, error) {
-	res, err := ApplyFixesDetailed(path, findings, suffix, validate)
+func ApplyFixesWithValidation(ctx context.Context, path string, findings []scanner.Finding, suffix string, validate bool) (int, error) {
+	res, err := ApplyFixesDetailed(ctx, path, findings, suffix, validate)
 	return res.Applied, err
 }
 
-func ApplyFixesDetailed(path string, findings []scanner.Finding, suffix string, validate bool) (FixResult, error) {
+func ApplyFixesDetailed(ctx context.Context, path string, findings []scanner.Finding, suffix string, validate bool) (FixResult, error) {
 	filtered := make([]scanner.Finding, 0, len(findings))
 	for _, f := range findings {
 		if f.File == path && f.Fix != nil {
@@ -57,12 +58,12 @@ func ApplyFixesDetailed(path string, findings []scanner.Finding, suffix string, 
 			rows = append(rows, i)
 		}
 	}
-	return applyFixesDetailedColumns(path, &columns, rows, suffix, validate)
+	return applyFixesDetailedColumns(ctx, path, &columns, rows, suffix, validate)
 }
 
-func ApplyAllFixes(findings []scanner.Finding, suffix string) (int, int, []error) {
+func ApplyAllFixes(ctx context.Context, findings []scanner.Finding, suffix string) (int, int, []error) {
 	columns := scanner.CollectFindings(findings)
-	return ApplyAllFixesColumns(&columns, suffix)
+	return ApplyAllFixesColumns(ctx, &columns, suffix)
 }
 
 func TestApplyAllFixesColumns_TargetFile(t *testing.T) {
@@ -90,7 +91,7 @@ func TestApplyAllFixesColumns_TargetFile(t *testing.T) {
 		},
 	}})
 
-	applied, modified, errs := ApplyAllFixesColumns(&columns, "")
+	applied, modified, errs := ApplyAllFixesColumns(t.Context(), &columns, "")
 	if len(errs) > 0 {
 		t.Fatalf("ApplyAllFixesColumns errors: %v", errs)
 	}
@@ -144,7 +145,7 @@ func TestByteModeFix_SimpleReplace(t *testing.T) {
 		}),
 	}
 
-	n, err := ApplyFixes(path, findings, "")
+	n, err := ApplyFixes(t.Context(), path, findings, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -168,7 +169,7 @@ func TestByteModeFix_Deletion(t *testing.T) {
 		}),
 	}
 
-	n, err := ApplyFixes(path, findings, "")
+	n, err := ApplyFixes(t.Context(), path, findings, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -192,7 +193,7 @@ func TestByteModeFix_Insertion(t *testing.T) {
 		}),
 	}
 
-	n, err := ApplyFixes(path, findings, "")
+	n, err := ApplyFixes(t.Context(), path, findings, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -222,7 +223,7 @@ func TestByteModeFix_MultipleNonOverlapping(t *testing.T) {
 		}),
 	}
 
-	n, err := ApplyFixes(path, findings, "")
+	n, err := ApplyFixes(t.Context(), path, findings, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -252,7 +253,7 @@ func TestByteModeFix_OverlappingDedup(t *testing.T) {
 		}),
 	}
 
-	n, err := ApplyFixes(path, findings, "")
+	n, err := ApplyFixes(t.Context(), path, findings, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -282,7 +283,7 @@ func TestLineModeFix_ReplaceLine(t *testing.T) {
 		}),
 	}
 
-	n, err := ApplyFixes(path, findings, "")
+	n, err := ApplyFixes(t.Context(), path, findings, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -305,7 +306,7 @@ func TestLineModeFix_DeleteLine(t *testing.T) {
 		}),
 	}
 
-	n, err := ApplyFixes(path, findings, "")
+	n, err := ApplyFixes(t.Context(), path, findings, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -328,7 +329,7 @@ func TestLineModeFix_MultiLine(t *testing.T) {
 		}),
 	}
 
-	n, err := ApplyFixes(path, findings, "")
+	n, err := ApplyFixes(t.Context(), path, findings, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -352,7 +353,7 @@ func TestNoFixesApplied(t *testing.T) {
 		{File: path, Line: 1, Rule: "test", Message: "no fix"},
 	}
 
-	n, err := ApplyFixes(path, findings, "")
+	n, err := ApplyFixes(t.Context(), path, findings, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -376,7 +377,7 @@ func TestIdenticalContent(t *testing.T) {
 		}),
 	}
 
-	n, err := ApplyFixes(path, findings, "")
+	n, err := ApplyFixes(t.Context(), path, findings, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -398,7 +399,7 @@ func TestSuffixMode(t *testing.T) {
 		}),
 	}
 
-	n, err := ApplyFixes(path, findings, ".new")
+	n, err := ApplyFixes(t.Context(), path, findings, ".new")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -438,7 +439,7 @@ func TestApplyAllFixes_MultipleFiles(t *testing.T) {
 		},
 	}
 
-	totalFixes, filesModified, errs := ApplyAllFixes(findings, "")
+	totalFixes, filesModified, errs := ApplyAllFixes(t.Context(), findings, "")
 	if len(errs) > 0 {
 		t.Fatalf("unexpected errors: %v", errs)
 	}
@@ -495,13 +496,13 @@ func TestApplyAllFixesColumns_MatchesSliceBehavior(t *testing.T) {
 	}
 
 	sliceFindings, _, wantFiles := makeFixture(t)
-	wantFixes, wantModified, wantErrs := ApplyAllFixes(sliceFindings, "")
+	wantFixes, wantModified, wantErrs := ApplyAllFixes(t.Context(), sliceFindings, "")
 	if len(wantErrs) > 0 {
 		t.Fatalf("slice ApplyAllFixes errors: %v", wantErrs)
 	}
 
 	_, columns, gotFiles := makeFixture(t)
-	gotFixes, gotModified, gotErrs := ApplyAllFixesColumns(&columns, "")
+	gotFixes, gotModified, gotErrs := ApplyAllFixesColumns(t.Context(), &columns, "")
 	if len(gotErrs) > 0 {
 		t.Fatalf("columnar ApplyAllFixesColumns errors: %v", gotErrs)
 	}
@@ -543,14 +544,14 @@ func TestApplyFixesDetailedColumns_ReportsDroppedOverlapLikeSlicePath(t *testing
 	}
 
 	path := writeTestFile(t, "abcdefghij")
-	want, err := ApplyFixesDetailed(path, makeFindings(path), "", false)
+	want, err := ApplyFixesDetailed(t.Context(), path, makeFindings(path), "", false)
 	if err != nil {
 		t.Fatalf("slice ApplyFixesDetailed error: %v", err)
 	}
 
 	path = writeTestFile(t, "abcdefghij")
 	columns := scanner.CollectFindings(makeFindings(path))
-	got, err := applyFixesDetailedColumns(path, &columns, []int{0, 1}, "", false)
+	got, err := applyFixesDetailedColumns(t.Context(), path, &columns, []int{0, 1}, "", false)
 	if err != nil {
 		t.Fatalf("columnar applyFixesDetailedColumns error: %v", err)
 	}
@@ -580,7 +581,7 @@ func TestBoundsCheck_InvalidRange(t *testing.T) {
 		}),
 	}
 
-	n, err := ApplyFixes(path, findings, "")
+	n, err := ApplyFixes(t.Context(), path, findings, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -605,7 +606,7 @@ func TestBoundsCheck_NegativeStartByte(t *testing.T) {
 		}),
 	}
 
-	n, err := ApplyFixes(path, findings, "")
+	n, err := ApplyFixes(t.Context(), path, findings, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -629,7 +630,7 @@ func TestBoundsCheck_StartGreaterThanEnd(t *testing.T) {
 		}),
 	}
 
-	n, err := ApplyFixes(path, findings, "")
+	n, err := ApplyFixes(t.Context(), path, findings, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -648,7 +649,7 @@ func TestLineModeFix_InvalidLineRange(t *testing.T) {
 		}),
 	}
 
-	n, err := ApplyFixes(path, findings, "")
+	n, err := ApplyFixes(t.Context(), path, findings, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -730,7 +731,7 @@ func TestMixedMode_ReturnsError(t *testing.T) {
 		}),
 	}
 
-	_, err := ApplyFixes(path, findings, "")
+	_, err := ApplyFixes(t.Context(), path, findings, "")
 	if err == nil {
 		t.Fatalf("expected mixed-mode error, got nil")
 	}
@@ -754,7 +755,7 @@ func TestMixedMode_OnlyByte_NoRejection(t *testing.T) {
 			ByteMode:    true,
 		}),
 	}
-	n, err := ApplyFixes(path, findings, "")
+	n, err := ApplyFixes(t.Context(), path, findings, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -776,7 +777,7 @@ func TestMixedMode_OnlyLine_NoRejection(t *testing.T) {
 			Replacement: "REPLACED",
 		}),
 	}
-	n, err := ApplyFixes(path, findings, "")
+	n, err := ApplyFixes(t.Context(), path, findings, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -794,7 +795,7 @@ func TestMixedMode_OnlyLine_NoRejection(t *testing.T) {
 func TestValidateFixResult_ValidKotlin(t *testing.T) {
 	original := []byte("fun main() { println(\"hello\") }")
 	fixed := []byte("fun main() { println(\"world\") }")
-	err := ValidateFixResult("test.kt", original, fixed)
+	err := ValidateFixResult(t.Context(), "test.kt", original, fixed)
 	if err != nil {
 		t.Fatalf("expected no error for valid Kotlin, got: %v", err)
 	}
@@ -803,7 +804,7 @@ func TestValidateFixResult_ValidKotlin(t *testing.T) {
 func TestValidateFixResult_InvalidKotlin(t *testing.T) {
 	original := []byte("fun main() { println(\"hello\") }")
 	fixed := []byte("fun main() { println(\"hello\"")
-	err := ValidateFixResult("test.kt", original, fixed)
+	err := ValidateFixResult(t.Context(), "test.kt", original, fixed)
 	if err == nil {
 		t.Fatal("expected error for broken Kotlin syntax")
 	}
@@ -814,7 +815,7 @@ func TestValidateFixResult_InvalidKotlin(t *testing.T) {
 
 func TestValidateFixResult_NonKotlinFile(t *testing.T) {
 	// Non-Kotlin files are skipped
-	err := ValidateFixResult("test.java", []byte("broken{{{"), []byte("also broken{{{"))
+	err := ValidateFixResult(t.Context(), "test.java", []byte("broken{{{"), []byte("also broken{{{"))
 	if err != nil {
 		t.Fatalf("expected no error for non-Kotlin file, got: %v", err)
 	}
@@ -823,7 +824,7 @@ func TestValidateFixResult_NonKotlinFile(t *testing.T) {
 func TestValidateFixResult_KtsFile(t *testing.T) {
 	original := []byte("val x = 1")
 	fixed := []byte("val x = {{{")
-	err := ValidateFixResult("build.gradle.kts", original, fixed)
+	err := ValidateFixResult(t.Context(), "build.gradle.kts", original, fixed)
 	if err == nil {
 		t.Fatal("expected error for broken .kts syntax")
 	}
@@ -846,7 +847,7 @@ func TestApplyFixesWithValidation_RejectsInvalidFix(t *testing.T) {
 		}),
 	}
 
-	_, err := ApplyFixesWithValidation(path, findings, "", true)
+	_, err := ApplyFixesWithValidation(t.Context(), path, findings, "", true)
 	if err == nil {
 		t.Fatal("expected validation error")
 	}
@@ -879,7 +880,7 @@ func TestApplyFixesWithValidation_AcceptsValidFix(t *testing.T) {
 		}),
 	}
 
-	n, err := ApplyFixesWithValidation(path, findings, "", true)
+	n, err := ApplyFixesWithValidation(t.Context(), path, findings, "", true)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -923,7 +924,7 @@ func TestByteConflictDetection_DroppedFixReported(t *testing.T) {
 		}),
 	}
 
-	res, err := ApplyFixesDetailed(path, findings, "", false)
+	res, err := ApplyFixesDetailed(t.Context(), path, findings, "", false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -955,7 +956,7 @@ func TestByteConflictDetection_NoOverlap_NoDrop(t *testing.T) {
 		}),
 	}
 
-	res, err := ApplyFixesDetailed(path, findings, "", false)
+	res, err := ApplyFixesDetailed(t.Context(), path, findings, "", false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -982,7 +983,7 @@ func TestLineConflictDetection_DroppedFixReported(t *testing.T) {
 		}),
 	}
 
-	res, err := ApplyFixesDetailed(path, findings, "", false)
+	res, err := ApplyFixesDetailed(t.Context(), path, findings, "", false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1011,7 +1012,7 @@ func TestLineConflictDetection_NoOverlap_NoDrop(t *testing.T) {
 		}),
 	}
 
-	res, err := ApplyFixesDetailed(path, findings, "", false)
+	res, err := ApplyFixesDetailed(t.Context(), path, findings, "", false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1041,7 +1042,7 @@ func TestByteConflictDetection_MultipleDrops(t *testing.T) {
 		}),
 	}
 
-	res, err := ApplyFixesDetailed(path, findings, "", false)
+	res, err := ApplyFixesDetailed(t.Context(), path, findings, "", false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1107,7 +1108,7 @@ func TestApplyFixes_AtomicWrite_OriginalPreservedOnFailure(t *testing.T) {
 		}),
 	}
 
-	_, err := ApplyFixes(path, findings, "")
+	_, err := ApplyFixes(t.Context(), path, findings, "")
 	if err == nil {
 		t.Fatal("expected write failure, got nil")
 	}
@@ -1145,7 +1146,7 @@ func TestApplyFixes_AtomicWrite_PreservesFileMode(t *testing.T) {
 			ByteMode:    true,
 		}),
 	}
-	if _, err := ApplyFixes(path, findings, ""); err != nil {
+	if _, err := ApplyFixes(t.Context(), path, findings, ""); err != nil {
 		t.Fatalf("ApplyFixes: %v", err)
 	}
 

--- a/internal/mcp/tool_structure.go
+++ b/internal/mcp/tool_structure.go
@@ -70,7 +70,7 @@ func (s *Server) structureModules(args structureArgs) ToolResult {
 		return errorResult("project_root must be a directory")
 	}
 
-	graph, err := module.DiscoverModules(args.ProjectRoot)
+	graph, err := module.DiscoverModules(context.Background(), args.ProjectRoot)
 	if err != nil {
 		return errorResult("discovering modules: " + err.Error())
 	}
@@ -253,7 +253,7 @@ func (s *Server) structurePkgDrift(args structureArgs) ToolResult {
 
 	// Discover modules from the first path so we can resolve real source roots.
 	// Fall back to canonical /src/{main,test}/{kotlin,java} if no graph is found.
-	graph, _ := module.DiscoverModules(args.Paths[0])
+	graph, _ := module.DiscoverModules(context.Background(), args.Paths[0])
 
 	ktFiles, err := scanner.CollectKotlinFiles(args.Paths, nil)
 	if err != nil {

--- a/internal/module/discover.go
+++ b/internal/module/discover.go
@@ -1,6 +1,7 @@
 package module
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -12,7 +13,7 @@ var settingsFiles = []string{"settings.gradle.kts", "settings.gradle"}
 
 // DiscoverModules parses a Gradle settings file to discover all modules
 // in the project rooted at rootDir. Returns nil if no settings file is found.
-func DiscoverModules(rootDir string) (*Graph, error) {
+func DiscoverModules(ctx context.Context, rootDir string) (*Graph, error) {
 	rootDir, err := filepath.Abs(rootDir)
 	if err != nil {
 		return nil, err
@@ -35,7 +36,7 @@ func DiscoverModules(rootDir string) (*Graph, error) {
 		// Kotlin DSL — tree-sitter parse handles both static include()
 		// calls and dynamic dir.listFiles().forEach { include(...) }
 		// idioms. See discover_kts.go.
-		parsed := parseSettingsKts(rootDir, content)
+		parsed := parseSettingsKts(ctx, rootDir, content)
 		modulePaths = parsed.paths
 		dirOverrides = parsed.overrides
 	} else {

--- a/internal/module/discover_kts.go
+++ b/internal/module/discover_kts.go
@@ -45,12 +45,12 @@ type parsedSettings struct {
 // projectDir overrides go through the regex parseProjectDirOverrides
 // because tree-sitter Kotlin doesn't model script-level assignments
 // cleanly.
-func parseSettingsKts(rootDir, src string) parsedSettings {
+func parseSettingsKts(ctx context.Context, rootDir, src string) parsedSettings {
 	parser := sitter.NewParser()
 	defer parser.Close()
 	parser.SetLanguage(kotlin.GetLanguage())
 
-	tree, err := parser.ParseCtx(context.Background(), nil, []byte(src))
+	tree, err := parser.ParseCtx(ctx, nil, []byte(src))
 	if err != nil || tree == nil {
 		return parsedSettings{overrides: parseProjectDirOverrides(src)}
 	}

--- a/internal/module/discover_test.go
+++ b/internal/module/discover_test.go
@@ -195,7 +195,7 @@ rootProject.projectDir.resolve("compat").listFiles()!!.forEach {
 		t.Fatal(err)
 	}
 
-	graph, err := DiscoverModules(dir)
+	graph, err := DiscoverModules(t.Context(), dir)
 	if err != nil {
 		t.Fatalf("DiscoverModules: %v", err)
 	}
@@ -244,7 +244,7 @@ compatDir.listFiles()!!.forEach {
 		}
 	}
 
-	graph, err := DiscoverModules(dir)
+	graph, err := DiscoverModules(t.Context(), dir)
 	if err != nil {
 		t.Fatalf("DiscoverModules: %v", err)
 	}
@@ -278,7 +278,7 @@ rootProject.projectDir.resolve("samples").listFiles()?.forEach { f ->
 		}
 	}
 
-	graph, err := DiscoverModules(dir)
+	graph, err := DiscoverModules(t.Context(), dir)
 	if err != nil {
 		t.Fatalf("DiscoverModules: %v", err)
 	}
@@ -309,7 +309,7 @@ rootProject.projectDir.resolve("apps").listFiles()!!.forEach {
 		t.Fatal(err)
 	}
 
-	graph, err := DiscoverModules(dir)
+	graph, err := DiscoverModules(t.Context(), dir)
 	if err != nil {
 		t.Fatalf("DiscoverModules: %v", err)
 	}
@@ -340,7 +340,7 @@ rootProject.projectDir.resolve("apps").listFiles()!!.forEach {
 		t.Fatal(err)
 	}
 
-	graph, err := DiscoverModules(dir)
+	graph, err := DiscoverModules(t.Context(), dir)
 	if err != nil {
 		t.Fatalf("DiscoverModules: %v", err)
 	}
@@ -376,7 +376,7 @@ rootProject.projectDir.resolve("compat").listFiles()!!.forEach {
 		}
 	}
 
-	graph, err := DiscoverModules(dir)
+	graph, err := DiscoverModules(t.Context(), dir)
 	if err != nil {
 		t.Fatalf("DiscoverModules: %v", err)
 	}
@@ -400,7 +400,7 @@ for (f in compatDir.listFiles()!!) {
 	makeModule(t, dir, "compat", "k220")
 	makeModule(t, dir, "compat", "k230")
 
-	graph, err := DiscoverModules(dir)
+	graph, err := DiscoverModules(t.Context(), dir)
 	if err != nil {
 		t.Fatalf("DiscoverModules: %v", err)
 	}
@@ -427,7 +427,7 @@ rootProject.projectDir.resolve("apps").walk().forEach {
 	makeModule(t, dir, "apps", "alpha")
 	makeModule(t, dir, "apps", "nested", "beta")
 
-	graph, err := DiscoverModules(dir)
+	graph, err := DiscoverModules(t.Context(), dir)
 	if err != nil {
 		t.Fatalf("DiscoverModules: %v", err)
 	}
@@ -450,7 +450,7 @@ rootProject.projectDir.resolve("compat").listFiles()!!
 	writeSettings(t, dir, content)
 	makeModule(t, dir, "compat", "k220")
 
-	graph, err := DiscoverModules(dir)
+	graph, err := DiscoverModules(t.Context(), dir)
 	if err != nil {
 		t.Fatalf("DiscoverModules: %v", err)
 	}
@@ -472,7 +472,7 @@ rootProject.projectDir.resolve("apps").listFiles()!!
 	writeSettings(t, dir, content)
 	makeModule(t, dir, "apps", "alpha")
 
-	graph, err := DiscoverModules(dir)
+	graph, err := DiscoverModules(t.Context(), dir)
 	if err != nil {
 		t.Fatalf("DiscoverModules: %v", err)
 	}
@@ -494,7 +494,7 @@ java.nio.file.Files.list(rootProject.projectDir.resolve("apps")).forEach {
 	writeSettings(t, dir, content)
 	makeModule(t, dir, "apps", "alpha")
 
-	graph, err := DiscoverModules(dir)
+	graph, err := DiscoverModules(t.Context(), dir)
 	if err != nil {
 		t.Fatalf("DiscoverModules: %v", err)
 	}
@@ -520,7 +520,7 @@ compatRoot.listFiles()!!.forEach {
 	makeModule(t, dir, "compat", "k220")
 	makeModule(t, dir, "compat", "k230")
 
-	graph, err := DiscoverModules(dir)
+	graph, err := DiscoverModules(t.Context(), dir)
 	if err != nil {
 		t.Fatalf("DiscoverModules: %v", err)
 	}
@@ -542,7 +542,7 @@ include(":${prefix}:bar")
 `
 	writeSettings(t, dir, content)
 
-	graph, err := DiscoverModules(dir)
+	graph, err := DiscoverModules(t.Context(), dir)
 	if err != nil {
 		t.Fatalf("DiscoverModules: %v", err)
 	}
@@ -565,7 +565,7 @@ rootProject.projectDir.resolve("compat").listFiles()!!.forEach {
 	writeSettings(t, dir, content)
 	makeModule(t, dir, "compat", "k220")
 
-	graph, err := DiscoverModules(dir)
+	graph, err := DiscoverModules(t.Context(), dir)
 	if err != nil {
 		t.Fatalf("DiscoverModules: %v", err)
 	}
@@ -585,7 +585,7 @@ include(":app")
 `
 	writeSettings(t, dir, content)
 
-	graph, err := DiscoverModules(dir)
+	graph, err := DiscoverModules(t.Context(), dir)
 	if err != nil {
 		t.Fatalf("DiscoverModules: %v", err)
 	}
@@ -621,7 +621,7 @@ func makeModule(t *testing.T, dir string, parts ...string) {
 
 func TestDiscoverModulesNoSettingsFile(t *testing.T) {
 	dir := t.TempDir()
-	graph, err := DiscoverModules(dir)
+	graph, err := DiscoverModules(t.Context(), dir)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -646,7 +646,7 @@ project(":tools").projectDir = file("build-tools/custom")
 		t.Fatal(err)
 	}
 
-	graph, err := DiscoverModules(dir)
+	graph, err := DiscoverModules(t.Context(), dir)
 	if err != nil {
 		t.Fatalf("DiscoverModules: %v", err)
 	}

--- a/internal/pipeline/fixup.go
+++ b/internal/pipeline/fixup.go
@@ -52,7 +52,7 @@ func (FixupPhase) Name() string { return "fixup" }
 // Per-file fix errors are returned via FixupResult.FixErrors — they do
 // not cause Run itself to fail. Only catastrophic failures bubble up as
 // a non-nil error return.
-func (FixupPhase) Run(_ context.Context, in FixupInput) (FixupResult, error) {
+func (FixupPhase) Run(ctx context.Context, in FixupInput) (FixupResult, error) {
 	if !in.Apply && !in.ApplyBinary && !in.CountOnly {
 		return FixupResult{CrossFileResult: in.CrossFileResult}, nil
 	}
@@ -103,7 +103,7 @@ func (FixupPhase) Run(_ context.Context, in FixupInput) (FixupResult, error) {
 			touched[columns.FileAt(row)] = struct{}{}
 		})
 
-		applied, _, errs := fixer.ApplyAllFixesColumns(&columns, in.Suffix)
+		applied, _, errs := fixer.ApplyAllFixesColumns(ctx, &columns, in.Suffix)
 		textFixes = applied
 		fixErrs = append(fixErrs, errs...)
 

--- a/internal/pipeline/index.go
+++ b/internal/pipeline/index.go
@@ -518,7 +518,7 @@ func resolverFingerprint(files []*scanner.File) string {
 
 // discoverModuleGraph performs a best-effort module discovery when
 // SkipModules is false and BuildModuleIndex is not set.
-func (p IndexPhase) discoverModuleGraph(in IndexInput) *module.Graph {
+func (p IndexPhase) discoverModuleGraph(ctx context.Context, in IndexInput) *module.Graph {
 	if p.SkipModules || in.BuildModuleIndex {
 		return nil
 	}
@@ -529,7 +529,7 @@ func (p IndexPhase) discoverModuleGraph(in IndexInput) *module.Graph {
 			scanRoot = in.Paths[0]
 		}
 	}
-	graph, err := module.DiscoverModules(scanRoot)
+	graph, err := module.DiscoverModules(ctx, scanRoot)
 	if err != nil {
 		return nil
 	}
@@ -671,7 +671,7 @@ func (p IndexPhase) Run(ctx context.Context, in IndexInput) (IndexResult, error)
 	})
 
 	track("discoverModuleGraph", func() {
-		if graph := p.discoverModuleGraph(in); graph != nil {
+		if graph := p.discoverModuleGraph(ctx, in); graph != nil {
 			result.Graph = graph
 		}
 	})
@@ -685,7 +685,7 @@ func (p IndexPhase) Run(ctx context.Context, in IndexInput) (IndexResult, error)
 	}
 
 	if in.BuildModuleIndex {
-		p.runModuleIndexBuild(in, &result)
+		p.runModuleIndexBuild(ctx, in, &result)
 	}
 
 	if !in.SkipCache && in.CacheEnabled {
@@ -1192,7 +1192,7 @@ func addJavaIndexPerfEntries(tracker perf.Tracker, s scanner.JavaIndexPerfSnapsh
 // builds the PerModuleIndex. The caller supplies the
 // "moduleAwareAnalysis" parent tracker and End()-s it after rule
 // execution siblings have run. Rule execution itself stays in main.go.
-func (p IndexPhase) runModuleIndexBuild(in IndexInput, result *IndexResult) {
+func (p IndexPhase) runModuleIndexBuild(ctx context.Context, in IndexInput, result *IndexResult) {
 	if in.ModuleParentTracker == nil {
 		return
 	}
@@ -1211,7 +1211,7 @@ func (p IndexPhase) runModuleIndexBuild(in IndexInput, result *IndexResult) {
 		modErr error
 	)
 	moduleTracker.TrackVoid("moduleDiscovery", func() {
-		graph, modErr = module.DiscoverModules(scanRoot)
+		graph, modErr = module.DiscoverModules(ctx, scanRoot)
 	})
 	if modErr != nil && in.Verbose {
 		in.logf("verbose: Module discovery error: %v\n", modErr)

--- a/internal/rules/android_manifest_security.go
+++ b/internal/rules/android_manifest_security.go
@@ -1,6 +1,7 @@
 package rules
 
 import (
+	"context"
 	"encoding/xml"
 	"fmt"
 	"os"
@@ -595,7 +596,7 @@ func (r *NetworkSecurityConfigDebugOverridesRule) check(ctx *api.Context) {
 	if err != nil {
 		return
 	}
-	root, err := android.ParseXMLAST(data)
+	root, err := android.ParseXMLAST(context.Background(), data)
 	if err != nil {
 		return
 	}

--- a/internal/rules/android_resource_values.go
+++ b/internal/rules/android_resource_values.go
@@ -3,6 +3,7 @@ package rules
 // Android Resource XML rules: Value/string rules.
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -357,7 +358,7 @@ func readLocaleConfigLocales(path string) ([]string, int, error) {
 	if err != nil {
 		return nil, 0, err
 	}
-	root, err := android.ParseXMLAST(data)
+	root, err := android.ParseXMLAST(context.Background(), data)
 	if err != nil {
 		return nil, 0, err
 	}

--- a/internal/rules/fix_test.go
+++ b/internal/rules/fix_test.go
@@ -223,7 +223,7 @@ func applyAndCompare(t *testing.T, sourcePath, baseName string, findings []scann
 	}
 
 	columns := scanner.CollectFindings(findings)
-	nFixes, _, fixErrs := fixer.ApplyAllFixesColumns(&columns, "")
+	nFixes, _, fixErrs := fixer.ApplyAllFixesColumns(t.Context(), &columns, "")
 	if len(fixErrs) > 0 {
 		t.Fatalf("ApplyAllFixesColumns error: %v", fixErrs[0])
 	}

--- a/internal/rules/i18n_plurals.go
+++ b/internal/rules/i18n_plurals.go
@@ -1,6 +1,7 @@
 package rules
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -187,7 +188,7 @@ func (r *PluralsMissingZeroRule) scanValuesDir(ctx *api.Context, dir, lang strin
 		if err != nil {
 			continue
 		}
-		root, err := android.ParseXMLAST(data)
+		root, err := android.ParseXMLAST(context.Background(), data)
 		if err != nil || root == nil || root.Tag != "resources" {
 			continue
 		}

--- a/internal/rules/i18n_string_resource_placeholder_order.go
+++ b/internal/rules/i18n_string_resource_placeholder_order.go
@@ -1,6 +1,7 @@
 package rules
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -110,7 +111,7 @@ func forEachStringInValuesDir(dir string, visit func(path string, s *android.XML
 		if err != nil {
 			continue
 		}
-		root, err := android.ParseXMLAST(data)
+		root, err := android.ParseXMLAST(context.Background(), data)
 		if err != nil || root == nil || root.Tag != "resources" {
 			continue
 		}

--- a/internal/rules/release_engineering_test.go
+++ b/internal/rules/release_engineering_test.go
@@ -1014,7 +1014,7 @@ func TestGradleBuildContainsTodo(t *testing.T) {
 func runConventionPluginDeadCodeRule(t *testing.T, projectDir string) []scanner.Finding {
 	t.Helper()
 
-	graph, err := module.DiscoverModules(projectDir)
+	graph, err := module.DiscoverModules(t.Context(), projectDir)
 	if err != nil {
 		t.Fatalf("DiscoverModules(%s): %v", projectDir, err)
 	}
@@ -1092,7 +1092,7 @@ func configTemplate() config.ModuleTemplateConfig {
 func runModuleTemplateConformanceRule(t *testing.T, projectDir string, tmpl config.ModuleTemplateConfig) []scanner.Finding {
 	t.Helper()
 
-	graph, err := module.DiscoverModules(projectDir)
+	graph, err := module.DiscoverModules(t.Context(), projectDir)
 	if err != nil {
 		t.Fatalf("DiscoverModules(%s): %v", projectDir, err)
 	}

--- a/internal/rules/supply_catalog_buildsrc_mismatch_internal_test.go
+++ b/internal/rules/supply_catalog_buildsrc_mismatch_internal_test.go
@@ -73,7 +73,7 @@ func TestParseLibraryRHS(t *testing.T) {
 
 func runVersionCatalogBuildSrcMismatch(t *testing.T, projectDir string) []scanner.Finding {
 	t.Helper()
-	graph, err := module.DiscoverModules(projectDir)
+	graph, err := module.DiscoverModules(t.Context(), projectDir)
 	if err != nil {
 		t.Fatalf("DiscoverModules(%s): %v", projectDir, err)
 	}

--- a/internal/rules/supply_catalog_duplicate_version_internal_test.go
+++ b/internal/rules/supply_catalog_duplicate_version_internal_test.go
@@ -51,7 +51,7 @@ func TestVersionCatalogDuplicateVersion(t *testing.T) {
 
 func runVersionCatalogDuplicateVersion(t *testing.T, projectDir string) []scanner.Finding {
 	t.Helper()
-	graph, err := module.DiscoverModules(projectDir)
+	graph, err := module.DiscoverModules(t.Context(), projectDir)
 	if err != nil {
 		t.Fatalf("DiscoverModules(%s): %v", projectDir, err)
 	}

--- a/internal/rules/supply_catalog_internal_test.go
+++ b/internal/rules/supply_catalog_internal_test.go
@@ -102,7 +102,7 @@ func TestAccessorReferencedRespectsBoundaries(t *testing.T) {
 
 func runVersionCatalogUnused(t *testing.T, projectDir string, ignored []string, scanConvention bool) []scanner.Finding {
 	t.Helper()
-	graph, err := module.DiscoverModules(projectDir)
+	graph, err := module.DiscoverModules(t.Context(), projectDir)
 	if err != nil {
 		t.Fatalf("DiscoverModules(%s): %v", projectDir, err)
 	}

--- a/internal/rules/supply_catalog_raw_version_in_build_internal_test.go
+++ b/internal/rules/supply_catalog_raw_version_in_build_internal_test.go
@@ -110,7 +110,7 @@ func TestMaskGradleComments(t *testing.T) {
 
 func runVersionCatalogRawVersionInBuild(t *testing.T, projectDir string) []scanner.Finding {
 	t.Helper()
-	graph, err := module.DiscoverModules(projectDir)
+	graph, err := module.DiscoverModules(t.Context(), projectDir)
 	if err != nil {
 		t.Fatalf("DiscoverModules(%s): %v", projectDir, err)
 	}

--- a/internal/rules/supply_chain_test.go
+++ b/internal/rules/supply_chain_test.go
@@ -51,7 +51,7 @@ func TestCompileSdkMismatchAcrossModules(t *testing.T) {
 func runCompileSdkMismatchAcrossModulesRule(t *testing.T, projectDir string) []scanner.Finding {
 	t.Helper()
 
-	graph, err := module.DiscoverModules(projectDir)
+	graph, err := module.DiscoverModules(t.Context(), projectDir)
 	if err != nil {
 		t.Fatalf("DiscoverModules(%s): %v", projectDir, err)
 	}
@@ -463,7 +463,7 @@ func applySuggestionEdits(t *testing.T, finding scanner.Finding, suggestionID st
 		})
 	}
 	columns := scanner.CollectFindings(edits)
-	applied, _, errs := fixer.ApplyAllFixesColumns(&columns, "")
+	applied, _, errs := fixer.ApplyAllFixesColumns(t.Context(), &columns, "")
 	if len(errs) > 0 {
 		t.Fatalf("ApplyAllFixesColumns errors: %v", errs)
 	}

--- a/internal/rules/supply_drift_internal_test.go
+++ b/internal/rules/supply_drift_internal_test.go
@@ -56,7 +56,7 @@ func TestConventionPluginAppliedToWrongTarget(t *testing.T) {
 
 func runConventionPluginAppliedToWrongTarget(t *testing.T, root string, pluginTargetMap []string) []scanner.Finding {
 	t.Helper()
-	graph, err := module.DiscoverModules(root)
+	graph, err := module.DiscoverModules(t.Context(), root)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/scanner/arena_benchmark_test.go
+++ b/internal/scanner/arena_benchmark_test.go
@@ -1,7 +1,6 @@
 package scanner
 
 import (
-	"context"
 	"fmt"
 	"strings"
 	"testing"
@@ -57,7 +56,7 @@ func benchmarkParseKotlinTree(b *testing.B, src string) (*sitter.Tree, []byte) {
 	parser := GetKotlinParser()
 	defer PutKotlinParser(parser)
 
-	tree, err := parser.ParseCtx(context.Background(), nil, content)
+	tree, err := parser.ParseCtx(b.Context(), nil, content)
 	if err != nil {
 		b.Fatalf("failed to parse Kotlin benchmark source: %v", err)
 	}

--- a/internal/scanner/benchmark_test.go
+++ b/internal/scanner/benchmark_test.go
@@ -1,7 +1,6 @@
 package scanner
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -17,9 +16,9 @@ func helperParseFixture(b *testing.B, relPath string) *File {
 	if err != nil {
 		b.Fatalf("cannot resolve path %s: %v", relPath, err)
 	}
-	f, err := ParseFile(context.Background(), abs)
+	f, err := ParseFile(b.Context(), abs)
 	if err != nil {
-		b.Fatalf("ParseFile(context.Background(), %s): %v", abs, err)
+		b.Fatalf("ParseFile(%s): %v", abs, err)
 	}
 	return f
 }
@@ -35,7 +34,7 @@ func BenchmarkParseFile(b *testing.B) {
 	}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, err := ParseFile(context.Background(), path)
+		_, err := ParseFile(b.Context(), path)
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -52,7 +51,7 @@ func BenchmarkParseFile_Large(b *testing.B) {
 	}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, err := ParseFile(context.Background(), path)
+		_, err := ParseFile(b.Context(), path)
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -85,7 +84,7 @@ func BenchmarkParseFile_Inline(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, err := ParseFile(context.Background(), tmpFile)
+		_, err := ParseFile(b.Context(), tmpFile)
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -106,7 +105,7 @@ func BenchmarkParseFile_WithPool(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, err := ParseFile(context.Background(), path)
+		_, err := ParseFile(b.Context(), path)
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -132,9 +131,9 @@ fun shared%d(): Int = %d
 		if err := os.WriteFile(path, []byte(content), 0644); err != nil {
 			b.Fatalf("write %s: %v", path, err)
 		}
-		file, err := ParseFile(context.Background(), path)
+		file, err := ParseFile(b.Context(), path)
 		if err != nil {
-			b.Fatalf("ParseFile(context.Background(), %s): %v", path, err)
+			b.Fatalf("ParseFile(%s): %v", path, err)
 		}
 		files = append(files, file)
 	}
@@ -218,9 +217,9 @@ func benchParseIdentifiers(b *testing.B) (*File, []uint32) {
 		b.Fatal(err)
 	}
 
-	f, err := ParseFile(context.Background(), tmpFile)
+	f, err := ParseFile(b.Context(), tmpFile)
 	if err != nil {
-		b.Fatalf("ParseFile(context.Background(), %s): %v", tmpFile, err)
+		b.Fatalf("ParseFile(%s): %v", tmpFile, err)
 	}
 
 	var identifiers []uint32
@@ -282,9 +281,9 @@ func BenchmarkFlatHasModifier(b *testing.B) {
 		b.Fatal(err)
 	}
 
-	f, err := ParseFile(context.Background(), tmpFile)
+	f, err := ParseFile(b.Context(), tmpFile)
 	if err != nil {
-		b.Fatalf("ParseFile(context.Background(), %s): %v", tmpFile, err)
+		b.Fatalf("ParseFile(%s): %v", tmpFile, err)
 	}
 
 	var decls []uint32
@@ -357,9 +356,9 @@ func BenchmarkNodeTextVsZeroCopy(b *testing.B) {
 		b.Fatal(err)
 	}
 
-	f, err := ParseFile(context.Background(), tmpFile)
+	f, err := ParseFile(b.Context(), tmpFile)
 	if err != nil {
-		b.Fatalf("ParseFile(context.Background(), %s): %v", tmpFile, err)
+		b.Fatalf("ParseFile(%s): %v", tmpFile, err)
 	}
 
 	var allNodes []uint32

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -707,6 +707,9 @@ func scanFilesParallel(ctx context.Context, paths []string, workers int, parse f
 			errs = append(errs, errSlots[i])
 		}
 	}
+	if err := ctx.Err(); err != nil {
+		errs = append(errs, err)
+	}
 	return files, errs
 }
 

--- a/internal/scanner/scanner_cancel_test.go
+++ b/internal/scanner/scanner_cancel_test.go
@@ -4,58 +4,54 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
-	"path/filepath"
 	"testing"
 	"time"
 )
+
+const kotlinFixtureSrc = "package fixture\n\nclass Sample { fun greet() = \"hi\" }\n"
 
 func writeKotlinFixtures(t *testing.T, count int) []string {
 	t.Helper()
 	dir := t.TempDir()
 	paths := make([]string, count)
-	src := []byte("package fixture\n\nclass Sample { fun greet() = \"hi\" }\n")
 	for i := 0; i < count; i++ {
-		p := filepath.Join(dir, fmt.Sprintf("Sample%d.kt", i))
-		if err := os.WriteFile(p, src, 0o644); err != nil {
-			t.Fatalf("write fixture: %v", err)
-		}
-		paths[i] = p
+		paths[i] = writeKotlin(t, dir, fmt.Sprintf("Sample%d.kt", i), kotlinFixtureSrc)
 	}
 	return paths
 }
 
-func TestScanFilesPreCancelledCtxStopsShort(t *testing.T) {
-	paths := writeKotlinFixtures(t, 16)
-
-	ctx, cancel := context.WithCancel(t.Context())
-	cancel()
-
-	files, errs := ScanFiles(ctx, paths, 4)
-
-	if len(files) != 0 {
-		t.Fatalf("expected zero files parsed for pre-cancelled ctx, got %d", len(files))
-	}
-	if !errsContain(errs, context.Canceled) {
-		t.Fatalf("expected context.Canceled in errs, got %v", errs)
-	}
-}
-
-func TestScanFilesPreCancelledCtxReturnsCancelErr(t *testing.T) {
+func TestScanFilesPreCancelledCtxSurfacesCancellation(t *testing.T) {
 	paths := writeKotlinFixtures(t, 8)
 
-	ctx, cancel := context.WithCancel(t.Context())
-	cancel()
+	type scanFn func(context.Context, []string, int) ([]*File, []error)
+	cases := []struct {
+		name string
+		scan scanFn
+	}{
+		{"ScanFiles", ScanFiles},
+		{"ScanFilesCached", func(ctx context.Context, p []string, w int) ([]*File, []error) {
+			return ScanFilesCached(ctx, p, w, nil)
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(t.Context())
+			cancel()
 
-	_, errs := ScanFilesCached(ctx, paths, 2, nil)
+			files, errs := tc.scan(ctx, paths, 4)
 
-	if !errsContain(errs, context.Canceled) {
-		t.Fatalf("expected context.Canceled in errs, got %v", errs)
+			if len(files) != 0 {
+				t.Fatalf("expected zero files for pre-cancelled ctx, got %d", len(files))
+			}
+			if got := countErrs(errs, context.Canceled); got != 1 {
+				t.Fatalf("expected exactly one context.Canceled error, got %d (errs=%v)", got, errs)
+			}
+		})
 	}
 }
 
-func TestScanFilesDeadlineSurfacesError(t *testing.T) {
-	paths := writeKotlinFixtures(t, 64)
+func TestScanFilesDeadlineSurfacesDeadlineExceeded(t *testing.T) {
+	paths := writeKotlinFixtures(t, 8)
 
 	ctx, cancel := context.WithDeadline(t.Context(), time.Now().Add(-time.Second))
 	defer cancel()
@@ -65,8 +61,8 @@ func TestScanFilesDeadlineSurfacesError(t *testing.T) {
 	if len(files) != 0 {
 		t.Fatalf("expected zero files for expired deadline, got %d", len(files))
 	}
-	if !errsContainAny(errs, context.DeadlineExceeded, context.Canceled) {
-		t.Fatalf("expected DeadlineExceeded or Canceled in errs, got %v", errs)
+	if !errsContain(errs, context.DeadlineExceeded) {
+		t.Fatalf("expected context.DeadlineExceeded in errs, got %v", errs)
 	}
 }
 
@@ -83,20 +79,16 @@ func TestScanFilesSucceedsWithLiveCtx(t *testing.T) {
 	}
 }
 
-func errsContain(errs []error, target error) bool {
+func countErrs(errs []error, target error) int {
+	n := 0
 	for _, e := range errs {
 		if errors.Is(e, target) {
-			return true
+			n++
 		}
 	}
-	return false
+	return n
 }
 
-func errsContainAny(errs []error, targets ...error) bool {
-	for _, t := range targets {
-		if errsContain(errs, t) {
-			return true
-		}
-	}
-	return false
+func errsContain(errs []error, target error) bool {
+	return countErrs(errs, target) > 0
 }

--- a/internal/scanner/scanner_cancel_test.go
+++ b/internal/scanner/scanner_cancel_test.go
@@ -1,0 +1,102 @@
+package scanner
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func writeKotlinFixtures(t *testing.T, count int) []string {
+	t.Helper()
+	dir := t.TempDir()
+	paths := make([]string, count)
+	src := []byte("package fixture\n\nclass Sample { fun greet() = \"hi\" }\n")
+	for i := 0; i < count; i++ {
+		p := filepath.Join(dir, fmt.Sprintf("Sample%d.kt", i))
+		if err := os.WriteFile(p, src, 0o644); err != nil {
+			t.Fatalf("write fixture: %v", err)
+		}
+		paths[i] = p
+	}
+	return paths
+}
+
+func TestScanFilesPreCancelledCtxStopsShort(t *testing.T) {
+	paths := writeKotlinFixtures(t, 16)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	files, errs := ScanFiles(ctx, paths, 4)
+
+	if len(files) != 0 {
+		t.Fatalf("expected zero files parsed for pre-cancelled ctx, got %d", len(files))
+	}
+	if !errsContain(errs, context.Canceled) {
+		t.Fatalf("expected context.Canceled in errs, got %v", errs)
+	}
+}
+
+func TestScanFilesPreCancelledCtxReturnsCancelErr(t *testing.T) {
+	paths := writeKotlinFixtures(t, 8)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	_, errs := ScanFilesCached(ctx, paths, 2, nil)
+
+	if !errsContain(errs, context.Canceled) {
+		t.Fatalf("expected context.Canceled in errs, got %v", errs)
+	}
+}
+
+func TestScanFilesDeadlineSurfacesError(t *testing.T) {
+	paths := writeKotlinFixtures(t, 64)
+
+	ctx, cancel := context.WithDeadline(t.Context(), time.Now().Add(-time.Second))
+	defer cancel()
+
+	files, errs := ScanFiles(ctx, paths, 4)
+
+	if len(files) != 0 {
+		t.Fatalf("expected zero files for expired deadline, got %d", len(files))
+	}
+	if !errsContainAny(errs, context.DeadlineExceeded, context.Canceled) {
+		t.Fatalf("expected DeadlineExceeded or Canceled in errs, got %v", errs)
+	}
+}
+
+func TestScanFilesSucceedsWithLiveCtx(t *testing.T) {
+	paths := writeKotlinFixtures(t, 4)
+
+	files, errs := ScanFiles(t.Context(), paths, 2)
+
+	if len(files) != len(paths) {
+		t.Fatalf("expected %d files, got %d (errs: %v)", len(paths), len(files), errs)
+	}
+	if len(errs) != 0 {
+		t.Fatalf("expected no errs for live ctx, got %v", errs)
+	}
+}
+
+func errsContain(errs []error, target error) bool {
+	for _, e := range errs {
+		if errors.Is(e, target) {
+			return true
+		}
+	}
+	return false
+}
+
+func errsContainAny(errs []error, targets ...error) bool {
+	for _, t := range targets {
+		if errsContain(errs, t) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/snapshot/capture.go
+++ b/internal/snapshot/capture.go
@@ -72,7 +72,7 @@ func Capture(opts CaptureOptions) (*Result, error) {
 		version = "dev"
 	}
 
-	graph, err := module.DiscoverModules(root)
+	graph, err := module.DiscoverModules(context.Background(), root)
 	if err != nil {
 		return nil, fmt.Errorf("snapshot: discover modules: %w", err)
 	}

--- a/internal/snapshot/capture.go
+++ b/internal/snapshot/capture.go
@@ -15,6 +15,9 @@ import (
 
 // CaptureOptions controls a single Capture invocation.
 type CaptureOptions struct {
+	// Ctx is the parent context for module discovery, file collection,
+	// parsing, and findings sub-runs. Nil defaults to context.Background().
+	Ctx         context.Context
 	RepoRoot    string
 	CommitSHA   string
 	KritVersion string
@@ -71,15 +74,19 @@ func Capture(opts CaptureOptions) (*Result, error) {
 	if version == "" {
 		version = "dev"
 	}
+	ctx := opts.Ctx
+	if ctx == nil {
+		ctx = context.Background()
+	}
 
-	graph, err := module.DiscoverModules(context.Background(), root)
+	graph, err := module.DiscoverModules(ctx, root)
 	if err != nil {
 		return nil, fmt.Errorf("snapshot: discover modules: %w", err)
 	}
 
-	ktPaths, javaPaths, fileToModule := collectSources(graph, root)
-	ktFiles, _ := scanner.ScanFilesCached(context.Background(), ktPaths, workers, nil)
-	javaFiles, _ := scanner.ScanJavaFilesCached(context.Background(), javaPaths, workers, nil)
+	ktPaths, javaPaths, fileToModule := collectSources(ctx, graph, root)
+	ktFiles, _ := scanner.ScanFilesCached(ctx, ktPaths, workers, nil)
+	javaFiles, _ := scanner.ScanJavaFilesCached(ctx, javaPaths, workers, nil)
 
 	idx := scanner.BuildIndex(ktFiles, workers, javaFiles...)
 
@@ -101,7 +108,7 @@ func Capture(opts CaptureOptions) (*Result, error) {
 	result := &Result{Blob: blob, Metrics: metrics}
 
 	if opts.WithFindings {
-		findings, err := RunFindings(context.Background(), root, opts.CommitSHA, FindingsRunOptions{
+		findings, err := RunFindings(ctx, root, opts.CommitSHA, FindingsRunOptions{
 			RepoRelativeTo: root,
 			Workers:        workers,
 		})
@@ -126,7 +133,7 @@ func Capture(opts CaptureOptions) (*Result, error) {
 // attribution for downstream rollups. When the project has no Gradle
 // modules (e.g. a plain Kotlin tree) it falls back to a single
 // repo-root walk.
-func collectSources(graph *module.Graph, repoRoot string) (kotlin, java []string, fileToModule map[string]string) {
+func collectSources(ctx context.Context, graph *module.Graph, repoRoot string) (kotlin, java []string, fileToModule map[string]string) {
 	fileToModule = make(map[string]string)
 	seenKt := make(map[string]bool)
 	seenJv := make(map[string]bool)
@@ -143,7 +150,7 @@ func collectSources(graph *module.Graph, repoRoot string) (kotlin, java []string
 			if len(roots) == 0 {
 				roots = []string{filepath.Join(mod.Dir, "src", "main", "kotlin"), filepath.Join(mod.Dir, "src", "main", "java")}
 			}
-			ktForMod, jvForMod, _ := scanner.CollectKotlinAndJavaFiles(context.Background(), roots, nil)
+			ktForMod, jvForMod, _ := scanner.CollectKotlinAndJavaFiles(ctx, roots, nil)
 			for _, p := range ktForMod {
 				if !seenKt[p] {
 					seenKt[p] = true
@@ -162,7 +169,7 @@ func collectSources(graph *module.Graph, repoRoot string) (kotlin, java []string
 	}
 
 	if len(kotlin) == 0 && len(java) == 0 {
-		ktForRoot, jvForRoot, _ := scanner.CollectKotlinAndJavaFiles(context.Background(), []string{repoRoot}, nil)
+		ktForRoot, jvForRoot, _ := scanner.CollectKotlinAndJavaFiles(ctx, []string{repoRoot}, nil)
 		for _, p := range ktForRoot {
 			if !seenKt[p] {
 				seenKt[p] = true


### PR DESCRIPTION
## Summary
Follow-up to #341, completing the ctx-plumbing pass.

- **More ParseCtx callers threaded** — `codemod/engine`, `fixer/fixer`, `android/xmlast`, and `module/discover_kts` now take ctx and forward it to `parser.ParseCtx`, matching `pipeline/bootstrap.go`. Pipeline phases (`FixupPhase`, `IndexPhase`) bind their previously-discarded ctx parameter; deadcode `Plan.Apply`, `module.DiscoverModules` callers, and rule/test sites updated.
- **`scanFilesParallel` surfaces cancellation** — appends `ctx.Err()` to the returned errs slice after `wg.Wait()` so cancelled scans are no longer silently reported as partial success. Downstream `ctx.Err()` checks in the pipeline parse phase now surface real cancellation.
- **Regression test** — new `internal/scanner/scanner_cancel_test.go` locks both the per-worker short-circuit and the post-Wait error append: covers `ScanFiles` and `ScanFilesCached` with pre-cancelled ctx (table-driven), pinned `DeadlineExceeded` for expired deadline, exactly-one cancellation entry, and a live-ctx baseline.
- **Reuse cleanup** — `snapshot.Capture` consolidates its six independent `context.Background()` calls behind a single `CaptureOptions.Ctx` field; scanner benchmarks migrated to `b.Context()`.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...`
- [x] `make lint-rules`
- [x] `go test ./... -count=1` (full suite green, includes 4 new cancellation tests)