### PR TITLE
feat(android): honor tools:node="remove"/"removeAll" on uses-permission

### DIFF
--- a/internal/android/convert.go
+++ b/internal/android/convert.go
@@ -119,6 +119,12 @@ func convertPermissions(m *Manifest, cm *ConvertedManifest) {
 		if perm.Name == "" {
 			continue
 		}
+		// tools:node="remove"/"removeAll" instructs the manifest merger
+		// to drop a permission contributed by a library — the app is not
+		// requesting it.
+		if perm.ToolsNode == ToolsNodeRemove || perm.ToolsNode == ToolsNodeRemoveAll {
+			continue
+		}
 		cm.UsesPermissions = append(cm.UsesPermissions, perm.Name)
 	}
 	for _, perm := range m.Permissions {

--- a/internal/android/convert_test.go
+++ b/internal/android/convert_test.go
@@ -116,6 +116,32 @@ func TestConvertManifest_UsesTreeSitterLines(t *testing.T) {
 	}
 }
 
+func TestConvertManifest_DropsUsesPermissionWithToolsNodeRemove(t *testing.T) {
+	m := &Manifest{
+		UsesPermissions: []UsesPermission{
+			{Name: "android.permission.INTERNET"},
+			{Name: "android.permission.READ_EXTERNAL_STORAGE", ToolsNode: ToolsNodeRemove},
+			{Name: "android.permission.WRITE_EXTERNAL_STORAGE", ToolsNode: ToolsNodeRemoveAll},
+			{Name: "android.permission.CAMERA", ToolsNode: "replace"},
+		},
+	}
+
+	got := ConvertManifest(m, "/tmp/AndroidManifest.xml")
+
+	want := []string{
+		"android.permission.INTERNET",
+		"android.permission.CAMERA",
+	}
+	if len(got.UsesPermissions) != len(want) {
+		t.Fatalf("UsesPermissions = %#v, want %#v", got.UsesPermissions, want)
+	}
+	for i, p := range got.UsesPermissions {
+		if p != want[i] {
+			t.Errorf("UsesPermissions[%d] = %q, want %q", i, p, want[i])
+		}
+	}
+}
+
 func TestConvertManifest_PreservesLocaleConfigWithoutOtherApplicationFields(t *testing.T) {
 	m := &Manifest{
 		Application: Application{

--- a/internal/android/manifest.go
+++ b/internal/android/manifest.go
@@ -30,9 +30,17 @@ type UsesSdk struct {
 	TargetSdkVersion string `xml:"http://schemas.android.com/apk/res/android targetSdkVersion,attr"`
 }
 
+// Manifest-merger tools:node directives used by libraries and apps to
+// override library-contributed elements.
+const (
+	ToolsNodeRemove    = "remove"
+	ToolsNodeRemoveAll = "removeAll"
+)
+
 // UsesPermission is a <uses-permission> element.
 type UsesPermission struct {
-	Name string `xml:"http://schemas.android.com/apk/res/android name,attr"`
+	Name      string `xml:"http://schemas.android.com/apk/res/android name,attr"`
+	ToolsNode string `xml:"http://schemas.android.com/tools node,attr"`
 }
 
 // Permission is a <permission> element.

--- a/internal/android/manifest_test.go
+++ b/internal/android/manifest_test.go
@@ -1,6 +1,7 @@
 package android
 
 import (
+	"encoding/xml"
 	"path/filepath"
 	"runtime"
 	"testing"
@@ -60,6 +61,31 @@ func TestParseManifest_UsesPermissions(t *testing.T) {
 		if up.Name != want[i] {
 			t.Errorf("UsesPermissions[%d] = %q, want %q", i, up.Name, want[i])
 		}
+	}
+}
+
+func TestParseManifest_UsesPermissionToolsNode(t *testing.T) {
+	const data = `<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    package="com.example.app">
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"
+        tools:node="remove" />
+</manifest>`
+
+	var m Manifest
+	if err := xml.Unmarshal([]byte(data), &m); err != nil {
+		t.Fatalf("xml.Unmarshal: %v", err)
+	}
+	if len(m.UsesPermissions) != 2 {
+		t.Fatalf("UsesPermissions count = %d, want 2", len(m.UsesPermissions))
+	}
+	if m.UsesPermissions[0].ToolsNode != "" {
+		t.Errorf("UsesPermissions[0].ToolsNode = %q, want empty", m.UsesPermissions[0].ToolsNode)
+	}
+	if m.UsesPermissions[1].ToolsNode != ToolsNodeRemove {
+		t.Errorf("UsesPermissions[1].ToolsNode = %q, want %q", m.UsesPermissions[1].ToolsNode, ToolsNodeRemove)
 	}
 }
 


### PR DESCRIPTION
## Summary
- `<uses-permission>` entries with `tools:node="remove"` or `tools:node="removeAll"` are excluded from `ConvertedManifest.UsesPermissions` so the manifest-merger directive is respected.
- Add `ToolsNode` field on the `UsesPermission` parser struct and `ToolsNodeRemove` / `ToolsNodeRemoveAll` constants for the merge directives.

## Test plan
- [x] `go build -o krit ./cmd/krit/`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...`
- [x] `go test ./... -count=1`
- [x] New parser test (`TestParseManifest_UsesPermissionToolsNode`) and converter test (`TestConvertManifest_DropsUsesPermissionWithToolsNodeRemove`) cover the removal directives and the negative `replace` case.