### PR TITLE
fix(scanner): guard File.lineOffsets cache with sync.Once

### DIFF
--- a/internal/scanner/benchmark_test.go
+++ b/internal/scanner/benchmark_test.go
@@ -155,11 +155,12 @@ func BenchmarkCollectIndexDataSharded_16Workers(b *testing.B) {
 
 func BenchmarkLineOffsets(b *testing.B) {
 	f := helperParseFixture(b, "../../tests/fixtures/positive/complexity/LargeClass.kt")
+	content := f.Content
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		// Clear cache to force recomputation
-		f.lineOffsets = nil
-		_ = f.LineOffsets()
+		// Fresh File so sync.Once fires each iteration.
+		fresh := &File{Content: content}
+		_ = fresh.LineOffsets()
 	}
 }
 

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -119,12 +119,13 @@ func (l Language) String() string {
 // File holds parsed source in flat form. The cgo parse tree is used
 // only during flattening and is not retained on the File.
 type File struct {
-	Path        string
-	Language    Language
-	Content     []byte
-	Lines       []string
-	FlatTree    *FlatTree
-	lineOffsets []int // cached byte offset of each line start
+	Path            string
+	Language        Language
+	Content         []byte
+	Lines           []string
+	FlatTree        *FlatTree
+	lineOffsets     []int // cached byte offset of each line start; populated under lineOffsetsOnce
+	lineOffsetsOnce sync.Once
 
 	// Generated is true when the file came from a build/generated/**
 	// directory and was kept by the parse phase's known-safe-generator
@@ -160,18 +161,21 @@ type File struct {
 	Suppression *SuppressionFilter
 }
 
-// LineOffsets returns the byte offset of each line start, computed lazily and cached.
+// LineOffsets returns the byte offset of each line start, computed lazily
+// and cached. The cache is populated exactly once via sync.Once so that
+// concurrent callers — the cross-file rule worker pool, suppression
+// filters, and rule bodies — can safely share a *File without racing on
+// the slice header.
 func (f *File) LineOffsets() []int {
-	if f.lineOffsets != nil {
-		return f.lineOffsets
-	}
-	offsets := []int{0}
-	for i, b := range f.Content {
-		if b == '\n' {
-			offsets = append(offsets, i+1)
+	f.lineOffsetsOnce.Do(func() {
+		offsets := []int{0}
+		for i, b := range f.Content {
+			if b == '\n' {
+				offsets = append(offsets, i+1)
+			}
 		}
-	}
-	f.lineOffsets = offsets
+		f.lineOffsets = offsets
+	})
 	return f.lineOffsets
 }
 

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"strings"
+	"sync"
 	"testing"
 	"unsafe"
 
@@ -87,6 +88,40 @@ func TestLineOffsets_Cached(t *testing.T) {
 	// Should be the same slice (cached)
 	if &offsets1[0] != &offsets2[0] {
 		t.Fatal("expected LineOffsets to return cached result")
+	}
+}
+
+// TestLineOffsets_Concurrent stresses the lazy cache from many goroutines
+// at once. Before the sync.Once fix, this raced on the f.lineOffsets
+// slice header (detected under `go test -race`) and could return torn
+// or empty results from concurrent suppression lookups.
+func TestLineOffsets_Concurrent(t *testing.T) {
+	var content strings.Builder
+	for i := 0; i < 1024; i++ {
+		content.WriteString("line\n")
+	}
+	f := &File{Content: []byte(content.String())}
+
+	const workers = 32
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	first := make([][]int, workers)
+	for w := 0; w < workers; w++ {
+		go func(idx int) {
+			defer wg.Done()
+			first[idx] = f.LineOffsets()
+		}(w)
+	}
+	wg.Wait()
+
+	want := first[0]
+	if len(want) != 1025 {
+		t.Fatalf("expected 1025 offsets, got %d", len(want))
+	}
+	for i := 1; i < workers; i++ {
+		if &first[i][0] != &want[0] {
+			t.Fatalf("worker %d observed a different cached slice", i)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- `File.LineOffsets()` lazily wrote `f.lineOffsets` with no synchronization. The cross-file rule worker pool ([internal/pipeline/crossfile.go:590](https://github.com/kaeawc/krit/blob/main/internal/pipeline/crossfile.go#L590)) calls `SuppressionFilter.IsSuppressed` → `file.LineOffset(...)` concurrently on the same `*File`, racing the slice header — at best wrong suppression offsets, at worst a panic.
- Populate the cache under `sync.Once`. The benchmark that cleared the cache mid-loop now constructs a fresh `*File` per iteration so the once still fires.
- New `TestLineOffsets_Concurrent` hammers `LineOffsets` from 32 goroutines and confirms a single shared backing slice. It fails under `go test -race` without the fix.

## Test plan

- [x] `go test -race ./internal/scanner/ -run TestLineOffsets -count=1`
- [x] `go build -o krit ./cmd/krit/`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...`
- [x] `go test ./... -count=1`