### PR TITLE
fix(fixer): trim trailing newline in line-mode replacement

### DIFF
--- a/internal/fixer/fixer.go
+++ b/internal/fixer/fixer.go
@@ -259,9 +259,15 @@ func applyLineFixes(result string, lineFixes []textFixRow, path string) (string,
 		if start < 0 || end > len(lines) || start > end {
 			continue
 		}
-		replacement := strings.Split(fix.Replacement, "\n")
-		if fix.Replacement == "" {
-			replacement = nil
+		// Trim one trailing newline before splitting: `lines` was built
+		// with strings.Split on "\n", so each element is a line without
+		// a trailing newline. A Replacement like "// noop\n" would split
+		// into ["// noop", ""], appending a blank line on every pass and
+		// breaking idempotency. Treat the trailing "\n" as the line
+		// terminator the lines model already implies.
+		var replacement []string
+		if fix.Replacement != "" {
+			replacement = strings.Split(strings.TrimSuffix(fix.Replacement, "\n"), "\n")
 		}
 		newLines := make([]string, 0, len(lines)-end+start+len(replacement))
 		newLines = append(newLines, lines[:start]...)

--- a/internal/fixer/fixer_test.go
+++ b/internal/fixer/fixer_test.go
@@ -342,6 +342,37 @@ func TestLineModeFix_MultiLine(t *testing.T) {
 	}
 }
 
+// TestLineModeFix_TrailingNewlineIdempotent guards against a regression in
+// applyLineFixes where strings.Split("// noop\n", "\n") yielded
+// ["// noop", ""], so each --fix pass inserted an extra blank line. Two
+// passes with the same Replacement must produce the same content as one.
+func TestLineModeFix_TrailingNewlineIdempotent(t *testing.T) {
+	path := writeTestFile(t, "line1\nline2\nline3")
+	makeFinding := func() scanner.Finding {
+		return finding(path, &scanner.Fix{
+			StartLine:   2,
+			EndLine:     2,
+			Replacement: "// noop\n",
+		})
+	}
+
+	if _, err := ApplyFixes(t.Context(), path, []scanner.Finding{makeFinding()}, ""); err != nil {
+		t.Fatalf("first pass: %v", err)
+	}
+	afterFirst := readFile(t, path)
+	if afterFirst != "line1\n// noop\nline3" {
+		t.Fatalf("after first pass: got %q, want %q", afterFirst, "line1\n// noop\nline3")
+	}
+
+	if _, err := ApplyFixes(t.Context(), path, []scanner.Finding{makeFinding()}, ""); err != nil {
+		t.Fatalf("second pass: %v", err)
+	}
+	afterSecond := readFile(t, path)
+	if afterSecond != afterFirst {
+		t.Fatalf("second pass not idempotent: got %q, want %q", afterSecond, afterFirst)
+	}
+}
+
 // --------------- Edge cases ---------------
 
 func TestNoFixesApplied(t *testing.T) {


### PR DESCRIPTION
## Summary
- `applyLineFixes` split `Replacement` on `\n` but `lines` (also built via `strings.Split(result, "\n")`) holds entries without trailing newlines, so a `Replacement` like `"// noop\n"` produced `["// noop", ""]` and inserted a blank line on every `--fix` pass — breaking idempotency.
- Trim a single trailing `\n` from `Replacement` before splitting so the line model stays consistent and double-apply is a no-op.
- Added `TestLineModeFix_TrailingNewlineIdempotent` to lock the contract.

## Test plan
- [x] `go build -o krit ./cmd/krit/`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...`
- [x] `go test ./... -count=1`