### PR TITLE
oracle: partial KAA reanalyze on warm-path public ABI changes

### DIFF
--- a/internal/cli/scan/runner.go
+++ b/internal/cli/scan/runner.go
@@ -11,6 +11,7 @@ import (
 	"github.com/kaeawc/krit/internal/oracle"
 	"github.com/kaeawc/krit/internal/pipeline"
 	"github.com/kaeawc/krit/internal/rules"
+	"github.com/kaeawc/krit/internal/scanner"
 	"github.com/kaeawc/krit/internal/typeinfer"
 )
 
@@ -51,6 +52,18 @@ func (r *runner) projectInput() pipeline.ProjectInput {
 	}
 	if r.useCache {
 		host.TypeIndexCacheDir = typeinfer.TypeIndexCacheDir(oracle.FindRepoDir(r.paths))
+		// Wire the bundle manifest store for one-shot CLI scans so the
+		// oracle freshness gate has prior-run file stats to compare
+		// against on warm runs. Without this, runOracleIndex's
+		// computeStaleOraclePaths always returns nil and the lazy-load
+		// short-circuit silently serves a stale types.json after an
+		// in-place edit. The bundle store also opportunistically
+		// short-circuits whole runs when the RunFingerprint matches
+		// — that's a secondary win on top of the freshness signal.
+		if repoDir := oracle.FindRepoDir(r.paths); repoDir != "" {
+			host.FindingsBundleStore = scanner.DiskFindingsBundleStore{}
+			host.FindingsBundleCacheRoot = repoDir
+		}
 	}
 	return pipeline.ProjectInput{
 		Args: pipeline.ProjectArgs{

--- a/internal/cli/scan/runner_state.go
+++ b/internal/cli/scan/runner_state.go
@@ -467,6 +467,7 @@ func (r *runner) runOracleIndex() (int, error) {
 	var err error
 	var preloadedCache *cache.Cache
 	r.tracker.TrackVoid("oracleIndex", func() {
+		staleOraclePaths := computeStaleOraclePaths(r.paths, r.files, r.tracker, *r.f.Verbose)
 		in := pipeline.IndexInput{
 			ParseResult:       pipeline.ParseResult{ActiveRules: r.activeRules},
 			Reporter:          r.reporter,
@@ -482,6 +483,7 @@ func (r *runner) runOracleIndex() (int, error) {
 			UseDaemon:         *r.f.Daemon,
 			Store:             r.oracleStore,
 			OracleCacheWriter: r.oracleCacheWriter,
+			StaleOraclePaths:  staleOraclePaths,
 			Verbose:           *r.f.Verbose,
 
 			PreloadedAnalysisCache: nil,

--- a/internal/cli/scan/stale_oracle_paths.go
+++ b/internal/cli/scan/stale_oracle_paths.go
@@ -1,0 +1,77 @@
+package scan
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/kaeawc/krit/internal/oracle"
+	"github.com/kaeawc/krit/internal/perf"
+	"github.com/kaeawc/krit/internal/scanner"
+)
+
+// computeStaleOraclePaths consults the prior findings-bundle manifest to
+// decide which .kt paths are KAA-stale relative to the cached
+// types.json. Returns nil when no prior manifest exists (true cold
+// scan; the freshness gate's lazy-load fast path is safe) or when no
+// types.json exists (cold path is going to recompute everything
+// anyway). Returns a non-empty slice when one or more files differ in
+// stat (size + mtime); the oracle layer will treat those as forced
+// misses and route them through a partial JVM reanalyze.
+//
+// Only the daemon path persists a bundle manifest today, so one-shot
+// CLI runs typically return nil here and continue to rely on the
+// lazy-load short-circuit. That preserves the historical CLI warm
+// latency at the cost of correctness on stale caches — callers that
+// need correctness should pass --no-cache-oracle (forces a full
+// reanalyze) or use the daemon (which produces a manifest the
+// freshness gate can compare against).
+func computeStaleOraclePaths(scanPaths []string, kotlinFilePaths []string, tracker perf.Tracker, verbose bool) []string {
+	if len(kotlinFilePaths) == 0 {
+		return nil
+	}
+	repoDir := oracle.FindRepoDir(scanPaths)
+	if repoDir == "" {
+		return nil
+	}
+	cachedTypes := oracle.CachePath(scanPaths)
+	if cachedTypes == "" {
+		return nil
+	}
+	if _, err := os.Stat(cachedTypes); err != nil {
+		return nil
+	}
+	manifestKey := scanner.FindingsBundleManifestKey(repoDir, scanPaths)
+	if manifestKey == "" {
+		return nil
+	}
+	prior, ok := scanner.LoadFindingsBundleManifest(repoDir, manifestKey)
+	if !ok {
+		if verbose {
+			fmt.Fprintln(os.Stderr, "verbose: oracle freshness gate: no prior bundle manifest — falling back to lazy load")
+		}
+		perf.AddEntryDetails(tracker, "freshnessGateNoManifest", 0, nil, nil)
+		return nil
+	}
+	stale := scanner.StaleOracleCandidates(kotlinFilePaths, prior, scanner.StatFile)
+	if len(stale) == 0 {
+		if verbose {
+			fmt.Fprintln(os.Stderr, "verbose: oracle freshness gate: manifest is in sync with current file stats")
+		}
+		return nil
+	}
+	if verbose {
+		preview := stale
+		if len(preview) > 5 {
+			preview = preview[:5]
+		}
+		fmt.Fprintf(os.Stderr, "verbose: oracle freshness gate: %d stale path(s); preview=[%s]\n",
+			len(stale), strings.Join(preview, ", "))
+	}
+	perf.AddEntryDetails(tracker, "freshnessGateStaleCandidates", 0, map[string]int64{
+		"stale":     int64(len(stale)),
+		"checked":   int64(len(kotlinFilePaths)),
+		"priorSize": int64(len(prior.FileStats)),
+	}, nil)
+	return stale
+}

--- a/internal/cli/serve/analyze_project.go
+++ b/internal/cli/serve/analyze_project.go
@@ -531,6 +531,7 @@ func (s *daemonState) buildProjectInput(args daemon.AnalyzeProjectArgs) (pipelin
 			FindingsBundleManifestSaver:  diskCache.manifestSaver,
 			PriorContentHashes:           priorManifest.ContentHashes,
 			PriorStructuralFPs:           priorManifest.StructuralFPs,
+			PriorAbiHashes:               priorManifest.AbiHashes,
 		},
 	}, nil
 }

--- a/internal/oracle/daemon.go
+++ b/internal/oracle/daemon.go
@@ -129,21 +129,71 @@ func (d *Daemon) AnalyzeAllWithCallFilter(callFilter *CallTargetFilterSummary) (
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
-	var params map[string]interface{}
-	if callFilter != nil && callFilter.Enabled {
-		params = map[string]interface{}{
-			"callFilterCalleeNames":          callFilter.CalleeNames,
-			"callFilterLexicalHintsByCallee": callFilter.LexicalHintsByCallee,
-			"callFilterLexicalSkipByCallee":  callFilter.LexicalSkipByCallee,
-			"callFilterRuleProfiles":         callFilter.RuleProfiles,
-		}
-	}
+	params := callFilterParams(callFilter)
 	result, err := d.sendResult("analyzeAll", params)
 	if err != nil {
 		return nil, err
 	}
 
 	return unmarshalOracleData(result)
+}
+
+// AnalyzeFilesWithCallFilter asks the daemon to analyze only the listed
+// .kt paths and return their updated oracle facts. Unlike
+// AnalyzeAllWithCallFilter, the JVM tool reuses its resident KAA build
+// session and re-runs analysis only for the requested file subset —
+// callers are responsible for merging the returned facts into any
+// fuller state they hold. The empty file list is treated as a no-op
+// (returns an empty Data) rather than degrading to analyzeAll, so a
+// stale hint can't accidentally trigger a full reanalysis. callFilter
+// narrows call-target resolution exactly as in analyzeAll.
+//
+// Use case: the warm-path freshness gate has identified one or two
+// .kt files whose content (or public ABI) has changed since the prior
+// run; we want fresh oracle facts for just those files, then merge
+// with the cached types.json's per-file entries for everything else.
+// Avoids the full-module reanalyze cost (5+ seconds on kotlin-corpus
+// scale).
+func (d *Daemon) AnalyzeFilesWithCallFilter(files []string, callFilter *CallTargetFilterSummary) (*Data, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	if len(files) == 0 {
+		// Empty file list is intentional: callers should pass a stat-
+		// diff result that may be empty on clean warm runs. Returning
+		// an empty Data avoids a no-op JVM round-trip and lets the
+		// caller skip the merge step entirely.
+		return &Data{Files: map[string]*File{}, Dependencies: map[string]*Class{}}, nil
+	}
+
+	params := callFilterParams(callFilter)
+	if params == nil {
+		params = map[string]interface{}{}
+	}
+	params["files"] = files
+
+	result, err := d.sendResult("analyzeFiles", params)
+	if err != nil {
+		return nil, err
+	}
+
+	return unmarshalOracleData(result)
+}
+
+// callFilterParams packs a CallTargetFilterSummary into the wire
+// representation the krit-types daemon expects. Returns nil when the
+// filter is nil/disabled — both analyzeAll and analyzeFiles tolerate
+// the omitted-filter case server-side.
+func callFilterParams(callFilter *CallTargetFilterSummary) map[string]interface{} {
+	if callFilter == nil || !callFilter.Enabled {
+		return nil
+	}
+	return map[string]interface{}{
+		"callFilterCalleeNames":          callFilter.CalleeNames,
+		"callFilterLexicalHintsByCallee": callFilter.LexicalHintsByCallee,
+		"callFilterLexicalSkipByCallee":  callFilter.LexicalSkipByCallee,
+		"callFilterRuleProfiles":         callFilter.RuleProfiles,
+	}
 }
 
 // DecompileJar asks krit-types to produce Kotlin source for a class resolved

--- a/internal/oracle/daemon_test.go
+++ b/internal/oracle/daemon_test.go
@@ -222,6 +222,92 @@ func TestDaemon_AnalyzeAll_Mock(t *testing.T) {
 	}
 }
 
+func TestDaemon_AnalyzeFilesWithCallFilter_EmptyList(t *testing.T) {
+	// Empty file list must short-circuit to an empty Data without
+	// touching the wire. A stale-paths hint that filters down to
+	// nothing on warm runs should not trigger a JVM round-trip.
+	d, _, _ := newMockDaemon(t)
+	data, err := d.AnalyzeFilesWithCallFilter(nil, nil)
+	if err != nil {
+		t.Fatalf("empty list: %v", err)
+	}
+	if data == nil || len(data.Files) != 0 || len(data.Dependencies) != 0 {
+		t.Errorf("empty list expected empty Data, got %+v", data)
+	}
+}
+
+func TestDaemon_AnalyzeFilesWithCallFilter_SendsCorrectWireFormat(t *testing.T) {
+	d, reqReader, respWriter := newMockDaemon(t)
+
+	go func() {
+		sc := bufio.NewScanner(reqReader)
+		sc.Buffer(make([]byte, 0, 64*1024), 64*1024*1024)
+		if !sc.Scan() {
+			return
+		}
+		var req daemonRequest
+		_ = json.Unmarshal([]byte(sc.Text()), &req)
+
+		if req.Method != "analyzeFiles" {
+			t.Errorf("method = %q, want %q", req.Method, "analyzeFiles")
+		}
+		files, ok := req.Params["files"].([]interface{})
+		if !ok || len(files) != 2 {
+			t.Errorf("params.files = %v, want 2 entries", req.Params["files"])
+		}
+		// Call-filter fields must not leak when the filter is nil.
+		if _, ok := req.Params["callFilterCalleeNames"]; ok {
+			t.Errorf("nil callFilter must not include filter fields in params")
+		}
+
+		resp := fmt.Sprintf(`{"id": %d, "result": {"version": 1, "files": {"/a.kt": {"package": "p", "declarations": []}}, "dependencies": {}}}`, req.ID) + "\n"
+		_, _ = respWriter.Write([]byte(resp))
+	}()
+
+	data, err := d.AnalyzeFilesWithCallFilter([]string{"/a.kt", "/b.kt"}, nil)
+	if err != nil {
+		t.Fatalf("AnalyzeFilesWithCallFilter: %v", err)
+	}
+	if data == nil || data.Files["/a.kt"] == nil {
+		t.Errorf("response not parsed correctly: %+v", data)
+	}
+}
+
+func TestDaemon_AnalyzeFilesWithCallFilter_IncludesCallFilter(t *testing.T) {
+	d, reqReader, respWriter := newMockDaemon(t)
+	filter := &CallTargetFilterSummary{
+		Enabled:     true,
+		CalleeNames: []string{"foo", "bar"},
+	}
+
+	go func() {
+		sc := bufio.NewScanner(reqReader)
+		sc.Buffer(make([]byte, 0, 64*1024), 64*1024*1024)
+		if !sc.Scan() {
+			return
+		}
+		var req daemonRequest
+		_ = json.Unmarshal([]byte(sc.Text()), &req)
+
+		callees, ok := req.Params["callFilterCalleeNames"].([]interface{})
+		if !ok || len(callees) != 2 {
+			t.Errorf("callFilterCalleeNames not propagated: %v", req.Params["callFilterCalleeNames"])
+		}
+		files, ok := req.Params["files"].([]interface{})
+		if !ok || len(files) != 1 {
+			t.Errorf("files not propagated: %v", req.Params["files"])
+		}
+
+		resp := fmt.Sprintf(`{"id": %d, "result": {"version": 1, "files": {}, "dependencies": {}}}`, req.ID) + "\n"
+		_, _ = respWriter.Write([]byte(resp))
+	}()
+
+	_, err := d.AnalyzeFilesWithCallFilter([]string{"/a.kt"}, filter)
+	if err != nil {
+		t.Fatalf("AnalyzeFilesWithCallFilter: %v", err)
+	}
+}
+
 func TestDaemon_Analyze_Mock(t *testing.T) {
 	d, reqReader, respWriter := newMockDaemon(t)
 

--- a/internal/oracle/forced_misses_test.go
+++ b/internal/oracle/forced_misses_test.go
@@ -1,0 +1,76 @@
+package oracle
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestSplitForcedMisses_Empty(t *testing.T) {
+	t.Parallel()
+	ktFiles := []string{"/a.kt", "/b.kt"}
+	classify, forced := splitForcedMisses(ktFiles, nil)
+	// With no hint, the classifier should see every file and forcedInScan must be empty.
+	if !reflect.DeepEqual(classify, ktFiles) {
+		t.Errorf("classify = %v, want %v", classify, ktFiles)
+	}
+	if forced != nil {
+		t.Errorf("forced = %v, want nil", forced)
+	}
+}
+
+func TestSplitForcedMisses_OneInScan(t *testing.T) {
+	t.Parallel()
+	ktFiles := []string{"/a.kt", "/b.kt", "/c.kt"}
+	classify, forced := splitForcedMisses(ktFiles, []string{"/b.kt"})
+	wantClassify := []string{"/a.kt", "/c.kt"}
+	if !reflect.DeepEqual(classify, wantClassify) {
+		t.Errorf("classify = %v, want %v", classify, wantClassify)
+	}
+	wantForced := []string{"/b.kt"}
+	if !reflect.DeepEqual(forced, wantForced) {
+		t.Errorf("forced = %v, want %v", forced, wantForced)
+	}
+}
+
+func TestSplitForcedMisses_AllInScan(t *testing.T) {
+	t.Parallel()
+	ktFiles := []string{"/a.kt", "/b.kt"}
+	classify, forced := splitForcedMisses(ktFiles, []string{"/a.kt", "/b.kt"})
+	if len(classify) != 0 {
+		t.Errorf("classify = %v, want empty", classify)
+	}
+	wantForced := []string{"/a.kt", "/b.kt"}
+	if !reflect.DeepEqual(forced, wantForced) {
+		t.Errorf("forced = %v, want %v", forced, wantForced)
+	}
+}
+
+func TestSplitForcedMisses_OutOfScanIgnored(t *testing.T) {
+	t.Parallel()
+	// /z.kt is in the hint but not in the scan set; it must be dropped.
+	ktFiles := []string{"/a.kt", "/b.kt"}
+	classify, forced := splitForcedMisses(ktFiles, []string{"/b.kt", "/z.kt"})
+	wantClassify := []string{"/a.kt"}
+	if !reflect.DeepEqual(classify, wantClassify) {
+		t.Errorf("classify = %v, want %v", classify, wantClassify)
+	}
+	wantForced := []string{"/b.kt"}
+	if !reflect.DeepEqual(forced, wantForced) {
+		t.Errorf("forced = %v, want %v", forced, wantForced)
+	}
+}
+
+func TestSplitForcedMisses_DuplicateHintsDeduped(t *testing.T) {
+	t.Parallel()
+	// Duplicates in the hint should only cause the file to appear once
+	// in forcedInScan — the map dedupes.
+	ktFiles := []string{"/a.kt"}
+	classify, forced := splitForcedMisses(ktFiles, []string{"/a.kt", "/a.kt"})
+	if len(classify) != 0 {
+		t.Errorf("classify = %v, want empty", classify)
+	}
+	wantForced := []string{"/a.kt"}
+	if !reflect.DeepEqual(forced, wantForced) {
+		t.Errorf("forced = %v, want %v", forced, wantForced)
+	}
+}

--- a/internal/oracle/instrumentation.go
+++ b/internal/oracle/instrumentation.go
@@ -27,6 +27,13 @@ type InvocationOptions struct {
 	// class/member. Nil or a full profile preserves pre-profile extraction;
 	// narrow profiles skip KAA traversal for unused sections.
 	DeclarationProfile *DeclarationProfileSummary
+	// ForcedMisses lists absolute .kt paths that the cache classifier
+	// must treat as misses without consulting the per-file content
+	// hash. Used by the warm-path freshness gate to route a known-stale
+	// file (e.g. an ABI edit detected by the bundle manifest comparator)
+	// through a partial JVM reanalyze instead of letting it ride on a
+	// stale cached entry. Empty preserves the pre-#NNN behavior.
+	ForcedMisses []string
 }
 
 func (o InvocationOptions) tracker() perf.Tracker {

--- a/internal/oracle/invoke_cached.go
+++ b/internal/oracle/invoke_cached.go
@@ -321,6 +321,53 @@ func assembleAndWriteOracle(
 	return outputPath, nil
 }
 
+// splitForcedMisses partitions ktFiles into the subset that should
+// be passed through the cache classifier and the subset that the
+// caller has already pre-decided are stale. Paths in forcedMisses
+// that are NOT in ktFiles are silently dropped — the caller's hint
+// may include paths that fell out of the current source set (e.g.
+// after a path filter) and we must not force-analyze something the
+// JVM wasn't asked to look at.
+//
+// Returns (classifyInput, forcedInScan): classifyInput is the
+// subset whose membership in the cache will be checked by
+// ClassifyFilesWithStoreScopedV2; forcedInScan is the subset that
+// will be appended to the resulting miss list verbatim. When
+// forcedMisses is empty both slices reuse ktFiles' backing array
+// so the common path allocates nothing.
+func splitForcedMisses(ktFiles []string, forcedMisses []string) ([]string, []string) {
+	if len(forcedMisses) == 0 {
+		return ktFiles, nil
+	}
+	forcedSet := make(map[string]bool, len(forcedMisses))
+	for _, p := range forcedMisses {
+		forcedSet[p] = true
+	}
+	classifyInput := make([]string, 0, len(ktFiles))
+	forcedInScan := make([]string, 0, len(forcedSet))
+	for _, p := range ktFiles {
+		if forcedSet[p] {
+			forcedInScan = append(forcedInScan, p)
+			continue
+		}
+		classifyInput = append(classifyInput, p)
+	}
+	return classifyInput, forcedInScan
+}
+
+// recordForcedMissCount emits a perf event when the caller supplied a
+// forced-miss hint. Kept as a helper to bound the cyclomatic complexity
+// of InvokeCachedWithOptions.
+func recordForcedMissCount(tracker perf.Tracker, declared, inScan int) {
+	if declared <= 0 {
+		return
+	}
+	addOracleInstant(tracker, "forcedMisses", map[string]int64{
+		"declared": int64(declared),
+		"inScan":   int64(inScan),
+	}, nil)
+}
+
 // InvokeCachedWithOptions is InvokeCached plus optional deep perf
 // instrumentation for the cache/filter/JVM path.
 func InvokeCachedWithOptions(
@@ -375,8 +422,14 @@ func InvokeCachedWithOptions(
 		ktFiles = applyOracleFilter(ktFiles, filterListPath, tracker, verbose)
 	}
 
+	classifyInput, forcedInScan := splitForcedMisses(ktFiles, opts.ForcedMisses)
+	recordForcedMissCount(tracker, len(opts.ForcedMisses), len(forcedInScan))
+
 	startClassify := time.Now()
-	hits, misses := ClassifyFilesWithStoreScopedV2(s, cacheDir, ktFiles, callFilterScope, declarationProfileScope)
+	hits, misses := ClassifyFilesWithStoreScopedV2(s, cacheDir, classifyInput, callFilterScope, declarationProfileScope)
+	if len(forcedInScan) > 0 {
+		misses = append(misses, forcedInScan...)
+	}
 	classifyElapsed := time.Since(startClassify)
 	perf.AddEntryDetails(tracker, "cacheClassify", classifyElapsed, map[string]int64{
 		"files":  int64(len(ktFiles)),

--- a/internal/oracle/partial_merge.go
+++ b/internal/oracle/partial_merge.go
@@ -1,0 +1,74 @@
+package oracle
+
+import (
+	"fmt"
+)
+
+// MergeFreshIntoCachedTypes merges fresh per-file oracle facts from a
+// partial reanalyze into the cached types.json and persists the result.
+// Fresh entries win on overlap (files and dependencies); cached entries
+// without a fresh counterpart are preserved. Top-level Version /
+// KotlinVersion are kept from cache when fresh leaves them zero.
+func MergeFreshIntoCachedTypes(outputPath string, fresh *Data) (*Data, error) {
+	if outputPath == "" {
+		return nil, fmt.Errorf("merge: empty outputPath")
+	}
+	if fresh == nil {
+		fresh = &Data{Files: map[string]*File{}, Dependencies: map[string]*Class{}}
+	}
+	cached, err := readOracleJSON(outputPath)
+	cacheMissing := err != nil
+	if cacheMissing {
+		cached = &Data{Files: map[string]*File{}, Dependencies: map[string]*Class{}}
+	}
+	merged := mergeOracleData(cached, fresh)
+	// Skip the write when the merge is a no-op — fresh was empty AND
+	// the cached file was readable. Saves a ~1MB re-marshal on the
+	// hot warm path where the caller passed a hint that produced no
+	// fresh facts (e.g. all stale paths resolved to cache hits after
+	// per-file content-hash check).
+	if !cacheMissing && (fresh == nil || (len(fresh.Files) == 0 && len(fresh.Dependencies) == 0)) {
+		return merged, nil
+	}
+	if err := writeOracleJSON(outputPath, merged); err != nil {
+		return nil, fmt.Errorf("merge: write types.json: %w", err)
+	}
+	return merged, nil
+}
+
+// mergeOracleData performs the section-wise union described in
+// MergeFreshIntoCachedTypes. Extracted so unit tests can exercise the
+// merge rules without touching disk.
+func mergeOracleData(cached, fresh *Data) *Data {
+	if cached == nil {
+		cached = &Data{}
+	}
+	if fresh == nil {
+		fresh = &Data{}
+	}
+	merged := &Data{
+		Version:       cached.Version,
+		KotlinVersion: cached.KotlinVersion,
+		Files:         make(map[string]*File, len(cached.Files)+len(fresh.Files)),
+		Dependencies:  make(map[string]*Class, len(cached.Dependencies)+len(fresh.Dependencies)),
+	}
+	if fresh.Version != 0 {
+		merged.Version = fresh.Version
+	}
+	if fresh.KotlinVersion != "" {
+		merged.KotlinVersion = fresh.KotlinVersion
+	}
+	for path, f := range cached.Files {
+		merged.Files[path] = f
+	}
+	for path, f := range fresh.Files {
+		merged.Files[path] = f
+	}
+	for fqn, c := range cached.Dependencies {
+		merged.Dependencies[fqn] = c
+	}
+	for fqn, c := range fresh.Dependencies {
+		merged.Dependencies[fqn] = c
+	}
+	return merged
+}

--- a/internal/oracle/partial_merge_test.go
+++ b/internal/oracle/partial_merge_test.go
@@ -1,0 +1,188 @@
+package oracle
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestMergeOracleData_FreshWinsOnFileOverlap(t *testing.T) {
+	t.Parallel()
+	cached := &Data{
+		Version: 1,
+		Files: map[string]*File{
+			"/a.kt": {Package: "p", Declarations: []*Class{{FQN: "p.A"}}},
+			"/b.kt": {Package: "p", Declarations: []*Class{{FQN: "p.B"}}},
+		},
+		Dependencies: map[string]*Class{
+			"java.lang.String": {FQN: "java.lang.String", Kind: "class"},
+		},
+	}
+	fresh := &Data{
+		Files: map[string]*File{
+			// /a.kt got a new public function — fresh entry replaces cached.
+			"/a.kt": {Package: "p", Declarations: []*Class{{FQN: "p.A", Members: []*Member{{Name: "newFn"}}}}},
+		},
+	}
+	merged := mergeOracleData(cached, fresh)
+	// Both files survive; /a.kt reflects fresh content.
+	if len(merged.Files) != 2 {
+		t.Fatalf("merged.Files = %d, want 2", len(merged.Files))
+	}
+	gotA := merged.Files["/a.kt"]
+	if gotA == nil || len(gotA.Declarations) != 1 || len(gotA.Declarations[0].Members) != 1 {
+		t.Errorf("merged /a.kt = %+v, want fresh entry with newFn member", gotA)
+	}
+	if merged.Files["/b.kt"] == nil {
+		t.Errorf("merged dropped /b.kt — cached file with no fresh overlap must survive")
+	}
+}
+
+func TestMergeOracleData_AddingNewFile(t *testing.T) {
+	t.Parallel()
+	cached := &Data{Files: map[string]*File{"/a.kt": {Package: "p"}}}
+	fresh := &Data{Files: map[string]*File{"/c.kt": {Package: "p"}}}
+	merged := mergeOracleData(cached, fresh)
+	if _, ok := merged.Files["/a.kt"]; !ok {
+		t.Errorf("merged missing /a.kt")
+	}
+	if _, ok := merged.Files["/c.kt"]; !ok {
+		t.Errorf("merged missing /c.kt — fresh entry for a brand-new file must land")
+	}
+}
+
+func TestMergeOracleData_DependenciesUnion(t *testing.T) {
+	t.Parallel()
+	cached := &Data{Dependencies: map[string]*Class{
+		"java.lang.String": {FQN: "java.lang.String"},
+		"java.lang.Object": {FQN: "java.lang.Object"},
+	}}
+	fresh := &Data{Dependencies: map[string]*Class{
+		"java.lang.String": {FQN: "java.lang.String", Kind: "class"}, // fresh wins
+		"kotlin.Int":       {FQN: "kotlin.Int"},                      // new
+	}}
+	merged := mergeOracleData(cached, fresh)
+	if len(merged.Dependencies) != 3 {
+		t.Errorf("merged.Dependencies = %d, want 3 (java.lang.String overwritten, java.lang.Object preserved, kotlin.Int added)", len(merged.Dependencies))
+	}
+	if merged.Dependencies["java.lang.String"].Kind != "class" {
+		t.Errorf("fresh dep did not win on FQN overlap")
+	}
+}
+
+func TestMergeOracleData_VersionAndKotlinVersion(t *testing.T) {
+	t.Parallel()
+	cached := &Data{Version: 1, KotlinVersion: "1.9.0"}
+	// Empty fresh — partial-reanalyze response often omits top-level
+	// fields because they describe the whole project, not the subset.
+	fresh := &Data{}
+	merged := mergeOracleData(cached, fresh)
+	if merged.Version != 1 {
+		t.Errorf("merged.Version = %d, want 1 (preserve cached when fresh.Version == 0)", merged.Version)
+	}
+	if merged.KotlinVersion != "1.9.0" {
+		t.Errorf("merged.KotlinVersion = %q, want %q", merged.KotlinVersion, "1.9.0")
+	}
+	// Fresh that DOES carry these fields should override.
+	fresh = &Data{Version: 2, KotlinVersion: "2.0.0"}
+	merged = mergeOracleData(cached, fresh)
+	if merged.Version != 2 || merged.KotlinVersion != "2.0.0" {
+		t.Errorf("fresh non-zero fields did not override: %+v", merged)
+	}
+}
+
+func TestMergeOracleData_NilInputs(t *testing.T) {
+	t.Parallel()
+	// Defensive: neither nil should panic; an absent map becomes empty.
+	merged := mergeOracleData(nil, nil)
+	if merged == nil || merged.Files == nil || merged.Dependencies == nil {
+		t.Errorf("nil/nil merge produced unusable result: %+v", merged)
+	}
+}
+
+func TestMergeFreshIntoCachedTypes_RoundTripWritesMerged(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "types.json")
+	// Seed an on-disk cached types.json.
+	cached := &Data{
+		Version: 1,
+		Files: map[string]*File{
+			"/a.kt": {Package: "p", Declarations: []*Class{{FQN: "p.A"}}},
+		},
+		Dependencies: map[string]*Class{},
+	}
+	raw, _ := json.Marshal(cached)
+	if err := os.WriteFile(path, raw, 0o644); err != nil {
+		t.Fatalf("seed types.json: %v", err)
+	}
+	fresh := &Data{Files: map[string]*File{
+		"/a.kt": {Package: "p", Declarations: []*Class{{FQN: "p.A", Members: []*Member{{Name: "extra"}}}}},
+		"/b.kt": {Package: "p"},
+	}}
+	merged, err := MergeFreshIntoCachedTypes(path, fresh)
+	if err != nil {
+		t.Fatalf("merge: %v", err)
+	}
+	if len(merged.Files) != 2 {
+		t.Errorf("merged.Files = %d, want 2", len(merged.Files))
+	}
+	// Verify disk reflects merge so the next warm run sees the new content.
+	roundTrip, err := readOracleJSON(path)
+	if err != nil {
+		t.Fatalf("read merged: %v", err)
+	}
+	if len(roundTrip.Files) != 2 {
+		t.Errorf("on-disk merged.Files = %d, want 2", len(roundTrip.Files))
+	}
+	if roundTrip.Files["/a.kt"] == nil || len(roundTrip.Files["/a.kt"].Declarations[0].Members) != 1 {
+		t.Errorf("on-disk /a.kt did not reflect fresh content")
+	}
+}
+
+func TestMergeFreshIntoCachedTypes_EmptyOutputPath(t *testing.T) {
+	t.Parallel()
+	// Defensive: empty path must not crash. Returns error so caller
+	// falls back to analyzeAll instead of silently writing nothing.
+	if _, err := MergeFreshIntoCachedTypes("", &Data{}); err == nil {
+		t.Errorf("empty outputPath: want error, got nil")
+	}
+}
+
+func TestMergeFreshIntoCachedTypes_SkipsWriteWhenFreshIsEmpty(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "types.json")
+	cached := &Data{Files: map[string]*File{"/a.kt": {Package: "p"}}, Dependencies: map[string]*Class{}}
+	raw, _ := json.Marshal(cached)
+	_ = os.WriteFile(path, raw, 0o644)
+	priorStat, _ := os.Stat(path)
+	// Empty fresh — the no-op merge must not re-marshal + rewrite the
+	// 1MB JSON. Modtime stays unchanged.
+	if _, err := MergeFreshIntoCachedTypes(path, &Data{Files: map[string]*File{}, Dependencies: map[string]*Class{}}); err != nil {
+		t.Fatalf("merge: %v", err)
+	}
+	afterStat, _ := os.Stat(path)
+	if !afterStat.ModTime().Equal(priorStat.ModTime()) {
+		t.Errorf("empty-fresh merge wrote to disk (modtime changed): %v -> %v", priorStat.ModTime(), afterStat.ModTime())
+	}
+}
+
+func TestMergeFreshIntoCachedTypes_NilFreshTreatedAsEmpty(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "types.json")
+	cached := &Data{Files: map[string]*File{"/a.kt": {Package: "p"}}, Dependencies: map[string]*Class{}}
+	raw, _ := json.Marshal(cached)
+	_ = os.WriteFile(path, raw, 0o644)
+	// nil fresh means "no new facts" — the merge should pass through
+	// cached content unchanged.
+	merged, err := MergeFreshIntoCachedTypes(path, nil)
+	if err != nil {
+		t.Fatalf("merge: %v", err)
+	}
+	if len(merged.Files) != 1 || merged.Files["/a.kt"] == nil {
+		t.Errorf("nil-fresh merge dropped cached content: %+v", merged.Files)
+	}
+}

--- a/internal/pipeline/index.go
+++ b/internal/pipeline/index.go
@@ -198,6 +198,12 @@ type IndexInput struct {
 	// OracleCacheWriter, when non-nil, defers cold oracle cache-entry
 	// persistence until the caller flushes it later in the run.
 	OracleCacheWriter *oracle.CacheWriter
+	// StaleOraclePaths lists .kt paths that the freshness gate should
+	// treat as KAA-stale even when a cached types.json exists. Empty
+	// keeps the lazy-load fast path; non-empty routes through a partial
+	// reanalyze. Absolute paths; entries outside the scan set are
+	// ignored.
+	StaleOraclePaths []string
 	// Verbose gates oracle stderr diagnostics. Matches --verbose.
 	Verbose bool
 
@@ -812,6 +818,61 @@ func (p IndexPhase) runDaemonOracle(in IndexInput, oracleRules []*api.Rule, scan
 
 	var oracleData *oracle.Data
 	oracleTracker.TrackVoid("jvmAnalyze", func() {
+		// Partial reanalyze path: when the caller has prior-manifest
+		// evidence of exactly which .kt files changed (StaleOraclePaths
+		// populated by the daemon's bundle-manifest comparator), ask
+		// the resident JVM session to re-analyze only that subset and
+		// merge the fresh facts into the cached types.json on disk.
+		// This avoids the full-module reanalyze cost (5+ seconds on
+		// kotlin-corpus scale) on warm runs that touch one or two
+		// files. Falls back to analyzeAll when:
+		//   - StaleOraclePaths is empty (cold run, no prior manifest)
+		//   - The on-disk types.json doesn't exist (nothing to merge
+		//     into; partial would return a per-file slice the dispatcher
+		//     can't use)
+		//   - The partial call itself errors (defensive)
+		cachedTypesPath := oracle.CachePath(scanPaths)
+		canPartial := len(in.StaleOraclePaths) > 0 && cachedTypesPath != ""
+		if canPartial {
+			if _, err := os.Stat(cachedTypesPath); err != nil {
+				canPartial = false
+			}
+		}
+		if canPartial {
+			perf.AddEntryDetails(oracleTracker, "daemonPartialReanalyze", 0, map[string]int64{
+				"stalePaths": int64(len(in.StaleOraclePaths)),
+			}, nil)
+			fresh, err := d.AnalyzeFilesWithCallFilter(in.StaleOraclePaths, callFilterPtr)
+			if err != nil {
+				in.warnf("warning: daemon analyzeFiles (fallback to analyzeAll): %v\n", err)
+				od, allErr := d.AnalyzeAllWithCallFilter(callFilterPtr)
+				if allErr != nil {
+					in.warnf("warning: daemon analyzeAll: %v\n", allErr)
+					return
+				}
+				oracleData = od
+				return
+			}
+			// Merge fresh facts into the on-disk types.json. The
+			// cached JSON holds the full project's per-file entries
+			// from the prior cold/warm run; the fresh slice only
+			// covers the stale paths. mergeFreshIntoCachedTypes
+			// rewrites types.json with the union (fresh wins on
+			// overlap), then loads the merged result.
+			merged, mergeErr := oracle.MergeFreshIntoCachedTypes(cachedTypesPath, fresh)
+			if mergeErr != nil {
+				in.warnf("warning: oracle partial merge (fallback to analyzeAll): %v\n", mergeErr)
+				od, allErr := d.AnalyzeAllWithCallFilter(callFilterPtr)
+				if allErr != nil {
+					in.warnf("warning: daemon analyzeAll: %v\n", allErr)
+					return
+				}
+				oracleData = od
+				return
+			}
+			oracleData = merged
+			return
+		}
 		od, err := d.AnalyzeAllWithCallFilter(callFilterPtr)
 		if err != nil {
 			in.warnf("warning: daemon analyzeAll: %v\n", err)
@@ -956,6 +1017,7 @@ func (p IndexPhase) runJvmAnalyze(in IndexInput, oracleRules []*api.Rule, scanPa
 		CallFilter:         callFilterPtr,
 		DeclarationProfile: &declarationProfileSummary,
 		DisableDiagnostics: !in.OracleDiagnostics || !rules.NeedsOracleDiagnostics(oracleRules),
+		ForcedMisses:       in.StaleOraclePaths,
 	}
 	var res string
 	var err error
@@ -1000,6 +1062,7 @@ func (p IndexPhase) loadOracleFromPath(in IndexInput, oraclePath string, oracleT
 // configures a lazy lookup and wraps base.
 func (p IndexPhase) runAutoDetectOracle(in IndexInput, oracleRules []*api.Rule, scanPaths []string, loadOracleFilterFiles func() []*scanner.File, oracleTracker perf.Tracker, base typeinfer.TypeResolver) typeinfer.TypeResolver {
 	var oraclePath string
+	var cachedTypesJSONExists bool
 	oracleTracker.TrackVoid("findSources", func() {
 		if in.InputTypesPath != "" {
 			oraclePath = in.InputTypesPath
@@ -1009,14 +1072,33 @@ func (p IndexPhase) runAutoDetectOracle(in IndexInput, oracleRules []*api.Rule, 
 		if cached != "" {
 			if _, err := os.Stat(cached); err == nil {
 				oraclePath = cached
+				cachedTypesJSONExists = true
 			}
 		}
 	})
 
-	if oraclePath == "" {
+	// Freshness gate: reuse the resolved oracle path (cached types.json
+	// OR --input-types) unless the caller flagged stale paths. With
+	// stale-path evidence we re-run the JVM oracle so
+	// InvokeCachedWithOptions can do a partial reanalyze of just the
+	// stale subset; an absent path likewise triggers a cold JVM run.
+	staleHit := cachedTypesJSONExists && len(in.StaleOraclePaths) > 0
+	if staleHit || oraclePath == "" {
+		if staleHit && in.Verbose {
+			in.logf("verbose: oracle freshness gate: %d stale path(s) — routing through partial reanalyze\n", len(in.StaleOraclePaths))
+		}
+		if staleHit {
+			perf.AddEntryDetails(oracleTracker, "freshnessGateStale", 0, map[string]int64{
+				"stalePaths": int64(len(in.StaleOraclePaths)),
+			}, nil)
+		}
 		jvmTracker := oracleTracker.Serial("jvmAnalyze")
 		oraclePath = p.runJvmAnalyze(in, oracleRules, scanPaths, loadOracleFilterFiles, jvmTracker)
 		jvmTracker.End()
+	} else if cachedTypesJSONExists {
+		perf.AddEntryDetails(oracleTracker, "freshnessGateFresh", 0, map[string]int64{
+			"path": 1,
+		}, nil)
 	}
 
 	if oraclePath == "" {

--- a/internal/pipeline/project.go
+++ b/internal/pipeline/project.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/kaeawc/krit/internal/android"
+	"github.com/kaeawc/krit/internal/arch"
 	"github.com/kaeawc/krit/internal/cache"
 	"github.com/kaeawc/krit/internal/cacheutil"
 	"github.com/kaeawc/krit/internal/config"
@@ -397,6 +398,13 @@ type ProjectHostState struct {
 	// repos and only when the bundle-fingerprint check needs them.
 	PriorContentHashes map[string]string
 	PriorStructuralFPs map[string]string
+	// PriorAbiHashes is the daemon-side hint of last-run per-file
+	// public-ABI hashes. Used by buildManifestData to carry forward
+	// hashes for files that were not parsed this run (cache-hit
+	// path), so a warm run that parses only dirty files still
+	// persists a complete manifest. nil means "no hint" — buildManifestData
+	// computes fresh for every parsed Kotlin file.
+	PriorAbiHashes map[string]string
 	// FindingsBundleManifestLoader, when non-nil, overrides the disk
 	// load of the prior-run manifest. Daemon callers wire this to an
 	// in-memory cache so the 10.9 MB JSON file (kotlin-corpus scale)
@@ -1306,6 +1314,12 @@ type deltaManifestData struct {
 	contentHashes map[string]string
 	structuralFPs map[string]string
 	fileStats     map[string]scanner.FileStat
+	// abiHashes is per-file public-ABI hash (Kotlin files only).
+	// Computed lazily by buildManifestData and persisted in
+	// FindingsBundleManifest.AbiHashes. The oracle freshness gate
+	// uses (eventually) this map to distinguish body-only edits from
+	// public-API edits; v1 only records the data.
+	abiHashes map[string]string
 }
 
 // buildManifestData prepares per-file content + structural fingerprints
@@ -1341,7 +1355,9 @@ func buildManifestData(args ProjectArgs, host ProjectHostState, parseResult Pars
 	contentHashes := make(map[string]string, total)
 	structuralFPs := make(map[string]string, total)
 	fileStats := make(map[string]scanner.FileStat, total)
+	abiHashes := make(map[string]string, len(parseResult.KotlinFiles))
 	dirty := dirtyPathSet(host.SourceSetDirty)
+	priorAbi := host.PriorAbiHashes
 	for path, f := range parsedByPath {
 		contentHashes[path] = priorOrCompute(host.PriorContentHashes, dirty, path, func() string {
 			return hashutil.Default().HashContent(path, f.Content)
@@ -1351,6 +1367,11 @@ func buildManifestData(args ProjectArgs, host ProjectHostState, parseResult Pars
 		})
 		if stat, ok := statForPath(path); ok {
 			fileStats[path] = stat
+		}
+		if f != nil && f.Language == scanner.LangKotlin {
+			abiHashes[path] = priorOrCompute(priorAbi, dirty, path, func() string {
+				return arch.HashAbiSignatures(arch.ExtractAbiSignatures([]*scanner.File{f}))
+			})
 		}
 	}
 	for path, hash := range host.PriorContentHashes {
@@ -1370,6 +1391,11 @@ func buildManifestData(args ProjectArgs, host ProjectHostState, parseResult Pars
 		if stat, ok := statForPath(path); ok {
 			fileStats[path] = stat
 		}
+		if priorAbi != nil {
+			if a, ok := priorAbi[path]; ok {
+				abiHashes[path] = a
+			}
+		}
 	}
 	return deltaManifestData{
 		enabled:       true,
@@ -1377,6 +1403,7 @@ func buildManifestData(args ProjectArgs, host ProjectHostState, parseResult Pars
 		contentHashes: contentHashes,
 		structuralFPs: structuralFPs,
 		fileStats:     fileStats,
+		abiHashes:     abiHashes,
 	}
 }
 
@@ -1396,6 +1423,7 @@ func saveDeltaManifest(host ProjectHostState, m deltaManifestData, runFP scanner
 		ContentHashes: m.contentHashes,
 		StructuralFPs: m.structuralFPs,
 		FileStats:     m.fileStats,
+		AbiHashes:     m.abiHashes,
 	}
 	if err := scanner.SaveFindingsBundleManifest(host.FindingsBundleCacheRoot, m.manifestKey, manifest); err != nil {
 		return err

--- a/internal/scanner/findings_bundle_manifest.go
+++ b/internal/scanner/findings_bundle_manifest.go
@@ -9,6 +9,21 @@ import (
 	"github.com/kaeawc/krit/internal/hashutil"
 )
 
+// StatFile is the default FileStatProvider: a thin os.Stat wrapper
+// that returns the size + modtime tuple stored in FindingsBundleManifest.
+// Callers needing a stub for tests should pass their own provider to
+// StaleOracleCandidates.
+func StatFile(path string) (FileStat, bool) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return FileStat{}, false
+	}
+	return FileStat{
+		Size:            info.Size(),
+		ModTimeUnixNano: info.ModTime().UnixNano(),
+	}, true
+}
+
 // FindingsBundleManifest persists the data the ConservativeDeltaPlanner
 // needs to decide whether a single-file edit can take the delta path:
 //
@@ -23,7 +38,16 @@ import (
 //
 // Keyed by a stable run identifier (the project root + sorted scan
 // paths) so distinct projects don't trample each other.
-const findingsBundleManifestVersion = 1
+// findingsBundleManifestVersion bumps whenever the on-disk schema
+// changes in a way that prior daemons would mis-read. Bumping this
+// invalidates every cached manifest so callers fall back to recompute;
+// daemons forward-compat by virtue of treating "wrong version" as
+// "missing" in LoadFindingsBundleManifestFromPath.
+//
+// v1 → v2: AbiHashes added. v1 readers silently ignore the new field;
+// v2 readers tolerate v1 manifests at load time (treated as ok=false
+// in LoadFindingsBundleManifestFromPath so the next save rewrites).
+const findingsBundleManifestVersion = 2
 
 type FindingsBundleManifest struct {
 	Version       int                 `json:"version"`
@@ -33,6 +57,15 @@ type FindingsBundleManifest struct {
 	ContentHashes map[string]string   `json:"contentHashes"`
 	StructuralFPs map[string]string   `json:"structuralFps,omitempty"`
 	FileStats     map[string]FileStat `json:"fileStats,omitempty"`
+	// AbiHashes is per-file public-API hash computed via
+	// arch.ExtractAbiSignatures + arch.HashAbiSignatures. Populated by
+	// buildManifestData when bundleEnabled. The oracle freshness gate
+	// reads this field to distinguish body-only edits (skip dependent
+	// invalidation) from public-ABI edits (eventually drives
+	// transitive invalidation in a future iteration; v1 only invalidates
+	// the edited file itself via stat comparison). Kotlin files only;
+	// Java entries are absent.
+	AbiHashes map[string]string `json:"abiHashes,omitempty"`
 }
 
 type FileStat struct {
@@ -122,6 +155,62 @@ func LoadFindingsBundleManifestFromPath(path string) (FindingsBundleManifest, bo
 		return FindingsBundleManifest{}, false
 	}
 	return m, true
+}
+
+// FileStatProvider returns the on-disk stat for a path. Callers pass
+// os.Stat-backed implementations in production; tests substitute a
+// stub for deterministic input.
+type FileStatProvider func(path string) (FileStat, bool)
+
+// StaleOracleCandidates returns the subset of paths whose file stat
+// differs from the prior manifest entry. Used by the oracle
+// freshness gate to identify .kt files that need a partial KAA
+// reanalyze without paying for a full content-hash recompute first
+// — the InvokeCachedWithOptions classifier then verifies via SHA-256
+// inside the JVM-bound miss path. A nil or empty prior manifest is
+// treated as "everything is potentially stale" so we never silently
+// reuse an oracle JSON that has no manifest evidence behind it; the
+// caller should special-case this if the historical lazy-load
+// behavior is desired (e.g. one-shot CLI with no daemon).
+//
+// stat is required and must be non-nil. Files whose stat is
+// unavailable (deleted, unreadable) are treated as stale.
+func StaleOracleCandidates(paths []string, prior FindingsBundleManifest, stat FileStatProvider) []string {
+	if stat == nil {
+		return paths
+	}
+	if len(prior.FileStats) == 0 && len(prior.ContentHashes) == 0 {
+		return paths
+	}
+	priorStats := prior.FileStats
+	stale := make([]string, 0)
+	for _, path := range paths {
+		current, ok := stat(path)
+		if !ok {
+			stale = append(stale, path)
+			continue
+		}
+		if priorStats == nil {
+			// Manifest predates FileStats — fall back to "if prior
+			// had a content hash we trust it, otherwise stale". This
+			// keeps freshly-upgraded daemons from re-running every
+			// file when the on-disk manifest format is one version
+			// behind.
+			if _, hadHash := prior.ContentHashes[path]; !hadHash {
+				stale = append(stale, path)
+			}
+			continue
+		}
+		priorStat, hadStat := priorStats[path]
+		if !hadStat {
+			stale = append(stale, path)
+			continue
+		}
+		if priorStat != current {
+			stale = append(stale, path)
+		}
+	}
+	return stale
 }
 
 // SaveFindingsBundleManifest persists the run manifest atomically.

--- a/internal/scanner/stale_oracle_candidates_test.go
+++ b/internal/scanner/stale_oracle_candidates_test.go
@@ -1,0 +1,164 @@
+package scanner
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+)
+
+func TestStaleOracleCandidates_NilStat_TreatsAllAsStale(t *testing.T) {
+	t.Parallel()
+	paths := []string{"/a.kt", "/b.kt"}
+	stale := StaleOracleCandidates(paths, FindingsBundleManifest{}, nil)
+	if !reflect.DeepEqual(stale, paths) {
+		t.Errorf("stale = %v, want %v", stale, paths)
+	}
+}
+
+func TestStaleOracleCandidates_NoPriorManifest_AllStale(t *testing.T) {
+	t.Parallel()
+	paths := []string{"/a.kt", "/b.kt"}
+	stat := func(string) (FileStat, bool) {
+		return FileStat{Size: 1, ModTimeUnixNano: 1}, true
+	}
+	stale := StaleOracleCandidates(paths, FindingsBundleManifest{}, stat)
+	// With no manifest evidence, every path must be reported stale so
+	// the caller doesn't reuse an oracle JSON we cannot verify.
+	if !reflect.DeepEqual(stale, paths) {
+		t.Errorf("stale = %v, want %v", stale, paths)
+	}
+}
+
+func TestStaleOracleCandidates_AllMatching_Empty(t *testing.T) {
+	t.Parallel()
+	paths := []string{"/a.kt", "/b.kt"}
+	prior := FindingsBundleManifest{
+		FileStats: map[string]FileStat{
+			"/a.kt": {Size: 10, ModTimeUnixNano: 100},
+			"/b.kt": {Size: 20, ModTimeUnixNano: 200},
+		},
+		ContentHashes: map[string]string{"/a.kt": "x", "/b.kt": "y"},
+	}
+	stat := func(p string) (FileStat, bool) {
+		return prior.FileStats[p], true
+	}
+	stale := StaleOracleCandidates(paths, prior, stat)
+	if len(stale) != 0 {
+		t.Errorf("stale = %v, want empty when stats match", stale)
+	}
+}
+
+func TestStaleOracleCandidates_StatMismatch_FlaggedStale(t *testing.T) {
+	t.Parallel()
+	paths := []string{"/a.kt", "/b.kt"}
+	prior := FindingsBundleManifest{
+		FileStats: map[string]FileStat{
+			"/a.kt": {Size: 10, ModTimeUnixNano: 100},
+			"/b.kt": {Size: 20, ModTimeUnixNano: 200},
+		},
+	}
+	// /b.kt's mtime moved forward — must be flagged stale; /a.kt unchanged.
+	stat := func(p string) (FileStat, bool) {
+		if p == "/b.kt" {
+			return FileStat{Size: 20, ModTimeUnixNano: 999}, true
+		}
+		return prior.FileStats[p], true
+	}
+	stale := StaleOracleCandidates(paths, prior, stat)
+	want := []string{"/b.kt"}
+	if !reflect.DeepEqual(stale, want) {
+		t.Errorf("stale = %v, want %v", stale, want)
+	}
+}
+
+func TestStaleOracleCandidates_StatUnavailable_FlaggedStale(t *testing.T) {
+	t.Parallel()
+	paths := []string{"/a.kt", "/missing.kt"}
+	prior := FindingsBundleManifest{
+		FileStats: map[string]FileStat{
+			"/a.kt": {Size: 10, ModTimeUnixNano: 100},
+		},
+	}
+	// /missing.kt's stat returns !ok; that must mark it stale rather
+	// than silently treating it as fresh.
+	stat := func(p string) (FileStat, bool) {
+		if p == "/missing.kt" {
+			return FileStat{}, false
+		}
+		return prior.FileStats[p], true
+	}
+	stale := StaleOracleCandidates(paths, prior, stat)
+	want := []string{"/missing.kt"}
+	if !reflect.DeepEqual(stale, want) {
+		t.Errorf("stale = %v, want %v", stale, want)
+	}
+}
+
+func TestStaleOracleCandidates_PriorMissingPath_FlaggedStale(t *testing.T) {
+	t.Parallel()
+	// /b.kt has no entry in the prior manifest's FileStats — treat as
+	// stale (it's effectively a new file from the cache's POV).
+	paths := []string{"/a.kt", "/b.kt"}
+	prior := FindingsBundleManifest{
+		FileStats: map[string]FileStat{
+			"/a.kt": {Size: 10, ModTimeUnixNano: 100},
+		},
+	}
+	stat := func(p string) (FileStat, bool) {
+		switch p {
+		case "/a.kt":
+			return prior.FileStats["/a.kt"], true
+		case "/b.kt":
+			return FileStat{Size: 5, ModTimeUnixNano: 500}, true
+		}
+		return FileStat{}, false
+	}
+	stale := StaleOracleCandidates(paths, prior, stat)
+	want := []string{"/b.kt"}
+	if !reflect.DeepEqual(stale, want) {
+		t.Errorf("stale = %v, want %v", stale, want)
+	}
+}
+
+func TestStaleOracleCandidates_LegacyManifestNoFileStats(t *testing.T) {
+	t.Parallel()
+	// Legacy manifests (pre-FileStats) only have ContentHashes. We
+	// can't compare stats — paths present in ContentHashes are
+	// trusted; new paths are flagged.
+	paths := []string{"/a.kt", "/new.kt"}
+	prior := FindingsBundleManifest{
+		ContentHashes: map[string]string{"/a.kt": "hashA"},
+	}
+	stat := func(string) (FileStat, bool) {
+		return FileStat{Size: 1, ModTimeUnixNano: 1}, true
+	}
+	stale := StaleOracleCandidates(paths, prior, stat)
+	want := []string{"/new.kt"}
+	if !reflect.DeepEqual(stale, want) {
+		t.Errorf("stale = %v, want %v", stale, want)
+	}
+}
+
+func TestStaleOracleCandidates_OrderPreserved(t *testing.T) {
+	t.Parallel()
+	// The result must reflect the input order so downstream
+	// classifier behavior is stable across runs (helps debug perf
+	// regressions).
+	paths := []string{"/c.kt", "/a.kt", "/b.kt"}
+	prior := FindingsBundleManifest{
+		FileStats: map[string]FileStat{}, // every path is "new"
+	}
+	stat := func(string) (FileStat, bool) {
+		return FileStat{Size: 1, ModTimeUnixNano: 1}, true
+	}
+	stale := StaleOracleCandidates(paths, prior, stat)
+	sorted := append([]string(nil), stale...)
+	sort.Strings(sorted)
+	if reflect.DeepEqual(stale, sorted) {
+		// If the result happens to be sorted, this test would still pass
+		// for the wrong reason — make the assertion explicit on input order.
+		if !reflect.DeepEqual(stale, paths) {
+			t.Errorf("stale = %v, want input order %v", stale, paths)
+		}
+	}
+}

--- a/tools/krit-types/src/main/kotlin/dev/jasonpearson/krit/types/Main.kt
+++ b/tools/krit-types/src/main/kotlin/dev/jasonpearson/krit/types/Main.kt
@@ -205,6 +205,7 @@ fun handleRequestLine(
         when (request.method) {
             "analyze" -> RequestResult.Response(session.handleAnalyze(request))
             "analyzeAll" -> RequestResult.Response(session.handleAnalyzeAll(request))
+            "analyzeFiles" -> RequestResult.Response(session.handleAnalyzeFiles(request))
             "analyzeWithDeps" -> RequestResult.Response(session.handleAnalyzeWithDeps(request))
             "listPlugins" -> RequestResult.Response(session.handleListPlugins(request))
             "analyzeFile" -> RequestResult.Response(session.handleAnalyzeFileWithPlugins(request))
@@ -309,6 +310,60 @@ class DaemonSession(
                 if (lastMtime == null || currentMtime != lastMtime) {
                     filesToAnalyze.add(ktFile)
                     fileTimestamps[ktFile.virtualFilePath] = currentMtime
+                }
+            } else {
+                errors[requestedPath] = "File not found in source module"
+            }
+        }
+
+        val files = mutableMapOf<String, FileResult>()
+        val deps = mutableMapOf<String, ClassResult>()
+        val callFilter = request.callFilter ?: args.callFilter
+
+        for (ktFile in filesToAnalyze) {
+            try {
+                analyzeKtFile(ktFile, files, deps, args.expressions, memo = memo, callFilter = callFilter, declarationProfile = args.declarationProfile, callTargetMemo = callTargetMemo, includeDiagnostics = args.diagnostics)
+            } catch (e: Exception) {
+                errors[ktFile.virtualFilePath] = e.message ?: "Analysis failed"
+                System.err.println("Error analyzing ${ktFile.virtualFilePath}: ${e.message}")
+            }
+        }
+
+        return buildDaemonResponse(request.id, files, deps, errors)
+    }
+
+    // Variant of handleAnalyze for the freshness gate. Skips the
+    // mtime short-circuit (the Go caller has already proved the files
+    // are dirty; re-checking would corrupt the cache by returning an
+    // empty FileResult). No cacheDeps output — partial reanalyze
+    // merges into the existing types.json without touching the per-file
+    // cache.
+    @OptIn(KaExperimentalApi::class)
+    fun handleAnalyzeFiles(request: DaemonRequest): String {
+        val requestedFiles = request.files
+        if (requestedFiles.isNullOrEmpty()) {
+            return """{"id":${request.id},"result":{"files":{},"dependencies":{}}}"""
+        }
+
+        val ktFiles = sourceModule.psiRoots.filterIsInstance<KtFile>()
+        val filesToAnalyze = mutableListOf<KtFile>()
+        val errors = mutableMapOf<String, String>()
+
+        for (requestedPath in requestedFiles) {
+            val resolvedPath = File(requestedPath).canonicalPath
+            val ktFile = ktFiles.find { file ->
+                file.virtualFilePath == resolvedPath ||
+                    file.virtualFilePath.endsWith(requestedPath) ||
+                    file.virtualFilePath == requestedPath
+            }
+            if (ktFile != null) {
+                filesToAnalyze.add(ktFile)
+                // Update the timestamp so any subsequent handleAnalyze
+                // call on the same session won't redundantly re-analyze
+                // a file we just refreshed.
+                val fileOnDisk = File(ktFile.virtualFilePath)
+                if (fileOnDisk.exists()) {
+                    fileTimestamps[ktFile.virtualFilePath] = fileOnDisk.lastModified()
                 }
             } else {
                 errors[requestedPath] = "File not found in source module"


### PR DESCRIPTION
## Summary

The warm-path oracle short-circuit in `runAutoDetectOracle` (index.go:1008) silently served stale KAA facts after any in-place `.kt` edit. This adds a freshness gate that detects stat-stale files via the bundle manifest, then routes them through a partial JVM reanalyze instead of the lazy-load. Daemon mode learns a new `analyzeFiles` JVM command so its resident KAA session can do incremental partial reanalysis. Per-file public-ABI hashes are now persisted (manifest v2) for future transitive invalidation.

## Behavior

| Run | Wall | KAA time | Notes |
|---|---:|---:|---|
| Cold (`compiler/frontend`, 464 .kt) | 11.8s | 4.6s (464 files) | unchanged |
| Warm, no edit | 3.1s | 0ms | `freshnessGateFresh` — lazy-load preserved |
| Warm + K1 ABI edit | 11.6s | partial (1 file) | `freshnessGateStale` → partial reanalyze |

Findings parity preserved; warm+edit produces +3 findings consistent with the new public method.

## Implementation

- `IndexInput.StaleOraclePaths` + `InvocationOptions.ForcedMisses` plumb the stale-file hint from CLI/daemon into the existing per-file miss path
- `FindingsBundleManifest` v2 adds `AbiHashes` (computed via `arch.HashAbiSignatures`)
- New `oracle.Daemon.AnalyzeFilesWithCallFilter` + `analyzeFiles` JSON wire command
- `MergeFreshIntoCachedTypes` overlays partial daemon results onto the cached `types.json`; skips re-marshal when fresh is empty
- CLI runner now wires `FindingsBundleCacheRoot` so one-shot scans persist a manifest the gate can compare against

## Test plan

- [x] `go test ./... -count=1` — 70+ packages, all pass
- [x] `golangci-lint run ./...` — clean
- [x] 16 new unit tests (`splitForcedMisses`, `StaleOracleCandidates`, `mergeOracleData`, `MergeFreshIntoCachedTypes`, `AnalyzeFilesWithCallFilter`)
- [x] Manual cold/warm/warm+ABI benchmark against `~/github/kotlin/compiler/frontend/` confirms partial reanalyze fires and reports `forcedMisses` perf event

## Follow-up

Transitive ABI invalidation (when file X's ABI changes, also invalidate files referencing X's public API) requires the cross-file lookup map at oracle-decision time, but today `runOracle` is invoked before `runCodeIndexBuild`. Two viable paths documented inline; v3 will pursue reordering. `AbiHashes` are already collected so v3 needs only the dependents query.