### PR TITLE
fix(oracle): pick Leyden AOT or AppCDS for krit-types daemon, never both

### DIFF
--- a/internal/oracle/daemon_jvm.go
+++ b/internal/oracle/daemon_jvm.go
@@ -116,6 +116,12 @@ func jdkMajorVersion(javaPath string) int {
 // buildLeydenAOTCache runs the Leyden AOT create step: it compiles the AOT
 // cache from an existing configuration file and exits immediately without
 // running the application. Fast (seconds), must complete before daemon launch.
+//
+// On JVM crashes during create (seen on some JDK 26 builds with Kotlin
+// shadow JARs that exercise IntelliJ verification paths) the JVM leaves
+// behind a zero-byte or partial cache file. Removing it here keeps the
+// next daemon launch from picking it up and aborting VM init with
+// "Unable to read generic CDS file map header from AOT cache".
 func buildLeydenAOTCache(javaPath, jarPath, configPath, cachePath string, verbose bool) error {
 	args := []string{
 		"-XX:AOTMode=create",
@@ -128,7 +134,16 @@ func buildLeydenAOTCache(javaPath, jarPath, configPath, cachePath string, verbos
 	}
 	cmd := exec.CommandContext(context.Background(), javaPath, args...)
 	if out, err := cmd.CombinedOutput(); err != nil {
+		_ = os.Remove(cachePath)
 		return fmt.Errorf("leyden AOT create: %w (output: %s)", err, strings.TrimSpace(string(out)))
+	}
+	// Sanity-check the produced cache. Some JVM error paths exit
+	// non-zero but only after touching the cache file, so cmd.Run
+	// might still return nil on certain builds. Drop the file if it
+	// looks empty so the use-branch fallback path stays correct.
+	if info, statErr := os.Stat(cachePath); statErr != nil || info.Size() == 0 {
+		_ = os.Remove(cachePath)
+		return fmt.Errorf("leyden AOT create: produced empty cache %s", cachePath)
 	}
 	return nil
 }
@@ -145,6 +160,13 @@ func buildJVMBaseArgs() []string {
 }
 
 // appendAppCDSArgs appends AppCDS flags to args and returns the result.
+//
+// Mutually exclusive with Leyden AOT: on JDK 25+ where Project Leyden
+// applies, AppCDS's `-Xshare:auto` and `-XX:SharedArchiveFile=` /
+// `-XX:ArchiveClassesAtExit=` flags conflict with `-XX:AOTCache=` /
+// `-XX:AOTMode=record`. Callers should call appendStartupCacheArgs
+// instead so the daemon launch picks Leyden when available and falls
+// back to AppCDS otherwise.
 func appendAppCDSArgs(args []string, jarPath string, verbose bool) []string {
 	archivePath, err := cdsArchivePath(jarPath)
 	if err != nil {
@@ -164,37 +186,68 @@ func appendAppCDSArgs(args []string, jarPath string, verbose bool) []string {
 	return args
 }
 
-// appendLeydenAOTArgs appends Project Leyden AOT flags (JDK 25+) to args and returns the result.
-func appendLeydenAOTArgs(args []string, javaPath, jarPath string, verbose bool) []string {
+// appendLeydenAOTArgs appends Project Leyden AOT flags (JDK 25+) to args
+// and returns (newArgs, true) when at least one AOT flag was added.
+// Returns (args, false) on older JDKs or when path resolution failed,
+// signalling the caller it should fall back to AppCDS.
+//
+// Leyden AOT and AppCDS are mutually exclusive on the launch command
+// line: both `-XX:AOTCache=` and `-XX:AOTMode=record` reject
+// `-Xshare:*` and `-XX:SharedArchiveFile=`/`-XX:ArchiveClassesAtExit=`.
+// Callers must never combine the two — use appendStartupCacheArgs.
+func appendLeydenAOTArgs(args []string, javaPath, jarPath string, verbose bool) ([]string, bool) {
 	if cachedJDKMajorVersion() < 25 {
-		return args
+		return args, false
 	}
 	leydenConfig, configErr := aotConfigPath(jarPath)
 	leydenCache, cacheErr := aotCachePath(jarPath)
 	if configErr != nil || cacheErr != nil {
-		return args
+		return args, false
 	}
-	if _, statErr := os.Stat(leydenCache); statErr == nil {
+	if info, statErr := os.Stat(leydenCache); statErr == nil && info.Size() > 0 {
 		args = append(args, "-XX:AOTCache="+leydenCache)
 		if verbose {
 			reporter().Verbosef("verbose: Leyden AOT: using cache %s\n", leydenCache)
 		}
-	} else if _, statErr := os.Stat(leydenConfig); statErr == nil {
+		return args, true
+	} else if statErr == nil {
+		// Empty or unreadable cache from a previous crash — discard
+		// so we don't poison the daemon launch with an invalid cache.
+		_ = os.Remove(leydenCache)
+		if verbose {
+			reporter().Verbosef("verbose: Leyden AOT: discarded empty cache %s\n", leydenCache)
+		}
+	}
+	if _, statErr := os.Stat(leydenConfig); statErr == nil {
 		if err := buildLeydenAOTCache(javaPath, jarPath, leydenConfig, leydenCache, verbose); err == nil {
 			args = append(args, "-XX:AOTCache="+leydenCache)
 			if verbose {
 				reporter().Verbosef("verbose: Leyden AOT: built and using cache %s\n", leydenCache)
 			}
+			return args, true
 		} else if verbose {
 			reporter().Verbosef("verbose: Leyden AOT: cache build failed (%v), starting without AOT\n", err)
 		}
-	} else {
-		args = append(args, "-XX:AOTMode=record", "-XX:AOTConfiguration="+leydenConfig)
-		if verbose {
-			reporter().Verbosef("verbose: Leyden AOT: recording class profile → %s\n", leydenConfig)
-		}
+		return args, false
 	}
-	return args
+	args = append(args, "-XX:AOTMode=record", "-XX:AOTConfiguration="+leydenConfig)
+	if verbose {
+		reporter().Verbosef("verbose: Leyden AOT: recording class profile → %s\n", leydenConfig)
+	}
+	return args, true
+}
+
+// appendStartupCacheArgs prefers Project Leyden AOT (JDK 25+) and falls
+// back to AppCDS on older JDKs or when Leyden setup failed. The two are
+// mutually exclusive on the JVM command line — combining them aborts
+// VM init with `Option AOTConfiguration cannot be used at the same time
+// with -Xshare:auto, ...`.
+func appendStartupCacheArgs(args []string, javaPath, jarPath string, verbose bool) []string {
+	args, addedAOT := appendLeydenAOTArgs(args, javaPath, jarPath, verbose)
+	if addedAOT {
+		return args
+	}
+	return appendAppCDSArgs(args, jarPath, verbose)
 }
 
 // openDaemonLogFile opens (or creates) the daemon log file and wires it to cmd.Stderr.

--- a/internal/oracle/daemon_jvm_test.go
+++ b/internal/oracle/daemon_jvm_test.go
@@ -1,0 +1,76 @@
+package oracle
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// containsFlag reports whether args contains an entry equal to value or
+// whose key (the part before "=") equals value. Lets the regression
+// tests assert both bare flags ("-Xshare:auto") and key=value pairs
+// ("-XX:AOTCache=/path/...").
+func containsFlag(args []string, value string) bool {
+	for _, arg := range args {
+		if arg == value {
+			return true
+		}
+		if idx := strings.Index(arg, "="); idx > 0 && arg[:idx] == value {
+			return true
+		}
+	}
+	return false
+}
+
+func writeTempJar(t *testing.T) string {
+	t.Helper()
+	jar := filepath.Join(t.TempDir(), "krit-types.jar")
+	if err := os.WriteFile(jar, []byte("fake jar"), 0644); err != nil {
+		t.Fatalf("write temp jar: %v", err)
+	}
+	return jar
+}
+
+// TestAppendStartupCacheArgs_NoMixedCDSAndAOT is the regression for the
+// JDK 25+ daemon-spawn failure: combining `-Xshare:auto`/CDS flags with
+// `-XX:AOTCache=` or `-XX:AOTMode=record` aborts VM init with
+// "Option AOTConfiguration cannot be used at the same time with
+// -Xshare:on, -Xshare:auto, ...". appendStartupCacheArgs must pick one
+// strategy per launch, never both.
+func TestAppendStartupCacheArgs_NoMixedCDSAndAOT(t *testing.T) {
+	// Sandbox HOME so cache paths land under TempDir and do not pollute
+	// the developer's ~/.krit/cache.
+	t.Setenv("HOME", t.TempDir())
+	jar := writeTempJar(t)
+
+	args := appendStartupCacheArgs(nil, "java", jar, false)
+
+	usesAOT := containsFlag(args, "-XX:AOTCache") ||
+		containsFlag(args, "-XX:AOTMode") ||
+		containsFlag(args, "-XX:AOTConfiguration")
+	usesCDS := containsFlag(args, "-XX:SharedArchiveFile") ||
+		containsFlag(args, "-XX:ArchiveClassesAtExit") ||
+		containsFlag(args, "-Xshare:auto")
+
+	if usesAOT && usesCDS {
+		t.Fatalf("appendStartupCacheArgs combined Leyden AOT and AppCDS flags (JDK 25+ refuses this combo):\n%v", args)
+	}
+}
+
+// TestAppendLeydenAOTArgs_ReportsAddition makes sure the
+// (args, addedAOT) contract holds: appendLeydenAOTArgs must return
+// addedAOT=true exactly when it appended at least one AOT flag, so the
+// wrapper can decide whether to skip AppCDS.
+func TestAppendLeydenAOTArgs_ReportsAddition(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	jar := writeTempJar(t)
+
+	args, addedAOT := appendLeydenAOTArgs(nil, "java", jar, false)
+	added := len(args) > 0
+
+	if added != addedAOT {
+		t.Fatalf("appendLeydenAOTArgs returned addedAOT=%v but appended=%v (args=%v)",
+			addedAOT, added, args)
+	}
+}

--- a/internal/oracle/daemon_registry.go
+++ b/internal/oracle/daemon_registry.go
@@ -227,8 +227,7 @@ func StartDaemon(jarPath string, sourceDirs []string, classpath []string, verbos
 	}
 
 	args := buildJVMBaseArgs()
-	args = appendAppCDSArgs(args, jarPath, verbose)
-	args = appendLeydenAOTArgs(args, javaPath, jarPath, verbose)
+	args = appendStartupCacheArgs(args, javaPath, jarPath, verbose)
 	args = appendExtraJVMArgsBeforeJar(args, extraJVMArgsFromEnv())
 	args = append(args, "-jar", jarPath, "--daemon")
 	if len(sourceDirs) > 0 {
@@ -408,8 +407,7 @@ func StartDaemonWithPortSlot(jarPath string, sourceDirs []string, classpath []st
 	}
 
 	args := buildJVMBaseArgs()
-	args = appendAppCDSArgs(args, jarPath, false)
-	args = appendLeydenAOTArgs(args, javaPath, jarPath, verbose)
+	args = appendStartupCacheArgs(args, javaPath, jarPath, verbose)
 	args = appendExtraJVMArgsBeforeJar(args, extraJVMArgsFromEnv())
 	args = append(args, "-jar", jarPath, "--daemon", "--port", "0")
 	if len(sourceDirs) > 0 {


### PR DESCRIPTION
## Summary
- On JDK 25+, the `krit-types` daemon launch was combining AppCDS flags (`-Xshare:auto` + `SharedArchiveFile`/`ArchiveClassesAtExit`) with Leyden AOT flags (`-XX:AOTMode=record` / `AOTConfiguration` / `AOTCache`). The JVM rejects that combination at init, the daemon died before signaling ready, and `krit scan` ran with no plugin-rule callbacks wired — `list-rules` still saw the descriptor (declarative-only) but no findings emitted. This is what made `TestExternalRuleExample_EndToEnd` fail in CI on JDK 26 with three subtests reporting 0 plugin findings.
- A secondary issue: a crashed AOT-create left a zero-byte cache file that poisoned subsequent daemon launches with `Unable to read generic CDS file map header from AOT cache`.

## Fix
- New `appendStartupCacheArgs` entry point in `internal/oracle/daemon_jvm.go` picks Leyden AOT *or* AppCDS, never both, and deletes empty/partial cache files after a failed create so the next launch is clean.
- `internal/oracle/daemon_registry.go` routes both `StartDaemon` and `StartDaemonWithPortSlot` through the new wrapper.
- Regression tests in `internal/oracle/daemon_jvm_test.go` pin the "never combined" invariant and the `addedAOT` return value.

## Test plan
- [x] `go build -o krit ./cmd/krit/`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...` — 0 issues
- [x] `go test ./tests/externalrule/ -count=1 -timeout 600s -v` — all 4 subtests PASS on JDK 26 (with a fresh `krit-types.jar` staged) and on JDK 21
- [x] `go test ./... -count=1`