### PR TITLE
fix(daemon): clean up oracle JVM children on serve exit

### DIFF
--- a/internal/cli/serve/serve.go
+++ b/internal/cli/serve/serve.go
@@ -143,6 +143,13 @@ func Run(args []string) int {
 	}
 
 	state := newDaemonState(root)
+	// Shut down every oracle JVM child this serve invocation owns
+	// before returning. Shared (PID-file-reused) daemons just drop the
+	// TCP connection; owned daemons get a graceful Shutdown→Kill. The
+	// defer covers normal exit, srv.Wait() return, and signalContext
+	// cancellation — SIGKILL still orphans the children, but that's
+	// the expected ceiling for unrecoverable parent death.
+	defer state.closeOracleDaemons()
 	state.strictVerify = *strictVerifyFlag
 	state.workspace.SetMaxParsedBytes(*maxParseBytesFlag)
 	warmStart := time.Now()
@@ -517,8 +524,16 @@ func (s *daemonState) pingOracleDaemon() {
 	}
 }
 
-// closeOracleDaemons shuts down every cached daemon. Called from the
-// serve shutdown hook so JVM children don't survive their parent.
+// closeOracleDaemons shuts down every cached daemon. Deferred from
+// Run() so the JVM children this serve invocation owns don't survive
+// their parent on normal exit (signalContext cancel, srv.Wait return,
+// or any return path). SIGKILL on serve still orphans the children —
+// they self-terminate on the 30-minute idle timeout in that case.
+//
+// Daemons connected to via PID-file reuse (shared=true) have their
+// TCP connections closed but the underlying process is left alive
+// for the next krit invocation to find. Daemons started by serve
+// (shared=false) get a graceful Shutdown→Kill via Daemon.Close.
 func (s *daemonState) closeOracleDaemons() {
 	if s == nil {
 		return

--- a/internal/lsp/oracle_workspace_indexer.go
+++ b/internal/lsp/oracle_workspace_indexer.go
@@ -33,6 +33,18 @@ func (o OracleWorkspaceIndexer) BuildWorkspaceIndex(ctx context.Context, root st
 		}
 		return nil, err
 	}
+	// Ready, when set, transfers ownership of the daemon handle to the
+	// caller (the LSP server stores it in oracleDaemon and releases on
+	// handleShutdown). When Ready is nil, no one else will release the
+	// connection — drop it on return so the TCP socket and log file
+	// handle don't leak. The daemon process itself stays alive on its
+	// idle timer either way.
+	releaseOnReturn := o.Ready == nil
+	defer func() {
+		if releaseOnReturn {
+			_ = d.Release()
+		}
+	}()
 	if o.Ready != nil {
 		o.Ready(d)
 	}

--- a/internal/oracle/daemon_registry.go
+++ b/internal/oracle/daemon_registry.go
@@ -404,25 +404,49 @@ func cleanStaleDaemonSlot(sourceDirs []string, verbose bool, slot int) {
 		return
 	}
 
-	// Try SIGTERM first, then SIGKILL after timeout
-	proc.Signal(syscall.SIGTERM)
-
-	// Wait up to 5 seconds for graceful exit
-	deadline := time.Now().Add(5 * time.Second)
-	for time.Now().Before(deadline) {
-		if !isProcessAlive(info.PID) {
-			break
-		}
-		time.Sleep(200 * time.Millisecond)
+	// SIGTERM, then SIGKILL after timeout. The PID file is only removed
+	// once the process is confirmed dead — otherwise a follow-up
+	// StartDaemonWithPort race could write a new PID file while a stale
+	// JVM is still binding the same TCP port. waitUntilDead handles the
+	// "SIGKILL needs more than a few hundred ms" case (loaded host,
+	// kernel reaping lag) with a longer bounded loop.
+	_ = proc.Signal(syscall.SIGTERM)
+	if waitUntilDead(info.PID, 5*time.Second) {
+		removePIDFileSlot(hash, slot)
+		return
 	}
 
-	// Force kill if still alive
-	if isProcessAlive(info.PID) {
-		proc.Signal(syscall.SIGKILL)
-		time.Sleep(500 * time.Millisecond)
+	if verbose {
+		reporter().Verbosef("verbose: SIGTERM ignored by daemon slot %d (PID %d); sending SIGKILL\n", slot, info.PID)
+	}
+	_ = proc.Signal(syscall.SIGKILL)
+	if waitUntilDead(info.PID, 3*time.Second) {
+		removePIDFileSlot(hash, slot)
+		return
 	}
 
+	// SIGKILL didn't take effect within the bound — best-effort report
+	// and drop the PID file anyway so future invocations don't get
+	// wedged on it. The kernel will eventually reap; the worst case is
+	// a brief window where the new daemon's port-0 bind dodges the
+	// zombie's old port (port-0 always picks an unused one).
+	reporter().Verbosef("verbose: daemon slot %d (PID %d) survived SIGKILL within timeout; PID file removed regardless\n", slot, info.PID)
 	removePIDFileSlot(hash, slot)
+}
+
+// waitUntilDead polls isProcessAlive at 100ms intervals up to timeout.
+// Returns true if the process is observed dead before timeout. Used by
+// cleanStaleDaemonSlot to confirm SIGTERM/SIGKILL took effect before
+// removing the PID file.
+func waitUntilDead(pid int, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if !isProcessAlive(pid) {
+			return true
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	return !isProcessAlive(pid)
 }
 
 // StartDaemonWithPort launches the krit-types JVM process in daemon mode with


### PR DESCRIPTION
## Summary

- **`krit serve` now releases its oracle JVM children on exit.** `closeOracleDaemons` existed but was only reachable from tests — the comment claimed it was "called from the serve shutdown hook" but no caller existed. Wired `defer state.closeOracleDaemons()` into `Run()` so owned daemons get a graceful Shutdown→Kill on any return path (signalContext cancel, `srv.Wait()` return, error exits). Shared (PID-file-reused) daemons just drop the TCP connection — the persistence-across-CLI-invocations design is preserved.
- **Hardened `cleanStaleDaemonSlot`.** The old code unconditionally removed the PID file after a 500ms post-SIGKILL sleep, even if the process was still alive. New `waitUntilDead` poll confirms death before removing the PID file, and surfaces a verbose-mode warning when SIGKILL doesn't take effect within the timeout. Closes the race where a stale JVM could still be bound when `StartDaemonWithPort` ran next.
- **Defensive `defer Release()` in `OracleWorkspaceIndexer`** when the `Ready` callback is nil. Production callers (LSP) always set Ready and release via `handleShutdown`; this just plugs the leak for standalone usage.

### What I deliberately did not change

JVM oracle/fir daemons remain persistent across CLI invocations (per-repo PID file + 30-min idle timeout). Adding `Pdeathsig` or process-group-kill on parent exit would force every CLI run to pay full JVM warmup, defeating the persistent-daemon model.

## Test plan

- [x] `go build -o krit ./cmd/krit/`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...` (0 issues)
- [x] `go test ./... -count=1` (full suite green)