### PR TITLE
fix(fixer): preserve CRLF line endings in line-mode fix application

### DIFF
--- a/internal/fixer/fixer.go
+++ b/internal/fixer/fixer.go
@@ -251,7 +251,8 @@ func applyLineFixes(result string, lineFixes []textFixRow, path string) (string,
 	canonicalSortLineFixes(lineFixes)
 	var dropped []DroppedFix
 	lineFixes, dropped = deduplicateFixesReverse(lineFixes, textFixRowLineEnd, textFixRowLineStart, textFixRowDroppedFor(path))
-	lines := strings.Split(result, "\n")
+	sep := detectLineEnding(result)
+	lines := splitLinesForJoin(result, sep)
 	for _, f := range lineFixes {
 		fix := f.fix
 		start := fix.StartLine - 1
@@ -267,7 +268,7 @@ func applyLineFixes(result string, lineFixes []textFixRow, path string) (string,
 		// terminator the lines model already implies.
 		var replacement []string
 		if fix.Replacement != "" {
-			replacement = strings.Split(strings.TrimSuffix(fix.Replacement, "\n"), "\n")
+			replacement = splitLinesForJoin(strings.TrimSuffix(fix.Replacement, "\n"), sep)
 		}
 		newLines := make([]string, 0, len(lines)-end+start+len(replacement))
 		newLines = append(newLines, lines[:start]...)
@@ -275,7 +276,32 @@ func applyLineFixes(result string, lineFixes []textFixRow, path string) (string,
 		newLines = append(newLines, lines[end:]...)
 		lines = newLines
 	}
-	return strings.Join(lines, "\n"), dropped
+	return strings.Join(lines, sep), dropped
+}
+
+// detectLineEnding returns "\r\n" if the first newline in s is preceded by
+// a carriage return, otherwise "\n". Rules emit replacement text with bare
+// "\n", so applyLineFixes needs the source's ending to avoid producing a
+// file with mixed CRLF/LF lines (which corrupts Windows checkouts).
+func detectLineEnding(s string) string {
+	i := strings.IndexByte(s, '\n')
+	if i > 0 && s[i-1] == '\r' {
+		return "\r\n"
+	}
+	return "\n"
+}
+
+// splitLinesForJoin splits s on "\n" and, when sep is "\r\n", strips the
+// trailing "\r" each line carries so that the subsequent Join(sep) produces
+// uniform CRLF output instead of leaving stray "\r" embedded mid-line.
+func splitLinesForJoin(s, sep string) []string {
+	lines := strings.Split(s, "\n")
+	if sep == "\r\n" {
+		for i, ln := range lines {
+			lines[i] = strings.TrimSuffix(ln, "\r")
+		}
+	}
+	return lines
 }
 
 // canonicalSortByteFixes orders byte-mode fixes for reverse-walk

--- a/internal/fixer/fixer_test.go
+++ b/internal/fixer/fixer_test.go
@@ -373,6 +373,78 @@ func TestLineModeFix_TrailingNewlineIdempotent(t *testing.T) {
 	}
 }
 
+func TestLineModeFix_PreservesCRLF(t *testing.T) {
+	path := writeTestFile(t, "line1\r\nline2\r\nline3\r\n")
+	findings := []scanner.Finding{
+		finding(path, &scanner.Fix{
+			StartLine:   2,
+			EndLine:     2,
+			Replacement: "replaced",
+		}),
+	}
+
+	n, err := ApplyFixes(t.Context(), path, findings, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("expected 1 fix applied, got %d", n)
+	}
+	got := readFile(t, path)
+	want := "line1\r\nreplaced\r\nline3\r\n"
+	if got != want {
+		t.Fatalf("expected %q, got %q", want, got)
+	}
+}
+
+func TestLineModeFix_CRLF_MultiLineReplacement(t *testing.T) {
+	path := writeTestFile(t, "line1\r\nline2\r\nline3\r\n")
+	findings := []scanner.Finding{
+		finding(path, &scanner.Fix{
+			StartLine:   2,
+			EndLine:     2,
+			Replacement: "a\nb",
+		}),
+	}
+
+	n, err := ApplyFixes(t.Context(), path, findings, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("expected 1 fix applied, got %d", n)
+	}
+	got := readFile(t, path)
+	want := "line1\r\na\r\nb\r\nline3\r\n"
+	if got != want {
+		t.Fatalf("expected %q, got %q", want, got)
+	}
+}
+
+func TestLineModeFix_CRLF_DeleteLine(t *testing.T) {
+	path := writeTestFile(t, "line1\r\nline2\r\nline3\r\n")
+	findings := []scanner.Finding{
+		finding(path, &scanner.Fix{
+			StartLine:   2,
+			EndLine:     2,
+			Replacement: "",
+		}),
+	}
+
+	n, err := ApplyFixes(t.Context(), path, findings, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("expected 1 fix applied, got %d", n)
+	}
+	got := readFile(t, path)
+	want := "line1\r\nline3\r\n"
+	if got != want {
+		t.Fatalf("expected %q, got %q", want, got)
+	}
+}
+
 // --------------- Edge cases ---------------
 
 func TestNoFixesApplied(t *testing.T) {


### PR DESCRIPTION
## Summary
- `applyLineFixes` split on `\n` and joined on `\n`, so on a CRLF file the trailing `\r` stayed glued to every untouched line while replacement lines (split from rule output, which uses `\n`) had none — producing mixed endings that corrupt Windows checkouts.
- Detect the dominant ending from the source (first newline preceded by `\r` ⇒ CRLF, else LF), strip `\r` from each split line under CRLF, and rejoin with the detected separator. Replacement strings are normalized to the same separator so rule-emitted `\n` becomes `\r\n` on CRLF files.
- Byte-mode fixes are unaffected — they operate on raw offsets and never touch the line splitter.

## Test plan
- [x] New regression tests: `TestLineModeFix_PreservesCRLF`, `TestLineModeFix_CRLF_MultiLineReplacement`, `TestLineModeFix_CRLF_DeleteLine` — each writes a CRLF source, applies a line-mode fix, asserts output is uniform CRLF.
- [x] Existing LF tests (`TestLineModeFix_ReplaceLine` / `DeleteLine` / `MultiLine`) still pass — detection returns `\n` so split/join behavior is identical to before.
- [x] `go build ./cmd/krit/`, `go vet ./...`, `golangci-lint run ./internal/fixer/...`, `go test ./... -count=1` all green.