### PR TITLE
fix(scan): forward --custom-rule-jars to daemon analyze args

### DIFF
--- a/internal/cli/scan/daemon_delegate.go
+++ b/internal/cli/scan/daemon_delegate.go
@@ -611,6 +611,7 @@ func buildDaemonAnalyzeArgs(f *scanFlags, paths []string) daemon.AnalyzeProjectA
 		Experimental:     *f.Experimental,
 		EnableRules:      *f.EnableRules,
 		DisableRules:     *f.DisableRules,
+		CustomRuleJars:   parseCustomRuleJars(*f.CustomRuleJars),
 		ShowPerf:         *f.Perf || *f.PerfRules,
 		PerfRules:        *f.PerfRules,
 		InputTypesPath:   inputTypesPath,

--- a/internal/cli/scan/daemon_delegate_test.go
+++ b/internal/cli/scan/daemon_delegate_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 	"time"
 
@@ -657,6 +658,26 @@ func TestBuildDaemonAnalyzeArgs_ForwardsNoCache(t *testing.T) {
 	args2 := buildDaemonAnalyzeArgs(f2, []string{"/tmp"})
 	if args2.NoCache {
 		t.Errorf("NoCache = true with default flags, want false")
+	}
+}
+
+// TestBuildDaemonAnalyzeArgs_ForwardsCustomRuleJars confirms the
+// --custom-rule-jars flag rides on AnalyzeProjectArgs.CustomRuleJars
+// so the daemon's analyze-project path loads the plugin rules.
+// Without this the daemon runs the scan without plugin dispatch and
+// returns zero plugin findings.
+func TestBuildDaemonAnalyzeArgs_ForwardsCustomRuleJars(t *testing.T) {
+	f := freshScanFlags(t)
+	*f.CustomRuleJars = "/tmp/a.jar,/tmp/b.jar"
+	args := buildDaemonAnalyzeArgs(f, []string{"/tmp"})
+	want := []string{"/tmp/a.jar", "/tmp/b.jar"}
+	if !reflect.DeepEqual(args.CustomRuleJars, want) {
+		t.Errorf("CustomRuleJars = %v, want %v", args.CustomRuleJars, want)
+	}
+	f2 := freshScanFlags(t)
+	args2 := buildDaemonAnalyzeArgs(f2, []string{"/tmp"})
+	if len(args2.CustomRuleJars) != 0 {
+		t.Errorf("CustomRuleJars = %v with default flags, want empty", args2.CustomRuleJars)
 	}
 }
 


### PR DESCRIPTION
## Summary
- `buildDaemonAnalyzeArgs` was dropping the parsed `CustomRuleJars` slice, so the daemon analyze-project path silently ran without plugin dispatch even when `--custom-rule-jars` was set on the CLI.
- Wire `CustomRuleJars: parseCustomRuleJars(*f.CustomRuleJars)` into the daemon args alongside the existing flag forwarders.
- Add a regression test (`TestBuildDaemonAnalyzeArgs_ForwardsCustomRuleJars`) covering both the populated case and the default-empty case so the field can't silently regress.

Spotted while reviewing the ctx-followups branch (PR #345) — the gap is independent of that change but explains why the `external-rule-example` job intermittently sees zero plugin findings on daemon runs.

## Test plan
- [x] `go vet ./internal/cli/scan/`
- [x] `go test ./internal/cli/scan/ -run TestBuildDaemonAnalyzeArgs -count=1`
- [x] `go build -o /tmp/krit-verify ./cmd/krit/`
- [x] CI: `external-rule-example` should now pass on the daemon path