### PR TITLE
fix(config): honor ij_kotlin_indent_size as indent_size fallback

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -945,6 +945,58 @@ ktfmt_style = google
 	// Vendor props should be silently ignored (no error, no side effects)
 }
 
+func TestLoadEditorConfigKotlinIndentSizeFallback(t *testing.T) {
+	t.Run("ij_kotlin_indent_size populates IndentSize when indent_size absent", func(t *testing.T) {
+		dir := t.TempDir()
+		ecPath := filepath.Join(dir, ".editorconfig")
+		os.WriteFile(ecPath, []byte(`
+root = true
+
+[*.kt]
+ij_kotlin_indent_size = 2
+`), 0644)
+
+		ec := LoadEditorConfig(dir)
+		if ec.IndentSize != 2 {
+			t.Errorf("expected IndentSize=2 from ij_kotlin_indent_size fallback, got %d", ec.IndentSize)
+		}
+	})
+
+	t.Run("standard indent_size wins over ij_kotlin_indent_size", func(t *testing.T) {
+		dir := t.TempDir()
+		ecPath := filepath.Join(dir, ".editorconfig")
+		os.WriteFile(ecPath, []byte(`
+root = true
+
+[*.kt]
+indent_size = 4
+ij_kotlin_indent_size = 2
+`), 0644)
+
+		ec := LoadEditorConfig(dir)
+		if ec.IndentSize != 4 {
+			t.Errorf("expected indent_size=4 to win over ij_kotlin_indent_size, got %d", ec.IndentSize)
+		}
+	})
+
+	t.Run("ij_kotlin_indent_size flows through ApplyToConfig to NoTabs", func(t *testing.T) {
+		dir := t.TempDir()
+		ecPath := filepath.Join(dir, ".editorconfig")
+		os.WriteFile(ecPath, []byte(`
+root = true
+
+[*.kt]
+ij_kotlin_indent_size = 2
+`), 0644)
+
+		cfg := NewConfig()
+		LoadEditorConfig(dir).ApplyToConfig(cfg)
+		if got := cfg.GetInt("style", "NoTabs", "indentSize", 0); got != 2 {
+			t.Errorf("expected NoTabs.indentSize=2 from ij_kotlin_indent_size, got %d", got)
+		}
+	})
+}
+
 func TestApplyToConfig(t *testing.T) {
 	cfg := NewConfig()
 

--- a/internal/config/editorconfig.go
+++ b/internal/config/editorconfig.go
@@ -10,7 +10,9 @@ import (
 
 // EditorConfig holds parsed .editorconfig properties relevant to krit.
 // Only reads standard properties that affect analysis rules.
-// Does NOT read ktlint_*, ij_kotlin_*, or ktfmt_* properties.
+// Does NOT read ktlint_* or ktfmt_* properties. From the ij_* namespace,
+// only ij_kotlin_indent_size is consulted, as a fallback for indent_size
+// when projects configure indent width via the IntelliJ key alone.
 type EditorConfig struct {
 	MaxLineLength          int    // max_line_length (0 = not set, -1 = off)
 	IndentSize             int    // indent_size (0 = not set)
@@ -113,10 +115,12 @@ func parseEditorConfig(path string) (props map[string]string, isRoot bool) {
 			if len(parts) == 2 {
 				key := strings.TrimSpace(strings.ToLower(parts[0]))
 				value := strings.TrimSpace(parts[1])
-				// Only read standard properties — skip ktlint_*, ij_*, ktfmt_*
+				// Only read standard properties — skip ktlint_*, ktfmt_*, and
+				// most ij_* keys. ij_kotlin_indent_size is allowed through as
+				// a fallback for the standard indent_size key.
 				if !strings.HasPrefix(key, "ktlint_") &&
-					!strings.HasPrefix(key, "ij_") &&
-					!strings.HasPrefix(key, "ktfmt_") {
+					!strings.HasPrefix(key, "ktfmt_") &&
+					(!strings.HasPrefix(key, "ij_") || key == "ij_kotlin_indent_size") {
 					props[key] = value
 				}
 			}
@@ -156,6 +160,12 @@ func applyProps(ec *EditorConfig, props map[string]string) {
 				ec.IndentSize = ec.TabWidth
 			}
 		} else if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			ec.IndentSize = n
+		}
+	} else if v, ok := props["ij_kotlin_indent_size"]; ok {
+		// Fallback: projects that only set the IntelliJ-style key still
+		// get a coherent indent width for indent-touching fixes (NoTabs).
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
 			ec.IndentSize = n
 		}
 	}


### PR DESCRIPTION
## Summary
- `internal/config/editorconfig.go` skipped every `ij_*` key, dropping `ij_kotlin_indent_size`. Projects that configure indent width via the IntelliJ-style key alone (common in Kotlin repos that lean on IntelliJ/ktfmt formatting) got no value, so indent-touching fixes like `NoTabs` diverged from formatter behavior.
- Vendor-prop filter now allows only `ij_kotlin_indent_size` through, and `applyProps` uses it as a fallback for the standard `indent_size`. Standard `indent_size` still wins when both are present.
- Regression test covers fallback, precedence, and the flow through `ApplyToConfig` to `NoTabs.indentSize`.

## Test plan
- [x] `go build -o krit ./cmd/krit/`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...`
- [x] `go test ./... -count=1`