### PR TITLE
fix(daemon): module-aware rules + columnar formats over wire

### DIFF
--- a/internal/cli/scan/daemon_delegate.go
+++ b/internal/cli/scan/daemon_delegate.go
@@ -587,10 +587,15 @@ func daemonCompatibleFlags(f *scanFlags) bool {
 // propagated; anything outside that set should have been filtered
 // upstream.
 func buildDaemonAnalyzeArgs(f *scanFlags, paths []string) daemon.AnalyzeProjectArgs {
-	format := *f.Format
-	if *f.Report != "" {
-		format = *f.Report
-	}
+	// Use resolveEffectiveFormat so the wire-side and the local-side
+	// (writeDaemonFindings) agree on what the CLI is going to render:
+	// `-f json` to a char-device stdout (e.g. /dev/null in CI's
+	// run_lint_test) auto-promotes to "plain", and if the wire decision
+	// here is taken on raw *f.Format the daemon ships no columns while
+	// writeDaemonFindings tries to render them. See formatNeedsLocalColumnar
+	// below — the includeColumns / wireFormat rewrite for plain / checkstyle
+	// only fires when both sides see the promoted "plain".
+	format := resolveEffectiveFormat(f)
 	// --sample-rule asks for JSON findings post-processed on the CLI
 	// side. Force the daemon to emit JSON regardless of the user's
 	// --format choice so the writer can decode the envelope. The

--- a/internal/cli/scan/daemon_delegate.go
+++ b/internal/cli/scan/daemon_delegate.go
@@ -140,6 +140,34 @@ func dispatchDaemonShortCircuits(f *scanFlags, paths []string, res daemon.Analyz
 	return false, 0
 }
 
+// formatNeedsLocalColumnar reports whether the configured output
+// format is non-JSON-shaped and must be rendered locally from the
+// daemon-shipped FindingColumns. AnalyzeProjectResult.Findings is a
+// json.RawMessage on the wire, so checkstyle XML / plain text bytes
+// would corrupt the envelope JSON if formatted daemon-side.
+func formatNeedsLocalColumnar(format string) bool {
+	return format == "checkstyle" || format == "plain"
+}
+
+// writeDaemonColumnarFindings decodes the daemon-shipped FindingColumns
+// segment and runs the columnar formatter for non-JSON-shaped outputs.
+// Called when formatNeedsLocalColumnar(format) is true.
+func writeDaemonColumnarFindings(w io.Writer, format string, rawColumns json.RawMessage) error {
+	cols, err := decodeDaemonColumns(rawColumns)
+	if err != nil {
+		return fmt.Errorf("decode columns: %w", err)
+	}
+	switch format {
+	case "plain":
+		output.FormatPlainColumns(w, cols)
+	case "checkstyle":
+		output.FormatCheckstyleColumns(w, cols)
+	default:
+		return fmt.Errorf("unsupported columnar format: %s", format)
+	}
+	return nil
+}
+
 // writeDaemonFindings handles the common path: stream the daemon's
 // findings JSON to the configured output writer, surface any
 // profile warnings, render the dispatch-profile table when armed,
@@ -150,7 +178,14 @@ func writeDaemonFindings(f *scanFlags, res daemon.AnalyzeProjectResult, start ti
 		fmt.Fprintf(os.Stderr, "error: %v\n", openErr)
 		return 2
 	}
-	if _, err := w.Write(res.Findings); err != nil {
+	effectiveFormat := resolveEffectiveFormat(f)
+	if formatNeedsLocalColumnar(effectiveFormat) {
+		if err := writeDaemonColumnarFindings(w, effectiveFormat, res.Columns); err != nil {
+			_ = closer()
+			fmt.Fprintf(os.Stderr, "error: %v\n", err)
+			return 2
+		}
+	} else if _, err := w.Write(res.Findings); err != nil {
 		_ = closer()
 		fmt.Fprintf(os.Stderr, "error: write findings: %v\n", err)
 		return 2
@@ -597,11 +632,23 @@ func buildDaemonAnalyzeArgs(f *scanFlags, paths []string) daemon.AnalyzeProjectA
 	// directly and discards the findings JSON, but the daemon still
 	// streams it. --baseline-audit / --delta tolerate any format on
 	// the daemon side because the bytes are discarded the same way.
+	//
+	// Non-JSON-shaped formats (checkstyle XML / plain text) must also
+	// ride the columns wire: AnalyzeProjectResult.Findings is a
+	// json.RawMessage, so daemon-side formatted XML / text would
+	// corrupt the envelope JSON. Force the daemon to emit JSON for
+	// findings (cheap, columns are the source of truth) and run the
+	// columnar formatter locally in writeDaemonFindings.
+	wireFormat := format
 	includeColumns := *f.RuleAudit || *f.BaselineAudit || *f.Delta != "" ||
 		*f.Fix || *f.FixBinary || *f.RemoveDeadCode
+	if formatNeedsLocalColumnar(format) {
+		includeColumns = true
+		wireFormat = "json"
+	}
 	return daemon.AnalyzeProjectArgs{
 		Paths:            paths,
-		Format:           format,
+		Format:           wireFormat,
 		BaselinePath:     baselinePath,
 		DiffRef:          *f.Diff,
 		MinConfidence:    *f.MinConfidence,

--- a/internal/cli/scan/daemon_delegate_test.go
+++ b/internal/cli/scan/daemon_delegate_test.go
@@ -3,17 +3,20 @@ package scan
 import (
 	"context"
 	"encoding/json"
+	"encoding/xml"
 	"flag"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/kaeawc/krit/internal/cli/daemonclient"
 	"github.com/kaeawc/krit/internal/daemon"
+	"github.com/kaeawc/krit/internal/scanner"
 )
 
 // TestTryDaemonDelegate_NoDaemonShortCircuits guards the
@@ -132,6 +135,125 @@ func TestTryDaemonDelegate_FixRoutesViaDaemon(t *testing.T) {
 	handled, _ := tryDaemonDelegate(f, []string{root}, root)
 	if !handled {
 		t.Fatalf("expected handled=true with --fix routed through daemon; got fall-through")
+	}
+}
+
+// TestTryDaemonDelegate_CheckstyleRoutesViaColumns confirms `-f
+// checkstyle` rides the FindingColumns wire segment (IncludeColumns=true)
+// so the daemon's findings JSON byte stream cannot corrupt the envelope.
+// The CLI renders the columnar Checkstyle XML locally; the daemon's
+// AnalyzeProjectResult.Findings carries inert JSON that's discarded by
+// writeDaemonFindings on this branch.
+func TestTryDaemonDelegate_CheckstyleRoutesViaColumns(t *testing.T) {
+	cols := scanner.CollectFindings([]scanner.Finding{{
+		File:     "foo.kt",
+		Line:     12,
+		Col:      3,
+		Severity: "warning",
+		RuleSet:  "rs",
+		Rule:     "R1",
+		Message:  "msg",
+	}})
+	colsBytes, err := json.Marshal(&cols)
+	if err != nil {
+		t.Fatalf("marshal columns: %v", err)
+	}
+	socketDir := startMockDaemon(t, mockBehavior{
+		findings:      `{"rules":["R1"],"line":[12]}`,
+		findingsCount: 1,
+		columns:       string(colsBytes),
+	})
+	root := newRoot(t)
+	linkSock(t, root, filepath.Join(socketDir, "d.sock"))
+
+	out := redirectStdout(t)
+	f := freshScanFlags(t)
+	*f.Format = "checkstyle"
+
+	handled, code := tryDaemonDelegate(f, []string{root}, root)
+	if !handled {
+		t.Fatalf("expected handled=true for -f checkstyle via daemon")
+	}
+	if code != 1 {
+		t.Errorf("expected exit 1 with findings; got %d", code)
+	}
+	got := out()
+	if !strings.HasPrefix(got, "<?xml") {
+		t.Fatalf("expected checkstyle XML output; got %q", got)
+	}
+	if err := xml.Unmarshal([]byte(got), new(struct {
+		XMLName xml.Name `xml:"checkstyle"`
+	})); err != nil {
+		t.Fatalf("checkstyle output does not parse as XML: %v\nbody: %s", err, got)
+	}
+	if !strings.Contains(got, "foo.kt") || !strings.Contains(got, "R1") {
+		t.Errorf("checkstyle output missing finding fields:\n%s", got)
+	}
+}
+
+// TestTryDaemonDelegate_PlainRoutesViaColumns mirrors the checkstyle
+// case for `-f plain`: the daemon ships FindingColumns, the CLI runs
+// FormatPlainColumns locally.
+func TestTryDaemonDelegate_PlainRoutesViaColumns(t *testing.T) {
+	cols := scanner.CollectFindings([]scanner.Finding{{
+		File:     "bar.kt",
+		Line:     7,
+		Col:      4,
+		Severity: "error",
+		RuleSet:  "rs",
+		Rule:     "R2",
+		Message:  "boom",
+	}})
+	colsBytes, err := json.Marshal(&cols)
+	if err != nil {
+		t.Fatalf("marshal columns: %v", err)
+	}
+	socketDir := startMockDaemon(t, mockBehavior{
+		findings:      `{"rules":["R2"],"line":[7]}`,
+		findingsCount: 1,
+		columns:       string(colsBytes),
+	})
+	root := newRoot(t)
+	linkSock(t, root, filepath.Join(socketDir, "d.sock"))
+
+	out := redirectStdout(t)
+	f := freshScanFlags(t)
+	*f.Format = "plain"
+
+	handled, code := tryDaemonDelegate(f, []string{root}, root)
+	if !handled {
+		t.Fatalf("expected handled=true for -f plain via daemon")
+	}
+	if code != 1 {
+		t.Errorf("expected exit 1 with findings; got %d", code)
+	}
+	got := out()
+	if got == "" {
+		t.Fatal("expected non-empty plain output")
+	}
+	if !strings.Contains(got, "bar.kt") || !strings.Contains(got, "R2") || !strings.Contains(got, "boom") {
+		t.Errorf("plain output missing finding fields:\n%s", got)
+	}
+}
+
+// TestBuildDaemonAnalyzeArgs_ForwardsColumnsForNonJSONFormat pins the
+// daemon-side optimisation: -f checkstyle / -f plain set IncludeColumns
+// (so the columnar wire segment ships back) and rewrite Format=json on
+// the wire so the daemon does not waste cycles formatting XML/text the
+// CLI is going to discard anyway.
+func TestBuildDaemonAnalyzeArgs_ForwardsColumnsForNonJSONFormat(t *testing.T) {
+	for _, format := range []string{"checkstyle", "plain"} {
+		t.Run(format, func(t *testing.T) {
+			f := freshScanFlags(t)
+			*f.Format = format
+			args := buildDaemonAnalyzeArgs(f, []string{"/tmp"})
+			if !args.IncludeColumns {
+				t.Errorf("IncludeColumns = false, want true for -f %s", format)
+			}
+			if args.Format != "json" {
+				t.Errorf("wire Format = %q, want %q for -f %s", args.Format, "json", format)
+			}
+		})
 	}
 }
 

--- a/internal/cli/scan/daemon_delegate_test.go
+++ b/internal/cli/scan/daemon_delegate_test.go
@@ -257,6 +257,28 @@ func TestBuildDaemonAnalyzeArgs_ForwardsColumnsForNonJSONFormat(t *testing.T) {
 	}
 }
 
+// TestBuildDaemonAnalyzeArgs_RespectsReportOverride pins the regression
+// path that broke CI: --report (or resolveEffectiveFormat's auto-promote
+// json -> plain when stdout is a char device) must flow into the wire
+// args alongside writeDaemonFindings's same decision. If the wire side
+// uses raw *f.Format while the local renderer uses resolveEffectiveFormat,
+// the daemon ships no columns ("json" wire, IncludeColumns=false) and
+// the CLI tries to render "plain" from an empty columns segment, exit 2.
+// CI's run_lint_test redirects -f json to /dev/null (char-device on
+// Linux) and tripped exactly this skew.
+func TestBuildDaemonAnalyzeArgs_RespectsReportOverride(t *testing.T) {
+	f := freshScanFlags(t)
+	*f.Format = "json"
+	*f.Report = "plain"
+	args := buildDaemonAnalyzeArgs(f, []string{"/tmp"})
+	if !args.IncludeColumns {
+		t.Errorf("IncludeColumns = false, want true when --report=plain promotes the effective format")
+	}
+	if args.Format != "json" {
+		t.Errorf("wire Format = %q, want %q (plain riding the columns wire)", args.Format, "json")
+	}
+}
+
 // TestTryDaemonDelegate_HappyPathReturnsExitFromFindings closes the
 // loop: on a clean delegation, the CLI surfaces FindingsCount via
 // the standard exit-code rule (0 = clean, 1 = any finding).

--- a/internal/cli/serve/analyze_project.go
+++ b/internal/cli/serve/analyze_project.go
@@ -494,6 +494,12 @@ func (s *daemonState) buildProjectInput(args daemon.AnalyzeProjectArgs) (pipelin
 			// Wire is line-delimited; compact JSON keeps the body
 			// free of internal newlines.
 			JSONCompact: true,
+			// IncludeColumns asks the pipeline for the post-pipeline
+			// FindingColumns so streamingAnalyzeResponse can ship them
+			// in the "columns" wire segment. Without this the pre-Load
+			// BundleOutput cache fast-path returns FinalFindings empty
+			// and the CLI gets {} for columns.
+			RequireFinalFindings: args.IncludeColumns,
 		},
 		Host: pipeline.ProjectHostState{
 			ParseCache:                   parseCache,

--- a/internal/pipeline/index.go
+++ b/internal/pipeline/index.go
@@ -1179,10 +1179,14 @@ func loadFilesForOracleFilter(paths []string) []*scanner.File {
 // "indexBuild") stay under the caller-supplied "crossFileAnalysis"
 // parent so rule execution siblings can continue to nest under it.
 func (p IndexPhase) runCodeIndexBuild(ctx context.Context, in IndexInput, result *IndexResult) {
-	if in.CrossFileParentTracker == nil {
-		return
-	}
+	// Treat a nil tracker as "no perf telemetry" rather than "skip
+	// this phase entirely" — callers that don't enable --perf still
+	// need a populated CodeIndex so NeedsCrossFile rules see the
+	// project's symbol/reference graph.
 	crossTracker := in.CrossFileParentTracker
+	if crossTracker == nil {
+		crossTracker = perf.New(false)
+	}
 	parsedFiles := in.KotlinFiles
 	paths := in.Paths
 
@@ -1275,10 +1279,18 @@ func addJavaIndexPerfEntries(tracker perf.Tracker, s scanner.JavaIndexPerfSnapsh
 // "moduleAwareAnalysis" parent tracker and End()-s it after rule
 // execution siblings have run. Rule execution itself stays in main.go.
 func (p IndexPhase) runModuleIndexBuild(ctx context.Context, in IndexInput, result *IndexResult) {
-	if in.ModuleParentTracker == nil {
-		return
-	}
+	// Treat a nil tracker as "no perf telemetry" rather than "skip
+	// this phase entirely" — callers that don't enable --perf still
+	// need result.Graph + result.ModuleIndex populated so
+	// NeedsModuleIndex rules (ModuleDeadCode, PackageDependencyCycle,
+	// VersionCatalogUnused, ...) actually execute. The daemon hit
+	// this bug: without --perf it returned ~31k fewer findings than
+	// the in-process baseline on Signal-Android because every
+	// module-aware rule saw a nil Graph.
 	moduleTracker := in.ModuleParentTracker
+	if moduleTracker == nil {
+		moduleTracker = perf.New(false)
+	}
 
 	scanRoot := in.ModuleScanRoot
 	if scanRoot == "" {

--- a/internal/pipeline/project.go
+++ b/internal/pipeline/project.go
@@ -144,6 +144,13 @@ type ProjectArgs struct {
 	// ShowPerf builds OutputInput.CacheBudget. Zero falls back to
 	// cacheutil.DefaultParseCacheCapBytes.
 	ParseCacheCapBytes int64
+	// RequireFinalFindings forces the pipeline to populate
+	// ProjectResult.FinalFindings even when the streaming bundle-output
+	// fast-path could otherwise skip loading the FindingsBundle. The
+	// daemon sets this when AnalyzeProjectArgs.IncludeColumns is true so
+	// the wire's "columns" segment carries real column data; without it,
+	// the pre-Load BundleOutput cache hit returns empty findings.
+	RequireFinalFindings bool
 }
 
 // ProjectHostState is the long-lived subset of ProjectInput: state a
@@ -764,13 +771,28 @@ func awaitAnalysisCacheFuture(host ProjectHostState) ProjectHostState {
 
 func runProjectIndexPhase(ctx context.Context, args ProjectArgs, host ProjectHostState, warm warmAnalysisCachePlan, parseResult ParseResult) (IndexResult, error) {
 	hasIndexBackedCrossFileRule, hasParsedFilesRule, hasModuleAwareRule := ClassifyCrossFileNeeds(args.ActiveRules)
+	// IndexPhase's runCodeIndexBuild and runModuleIndexBuild treat a
+	// nil parent tracker as "this phase is disabled" and early-return
+	// without producing CodeIndex / Graph / ModuleIndex. That coupling
+	// is correct when perf timing is the only consumer, but it silently
+	// drops cross-file / module-aware findings when callers (like the
+	// daemon, which sets host.Tracker to a nil interface unless --perf
+	// is requested) leave host.Tracker unset. Fall back to a no-op
+	// tracker so the IndexPhase steps still execute. Issue: warm-path
+	// daemon returns ~31k fewer findings than in-process on Signal-
+	// Android because ModuleDeadCode / cross-file rules see nil Graph
+	// / CodeIndex.
+	hostTracker := host.Tracker
+	if hostTracker == nil {
+		hostTracker = perf.New(false)
+	}
 	var crossTracker perf.Tracker
-	if host.Tracker != nil && (hasIndexBackedCrossFileRule || hasParsedFilesRule) {
-		crossTracker = host.Tracker.Serial("crossFileAnalysis")
+	if hasIndexBackedCrossFileRule || hasParsedFilesRule {
+		crossTracker = hostTracker.Serial("crossFileAnalysis")
 	}
 	var moduleTracker perf.Tracker
-	if host.Tracker != nil && hasModuleAwareRule {
-		moduleTracker = host.Tracker.Serial("moduleAwareAnalysis")
+	if hasModuleAwareRule {
+		moduleTracker = hostTracker.Serial("moduleAwareAnalysis")
 	}
 	scanRoot := "."
 	if len(args.Paths) > 0 {
@@ -1902,6 +1924,15 @@ func canUseBundleOutputCache(args ProjectArgs, host ProjectHostState) bool {
 		return false
 	}
 	if args.WarningsAsErrors || args.MinConfidence > 0 {
+		return false
+	}
+	// RequireFinalFindings means the caller (daemon w/ IncludeColumns)
+	// needs the post-pipeline FindingColumns alongside the formatted
+	// bytes. The pre-Load BundleOutput cache path skips
+	// FindingsBundleStore.Load and leaves FinalFindings empty, which
+	// would ship empty columns on the wire — fall through to the bundle
+	// load + OutputPhase route so FinalFindings is populated.
+	if args.RequireFinalFindings {
 		return false
 	}
 	return true

--- a/internal/pipeline/project_test.go
+++ b/internal/pipeline/project_test.go
@@ -168,3 +168,78 @@ func TestRunProjectAnalysis_RunsTargetedResolutionBeforeDispatch(t *testing.T) {
 		t.Fatalf("expected resolver request for %s; got %v", path, resolver.calls[0])
 	}
 }
+
+// TestRunProjectAnalysis_ModuleAwareRule_RunsWithoutTracker is the
+// regression test for the daemon warm-path bug where module-aware
+// rules silently emitted zero findings when host.Tracker was nil
+// (i.e. --perf not enabled).
+//
+// IndexPhase.runModuleIndexBuild used to early-return when
+// in.ModuleParentTracker was nil, which left result.Graph and
+// result.ModuleIndex unset. CrossFilePhase.collectModuleAwareFindings
+// then bailed because in.Graph was nil and no NeedsModuleIndex rule
+// ever ran. On Signal-Android with -all-rules this dropped ~31k
+// findings (ModuleDeadCode, PackageDependencyCycle,
+// VersionCatalogUnused, ...) from the daemon's response relative to
+// in-process.
+//
+// The fix substitutes a no-op tracker when host.Tracker is nil so the
+// IndexPhase steps still produce their outputs. This test pins that
+// behavior by constructing a minimal multi-module Gradle project,
+// registering a NeedsModuleIndex rule, and asserting it actually
+// runs even when ProjectHostState carries no Tracker.
+func TestRunProjectAnalysis_ModuleAwareRule_RunsWithoutTracker(t *testing.T) {
+	dir := t.TempDir()
+	// settings.gradle.kts with one explicit module so DiscoverModules
+	// returns a non-empty Graph and ModuleHasAwareRule fires.
+	if err := os.WriteFile(filepath.Join(dir, "settings.gradle.kts"),
+		[]byte("include(\":app\")\n"), 0644); err != nil {
+		t.Fatalf("write settings: %v", err)
+	}
+	appDir := filepath.Join(dir, "app")
+	srcDir := filepath.Join(appDir, "src", "main", "kotlin")
+	if err := os.MkdirAll(srcDir, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(appDir, "build.gradle.kts"),
+		[]byte("plugins { kotlin(\"jvm\") }\n"), 0644); err != nil {
+		t.Fatalf("write app build: %v", err)
+	}
+	ktPath := filepath.Join(srcDir, "Sample.kt")
+	if err := os.WriteFile(ktPath,
+		[]byte("package p\nclass X\n"), 0644); err != nil {
+		t.Fatalf("write sample: %v", err)
+	}
+
+	// Register a fake NeedsModuleIndex rule that counts invocations.
+	var moduleRuleCalls int
+	rule := &api.Rule{
+		ID:          "FakeModuleAwareRule",
+		Category:    "test",
+		Description: "module-aware test rule",
+		Needs:       api.NeedsModuleIndex,
+		Check: func(ctx *api.Context) {
+			moduleRuleCalls++
+			if ctx.ModuleIndex == nil {
+				t.Errorf("module-aware rule got nil ModuleIndex")
+			}
+		},
+	}
+
+	// Crucial: leave host.Tracker unset (nil interface) — that's the
+	// exact daemon-without-perf condition that triggered the bug.
+	_, err := RunProjectAnalysis(context.Background(), ProjectInput{
+		Args: ProjectArgs{
+			Config:      config.NewConfig(),
+			Paths:       []string{dir},
+			ActiveRules: []*api.Rule{rule},
+		},
+		Host: ProjectHostState{},
+	})
+	if err != nil {
+		t.Fatalf("RunProjectAnalysis: %v", err)
+	}
+	if moduleRuleCalls == 0 {
+		t.Fatalf("expected module-aware rule to run at least once with nil Tracker; got 0 calls")
+	}
+}


### PR DESCRIPTION
## Summary

Two daemon warm-path fixes that were silently dropping findings or producing malformed output:

- **Module-aware / cross-file rules emitted zero findings without `--perf`.** `IndexPhase.runCodeIndexBuild` and `runModuleIndexBuild` early-returned whenever their parent tracker was nil, treating "no perf telemetry" as "skip the phase". The daemon leaves `host.Tracker` unset unless `--perf` is requested, so `CodeIndex`, `Graph`, and `ModuleIndex` were left empty and every `NeedsCrossFile` / `NeedsModuleIndex` rule saw nil context. On Signal-Android with `-all-rules` the daemon emitted ~31k fewer findings than in-process. Fix: substitute a no-op `perf.New(false)` tracker so the index phases still execute.
- **`-f checkstyle` / `-f plain` corrupted the wire envelope.** Those formats produced raw XML / text inside `AnalyzeProjectResult.Findings` (a `json.RawMessage`), breaking the JSON envelope. Fix: when the CLI requests a non-JSON-shaped format, force the wire `Format` to `"json"` and set `IncludeColumns=true`, then render Checkstyle / plain locally from the daemon-shipped `FindingColumns`. Adds `ProjectArgs.RequireFinalFindings` so the daemon's pre-Load `BundleOutput` cache path doesn't short-circuit before columns are populated.

## Test plan

- [x] `go build -o krit ./cmd/krit/`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...`
- [x] `go test ./... -count=1`
- [x] New regression tests:
  - `TestRunProjectAnalysis_ModuleAwareRule_RunsWithoutTracker` — pins nil-tracker fix with a `NeedsModuleIndex` rule on a minimal Gradle project.
  - `TestTryDaemonDelegate_CheckstyleRoutesViaColumns` / `TestTryDaemonDelegate_PlainRoutesViaColumns` — pin daemon columnar wire rendering.
  - `TestBuildDaemonAnalyzeArgs_ForwardsColumnsForNonJSONFormat` — pins wire-format rewrite.
- [ ] `make integration` (recommend running in CI; not run locally)