### PR TITLE
refactor(rules): GradleBuildContainsTodo runs in Gradle scope

### DIFF
--- a/internal/rules/android_gradle.go
+++ b/internal/rules/android_gradle.go
@@ -129,6 +129,41 @@ func isGradleCommentLine(line string) bool {
 	return strings.HasPrefix(t, "//") || strings.HasPrefix(t, "*") || strings.HasPrefix(t, "/*")
 }
 
+// gradleLineCommentStart returns the byte index of the first `//` that
+// begins a real Gradle line comment — i.e. one outside a single- or
+// double-quoted string literal. Returns -1 when the line has no comment
+// or only sees `//` inside a string (e.g. `"https://x"`). Backslash
+// escapes inside literals are honored.
+func gradleLineCommentStart(line string) int {
+	var inQuote byte
+	escaped := false
+	for i := 0; i < len(line); i++ {
+		c := line[i]
+		if inQuote != 0 {
+			if escaped {
+				escaped = false
+				continue
+			}
+			if c == '\\' {
+				escaped = true
+				continue
+			}
+			if c == inQuote {
+				inQuote = 0
+			}
+			continue
+		}
+		if c == '"' || c == '\'' {
+			inQuote = c
+			continue
+		}
+		if c == '/' && i+1 < len(line) && line[i+1] == '/' {
+			return i
+		}
+	}
+	return -1
+}
+
 // ---------------------------------------------------------------------------
 // Rule: GradlePluginCompatibility
 // ---------------------------------------------------------------------------

--- a/internal/rules/registry_release_engineering.go
+++ b/internal/rules/registry_release_engineering.go
@@ -274,7 +274,7 @@ func registerReleaseEngineeringRules() {
 		r := &GradleBuildContainsTodoRule{BaseRule: BaseRule{RuleName: "GradleBuildContainsTodo", RuleSetName: releaseEngineeringRuleSet, Sev: "info", Desc: "Detects TODO comments in build.gradle(.kts) files that may block release readiness."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			Needs: api.NeedsLinePass, Implementation: r,
+			Needs: api.NeedsGradle, AndroidDeps: uint32(AndroidDepGradle), Confidence: r.Confidence(), Implementation: r,
 			Check: r.check,
 		})
 	}

--- a/internal/rules/release_engineering.go
+++ b/internal/rules/release_engineering.go
@@ -134,7 +134,7 @@ type CommentedOutCodeBlockRule struct {
 // GradleBuildContainsTodoRule flags TODO line comments in build.gradle(.kts)
 // scripts so release-affecting build work does not linger unnoticed.
 type GradleBuildContainsTodoRule struct {
-	LineBase
+	GradleBase
 	BaseRule
 }
 
@@ -144,24 +144,20 @@ type GradleBuildContainsTodoRule struct {
 func (r *GradleBuildContainsTodoRule) Confidence() float64 { return 0.75 }
 
 func (r *GradleBuildContainsTodoRule) check(ctx *api.Context) {
-	file := ctx.File
-	if !isGradleBuildScript(file.Path) {
-		return
-	}
-
-	for i, line := range file.Lines {
-		commentIdx := strings.Index(line, "//")
+	for i, raw := range strings.Split(ctx.GradleContent, "\n") {
+		commentIdx := gradleLineCommentStart(raw)
 		if commentIdx < 0 {
 			continue
 		}
-
-		comment := strings.TrimSpace(line[commentIdx+2:])
-		if !strings.HasPrefix(comment, "TODO") {
+		if !strings.HasPrefix(strings.TrimSpace(raw[commentIdx+2:]), "TODO") {
 			continue
 		}
-
-		ctx.Emit(r.Finding(file, i+1, commentIdx+1,
-			"TODO comment found in build.gradle(.kts); track build work in an issue or finish it before release."))
+		ctx.Emit(scanner.Finding{
+			File:    ctx.GradlePath,
+			Line:    i + 1,
+			Col:     commentIdx + 1,
+			Message: "TODO comment found in build.gradle(.kts); track build work in an issue or finish it before release.",
+		})
 	}
 }
 

--- a/internal/rules/release_engineering_test.go
+++ b/internal/rules/release_engineering_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/kaeawc/krit/internal/android"
 	"github.com/kaeawc/krit/internal/config"
 	"github.com/kaeawc/krit/internal/module"
 	"github.com/kaeawc/krit/internal/oracle"
@@ -985,30 +986,40 @@ func TestGradleBuildContainsTodo(t *testing.T) {
 	}
 
 	root := fixtureRoot(t)
-	positivePath := filepath.Join(root, "positive", "release-engineering", "gradle-build-contains-todo", "build.gradle.kts")
-	negativePath := filepath.Join(root, "negative", "release-engineering", "gradle-build-contains-todo", "build.gradle.kts")
+	cases := []struct {
+		name string
+		path string
+	}{
+		{name: "kts", path: filepath.Join("gradle-build-contains-todo", "build.gradle.kts")},
+		{name: "groovy", path: filepath.Join("gradle-build-contains-todo", "build.gradle")},
+	}
 
-	t.Run("positive fixture triggers", func(t *testing.T) {
-		file, err := scanner.ParseFile(context.Background(), positivePath)
+	runFixture := func(t *testing.T, full string) []scanner.Finding {
+		t.Helper()
+		content, err := os.ReadFile(full)
 		if err != nil {
-			t.Fatalf("ParseFile(%s): %v", positivePath, err)
+			t.Fatalf("ReadFile(%s): %v", full, err)
 		}
-		findings := runRule(t, rule, file)
-		if len(findings) != 1 {
-			t.Fatalf("expected 1 finding, got %d", len(findings))
-		}
-	})
+		cfg, _ := android.ParseBuildGradleContent(string(content))
+		return runGradleRule(rule, full, string(content), cfg)
+	}
 
-	t.Run("negative fixture is clean", func(t *testing.T) {
-		file, err := scanner.ParseFile(context.Background(), negativePath)
-		if err != nil {
-			t.Fatalf("ParseFile(%s): %v", negativePath, err)
-		}
-		findings := runRule(t, rule, file)
-		if len(findings) != 0 {
-			t.Fatalf("expected 0 findings, got %d", len(findings))
-		}
-	})
+	for _, tc := range cases {
+		t.Run(tc.name+"/positive", func(t *testing.T) {
+			full := filepath.Join(root, "positive", "release-engineering", tc.path)
+			findings := runFixture(t, full)
+			if len(findings) != 1 {
+				t.Fatalf("expected 1 finding, got %d", len(findings))
+			}
+		})
+		t.Run(tc.name+"/negative", func(t *testing.T) {
+			full := filepath.Join(root, "negative", "release-engineering", tc.path)
+			findings := runFixture(t, full)
+			if len(findings) != 0 {
+				t.Fatalf("expected 0 findings, got %d", len(findings))
+			}
+		})
+	}
 }
 
 func runConventionPluginDeadCodeRule(t *testing.T, projectDir string) []scanner.Finding {

--- a/schemas/krit-config.schema.json
+++ b/schemas/krit-config.schema.json
@@ -12326,7 +12326,7 @@
           }
         },
         "GradleBuildContainsTodo": {
-          "description": "Detects TODO comments in build.gradle(.kts) files that may block release readiness. [precision: heuristic/text-backed] [noisiness: noisy] [capabilities: line-pass]",
+          "description": "Detects TODO comments in build.gradle(.kts) files that may block release readiness. [precision: project-structure-aware] [noisiness: normal] [capabilities: gradle]",
           "type": "object",
           "additionalProperties": false,
           "properties": {

--- a/tests/fixtures/negative/release-engineering/gradle-build-contains-todo/build.gradle
+++ b/tests/fixtures/negative/release-engineering/gradle-build-contains-todo/build.gradle
@@ -1,0 +1,12 @@
+plugins {
+    id 'org.jetbrains.kotlin.jvm' version '2.1.0'
+}
+
+repositories {
+    maven { url 'https://example.com/// TODO not really a comment' }
+}
+
+dependencies {
+    // Release dependency graph is intentionally finalized here.
+    implementation 'com.squareup.retrofit2:retrofit:2.11.0'
+}

--- a/tests/fixtures/negative/release-engineering/gradle-build-contains-todo/build.gradle.kts
+++ b/tests/fixtures/negative/release-engineering/gradle-build-contains-todo/build.gradle.kts
@@ -2,6 +2,10 @@ plugins {
     kotlin("jvm") version "2.1.0"
 }
 
+repositories {
+    maven("https://example.com/// TODO not really a comment")
+}
+
 dependencies {
     // Release dependency graph is intentionally finalized here.
     implementation("com.squareup.retrofit2:retrofit:2.11.0")

--- a/tests/fixtures/positive/release-engineering/gradle-build-contains-todo/build.gradle
+++ b/tests/fixtures/positive/release-engineering/gradle-build-contains-todo/build.gradle
@@ -1,0 +1,8 @@
+plugins {
+    id 'org.jetbrains.kotlin.jvm' version '2.1.0'
+}
+
+dependencies {
+    // TODO: finish wiring this dependency set before cutting the release.
+    implementation 'com.squareup.retrofit2:retrofit:2.11.0'
+}


### PR DESCRIPTION
## Summary

Convert `GradleBuildContainsTodoRule` from a `NeedsLinePass` per-Kotlin-file scan to a `NeedsGradle` project-scope rule dispatched via `RunGradle`.

### Wins
- **Groovy `build.gradle` coverage**: the old `LineBase` scan only ran on files parsed by `scanner.ParseFile` (`.kt` / `.kts`), so Groovy build scripts were invisible. The Android phase already collects both flavors into `Project.GradlePaths` (`internal/android/detect.go:120,169`), so the converted rule now fires on either DSL.
- **No more per-Kotlin-file invocation**: the rule previously executed on every parsed Kotlin file, only to early-return via `isGradleBuildScript`. Now it runs once per build script.
- **Gradle phase findings cache**: warm runs hit the bundle-level + per-path content+rule-hash cache in `internal/pipeline/android.go:822`, which the line-pass version did not benefit from.

### Correctness mitigation
Added `gradleLineCommentStart` — a string-literal-aware scanner for the first real `//` outside quotes. Without it, the rule would false-fire on a Gradle string literal containing `// TODO` (e.g. `maven { url 'https://x/// TODO' }`). Both negative fixtures lock this guard.

### Notes
- `DefaultActive: false` unchanged (still opt-in).
- The Gradle phase fires whenever any active rule declares `NeedsGradle` (`android.go:139,1223`), so this works on pure-JVM repos with `build.gradle(.kts)` — not gated on Android detection.
- Schema regenerated; rule description now reads `[precision: project-structure-aware] [noisiness: normal] [capabilities: gradle]`.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run ./internal/rules/...`
- [x] `go test ./internal/rules/ -run TestGradleBuildContainsTodo -v` — kts + groovy × positive + negative all pass
- [x] `go test ./internal/rules/ -count=1`
- [x] `make lint-rules` — capability gate clean
- [x] `make integration` — 11/11 pass
- [x] `make regression` — playground/webservice + android-app within expected bands