### PR TITLE
feat(plugin-sdk): stabilize @KritRuleInfo capability semantics (#310)

### DIFF
--- a/docs/external-rules.md
+++ b/docs/external-rules.md
@@ -301,25 +301,53 @@ may not be known to the binary at config-load time.
 ## Capability semantics
 
 `@KritRuleInfo.needs` declares which project-scope facts the rule
-expects. Today the daemon reports declared capabilities back through
-`listPlugins` but does not yet plumb every one of them into the
-`RuleContext` exposed to `check()`. Treat the list below as
-*request now, receive when the SDK lands the corresponding hook*.
+expects. The daemon either delivers the requested fact into
+`RuleContext` or refuses to load the jar — there is no third "advisory"
+state. The list below is the supported surface today; the unsupported
+entries stay in the enum so existing source continues to compile, but
+the values are `@Deprecated` (warn) and a rule that declares one fails
+at jar load with a clear, copy-pasteable diagnostic. Tracked on
+[#308](https://github.com/kaeawc/krit/issues/308).
 
-| Capability | Today | Target (per [#308](https://github.com/kaeawc/krit/issues/308)) |
+| Capability | Status | What it gives you |
 | --- | --- | --- |
-| `NEEDS_RESOLVER` | `RuleContext.resolver` is non-null. Methods: `isSuspendCall`, `resolvedCallFqName`, `isLambdaSuspend`, `expressionType`. The bridge opens a fresh Kotlin Analysis API session per query; expect microsecond-class overhead per call. | Wider `KaSession` exposure (symbols, supertype queries, diagnostics) once the API surface stabilizes. |
-| `NEEDS_CROSS_FILE` | Advisory. | Cross-file declaration index (decl → references, references → decl). |
-| `NEEDS_MODULE_INDEX` | Advisory. | Gradle module identity + per-module dependency graph. |
-| `NEEDS_PARSED_FILES` | Already true for Kotlin custom rules — the daemon parses the file before invoking `check()`. | No change. |
-| `NEEDS_MANIFEST` | Advisory. | Android `AndroidManifest.xml` view. |
-| `NEEDS_RESOURCES` | Advisory. | Parsed `res/` tree (strings, drawables, layouts). |
-| `NEEDS_GRADLE` | Advisory. | Version catalog + applied plugins / dependencies. |
+| `NEEDS_RESOLVER` | **supported** | Populates `RuleContext.resolver` with the [`Resolver`](#) bridge. Methods: `isSuspendCall`, `resolvedCallFqName`, `isLambdaSuspend`, `expressionType`. Each call opens a Kotlin Analysis API session — expect microsecond-class overhead per query. |
+| `NEEDS_PARSED_FILES` | **supported (implicit)** | The daemon always parses the Kotlin file before invoking `check()` and exposes the result on `KritFile.ktFile`. Declaring it is a forward-compatible hint; omitting it changes nothing today. |
+| `NEEDS_CROSS_FILE` | `@Deprecated` — fails load | Cross-file declaration index (decl → references, references → decl). Not yet plumbed. |
+| `NEEDS_MODULE_INDEX` | `@Deprecated` — fails load | Gradle module identity + per-module dependency graph. Not yet plumbed. |
+| `NEEDS_MANIFEST` | `@Deprecated` — fails load | Android `AndroidManifest.xml` view. Not yet plumbed. |
+| `NEEDS_RESOURCES` | `@Deprecated` — fails load | Parsed `res/` tree (strings, drawables, layouts). Not yet plumbed. |
+| `NEEDS_GRADLE` | `@Deprecated` — fails load | Version catalog + applied plugins / dependencies. Not yet plumbed. |
 
-Declaring a capability you do not yet need is harmless — declaring one
-you do need is the forward-compatible way to opt in once the
-corresponding hook lands. Capabilities the daemon does not expose
-today are tracked on [#308](https://github.com/kaeawc/krit/issues/308).
+### What a load failure looks like
+
+A jar that declares an unsupported capability is rejected at
+`listPlugins` time, before any rule from that jar runs:
+
+```
+error: krit-rule-api: /tmp/acme-rules.jar: rule jar declares capabilities
+the daemon does not yet provide to plugin rules; the rule would run
+without the facts it asked for. Remove the declaration(s) or wait for
+support (tracked on https://github.com/kaeawc/krit/issues/308).
+Unsupported: [acme.NoTodo: NEEDS_GRADLE]
+```
+
+The diagnostic surfaces on the same channels as the SDK-compat verdict:
+`--list-rules` prints it before the rule table, `krit` (scan) fails the
+run, and `listPlugins` returns it under `result.diagnostics`. The
+remediation is to either delete the bad enum from `@KritRuleInfo.needs`
+or — once the corresponding hook lands — rebuild against a daemon that
+moves the entry into the supported set.
+
+### Promoting a capability from deprecated to supported
+
+When the daemon learns to deliver one of the deprecated capabilities
+(e.g. `NEEDS_GRADLE`), promotion is a minor-version change on
+`krit-rule-api`: the `@Deprecated` marker is removed, `RuleContext`
+grows the new accessor, the daemon adds the entry to
+`PluginCapabilities.SUPPORTED`, and the matrix above flips. Existing
+rule jars that already declared the capability start running with the
+new fact wired in — no rule-jar rebuild required.
 
 ## FixSafety levels
 

--- a/internal/pipeline/custom_kotlin_rules.go
+++ b/internal/pipeline/custom_kotlin_rules.go
@@ -126,10 +126,12 @@ func pluginFixToScanner(fix *oracle.PluginFix) *scanner.Fix {
 	return out
 }
 
-// reportPluginDiagnostics surfaces per-jar SDK-compatibility verdicts from
-// the daemon. Errors fail the run because the daemon already refused to
-// load any rules from those jars — silently dropping them would hide the
-// fact that the rules never ran.
+// reportPluginDiagnostics surfaces per-jar load-time verdicts from the
+// daemon (SDK-compat verdicts plus capability gate from
+// docs/external-rules.md#capability-semantics). Errors fail the run
+// because the daemon already refused to load any rules from those jars
+// — silently dropping them would hide the fact that the rules never
+// ran.
 func reportPluginDiagnostics(reporter *diag.Reporter, diagnostics []oracle.PluginLoadDiagnostic) error {
 	var fatal []string
 	for _, d := range diagnostics {
@@ -145,7 +147,7 @@ func reportPluginDiagnostics(reporter *diag.Reporter, diagnostics []oracle.Plugi
 	}
 	sort.Strings(fatal)
 	return fmt.Errorf(
-		"incompatible custom rule jar(s); rebuild against the daemon's krit-rule-api version:\n  %s",
+		"custom rule jar(s) failed to load; see per-jar message for the fix (rebuild against the daemon's krit-rule-api version, or remove unsupported capability declarations):\n  %s",
 		strings.Join(fatal, "\n  "),
 	)
 }

--- a/internal/pipeline/custom_kotlin_rules_test.go
+++ b/internal/pipeline/custom_kotlin_rules_test.go
@@ -307,8 +307,14 @@ func TestReportPluginDiagnosticsWarnsAndAggregatesErrors(t *testing.T) {
 			t.Fatalf("errors not sorted: %q", msg)
 		}
 	}
-	if !strings.Contains(msg, "incompatible custom rule jar(s); rebuild") {
+	if !strings.Contains(msg, "custom rule jar(s) failed to load") {
 		t.Errorf("error missing remediation prefix: %q", msg)
+	}
+	if !strings.Contains(msg, "rebuild against the daemon's krit-rule-api version") {
+		t.Errorf("error missing SDK-rebuild hint: %q", msg)
+	}
+	if !strings.Contains(msg, "remove unsupported capability declarations") {
+		t.Errorf("error missing capability remediation hint: %q", msg)
 	}
 
 	gotWarn := warn.String()

--- a/tools/krit-rule-api/src/main/kotlin/dev/jasonpearson/krit/api/KritRule.kt
+++ b/tools/krit-rule-api/src/main/kotlin/dev/jasonpearson/krit/api/KritRule.kt
@@ -179,14 +179,77 @@ enum class Severity { ERROR, WARNING, INFO }
 /** Rule maturity used for default activation and experimental gating. */
 enum class Maturity { STABLE, EXPERIMENTAL, DEPRECATED }
 
-/** Capabilities a custom rule needs from the Krit daemon. */
+/**
+ * Capabilities a custom rule needs from the Krit daemon.
+ *
+ * Each value documents which `RuleContext` hook the daemon wires up when
+ * the rule declares it. Capabilities marked `@Deprecated` are not yet
+ * delivered to plugin rules — declaring one of those fails the jar at
+ * load time with a clear message (see `PluginRules.kt`). The
+ * load-time gate exists so a typo or a too-optimistic declaration
+ * cannot silently degrade to "rule runs without the facts it asked
+ * for". Tracked on https://github.com/kaeawc/krit/issues/308.
+ *
+ * Adding a new capability is a minor-version change (additive, default
+ * not-required). Promoting a deprecated entry to "supported" is also a
+ * minor-version change. Removing a deprecated entry is a major-version
+ * change.
+ */
 enum class Capability {
+    /**
+     * Populates [RuleContext.resolver] with a [Resolver] backed by per-
+     * call Kotlin Analysis API sessions. Honored when the daemon
+     * successfully prepares a session for the current file.
+     */
     NEEDS_RESOLVER,
+
+    @Deprecated(
+        message = "NEEDS_CROSS_FILE is not yet delivered to plugin rules. " +
+            "Declaring it causes the rule jar to fail at load time. Tracked " +
+            "on https://github.com/kaeawc/krit/issues/308.",
+        level = DeprecationLevel.WARNING,
+    )
     NEEDS_CROSS_FILE,
+
+    @Deprecated(
+        message = "NEEDS_MODULE_INDEX is not yet delivered to plugin rules. " +
+            "Declaring it causes the rule jar to fail at load time. Tracked " +
+            "on https://github.com/kaeawc/krit/issues/308.",
+        level = DeprecationLevel.WARNING,
+    )
     NEEDS_MODULE_INDEX,
+
+    /**
+     * Indicates the rule walks a parsed Kotlin file. Always satisfied
+     * for Kotlin plugin rules — the daemon parses the source before
+     * invoking `check()` and exposes the result on [KritFile.ktFile].
+     * Declaring this capability is a forward-compatible hint; omitting
+     * it changes nothing today.
+     */
     NEEDS_PARSED_FILES,
+
+    @Deprecated(
+        message = "NEEDS_MANIFEST is not yet delivered to plugin rules. " +
+            "Declaring it causes the rule jar to fail at load time. Tracked " +
+            "on https://github.com/kaeawc/krit/issues/308.",
+        level = DeprecationLevel.WARNING,
+    )
     NEEDS_MANIFEST,
+
+    @Deprecated(
+        message = "NEEDS_RESOURCES is not yet delivered to plugin rules. " +
+            "Declaring it causes the rule jar to fail at load time. Tracked " +
+            "on https://github.com/kaeawc/krit/issues/308.",
+        level = DeprecationLevel.WARNING,
+    )
     NEEDS_RESOURCES,
+
+    @Deprecated(
+        message = "NEEDS_GRADLE is not yet delivered to plugin rules. " +
+            "Declaring it causes the rule jar to fail at load time. Tracked " +
+            "on https://github.com/kaeawc/krit/issues/308.",
+        level = DeprecationLevel.WARNING,
+    )
     NEEDS_GRADLE,
 }
 

--- a/tools/krit-types/src/main/kotlin/dev/jasonpearson/krit/types/PluginRules.kt
+++ b/tools/krit-types/src/main/kotlin/dev/jasonpearson/krit/types/PluginRules.kt
@@ -142,12 +142,72 @@ internal data class Semver(val major: Int, val minor: Int, val patch: Int) {
     }
 }
 
+internal data class CapabilityViolation(
+    val ruleId: String,
+    val unsupported: List<String>,
+)
+
+/**
+ * Single source of truth for the set of [Capability] values the daemon
+ * can actually deliver into [RuleContext] today. Anything outside this
+ * set must be rejected at jar load time so a rule cannot silently run
+ * without the facts it asked for. See `docs/external-rules.md#capability-semantics`
+ * for the user-facing matrix and the policy.
+ */
+internal object PluginCapabilities {
+    const val TRACKING_ISSUE_URL: String = "https://github.com/kaeawc/krit/issues/308"
+
+    val SUPPORTED: Set<String> = setOf(
+        Capability.NEEDS_RESOLVER.name,
+        // The daemon always parses the Kotlin file before invoking the
+        // rule; declaring NEEDS_PARSED_FILES is honored as a no-op hint
+        // rather than rejected, so existing rules that opt in stay
+        // forward-compatible.
+        Capability.NEEDS_PARSED_FILES.name,
+    )
+
+    fun unsupported(needs: List<String>): List<String> =
+        needs.filter { it !in SUPPORTED }
+
+    fun buildLoadDiagnostic(
+        jar: String,
+        ruleSdkVersion: String,
+        daemonSdkVersion: String,
+        violations: List<CapabilityViolation>,
+    ): PluginLoadDiagnostic {
+        // Sort by rule ID so the message is deterministic across
+        // ServiceLoader iteration order — otherwise the same offending
+        // jar would produce different diagnostic strings on different
+        // runs, breaking exact-match assertions in downstream tests.
+        val rendered = violations
+            .sortedBy { it.ruleId }
+            .joinToString(separator = "; ") { (id, caps) ->
+                "$id: ${caps.joinToString(separator = ", ")}"
+            }
+        val message = "rule jar declares capabilities the daemon does not yet provide " +
+            "to plugin rules; the rule would run without the facts it asked for. " +
+            "Remove the declaration(s) or wait for support (tracked on " +
+            "$TRACKING_ISSUE_URL). Unsupported: [$rendered]"
+        return PluginLoadDiagnostic(
+            jar = jar,
+            level = PluginLoadDiagnostic.Level.ERROR,
+            ruleSdkVersion = ruleSdkVersion,
+            daemonSdkVersion = daemonSdkVersion,
+            message = message,
+        )
+    }
+}
+
 private object PluginRuleRegistry {
     private val classloaders = mutableListOf<URLClassLoader>()
     private val loadedJars = linkedSetOf<String>()
     private val ruleIdsByJar = linkedMapOf<String, MutableList<String>>()
     private val rules = linkedMapOf<String, LoadedPluginRule>()
-    private val diagnosticsByJar = linkedMapOf<String, PluginLoadDiagnostic>()
+    // Multiple diagnostics per jar: a jar can carry both an SDK-compat
+    // warn AND a capability-error in the same load. Keeping them as a
+    // flat ordered list preserves emission order for deterministic
+    // listPlugins responses.
+    private val diagnostics: MutableList<PluginLoadDiagnostic> = mutableListOf()
 
     @Synchronized
     fun load(jars: List<String>) {
@@ -160,9 +220,9 @@ private object PluginRuleRegistry {
                 continue
             }
             val sdkVersion = readSdkVersion(file)
-            val diagnostic = SdkCompatibility.check(file.path, sdkVersion)
-            diagnostic?.let { diagnosticsByJar[file.path] = it }
-            if (diagnostic?.level == PluginLoadDiagnostic.Level.ERROR) {
+            val sdkDiagnostic = SdkCompatibility.check(file.path, sdkVersion)
+            sdkDiagnostic?.let { diagnostics.add(it) }
+            if (sdkDiagnostic?.level == PluginLoadDiagnostic.Level.ERROR) {
                 // Mark the jar as visited so a repeat listPlugins call
                 // doesn't reopen an incompatible jar; the diagnostic itself
                 // surfaces in the response.
@@ -170,54 +230,85 @@ private object PluginRuleRegistry {
                 continue
             }
             val loader = URLClassLoader(arrayOf(file.toURI().toURL()), KritRule::class.java.classLoader)
+            val staged: List<LoadedPluginRule>
             try {
-                val serviceRules = ServiceLoader.load(KritRule::class.java, loader).iterator()
-                val jarRuleIds = ruleIdsByJar.getOrPut(file.path) { mutableListOf() }
-                while (serviceRules.hasNext()) {
-                    val rule = serviceRules.next()
-                    val info = rule.javaClass.getAnnotation(KritRuleInfo::class.java)
-                    val descriptor = if (info != null) {
-                        PluginRuleDescriptor(
-                            ruleId = info.id,
-                            category = info.category,
-                            severity = info.severity.name.lowercase(),
-                            maturity = info.maturity.name.lowercase(),
-                            languages = info.languages.map { it.name.lowercase() },
-                            needs = info.needs.map { it.name },
-                            sdkVersion = sdkVersion,
-                        )
-                    } else {
-                        PluginRuleDescriptor(
-                            ruleId = rule.javaClass.name,
-                            category = "custom",
-                            severity = "warning",
-                            maturity = "experimental",
-                            languages = listOf("kotlin"),
-                            needs = emptyList(),
-                            sdkVersion = sdkVersion,
-                        )
-                    }
-                    jarRuleIds.add(descriptor.ruleId)
-                    rules[descriptor.ruleId] = LoadedPluginRule(rule, descriptor)
-                }
-                loadedJars.add(file.path)
-                classloaders.add(loader)
+                staged = stageRules(loader, sdkVersion)
             } catch (t: Throwable) {
-                ruleIdsByJar.remove(file.path)
-                try {
-                    loader.close()
-                } catch (_: Exception) {
-                }
+                loader.closeQuietly()
                 throw t
             }
+            val violations = staged.mapNotNull { loaded ->
+                val unsupported = PluginCapabilities.unsupported(loaded.descriptor.needs)
+                if (unsupported.isEmpty()) null else CapabilityViolation(loaded.descriptor.ruleId, unsupported)
+            }
+            if (violations.isNotEmpty()) {
+                diagnostics.add(
+                    PluginCapabilities.buildLoadDiagnostic(
+                        jar = file.path,
+                        ruleSdkVersion = sdkVersion,
+                        daemonSdkVersion = SdkCompatibility.DAEMON_SDK_VERSION,
+                        violations = violations,
+                    ),
+                )
+                loadedJars.add(file.path)
+                loader.closeQuietly()
+                continue
+            }
+            val jarRuleIds = ruleIdsByJar.getOrPut(file.path) { mutableListOf() }
+            for (loaded in staged) {
+                jarRuleIds.add(loaded.descriptor.ruleId)
+                rules[loaded.descriptor.ruleId] = loaded
+            }
+            loadedJars.add(file.path)
+            classloaders.add(loader)
         }
+    }
+
+    // Loader close is best-effort: a failure to release JAR file
+    // handles shouldn't mask the diagnostic or error we're about to
+    // surface, since the diagnostic is the user-actionable signal.
+    private fun URLClassLoader.closeQuietly() {
+        try {
+            close()
+        } catch (_: Exception) {
+        }
+    }
+
+    private fun stageRules(loader: URLClassLoader, sdkVersion: String): List<LoadedPluginRule> {
+        val staged = mutableListOf<LoadedPluginRule>()
+        for (rule in ServiceLoader.load(KritRule::class.java, loader)) {
+            val info = rule.javaClass.getAnnotation(KritRuleInfo::class.java)
+            val descriptor = if (info != null) {
+                PluginRuleDescriptor(
+                    ruleId = info.id,
+                    category = info.category,
+                    severity = info.severity.name.lowercase(),
+                    maturity = info.maturity.name.lowercase(),
+                    languages = info.languages.map { it.name.lowercase() },
+                    needs = info.needs.map { it.name },
+                    sdkVersion = sdkVersion,
+                )
+            } else {
+                PluginRuleDescriptor(
+                    ruleId = rule.javaClass.name,
+                    category = "custom",
+                    severity = "warning",
+                    maturity = "experimental",
+                    languages = listOf("kotlin"),
+                    needs = emptyList(),
+                    sdkVersion = sdkVersion,
+                )
+            }
+            staged.add(LoadedPluginRule(rule, descriptor))
+        }
+        return staged
     }
 
     @Synchronized
     fun diagnosticsForJars(jars: List<String>): List<PluginLoadDiagnostic> {
         if (jars.isEmpty()) return emptyList()
         val wanted = jars.map { File(it).canonicalFile.path }.toSet()
-        return diagnosticsByJar.values.filter { it.jar in wanted }
+        return diagnostics.filter { it.jar in wanted }
     }
 
     @Synchronized

--- a/tools/krit-types/src/test/kotlin/dev/jasonpearson/krit/types/PluginCapabilitiesTest.kt
+++ b/tools/krit-types/src/test/kotlin/dev/jasonpearson/krit/types/PluginCapabilitiesTest.kt
@@ -1,0 +1,106 @@
+package dev.jasonpearson.krit.types
+
+import dev.jasonpearson.krit.api.Capability
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class PluginCapabilitiesTest {
+
+    private val jar = "/tmp/acme-rules.jar"
+
+    @Test
+    fun resolverAndParsedFilesAreSupported() {
+        assertTrue(PluginCapabilities.unsupported(listOf(Capability.NEEDS_RESOLVER.name)).isEmpty())
+        assertTrue(PluginCapabilities.unsupported(listOf(Capability.NEEDS_PARSED_FILES.name)).isEmpty())
+    }
+
+    @Suppress("DEPRECATION")
+    @Test
+    fun unsupportedListsEveryDeprecatedCapability() {
+        val unsupported = PluginCapabilities.unsupported(
+            listOf(
+                Capability.NEEDS_RESOLVER.name,
+                Capability.NEEDS_CROSS_FILE.name,
+                Capability.NEEDS_MODULE_INDEX.name,
+                Capability.NEEDS_PARSED_FILES.name,
+                Capability.NEEDS_MANIFEST.name,
+                Capability.NEEDS_RESOURCES.name,
+                Capability.NEEDS_GRADLE.name,
+            ),
+        )
+        assertEquals(
+            listOf(
+                Capability.NEEDS_CROSS_FILE.name,
+                Capability.NEEDS_MODULE_INDEX.name,
+                Capability.NEEDS_MANIFEST.name,
+                Capability.NEEDS_RESOURCES.name,
+                Capability.NEEDS_GRADLE.name,
+            ),
+            unsupported,
+        )
+    }
+
+    @Test
+    fun emptyNeedsListIsAlwaysSupported() {
+        assertTrue(PluginCapabilities.unsupported(emptyList()).isEmpty())
+    }
+
+    @Test
+    fun unknownEnumNameIsRejectedRatherThanSilentlyAccepted() {
+        // Defensive: if a rule jar carries a capability the daemon
+        // doesn't recognize at all (e.g. ahead-of-daemon rule SDK),
+        // treat it as unsupported. The SDK-compat gate catches the
+        // version skew, but if the user has --no-strict-sdk or similar
+        // we still don't want to silently honor unknown facts.
+        val unsupported = PluginCapabilities.unsupported(listOf("NEEDS_TIME_TRAVEL"))
+        assertEquals(listOf("NEEDS_TIME_TRAVEL"), unsupported)
+    }
+
+    @Suppress("DEPRECATION")
+    @Test
+    fun loadDiagnosticIsErrorLevelWithRuleIdAndCapability() {
+        val diagnostic = PluginCapabilities.buildLoadDiagnostic(
+            jar = jar,
+            ruleSdkVersion = "1.2.3",
+            daemonSdkVersion = "1.2.3",
+            violations = listOf(
+                CapabilityViolation("acme.NoTodo", listOf(Capability.NEEDS_GRADLE.name)),
+                CapabilityViolation(
+                    "acme.NoFixme",
+                    listOf(Capability.NEEDS_MANIFEST.name, Capability.NEEDS_RESOURCES.name),
+                ),
+            ),
+        )
+        assertEquals(PluginLoadDiagnostic.Level.ERROR, diagnostic.level)
+        assertEquals(jar, diagnostic.jar)
+        assertEquals("1.2.3", diagnostic.ruleSdkVersion)
+        assertEquals("1.2.3", diagnostic.daemonSdkVersion)
+        assertTrue(diagnostic.message.contains("acme.NoTodo"), diagnostic.message)
+        assertTrue(diagnostic.message.contains("acme.NoFixme"), diagnostic.message)
+        assertTrue(diagnostic.message.contains(Capability.NEEDS_GRADLE.name), diagnostic.message)
+        assertTrue(diagnostic.message.contains(Capability.NEEDS_MANIFEST.name), diagnostic.message)
+        assertTrue(diagnostic.message.contains(Capability.NEEDS_RESOURCES.name), diagnostic.message)
+        assertTrue(
+            diagnostic.message.contains(PluginCapabilities.TRACKING_ISSUE_URL),
+            diagnostic.message,
+        )
+    }
+
+    @Suppress("DEPRECATION")
+    @Test
+    fun loadDiagnosticOrdersRulesAlphabeticallyForDeterminism() {
+        val diagnostic = PluginCapabilities.buildLoadDiagnostic(
+            jar = jar,
+            ruleSdkVersion = "1.2.3",
+            daemonSdkVersion = "1.2.3",
+            violations = listOf(
+                CapabilityViolation("z.RuleZ", listOf(Capability.NEEDS_GRADLE.name)),
+                CapabilityViolation("a.RuleA", listOf(Capability.NEEDS_MANIFEST.name)),
+            ),
+        )
+        val idxA = diagnostic.message.indexOf("a.RuleA")
+        val idxZ = diagnostic.message.indexOf("z.RuleZ")
+        assertTrue(idxA in 0 until idxZ, "rules out of order: ${diagnostic.message}")
+    }
+}


### PR DESCRIPTION
## Summary

- `Capability` mixed one wired hook (`NEEDS_RESOLVER`) with six advisory no-ops; rule authors had no way to tell what they were actually opting into. This change makes the contract explicit: every value either has a tested code path or carries a `@Deprecated` marker AND fails the jar at load with a clear, copy-pasteable diagnostic.
- New `PluginCapabilities` object owns the supported set and the diagnostic factory, so promoting a deprecated entry to "supported" is a single-line change in one place.
- Go-side aggregate preamble widened to cover both SDK-compat and capability failure modes; per-jar message carries the specific remediation.

### Capability audit

| Value | Before | After |
| --- | --- | --- |
| `NEEDS_RESOLVER` | wired → `RuleContext.resolver` | unchanged — still wired |
| `NEEDS_PARSED_FILES` | always implicitly satisfied | supported (implicit hint) |
| `NEEDS_CROSS_FILE`, `NEEDS_MODULE_INDEX`, `NEEDS_MANIFEST`, `NEEDS_RESOURCES`, `NEEDS_GRADLE` | silently no-op | `@Deprecated(WARNING)` + load-time error referencing [#308](https://github.com/kaeawc/krit/issues/308) |

## Acceptance

- [x] Every value in `Capability` has either (a) a tested code path delivering it or (b) a deprecation marker.
- [x] A rule declaring an unsupported capability fails at jar load with a clear message.
- [x] Docs (`docs/external-rules.md#capability-semantics`) updated to reflect the strict gate + the promotion path.

## Test plan

- [x] `go build -o krit ./cmd/krit/` (clean)
- [x] `go vet ./...` (clean)
- [x] `golangci-lint run ./internal/pipeline/` (0 issues)
- [x] `go test ./... -count=1` (all packages pass)
- [x] `cd tools/krit-rule-api && ./gradlew jar` (clean)
- [x] `cd tools/krit-types && ./gradlew test` (all tests pass, incl. new `PluginCapabilitiesTest`)
- [x] `make integration` (11/11 pass)
- [x] `make lint-rules` (capability gate clean)

Closes #310.