### PR TITLE
refactor(rules): convert UseAlpha2 to a ValuesResourceBase rule

### DIFF
--- a/internal/rules/android_aosp_new_test.go
+++ b/internal/rules/android_aosp_new_test.go
@@ -1,7 +1,6 @@
 package rules_test
 
 import (
-	"strings"
 	"testing"
 
 	api "github.com/kaeawc/krit/internal/rules/api"
@@ -510,58 +509,6 @@ val path = "res/values-en/strings.xml"
 `)
 		if len(findings) != 0 {
 			t.Fatalf("expected 0 findings, got %d", len(findings))
-		}
-	})
-}
-
-// ---------------------------------------------------------------------------
-// UseAlpha2
-// ---------------------------------------------------------------------------
-
-func TestUseAlpha2(t *testing.T) {
-	t.Run("3-letter code triggers", func(t *testing.T) {
-		findings := runRuleByName(t, "UseAlpha2", `
-package test
-val path = "res/values-eng/strings.xml"
-`)
-		if len(findings) != 1 {
-			t.Fatalf("expected 1 finding, got %d", len(findings))
-		}
-		if !strings.Contains(findings[0].Message, "en") {
-			t.Fatalf("expected message to suggest 'en', got %s", findings[0].Message)
-		}
-	})
-
-	t.Run("2-letter code is clean", func(t *testing.T) {
-		findings := runRuleByName(t, "UseAlpha2", `
-package test
-val path = "res/values-en/strings.xml"
-`)
-		if len(findings) != 0 {
-			t.Fatalf("expected 0 findings, got %d", len(findings))
-		}
-	})
-
-	t.Run("unknown 3-letter code is clean", func(t *testing.T) {
-		findings := runRuleByName(t, "UseAlpha2", `
-package test
-val path = "res/values-xyz/strings.xml"
-`)
-		if len(findings) != 0 {
-			t.Fatalf("expected 0 findings (unknown code), got %d", len(findings))
-		}
-	})
-
-	t.Run("Japanese code triggers", func(t *testing.T) {
-		findings := runRuleByName(t, "UseAlpha2", `
-package test
-val path = "res/values-jpn/strings.xml"
-`)
-		if len(findings) != 1 {
-			t.Fatalf("expected 1 finding, got %d", len(findings))
-		}
-		if !strings.Contains(findings[0].Message, "ja") {
-			t.Fatalf("expected message to suggest 'ja', got %s", findings[0].Message)
 		}
 	})
 }

--- a/internal/rules/android_dependency_test.go
+++ b/internal/rules/android_dependency_test.go
@@ -19,6 +19,7 @@ func TestAndroidDependencyMetadata(t *testing.T) {
 	check("AllowBackupManifest", rules.AndroidDepManifest)
 	check("LocaleConfigMissing", rules.AndroidDepManifest)
 	check("LocaleConfigStale", rules.AndroidDepValues)
+	check("UseAlpha2", rules.AndroidDepValues)
 	check("HardcodedValuesResource", rules.AndroidDepLayout)
 	check("MissingQuantityResource", rules.AndroidDepValuesPlurals)
 	check("StringFormatInvalidResource", rules.AndroidDepValuesStrings)

--- a/internal/rules/android_resource_strings_test.go
+++ b/internal/rules/android_resource_strings_test.go
@@ -986,6 +986,144 @@ func TestLocaleConfigStale(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// UseAlpha2 (resource folder)
+// ---------------------------------------------------------------------------
+
+func TestUseAlpha2Resource(t *testing.T) {
+	r := findResourceRule(t, "UseAlpha2")
+
+	write := func(t *testing.T, path, content string) {
+		t.Helper()
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("MkdirAll(%s): %v", filepath.Dir(path), err)
+		}
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatalf("WriteFile(%s): %v", path, err)
+		}
+	}
+
+	scan := func(t *testing.T, root string) *android.ResourceIndex {
+		t.Helper()
+		idx, err := android.ScanResourceDir(root)
+		if err != nil {
+			t.Fatalf("ScanResourceDir(%s): %v", root, err)
+		}
+		return idx
+	}
+
+	writeBase := func(t *testing.T, resDir string) {
+		write(t, filepath.Join(resDir, "values", "strings.xml"),
+			"<resources><string name=\"app_name\">App</string></resources>\n")
+	}
+
+	t.Run("3-letter locale folder triggers", func(t *testing.T) {
+		resDir := filepath.Join(t.TempDir(), "res")
+		writeBase(t, resDir)
+		write(t, filepath.Join(resDir, "values-eng", "strings.xml"),
+			"<resources><string name=\"app_name\">App</string></resources>\n")
+
+		findings := runResourceRule(r, scan(t, resDir))
+		if len(findings) != 1 {
+			t.Fatalf("expected 1 finding, got %d", len(findings))
+		}
+		if !strings.Contains(findings[0].Message, "`en`") {
+			t.Fatalf("expected message to suggest `en`, got %q", findings[0].Message)
+		}
+		if !strings.Contains(findings[0].File, "values-eng") {
+			t.Fatalf("expected finding path to point at values-eng, got %q", findings[0].File)
+		}
+	})
+
+	t.Run("2-letter locale folder is clean", func(t *testing.T) {
+		resDir := filepath.Join(t.TempDir(), "res")
+		writeBase(t, resDir)
+		write(t, filepath.Join(resDir, "values-en", "strings.xml"),
+			"<resources><string name=\"app_name\">App</string></resources>\n")
+
+		findings := runResourceRule(r, scan(t, resDir))
+		if len(findings) != 0 {
+			t.Fatalf("expected 0 findings, got %d", len(findings))
+		}
+	})
+
+	t.Run("unknown 3-letter code is clean", func(t *testing.T) {
+		resDir := filepath.Join(t.TempDir(), "res")
+		writeBase(t, resDir)
+		write(t, filepath.Join(resDir, "values-xyz", "strings.xml"),
+			"<resources><string name=\"app_name\">App</string></resources>\n")
+
+		findings := runResourceRule(r, scan(t, resDir))
+		if len(findings) != 0 {
+			t.Fatalf("expected 0 findings (unknown code), got %d", len(findings))
+		}
+	})
+
+	t.Run("Japanese 3-letter folder triggers", func(t *testing.T) {
+		resDir := filepath.Join(t.TempDir(), "res")
+		writeBase(t, resDir)
+		write(t, filepath.Join(resDir, "values-jpn", "strings.xml"),
+			"<resources><string name=\"app_name\">App</string></resources>\n")
+
+		findings := runResourceRule(r, scan(t, resDir))
+		if len(findings) != 1 {
+			t.Fatalf("expected 1 finding, got %d", len(findings))
+		}
+		if !strings.Contains(findings[0].Message, "`ja`") {
+			t.Fatalf("expected message to suggest `ja`, got %q", findings[0].Message)
+		}
+	})
+
+	t.Run("3-letter language with region triggers", func(t *testing.T) {
+		resDir := filepath.Join(t.TempDir(), "res")
+		writeBase(t, resDir)
+		write(t, filepath.Join(resDir, "values-eng-rUS", "strings.xml"),
+			"<resources><string name=\"app_name\">App</string></resources>\n")
+
+		findings := runResourceRule(r, scan(t, resDir))
+		if len(findings) != 1 {
+			t.Fatalf("expected 1 finding, got %d", len(findings))
+		}
+		if !strings.Contains(findings[0].Message, "`en`") {
+			t.Fatalf("expected message to suggest `en`, got %q", findings[0].Message)
+		}
+	})
+
+	t.Run("BCP 47 b+eng+US triggers", func(t *testing.T) {
+		resDir := filepath.Join(t.TempDir(), "res")
+		writeBase(t, resDir)
+		write(t, filepath.Join(resDir, "values-b+eng+US", "strings.xml"),
+			"<resources><string name=\"app_name\">App</string></resources>\n")
+
+		findings := runResourceRule(r, scan(t, resDir))
+		if len(findings) != 1 {
+			t.Fatalf("expected 1 finding, got %d", len(findings))
+		}
+	})
+
+	t.Run("non-locale qualifier values-night is clean", func(t *testing.T) {
+		resDir := filepath.Join(t.TempDir(), "res")
+		writeBase(t, resDir)
+		write(t, filepath.Join(resDir, "values-night", "colors.xml"),
+			"<resources><color name=\"bg\">#000</color></resources>\n")
+
+		findings := runResourceRule(r, scan(t, resDir))
+		if len(findings) != 0 {
+			t.Fatalf("expected 0 findings (non-locale qualifier), got %d", len(findings))
+		}
+	})
+
+	t.Run("Kotlin string literal mentioning values-eng is clean", func(t *testing.T) {
+		// Regression: the previous line-scan implementation flagged this.
+		resDir := filepath.Join(t.TempDir(), "res")
+		writeBase(t, resDir)
+		findings := runResourceRule(r, scan(t, resDir))
+		if len(findings) != 0 {
+			t.Fatalf("expected 0 findings without a real values-eng folder, got %d", len(findings))
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
 // LayoutClickableWithoutMinSize
 // ---------------------------------------------------------------------------
 

--- a/internal/rules/android_resource_values.go
+++ b/internal/rules/android_resource_values.go
@@ -504,6 +504,100 @@ func diffLocaleSets(configLocales, valuesLocales []string) (missing, extra []str
 }
 
 // ---------------------------------------------------------------------------
+// UseAlpha2Resource
+// ---------------------------------------------------------------------------
+
+// UseAlpha2ResourceRule detects Android resource locale folders that use a
+// 3-letter ISO 639-2 language code instead of the 2-letter ISO 639-1 code
+// Android resource selection expects (e.g. `values-eng/` should be
+// `values-en/`).
+type UseAlpha2ResourceRule struct {
+	ValuesResourceBase
+	AndroidRule
+}
+
+// Confidence reports a tier-1 (high) base confidence. The check is a pure
+// structural match on real `values-<lang>` directory names recovered from
+// the merged resource index, with no source-text heuristics.
+func (r *UseAlpha2ResourceRule) Confidence() float64 { return 0.95 }
+
+var alpha3to2LocaleCode = map[string]string{
+	"eng": "en", "fra": "fr", "deu": "de", "spa": "es", "ita": "it",
+	"por": "pt", "rus": "ru", "jpn": "ja", "kor": "ko", "zho": "zh",
+	"ara": "ar", "hin": "hi", "tur": "tr", "pol": "pl", "nld": "nl",
+	"swe": "sv", "nor": "no", "dan": "da", "fin": "fi", "tha": "th",
+}
+
+func (r *UseAlpha2ResourceRule) check(ctx *api.Context) {
+	idx := ctx.ResourceIndex
+	if idx == nil {
+		return
+	}
+	for _, resRoot := range resourceRootsFromIndex(idx) {
+		entries, err := os.ReadDir(resRoot)
+		if err != nil {
+			continue
+		}
+		for _, entry := range entries {
+			if !entry.IsDir() {
+				continue
+			}
+			name := entry.Name()
+			code, ok := alpha3LanguageFromValuesDir(name)
+			if !ok {
+				continue
+			}
+			replacement, ok := alpha3to2LocaleCode[code]
+			if !ok {
+				continue
+			}
+			ctx.Emit(resourceFinding(filepath.Join(resRoot, name), 1, r.BaseRule,
+				fmt.Sprintf("Use 2-letter ISO 639-1 code `%s` instead of 3-letter code `%s` in locale folder.",
+					replacement, code)))
+		}
+	}
+}
+
+// alpha3LanguageFromValuesDir extracts the language code from a
+// `values-<qualifier>` directory name when the first qualifier segment is a
+// 3-letter language code. BCP 47 (`b+xxx+...`) directories are recognized;
+// other qualifiers (orientation, density, smallest width, etc.) and codes
+// that are not exactly three lowercase letters are rejected.
+func alpha3LanguageFromValuesDir(dir string) (string, bool) {
+	if !strings.HasPrefix(dir, "values-") {
+		return "", false
+	}
+	qualifier := strings.TrimPrefix(dir, "values-")
+	if strings.HasPrefix(qualifier, "b+") {
+		parts := strings.Split(strings.TrimPrefix(qualifier, "b+"), "+")
+		if len(parts) == 0 || !isAlpha3LowerCode(parts[0]) {
+			return "", false
+		}
+		return parts[0], true
+	}
+	first := qualifier
+	if i := strings.IndexByte(qualifier, '-'); i >= 0 {
+		first = qualifier[:i]
+	}
+	if !isAlpha3LowerCode(first) {
+		return "", false
+	}
+	return first, true
+}
+
+func isAlpha3LowerCode(s string) bool {
+	if len(s) != 3 {
+		return false
+	}
+	for _, r := range s {
+		if r < 'a' || r > 'z' {
+			return false
+		}
+	}
+	return true
+}
+
+// ---------------------------------------------------------------------------
 // MissingQuantityResource
 // ---------------------------------------------------------------------------
 

--- a/internal/rules/android_source_extra.go
+++ b/internal/rules/android_source_extra.go
@@ -2012,29 +2012,6 @@ func (r *LocaleFolderRule) check(ctx *api.Context) {
 	}
 }
 
-type UseAlpha2Rule struct {
-	LineBase
-	AndroidRule
-}
-
-var alpha3to2 = map[string]string{"eng": "en", "fra": "fr", "deu": "de", "spa": "es", "ita": "it", "por": "pt", "rus": "ru", "jpn": "ja", "kor": "ko", "zho": "zh", "ara": "ar", "hin": "hi", "tur": "tr", "pol": "pl", "nld": "nl", "swe": "sv", "nor": "no", "dan": "da", "fin": "fi", "tha": "th"}
-var alpha3FolderRe = regexp.MustCompile(`values-([a-z]{3})\b`)
-
-func (r *UseAlpha2Rule) check(ctx *api.Context) {
-	file := ctx.File
-	for i, line := range file.Lines {
-		if scanner.IsCommentLine(line) {
-			continue
-		}
-		if m := alpha3FolderRe.FindStringSubmatch(line); m != nil {
-			if repl, ok := alpha3to2[m[1]]; ok {
-				ctx.Emit(r.Finding(file, i+1, 1,
-					"Use 2-letter ISO 639-1 code `"+repl+"` instead of 3-letter code `"+m[1]+"` in locale folder."))
-			}
-		}
-	}
-}
-
 type MangledCRLFRule struct {
 	LineBase
 	AndroidRule

--- a/internal/rules/android_source_extra_test.go
+++ b/internal/rules/android_source_extra_test.go
@@ -1059,33 +1059,6 @@ val path = "res/values-en-rUS/strings.xml"
 }
 
 // =====================================================================
-// UseAlpha2 tests
-// =====================================================================
-
-func TestUseAlpha2_Extra(t *testing.T) {
-	t.Run("positive - 3-letter code", func(t *testing.T) {
-		findings := runRuleByName(t, "UseAlpha2", `
-package test
-
-val path = "res/values-eng/strings.xml"
-`)
-		if len(findings) != 1 {
-			t.Fatalf("expected 1 finding, got %d", len(findings))
-		}
-	})
-	t.Run("negative - 2-letter code", func(t *testing.T) {
-		findings := runRuleByName(t, "UseAlpha2", `
-package test
-
-val path = "res/values-en/strings.xml"
-`)
-		if len(findings) != 0 {
-			t.Fatalf("expected 0 findings, got %d", len(findings))
-		}
-	})
-}
-
-// =====================================================================
 // MangledCRLF tests
 // =====================================================================
 

--- a/internal/rules/meta_android_resource_values.go
+++ b/internal/rules/meta_android_resource_values.go
@@ -145,6 +145,15 @@ func (r *UnusedQuantityResourceRule) Meta() api.RuleDescriptor {
 	}
 }
 
+func (r *UseAlpha2ResourceRule) Meta() api.RuleDescriptor {
+	return api.RuleDescriptor{
+		ID:            "UseAlpha2",
+		RuleSet:       "android-lint",
+		DefaultActive: false,
+		OptInReason:   api.OptInReasonAndroidOnly,
+	}
+}
+
 func (r *WebViewInScrollViewResourceRule) Meta() api.RuleDescriptor {
 	return api.RuleDescriptor{
 		ID:            "WebViewInScrollViewResource",

--- a/internal/rules/meta_android_source_extra.go
+++ b/internal/rules/meta_android_source_extra.go
@@ -138,15 +138,6 @@ func (r *UnknownIDInLayoutRule) Meta() api.RuleDescriptor {
 	}
 }
 
-func (r *UseAlpha2Rule) Meta() api.RuleDescriptor {
-	return api.RuleDescriptor{
-		ID:            "UseAlpha2",
-		RuleSet:       "android-lint",
-		DefaultActive: false,
-		OptInReason:   api.OptInReasonAndroidOnly,
-	}
-}
-
 func (r *ViewConstructorRule) Meta() api.RuleDescriptor {
 	return api.RuleDescriptor{
 		ID:            "ViewConstructor",

--- a/internal/rules/meta_index.go
+++ b/internal/rules/meta_index.go
@@ -679,7 +679,7 @@ func AllMetaProviders() []api.MetaProvider {
 		(*UnusedResourcesRule)(nil),
 		(*UnusedUnaryOperatorRule)(nil),
 		(*UnusedVariableRule)(nil),
-		(*UseAlpha2Rule)(nil),
+		(*UseAlpha2ResourceRule)(nil),
 		(*UseAnyOrNoneInsteadOfFindRule)(nil),
 		(*UseArrayLiteralsInAnnotationsRule)(nil),
 		(*UseCheckNotNullRule)(nil),

--- a/internal/rules/registry_android_resource_values.go
+++ b/internal/rules/registry_android_resource_values.go
@@ -104,6 +104,22 @@ func registerAndroidResourceValuesRules() {
 		})
 	}
 	{
+		r := &UseAlpha2ResourceRule{AndroidRule: AndroidRule{
+			BaseRule:   BaseRule{RuleName: "UseAlpha2", RuleSetName: androidRuleSet, Sev: "warning"},
+			IssueID:    "UseAlpha2",
+			Brief:      "3-letter ISO code in locale folder",
+			Category:   ALCI18N,
+			ALSeverity: ALSWarning,
+			Priority:   6,
+			Origin:     "AOSP Android Lint",
+		}}
+		api.Register(&api.Rule{
+			ID: r.RuleName, Category: r.RuleSetName, Description: r.Description(), Sev: api.Severity(r.Sev),
+			Needs: api.NeedsResources, AndroidDeps: uint32(r.AndroidDependencies()), Confidence: r.Confidence(), Implementation: r,
+			Check: r.check,
+		})
+	}
+	{
 		r := &MissingQuantityResourceRule{AndroidRule: AndroidRule{
 			BaseRule:   BaseRule{RuleName: "MissingQuantityResource", RuleSetName: androidRuleSet, Sev: "error"},
 			IssueID:    "MissingQuantity",

--- a/internal/rules/registry_android_source_extra.go
+++ b/internal/rules/registry_android_source_extra.go
@@ -258,14 +258,6 @@ func registerAndroidSourceExtraRules() {
 		})
 	}
 	{
-		r := &UseAlpha2Rule{AndroidRule: AndroidRule{BaseRule: BaseRule{RuleName: "UseAlpha2", RuleSetName: androidRuleSet, Sev: "warning"}, IssueID: "UseAlpha2", Brief: "3-letter ISO code in locale folder", Category: ALCI18N, ALSeverity: ALSWarning, Priority: 6, Origin: "AOSP Android Lint"}}
-		api.Register(&api.Rule{
-			ID: r.RuleName, Category: r.RuleSetName, Description: r.Description(), Sev: api.Severity(r.Sev),
-			Needs: api.NeedsLinePass, Confidence: 0.75, Implementation: r,
-			Check: r.check,
-		})
-	}
-	{
 		r := &MangledCRLFRule{AndroidRule: AndroidRule{BaseRule: BaseRule{RuleName: "MangledCRLF", RuleSetName: androidRuleSet, Sev: "warning"}, IssueID: "MangledCRLF", Brief: "Mixed line endings in file", Category: ALCCorrectness, ALSeverity: ALSWarning, Priority: 3, Origin: "AOSP Android Lint"}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Description(), Sev: api.Severity(r.Sev),

--- a/schemas/krit-config.schema.json
+++ b/schemas/krit-config.schema.json
@@ -4635,7 +4635,7 @@
           }
         },
         "UseAlpha2": {
-          "description": "3-letter ISO code in locale folder [precision: heuristic/text-backed] [noisiness: noisy] [capabilities: line-pass]",
+          "description": "3-letter ISO code in locale folder [precision: project-structure-aware] [noisiness: normal] [capabilities: resources]",
           "type": "object",
           "additionalProperties": false,
           "properties": {


### PR DESCRIPTION
## Summary

- Convert `UseAlpha2` from a `LineBase` per-line text scan into a `ValuesResourceBase` rule that walks real Android `res/values-<qualifier>/` directories via the merged `ResourceIndex` and `os.ReadDir`.
- Rule ID stays `UseAlpha2`, so config / schema lookup is unchanged. Schema regenerated to reflect the capability/precision shift.
- Tests rewritten against real `os.ReadDir` fixtures using the existing `runResourceRule` helper, including a regression case for the previous line-scan false positive.

## Why

The previous implementation matched the substring `values-<3-letters>` on any line of any Kotlin or Java source file with no lexical-state awareness, so it fired on doc comments, string literals, and test fixtures — none of which represent an actual locale folder. CLAUDE.md's "lexical-state aware" guardrail was being violated.

## Wins (now reflected in rule metadata)

| | Before | After |
|---|---|---|
| precision | `heuristic/text-backed` | `project-structure-aware` |
| noisiness | `noisy` | `normal` |
| capabilities | `line-pass` | `resources` |
| confidence | 0.75 | 0.95 |
| dispatch | once per source-file line | once per `res/` root |

Net work is strictly less: a large multi-module app previously scanned every source-file line with a regex; now it scans ~tens to low-hundreds of `res/` directory entries per scan. No false positives from string literals or comments.

## What this is not

`LocaleFolderRule` (`values-XX_YY` line scanner) has the same defect and is a natural follow-up — left as a separate change.

A small follow-up to cache `os.ReadDir(resRoot)` results between rules (`LocaleConfigStaleResourceRule` already does this readdir too) is worth doing later but is not a blocker — the cost is well below the previous line-scan pass.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...` (0 issues)
- [x] `make lint-rules`
- [x] `go test ./... -count=1` (full suite)
- [x] `make integration` (11/11 pass)
- [x] `TestUseAlpha2Resource` covers: 3-letter trigger, 2-letter clean, unknown 3-letter clean, BCP 47 (`b+eng+US`), language+region (`eng-rUS`), non-locale qualifier (`values-night`) clean, regression for prior string-literal FP
- [x] `TestAndroidDependencyMetadata` asserts `AndroidDepValues`
- [x] `TestNewAospRulesRegistered` still finds `UseAlpha2` by ID