### PR TITLE
fix(editorconfig): resolve indent_size after tab_width; tighten Kotlin section match

### DIFF
--- a/internal/config/editorconfig.go
+++ b/internal/config/editorconfig.go
@@ -133,15 +133,76 @@ func parseEditorConfig(path string) (props map[string]string, isRoot bool) {
 	return props, isRoot
 }
 
-// matchesKotlin checks if an editorconfig section glob matches Kotlin files.
+// matchesKotlin reports whether an editorconfig section glob matches Kotlin
+// source files (.kt or .kts). Only true Kotlin-applicable globs return true;
+// substring lookalikes such as `*.kt.tmpl`, `*.ktx`, `*.ktm`, or `hot_keys.cfg`
+// must not apply Kotlin settings.
+//
+// The .editorconfig spec uses fnmatch-style globs with optional brace
+// alternation. We support the common forms used in practice:
+//   - `*` (universal)
+//   - `*.kt`, `*.kts`
+//   - compound extension lists: `*.{kt,kts}`, `*.{java,kt,kts}`
+//   - top-level brace alternation: `{*.kt,*.kts}`, `{*.kt,Makefile}`
+//
+// Patterns are anchored at the end after brace expansion: only branches that
+// actually terminate in `.kt` or `.kts` count as Kotlin matches.
 func matchesKotlin(section string) bool {
 	section = strings.TrimSpace(section)
+	if section == "" {
+		return false
+	}
 	if section == "*" {
 		return true
 	}
-	// Match common patterns: *.kt, *.kts, *.{kt,kts}, {*.kt,*.kts}
-	lower := strings.ToLower(section)
-	return strings.Contains(lower, "kt")
+	for _, branch := range expandBraces(section) {
+		if kotlinBranchMatches(branch) {
+			return true
+		}
+	}
+	return false
+}
+
+// kotlinBranchMatches reports whether a single (brace-free) glob branch
+// matches Kotlin source files. The pattern must end with `.kt` or `.kts` —
+// substring matches like `*.kt.tmpl` or `*.ktx` are rejected.
+func kotlinBranchMatches(branch string) bool {
+	branch = strings.TrimSpace(branch)
+	if branch == "" {
+		return false
+	}
+	lower := strings.ToLower(branch)
+	return strings.HasSuffix(lower, ".kt") || strings.HasSuffix(lower, ".kts")
+}
+
+// expandBraces performs a single level of brace alternation expansion on a
+// glob pattern. `*.{kt,kts}` expands to `*.kt`, `*.kts`; `{*.kt,*.kts}`
+// expands to `*.kt`, `*.kts`. Patterns without braces are returned as-is.
+// Nested or malformed braces fall back to returning the original string.
+func expandBraces(pattern string) []string {
+	openIdx := strings.IndexByte(pattern, '{')
+	if openIdx < 0 {
+		return []string{pattern}
+	}
+	closeIdx := strings.IndexByte(pattern[openIdx:], '}')
+	if closeIdx < 0 {
+		return []string{pattern}
+	}
+	closeIdx += openIdx
+
+	prefix := pattern[:openIdx]
+	suffix := pattern[closeIdx+1:]
+	inner := pattern[openIdx+1 : closeIdx]
+
+	var out []string
+	for _, alt := range strings.Split(inner, ",") {
+		alt = strings.TrimSpace(alt)
+		expanded := prefix + alt + suffix
+		// Allow one additional pass for patterns like `*.{kt,kts}` nested
+		// inside an outer `{...,...}` block.
+		out = append(out, expandBraces(expanded)...)
+	}
+	return out
 }
 
 func applyProps(ec *EditorConfig, props map[string]string) {
@@ -150,6 +211,16 @@ func applyProps(ec *EditorConfig, props map[string]string) {
 			ec.MaxLineLength = -1
 		} else if n, err := strconv.Atoi(v); err == nil && n > 0 {
 			ec.MaxLineLength = n
+		}
+	}
+
+	// Resolve tab_width first so indent_size = tab in the same section sees
+	// the section's own tab_width rather than stale state from a previous
+	// merge pass or a zero default. map iteration order is randomized, so
+	// the previous ordering by chance was unreliable.
+	if v, ok := props["tab_width"]; ok {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			ec.TabWidth = n
 		}
 	}
 
@@ -167,12 +238,6 @@ func applyProps(ec *EditorConfig, props map[string]string) {
 		// get a coherent indent width for indent-touching fixes (NoTabs).
 		if n, err := strconv.Atoi(v); err == nil && n > 0 {
 			ec.IndentSize = n
-		}
-	}
-
-	if v, ok := props["tab_width"]; ok {
-		if n, err := strconv.Atoi(v); err == nil && n > 0 {
-			ec.TabWidth = n
 		}
 	}
 

--- a/internal/config/editorconfig_test.go
+++ b/internal/config/editorconfig_test.go
@@ -1,0 +1,188 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestIndentSizeTabResolvedAfterTabWidth verifies that when a section sets
+// both indent_size = tab and tab_width, the resulting IndentSize uses the
+// section's tab_width regardless of the order properties appear in the file
+// (and regardless of the random map-iteration order applyProps observes).
+func TestIndentSizeTabResolvedAfterTabWidth(t *testing.T) {
+	cases := []struct {
+		name       string
+		content    string
+		wantIndent int
+		wantTab    int
+	}{
+		{
+			name: "tab_width=8 same section",
+			content: `root = true
+[*.kt]
+indent_size = tab
+tab_width = 8
+`,
+			wantIndent: 8,
+			wantTab:    8,
+		},
+		{
+			name: "tab_width=4 same section",
+			content: `root = true
+[*.kt]
+indent_size = tab
+tab_width = 4
+`,
+			wantIndent: 4,
+			wantTab:    4,
+		},
+		{
+			// tab_width listed before indent_size: must also resolve correctly.
+			name: "tab_width listed first",
+			content: `root = true
+[*.kt]
+tab_width = 6
+indent_size = tab
+`,
+			wantIndent: 6,
+			wantTab:    6,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			if err := os.WriteFile(filepath.Join(dir, ".editorconfig"), []byte(tc.content), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			ec := LoadEditorConfig(dir)
+			if ec.IndentSize != tc.wantIndent {
+				t.Errorf("IndentSize = %d, want %d", ec.IndentSize, tc.wantIndent)
+			}
+			if ec.TabWidth != tc.wantTab {
+				t.Errorf("TabWidth = %d, want %d", ec.TabWidth, tc.wantTab)
+			}
+		})
+	}
+}
+
+// TestIndentSizeTabDoesNotLeakAcrossFiles verifies that the resolution of
+// `indent_size = tab` does not depend on stale TabWidth state from earlier
+// processing in the same merge. Each per-section apply must use the
+// tab_width declared in that section.
+func TestIndentSizeTabDoesNotLeakAcrossFiles(t *testing.T) {
+	// Parent .editorconfig sets a large tab_width but child overrides.
+	parent := t.TempDir()
+	child := filepath.Join(parent, "sub")
+	if err := os.MkdirAll(child, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	parentContent := `root = true
+[*.kt]
+tab_width = 12
+indent_size = 2
+`
+	childContent := `[*.kt]
+indent_size = tab
+tab_width = 4
+`
+	if err := os.WriteFile(filepath.Join(parent, ".editorconfig"), []byte(parentContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(child, ".editorconfig"), []byte(childContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	ec := LoadEditorConfig(child)
+	if ec.IndentSize != 4 {
+		t.Errorf("IndentSize = %d, want 4 (closest tab_width)", ec.IndentSize)
+	}
+	if ec.TabWidth != 4 {
+		t.Errorf("TabWidth = %d, want 4", ec.TabWidth)
+	}
+}
+
+func TestMatchesKotlin(t *testing.T) {
+	cases := []struct {
+		section string
+		want    bool
+	}{
+		// Should match
+		{"*", true},
+		{"*.kt", true},
+		{"*.kts", true},
+		{"*.{kt,kts}", true},
+		{"*.{kt, kts}", true},
+		{"{*.kt,*.kts}", true},
+		{"*.{java,kt,kts}", true},
+		{"*.{kt,java}", true},
+
+		// Should NOT match — substring lookalikes
+		{"*.kt.tmpl", false},
+		{"hot_keys.cfg", false},
+		{"*.ktx", false},
+		{"*.cfg", false},
+		{"Makefile", false},
+		{"*.java", false},
+		{"*.xml", false},
+		{"package.json", false},
+		{"*.{json,yml}", false},
+		{"*.ktm", false},
+		{"*.gradle.kts.bak", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.section, func(t *testing.T) {
+			got := matchesKotlin(tc.section)
+			if got != tc.want {
+				t.Errorf("matchesKotlin(%q) = %v, want %v", tc.section, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestEditorConfigIgnoresLookalikeSections verifies that lookalike section
+// headers do not apply their properties to Kotlin files.
+func TestEditorConfigIgnoresLookalikeSections(t *testing.T) {
+	dir := t.TempDir()
+	content := `root = true
+[*.kt.tmpl]
+indent_size = 99
+max_line_length = 999
+[hot_keys.cfg]
+indent_size = 77
+[*.kt]
+indent_size = 4
+`
+	if err := os.WriteFile(filepath.Join(dir, ".editorconfig"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ec := LoadEditorConfig(dir)
+	if ec.IndentSize != 4 {
+		t.Errorf("IndentSize = %d, want 4 (lookalike sections must not apply)", ec.IndentSize)
+	}
+	if ec.MaxLineLength != 0 {
+		t.Errorf("MaxLineLength = %d, want 0 (lookalike sections must not apply)", ec.MaxLineLength)
+	}
+}
+
+// TestEditorConfigCompoundKotlinSection verifies that `[*.{kt,kts}]` applies.
+func TestEditorConfigCompoundKotlinSection(t *testing.T) {
+	dir := t.TempDir()
+	content := `root = true
+[*.{kt,kts}]
+indent_size = 4
+max_line_length = 120
+`
+	if err := os.WriteFile(filepath.Join(dir, ".editorconfig"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ec := LoadEditorConfig(dir)
+	if ec.IndentSize != 4 {
+		t.Errorf("IndentSize = %d, want 4", ec.IndentSize)
+	}
+	if ec.MaxLineLength != 120 {
+		t.Errorf("MaxLineLength = %d, want 120", ec.MaxLineLength)
+	}
+}


### PR DESCRIPTION
## Summary

Two .editorconfig parsing bugs in `internal/config/editorconfig.go`.

### Bug A: `indent_size = tab` sometimes uses stale `tab_width`

`applyProps` walks a Go map of section properties. Map iteration order is randomized in Go, so when a section sets both `indent_size = tab` and `tab_width`, the `tab` fallback would sometimes read the zero default or a prior value rather than this section's `tab_width`. Fix: resolve `tab_width` before handling `indent_size`.

### Bug B: `matchesKotlin` accepted any section name containing the substring `kt`

The previous `strings.Contains(lower, \"kt\")` matched `[*.kt.tmpl]`, `[*.ktx]`, `[*.ktm]`, `[hot_keys.cfg]`, and other lookalikes, applying their settings to Kotlin sources. Fix: expand brace alternation (`*.{kt,kts}`, `{*.kt,*.kts}`) and require each branch to end in `.kt` or `.kts`.

## Tests

- `TestIndentSizeTabResolvedAfterTabWidth` — `indent_size = tab` resolves to this section's `tab_width` regardless of source ordering.
- `TestIndentSizeTabDoesNotLeakAcrossFiles` — child `.editorconfig` `tab_width` wins over parent.
- `TestMatchesKotlin` — table-driven positives (`*`, `*.kt`, `*.kts`, `*.{kt,kts}`, `{*.kt,*.kts}`, `*.{java,kt,kts}`) and negatives (`*.kt.tmpl`, `*.ktx`, `*.ktm`, `hot_keys.cfg`, `*.cfg`, `Makefile`, `package.json`, `*.{json,yml}`, `*.java`, `*.xml`).
- `TestEditorConfigIgnoresLookalikeSections` — `[*.kt.tmpl]` and `[hot_keys.cfg]` do not bleed into `[*.kt]`.
- `TestEditorConfigCompoundKotlinSection` — `[*.{kt,kts}]` applies as expected.

## Test plan

- [ ] CI passes (build, vet, lint, full test suite).
- [ ] Auto-merge with squash once green.