### PR TITLE
refactor(rules): SpacingAfterPackageAndImports → FlatDispatchBase

### DIFF
--- a/internal/rules/registry_style_format.go
+++ b/internal/rules/registry_style_format.go
@@ -53,7 +53,13 @@ func registerStyleFormatRules() {
 		r := &SpacingAfterPackageAndImportsRule{BaseRule: BaseRule{RuleName: "SpacingAfterPackageAndImports", RuleSetName: "style", Sev: "warning", Desc: "Detects missing blank lines after package and import declarations."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			Needs: api.NeedsLinePass, Languages: []scanner.Language{scanner.LangKotlin, scanner.LangJava}, Fix: api.FixCosmetic, Implementation: r,
+			NodeTypes: []string{
+				"package_header", "import_header",
+				"package_declaration", "import_declaration",
+			},
+			Languages:  []scanner.Language{scanner.LangKotlin, scanner.LangJava},
+			Confidence: 0.95,
+			Fix:        api.FixCosmetic, Implementation: r,
 			Check: r.check,
 		})
 	}

--- a/internal/rules/style_format.go
+++ b/internal/rules/style_format.go
@@ -3,6 +3,7 @@ package rules
 import (
 	"fmt"
 	"regexp"
+	"sort"
 	"strings"
 
 	api "github.com/kaeawc/krit/internal/rules/api"
@@ -424,52 +425,90 @@ func (r *NewLineAtEndOfFileRule) check(ctx *api.Context) {
 
 // SpacingAfterPackageAndImportsRule checks for blank line after package/imports.
 type SpacingAfterPackageAndImportsRule struct {
-	LineBase
+	FlatDispatchBase
 	BaseRule
 }
 
-// Confidence bumps this line rule from the 0.75 line-rule default to
-// 0.95 — the detection uses `strings.HasPrefix(trimmed, "package ")`
-// and `"import "`, which are unambiguous line starts in Kotlin. No
-// heuristic path.
-func (r *SpacingAfterPackageAndImportsRule) Confidence() float64 { return 0.95 }
-
 func (r *SpacingAfterPackageAndImportsRule) check(ctx *api.Context) {
-	file := ctx.File
-	lastImportLine := -1
-	packageLine := -1
+	file, idx := ctx.File, ctx.Idx
 
-	for i, line := range file.Lines {
-		trimmed := strings.TrimSpace(line)
-		if strings.HasPrefix(trimmed, "package ") {
-			packageLine = i
-		}
-		if strings.HasPrefix(trimmed, "import ") {
-			lastImportLine = i
+	// Kotlin's import_list span includes trailing blank lines, so fire on
+	// the trailing import_header / package_header and climb out of the list
+	// to see its successor — each file emits at most once.
+	next, hasNext := nextPreludeSibling(file, idx)
+	if hasNext {
+		switch file.FlatType(next) {
+		case "package_header", "import_list", "import_header",
+			"package_declaration", "import_declaration":
+			return
 		}
 	}
 
-	checkLine := lastImportLine
-	if checkLine < 0 {
-		checkLine = packageLine
+	endRow := lineOfByte(file, int(preludeCodeEndByte(file, idx)))
+	if endRow+1 >= len(file.Lines) {
+		return
 	}
-	if checkLine >= 0 && checkLine < len(file.Lines)-1 {
-		next := strings.TrimSpace(file.Lines[checkLine+1])
-		if next != "" {
-			f := r.Finding(file, checkLine+2, 1,
-				"Missing blank line after package/import declarations.")
-			// Insert a blank line after the checkLine
-			lineStart := file.LineOffset(checkLine + 1)
-			// Insert a newline at the position right after the checkLine's newline
-			f.Fix = &scanner.Fix{
-				ByteMode:    true,
-				StartByte:   lineStart,
-				EndByte:     lineStart,
-				Replacement: "\n",
-			}
-			ctx.Emit(f)
+	if strings.TrimSpace(file.Lines[endRow+1]) == "" {
+		return
+	}
+
+	lineStart := file.LineOffset(endRow + 1)
+	f := r.Finding(file, endRow+2, 1,
+		"Missing blank line after package/import declarations.")
+	f.Fix = &scanner.Fix{
+		ByteMode:    true,
+		StartByte:   lineStart,
+		EndByte:     lineStart,
+		Replacement: "\n",
+	}
+	ctx.Emit(f)
+}
+
+// lineOfByte returns the 0-based line index containing byteOffset.
+func lineOfByte(file *scanner.File, byteOffset int) int {
+	offsets := file.LineOffsets()
+	if len(offsets) == 0 {
+		return 0
+	}
+	i := sort.Search(len(offsets), func(j int) bool { return offsets[j] > byteOffset })
+	if i == 0 {
+		return 0
+	}
+	return i - 1
+}
+
+// nextPreludeSibling returns the next file-scope sibling of a package/import
+// node. When idx is the last import_header inside a Kotlin import_list, it
+// climbs out and returns the list's next sibling instead — the list itself
+// is never dispatched.
+func nextPreludeSibling(file *scanner.File, idx uint32) (uint32, bool) {
+	if next, ok := file.FlatNextSibling(idx); ok {
+		return next, true
+	}
+	parent, ok := file.FlatParent(idx)
+	if !ok || file.FlatType(parent) != "import_list" {
+		return 0, false
+	}
+	return file.FlatNextSibling(parent)
+}
+
+// preludeCodeEndByte returns the end byte of the code portion of a
+// package/import declaration, ignoring trailing comment children. Kotlin
+// tree-sitter attaches trailing block/line comments to the preceding
+// import_header, so its raw EndByte sweeps past the real declaration.
+func preludeCodeEndByte(file *scanner.File, idx uint32) uint32 {
+	var lastCode uint32
+	for c := file.FlatFirstChild(idx); c != 0; c = file.FlatNextSib(c) {
+		switch file.FlatType(c) {
+		case "line_comment", "block_comment", "multiline_comment", "comment":
+			continue
 		}
+		lastCode = c
 	}
+	if lastCode != 0 {
+		return file.FlatEndByte(lastCode)
+	}
+	return file.FlatEndByte(idx)
 }
 
 // MaxChainedCallsOnSameLineRule limits chained method calls on a single line.

--- a/internal/rules/style_format_test.go
+++ b/internal/rules/style_format_test.go
@@ -163,6 +163,57 @@ func TestSpacingAfterPackageAndImports_Negative(t *testing.T) {
 	}
 }
 
+// Import-shaped text inside a block comment must not anchor the finding.
+func TestSpacingAfterPackageAndImports_IgnoresImportTextInBlockComment(t *testing.T) {
+	code := "package style\n\n" +
+		"import com.example.Foo\n\n" +
+		"/*\nimport faux.Bar\n*/\n" +
+		"class MyClass\n"
+	findings := runRuleByName(t, "SpacingAfterPackageAndImports", code)
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings; got %d: %+v", len(findings), findings)
+	}
+}
+
+// Import-shaped text inside a raw string must not anchor the finding.
+func TestSpacingAfterPackageAndImports_IgnoresImportTextInRawString(t *testing.T) {
+	code := "package style\n\n" +
+		"import com.example.Foo\n\n" +
+		"val s = \"\"\"\nimport faux.Bar\n\"\"\"\n\n" +
+		"class MyClass\n"
+	findings := runRuleByName(t, "SpacingAfterPackageAndImports", code)
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings; got %d: %+v", len(findings), findings)
+	}
+}
+
+// Java: import-shaped text inside a block comment must not anchor the finding.
+func TestSpacingAfterPackageAndImports_JavaIgnoresImportTextInBlockComment(t *testing.T) {
+	code := "package style;\n\n" +
+		"import java.util.List;\n\n" +
+		"/*\nimport faux.Bar;\n*/\n" +
+		"class C {}\n"
+	findings := runRuleByNameOnJava(t, "SpacingAfterPackageAndImports", code)
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings; got %d: %+v", len(findings), findings)
+	}
+}
+
+// Java: only the LAST import anchors; expect one finding at the class line.
+func TestSpacingAfterPackageAndImports_JavaMultipleImports(t *testing.T) {
+	code := "package style;\n" +
+		"import java.util.List;\n" +
+		"import java.util.Map;\n" +
+		"class C {}\n"
+	findings := runRuleByNameOnJava(t, "SpacingAfterPackageAndImports", code)
+	if len(findings) != 1 {
+		t.Fatalf("expected exactly 1 finding; got %d: %+v", len(findings), findings)
+	}
+	if findings[0].Line != 4 {
+		t.Fatalf("expected finding at line 4 (class line); got line %d", findings[0].Line)
+	}
+}
+
 // --- MaxChainedCallsOnSameLine ---
 
 func TestMaxChainedCallsOnSameLine_Positive(t *testing.T) {


### PR DESCRIPTION
## Summary
- Convert `SpacingAfterPackageAndImportsRule` from a `LineBase` (line-pass) rule to a `FlatDispatchBase` rule dispatching on `package_header` / `import_header` / `package_declaration` / `import_declaration`.
- The old line-prefix match (`HasPrefix(trimmed, "package ") / "import "`) fired on import-shaped text inside block comments and raw strings — a CLAUDE.md lexical-state-awareness violation. AST dispatch only sees real declarations.
- Fix output is unchanged; no schema / config impact; the rule remains `DefaultActive: false` opt-in cosmetic.

## Tree-sitter quirks handled
- Kotlin may wrap imports in `import_list` (its span sweeps trailing blank lines) or emit them as direct file children — `nextPreludeSibling` climbs out of `import_list` when looking for the next file-scope sibling.
- Kotlin tree-sitter attaches trailing block/line comments as children of the preceding `import_header`, padding its `EndByte` past the real declaration — `preludeCodeEndByte` trims trailing comment children before mapping to a line index.
- Java emits multiple sibling `import_declaration` nodes — the next-sibling gate ensures only the trailing one emits.

## Regression coverage (would have fired under the old line scanner)
- Kotlin block comment containing `import faux.Bar`
- Kotlin raw string containing `import faux.Bar`
- Java block comment containing `import faux.Bar;`
- Java multi-import file: one finding anchored at the last import

## Test plan
- [x] `go build -o krit ./cmd/krit/`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...` (0 issues)
- [x] `go test ./... -count=1`
- [x] `make integration` (11 passed, 0 failed)
- [x] `make lint-rules`
- [x] Existing positive/negative/fixable fixtures for `SpacingAfterPackageAndImports` pass unchanged