### PR TITLE
fix(rules): honor RequiresPermission anyOf/allOf semantics

### DIFF
--- a/internal/rules/android_source_extra.go
+++ b/internal/rules/android_source_extra.go
@@ -18,45 +18,131 @@ import (
 type permissionAPI struct {
 	api             string
 	callee          string
-	perm            string
+	requirement     missingPermissionRequirement
 	callTargets     []string
 	receiverTypes   []string
 	staticReceivers []string
+}
+
+// missingPermissionRequirementKind mirrors AOSP Lint's PermissionRequirement /
+// PermissionHolder model: a @RequiresPermission may name a single permission,
+// require all of a set (allOf), or accept any one of a set (anyOf). Each
+// flavor has distinct guard-coverage semantics.
+type missingPermissionRequirementKind int
+
+const (
+	missingPermissionRequirementSingle missingPermissionRequirementKind = iota
+	missingPermissionRequirementAnyOf
+	missingPermissionRequirementAllOf
+)
+
+type missingPermissionRequirement struct {
+	kind  missingPermissionRequirementKind
+	perms []string
+}
+
+func singlePermRequirement(perm string) missingPermissionRequirement {
+	return missingPermissionRequirement{kind: missingPermissionRequirementSingle, perms: []string{perm}}
+}
+
+func (r missingPermissionRequirement) empty() bool { return len(r.perms) == 0 }
+
+// describe renders the requirement for the diagnostic message.
+func (r missingPermissionRequirement) describe() string {
+	if len(r.perms) == 0 {
+		return ""
+	}
+	if len(r.perms) == 1 {
+		return r.perms[0]
+	}
+	sep := " and "
+	if r.kind == missingPermissionRequirementAnyOf {
+		sep = " or "
+	}
+	return strings.Join(r.perms, sep)
+}
+
+// messageSuffix returns "permission" or "permissions" to match the requirement
+// arity in the diagnostic.
+func (r missingPermissionRequirement) messageSuffix() string {
+	if len(r.perms) > 1 {
+		return "permissions"
+	}
+	return "permission"
+}
+
+// satisfied reports whether the requirement is fully met given a predicate
+// that answers whether a specific permission is guarded at the call site.
+// anyOf is satisfied by any guarded perm; allOf requires every perm guarded.
+func (r missingPermissionRequirement) satisfied(has func(perm string) bool) bool {
+	if len(r.perms) == 0 {
+		return false
+	}
+	if r.kind == missingPermissionRequirementAllOf {
+		for _, p := range r.perms {
+			if !has(p) {
+				return false
+			}
+		}
+		return true
+	}
+	for _, p := range r.perms {
+		if has(p) {
+			return true
+		}
+	}
+	return false
+}
+
+// covers reports whether holding this requirement (e.g. on an enclosing
+// function) guarantees the caller holds the given specific permission.
+// allOf=[A,B] covers A and B; single P covers P; anyOf never covers a
+// specific permission because the actual held perm is unknown.
+func (r missingPermissionRequirement) covers(perm string) bool {
+	if perm == "" || len(r.perms) == 0 || r.kind == missingPermissionRequirementAnyOf {
+		return false
+	}
+	for _, p := range r.perms {
+		if p == perm {
+			return true
+		}
+	}
+	return false
 }
 
 var missingPermissionAPIs = []permissionAPI{
 	{
 		api:           "requestLocationUpdates",
 		callee:        "requestLocationUpdates",
-		perm:          "ACCESS_FINE_LOCATION",
+		requirement:   singlePermRequirement("ACCESS_FINE_LOCATION"),
 		callTargets:   []string{"android.location.LocationManager.requestLocationUpdates"},
 		receiverTypes: []string{"android.location.LocationManager"},
 	},
 	{
 		api:           "getLastKnownLocation",
 		callee:        "getLastKnownLocation",
-		perm:          "ACCESS_FINE_LOCATION",
+		requirement:   singlePermRequirement("ACCESS_FINE_LOCATION"),
 		callTargets:   []string{"android.location.LocationManager.getLastKnownLocation"},
 		receiverTypes: []string{"android.location.LocationManager"},
 	},
 	{
 		api:           "getCellLocation",
 		callee:        "getCellLocation",
-		perm:          "ACCESS_COARSE_LOCATION",
+		requirement:   singlePermRequirement("ACCESS_COARSE_LOCATION"),
 		callTargets:   []string{"android.telephony.TelephonyManager.getCellLocation"},
 		receiverTypes: []string{"android.telephony.TelephonyManager"},
 	},
 	{
 		api:             "Camera.open",
 		callee:          "open",
-		perm:            "CAMERA",
+		requirement:     singlePermRequirement("CAMERA"),
 		callTargets:     []string{"android.hardware.Camera.open"},
 		staticReceivers: []string{"android.hardware.Camera"},
 	},
 	{
 		api:           "setAudioSource",
 		callee:        "setAudioSource",
-		perm:          "RECORD_AUDIO",
+		requirement:   singlePermRequirement("RECORD_AUDIO"),
 		callTargets:   []string{"android.media.MediaRecorder.setAudioSource"},
 		receiverTypes: []string{"android.media.MediaRecorder"},
 	},
@@ -815,13 +901,13 @@ func (r *MissingPermissionRule) check(ctx *api.Context) {
 	if !ok {
 		return
 	}
-	if missingPermissionHasStructuralGuard(ctx, ctx.Idx, match.perm) {
+	if missingPermissionHasStructuralGuard(ctx, ctx.Idx, match.requirement) {
 		return
 	}
 	line := file.FlatRow(ctx.Idx) + 1
 	col := file.FlatCol(ctx.Idx) + 1
 	f := r.Finding(file, line, col,
-		match.api+" requires "+match.perm+" permission. Ensure checkSelfPermission() is called before this API.")
+		match.api+" requires "+match.requirement.describe()+" "+match.requirement.messageSuffix()+". Ensure checkSelfPermission() is called before this API.")
 	f.Confidence = confidence
 	ctx.Emit(f)
 }
@@ -868,7 +954,7 @@ func missingPermissionHasAnnotatedSameFileCandidate(ctx *api.Context, call uint3
 		if found || !missingPermissionFunctionHasName(file, fn, callee) {
 			return
 		}
-		if _, ok := missingPermissionRequiredPermissionAnnotation(ctx, fn); ok && semantics.SameFileDeclarationMatch(ctx, fn, call) {
+		if req, ok := missingPermissionRequiredPermissionAnnotation(ctx, fn); ok && !req.empty() && semantics.SameFileDeclarationMatch(ctx, fn, call) {
 			found = true
 		}
 	})
@@ -981,21 +1067,27 @@ func missingPermissionAnnotatedSameFileTarget(ctx *api.Context, call uint32, tar
 		if found || !semantics.SameFileDeclarationMatch(ctx, fn, call) {
 			return
 		}
-		perm, ok := missingPermissionRequiredPermissionAnnotation(ctx, fn)
-		if !ok {
+		req, ok := missingPermissionRequiredPermissionAnnotation(ctx, fn)
+		if !ok || req.empty() {
 			return
 		}
-		out = permissionAPI{api: target.CalleeName, callee: target.CalleeName, perm: perm}
+		out = permissionAPI{api: target.CalleeName, callee: target.CalleeName, requirement: req}
 		found = true
 	})
 	return out, found
 }
 
-func missingPermissionHasStructuralGuard(ctx *api.Context, call uint32, perm string) bool {
-	return missingPermissionEnclosingPermissionCondition(ctx, call, perm) ||
-		missingPermissionHasPrecedingGrantedReturnGuard(ctx, call, perm) ||
-		missingPermissionEnclosingAnnotationRequires(ctx, call, perm) ||
-		missingPermissionEnclosingCatchesSecurityException(ctx, call)
+func missingPermissionHasStructuralGuard(ctx *api.Context, call uint32, req missingPermissionRequirement) bool {
+	// SecurityException catches do not name a specific permission, so they
+	// cover the requirement regardless of arity.
+	if missingPermissionEnclosingCatchesSecurityException(ctx, call) {
+		return true
+	}
+	return req.satisfied(func(perm string) bool {
+		return missingPermissionEnclosingPermissionCondition(ctx, call, perm) ||
+			missingPermissionHasPrecedingGrantedReturnGuard(ctx, call, perm) ||
+			missingPermissionEnclosingAnnotationRequires(ctx, call, perm)
+	})
 }
 
 type missingPermissionGuardState int
@@ -1212,7 +1304,7 @@ func missingPermissionEnclosingAnnotationRequires(ctx *api.Context, call uint32,
 	for owner, ok := ctx.File.FlatParent(call); ok; owner, ok = ctx.File.FlatParent(owner) {
 		switch ctx.File.FlatType(owner) {
 		case "function_declaration", "class_declaration", "object_declaration":
-			if required, ok := missingPermissionRequiredPermissionAnnotation(ctx, owner); ok && required == perm {
+			if required, ok := missingPermissionRequiredPermissionAnnotation(ctx, owner); ok && required.covers(perm) {
 				return true
 			}
 		}
@@ -1220,34 +1312,58 @@ func missingPermissionEnclosingAnnotationRequires(ctx *api.Context, call uint32,
 	return false
 }
 
-func missingPermissionRequiredPermissionAnnotation(ctx *api.Context, node uint32) (string, bool) {
+func missingPermissionRequiredPermissionAnnotation(ctx *api.Context, node uint32) (missingPermissionRequirement, bool) {
 	file := ctx.File
 	if mods, ok := file.FlatFindChild(node, "modifiers"); ok {
-		if perm, ok := missingPermissionAnnotationContainerPermission(ctx, mods); ok {
-			return perm, true
+		if req, ok := missingPermissionAnnotationContainerRequirement(ctx, mods); ok {
+			return req, true
 		}
 	}
 	for prev, ok := file.FlatPrevSibling(node); ok; prev, ok = file.FlatPrevSibling(prev) {
 		switch file.FlatType(prev) {
 		case "prefix_expression", "annotation", "modifiers":
-			if perm, ok := missingPermissionAnnotationContainerPermission(ctx, prev); ok {
-				return perm, true
+			if req, ok := missingPermissionAnnotationContainerRequirement(ctx, prev); ok {
+				return req, true
 			}
 		default:
 			if strings.TrimSpace(file.FlatNodeText(prev)) != "" {
-				return "", false
+				return missingPermissionRequirement{}, false
 			}
 		}
 	}
-	return "", false
+	return missingPermissionRequirement{}, false
 }
 
-func missingPermissionAnnotationContainerPermission(ctx *api.Context, container uint32) (string, bool) {
+func missingPermissionAnnotationContainerRequirement(ctx *api.Context, container uint32) (missingPermissionRequirement, bool) {
 	file := ctx.File
-	var perm string
 	if !missingPermissionAnnotationContainerHasRequiresPermission(file, container) {
-		return "", false
+		return missingPermissionRequirement{}, false
 	}
+	// Inspect named arguments first so anyOf/allOf semantics win over the
+	// fall-back scan that would otherwise grab the first permission literal.
+	var named missingPermissionRequirement
+	file.FlatWalkNodes(container, "value_argument", func(arg uint32) {
+		if !named.empty() {
+			return
+		}
+		name := missingPermissionValueArgumentName(file, arg)
+		if name != "anyOf" && name != "allOf" {
+			return
+		}
+		perms := missingPermissionCollectPerms(ctx, arg)
+		if len(perms) == 0 {
+			return
+		}
+		kind := missingPermissionRequirementAnyOf
+		if name == "allOf" {
+			kind = missingPermissionRequirementAllOf
+		}
+		named = missingPermissionRequirement{kind: kind, perms: perms}
+	})
+	if !named.empty() {
+		return named, true
+	}
+	var perm string
 	file.FlatWalkAllNodes(container, func(candidate uint32) {
 		if perm != "" {
 			return
@@ -1256,7 +1372,64 @@ func missingPermissionAnnotationContainerPermission(ctx *api.Context, container 
 			perm = p
 		}
 	})
-	return perm, perm != ""
+	if perm == "" {
+		return missingPermissionRequirement{}, false
+	}
+	return singlePermRequirement(perm), true
+}
+
+// missingPermissionValueArgumentName returns the name of a Kotlin named value
+// argument (e.g. "anyOf" in `anyOf = [...]`), or "" for positional arguments.
+// Mirrors valueArgumentExpression's label handling but extracts the label
+// rather than skipping it.
+func missingPermissionValueArgumentName(file *scanner.File, arg uint32) string {
+	if file == nil || arg == 0 || file.FlatType(arg) != "value_argument" {
+		return ""
+	}
+	for child := file.FlatFirstChild(arg); child != 0; child = file.FlatNextSib(child) {
+		if !file.FlatIsNamed(child) {
+			continue
+		}
+		switch file.FlatType(child) {
+		case "value_argument_label":
+			var name string
+			file.FlatWalkAllNodes(child, func(node uint32) {
+				if name == "" && file.FlatType(node) == "simple_identifier" {
+					name = file.FlatNodeString(node, nil)
+				}
+			})
+			return name
+		case "simple_identifier":
+			if next, ok := file.FlatNextSibling(child); ok && file.FlatType(next) == "=" {
+				return file.FlatNodeString(child, nil)
+			}
+			return ""
+		default:
+			return ""
+		}
+	}
+	return ""
+}
+
+// missingPermissionCollectPerms walks a value-argument subtree (typically a
+// collection literal in anyOf/allOf) and returns each recognized permission
+// constant in source order, de-duplicated.
+func missingPermissionCollectPerms(ctx *api.Context, node uint32) []string {
+	file := ctx.File
+	if file == nil || node == 0 {
+		return nil
+	}
+	seen := make(map[string]bool)
+	var out []string
+	file.FlatWalkAllNodes(node, func(candidate uint32) {
+		p, ok := missingPermissionExprPermissionName(ctx, candidate)
+		if !ok || seen[p] {
+			return
+		}
+		seen[p] = true
+		out = append(out, p)
+	})
+	return out
 }
 
 func missingPermissionFileHasRequiresPermissionAnnotation(file *scanner.File) bool {

--- a/internal/rules/android_source_extra_test.go
+++ b/internal/rules/android_source_extra_test.go
@@ -809,6 +809,183 @@ class Screen {
 			t.Fatalf("expected 0 findings, got %d", len(findings))
 		}
 	})
+
+	// anyOf / allOf semantics — mirror AOSP PermissionRequirement model so that
+	// callers guarding any-of-N or all-of-N permissions are not flagged falsely.
+	t.Run("negative - anyOf annotation satisfied by coarse guard", func(t *testing.T) {
+		findings := runRuleByName(t, "MissingPermission", `
+package test
+import android.Manifest
+import androidx.annotation.RequiresPermission
+
+@RequiresPermission(anyOf = [Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_COARSE_LOCATION])
+fun locateUser() {}
+
+fun open() {
+    if (checkSelfPermission(Manifest.permission.ACCESS_COARSE_LOCATION) == PERMISSION_GRANTED) {
+        locateUser()
+    }
+}
+`)
+		if len(findings) != 0 {
+			t.Fatalf("expected 0 findings, got %d", len(findings))
+		}
+	})
+	t.Run("negative - anyOf annotation satisfied by fine guard", func(t *testing.T) {
+		findings := runRuleByName(t, "MissingPermission", `
+package test
+import android.Manifest
+import androidx.annotation.RequiresPermission
+
+@RequiresPermission(anyOf = [Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_COARSE_LOCATION])
+fun locateUser() {}
+
+fun open() {
+    if (checkSelfPermission(Manifest.permission.ACCESS_FINE_LOCATION) == PERMISSION_GRANTED) {
+        locateUser()
+    }
+}
+`)
+		if len(findings) != 0 {
+			t.Fatalf("expected 0 findings, got %d", len(findings))
+		}
+	})
+	t.Run("positive - anyOf annotation with no listed permission guarded", func(t *testing.T) {
+		findings := runRuleByName(t, "MissingPermission", `
+package test
+import android.Manifest
+import androidx.annotation.RequiresPermission
+
+@RequiresPermission(anyOf = [Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_COARSE_LOCATION])
+fun locateUser() {}
+
+fun open() {
+    if (checkSelfPermission(Manifest.permission.CAMERA) == PERMISSION_GRANTED) {
+        locateUser()
+    }
+}
+`)
+		if len(findings) != 1 {
+			t.Fatalf("expected 1 finding, got %d", len(findings))
+		}
+	})
+	t.Run("positive - allOf annotation needs every listed permission guarded", func(t *testing.T) {
+		findings := runRuleByName(t, "MissingPermission", `
+package test
+import android.Manifest
+import androidx.annotation.RequiresPermission
+
+@RequiresPermission(allOf = [Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_COARSE_LOCATION])
+fun locateUserStrict() {}
+
+fun open() {
+    if (checkSelfPermission(Manifest.permission.ACCESS_FINE_LOCATION) == PERMISSION_GRANTED) {
+        locateUserStrict()
+    }
+}
+`)
+		if len(findings) != 1 {
+			t.Fatalf("expected 1 finding, got %d", len(findings))
+		}
+	})
+	t.Run("negative - allOf annotation satisfied by guarding every permission", func(t *testing.T) {
+		findings := runRuleByName(t, "MissingPermission", `
+package test
+import android.Manifest
+import androidx.annotation.RequiresPermission
+
+@RequiresPermission(allOf = [Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_COARSE_LOCATION])
+fun locateUserStrict() {}
+
+fun open() {
+    if (checkSelfPermission(Manifest.permission.ACCESS_FINE_LOCATION) == PERMISSION_GRANTED) {
+        if (checkSelfPermission(Manifest.permission.ACCESS_COARSE_LOCATION) == PERMISSION_GRANTED) {
+            locateUserStrict()
+        }
+    }
+}
+`)
+		if len(findings) != 0 {
+			t.Fatalf("expected 0 findings, got %d", len(findings))
+		}
+	})
+	t.Run("negative - enclosing allOf annotation covers location call", func(t *testing.T) {
+		findings := runRuleByName(t, "MissingPermission", `
+package test
+import android.Manifest
+import android.location.LocationManager
+import androidx.annotation.RequiresPermission
+
+@RequiresPermission(allOf = [Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_COARSE_LOCATION])
+fun track(manager: LocationManager) {
+    manager.requestLocationUpdates("gps", 0, 0f, listener)
+}
+`)
+		if len(findings) != 0 {
+			t.Fatalf("expected 0 findings, got %d", len(findings))
+		}
+	})
+	t.Run("positive - enclosing anyOf annotation does not cover specific perm", func(t *testing.T) {
+		findings := runRuleByName(t, "MissingPermission", `
+package test
+import android.Manifest
+import android.location.LocationManager
+import androidx.annotation.RequiresPermission
+
+@RequiresPermission(anyOf = [Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_COARSE_LOCATION])
+fun track(manager: LocationManager) {
+    manager.requestLocationUpdates("gps", 0, 0f, listener)
+}
+`)
+		if len(findings) != 1 {
+			t.Fatalf("expected 1 finding, got %d", len(findings))
+		}
+	})
+	t.Run("message - anyOf describes alternatives with 'or'", func(t *testing.T) {
+		findings := runRuleByName(t, "MissingPermission", `
+package test
+import android.Manifest
+import androidx.annotation.RequiresPermission
+
+@RequiresPermission(anyOf = [Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_COARSE_LOCATION])
+fun locateUser() {}
+
+fun open() {
+    locateUser()
+}
+`)
+		if len(findings) != 1 {
+			t.Fatalf("expected 1 finding, got %d", len(findings))
+		}
+		msg := findings[0].Message
+		if !strings.Contains(msg, "ACCESS_FINE_LOCATION or ACCESS_COARSE_LOCATION") {
+			t.Fatalf("expected message to describe anyOf alternatives with 'or'; got %q", msg)
+		}
+		if !strings.Contains(msg, "permissions") {
+			t.Fatalf("expected plural 'permissions' suffix; got %q", msg)
+		}
+	})
+	t.Run("message - allOf describes conjunction with 'and'", func(t *testing.T) {
+		findings := runRuleByName(t, "MissingPermission", `
+package test
+import android.Manifest
+import androidx.annotation.RequiresPermission
+
+@RequiresPermission(allOf = [Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_COARSE_LOCATION])
+fun locateUserStrict() {}
+
+fun open() {
+    locateUserStrict()
+}
+`)
+		if len(findings) != 1 {
+			t.Fatalf("expected 1 finding, got %d", len(findings))
+		}
+		msg := findings[0].Message
+		if !strings.Contains(msg, "ACCESS_FINE_LOCATION and ACCESS_COARSE_LOCATION") {
+			t.Fatalf("expected message to describe allOf conjunction with 'and'; got %q", msg)
+		}
+	})
 }
 
 // =====================================================================

--- a/internal/rules/missing_permission_internal_test.go
+++ b/internal/rules/missing_permission_internal_test.go
@@ -1,0 +1,80 @@
+package rules
+
+import "testing"
+
+func TestMissingPermissionRequirement_Helpers(t *testing.T) {
+	t.Run("single covers exact perm only", func(t *testing.T) {
+		r := singlePermRequirement("CAMERA")
+		if !r.covers("CAMERA") {
+			t.Fatal("single CAMERA should cover CAMERA")
+		}
+		if r.covers("RECORD_AUDIO") {
+			t.Fatal("single CAMERA should not cover RECORD_AUDIO")
+		}
+	})
+	t.Run("anyOf never covers a specific perm", func(t *testing.T) {
+		r := missingPermissionRequirement{kind: missingPermissionRequirementAnyOf, perms: []string{"A", "B"}}
+		if r.covers("A") || r.covers("B") {
+			t.Fatal("anyOf must not be treated as a coverage guarantee for any specific permission")
+		}
+	})
+	t.Run("allOf covers every listed perm", func(t *testing.T) {
+		r := missingPermissionRequirement{kind: missingPermissionRequirementAllOf, perms: []string{"A", "B"}}
+		if !r.covers("A") || !r.covers("B") {
+			t.Fatal("allOf must cover every listed permission")
+		}
+		if r.covers("C") {
+			t.Fatal("allOf must not cover an unrelated permission")
+		}
+	})
+	t.Run("anyOf satisfied when any predicate holds", func(t *testing.T) {
+		r := missingPermissionRequirement{kind: missingPermissionRequirementAnyOf, perms: []string{"A", "B"}}
+		if !r.satisfied(func(p string) bool { return p == "B" }) {
+			t.Fatal("anyOf should be satisfied when one alternative is guarded")
+		}
+		if r.satisfied(func(p string) bool { return false }) {
+			t.Fatal("anyOf with no perm guarded should not be satisfied")
+		}
+	})
+	t.Run("allOf satisfied only when every predicate holds", func(t *testing.T) {
+		r := missingPermissionRequirement{kind: missingPermissionRequirementAllOf, perms: []string{"A", "B"}}
+		if r.satisfied(func(p string) bool { return p == "A" }) {
+			t.Fatal("allOf should not be satisfied when one perm is missing")
+		}
+		if !r.satisfied(func(p string) bool { return true }) {
+			t.Fatal("allOf should be satisfied when all perms are guarded")
+		}
+	})
+	t.Run("empty requirement is never satisfied", func(t *testing.T) {
+		var r missingPermissionRequirement
+		if !r.empty() {
+			t.Fatal("zero requirement should report empty")
+		}
+		if r.satisfied(func(string) bool { return true }) {
+			t.Fatal("empty requirement should never be satisfied")
+		}
+	})
+	t.Run("describe joins anyOf with or and allOf with and", func(t *testing.T) {
+		anyR := missingPermissionRequirement{kind: missingPermissionRequirementAnyOf, perms: []string{"A", "B"}}
+		if got := anyR.describe(); got != "A or B" {
+			t.Fatalf("anyOf describe: want %q, got %q", "A or B", got)
+		}
+		allR := missingPermissionRequirement{kind: missingPermissionRequirementAllOf, perms: []string{"A", "B"}}
+		if got := allR.describe(); got != "A and B" {
+			t.Fatalf("allOf describe: want %q, got %q", "A and B", got)
+		}
+		single := singlePermRequirement("CAMERA")
+		if got := single.describe(); got != "CAMERA" {
+			t.Fatalf("single describe: want %q, got %q", "CAMERA", got)
+		}
+	})
+	t.Run("messageSuffix is plural for multi-perm requirements", func(t *testing.T) {
+		if got := singlePermRequirement("CAMERA").messageSuffix(); got != "permission" {
+			t.Fatalf("single suffix: want %q, got %q", "permission", got)
+		}
+		r := missingPermissionRequirement{kind: missingPermissionRequirementAnyOf, perms: []string{"A", "B"}}
+		if got := r.messageSuffix(); got != "permissions" {
+			t.Fatalf("multi suffix: want %q, got %q", "permissions", got)
+		}
+	})
+}

--- a/tests/fixtures/negative/android-lint/MissingPermission.kt
+++ b/tests/fixtures/negative/android-lint/MissingPermission.kt
@@ -45,3 +45,23 @@ class Fake {
 fun localSameName(fake: Fake) {
     fake.requestLocationUpdates()
 }
+
+@androidx.annotation.RequiresPermission(anyOf = [Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_COARSE_LOCATION])
+fun locateUser() {}
+
+fun openWithCoarseGuard() {
+    if (ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_COARSE_LOCATION) == GRANTED) {
+        locateUser()
+    }
+}
+
+@androidx.annotation.RequiresPermission(allOf = [Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_COARSE_LOCATION])
+fun locateUserStrict() {}
+
+fun openWithBothGuards() {
+    if (ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_FINE_LOCATION) == GRANTED) {
+        if (ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_COARSE_LOCATION) == GRANTED) {
+            locateUserStrict()
+        }
+    }
+}

--- a/tests/fixtures/positive/android-lint/MissingPermission.kt
+++ b/tests/fixtures/positive/android-lint/MissingPermission.kt
@@ -39,3 +39,19 @@ class LocationTracker {
         }
     }
 }
+
+@androidx.annotation.RequiresPermission(anyOf = [android.Manifest.permission.ACCESS_FINE_LOCATION, android.Manifest.permission.ACCESS_COARSE_LOCATION])
+fun locateUser() {}
+
+fun openAnyOfWithoutAnyGuard() {
+    locateUser()
+}
+
+@androidx.annotation.RequiresPermission(allOf = [android.Manifest.permission.ACCESS_FINE_LOCATION, android.Manifest.permission.ACCESS_COARSE_LOCATION])
+fun locateUserStrict() {}
+
+fun openAllOfWithOnlyOneGuard() {
+    if (checkSelfPermission(android.Manifest.permission.ACCESS_FINE_LOCATION) == PERMISSION_GRANTED) {
+        locateUserStrict()
+    }
+}


### PR DESCRIPTION
## Summary

- `MissingPermission` used to grab the first permission constant it
  saw inside `@RequiresPermission(...)` and demand a guard for that one
  perm. `anyOf=[FINE, COARSE]` with a `COARSE` guard fired a false
  positive; `allOf=[FINE, COARSE]` was satisfied by a single guard
  (false negative).
- Annotations now resolve to a `missingPermissionRequirement` with
  `single | anyOf | allOf` semantics, mirroring AOSP Lint's
  `PermissionRequirement` / `PermissionHolder` model. `anyOf` is met
  when any listed perm is guarded; `allOf` requires every perm; an
  enclosing `allOf` covers any single perm in its set, an enclosing
  `anyOf` does not.
- Diagnostic message is grammar-aware: `requires X or Y permissions`
  vs `requires X and Y permissions` vs `requires X permission`.

## Test plan
- [x] `go build -o krit ./cmd/krit/`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...` (0 issues)
- [x] `go test ./... -count=1`
- [x] `make integration` (11/11 passed)
- [x] 8 new behavioral subtests for `TestMissingPermission_Extra`
  (anyOf/allOf negatives + positives, enclosing-annotation coverage,
  message formatting)
- [x] 8 new internal-package unit tests for the requirement helpers
  (`covers` / `satisfied` / `describe` / `messageSuffix` / `empty`)
- [x] Positive + negative fixtures extended under
  `tests/fixtures/{positive,negative}/android-lint/MissingPermission.kt`