### PR TITLE
docs(plugin-sdk): retarget capability tracker to #357

### DIFF
--- a/docs/external-rules.md
+++ b/docs/external-rules.md
@@ -307,7 +307,7 @@ state. The list below is the supported surface today; the unsupported
 entries stay in the enum so existing source continues to compile, but
 the values are `@Deprecated` (warn) and a rule that declares one fails
 at jar load with a clear, copy-pasteable diagnostic. Tracked on
-[#308](https://github.com/kaeawc/krit/issues/308).
+[#357](https://github.com/kaeawc/krit/issues/357).
 
 | Capability | Status | What it gives you |
 | --- | --- | --- |
@@ -328,7 +328,7 @@ A jar that declares an unsupported capability is rejected at
 error: krit-rule-api: /tmp/acme-rules.jar: rule jar declares capabilities
 the daemon does not yet provide to plugin rules; the rule would run
 without the facts it asked for. Remove the declaration(s) or wait for
-support (tracked on https://github.com/kaeawc/krit/issues/308).
+support (tracked on https://github.com/kaeawc/krit/issues/357).
 Unsupported: [acme.NoTodo: NEEDS_GRADLE]
 ```
 

--- a/tools/krit-rule-api/src/main/kotlin/dev/jasonpearson/krit/api/KritRule.kt
+++ b/tools/krit-rule-api/src/main/kotlin/dev/jasonpearson/krit/api/KritRule.kt
@@ -188,7 +188,7 @@ enum class Maturity { STABLE, EXPERIMENTAL, DEPRECATED }
  * load time with a clear message (see `PluginRules.kt`). The
  * load-time gate exists so a typo or a too-optimistic declaration
  * cannot silently degrade to "rule runs without the facts it asked
- * for". Tracked on https://github.com/kaeawc/krit/issues/308.
+ * for". Tracked on https://github.com/kaeawc/krit/issues/357.
  *
  * Adding a new capability is a minor-version change (additive, default
  * not-required). Promoting a deprecated entry to "supported" is also a
@@ -206,7 +206,7 @@ enum class Capability {
     @Deprecated(
         message = "NEEDS_CROSS_FILE is not yet delivered to plugin rules. " +
             "Declaring it causes the rule jar to fail at load time. Tracked " +
-            "on https://github.com/kaeawc/krit/issues/308.",
+            "on https://github.com/kaeawc/krit/issues/357.",
         level = DeprecationLevel.WARNING,
     )
     NEEDS_CROSS_FILE,
@@ -214,7 +214,7 @@ enum class Capability {
     @Deprecated(
         message = "NEEDS_MODULE_INDEX is not yet delivered to plugin rules. " +
             "Declaring it causes the rule jar to fail at load time. Tracked " +
-            "on https://github.com/kaeawc/krit/issues/308.",
+            "on https://github.com/kaeawc/krit/issues/357.",
         level = DeprecationLevel.WARNING,
     )
     NEEDS_MODULE_INDEX,
@@ -231,7 +231,7 @@ enum class Capability {
     @Deprecated(
         message = "NEEDS_MANIFEST is not yet delivered to plugin rules. " +
             "Declaring it causes the rule jar to fail at load time. Tracked " +
-            "on https://github.com/kaeawc/krit/issues/308.",
+            "on https://github.com/kaeawc/krit/issues/357.",
         level = DeprecationLevel.WARNING,
     )
     NEEDS_MANIFEST,
@@ -239,7 +239,7 @@ enum class Capability {
     @Deprecated(
         message = "NEEDS_RESOURCES is not yet delivered to plugin rules. " +
             "Declaring it causes the rule jar to fail at load time. Tracked " +
-            "on https://github.com/kaeawc/krit/issues/308.",
+            "on https://github.com/kaeawc/krit/issues/357.",
         level = DeprecationLevel.WARNING,
     )
     NEEDS_RESOURCES,
@@ -247,7 +247,7 @@ enum class Capability {
     @Deprecated(
         message = "NEEDS_GRADLE is not yet delivered to plugin rules. " +
             "Declaring it causes the rule jar to fail at load time. Tracked " +
-            "on https://github.com/kaeawc/krit/issues/308.",
+            "on https://github.com/kaeawc/krit/issues/357.",
         level = DeprecationLevel.WARNING,
     )
     NEEDS_GRADLE,

--- a/tools/krit-types/src/main/kotlin/dev/jasonpearson/krit/types/PluginRules.kt
+++ b/tools/krit-types/src/main/kotlin/dev/jasonpearson/krit/types/PluginRules.kt
@@ -155,7 +155,7 @@ internal data class CapabilityViolation(
  * for the user-facing matrix and the policy.
  */
 internal object PluginCapabilities {
-    const val TRACKING_ISSUE_URL: String = "https://github.com/kaeawc/krit/issues/308"
+    const val TRACKING_ISSUE_URL: String = "https://github.com/kaeawc/krit/issues/357"
 
     val SUPPORTED: Set<String> = setOf(
         Capability.NEEDS_RESOLVER.name,


### PR DESCRIPTION
## Summary

[#310](https://github.com/kaeawc/krit/issues/310) (closed by [#354](https://github.com/kaeawc/krit/pull/354)) wired the capability gate and pointed users at [#308](https://github.com/kaeawc/krit/issues/308) for the plumb-through follow-up — but #308 (PSI/resolver exposure) closed on 2026-05-17, ~8h before #354 opened. The five \`@Deprecated\` capabilities now point at the dedicated tracker [#357](https://github.com/kaeawc/krit/issues/357).

Touched:
- All 5 \`@Deprecated(message=...)\` strings in [KritRule.kt](tools/krit-rule-api/src/main/kotlin/dev/jasonpearson/krit/api/KritRule.kt)
- \`PluginCapabilities.TRACKING_ISSUE_URL\` in [PluginRules.kt](tools/krit-types/src/main/kotlin/dev/jasonpearson/krit/types/PluginRules.kt)
- Capability semantics section in [docs/external-rules.md](docs/external-rules.md)

## Test plan

- [x] \`go build\`, \`go vet\`, \`golangci-lint run ./internal/pipeline/\` clean.
- [x] \`cd tools/krit-types && ./gradlew test\` passes (\`PluginCapabilitiesTest.loadDiagnosticIsErrorLevelWithRuleIdAndCapability\` asserts against \`PluginCapabilities.TRACKING_ISSUE_URL\`, so the URL change is verified end-to-end).