### PR TITLE
feat(plugin-sdk): semver compat gate for custom rule jars (#309)

### DIFF
--- a/docs/external-rules.md
+++ b/docs/external-rules.md
@@ -370,13 +370,66 @@ underlying KAA calls may change without notice between Krit releases.
 
 **SDK version.** Krit publishes `dev.jasonpearson.krit:krit-rule-api`
 to Maven Central in lockstep with each Krit release (see
-[release notes](release.md)). A rule jar built against
-`krit-rule-api:X.Y.Z` is expected to run on Krit `X.Y.Z`. Patch-level
-binary compatibility (rule jar built on `0.2.0` running on `0.2.1`)
-is intended; minor and major bumps may require a recompile. The
-`Krit-SDK-Version` manifest attribute is the audit trail — Krit reads
-it when listing plugins and will use it to surface a mismatch warning
-once the gate lands.
+[release notes](release.md)). The `krit-rule-api` jar carries an
+`Implementation-Version` manifest attribute matching the published
+coordinate, and the `dev.jasonpearson.krit.custom` plugin stamps
+`Krit-SDK-Version` into every consumer rule jar's manifest. The Krit
+daemon reads both at load time and compares them via the
+[compatibility matrix](#compatibility-matrix) below.
+
+#### Compatibility matrix
+
+The daemon's verdict for a rule jar's `Krit-SDK-Version` vs. the
+daemon's own bundled `krit-rule-api` version:
+
+| Rule jar SDK | Daemon SDK | Verdict | Behavior |
+| --- | --- | --- | --- |
+| Exact match | — | ok | Silent. |
+| Patch differs only (e.g. `1.2.3` vs. `1.2.7`) | within same `1.x.y` | ok | Silent. The API is source- and binary-compatible across patch releases. |
+| Minor differs (e.g. `1.2.x` vs. `1.3.x`), major ≥ 1 | same major | warn | Rules still load; reporter prints a drift warning. New `Resolver` methods may not exist; rebuild against the daemon's version to stay supported. |
+| Minor differs under `0.x` (e.g. `0.2.x` vs. `0.3.x`) | major = 0 | error | Daemon refuses to load any rules from the jar. Pre-1.0 minor bumps are treated as breaking under semver. |
+| Major differs (e.g. `1.x.y` vs. `2.x.y`) | — | error | Daemon refuses to load. Rebuild required. |
+| Missing `Krit-SDK-Version` manifest attribute | — | warn | Rules still load. Suggests the jar was built by hand or with an old version of the custom-rule plugin. |
+| Unparseable version string | — | warn | Rules still load; the daemon cannot reason about compatibility. |
+| Either side `0.0.0-SNAPSHOT` (local dev) | — | ok | Silent — composite-build dogfooding wouldn't otherwise be useful. |
+
+Diagnostics surface in two places:
+
+- **CLI**: `--list-rules --custom-rule-jars …` prints a `warn:` /
+  `error:` line per jar before the rule table.
+- **Scan**: warnings are routed through the standard warning stream
+  (stderr by default). An `error`-level diagnostic fails the run with
+  an `incompatible custom rule jar(s); rebuild …` message — silently
+  skipping the jar would hide the fact that the rules never ran.
+
+The same diagnostics ride on the daemon's `listPlugins` RPC response
+under `result.diagnostics`, so other consumers (LSP, MCP, Gradle) can
+render them their own way. `analyzeFile` does not re-emit them — call
+`listPlugins` first if you need to surface compatibility verdicts in
+a custom front-end.
+
+**Semver policy for `krit-rule-api`.** The rule API follows standard
+semver, with the usual pre-1.0 caveat that minor bumps may be
+breaking. Concretely:
+
+- **Patch** (`X.Y.Z` → `X.Y.(Z+1)`): bug fixes, doc-only changes,
+  internal refactors. Source- and binary-compatible. Existing rule
+  jars run unchanged.
+- **Minor** (`X.Y.*` → `X.(Y+1).0`): additive only — new `Resolver`
+  methods (with default implementations once Kotlin allows on
+  interfaces, otherwise via new abstract methods scoped to the
+  daemon-side implementation), new `Capability` enum entries, new
+  `KritRuleInfo` fields with defaults. Rebuilding against the new
+  version is recommended but not required to keep loading.
+- **Major** (`X.*.*` → `(X+1).0.0`): removed or renamed symbols,
+  changed method signatures, semantic changes to existing methods. A
+  rebuild is required.
+- **Pre-1.0** (`0.Y.Z`): minor bumps may be breaking. The daemon
+  treats them as breaking by default.
+
+Pre-release identifiers (`-rc1`, `-alpha`) and build metadata
+(`+sha.abc`) are ignored for compatibility comparisons; the policy is
+expressed in terms of `MAJOR.MINOR` only.
 
 **ServiceLoader contract.** The interface name
 `dev.jasonpearson.krit.api.KritRule` is stable. The metadata

--- a/internal/cli/scan/early_exits.go
+++ b/internal/cli/scan/early_exits.go
@@ -410,6 +410,9 @@ func listPluginRuleDescriptors(customRuleJars []string, paths []string) []oracle
 		fmt.Fprintf(os.Stderr, "error: custom-rule plugins: %v\n", err)
 		os.Exit(2)
 	}
+	for _, diag := range list.Diagnostics {
+		fmt.Fprintln(os.Stderr, diag.Format())
+	}
 	return list.Rules
 }
 

--- a/internal/oracle/daemon.go
+++ b/internal/oracle/daemon.go
@@ -238,13 +238,44 @@ type PluginRuleDescriptor struct {
 
 // ListPluginsResult is the result payload for the krit-types listPlugins verb.
 type ListPluginsResult struct {
-	Rules []PluginRuleDescriptor `json:"rules"`
+	Rules       []PluginRuleDescriptor `json:"rules"`
+	Diagnostics []PluginLoadDiagnostic `json:"diagnostics,omitempty"`
 }
 
 // AnalyzePluginFileResult is the result payload for the krit-types analyzeFile verb.
 type AnalyzePluginFileResult struct {
 	Findings []PluginFinding   `json:"findings"`
 	Errors   map[string]string `json:"errors,omitempty"`
+}
+
+// PluginDiagLevel mirrors PluginLoadDiagnostic.Level on the krit-types
+// Kotlin side (lowercased enum name). Typed so a switch over
+// d.Level gets exhaustiveness help and a typo like "WARN" fails at
+// compile time.
+type PluginDiagLevel string
+
+// Diagnostic level values emitted by PluginLoadDiagnostic.Level.
+const (
+	PluginDiagWarn  PluginDiagLevel = "warn"
+	PluginDiagError PluginDiagLevel = "error"
+)
+
+// PluginLoadDiagnostic is the per-jar load-time SDK compatibility verdict
+// emitted by the daemon. See docs/external-rules.md#compatibility-matrix.
+type PluginLoadDiagnostic struct {
+	Jar              string          `json:"jar"`
+	Level            PluginDiagLevel `json:"level"`
+	RuleSDKVersion   string          `json:"ruleSdkVersion"`
+	DaemonSDKVersion string          `json:"daemonSdkVersion"`
+	Message          string          `json:"message"`
+}
+
+// Format renders the diagnostic in the "<level>: krit-rule-api: <jar>:
+// <message>" shape shared by every sink (CLI early-exit, scan reporter,
+// fatal-aggregation prefix). Centralises the framing so the three
+// consumers can't drift.
+func (d PluginLoadDiagnostic) Format() string {
+	return fmt.Sprintf("%s: krit-rule-api: %s: %s", d.Level, d.Jar, d.Message)
 }
 
 // PluginFinding is a custom Kotlin rule finding before conversion into

--- a/internal/pipeline/custom_kotlin_rules.go
+++ b/internal/pipeline/custom_kotlin_rules.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/kaeawc/krit/internal/config"
+	"github.com/kaeawc/krit/internal/diag"
 	"github.com/kaeawc/krit/internal/oracle"
 	"github.com/kaeawc/krit/internal/rules"
 	"github.com/kaeawc/krit/internal/scanner"
@@ -27,6 +28,9 @@ func runKotlinPluginRulesAndMerge(ctx context.Context, args ProjectArgs, host Pr
 	list, err := daemon.ListPlugins(args.CustomRuleJars)
 	if err != nil {
 		return fmt.Errorf("list Kotlin custom rules: %w", err)
+	}
+	if err := reportPluginDiagnostics(host.Reporter, list.Diagnostics); err != nil {
+		return err
 	}
 	ruleIDs, ruleOptions := selectPluginRules(list.Rules, args.Config)
 	if len(ruleIDs) == 0 {
@@ -120,6 +124,30 @@ func pluginFixToScanner(fix *oracle.PluginFix) *scanner.Fix {
 		out.Safety = uint8(rules.FixSemantic)
 	}
 	return out
+}
+
+// reportPluginDiagnostics surfaces per-jar SDK-compatibility verdicts from
+// the daemon. Errors fail the run because the daemon already refused to
+// load any rules from those jars — silently dropping them would hide the
+// fact that the rules never ran.
+func reportPluginDiagnostics(reporter *diag.Reporter, diagnostics []oracle.PluginLoadDiagnostic) error {
+	var fatal []string
+	for _, d := range diagnostics {
+		line := d.Format()
+		if d.Level == oracle.PluginDiagError {
+			fatal = append(fatal, line)
+			continue
+		}
+		reporter.Warnf("%s\n", line)
+	}
+	if len(fatal) == 0 {
+		return nil
+	}
+	sort.Strings(fatal)
+	return fmt.Errorf(
+		"incompatible custom rule jar(s); rebuild against the daemon's krit-rule-api version:\n  %s",
+		strings.Join(fatal, "\n  "),
+	)
 }
 
 func formatPluginErrors(errors map[string]string) string {

--- a/internal/pipeline/custom_kotlin_rules_test.go
+++ b/internal/pipeline/custom_kotlin_rules_test.go
@@ -1,6 +1,7 @@
 package pipeline
 
 import (
+	"bytes"
 	"context"
 	"os"
 	"path/filepath"
@@ -9,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/kaeawc/krit/internal/config"
+	"github.com/kaeawc/krit/internal/diag"
 	"github.com/kaeawc/krit/internal/oracle"
 	"github.com/kaeawc/krit/internal/rules"
 	api "github.com/kaeawc/krit/internal/rules/api"
@@ -265,6 +267,94 @@ func TestSelectPluginRulesNilConfigKeepsEveryRuleWithoutOptions(t *testing.T) {
 	}
 	if len(opts) != 0 {
 		t.Fatalf("ruleOptions = %v, want empty", opts)
+	}
+}
+
+func TestReportPluginDiagnosticsWarnsAndAggregatesErrors(t *testing.T) {
+	warn := &bytes.Buffer{}
+	reporter := &diag.Reporter{Warning: warn}
+
+	err := reportPluginDiagnostics(reporter, []oracle.PluginLoadDiagnostic{
+		{
+			Jar: "/tmp/z.jar", Level: oracle.PluginDiagError,
+			RuleSDKVersion: "1.0.0", DaemonSDKVersion: "2.0.0",
+			Message: "rule jar built against krit-rule-api 1.0.0 is incompatible with daemon krit-rule-api 2.0.0 (major version mismatch); rebuild against 2.0.0",
+		},
+		{
+			Jar: "/tmp/a.jar", Level: oracle.PluginDiagWarn,
+			RuleSDKVersion: "1.2.0", DaemonSDKVersion: "1.3.0",
+			Message: "minor version differs",
+		},
+		{
+			Jar: "/tmp/m.jar", Level: oracle.PluginDiagError,
+			RuleSDKVersion: "", DaemonSDKVersion: "1.3.0",
+			Message: "missing manifest",
+		},
+	})
+	if err == nil {
+		t.Fatal("expected error from PluginDiagError diagnostics")
+	}
+	msg := err.Error()
+	// Errors are sorted by full formatted line so the output is
+	// deterministic across map iteration.
+	wantOrder := []string{"/tmp/m.jar", "/tmp/z.jar"}
+	for i, jar := range wantOrder {
+		idx := strings.Index(msg, jar)
+		if idx < 0 {
+			t.Fatalf("error missing %s: %q", jar, msg)
+		}
+		if i > 0 && idx < strings.Index(msg, wantOrder[i-1]) {
+			t.Fatalf("errors not sorted: %q", msg)
+		}
+	}
+	if !strings.Contains(msg, "incompatible custom rule jar(s); rebuild") {
+		t.Errorf("error missing remediation prefix: %q", msg)
+	}
+
+	gotWarn := warn.String()
+	if !strings.Contains(gotWarn, "warn: krit-rule-api: /tmp/a.jar: minor version differs") {
+		t.Errorf("warn output missing formatted warn line: %q", gotWarn)
+	}
+	if strings.Contains(gotWarn, "/tmp/z.jar") || strings.Contains(gotWarn, "/tmp/m.jar") {
+		t.Errorf("errors leaked into warn stream: %q", gotWarn)
+	}
+}
+
+func TestReportPluginDiagnosticsNoOpOnEmpty(t *testing.T) {
+	warn := &bytes.Buffer{}
+	reporter := &diag.Reporter{Warning: warn}
+	if err := reportPluginDiagnostics(reporter, nil); err != nil {
+		t.Fatalf("nil diagnostics should be a no-op: %v", err)
+	}
+	if warn.Len() != 0 {
+		t.Errorf("nil diagnostics wrote to reporter: %q", warn.String())
+	}
+}
+
+func TestReportPluginDiagnosticsUnknownLevelStillSurfaces(t *testing.T) {
+	warn := &bytes.Buffer{}
+	reporter := &diag.Reporter{Warning: warn}
+	err := reportPluginDiagnostics(reporter, []oracle.PluginLoadDiagnostic{
+		{Jar: "/tmp/x.jar", Level: oracle.PluginDiagLevel("info"), Message: "fyi"},
+	})
+	if err != nil {
+		t.Fatalf("unknown-level diagnostic should not be fatal: %v", err)
+	}
+	if !strings.Contains(warn.String(), "/tmp/x.jar") {
+		t.Errorf("unknown-level diagnostic should still print via warn stream: %q", warn.String())
+	}
+}
+
+func TestPluginLoadDiagnosticFormat(t *testing.T) {
+	d := oracle.PluginLoadDiagnostic{
+		Jar:     "/tmp/acme.jar",
+		Level:   oracle.PluginDiagWarn,
+		Message: "minor version differs",
+	}
+	got := d.Format()
+	want := "warn: krit-rule-api: /tmp/acme.jar: minor version differs"
+	if got != want {
+		t.Errorf("Format() = %q, want %q", got, want)
 	}
 }
 

--- a/tools/krit-rule-api/build.gradle.kts
+++ b/tools/krit-rule-api/build.gradle.kts
@@ -32,6 +32,54 @@ java {
     withJavadocJar()
 }
 
+// Codegen so RuleApiVersion.VERSION tracks `version` automatically rather
+// than drifting from a hand-edited constant; the daemon reads it at
+// jar-load time to compare against the consumer rule jar's Krit-SDK-Version.
+val generateRuleApiVersion = tasks.register("generateRuleApiVersion") {
+    val versionString = version.toString()
+    val outputDir = layout.buildDirectory.dir("generated/source/ruleApiVersion/main")
+    inputs.property("ruleApiVersion", versionString)
+    outputs.dir(outputDir)
+    doLast {
+        val pkgDir = outputDir.get().asFile.resolve("dev/jasonpearson/krit/api")
+        pkgDir.mkdirs()
+        pkgDir.resolve("RuleApiVersion.kt").writeText(
+            """
+            |package dev.jasonpearson.krit.api
+            |
+            |/**
+            | * Version of `dev.jasonpearson.krit:krit-rule-api` baked in at build time.
+            | *
+            | * The Krit daemon compares this against the `Krit-SDK-Version` manifest
+            | * attribute stamped by `dev.jasonpearson.krit.custom` on each rule jar to
+            | * emit a load-time compatibility diagnostic. See `docs/external-rules.md`.
+            | */
+            |public object RuleApiVersion {
+            |    public const val VERSION: String = "$versionString"
+            |}
+            |
+            """.trimMargin()
+        )
+    }
+}
+
+sourceSets {
+    named("main") {
+        java.srcDir(generateRuleApiVersion.map { layout.buildDirectory.dir("generated/source/ruleApiVersion/main") })
+    }
+}
+
+tasks.named<Jar>("jar") {
+    val versionString = version.toString()
+    manifest {
+        attributes(
+            "Implementation-Title" to "krit-rule-api",
+            "Implementation-Version" to versionString,
+            "Implementation-Vendor" to "dev.jasonpearson",
+        )
+    }
+}
+
 publishing {
     publications {
         create<MavenPublication>("maven") {

--- a/tools/krit-types/src/main/kotlin/dev/jasonpearson/krit/types/PluginRules.kt
+++ b/tools/krit-types/src/main/kotlin/dev/jasonpearson/krit/types/PluginRules.kt
@@ -7,6 +7,7 @@ import dev.jasonpearson.krit.api.KritFile
 import dev.jasonpearson.krit.api.KritRule
 import dev.jasonpearson.krit.api.KritRuleInfo
 import dev.jasonpearson.krit.api.Resolver
+import dev.jasonpearson.krit.api.RuleApiVersion
 import dev.jasonpearson.krit.api.RuleContext
 import org.jetbrains.kotlin.analysis.api.KaExperimentalApi
 import org.jetbrains.kotlin.analysis.api.analyze
@@ -48,11 +49,105 @@ private data class PluginRuleDescriptor(
     val sdkVersion: String,
 )
 
+internal data class PluginLoadDiagnostic(
+    val jar: String,
+    val level: Level,
+    val ruleSdkVersion: String,
+    val daemonSdkVersion: String,
+    val message: String,
+) {
+    enum class Level { WARN, ERROR }
+}
+
+/**
+ * Semver-based compatibility gate for the rule SDK. The compatibility
+ * matrix and the rationale for each verdict live in
+ * `docs/external-rules.md#compatibility-matrix` — keep that in sync when
+ * changing this policy.
+ */
+internal object SdkCompatibility {
+    val DAEMON_SDK_VERSION: String = RuleApiVersion.VERSION
+
+    private const val DEV_SNAPSHOT = "0.0.0-SNAPSHOT"
+
+    fun check(
+        jar: String,
+        ruleSdkVersion: String,
+        daemonSdkVersion: String = DAEMON_SDK_VERSION,
+    ): PluginLoadDiagnostic? {
+        if (ruleSdkVersion.isBlank()) {
+            return PluginLoadDiagnostic(
+                jar = jar,
+                level = PluginLoadDiagnostic.Level.WARN,
+                ruleSdkVersion = "",
+                daemonSdkVersion = daemonSdkVersion,
+                message = "rule jar is missing the Krit-SDK-Version manifest attribute; " +
+                    "rebuild against dev.jasonpearson.krit:krit-rule-api:$daemonSdkVersion",
+            )
+        }
+        if (ruleSdkVersion == DEV_SNAPSHOT || daemonSdkVersion == DEV_SNAPSHOT) {
+            return null
+        }
+        val rule = Semver.parse(ruleSdkVersion)
+        val daemon = Semver.parse(daemonSdkVersion)
+        if (rule == null) {
+            return PluginLoadDiagnostic(
+                jar = jar,
+                level = PluginLoadDiagnostic.Level.WARN,
+                ruleSdkVersion = ruleSdkVersion,
+                daemonSdkVersion = daemonSdkVersion,
+                message = "could not parse rule Krit-SDK-Version '$ruleSdkVersion'; " +
+                    "expected semver matching daemon $daemonSdkVersion",
+            )
+        }
+        if (daemon == null) return null
+        if (rule.major == daemon.major && rule.minor == daemon.minor) {
+            return null
+        }
+        val breaking = rule.major != daemon.major ||
+            (rule.major == 0 && rule.minor != daemon.minor)
+        val level = if (breaking) PluginLoadDiagnostic.Level.ERROR else PluginLoadDiagnostic.Level.WARN
+        val reason = when {
+            rule.major != daemon.major -> "major version mismatch"
+            rule.major == 0 -> "0.x minor version mismatch (treated as breaking under semver)"
+            else -> "minor version differs"
+        }
+        val verb = if (breaking) "is incompatible with" else "may not be fully compatible with"
+        return PluginLoadDiagnostic(
+            jar = jar,
+            level = level,
+            ruleSdkVersion = ruleSdkVersion,
+            daemonSdkVersion = daemonSdkVersion,
+            message = "rule jar built against krit-rule-api $ruleSdkVersion " +
+                "$verb daemon krit-rule-api $daemonSdkVersion ($reason); " +
+                "rebuild against $daemonSdkVersion",
+        )
+    }
+}
+
+internal data class Semver(val major: Int, val minor: Int, val patch: Int) {
+    companion object {
+        // Accept `1.2.3`, `1.2.3-rc1`, `1.2.3+build.7`. Pre-release / build
+        // metadata is ignored for compatibility comparisons — the policy is
+        // expressed in terms of MAJOR.MINOR only.
+        private val SEMVER = Regex("""^(\d+)\.(\d+)\.(\d+)(?:[-+].*)?$""")
+        fun parse(s: String): Semver? {
+            val m = SEMVER.matchEntire(s.trim()) ?: return null
+            return Semver(
+                major = m.groupValues[1].toInt(),
+                minor = m.groupValues[2].toInt(),
+                patch = m.groupValues[3].toInt(),
+            )
+        }
+    }
+}
+
 private object PluginRuleRegistry {
     private val classloaders = mutableListOf<URLClassLoader>()
     private val loadedJars = linkedSetOf<String>()
     private val ruleIdsByJar = linkedMapOf<String, MutableList<String>>()
     private val rules = linkedMapOf<String, LoadedPluginRule>()
+    private val diagnosticsByJar = linkedMapOf<String, PluginLoadDiagnostic>()
 
     @Synchronized
     fun load(jars: List<String>) {
@@ -64,9 +159,18 @@ private object PluginRuleRegistry {
             if (file.path in loadedJars) {
                 continue
             }
+            val sdkVersion = readSdkVersion(file)
+            val diagnostic = SdkCompatibility.check(file.path, sdkVersion)
+            diagnostic?.let { diagnosticsByJar[file.path] = it }
+            if (diagnostic?.level == PluginLoadDiagnostic.Level.ERROR) {
+                // Mark the jar as visited so a repeat listPlugins call
+                // doesn't reopen an incompatible jar; the diagnostic itself
+                // surfaces in the response.
+                loadedJars.add(file.path)
+                continue
+            }
             val loader = URLClassLoader(arrayOf(file.toURI().toURL()), KritRule::class.java.classLoader)
             try {
-                val sdkVersion = readSdkVersion(file)
                 val serviceRules = ServiceLoader.load(KritRule::class.java, loader).iterator()
                 val jarRuleIds = ruleIdsByJar.getOrPut(file.path) { mutableListOf() }
                 while (serviceRules.hasNext()) {
@@ -107,6 +211,13 @@ private object PluginRuleRegistry {
                 throw t
             }
         }
+    }
+
+    @Synchronized
+    fun diagnosticsForJars(jars: List<String>): List<PluginLoadDiagnostic> {
+        if (jars.isEmpty()) return emptyList()
+        val wanted = jars.map { File(it).canonicalFile.path }.toSet()
+        return diagnosticsByJar.values.filter { it.jar in wanted }
     }
 
     @Synchronized
@@ -158,7 +269,11 @@ fun DaemonSession.handleListPlugins(request: DaemonRequest): String {
     val jars = request.pluginJars.orEmpty()
     return try {
         PluginRuleRegistry.load(jars)
-        buildListPluginsResponse(request.id, PluginRuleRegistry.descriptorsForJars(jars))
+        buildListPluginsResponse(
+            id = request.id,
+            descriptors = PluginRuleRegistry.descriptorsForJars(jars),
+            diagnostics = PluginRuleRegistry.diagnosticsForJars(jars),
+        )
     } catch (t: Throwable) {
         """{"id":${request.id},"error":"${escJsonStr(t.message ?: "listPlugins failed")}"}"""
     }
@@ -195,7 +310,11 @@ fun DaemonSession.handleAnalyzeFileWithPlugins(request: DaemonRequest): String {
                 errors[loaded.descriptor.ruleId] = t.message ?: "rule failed"
             }
         }
-        buildAnalyzeFileResponse(request.id, findings, errors)
+        buildAnalyzeFileResponse(
+            id = request.id,
+            findings = findings,
+            errors = errors,
+        )
     } catch (t: Throwable) {
         """{"id":${request.id},"error":"${escJsonStr(t.message ?: "analyzeFile failed")}"}"""
     }
@@ -386,7 +505,11 @@ private fun toPluginFinding(path: String, descriptor: PluginRuleDescriptor, find
     )
 }
 
-private fun buildListPluginsResponse(id: Long, descriptors: List<PluginRuleDescriptor>): String {
+private fun buildListPluginsResponse(
+    id: Long,
+    descriptors: List<PluginRuleDescriptor>,
+    diagnostics: List<PluginLoadDiagnostic>,
+): String {
     val sb = StringBuilder()
     sb.append("""{"id":""").append(id).append(""","result":{"rules":[""")
     var first = true
@@ -406,8 +529,28 @@ private fun buildListPluginsResponse(id: Long, descriptors: List<PluginRuleDescr
         }
         sb.append('}')
     }
-    sb.append("]}}")
+    sb.append(']')
+    appendDiagnostics(sb, diagnostics)
+    sb.append('}').append('}')
     return sb.toString()
+}
+
+private fun appendDiagnostics(sb: StringBuilder, diagnostics: List<PluginLoadDiagnostic>) {
+    if (diagnostics.isEmpty()) return
+    sb.append(",\"diagnostics\":[")
+    var first = true
+    for (d in diagnostics) {
+        if (!first) sb.append(',')
+        first = false
+        sb.append('{')
+        sb.append("\"jar\":").append(esc(d.jar)).append(',')
+        sb.append("\"level\":").append(esc(d.level.name.lowercase())).append(',')
+        sb.append("\"ruleSdkVersion\":").append(esc(d.ruleSdkVersion)).append(',')
+        sb.append("\"daemonSdkVersion\":").append(esc(d.daemonSdkVersion)).append(',')
+        sb.append("\"message\":").append(esc(d.message))
+        sb.append('}')
+    }
+    sb.append(']')
 }
 
 private fun buildAnalyzeFileResponse(

--- a/tools/krit-types/src/test/kotlin/dev/jasonpearson/krit/types/SdkCompatibilityTest.kt
+++ b/tools/krit-types/src/test/kotlin/dev/jasonpearson/krit/types/SdkCompatibilityTest.kt
@@ -1,0 +1,80 @@
+package dev.jasonpearson.krit.types
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class SdkCompatibilityTest {
+
+    private val jar = "/tmp/acme-rules.jar"
+
+    @Test
+    fun exactMatchProducesNoDiagnostic() {
+        assertNull(SdkCompatibility.check(jar, "1.2.3", "1.2.3"))
+    }
+
+    @Test
+    fun patchDriftIsSilentlyOk() {
+        assertNull(SdkCompatibility.check(jar, "1.2.0", "1.2.7"))
+        assertNull(SdkCompatibility.check(jar, "1.2.7", "1.2.0"))
+    }
+
+    @Test
+    fun preReleaseAndBuildMetadataAreIgnoredForCompat() {
+        assertNull(SdkCompatibility.check(jar, "1.2.3-rc1", "1.2.3"))
+        assertNull(SdkCompatibility.check(jar, "1.2.3+sha.abc", "1.2.3"))
+    }
+
+    @Test
+    fun minorDriftWarnsOnOneXButDoesNotBlock() {
+        val d = SdkCompatibility.check(jar, "1.2.5", "1.3.0") ?: error("expected a diagnostic")
+        assertEquals(PluginLoadDiagnostic.Level.WARN, d.level)
+        assertEquals("1.2.5", d.ruleSdkVersion)
+        assertEquals("1.3.0", d.daemonSdkVersion)
+        assertTrue(d.message.contains("minor version differs"), d.message)
+    }
+
+    @Test
+    fun majorDriftIsBlocking() {
+        val d = SdkCompatibility.check(jar, "1.5.0", "2.0.0") ?: error("expected a diagnostic")
+        assertEquals(PluginLoadDiagnostic.Level.ERROR, d.level)
+        assertTrue(d.message.contains("major version mismatch"), d.message)
+    }
+
+    @Test
+    fun zeroXMinorDriftIsBlocking() {
+        val d = SdkCompatibility.check(jar, "0.2.0", "0.3.0") ?: error("expected a diagnostic")
+        assertEquals(PluginLoadDiagnostic.Level.ERROR, d.level)
+        assertTrue(d.message.contains("0.x"), d.message)
+    }
+
+    @Test
+    fun zeroXPatchDriftIsOk() {
+        assertNull(SdkCompatibility.check(jar, "0.2.0", "0.2.5"))
+    }
+
+    @Test
+    fun missingManifestWarnsWithGuidance() {
+        val d = SdkCompatibility.check(jar, "", "1.4.2") ?: error("expected a diagnostic")
+        assertEquals(PluginLoadDiagnostic.Level.WARN, d.level)
+        assertTrue(d.message.contains("missing"), d.message)
+        assertTrue(d.message.contains("1.4.2"), d.message)
+    }
+
+    @Test
+    fun unparseableVersionWarns() {
+        val d = SdkCompatibility.check(jar, "not.a.semver", "1.2.3") ?: error("expected a diagnostic")
+        assertEquals(PluginLoadDiagnostic.Level.WARN, d.level)
+        assertTrue(d.message.contains("not.a.semver"), d.message)
+    }
+
+    @Test
+    fun snapshotDaemonOrJarIsAlwaysCompatible() {
+        // Local dev builds never produce a spurious diagnostic against a
+        // -SNAPSHOT counterpart — that direction is the whole point of
+        // composite-build dogfooding.
+        assertNull(SdkCompatibility.check(jar, "0.0.0-SNAPSHOT", "1.2.3"))
+        assertNull(SdkCompatibility.check(jar, "1.2.3", "0.0.0-SNAPSHOT"))
+    }
+}


### PR DESCRIPTION
## Summary

Closes #309. Adds a load-time SDK compatibility check for custom Kotlin rule jars: the `krit-rule-api` jar stamps its own `Implementation-Version` manifest attribute and bakes the same value into a generated `RuleApiVersion.VERSION` constant; the daemon reads it (via `SdkCompatibility.check`) against each consumer jar's `Krit-SDK-Version` and emits a structured `PluginLoadDiagnostic` per jar — major or 0.x-minor drift errors out and refuses class loading, other minor drift warns, patch drift and `0.0.0-SNAPSHOT` on either side are silent. Diagnostics ride on `listPlugins.result.diagnostics`, the CLI's `--list-rules` output, and `host.Reporter` during scans.

- `tools/krit-rule-api/build.gradle.kts` — `generateRuleApiVersion` codegen + jar manifest attributes (`Implementation-{Title,Version,Vendor}`)
- `tools/krit-types/.../PluginRules.kt` — `SdkCompatibility` / `Semver` / `PluginLoadDiagnostic`, plumbed through `PluginRuleRegistry.load` and `listPlugins`
- `internal/oracle/daemon.go` — typed `PluginDiagLevel`, `PluginLoadDiagnostic.Format()` so CLI / scan / fatal-aggregation share one framing
- `internal/pipeline/custom_kotlin_rules.go` — `reportPluginDiagnostics` warns through `host.Reporter` and aggregates errors into a single fatal
- `internal/cli/scan/early_exits.go` — prints diagnostics in `--list-rules`
- `docs/external-rules.md` — semver policy + compatibility matrix

## Validation criteria

- [x] `go build -o krit ./cmd/krit/`
- [x] `go vet ./...`
- [x] `golangci-lint run ./internal/pipeline/... ./internal/cli/scan/... ./internal/oracle/...` — 0 issues
- [x] `go test ./internal/pipeline/... ./internal/cli/scan/... ./internal/oracle/... -count=1` — pass
- [x] `go test ./... -count=1` — pass
- [x] `tools/krit-types$ ./gradlew test --tests SdkCompatibilityTest` — 10 tests pass (exact, patch drift, prerelease/build metadata ignored, minor drift warn, major drift error, 0.x-minor error, 0.x-patch ok, missing manifest warn, unparseable warn, snapshot always-ok)
- [x] New Go tests: `TestReportPluginDiagnosticsWarnsAndAggregatesErrors`, `TestReportPluginDiagnosticsNoOpOnEmpty`, `TestReportPluginDiagnosticsUnknownLevelStillSurfaces`, `TestPluginLoadDiagnosticFormat`
- [x] Manifest sanity check: `unzip -p tools/krit-rule-api/build/libs/krit-rule-api-*.jar META-INF/MANIFEST.MF` shows `Implementation-Title/Version/Vendor`

## Test plan

- [ ] CI green
- [ ] Smoke: `krit --list-rules --custom-rule-jars <built-against-old-api>.jar` prints a `warn:` / `error:` line before the rule table
- [ ] Smoke: `krit scan --custom-rule-jars <incompatible>.jar` fails with `incompatible custom rule jar(s); rebuild …`