### PR TITLE
fix(lsp): map 1-based finding columns to 0-based LSP positions

### DIFF
--- a/internal/lsp/diagnostics.go
+++ b/internal/lsp/diagnostics.go
@@ -20,13 +20,17 @@ func FindingColumnsToDiagnostics(columns *scanner.FindingColumns) []Diagnostic {
 func rowToDiagnostic(columns *scanner.FindingColumns, row int) Diagnostic {
 	severity := mapSeverity(columns.SeverityAt(row))
 
-	// LSP lines and characters are 0-based; krit lines are 1-based, cols are 0-based.
+	// LSP lines and characters are 0-based; krit lines and columns are 1-based.
 	findingLine := columns.LineAt(row)
 	line := uint32(0)
 	if findingLine > 0 {
 		line = uint32(findingLine - 1)
 	}
-	col := uint32(columns.ColumnAt(row))
+	findingCol := columns.ColumnAt(row)
+	col := uint32(0)
+	if findingCol > 0 {
+		col = uint32(findingCol - 1)
+	}
 
 	return Diagnostic{
 		Range: Range{

--- a/internal/lsp/diagnostics_slice_test.go
+++ b/internal/lsp/diagnostics_slice_test.go
@@ -27,7 +27,10 @@ func FindingToDiagnostic(f scanner.Finding) Diagnostic {
 	if f.Line > 0 {
 		line = uint32(f.Line - 1)
 	}
-	col := uint32(f.Col)
+	col := uint32(0)
+	if f.Col > 0 {
+		col = uint32(f.Col - 1)
+	}
 
 	return Diagnostic{
 		Range: Range{

--- a/internal/lsp/server_test.go
+++ b/internal/lsp/server_test.go
@@ -561,8 +561,8 @@ func TestFindingToDiagnostic(t *testing.T) {
 			if d.Range.Start.Line != 9 {
 				t.Errorf("line: got %d, want 9", d.Range.Start.Line)
 			}
-			if d.Range.Start.Character != 5 {
-				t.Errorf("col: got %d, want 5", d.Range.Start.Character)
+			if d.Range.Start.Character != 4 {
+				t.Errorf("col: got %d, want 4", d.Range.Start.Character)
 			}
 			if d.Code != "style/TestRule" {
 				t.Errorf("code: got %q, want %q", d.Code, "style/TestRule")
@@ -3202,13 +3202,13 @@ func TestFindingsToDiagnostics_FieldMapping(t *testing.T) {
 
 	diags := FindingsToDiagnostics(findings)
 
-	// First finding: line 10 -> 9 (0-based), col 5, error -> severity 1
+	// First finding: line 10 -> 9 (0-based), col 5 -> 4 (0-based), error -> severity 1
 	d := diags[0]
 	if d.Range.Start.Line != 9 {
 		t.Errorf("expected line 9 (0-based), got %d", d.Range.Start.Line)
 	}
-	if d.Range.Start.Character != 5 {
-		t.Errorf("expected character 5, got %d", d.Range.Start.Character)
+	if d.Range.Start.Character != 4 {
+		t.Errorf("expected character 4 (0-based), got %d", d.Range.Start.Character)
 	}
 	if d.Range.End.Line != d.Range.Start.Line || d.Range.End.Character != d.Range.Start.Character {
 		t.Error("expected start and end positions to be equal")


### PR DESCRIPTION
## Summary
- `scanner.FindingColumns.ColumnAt` returns 1-based columns, and rule emitters set `Col: ... + 1`, but `FindingColumnsToDiagnostics` (and the slice test helper) passed the value unchanged into LSP's 0-based `Character` field, so diagnostics landed one column to the right of the real issue.
- Subtract 1 (guarded for 0) on both the columnar and slice paths in `internal/lsp/diagnostics.go` / `internal/lsp/diagnostics_slice_test.go`, and fix the misleading comment about column basing.
- Update the two tests that pinned the off-by-one (`TestFindingToDiagnostic` and `TestFindingsToDiagnostics_FieldMapping`) to expect the corrected column.

## Test plan
- [x] \`go build -o krit ./cmd/krit/\`
- [x] \`go vet ./internal/lsp/...\`
- [x] \`golangci-lint run ./internal/lsp/...\`
- [x] \`go test ./... -count=1\`