### PR TITLE
refactor(rules): LocaleFolder + UseAlpha2 read res/values-*/ instead of source

### DIFF
--- a/internal/rules/android_aosp_new_test.go
+++ b/internal/rules/android_aosp_new_test.go
@@ -1,7 +1,6 @@
 package rules_test
 
 import (
-	"strings"
 	"testing"
 
 	api "github.com/kaeawc/krit/internal/rules/api"
@@ -474,94 +473,6 @@ fun example() {
 }`)
 		if len(findings) != 0 {
 			t.Fatalf("expected 0 findings, got %d", len(findings))
-		}
-	})
-}
-
-// ---------------------------------------------------------------------------
-// LocaleFolder
-// ---------------------------------------------------------------------------
-
-func TestLocaleFolder(t *testing.T) {
-	t.Run("underscore locale triggers", func(t *testing.T) {
-		findings := runRuleByName(t, "LocaleFolder", `
-package test
-val path = "res/values-en_US/strings.xml"
-`)
-		if len(findings) != 1 {
-			t.Fatalf("expected 1 finding, got %d", len(findings))
-		}
-	})
-
-	t.Run("correct locale format is clean", func(t *testing.T) {
-		findings := runRuleByName(t, "LocaleFolder", `
-package test
-val path = "res/values-en-rUS/strings.xml"
-`)
-		if len(findings) != 0 {
-			t.Fatalf("expected 0 findings, got %d", len(findings))
-		}
-	})
-
-	t.Run("simple locale is clean", func(t *testing.T) {
-		findings := runRuleByName(t, "LocaleFolder", `
-package test
-val path = "res/values-en/strings.xml"
-`)
-		if len(findings) != 0 {
-			t.Fatalf("expected 0 findings, got %d", len(findings))
-		}
-	})
-}
-
-// ---------------------------------------------------------------------------
-// UseAlpha2
-// ---------------------------------------------------------------------------
-
-func TestUseAlpha2(t *testing.T) {
-	t.Run("3-letter code triggers", func(t *testing.T) {
-		findings := runRuleByName(t, "UseAlpha2", `
-package test
-val path = "res/values-eng/strings.xml"
-`)
-		if len(findings) != 1 {
-			t.Fatalf("expected 1 finding, got %d", len(findings))
-		}
-		if !strings.Contains(findings[0].Message, "en") {
-			t.Fatalf("expected message to suggest 'en', got %s", findings[0].Message)
-		}
-	})
-
-	t.Run("2-letter code is clean", func(t *testing.T) {
-		findings := runRuleByName(t, "UseAlpha2", `
-package test
-val path = "res/values-en/strings.xml"
-`)
-		if len(findings) != 0 {
-			t.Fatalf("expected 0 findings, got %d", len(findings))
-		}
-	})
-
-	t.Run("unknown 3-letter code is clean", func(t *testing.T) {
-		findings := runRuleByName(t, "UseAlpha2", `
-package test
-val path = "res/values-xyz/strings.xml"
-`)
-		if len(findings) != 0 {
-			t.Fatalf("expected 0 findings (unknown code), got %d", len(findings))
-		}
-	})
-
-	t.Run("Japanese code triggers", func(t *testing.T) {
-		findings := runRuleByName(t, "UseAlpha2", `
-package test
-val path = "res/values-jpn/strings.xml"
-`)
-		if len(findings) != 1 {
-			t.Fatalf("expected 1 finding, got %d", len(findings))
-		}
-		if !strings.Contains(findings[0].Message, "ja") {
-			t.Fatalf("expected message to suggest 'ja', got %s", findings[0].Message)
 		}
 	})
 }

--- a/internal/rules/android_resource_values.go
+++ b/internal/rules/android_resource_values.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -1349,6 +1350,103 @@ func (r *ExtraTextResourceRule) check(ctx *api.Context) {
 			fmt.Sprintf("Extraneous text `%s` found in resource file. "+
 				"Text outside elements is usually a mistake.",
 				truncate(et.Text, 40))))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// LocaleFolder / UseAlpha2
+// ---------------------------------------------------------------------------
+
+// LocaleFolderRule flags `values-XX_YY` style directory names — the BCP-47
+// underscore form Android does not accept. The correct form is
+// `values-<lang>-r<REGION>`.
+type LocaleFolderRule struct {
+	ValuesResourceBase
+	AndroidRule
+}
+
+var localeFolderBadRe = regexp.MustCompile(`^values-(?:[a-z0-9]+-)*([a-z]{2})_([A-Z]{2})(?:-|$)`)
+
+// Confidence reports a tier-3 (high) base confidence: the rule matches against
+// actual `res/values-*/` directory names from `os.ReadDir`, not source text,
+// so the only error path is a filesystem read failure.
+func (r *LocaleFolderRule) Confidence() float64 { return 0.95 }
+
+func (r *LocaleFolderRule) check(ctx *api.Context) {
+	forEachValuesQualifierDir(ctx, func(resRoot, name string) {
+		m := localeFolderBadRe.FindStringSubmatch(name)
+		if m == nil {
+			return
+		}
+		ctx.Emit(resourceFinding(filepath.Join(resRoot, name), 1, r.BaseRule,
+			"Wrong locale folder naming `"+name+"`. Use `values-<lang>-r<REGION>` format (e.g., `values-"+m[1]+"-r"+m[2]+"`)."))
+	})
+}
+
+// UseAlpha2Rule flags 3-letter ISO 639-2 locale codes (e.g. `values-eng`)
+// that have a 2-letter ISO 639-1 equivalent — Android resource resolution
+// uses 639-1 codes, so `values-eng/` is silently ignored.
+type UseAlpha2Rule struct {
+	ValuesResourceBase
+	AndroidRule
+}
+
+var alpha3to2 = map[string]string{"eng": "en", "fra": "fr", "deu": "de", "spa": "es", "ita": "it", "por": "pt", "rus": "ru", "jpn": "ja", "kor": "ko", "zho": "zh", "ara": "ar", "hin": "hi", "tur": "tr", "pol": "pl", "nld": "nl", "swe": "sv", "nor": "no", "dan": "da", "fin": "fi", "tha": "th"}
+var alpha3FolderRe = regexp.MustCompile(`^values-([a-z]{3})(?:-|$)`)
+
+// Confidence reports a tier-3 (high) base confidence: the 3→2 letter mapping
+// is a closed allow-list, so an unknown 3-letter token (`mcc`, `xyz`, ...)
+// cannot trigger a false positive.
+func (r *UseAlpha2Rule) Confidence() float64 { return 0.95 }
+
+func (r *UseAlpha2Rule) check(ctx *api.Context) {
+	forEachValuesQualifierDir(ctx, func(resRoot, name string) {
+		m := alpha3FolderRe.FindStringSubmatch(name)
+		if m == nil {
+			return
+		}
+		repl, ok := alpha3to2[m[1]]
+		if !ok {
+			return
+		}
+		ctx.Emit(resourceFinding(filepath.Join(resRoot, name), 1, r.BaseRule,
+			"Use 2-letter ISO 639-1 code `"+repl+"` instead of 3-letter code `"+m[1]+"` in locale folder."))
+	})
+}
+
+// forEachValuesQualifierDir visits every `values-*` sub-directory under each
+// resource root inferred from ctx.ResourceIndex. The walk is sorted and reads
+// each resource root at most once per rule invocation.
+//
+// Caveat: the resource-findings cache is keyed by `resDirContentFingerprint`,
+// which hashes file paths but not bare directory entries. An *empty*
+// `values-XX_YY/` (committed without any XML file) therefore does not
+// invalidate cached findings — in practice users always commit a strings.xml
+// alongside the new qualifier, so the gap is narrow.
+func forEachValuesQualifierDir(ctx *api.Context, visit func(resRoot, dirName string)) {
+	if ctx == nil || ctx.ResourceIndex == nil {
+		return
+	}
+	for _, resRoot := range resourceRootsFromIndex(ctx.ResourceIndex) {
+		entries, err := os.ReadDir(resRoot)
+		if err != nil {
+			continue
+		}
+		names := make([]string, 0, len(entries))
+		for _, e := range entries {
+			if !e.IsDir() {
+				continue
+			}
+			name := e.Name()
+			if !strings.HasPrefix(name, "values-") {
+				continue
+			}
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		for _, name := range names {
+			visit(resRoot, name)
+		}
 	}
 }
 

--- a/internal/rules/android_source_extra.go
+++ b/internal/rules/android_source_extra.go
@@ -1984,57 +1984,6 @@ type GridLayoutRule struct {
 // Classified per roadmap/17.
 func (r *GridLayoutRule) Confidence() float64 { return 0.85 }
 
-type LocaleFolderRule struct {
-	LineBase
-	AndroidRule
-}
-
-var localeFolderBadRe = regexp.MustCompile(`values-[a-z]{2}_[A-Z]{2}`)
-
-// Confidence reports a tier-2 (medium) base confidence. This is an
-// Android-lint port from AOSP; the detection relies on source-text
-// patterns (call names, string literal contents, hardcoded allow-
-// lists of API names) rather than type resolution, so project-
-// specific wrapper APIs can cause false positives or negatives.
-// Classified per roadmap/17.
-func (r *LocaleFolderRule) Confidence() float64 { return 0.75 }
-
-func (r *LocaleFolderRule) check(ctx *api.Context) {
-	file := ctx.File
-	for i, line := range file.Lines {
-		if scanner.IsCommentLine(line) {
-			continue
-		}
-		if localeFolderBadRe.MatchString(line) {
-			ctx.Emit(r.Finding(file, i+1, 1,
-				"Wrong locale folder naming `"+localeFolderBadRe.FindString(line)+"`. Use `values-<lang>-r<REGION>` format (e.g., `values-en-rUS`)."))
-		}
-	}
-}
-
-type UseAlpha2Rule struct {
-	LineBase
-	AndroidRule
-}
-
-var alpha3to2 = map[string]string{"eng": "en", "fra": "fr", "deu": "de", "spa": "es", "ita": "it", "por": "pt", "rus": "ru", "jpn": "ja", "kor": "ko", "zho": "zh", "ara": "ar", "hin": "hi", "tur": "tr", "pol": "pl", "nld": "nl", "swe": "sv", "nor": "no", "dan": "da", "fin": "fi", "tha": "th"}
-var alpha3FolderRe = regexp.MustCompile(`values-([a-z]{3})\b`)
-
-func (r *UseAlpha2Rule) check(ctx *api.Context) {
-	file := ctx.File
-	for i, line := range file.Lines {
-		if scanner.IsCommentLine(line) {
-			continue
-		}
-		if m := alpha3FolderRe.FindStringSubmatch(line); m != nil {
-			if repl, ok := alpha3to2[m[1]]; ok {
-				ctx.Emit(r.Finding(file, i+1, 1,
-					"Use 2-letter ISO 639-1 code `"+repl+"` instead of 3-letter code `"+m[1]+"` in locale folder."))
-			}
-		}
-	}
-}
-
 type MangledCRLFRule struct {
 	LineBase
 	AndroidRule

--- a/internal/rules/android_source_extra_test.go
+++ b/internal/rules/android_source_extra_test.go
@@ -1032,60 +1032,6 @@ fun build(ctx: Context) {
 }
 
 // =====================================================================
-// LocaleFolder tests
-// =====================================================================
-
-func TestLocaleFolder_Extra(t *testing.T) {
-	t.Run("positive - underscore locale folder", func(t *testing.T) {
-		findings := runRuleByName(t, "LocaleFolder", `
-package test
-
-val path = "res/values-en_US/strings.xml"
-`)
-		if len(findings) != 1 {
-			t.Fatalf("expected 1 finding, got %d", len(findings))
-		}
-	})
-	t.Run("negative - correct locale folder", func(t *testing.T) {
-		findings := runRuleByName(t, "LocaleFolder", `
-package test
-
-val path = "res/values-en-rUS/strings.xml"
-`)
-		if len(findings) != 0 {
-			t.Fatalf("expected 0 findings, got %d", len(findings))
-		}
-	})
-}
-
-// =====================================================================
-// UseAlpha2 tests
-// =====================================================================
-
-func TestUseAlpha2_Extra(t *testing.T) {
-	t.Run("positive - 3-letter code", func(t *testing.T) {
-		findings := runRuleByName(t, "UseAlpha2", `
-package test
-
-val path = "res/values-eng/strings.xml"
-`)
-		if len(findings) != 1 {
-			t.Fatalf("expected 1 finding, got %d", len(findings))
-		}
-	})
-	t.Run("negative - 2-letter code", func(t *testing.T) {
-		findings := runRuleByName(t, "UseAlpha2", `
-package test
-
-val path = "res/values-en/strings.xml"
-`)
-		if len(findings) != 0 {
-			t.Fatalf("expected 0 findings, got %d", len(findings))
-		}
-	})
-}
-
-// =====================================================================
 // MangledCRLF tests
 // =====================================================================
 

--- a/internal/rules/locale_folder_test.go
+++ b/internal/rules/locale_folder_test.go
@@ -1,0 +1,206 @@
+package rules
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kaeawc/krit/internal/android"
+	api "github.com/kaeawc/krit/internal/rules/api"
+	"github.com/kaeawc/krit/internal/scanner"
+)
+
+func TestLocaleFolder_FlagsUnderscoreRegion(t *testing.T) {
+	resRoot := writeValuesFixture(t, map[string]string{
+		"values/strings.xml":       `<resources><string name="x">x</string></resources>`,
+		"values-en_US/strings.xml": `<resources><string name="x">x</string></resources>`,
+	})
+	findings := runLocaleFolderRule(t, resRoot)
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding, got %d: %+v", len(findings), findings)
+	}
+	if !strings.Contains(findings[0].Message, "values-en_US") {
+		t.Fatalf("expected message to mention values-en_US, got: %s", findings[0].Message)
+	}
+	if !strings.Contains(findings[0].Message, "values-en-rUS") {
+		t.Fatalf("expected message to suggest values-en-rUS, got: %s", findings[0].Message)
+	}
+}
+
+func TestLocaleFolder_AcceptsCorrectFormat(t *testing.T) {
+	resRoot := writeValuesFixture(t, map[string]string{
+		"values/strings.xml":        `<resources><string name="x">x</string></resources>`,
+		"values-en-rUS/strings.xml": `<resources><string name="x">x</string></resources>`,
+		"values-en/strings.xml":     `<resources><string name="x">x</string></resources>`,
+	})
+	findings := runLocaleFolderRule(t, resRoot)
+	if len(findings) != 0 {
+		t.Fatalf("expected 0 findings, got %d: %+v", len(findings), findings)
+	}
+}
+
+func TestLocaleFolder_IgnoresNonLocaleQualifiers(t *testing.T) {
+	resRoot := writeValuesFixture(t, map[string]string{
+		"values/strings.xml":        `<resources><string name="x">x</string></resources>`,
+		"values-night/strings.xml":  `<resources><string name="x">x</string></resources>`,
+		"values-w600dp/strings.xml": `<resources><string name="x">x</string></resources>`,
+	})
+	findings := runLocaleFolderRule(t, resRoot)
+	if len(findings) != 0 {
+		t.Fatalf("expected 0 findings, got %d: %+v", len(findings), findings)
+	}
+}
+
+func TestLocaleFolder_IgnoresKotlinStringLiteralLookalike(t *testing.T) {
+	// The legacy LineBase implementation false-fired on any source file that
+	// happened to contain the substring `values-en_US`. The resource-backed
+	// rule should not see this file at all.
+	resRoot := writeValuesFixture(t, map[string]string{
+		"values/strings.xml": `<resources><string name="x">x</string></resources>`,
+	})
+	kotlinPath := filepath.Join(filepath.Dir(resRoot), "Helper.kt")
+	if err := os.WriteFile(kotlinPath, []byte(`val p = "res/values-en_US/strings.xml"`+"\n"), 0o644); err != nil {
+		t.Fatalf("write kt file: %v", err)
+	}
+	findings := runLocaleFolderRule(t, resRoot)
+	if len(findings) != 0 {
+		t.Fatalf("expected 0 findings (no misnamed folder), got %d: %+v", len(findings), findings)
+	}
+}
+
+func TestUseAlpha2_FlagsKnown3LetterCode(t *testing.T) {
+	resRoot := writeValuesFixture(t, map[string]string{
+		"values/strings.xml":     `<resources><string name="x">x</string></resources>`,
+		"values-eng/strings.xml": `<resources><string name="x">x</string></resources>`,
+	})
+	findings := runUseAlpha2Rule(t, resRoot)
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding, got %d: %+v", len(findings), findings)
+	}
+	if !strings.Contains(findings[0].Message, "`en`") {
+		t.Fatalf("expected message to suggest `en`, got: %s", findings[0].Message)
+	}
+}
+
+func TestUseAlpha2_FlagsJpn(t *testing.T) {
+	resRoot := writeValuesFixture(t, map[string]string{
+		"values/strings.xml":     `<resources><string name="x">x</string></resources>`,
+		"values-jpn/strings.xml": `<resources><string name="x">x</string></resources>`,
+	})
+	findings := runUseAlpha2Rule(t, resRoot)
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding, got %d: %+v", len(findings), findings)
+	}
+	if !strings.Contains(findings[0].Message, "`ja`") {
+		t.Fatalf("expected message to suggest `ja`, got: %s", findings[0].Message)
+	}
+}
+
+func TestUseAlpha2_Accepts2LetterCode(t *testing.T) {
+	resRoot := writeValuesFixture(t, map[string]string{
+		"values/strings.xml":    `<resources><string name="x">x</string></resources>`,
+		"values-en/strings.xml": `<resources><string name="x">x</string></resources>`,
+		"values-ja/strings.xml": `<resources><string name="x">x</string></resources>`,
+	})
+	findings := runUseAlpha2Rule(t, resRoot)
+	if len(findings) != 0 {
+		t.Fatalf("expected 0 findings, got %d: %+v", len(findings), findings)
+	}
+}
+
+func TestUseAlpha2_IgnoresUnknown3LetterCode(t *testing.T) {
+	resRoot := writeValuesFixture(t, map[string]string{
+		"values/strings.xml":     `<resources><string name="x">x</string></resources>`,
+		"values-xyz/strings.xml": `<resources><string name="x">x</string></resources>`,
+	})
+	findings := runUseAlpha2Rule(t, resRoot)
+	if len(findings) != 0 {
+		t.Fatalf("expected 0 findings, got %d: %+v", len(findings), findings)
+	}
+}
+
+func TestUseAlpha2_IgnoresMccQualifier(t *testing.T) {
+	// `values-mcc310` starts with `mcc` (3 letters) but isn't a locale code
+	// and shouldn't be flagged.
+	resRoot := writeValuesFixture(t, map[string]string{
+		"values/strings.xml":        `<resources><string name="x">x</string></resources>`,
+		"values-mcc310/strings.xml": `<resources><string name="x">x</string></resources>`,
+	})
+	findings := runUseAlpha2Rule(t, resRoot)
+	if len(findings) != 0 {
+		t.Fatalf("expected 0 findings, got %d: %+v", len(findings), findings)
+	}
+}
+
+func TestLocaleFolderAndUseAlpha2_HandleMissingResRoot(t *testing.T) {
+	// Index seeded with a non-existent file path: os.ReadDir on the derived
+	// root returns ENOENT and the rules should silently no-op rather than
+	// panicking.
+	idx := &android.ResourceIndex{
+		StringsLocation: map[string]android.StringLocation{
+			"__seed__": {FilePath: "/no/such/path/res/values/strings.xml", Line: 1},
+		},
+	}
+	if findings := dispatchLocaleRule(t, &LocaleFolderRule{}, idx); len(findings) != 0 {
+		t.Fatalf("expected 0 findings, got %d", len(findings))
+	}
+	if findings := dispatchLocaleRule(t, &UseAlpha2Rule{}, idx); len(findings) != 0 {
+		t.Fatalf("expected 0 findings, got %d", len(findings))
+	}
+}
+
+func writeValuesFixture(t *testing.T, files map[string]string) string {
+	t.Helper()
+	root := t.TempDir()
+	resRoot := filepath.Join(root, "res")
+	for rel, content := range files {
+		path := filepath.Join(resRoot, rel)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", path, err)
+		}
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatalf("write %s: %v", path, err)
+		}
+	}
+	return resRoot
+}
+
+func runLocaleFolderRule(t *testing.T, resRoot string) []scanner.Finding {
+	t.Helper()
+	r := &LocaleFolderRule{AndroidRule: AndroidRule{BaseRule: BaseRule{
+		RuleName: "LocaleFolder", RuleSetName: "android-lint", Sev: "error",
+	}}}
+	return dispatchLocaleRule(t, r, indexForResRoot(resRoot))
+}
+
+func runUseAlpha2Rule(t *testing.T, resRoot string) []scanner.Finding {
+	t.Helper()
+	r := &UseAlpha2Rule{AndroidRule: AndroidRule{BaseRule: BaseRule{
+		RuleName: "UseAlpha2", RuleSetName: "android-lint", Sev: "warning",
+	}}}
+	return dispatchLocaleRule(t, r, indexForResRoot(resRoot))
+}
+
+type localeRuleImpl interface {
+	check(ctx *api.Context)
+}
+
+func dispatchLocaleRule(t *testing.T, r localeRuleImpl, idx *android.ResourceIndex) []scanner.Finding {
+	t.Helper()
+	collector := scanner.NewFindingCollector(0)
+	ctx := &api.Context{ResourceIndex: idx, Collector: collector}
+	r.check(ctx)
+	return api.ContextFindings(ctx)
+}
+
+func indexForResRoot(resRoot string) *android.ResourceIndex {
+	return &android.ResourceIndex{
+		StringsLocation: map[string]android.StringLocation{
+			"__seed__": {
+				FilePath: filepath.Join(resRoot, "values", "strings.xml"),
+				Line:     1,
+			},
+		},
+	}
+}

--- a/internal/rules/meta_android_resource_values.go
+++ b/internal/rules/meta_android_resource_values.go
@@ -47,6 +47,15 @@ func (r *LocaleConfigStaleResourceRule) Meta() api.RuleDescriptor {
 	}
 }
 
+func (r *LocaleFolderRule) Meta() api.RuleDescriptor {
+	return api.RuleDescriptor{
+		ID:            "LocaleFolder",
+		RuleSet:       "android-lint",
+		DefaultActive: false,
+		OptInReason:   api.OptInReasonAndroidOnly,
+	}
+}
+
 func (r *MissingQuantityResourceRule) Meta() api.RuleDescriptor {
 	return api.RuleDescriptor{
 		ID:            "MissingQuantityResource",
@@ -142,6 +151,15 @@ func (r *UnusedQuantityResourceRule) Meta() api.RuleDescriptor {
 		ID:            "UnusedQuantityResource",
 		RuleSet:       "android-lint",
 		DefaultActive: true,
+	}
+}
+
+func (r *UseAlpha2Rule) Meta() api.RuleDescriptor {
+	return api.RuleDescriptor{
+		ID:            "UseAlpha2",
+		RuleSet:       "android-lint",
+		DefaultActive: false,
+		OptInReason:   api.OptInReasonAndroidOnly,
 	}
 }
 

--- a/internal/rules/meta_android_source_extra.go
+++ b/internal/rules/meta_android_source_extra.go
@@ -39,15 +39,6 @@ func (r *LibraryCustomViewRule) Meta() api.RuleDescriptor {
 	}
 }
 
-func (r *LocaleFolderRule) Meta() api.RuleDescriptor {
-	return api.RuleDescriptor{
-		ID:            "LocaleFolder",
-		RuleSet:       "android-lint",
-		DefaultActive: false,
-		OptInReason:   api.OptInReasonAndroidOnly,
-	}
-}
-
 func (r *MangledCRLFRule) Meta() api.RuleDescriptor {
 	return api.RuleDescriptor{
 		ID:            "MangledCRLF",
@@ -132,15 +123,6 @@ func (r *TrulyRandomRule) Meta() api.RuleDescriptor {
 func (r *UnknownIDInLayoutRule) Meta() api.RuleDescriptor {
 	return api.RuleDescriptor{
 		ID:            "UnknownIdInLayout",
-		RuleSet:       "android-lint",
-		DefaultActive: false,
-		OptInReason:   api.OptInReasonAndroidOnly,
-	}
-}
-
-func (r *UseAlpha2Rule) Meta() api.RuleDescriptor {
-	return api.RuleDescriptor{
-		ID:            "UseAlpha2",
 		RuleSet:       "android-lint",
 		DefaultActive: false,
 		OptInReason:   api.OptInReasonAndroidOnly,

--- a/internal/rules/registry_android_resource_values.go
+++ b/internal/rules/registry_android_resource_values.go
@@ -306,4 +306,36 @@ func registerAndroidResourceValuesRules() {
 			Check: r.check,
 		})
 	}
+	{
+		r := &LocaleFolderRule{AndroidRule: AndroidRule{
+			BaseRule:   BaseRule{RuleName: "LocaleFolder", RuleSetName: androidRuleSet, Sev: "error"},
+			IssueID:    "LocaleFolder",
+			Brief:      "Wrong locale folder naming",
+			Category:   ALCCorrectness,
+			ALSeverity: ALSError,
+			Priority:   6,
+			Origin:     "AOSP Android Lint",
+		}}
+		api.Register(&api.Rule{
+			ID: r.RuleName, Category: r.RuleSetName, Description: r.Description(), Sev: api.Severity(r.Sev),
+			Needs: api.NeedsResources, AndroidDeps: uint32(r.AndroidDependencies()), Confidence: r.Confidence(), Implementation: r,
+			Check: r.check,
+		})
+	}
+	{
+		r := &UseAlpha2Rule{AndroidRule: AndroidRule{
+			BaseRule:   BaseRule{RuleName: "UseAlpha2", RuleSetName: androidRuleSet, Sev: "warning"},
+			IssueID:    "UseAlpha2",
+			Brief:      "3-letter ISO code in locale folder",
+			Category:   ALCI18N,
+			ALSeverity: ALSWarning,
+			Priority:   6,
+			Origin:     "AOSP Android Lint",
+		}}
+		api.Register(&api.Rule{
+			ID: r.RuleName, Category: r.RuleSetName, Description: r.Description(), Sev: api.Severity(r.Sev),
+			Needs: api.NeedsResources, AndroidDeps: uint32(r.AndroidDependencies()), Confidence: r.Confidence(), Implementation: r,
+			Check: r.check,
+		})
+	}
 }

--- a/internal/rules/registry_android_source_extra.go
+++ b/internal/rules/registry_android_source_extra.go
@@ -250,22 +250,6 @@ func registerAndroidSourceExtraRules() {
 		})
 	}
 	{
-		r := &LocaleFolderRule{AndroidRule: AndroidRule{BaseRule: BaseRule{RuleName: "LocaleFolder", RuleSetName: androidRuleSet, Sev: "error"}, IssueID: "LocaleFolder", Brief: "Wrong locale folder naming", Category: ALCCorrectness, ALSeverity: ALSError, Priority: 6, Origin: "AOSP Android Lint"}}
-		api.Register(&api.Rule{
-			ID: r.RuleName, Category: r.RuleSetName, Description: r.Description(), Sev: api.Severity(r.Sev),
-			Needs: api.NeedsLinePass, Confidence: r.Confidence(), Implementation: r,
-			Check: r.check,
-		})
-	}
-	{
-		r := &UseAlpha2Rule{AndroidRule: AndroidRule{BaseRule: BaseRule{RuleName: "UseAlpha2", RuleSetName: androidRuleSet, Sev: "warning"}, IssueID: "UseAlpha2", Brief: "3-letter ISO code in locale folder", Category: ALCI18N, ALSeverity: ALSWarning, Priority: 6, Origin: "AOSP Android Lint"}}
-		api.Register(&api.Rule{
-			ID: r.RuleName, Category: r.RuleSetName, Description: r.Description(), Sev: api.Severity(r.Sev),
-			Needs: api.NeedsLinePass, Confidence: 0.75, Implementation: r,
-			Check: r.check,
-		})
-	}
-	{
 		r := &MangledCRLFRule{AndroidRule: AndroidRule{BaseRule: BaseRule{RuleName: "MangledCRLF", RuleSetName: androidRuleSet, Sev: "warning"}, IssueID: "MangledCRLF", Brief: "Mixed line endings in file", Category: ALCCorrectness, ALSeverity: ALSWarning, Priority: 3, Origin: "AOSP Android Lint"}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Description(), Sev: api.Severity(r.Sev),

--- a/tests/fixtures/.coverage-allowlist.txt
+++ b/tests/fixtures/.coverage-allowlist.txt
@@ -116,6 +116,7 @@ negative LgplStaticLinkingInApk
 negative LocalSuppress
 negative LocaleConfigMissing
 negative LocaleConfigStale
+negative LocaleFolder
 negative MainDispatcherInLibraryCode
 negative ManifestOrderManifest
 negative ManifestTypoManifest
@@ -221,6 +222,7 @@ negative UntestedPublicApi
 negative UnusedAttributeResource
 negative UnusedNamespaceResource
 negative UnusedQuantityResource
+negative UseAlpha2
 negative UseCheckPermissionManifest
 negative UseCompoundDrawablesResource
 negative UselessLeafResource
@@ -344,6 +346,7 @@ positive LgplStaticLinkingInApk
 positive LocalSuppress
 positive LocaleConfigMissing
 positive LocaleConfigStale
+positive LocaleFolder
 positive MainDispatcherInLibraryCode
 positive ManifestOrderManifest
 positive ManifestTypoManifest
@@ -449,6 +452,7 @@ positive UntestedPublicApi
 positive UnusedAttributeResource
 positive UnusedNamespaceResource
 positive UnusedQuantityResource
+positive UseAlpha2
 positive UseCheckPermissionManifest
 positive UseCompoundDrawablesResource
 positive UselessLeafResource

--- a/tests/fixtures/negative/android-lint/LocaleFolder.kt
+++ b/tests/fixtures/negative/android-lint/LocaleFolder.kt
@@ -1,7 +1,0 @@
-package com.example
-
-class ResourceHelper {
-    fun getLocalizedPath(): String {
-        return "res/values-en-rUS/strings.xml"
-    }
-}

--- a/tests/fixtures/negative/android-lint/UseAlpha2.kt
+++ b/tests/fixtures/negative/android-lint/UseAlpha2.kt
@@ -1,7 +1,0 @@
-package com.example
-
-class LocaleHelper {
-    fun getResourcePath(): String {
-        return "res/values-en/strings.xml"
-    }
-}

--- a/tests/fixtures/positive/android-lint/LocaleFolder.kt
+++ b/tests/fixtures/positive/android-lint/LocaleFolder.kt
@@ -1,7 +1,0 @@
-package com.example
-
-class ResourceHelper {
-    fun getLocalizedPath(): String {
-        return "res/values-en_US/strings.xml"
-    }
-}

--- a/tests/fixtures/positive/android-lint/UseAlpha2.kt
+++ b/tests/fixtures/positive/android-lint/UseAlpha2.kt
@@ -1,7 +1,0 @@
-package com.example
-
-class LocaleHelper {
-    fun getResourcePath(): String {
-        return "res/values-eng/strings.xml"
-    }
-}


### PR DESCRIPTION
## Summary

Both `LocaleFolderRule` and `UseAlpha2Rule` were AOSP-ported rules registered as `LineBase` rules. They scanned every parsed source file for path-like substrings (`values-XX_YY`, `values-XXX`) — so a Kotlin file containing `"res/values-en_US/strings.xml"` as a string literal would false-fire, and an actual misnamed `res/values-en_US/` directory would only be caught if its path happened to appear in source text. The existing `.kt` fixtures relied on the wrong behavior to "pass".

This PR moves both rules to `ValuesResourceBase`, walks `res/values-*/` directory entries inferred from the merged `ResourceIndex`, and emits findings against the actual offending folder. Confidence rises from 0.75 → 0.95 (no source-text heuristic). The shared helper `forEachValuesQualifierDir` lives next to `resourceRootsFromIndex` in `android_resource_values.go` and is documented with the known fingerprint-cache caveat (empty qualifier dirs don't invalidate cached findings — narrow in practice since users always commit a strings.xml alongside the new qualifier).

The `.kt` fixtures are replaced with tempdir-based unit tests modelled on `i18n_string_resource_placeholder_order_test.go`. The rule IDs are parked in the standard `.coverage-allowlist.txt` next to the other resource rules (`LocaleConfigStale`, `StringResourcePlaceholderOrder`, etc.).

## Test plan

- [x] `go build -o krit ./cmd/krit/`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...`
- [x] `go test ./... -count=1`
- [x] `make integration` — all 11 phases pass
- [x] `make lint-rules`
- [x] New unit tests cover: underscore region triggers, correct format clean, non-locale qualifiers ignored, source-file lookalike no longer false-fires, 3-letter known code triggers, 2-letter clean, unknown 3-letter ignored, `mcc310` qualifier ignored, missing res root no-ops