### PR TITLE
feat(plugin-sdk): plumb NEEDS_GRADLE into RuleContext.gradle (#357)

### DIFF
--- a/docs/external-rules.md
+++ b/docs/external-rules.md
@@ -125,6 +125,13 @@ class NoTodoRule : KritRule {
   session for the current file. Methods (see `Resolver` Kdoc):
   `isSuspendCall(KtCallExpression)`, `resolvedCallFqName(...)`,
   `isLambdaSuspend(KtLambdaExpression)`, `expressionType(...)`.
+- `gradle: GradleContext?` — project-wide Gradle facts (SDK versions,
+  tool versions, declared dependencies). Non-null when the rule
+  declared `Capability.NEEDS_GRADLE` and the daemon could derive
+  Gradle facts (null on bare Kotlin directories with no build files).
+  Properties: `minSdk`, `targetSdk`, `compileSdk`, `kotlinVersion`,
+  `javaTargetVersion`, `agpVersion`. Methods:
+  `hasDependency(group, name)`, `dependencyVersion(group, name)`.
 
 The PSI surface is the Kotlin compiler's. To compile against it, add
 the JetBrains intellij-dependencies redirector to your consumer
@@ -317,7 +324,7 @@ at jar load with a clear, copy-pasteable diagnostic. Tracked on
 | `NEEDS_MODULE_INDEX` | `@Deprecated` — fails load | Gradle module identity + per-module dependency graph. Not yet plumbed. |
 | `NEEDS_MANIFEST` | `@Deprecated` — fails load | Android `AndroidManifest.xml` view. Not yet plumbed. |
 | `NEEDS_RESOURCES` | `@Deprecated` — fails load | Parsed `res/` tree (strings, drawables, layouts). Not yet plumbed. |
-| `NEEDS_GRADLE` | `@Deprecated` — fails load | Version catalog + applied plugins / dependencies. Not yet plumbed. |
+| `NEEDS_GRADLE` | **supported** | Populates `RuleContext.gradle` with a `GradleContext`. Properties: `minSdk`, `targetSdk`, `compileSdk`, `kotlinVersion`, `javaTargetVersion`, `agpVersion`. Methods: `hasDependency(group, name)`, `dependencyVersion(group, name)`. Null when the project has no Gradle build files. |
 
 ### What a load failure looks like
 

--- a/internal/oracle/daemon.go
+++ b/internal/oracle/daemon.go
@@ -323,11 +323,30 @@ func (d *Daemon) ListPlugins(jars []string) (ListPluginsResult, error) {
 	return out, nil
 }
 
+// PluginGradleProfile is the wire payload that backs `RuleContext.gradle`
+// on the Kotlin side. The shape is intentionally narrow — see
+// `GradleContext` in tools/krit-rule-api for the rule-facing surface and
+// `GradleProfilePayload` in tools/krit-types for the daemon-side mirror.
+// SDK ints rely on `omitempty` to drop the "absent" case from the wire;
+// the krit-types parser reads any non-negative int and rejects negatives
+// defensively. `Deps` carries "group:name:version" strings.
+type PluginGradleProfile struct {
+	MinSdk            int      `json:"minSdk,omitempty"`
+	TargetSdk         int      `json:"targetSdk,omitempty"`
+	CompileSdk        int      `json:"compileSdk,omitempty"`
+	KotlinVersion     string   `json:"kotlinVersion,omitempty"`
+	JavaTargetVersion string   `json:"javaTargetVersion,omitempty"`
+	AGPVersion        string   `json:"agpVersion,omitempty"`
+	Deps              []string `json:"deps,omitempty"`
+}
+
 // AnalyzePluginFile runs selected Kotlin custom rules against one source file.
 // ruleConfigs maps each rule ID to its configured `options` map; an empty
 // or nil map is omitted from the request so the daemon's RuleContext.config
-// stays empty for those rules.
-func (d *Daemon) AnalyzePluginFile(jars []string, path string, source []byte, ruleIDs []string, ruleConfigs map[string]map[string]interface{}) (AnalyzePluginFileResult, error) {
+// stays empty for those rules. gradle is forwarded only when at least one
+// selected rule declared NEEDS_GRADLE — keeps wire size minimal for the
+// common case.
+func (d *Daemon) AnalyzePluginFile(jars []string, path string, source []byte, ruleIDs []string, ruleConfigs map[string]map[string]interface{}, gradle *PluginGradleProfile) (AnalyzePluginFileResult, error) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
@@ -339,6 +358,9 @@ func (d *Daemon) AnalyzePluginFile(jars []string, path string, source []byte, ru
 	}
 	if len(ruleConfigs) > 0 {
 		params["ruleConfigs"] = ruleConfigs
+	}
+	if gradle != nil {
+		params["gradle"] = gradle
 	}
 	result, err := d.sendResult("analyzeFile", params)
 	if err != nil {

--- a/internal/pipeline/custom_kotlin_rules.go
+++ b/internal/pipeline/custom_kotlin_rules.go
@@ -8,10 +8,16 @@ import (
 
 	"github.com/kaeawc/krit/internal/config"
 	"github.com/kaeawc/krit/internal/diag"
+	"github.com/kaeawc/krit/internal/librarymodel"
 	"github.com/kaeawc/krit/internal/oracle"
 	"github.com/kaeawc/krit/internal/rules"
 	"github.com/kaeawc/krit/internal/scanner"
 )
+
+// capabilityNeedsGradle mirrors `Capability.NEEDS_GRADLE.name` from
+// tools/krit-rule-api. Kept as a const so a typo can't silently turn
+// the gradle plumb into a no-op.
+const capabilityNeedsGradle = "NEEDS_GRADLE"
 
 func runKotlinPluginRulesAndMerge(ctx context.Context, args ProjectArgs, host ProjectHostState, indexResult IndexResult, crossFileResult *CrossFileResult, bundleHit bool) error {
 	if len(args.CustomRuleJars) == 0 || bundleHit {
@@ -37,6 +43,11 @@ func runKotlinPluginRulesAndMerge(ctx context.Context, args ProjectArgs, host Pr
 		return nil
 	}
 
+	var gradlePayload *oracle.PluginGradleProfile
+	if anyRuleNeedsGradle(list.Rules, ruleIDs) && indexResult.LibraryFacts != nil {
+		gradlePayload = buildGradlePayload(&indexResult.LibraryFacts.Profile)
+	}
+
 	collector := scanner.NewFindingCollector(crossFileResult.Findings.Len())
 	collector.AppendColumns(&crossFileResult.Findings)
 	for _, file := range indexResult.KotlinFiles {
@@ -48,7 +59,7 @@ func runKotlinPluginRulesAndMerge(ctx context.Context, args ProjectArgs, host Pr
 			return ctx.Err()
 		default:
 		}
-		result, err := daemon.AnalyzePluginFile(args.CustomRuleJars, file.Path, file.Content, ruleIDs, ruleOptions)
+		result, err := daemon.AnalyzePluginFile(args.CustomRuleJars, file.Path, file.Content, ruleIDs, ruleOptions, gradlePayload)
 		if err != nil {
 			return fmt.Errorf("run Kotlin custom rules on %s: %w", file.Path, err)
 		}
@@ -61,6 +72,79 @@ func runKotlinPluginRulesAndMerge(ctx context.Context, args ProjectArgs, host Pr
 	}
 	crossFileResult.Findings = *collector.Columns()
 	return nil
+}
+
+// anyRuleNeedsGradle reports whether any of the selected rules declared
+// NEEDS_GRADLE. Callers use this to skip building the Gradle wire
+// payload when no rule will read it — keeps the wire size minimal for
+// the common case where rules only need source.
+func anyRuleNeedsGradle(loaded []oracle.PluginRuleDescriptor, selected []string) bool {
+	if len(selected) == 0 {
+		return false
+	}
+	wanted := make(map[string]struct{}, len(selected))
+	for _, id := range selected {
+		wanted[id] = struct{}{}
+	}
+	for _, rule := range loaded {
+		if _, ok := wanted[rule.RuleID]; !ok {
+			continue
+		}
+		for _, need := range rule.Needs {
+			if need == capabilityNeedsGradle {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// buildGradlePayload projects a librarymodel.ProjectProfile into the
+// narrow wire schema the krit-types daemon expects on the analyzeFile
+// request. SDK ints use 0 as the "absent" sentinel (the krit-types
+// parser converts to null), and deps are flat "group:name:version"
+// strings — see PluginGradleProfile in internal/oracle/daemon.go.
+func buildGradlePayload(profile *librarymodel.ProjectProfile) *oracle.PluginGradleProfile {
+	if profile == nil {
+		return nil
+	}
+	deps := make([]string, 0, len(profile.Dependencies))
+	for _, dep := range profile.Dependencies {
+		if dep.Group == "" || dep.Name == "" || dep.Version == "" {
+			continue
+		}
+		deps = append(deps, dep.Group+":"+dep.Name+":"+dep.Version)
+	}
+	sort.Strings(deps)
+	// Different configurations can re-list the same coord/version pair —
+	// strip duplicates so the wire payload (and the Kotlin-side
+	// `versionByCoord` map build) does the minimum work.
+	deps = uniqueStrings(deps)
+	return &oracle.PluginGradleProfile{
+		MinSdk:            profile.MinSdkVersion,
+		TargetSdk:         profile.TargetSdkVersion,
+		CompileSdk:        profile.CompileSdkVersion,
+		KotlinVersion:     profile.Kotlin.EffectiveCompilerVersion(),
+		JavaTargetVersion: profile.JVM.EffectiveTargetBytecode(),
+		AGPVersion:        profile.Android.EffectiveAGPVersion(),
+		Deps:              deps,
+	}
+}
+
+// uniqueStrings collapses consecutive duplicates in a sorted slice in
+// place. Callers must sort first.
+func uniqueStrings(in []string) []string {
+	if len(in) < 2 {
+		return in
+	}
+	w := 1
+	for r := 1; r < len(in); r++ {
+		if in[r] != in[r-1] {
+			in[w] = in[r]
+			w++
+		}
+	}
+	return in[:w]
 }
 
 // selectPluginRules picks which jar-loaded rules to dispatch and collects

--- a/internal/pipeline/custom_kotlin_rules_test.go
+++ b/internal/pipeline/custom_kotlin_rules_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/kaeawc/krit/internal/config"
 	"github.com/kaeawc/krit/internal/diag"
+	"github.com/kaeawc/krit/internal/librarymodel"
 	"github.com/kaeawc/krit/internal/oracle"
 	"github.com/kaeawc/krit/internal/rules"
 	api "github.com/kaeawc/krit/internal/rules/api"
@@ -469,5 +470,72 @@ fun example() {
 	filtered = applySuppressionColumns(&keptCols, parse.KotlinFiles)
 	if filtered.Len() != 1 {
 		t.Fatalf("unsuppressed plugin finding Len = %d, want 1", filtered.Len())
+	}
+}
+
+func TestAnyRuleNeedsGradleHonorsSelection(t *testing.T) {
+	loaded := []oracle.PluginRuleDescriptor{
+		{RuleID: "acme.Resolver", Needs: []string{"NEEDS_RESOLVER"}},
+		{RuleID: "acme.Gradle", Needs: []string{"NEEDS_GRADLE"}},
+		{RuleID: "acme.GradleButInactive", Needs: []string{"NEEDS_GRADLE"}},
+	}
+
+	// acme.GradleButInactive is loaded but the user disabled it via
+	// krit.yml; the gradle payload should not be built just because a
+	// loaded-but-unselected rule declares NEEDS_GRADLE.
+	if anyRuleNeedsGradle(loaded, []string{"acme.Resolver"}) {
+		t.Errorf("unselected NEEDS_GRADLE rule must not trigger plumb")
+	}
+	// acme.Gradle is selected → true.
+	if !anyRuleNeedsGradle(loaded, []string{"acme.Resolver", "acme.Gradle"}) {
+		t.Errorf("acme.Gradle declares NEEDS_GRADLE; gradle plumb required")
+	}
+	// Empty selection → false.
+	if anyRuleNeedsGradle(loaded, nil) {
+		t.Errorf("empty selection should not trigger gradle plumb")
+	}
+	// Rules with no needs → false.
+	plain := []oracle.PluginRuleDescriptor{{RuleID: "x", Needs: nil}}
+	if anyRuleNeedsGradle(plain, []string{"x"}) {
+		t.Errorf("rule without NEEDS_GRADLE should not trigger plumb")
+	}
+}
+
+func TestBuildGradlePayloadProjectsSubsetOfProfile(t *testing.T) {
+	profile := &librarymodel.ProjectProfile{
+		MinSdkVersion:     24,
+		TargetSdkVersion:  34,
+		CompileSdkVersion: 34,
+		Dependencies: []librarymodel.Dependency{
+			{Group: "androidx.compose.ui", Name: "ui", Version: "1.6.0", Configuration: "implementation"},
+			// Same coord/version pair re-listed under a second config — must be deduped on the wire.
+			{Group: "androidx.compose.ui", Name: "ui", Version: "1.6.0", Configuration: "androidTestImplementation"},
+			{Group: "androidx.lifecycle", Name: "lifecycle-viewmodel-ktx", Version: "2.7.0", Configuration: "implementation"},
+			// Empty fields must be dropped — partial deps would corrupt the
+			// "group:name:version" parser on the Kotlin side.
+			{Group: "androidx.foo", Name: "", Version: "1.0.0"},
+			{Group: "", Name: "bar", Version: "1.0.0"},
+			{Group: "androidx.baz", Name: "baz", Version: ""},
+		},
+	}
+	got := buildGradlePayload(profile)
+	if got == nil {
+		t.Fatal("buildGradlePayload returned nil on a populated profile")
+	}
+	if got.MinSdk != 24 || got.TargetSdk != 34 || got.CompileSdk != 34 {
+		t.Errorf("SDK versions wrong: %+v", got)
+	}
+	wantDeps := []string{
+		"androidx.compose.ui:ui:1.6.0",
+		"androidx.lifecycle:lifecycle-viewmodel-ktx:2.7.0",
+	}
+	if !reflect.DeepEqual(got.Deps, wantDeps) {
+		t.Errorf("deps = %v, want %v", got.Deps, wantDeps)
+	}
+}
+
+func TestBuildGradlePayloadNilProfileReturnsNil(t *testing.T) {
+	if got := buildGradlePayload(nil); got != nil {
+		t.Errorf("nil profile must yield nil payload, got %+v", got)
 	}
 }

--- a/tools/krit-rule-api/src/main/kotlin/dev/jasonpearson/krit/api/KritRule.kt
+++ b/tools/krit-rule-api/src/main/kotlin/dev/jasonpearson/krit/api/KritRule.kt
@@ -90,6 +90,61 @@ interface Resolver {
 }
 
 /**
+ * Project-wide Gradle facts derived from build files and the version
+ * catalog. Available on [RuleContext.gradle] when the rule declares
+ * [Capability.NEEDS_GRADLE] and the daemon has Gradle facts for the
+ * project (e.g. running on a bare Kotlin directory still leaves this
+ * null).
+ *
+ * The surface is deliberately small — the underlying daemon-side
+ * profile is much larger, but additive growth here is the way to keep
+ * rule jars binary-compatible across Krit releases. See
+ * `docs/external-rules.md#capability-semantics` for the rationale and
+ * the long-form contract.
+ */
+interface GradleContext {
+    /** Android `minSdkVersion`, or null if unknown / not an Android project. */
+    val minSdk: Int?
+
+    /** Android `targetSdkVersion`, or null if unknown / not an Android project. */
+    val targetSdk: Int?
+
+    /** Android `compileSdkVersion`, or null if unknown / not an Android project. */
+    val compileSdk: Int?
+
+    /**
+     * Effective Kotlin compiler version (e.g. `"2.0.0"`), or null when
+     * the project has no Kotlin tooling configured.
+     */
+    val kotlinVersion: String?
+
+    /**
+     * Effective JVM bytecode target the project compiles for (e.g.
+     * `"17"`), or null when undeclared.
+     */
+    val javaTargetVersion: String?
+
+    /** Android Gradle Plugin version (e.g. `"8.5.0"`), or null when AGP is not applied. */
+    val agpVersion: String?
+
+    /**
+     * Returns true when the project declares a dependency on
+     * `[group]:[name]` (any version, any configuration). The current
+     * implementation matches the canonical Maven coordinate exactly;
+     * normalization (case folding, alias resolution) may be added in
+     * a future minor release without changing this contract.
+     */
+    fun hasDependency(group: String, name: String): Boolean
+
+    /**
+     * Returns the declared version for `[group]:[name]`, or null when
+     * the dependency is absent or its version was not resolved (e.g.
+     * inherited from a BOM the lightweight parser cannot follow).
+     */
+    fun dependencyVersion(group: String, name: String): String?
+}
+
+/**
  * Per-invocation context passed to custom rules.
  *
  * `config` is the per-rule options map from the consumer's `krit.yml`:
@@ -112,6 +167,12 @@ class RuleContext(
      * daemon successfully prepared a session for the current file.
      */
     val resolver: Resolver? = null,
+    /**
+     * Project-wide Gradle facts. Non-null only when the rule declared
+     * [Capability.NEEDS_GRADLE] and the daemon could derive Gradle
+     * facts for the project.
+     */
+    val gradle: GradleContext? = null,
 ) {
     /** Returns the [key] option as a String, or [default] if absent / wrong type. */
     fun stringOption(key: String, default: String = ""): String =
@@ -244,12 +305,12 @@ enum class Capability {
     )
     NEEDS_RESOURCES,
 
-    @Deprecated(
-        message = "NEEDS_GRADLE is not yet delivered to plugin rules. " +
-            "Declaring it causes the rule jar to fail at load time. Tracked " +
-            "on https://github.com/kaeawc/krit/issues/357.",
-        level = DeprecationLevel.WARNING,
-    )
+    /**
+     * Populates [RuleContext.gradle] with a [GradleContext] view of
+     * the project's parsed Gradle facts (SDK versions, tool versions,
+     * declared dependencies). Honored when the daemon has Gradle facts
+     * for the project; null when running on a bare Kotlin directory.
+     */
     NEEDS_GRADLE,
 }
 

--- a/tools/krit-types/src/main/kotlin/dev/jasonpearson/krit/types/Main.kt
+++ b/tools/krit-types/src/main/kotlin/dev/jasonpearson/krit/types/Main.kt
@@ -714,7 +714,30 @@ data class DaemonRequest(
     // configured `options` map from krit.yml's pluginRules section.
     // Null when the request omitted the field; an absent key inside
     // means no options were configured for that rule.
-    val ruleConfigs: Map<String, Map<String, Any?>>? = null
+    val ruleConfigs: Map<String, Map<String, Any?>>? = null,
+    // Project-wide Gradle facts forwarded by the Go-side caller when
+    // any selected rule declares NEEDS_GRADLE. Null when no rule asked
+    // for it (the common case — keeps wire size minimal).
+    val gradleProfile: GradleProfilePayload? = null,
+)
+
+/**
+ * Wire-format mirror of the subset of `librarymodel.ProjectProfile` that
+ * the daemon hands to plugin rules via `GradleContext`. Stays close to
+ * the Go-side schema in `internal/oracle/daemon.go` (PluginGradleProfile)
+ * — the Go encoder uses `omitempty` to drop SDK ints when absent, and
+ * the parser here treats any missing or negative SDK as `null` on the
+ * Kotlin side. Deps are flat `"group:name:version"` strings so the
+ * parser can lean on `extractJsonStringArray`.
+ */
+data class GradleProfilePayload(
+    val minSdk: Int?,
+    val targetSdk: Int?,
+    val compileSdk: Int?,
+    val kotlinVersion: String?,
+    val javaTargetVersion: String?,
+    val agpVersion: String?,
+    val deps: List<String>,
 )
 
 /** 1-based line/col tuple used in resolveExpressionTypes requests. */
@@ -749,7 +772,21 @@ fun parseRequest(json: String): DaemonRequest {
     val path = extractJsonString(json, "path")
     val source = extractJsonString(json, "source")
     val ruleConfigs = extractJsonNestedObjectMap(json, "ruleConfigs")
-    return DaemonRequest(id, method, files, timings, callFilter, declarationProfile, expressionPositions, jarPath, fqn, pluginJars, ruleIds, path, source, ruleConfigs)
+    val gradleProfile = extractGradleProfilePayload(json)
+    return DaemonRequest(id, method, files, timings, callFilter, declarationProfile, expressionPositions, jarPath, fqn, pluginJars, ruleIds, path, source, ruleConfigs, gradleProfile)
+}
+
+private fun extractGradleProfilePayload(json: String): GradleProfilePayload? {
+    val outer = extractJsonObjectBlock(json, "gradle") ?: return null
+    return GradleProfilePayload(
+        minSdk = extractJsonLong(outer, "minSdk")?.toInt()?.takeIf { it >= 0 },
+        targetSdk = extractJsonLong(outer, "targetSdk")?.toInt()?.takeIf { it >= 0 },
+        compileSdk = extractJsonLong(outer, "compileSdk")?.toInt()?.takeIf { it >= 0 },
+        kotlinVersion = extractJsonString(outer, "kotlinVersion"),
+        javaTargetVersion = extractJsonString(outer, "javaTargetVersion"),
+        agpVersion = extractJsonString(outer, "agpVersion"),
+        deps = extractJsonStringArray(outer, "deps").orEmpty(),
+    )
 }
 
 /**
@@ -1393,6 +1430,23 @@ fun extractRuleTargetProfiles(json: String, key: String = "ruleProfiles"): List<
     }
 }
 
+/**
+ * Returns the JSON substring for the object value at `[key]`
+ * (everything between the matching `{` and `}` inclusive), or null
+ * when the key is absent or not an object. Useful for nested payloads
+ * where the existing key-based extractors would also match keys
+ * deeper in the document.
+ */
+fun extractJsonObjectBlock(json: String, key: String): String? {
+    val keyPattern = """"$key""""
+    val keyIdx = json.indexOf(keyPattern)
+    if (keyIdx < 0) return null
+    val objStart = json.indexOf('{', keyIdx)
+    if (objStart < 0) return null
+    val end = scanJsonObjectEnd(json, objStart)
+    return if (end < 0) null else json.substring(objStart, end + 1)
+}
+
 fun extractJsonObjectArray(json: String, key: String): List<String>? {
     val keyPattern = """"$key""""
     val keyIdx = json.indexOf(keyPattern)
@@ -1400,11 +1454,43 @@ fun extractJsonObjectArray(json: String, key: String): List<String>? {
     val arrayStart = json.indexOf('[', keyIdx)
     if (arrayStart < 0) return null
     val out = mutableListOf<String>()
+    var i = arrayStart + 1
+    while (i < json.length) {
+        val c = json[i]
+        when (c) {
+            '{' -> {
+                val end = scanJsonObjectEnd(json, i)
+                if (end < 0) return out
+                out.add(json.substring(i, end + 1))
+                i = end + 1
+                continue
+            }
+            ']' -> return out
+            '"' -> {
+                // Bare strings inside a top-level array aren't expected
+                // for the object-array shape this extractor targets,
+                // but skip them defensively so a stray comment-like
+                // string doesn't trip the `{`-detector.
+                i = skipJsonString(json, i) + 1
+                continue
+            }
+        }
+        i++
+    }
+    return out
+}
+
+/**
+ * Returns the index of the matching `}` for the object starting at
+ * `[openIdx]` (which must point at the opening `{`), or `-1` if the
+ * object is unterminated. Handles `"`-quoted string values with `\`
+ * escapes so braces inside strings don't fool the depth counter.
+ */
+private fun scanJsonObjectEnd(json: String, openIdx: Int): Int {
     var depth = 0
-    var objStart = -1
     var inString = false
     var escaped = false
-    var i = arrayStart + 1
+    var i = openIdx
     while (i < json.length) {
         val c = json[i]
         if (inString) {
@@ -1420,22 +1506,37 @@ fun extractJsonObjectArray(json: String, key: String): List<String>? {
         }
         when (c) {
             '"' -> inString = true
-            '{' -> {
-                if (depth == 0) objStart = i
-                depth++
-            }
+            '{' -> depth++
             '}' -> {
                 depth--
-                if (depth == 0 && objStart >= 0) {
-                    out.add(json.substring(objStart, i + 1))
-                    objStart = -1
-                }
+                if (depth == 0) return i
             }
-            ']' -> if (depth == 0) return out
         }
         i++
     }
-    return out
+    return -1
+}
+
+/**
+ * Returns the index of the closing `"` for the string starting at
+ * `[openIdx]` (which must point at the opening `"`), or `json.length`
+ * if the string is unterminated.
+ */
+private fun skipJsonString(json: String, openIdx: Int): Int {
+    var escaped = false
+    var i = openIdx + 1
+    while (i < json.length) {
+        val c = json[i]
+        if (escaped) {
+            escaped = false
+        } else if (c == '\\') {
+            escaped = true
+        } else if (c == '"') {
+            return i
+        }
+        i++
+    }
+    return json.length
 }
 
 fun KotlinPerf.recordCallFilterSummary(filter: CallFilter?) {

--- a/tools/krit-types/src/main/kotlin/dev/jasonpearson/krit/types/PluginRules.kt
+++ b/tools/krit-types/src/main/kotlin/dev/jasonpearson/krit/types/PluginRules.kt
@@ -3,6 +3,7 @@ package dev.jasonpearson.krit.types
 import dev.jasonpearson.krit.api.Capability
 import dev.jasonpearson.krit.api.Finding
 import dev.jasonpearson.krit.api.FixSafety
+import dev.jasonpearson.krit.api.GradleContext
 import dev.jasonpearson.krit.api.KritFile
 import dev.jasonpearson.krit.api.KritRule
 import dev.jasonpearson.krit.api.KritRuleInfo
@@ -164,6 +165,11 @@ internal object PluginCapabilities {
         // rather than rejected, so existing rules that opt in stay
         // forward-compatible.
         Capability.NEEDS_PARSED_FILES.name,
+        // NEEDS_GRADLE delivers RuleContext.gradle when the Go-side
+        // caller forwards a GradleProfilePayload — see
+        // `runKotlinPluginRulesAndMerge` in
+        // internal/pipeline/custom_kotlin_rules.go.
+        Capability.NEEDS_GRADLE.name,
     )
 
     fun unsupported(needs: List<String>): List<String> =
@@ -385,6 +391,7 @@ fun DaemonSession.handleAnalyzeFileWithPlugins(request: DaemonRequest): String {
         val file = KritFile(path = ktFile?.virtualFilePath ?: path, text = text, ktFile = ktFile)
         val findings = mutableListOf<PluginFinding>()
         val errors = linkedMapOf<String, String>()
+        val gradleContext = request.gradleProfile?.let(::PayloadGradleContext)
         for (loaded in PluginRuleRegistry.selected(request.ruleIds)) {
             try {
                 val options = request.ruleConfigs?.get(loaded.descriptor.ruleId).orEmpty()
@@ -393,7 +400,12 @@ fun DaemonSession.handleAnalyzeFileWithPlugins(request: DaemonRequest): String {
                 } else {
                     null
                 }
-                val ctx = RuleContext(loaded.descriptor.ruleId, options, resolver)
+                val gradle = if (loaded.descriptor.needs.contains(Capability.NEEDS_GRADLE.name)) {
+                    gradleContext
+                } else {
+                    null
+                }
+                val ctx = RuleContext(loaded.descriptor.ruleId, options, resolver, gradle)
                 for (finding in loaded.rule.check(file, ctx)) {
                     findings.add(toPluginFinding(file.path, loaded.descriptor, finding))
                 }
@@ -532,6 +544,47 @@ private class AnalysisApiResolver(private val ktFile: KtFile) : Resolver {
 
     private fun org.jetbrains.kotlin.psi.KtElement.isInModule(): Boolean =
         containingKtFile === ktFile
+}
+
+/**
+ * [GradleContext] view backed by the [GradleProfilePayload] forwarded
+ * over the wire. The dependency lookup is built lazily on first call —
+ * most rules query SDK/tool versions and never touch deps, so paying
+ * the map-construction cost only when needed keeps the common path
+ * cheap.
+ */
+internal class PayloadGradleContext(payload: GradleProfilePayload) : GradleContext {
+    override val minSdk: Int? = payload.minSdk
+    override val targetSdk: Int? = payload.targetSdk
+    override val compileSdk: Int? = payload.compileSdk
+    override val kotlinVersion: String? = payload.kotlinVersion
+    override val javaTargetVersion: String? = payload.javaTargetVersion
+    override val agpVersion: String? = payload.agpVersion
+
+    // group:name -> version (last-write-wins on duplicate coords; the
+    // Go-side caller already de-dupes, but Kotlin's map semantics
+    // protect against a malformed payload).
+    private val versionByCoord: Map<String, String> by lazy {
+        val out = HashMap<String, String>(payload.deps.size)
+        for (entry in payload.deps) {
+            val firstColon = entry.indexOf(':')
+            if (firstColon <= 0) continue
+            val secondColon = entry.indexOf(':', firstColon + 1)
+            if (secondColon <= firstColon + 1) continue
+            val coord = entry.substring(0, secondColon)
+            val version = entry.substring(secondColon + 1)
+            if (version.isNotEmpty()) {
+                out[coord] = version
+            }
+        }
+        out
+    }
+
+    override fun hasDependency(group: String, name: String): Boolean =
+        versionByCoord.containsKey("$group:$name")
+
+    override fun dependencyVersion(group: String, name: String): String? =
+        versionByCoord["$group:$name"]
 }
 
 @OptIn(KaExperimentalApi::class)

--- a/tools/krit-types/src/test/kotlin/dev/jasonpearson/krit/types/GradleContextTest.kt
+++ b/tools/krit-types/src/test/kotlin/dev/jasonpearson/krit/types/GradleContextTest.kt
@@ -1,0 +1,148 @@
+package dev.jasonpearson.krit.types
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class GradleContextTest {
+
+    private fun ctx(
+        minSdk: Int? = null,
+        targetSdk: Int? = null,
+        compileSdk: Int? = null,
+        kotlinVersion: String? = null,
+        javaTargetVersion: String? = null,
+        agpVersion: String? = null,
+        deps: List<String> = emptyList(),
+    ) = PayloadGradleContext(
+        GradleProfilePayload(
+            minSdk = minSdk,
+            targetSdk = targetSdk,
+            compileSdk = compileSdk,
+            kotlinVersion = kotlinVersion,
+            javaTargetVersion = javaTargetVersion,
+            agpVersion = agpVersion,
+            deps = deps,
+        ),
+    )
+
+    @Test
+    fun scalarsPassThroughVerbatim() {
+        val gradle = ctx(
+            minSdk = 24,
+            targetSdk = 34,
+            compileSdk = 34,
+            kotlinVersion = "2.0.0",
+            javaTargetVersion = "17",
+            agpVersion = "8.5.0",
+        )
+        assertEquals(24, gradle.minSdk)
+        assertEquals(34, gradle.targetSdk)
+        assertEquals(34, gradle.compileSdk)
+        assertEquals("2.0.0", gradle.kotlinVersion)
+        assertEquals("17", gradle.javaTargetVersion)
+        assertEquals("8.5.0", gradle.agpVersion)
+    }
+
+    @Test
+    fun absentScalarsRemainNull() {
+        val gradle = ctx()
+        assertNull(gradle.minSdk)
+        assertNull(gradle.kotlinVersion)
+    }
+
+    @Test
+    fun hasDependencyMatchesGroupAndName() {
+        val gradle = ctx(deps = listOf("androidx.compose.ui:ui:1.6.0"))
+        assertTrue(gradle.hasDependency("androidx.compose.ui", "ui"))
+        assertFalse(gradle.hasDependency("androidx.compose.ui", "compiler"))
+        assertFalse(gradle.hasDependency("androidx", "compose.ui:ui"))
+    }
+
+    @Test
+    fun dependencyVersionReturnsTrailingSegment() {
+        val gradle = ctx(deps = listOf("androidx.compose.ui:ui:1.6.0"))
+        assertEquals("1.6.0", gradle.dependencyVersion("androidx.compose.ui", "ui"))
+        assertNull(gradle.dependencyVersion("androidx.compose.ui", "compiler"))
+    }
+
+    @Test
+    fun malformedDepEntriesAreIgnored() {
+        // Defensive — a stray entry without three colon segments must
+        // not corrupt the map or throw on parse. The Go-side caller
+        // drops these, but rules shouldn't blow up if a future caller
+        // forgets.
+        val gradle = ctx(
+            deps = listOf(
+                "no-colons",
+                "one:colon",
+                ":empty-group:1.0",
+                "group:empty-version:",
+                "androidx.compose.ui:ui:1.6.0",
+            ),
+        )
+        assertTrue(gradle.hasDependency("androidx.compose.ui", "ui"))
+        assertFalse(gradle.hasDependency("group", "empty-version"))
+    }
+
+    @Test
+    fun multiColonVersionPreservesEverythingAfterTheSecondColon() {
+        // Maven version strings sometimes include qualifiers separated
+        // by ':' under unusual packaging schemes. The contract is
+        // "group:name:version" so versions with colons are unsupported,
+        // but we should at least not lose data — preserve everything
+        // after the second colon as the version.
+        val gradle = ctx(deps = listOf("g:n:1.0.0:classifier"))
+        assertEquals("1.0.0:classifier", gradle.dependencyVersion("g", "n"))
+    }
+}
+
+class ExtractJsonObjectBlockTest {
+
+    @Test
+    fun extractsTopLevelObjectVerbatim() {
+        val json = """{"id":1,"gradle":{"minSdk":24,"deps":["g:n:v"]},"trailing":true}"""
+        val block = extractJsonObjectBlock(json, "gradle")
+        assertEquals("""{"minSdk":24,"deps":["g:n:v"]}""", block)
+    }
+
+    @Test
+    fun returnsNullWhenKeyAbsent() {
+        assertNull(extractJsonObjectBlock("""{"id":1}""", "gradle"))
+    }
+
+    @Test
+    fun balancesBracesInsideNestedObjects() {
+        val json = """{"x":{"a":{"b":1},"c":2}}"""
+        val block = extractJsonObjectBlock(json, "x")
+        assertEquals("""{"a":{"b":1},"c":2}""", block)
+    }
+
+    @Test
+    fun ignoresBracesInsideStrings() {
+        val json = """{"x":{"k":"value with } brace"}}"""
+        val block = extractJsonObjectBlock(json, "x")
+        assertEquals("""{"k":"value with } brace"}""", block)
+    }
+
+    @Test
+    fun parsesGradleProfileViaParseRequest() {
+        val json = """{"id":1,"method":"analyzeFile","params":{"path":"X.kt","gradle":{"minSdk":24,"targetSdk":34,"compileSdk":34,"kotlinVersion":"2.0.0","agpVersion":"8.5.0","deps":["g:n:v","g2:n2:v2"]}}}"""
+        val req = parseRequest(json)
+        val gradle = req.gradleProfile ?: error("gradleProfile must round-trip from parseRequest")
+        assertEquals(24, gradle.minSdk)
+        assertEquals(34, gradle.targetSdk)
+        assertEquals(34, gradle.compileSdk)
+        assertEquals("2.0.0", gradle.kotlinVersion)
+        assertEquals("8.5.0", gradle.agpVersion)
+        assertEquals(listOf("g:n:v", "g2:n2:v2"), gradle.deps)
+    }
+
+    @Test
+    fun parseRequestLeavesGradleProfileNullWhenAbsent() {
+        val json = """{"id":1,"method":"analyzeFile","params":{"path":"X.kt"}}"""
+        assertNull(parseRequest(json).gradleProfile)
+    }
+}

--- a/tools/krit-types/src/test/kotlin/dev/jasonpearson/krit/types/PluginCapabilitiesTest.kt
+++ b/tools/krit-types/src/test/kotlin/dev/jasonpearson/krit/types/PluginCapabilitiesTest.kt
@@ -35,7 +35,6 @@ class PluginCapabilitiesTest {
                 Capability.NEEDS_MODULE_INDEX.name,
                 Capability.NEEDS_MANIFEST.name,
                 Capability.NEEDS_RESOURCES.name,
-                Capability.NEEDS_GRADLE.name,
             ),
             unsupported,
         )


### PR DESCRIPTION
## Summary

Promotes \`Capability.NEEDS_GRADLE\` from \`@Deprecated\` to **supported**. Rules can now ask for project-wide Gradle facts via \`RuleContext.gradle\` — the second supported capability after \`NEEDS_RESOLVER\`, and the first plumb-through following the contract in [docs/external-rules.md#promoting-a-capability-from-deprecated-to-supported](docs/external-rules.md).

### New rule-facing surface ([KritRule.kt](tools/krit-rule-api/src/main/kotlin/dev/jasonpearson/krit/api/KritRule.kt))

\`\`\`kotlin
interface GradleContext {
    val minSdk: Int?
    val targetSdk: Int?
    val compileSdk: Int?
    val kotlinVersion: String?
    val javaTargetVersion: String?
    val agpVersion: String?

    fun hasDependency(group: String, name: String): Boolean
    fun dependencyVersion(group: String, name: String): String?
}
\`\`\`

Non-null on \`RuleContext.gradle\` when the rule declared \`NEEDS_GRADLE\` AND the daemon has Gradle facts for the project (null on a bare Kotlin directory).

### Wire-up

- **Go side** ([custom_kotlin_rules.go](internal/pipeline/custom_kotlin_rules.go), [daemon.go](internal/oracle/daemon.go)): new \`PluginGradleProfile\` struct; \`anyRuleNeedsGradle\` + \`buildGradlePayload\` project a subset of \`librarymodel.ProjectProfile\` into the wire payload. Sent **only when at least one selected rule declared NEEDS_GRADLE** — keeps wire size minimal for the common case.
- **Kotlin daemon side** ([Main.kt](tools/krit-types/src/main/kotlin/dev/jasonpearson/krit/types/Main.kt), [PluginRules.kt](tools/krit-types/src/main/kotlin/dev/jasonpearson/krit/types/PluginRules.kt)): \`GradleProfilePayload\` data class, new \`extractJsonObjectBlock\` parser (with a shared \`scanJsonObjectEnd\` helper reused by \`extractJsonObjectArray\` — both walkers now share the brace/string state machine), \`PayloadGradleContext\` impl with lazy \`versionByCoord\` map.
- \`PluginCapabilities.SUPPORTED\` gains \`NEEDS_GRADLE\`; the load-time gate now accepts it.
- Capability matrix in [external-rules.md](docs/external-rules.md) flipped to **supported**; the \`gradle\` accessor is documented next to \`resolver\`.

### What's *not* in this PR

- Per-session payload caching (currently per-file allocation; OK at typical project sizes).
- A \`setProjectFacts\` RPC to ship the payload once per session instead of per file.
- The other four deprecated capabilities (\`NEEDS_CROSS_FILE\`, \`NEEDS_MODULE_INDEX\`, \`NEEDS_MANIFEST\`, \`NEEDS_RESOURCES\`) — tracked on [#357](https://github.com/kaeawc/krit/issues/357).

## Test plan

- [x] \`go build -o krit ./cmd/krit/\` clean
- [x] \`go vet ./...\` clean
- [x] \`golangci-lint run ./internal/pipeline/ ./internal/oracle/\` clean
- [x] \`go test ./... -count=1\` all packages pass (incl. new \`TestAnyRuleNeedsGradleHonorsSelection\`, \`TestBuildGradlePayload*\`)
- [x] \`cd tools/krit-types && ./gradlew test\` passes (incl. new \`GradleContextTest\`, \`ExtractJsonObjectBlockTest\`)
- [x] /simplify pass applied: unified the JSON brace-walker, aligned sentinel docs, tightened KDoc.