### PR TITLE
fix(style): CascadingCallWrapping ignores raw strings and block comments

### DIFF
--- a/internal/rules/style_format.go
+++ b/internal/rules/style_format.go
@@ -515,11 +515,19 @@ func (r *CascadingCallWrappingRule) Confidence() float64 { return 0.75 }
 
 func (r *CascadingCallWrappingRule) check(ctx *api.Context) {
 	file := ctx.File
+	insideRawString := computeRawStringLines(file.Lines)
+	insideBlockComment := computeBlockCommentLines(file.Lines)
 	for i, line := range file.Lines {
+		if insideRawString[i] || insideBlockComment[i] {
+			continue
+		}
 		trimmed := strings.TrimSpace(line)
 		isDot := strings.HasPrefix(trimmed, ".")
 		isElvis := r.IncludeElvis && strings.HasPrefix(trimmed, "?:")
 		if (!isDot && !isElvis) || i == 0 {
+			continue
+		}
+		if insideRawString[i-1] || insideBlockComment[i-1] {
 			continue
 		}
 		prevTrimmed := strings.TrimSpace(file.Lines[i-1])

--- a/internal/rules/style_format_test.go
+++ b/internal/rules/style_format_test.go
@@ -430,6 +430,38 @@ fun main() {
 	}
 }
 
+func TestCascadingCallWrapping_IgnoresRawString(t *testing.T) {
+	findings := runRuleByName(t, "CascadingCallWrapping", `
+package test
+
+fun main() {
+    val sql = """
+        SELECT foo.bar
+        .baz
+        FROM t
+    """.trimIndent()
+}
+`)
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings inside raw string, got %d", len(findings))
+	}
+}
+
+func TestCascadingCallWrapping_IgnoresBlockComment(t *testing.T) {
+	findings := runRuleByName(t, "CascadingCallWrapping", `
+package test
+
+/*
+val x = foo.bar
+.baz
+*/
+fun main() {}
+`)
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings inside block comment, got %d", len(findings))
+	}
+}
+
 func TestCascadingCallWrapping_HonorsIncludeElvis(t *testing.T) {
 	// IncludeElvis was previously a dead config — exposed in metadata but
 	// never consulted. Configure it via the rule pointer and verify


### PR DESCRIPTION
## Summary
- `CascadingCallWrappingRule` now skips lines inside triple-quoted raw strings (Kotlin `"""` / Java text blocks) and `/* ... */` block comments, fixing a class of false positives where a `.foo` or `?:` line inside a string/comment was misread as a misindented chain continuation.
- Reuses `computeRawStringLines` / `computeBlockCommentLines` already shared with `MaxLineLength` and the release-engineering rules — no new lexical-state scanner.
- KDoc continuations (`*`-prefixed) don't match the dot/elvis prefix and need no separate filter; covered implicitly.

## Test plan
- [x] `go test ./internal/rules/ -run TestCascadingCallWrapping -count=1` — existing positive/negative + IncludeElvis tests still pass; new `IgnoresRawString` and `IgnoresBlockComment` regression tests cover the FPs.
- [x] `go vet ./...`, `golangci-lint run ./...` clean.
- [x] `go test ./... -count=1` full suite passes.