### PR TITLE
fix(rules): UnusedImport handles backtick-quoted identifiers

### DIFF
--- a/internal/rules/semantic_rule_helpers.go
+++ b/internal/rules/semantic_rule_helpers.go
@@ -1266,14 +1266,39 @@ func importShortNameFlat(file *scanner.File, idx uint32) string {
 		return ""
 	}
 	imp := strings.TrimSpace(strings.TrimPrefix(text, "import "))
-	if i := strings.Index(imp, " as "); i >= 0 {
-		return strings.TrimSpace(imp[i+4:])
+	aliasAt, lastDot := scanImportTail(imp)
+	if aliasAt >= 0 {
+		return strings.Trim(strings.TrimSpace(imp[aliasAt+4:]), "`")
 	}
-	parts := strings.Split(imp, ".")
-	if len(parts) == 0 || parts[len(parts)-1] == "*" {
+	last := imp[lastDot+1:]
+	if last == "" || last == "*" {
 		return ""
 	}
-	return parts[len(parts)-1]
+	return strings.Trim(last, "`")
+}
+
+// scanImportTail walks the import path once, returning the byte offset of an
+// " as " alias keyword (or -1) and the byte offset of the last '.' segment
+// separator (or -1). Backtick-quoted spans are opaque, so a space or '.'
+// inside `foo bar` or `a.b` does not split the path.
+func scanImportTail(imp string) (aliasAt, lastDot int) {
+	aliasAt, lastDot = -1, -1
+	inBacktick := false
+	for i := 0; i < len(imp); i++ {
+		switch imp[i] {
+		case '`':
+			inBacktick = !inBacktick
+		case ' ':
+			if !inBacktick && aliasAt < 0 && strings.HasPrefix(imp[i:], " as ") {
+				aliasAt = i
+			}
+		case '.':
+			if !inBacktick {
+				lastDot = i
+			}
+		}
+	}
+	return aliasAt, lastDot
 }
 
 var kotlinImplicitOperatorImportNames = map[string]struct{}{

--- a/internal/rules/style_unused.go
+++ b/internal/rules/style_unused.go
@@ -42,7 +42,8 @@ func collectReferenceNamesOutsideImports(file *scanner.File) map[string]struct{}
 			return
 		}
 		if name := semantics.ReferenceName(file, n); name != "" {
-			names[name] = struct{}{}
+			// `foo` and foo resolve to the same symbol; canonicalize for lookup.
+			names[strings.Trim(name, "`")] = struct{}{}
 		}
 	})
 	return names

--- a/internal/rules/style_unused_test.go
+++ b/internal/rules/style_unused_test.go
@@ -1,6 +1,7 @@
 package rules_test
 
 import (
+	"strings"
 	"testing"
 
 	api "github.com/kaeawc/krit/internal/rules/api"
@@ -62,6 +63,56 @@ fun main() {
 `)
 	if len(findings) != 0 {
 		t.Fatalf("expected no findings, got %d: %#v", len(findings), findings)
+	}
+}
+
+func TestUnusedImport_BacktickQuotedShortName(t *testing.T) {
+	// '@' stands in for a backtick — raw strings can't contain backticks.
+	bt := func(s string) string { return strings.ReplaceAll(s, "@", "`") }
+	cases := []struct {
+		name string
+		code string
+	}{
+		{
+			name: "both sides backtick-quoted",
+			code: bt(`
+package test
+import com.used.Foo.Bar.@baz@
+fun main() { println(@baz@()) }
+`),
+		},
+		{
+			name: "backtick import, plain reference",
+			code: bt(`
+package test
+import com.used.Foo.Bar.@baz@
+fun main() { println(baz()) }
+`),
+		},
+		{
+			name: "plain import, backtick reference",
+			code: bt(`
+package test
+import com.used.Foo.Bar.baz
+fun main() { println(@baz@()) }
+`),
+		},
+		{
+			name: "backtick alias",
+			code: bt(`
+package test
+import com.used.Foo.Bar.baz as @qux@
+fun main() { println(qux()) }
+`),
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			findings := runRuleByName(t, "UnusedImport", tc.code)
+			if len(findings) != 0 {
+				t.Fatalf("expected no findings, got %d: %#v", len(findings), findings)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary
- `importShortNameFlat` split on `.` and located ` as ` without backtick awareness, so `import com.used.Foo.Bar.\`baz\`` produced the short name `` `baz` `` (with backticks). The reference index stored the plain `baz`, the lookup missed, and the `FixIdiomatic` autofix deleted the valid import. Symmetric break for plain import + backtick-quoted reference.
- Replaced the `strings.Split` + `strings.Index` pair in [internal/rules/semantic_rule_helpers.go](internal/rules/semantic_rule_helpers.go) with a single backtick-aware scan (`scanImportTail`), and canonicalized the reference names collected in [internal/rules/style_unused.go](internal/rules/style_unused.go) by trimming surrounding backticks so both representations match.

## Test plan
- [x] `go test ./internal/rules/ -run TestUnusedImport -count=1`  (new `TestUnusedImport_BacktickQuotedShortName` covers both-backticked, backtick-import + plain-ref, plain-import + backtick-ref, and backtick alias)
- [x] `go test ./internal/rules/ ./internal/scanner/ -count=1`
- [x] `go build`, `go vet`, `golangci-lint run`