### PR TITLE
feat(android): broaden StateListReachable to subset-masking semantics

### DIFF
--- a/internal/android/resources.go
+++ b/internal/android/resources.go
@@ -790,6 +790,23 @@ func (idx *ResourceIndex) scanDrawableDir(dir string, maxWorkers int) {
 	}
 }
 
+// isSelectorStateAttr reports whether a `<selector><item>` attribute name
+// behaves as a state qualifier. An item matches when the runtime's current
+// state set is a superset of the item's qualifiers; items with no qualifiers
+// match everything. Android-namespaced state attrs (`android:state_*`) and
+// any non-android-namespaced attr (which may declare a custom state — see
+// https://issuetracker.google.com/22339) count as qualifiers; bare
+// presentation attrs like `android:drawable` do not.
+func isSelectorStateAttr(name string) bool {
+	if strings.HasPrefix(name, "android:state_") {
+		return true
+	}
+	if i := strings.IndexByte(name, ':'); i > 0 {
+		return name[:i] != "android"
+	}
+	return false
+}
+
 func (idx *ResourceIndex) parseDrawableSelectorBytes(path, resName string, data []byte) {
 	root, err := ParseXMLAST(context.Background(), data)
 	if err != nil || root == nil || root.Tag != "selector" {
@@ -806,7 +823,7 @@ func (idx *ResourceIndex) parseDrawableSelectorBytes(path, resName string, data 
 			StateAttrs: make(map[string]string),
 		}
 		for _, attr := range child.Attrs {
-			if strings.HasPrefix(attr.Name, "android:state_") {
+			if isSelectorStateAttr(attr.Name) {
 				item.StateAttrs[attr.Name] = attr.Value
 			}
 		}

--- a/internal/android/resources_test.go
+++ b/internal/android/resources_test.go
@@ -837,6 +837,39 @@ func TestScanResourceDir_ParsesDrawableSelectors(t *testing.T) {
 	if got := items[1].StateAttrs["android:state_pressed"]; got != "true" {
 		t.Fatalf("second item pressed state = %q, want true", got)
 	}
+	if _, present := items[1].StateAttrs["android:drawable"]; present {
+		t.Fatalf("bare android:drawable should not be tracked as a state qualifier: %#v", items[1].StateAttrs)
+	}
+}
+
+func TestScanResourceDir_DrawableSelectorCustomNamespaceState(t *testing.T) {
+	tmp := t.TempDir()
+	resDir := filepath.Join(tmp, "res")
+	drawableDir := filepath.Join(resDir, "drawable")
+	os.MkdirAll(drawableDir, 0o755)
+
+	writeFile(t, filepath.Join(drawableDir, "tile.xml"), `<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android"
+          xmlns:app="http://schemas.android.com/apk/res-auto">
+    <item app:state_custom="true" android:drawable="@drawable/custom" />
+    <item android:drawable="@drawable/normal" />
+</selector>
+`)
+
+	idx, err := ScanResourceDir(resDir)
+	if err != nil {
+		t.Fatalf("ScanResourceDir: %v", err)
+	}
+	items := idx.DrawableSelectors["tile"]
+	if len(items) != 2 {
+		t.Fatalf("expected 2 selector items, got %d", len(items))
+	}
+	if got := items[0].StateAttrs["app:state_custom"]; got != "true" {
+		t.Fatalf("custom-namespace state attr not tracked: %#v", items[0].StateAttrs)
+	}
+	if _, present := items[0].StateAttrs["android:drawable"]; present {
+		t.Fatalf("bare android:drawable should not be tracked: %#v", items[0].StateAttrs)
+	}
 }
 
 func TestIsLayoutView(t *testing.T) {

--- a/internal/rules/android_resource_layout_test.go
+++ b/internal/rules/android_resource_layout_test.go
@@ -761,7 +761,7 @@ func TestStateListReachableResource(t *testing.T) {
 		}
 	})
 
-	t.Run("catch-all item before later state triggers", func(t *testing.T) {
+	t.Run("catch-all item masks later state", func(t *testing.T) {
 		idx := emptyIndex()
 		idx.DrawableSelectors = map[string][]android.SelectorItem{
 			"button": {
@@ -773,8 +773,11 @@ func TestStateListReachableResource(t *testing.T) {
 		if len(findings) != 1 {
 			t.Fatalf("expected 1 finding, got %d", len(findings))
 		}
-		if findings[0].Line != 3 {
-			t.Fatalf("line = %d, want 3", findings[0].Line)
+		if findings[0].Line != 6 {
+			t.Fatalf("line = %d, want 6 (masked item)", findings[0].Line)
+		}
+		if !strings.Contains(findings[0].Message, "item #1") {
+			t.Fatalf("message should reference masking item #1: %q", findings[0].Message)
 		}
 	})
 
@@ -789,6 +792,66 @@ func TestStateListReachableResource(t *testing.T) {
 		findings := runResourceRule(r, idx)
 		if len(findings) != 0 {
 			t.Fatalf("expected 0 findings, got %d", len(findings))
+		}
+	})
+
+	t.Run("earlier subset masks later superset", func(t *testing.T) {
+		idx := emptyIndex()
+		idx.DrawableSelectors = map[string][]android.SelectorItem{
+			"button": {
+				{FilePath: "res/drawable/button.xml", Line: 3, StateAttrs: map[string]string{"android:state_pressed": "true"}},
+				{FilePath: "res/drawable/button.xml", Line: 6, StateAttrs: map[string]string{"android:state_pressed": "true", "android:state_focused": "true"}},
+			},
+		}
+		findings := runResourceRule(r, idx)
+		if len(findings) != 1 {
+			t.Fatalf("expected 1 finding, got %d", len(findings))
+		}
+		if findings[0].Line != 6 {
+			t.Fatalf("line = %d, want 6", findings[0].Line)
+		}
+	})
+
+	t.Run("conflicting values are not a subset", func(t *testing.T) {
+		idx := emptyIndex()
+		idx.DrawableSelectors = map[string][]android.SelectorItem{
+			"button": {
+				{FilePath: "res/drawable/button.xml", Line: 3, StateAttrs: map[string]string{"android:state_pressed": "true"}},
+				{FilePath: "res/drawable/button.xml", Line: 6, StateAttrs: map[string]string{"android:state_pressed": "false"}},
+			},
+		}
+		findings := runResourceRule(r, idx)
+		if len(findings) != 0 {
+			t.Fatalf("expected 0 findings, got %d", len(findings))
+		}
+	})
+
+	t.Run("custom-namespace state attr is treated as a qualifier", func(t *testing.T) {
+		idx := emptyIndex()
+		idx.DrawableSelectors = map[string][]android.SelectorItem{
+			"button": {
+				{FilePath: "res/drawable/button.xml", Line: 3, StateAttrs: map[string]string{"app:state_custom": "true"}},
+				{FilePath: "res/drawable/button.xml", Line: 6, StateAttrs: map[string]string{}},
+			},
+		}
+		findings := runResourceRule(r, idx)
+		if len(findings) != 0 {
+			t.Fatalf("expected 0 findings, got %d", len(findings))
+		}
+	})
+
+	t.Run("only first masking pair reported per selector", func(t *testing.T) {
+		idx := emptyIndex()
+		idx.DrawableSelectors = map[string][]android.SelectorItem{
+			"button": {
+				{FilePath: "res/drawable/button.xml", Line: 3, StateAttrs: map[string]string{}},
+				{FilePath: "res/drawable/button.xml", Line: 6, StateAttrs: map[string]string{"android:state_pressed": "true"}},
+				{FilePath: "res/drawable/button.xml", Line: 9, StateAttrs: map[string]string{"android:state_focused": "true"}},
+			},
+		}
+		findings := runResourceRule(r, idx)
+		if len(findings) != 2 {
+			t.Fatalf("expected 2 findings (one per masked item), got %d", len(findings))
 		}
 	})
 }

--- a/internal/rules/android_resource_style.go
+++ b/internal/rules/android_resource_style.go
@@ -783,16 +783,15 @@ func (r *AlwaysShowActionResourceRule) check(ctx *api.Context) {
 // ---------------------------------------------------------------------------
 
 // StateListReachableResourceRule detects unreachable items in selector
-// drawables. A non-last <item> with no state attributes (android:state_*)
-// catches all states, making subsequent items unreachable.
+// drawables. Selector items are matched top-down and chosen when the
+// runtime state set is a superset of the item's state qualifiers, so an
+// item whose qualifier set is a superset of any earlier item's is
+// unreachable.
 type StateListReachableResourceRule struct {
 	LayoutResourceBase
 	AndroidRule
 }
 
-// Confidence reports a tier-2 (medium) base confidence. Android style/theme resource rule. Detection flags style inheritance
-// anti-patterns and attribute mismatches via structural checks on style
-// XML. Classified per roadmap/17.
 func (r *StateListReachableResourceRule) Confidence() float64 { return 0.75 }
 
 func (r *StateListReachableResourceRule) check(ctx *api.Context) {
@@ -801,24 +800,36 @@ func (r *StateListReachableResourceRule) check(ctx *api.Context) {
 		return
 	}
 	for _, items := range idx.DrawableSelectors {
-		for i, item := range items {
-			if i == len(items)-1 {
-				continue
-			}
-			if len(item.StateAttrs) == 0 {
+		for j := 1; j < len(items); j++ {
+			for i := 0; i < j; i++ {
+				if !stateAttrsSubsetOf(items[i].StateAttrs, items[j].StateAttrs) {
+					continue
+				}
 				ctx.Emit(scanner.Finding{
-					File:       item.FilePath,
-					Line:       item.Line,
+					File:       items[j].FilePath,
+					Line:       items[j].Line,
 					Col:        1,
 					RuleSet:    r.RuleSetName,
 					Rule:       r.RuleName,
 					Severity:   r.Sev,
-					Message:    "Selector item without state attributes catches all states; subsequent items are unreachable.",
+					Message:    fmt.Sprintf("This selector item is unreachable because item #%d is a more general match.", i+1),
 					Confidence: r.Confidence(),
 				})
+				break
 			}
 		}
 	}
+}
+
+// stateAttrsSubsetOf reports whether a's qualifiers are a subset of b's —
+// meaning b is matched only when a is also matched, so b is unreachable.
+func stateAttrsSubsetOf(a, b map[string]string) bool {
+	for name, value := range a {
+		if bv, ok := b[name]; !ok || bv != value {
+			return false
+		}
+	}
+	return true
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Match AOSP's `StateListDetector` semantics for `StateListReachable`: in a `<selector>` drawable, an item is unreachable when its state qualifiers are a superset of any earlier item's. Previously Krit only caught the trivial case (a non-last item with no qualifiers).
- Findings now report at the *masked* (unreachable) item and reference the masking item's index in the message — matches AOSP and points the user at the dead code rather than the cause.
- Indexer now tracks non-`android:` namespaced attrs as state qualifiers (per [issuetracker 22339](https://issuetracker.google.com/22339)) so selectors using custom-namespace state attributes don't false-positive.

## Test plan

- [x] `go build`, `go vet`, `golangci-lint run ./...`, `go test ./... -count=1` all clean
- [x] `make lint-rules` passes (capability declarations unchanged)
- [x] New unit tests cover: subset-masking, conflicting-value negative, custom-namespace negative, multiple masked items per selector, and the existing catch-all/empty-state cases
- [x] New indexer test locks in custom-namespace state-attr tracking and confirms bare `android:drawable` is not tracked