### PR TITLE
fix(rules): skip license autofix when template is a regex

### DIFF
--- a/internal/rules/comments.go
+++ b/internal/rules/comments.go
@@ -229,15 +229,17 @@ func (r *AbsentOrWrongFileLicenseRule) check(ctx *api.Context) {
 			break
 		}
 	}
-	licenseComment := "/* " + r.LicenseTemplate + " */\n"
 	if !hasFirstComment {
 		f := r.Finding(file, 1, 1, "File does not have a valid license header.")
-		// Auto-fix: insert the license template at byte 0
-		f.Fix = &scanner.Fix{
-			ByteMode:    true,
-			StartByte:   0,
-			EndByte:     0,
-			Replacement: licenseComment,
+		// Auto-fix only when LicenseTemplate is a literal header — a regex
+		// pattern is not safe to inline as Kotlin source.
+		if !r.IsRegex {
+			f.Fix = &scanner.Fix{
+				ByteMode:    true,
+				StartByte:   0,
+				EndByte:     0,
+				Replacement: "/* " + r.LicenseTemplate + " */\n",
+			}
 		}
 		ctx.Emit(f)
 		return
@@ -260,12 +262,13 @@ func (r *AbsentOrWrongFileLicenseRule) check(ctx *api.Context) {
 		}
 	}
 	f := r.Finding(file, 1, 1, "File does not have a valid license header.")
-	// Auto-fix: replace existing wrong license comment with correct one
-	f.Fix = &scanner.Fix{
-		ByteMode:    true,
-		StartByte:   int(file.FlatStartByte(firstComment)),
-		EndByte:     int(file.FlatEndByte(firstComment)),
-		Replacement: "/* " + r.LicenseTemplate + " */",
+	if !r.IsRegex {
+		f.Fix = &scanner.Fix{
+			ByteMode:    true,
+			StartByte:   int(file.FlatStartByte(firstComment)),
+			EndByte:     int(file.FlatEndByte(firstComment)),
+			Replacement: "/* " + r.LicenseTemplate + " */",
+		}
 	}
 	ctx.Emit(f)
 }

--- a/internal/rules/comments_license_internal_test.go
+++ b/internal/rules/comments_license_internal_test.go
@@ -1,0 +1,109 @@
+package rules
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	api "github.com/kaeawc/krit/internal/rules/api"
+	"github.com/kaeawc/krit/internal/scanner"
+)
+
+func parseLicenseFixture(t *testing.T, code string) *scanner.File {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "test.kt")
+	if err := os.WriteFile(path, []byte(code), 0644); err != nil {
+		t.Fatal(err)
+	}
+	f, err := scanner.ParseFile(context.Background(), path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return f
+}
+
+func runLicenseRule(t *testing.T, r *AbsentOrWrongFileLicenseRule, file *scanner.File) []scanner.Finding {
+	t.Helper()
+	collector := scanner.NewFindingCollector(0)
+	rule := &api.Rule{
+		ID:             r.RuleName,
+		Category:       r.RuleSetName,
+		Description:    r.Desc,
+		Sev:            api.Severity(r.Sev),
+		Implementation: r,
+	}
+	ctx := &api.Context{File: file, Rule: rule, Collector: collector}
+	r.check(ctx)
+	return api.ContextFindings(ctx)
+}
+
+// Regression: when LicenseTemplate is a regex pattern, the autofix must not
+// dump the raw pattern into the source file. Earlier versions of this rule
+// wrapped the regex in "/* ... */" as a fake "license header"; the fix is to
+// emit the finding without an autofix in regex mode.
+func TestAbsentOrWrongFileLicense_RegexModeOmitsAutofix_NoComment(t *testing.T) {
+	file := parseLicenseFixture(t, `package test
+
+fun foo() {}
+`)
+	r := &AbsentOrWrongFileLicenseRule{
+		BaseRule:        BaseRule{RuleName: "AbsentOrWrongFileLicense", RuleSetName: "comments", Sev: "warning"},
+		LicenseTemplate: `(?i)copyright\s+\d{4}.*`,
+		IsRegex:         true,
+	}
+	findings := runLicenseRule(t, r, file)
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(findings))
+	}
+	if findings[0].Fix != nil {
+		t.Fatalf("regex-mode rule must not attach an autofix; got Fix with replacement %q",
+			findings[0].Fix.Replacement)
+	}
+}
+
+func TestAbsentOrWrongFileLicense_RegexModeOmitsAutofix_WrongComment(t *testing.T) {
+	file := parseLicenseFixture(t, `/* some unrelated header */
+package test
+
+fun foo() {}
+`)
+	r := &AbsentOrWrongFileLicenseRule{
+		BaseRule:        BaseRule{RuleName: "AbsentOrWrongFileLicense", RuleSetName: "comments", Sev: "warning"},
+		LicenseTemplate: `(?i)copyright\s+\d{4}.*`,
+		IsRegex:         true,
+	}
+	findings := runLicenseRule(t, r, file)
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(findings))
+	}
+	if findings[0].Fix != nil {
+		t.Fatalf("regex-mode rule must not attach an autofix; got Fix with replacement %q",
+			findings[0].Fix.Replacement)
+	}
+}
+
+// Literal-mode autofix still works — sanity check that the regex guard didn't
+// over-correct and disable the autofix for normal users.
+func TestAbsentOrWrongFileLicense_LiteralModeKeepsAutofix(t *testing.T) {
+	file := parseLicenseFixture(t, `package test
+
+fun foo() {}
+`)
+	r := &AbsentOrWrongFileLicenseRule{
+		BaseRule:        BaseRule{RuleName: "AbsentOrWrongFileLicense", RuleSetName: "comments", Sev: "warning"},
+		LicenseTemplate: "Copyright 2026 Acme",
+	}
+	findings := runLicenseRule(t, r, file)
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(findings))
+	}
+	fix := findings[0].Fix
+	if fix == nil {
+		t.Fatal("literal-mode rule must attach an autofix")
+	}
+	if !strings.Contains(fix.Replacement, "Copyright 2026 Acme") {
+		t.Fatalf("expected literal template in replacement, got %q", fix.Replacement)
+	}
+}


### PR DESCRIPTION
## Summary
- `AbsentOrWrongFileLicense` in regex mode was wrapping the raw regex pattern in a Kotlin comment and inserting it as a "license header" — e.g. for `licenseTemplate: '(?i)copyright\s+\d{4}.*'` the autofix wrote `/* (?i)copyright\s+\d{4}.* */` into the file, producing source that doesn't match its own pattern.
- When `IsRegex=true` the rule has no literal text to emit, so the autofix is now omitted in regex mode. The finding still fires; the user adds the header manually. Literal mode is unchanged.
- Added regression tests covering both the no-comment and wrong-comment branches in regex mode, plus a sanity test for the literal-mode autofix.

## Test plan
- [x] `go test ./internal/rules/ -run 'TestAbsentOrWrongFileLicense' -v -count=1`
- [x] `go test ./... -count=1`
- [x] Verified regression tests fail without the fix (raw regex appears in `Fix.Replacement`)
- [x] `go build`, `go vet`