### PR TITLE
fix(rules): tighten OrientationResource toward AOSP semantics

### DIFF
--- a/internal/rules/android_resource_layout.go
+++ b/internal/rules/android_resource_layout.go
@@ -392,6 +392,11 @@ func (r *OrientationResourceRule) check(ctx *api.Context) {
 			if _, ok := v.Attributes["android:orientation"]; ok {
 				return
 			}
+			// style="..." may define orientation via a referenced style.
+			// We cannot reliably resolve resources here, so suppress.
+			if _, ok := v.Attributes["style"]; ok {
+				return
+			}
 			// A LinearLayout with a fixed-dp or attribute-referenced
 			// layout_height (e.g. "48dp", "?attr/actionBarSize") is
 			// almost always a "row" where the default horizontal
@@ -403,10 +408,43 @@ func (r *OrientationResourceRule) check(ctx *api.Context) {
 					return
 				}
 			}
+			switch len(v.Children) {
+			case 0:
+				// AOSP heuristic: empty LinearLayouts populated dynamically
+				// (signaled by android:id) — orientation matters when
+				// children are added later.
+				if v.ID == "" {
+					return
+				}
+			case 1:
+				// Single child cannot be pushed off-screen by a wrong
+				// default orientation.
+				return
+			default:
+				// AOSP heuristic: at least one non-last child has
+				// match_parent/fill_parent width without layout_weight,
+				// which would hide later siblings under horizontal layout.
+				if !hasMatchParentChildBeforeLast(v.Children) {
+					return
+				}
+			}
 			ctx.Emit(resourceFinding(layout.FilePath, v.Line, r.BaseRule,
 				"`LinearLayout` missing explicit `android:orientation`. The default is horizontal, which may not be intended."))
 		})
 	}
+}
+
+func hasMatchParentChildBeforeLast(children []*android.View) bool {
+	for _, c := range children[:len(children)-1] {
+		if c.LayoutWidth != "match_parent" && c.LayoutWidth != "fill_parent" {
+			continue
+		}
+		if _, ok := c.Attributes["android:layout_weight"]; ok {
+			continue
+		}
+		return true
+	}
+	return false
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/rules/android_resource_layout_test.go
+++ b/internal/rules/android_resource_layout_test.go
@@ -693,7 +693,22 @@ func TestIncludeLayoutParamResource(t *testing.T) {
 func TestOrientationResource(t *testing.T) {
 	r := findResourceRule(t, "OrientationResource")
 
-	t.Run("LinearLayout without orientation triggers", func(t *testing.T) {
+	childWithWidth := func(width string) *android.View {
+		return &android.View{
+			Type:         "TextView",
+			Line:         2,
+			LayoutWidth:  width,
+			LayoutHeight: "wrap_content",
+			Attributes: map[string]string{
+				"android:layout_width":  width,
+				"android:layout_height": "wrap_content",
+			},
+		}
+	}
+	matchParentChild := func() *android.View { return childWithWidth("match_parent") }
+	wrapContentChild := func() *android.View { return childWithWidth("wrap_content") }
+
+	t.Run("multi-child match_parent triggers", func(t *testing.T) {
 		idx := indexWithLayout("main", "res/layout/main.xml", &android.View{
 			Type: "LinearLayout",
 			Line: 1,
@@ -701,6 +716,24 @@ func TestOrientationResource(t *testing.T) {
 				"android:layout_width":  "match_parent",
 				"android:layout_height": "match_parent",
 			},
+			Children: []*android.View{matchParentChild(), wrapContentChild()},
+		})
+		findings := runResourceRule(r, idx)
+		if len(findings) != 1 {
+			t.Fatalf("expected 1 finding, got %d", len(findings))
+		}
+	})
+
+	t.Run("multi-child fill_parent triggers", func(t *testing.T) {
+		fill := childWithWidth("fill_parent")
+		idx := indexWithLayout("main", "res/layout/main.xml", &android.View{
+			Type: "LinearLayout",
+			Line: 1,
+			Attributes: map[string]string{
+				"android:layout_width":  "match_parent",
+				"android:layout_height": "match_parent",
+			},
+			Children: []*android.View{fill, wrapContentChild()},
 		})
 		findings := runResourceRule(r, idx)
 		if len(findings) != 1 {
@@ -717,10 +750,126 @@ func TestOrientationResource(t *testing.T) {
 				"android:layout_height": "match_parent",
 				"android:orientation":   "vertical",
 			},
+			Children: []*android.View{matchParentChild(), wrapContentChild()},
 		})
 		findings := runResourceRule(r, idx)
 		if len(findings) != 0 {
 			t.Fatalf("expected 0 findings, got %d", len(findings))
+		}
+	})
+
+	t.Run("style attribute suppresses", func(t *testing.T) {
+		idx := indexWithLayout("main", "res/layout/main.xml", &android.View{
+			Type: "LinearLayout",
+			Line: 1,
+			Attributes: map[string]string{
+				"style":                 "@style/MyLinear",
+				"android:layout_width":  "match_parent",
+				"android:layout_height": "match_parent",
+			},
+			Children: []*android.View{matchParentChild(), wrapContentChild()},
+		})
+		findings := runResourceRule(r, idx)
+		if len(findings) != 0 {
+			t.Fatalf("expected 0 findings, got %d", len(findings))
+		}
+	})
+
+	t.Run("single child is clean", func(t *testing.T) {
+		idx := indexWithLayout("main", "res/layout/main.xml", &android.View{
+			Type: "LinearLayout",
+			Line: 1,
+			Attributes: map[string]string{
+				"android:layout_width":  "match_parent",
+				"android:layout_height": "match_parent",
+			},
+			Children: []*android.View{matchParentChild()},
+		})
+		findings := runResourceRule(r, idx)
+		if len(findings) != 0 {
+			t.Fatalf("expected 0 findings, got %d", len(findings))
+		}
+	})
+
+	t.Run("no match_parent siblings is clean", func(t *testing.T) {
+		idx := indexWithLayout("main", "res/layout/main.xml", &android.View{
+			Type: "LinearLayout",
+			Line: 1,
+			Attributes: map[string]string{
+				"android:layout_width":  "match_parent",
+				"android:layout_height": "match_parent",
+			},
+			Children: []*android.View{wrapContentChild(), wrapContentChild()},
+		})
+		findings := runResourceRule(r, idx)
+		if len(findings) != 0 {
+			t.Fatalf("expected 0 findings, got %d", len(findings))
+		}
+	})
+
+	t.Run("last-child-only match_parent is clean", func(t *testing.T) {
+		idx := indexWithLayout("main", "res/layout/main.xml", &android.View{
+			Type: "LinearLayout",
+			Line: 1,
+			Attributes: map[string]string{
+				"android:layout_width":  "match_parent",
+				"android:layout_height": "match_parent",
+			},
+			Children: []*android.View{wrapContentChild(), matchParentChild()},
+		})
+		findings := runResourceRule(r, idx)
+		if len(findings) != 0 {
+			t.Fatalf("expected 0 findings, got %d", len(findings))
+		}
+	})
+
+	t.Run("match_parent with layout_weight is clean", func(t *testing.T) {
+		weighted := matchParentChild()
+		weighted.Attributes["android:layout_weight"] = "1"
+		idx := indexWithLayout("main", "res/layout/main.xml", &android.View{
+			Type: "LinearLayout",
+			Line: 1,
+			Attributes: map[string]string{
+				"android:layout_width":  "match_parent",
+				"android:layout_height": "match_parent",
+			},
+			Children: []*android.View{weighted, wrapContentChild()},
+		})
+		findings := runResourceRule(r, idx)
+		if len(findings) != 0 {
+			t.Fatalf("expected 0 findings, got %d", len(findings))
+		}
+	})
+
+	t.Run("empty LinearLayout without id is clean", func(t *testing.T) {
+		idx := indexWithLayout("main", "res/layout/main.xml", &android.View{
+			Type: "LinearLayout",
+			Line: 1,
+			Attributes: map[string]string{
+				"android:layout_width":  "match_parent",
+				"android:layout_height": "match_parent",
+			},
+		})
+		findings := runResourceRule(r, idx)
+		if len(findings) != 0 {
+			t.Fatalf("expected 0 findings, got %d", len(findings))
+		}
+	})
+
+	t.Run("empty LinearLayout with id triggers", func(t *testing.T) {
+		idx := indexWithLayout("main", "res/layout/main.xml", &android.View{
+			Type: "LinearLayout",
+			Line: 1,
+			ID:   "@+id/container",
+			Attributes: map[string]string{
+				"android:id":            "@+id/container",
+				"android:layout_width":  "match_parent",
+				"android:layout_height": "match_parent",
+			},
+		})
+		findings := runResourceRule(r, idx)
+		if len(findings) != 1 {
+			t.Fatalf("expected 1 finding, got %d", len(findings))
 		}
 	})
 


### PR DESCRIPTION
## Summary

- `OrientationResource` previously fired on any `LinearLayout` missing `android:orientation`, which is broader and noisier than AOSP's `Orientation` lint.
- Tighten to AOSP semantics: only warn when the wrong horizontal default could actually break the layout.
- Carve-outs added:
  - `style="..."` set on the `LinearLayout` (style may supply orientation; we cannot resolve resources here)
  - Single-child layouts (no sibling can be pushed off-screen)
  - 2+ children: require at least one non-last child with `match_parent`/`fill_parent` width and no `layout_weight` (AOSP's "obviously broken horizontally" heuristic)
  - Empty layouts: require `android:id` (dynamic-children case)

## Test plan

- [x] `go test ./internal/rules/ -run TestOrientationResource -v -count=1` — 12 subtests pass, covering each carve-out branch
- [x] `go build ./cmd/krit/` clean
- [x] `go vet ./...` clean
- [x] `golangci-lint run ./internal/rules/...` clean
- [x] `make lint-rules` clean
- [x] `make integration` — 11/11 pass