### PR TITLE
fix(scanner): reset CodeIndex.Files on warm overlay rebuild

### DIFF
--- a/internal/scanner/index.go
+++ b/internal/scanner/index.go
@@ -189,7 +189,14 @@ func BuildIndexCachedWithLoaders(cacheDir string, files []*File, workers int, pr
 	}
 
 	if idx, ok := buildIndexFromPriorOverlay(cacheDir, entries, files, javaFiles, xmlFiles, workers, priorLoader, tracker); ok {
-		idx.Files = appendSourceFiles(idx.Files, files, javaFiles)
+		// The overlay path can return a daemon-resident *CodeIndex
+		// whose Files slice still holds the prior build's entries
+		// (BuildIndexIncremental mutates the prior in place). Replace
+		// the slice rather than appending so warm overlay rebuilds
+		// don't grow Files by len(files)+len(javaFiles) on every
+		// invocation. Disk-fallback priors arrive with Files == nil,
+		// so this is also correct for that case.
+		idx.Files = appendSourceFiles(nil, files, javaFiles)
 		idx.Fingerprint = fingerprint
 		if saver != nil {
 			saver(idx, snapshotMeta())

--- a/internal/scanner/index_cache_test.go
+++ b/internal/scanner/index_cache_test.go
@@ -374,6 +374,74 @@ func TestCrossFileOverlayCacheSmallEditAvoidsPayloadRewrite(t *testing.T) {
 	}
 }
 
+// TestWarmPriorOverlayDoesNotGrowFiles guards against the daemon-mode
+// memory leak where BuildIndexCachedWithLoaders' overlay path appended
+// the full kotlin+java file slice to a daemon-resident *CodeIndex
+// (returned by the prior loader) on every warm rebuild. Without the
+// fix, idx.Files grew by len(files)+len(javaFiles) on each invocation
+// and the saver stored the same pointer back, so the next call
+// appended on top of the previously-grown slice.
+func TestWarmPriorOverlayDoesNotGrowFiles(t *testing.T) {
+	dir := t.TempDir()
+	cacheDir := CrossFileCacheDir(dir)
+	aPath := filepath.Join(dir, "A.kt")
+	bPath := filepath.Join(dir, "B.kt")
+	if err := os.WriteFile(aPath, []byte("class A { fun call() = B() }\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(bPath, []byte("class B\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	aFile, err := ParseFile(context.Background(), aPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bFile, err := ParseFile(context.Background(), bPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var (
+		residentIdx  *CodeIndex
+		residentMeta CrossFileCacheMeta
+	)
+	loader := func() (*CodeIndex, CrossFileCacheMeta, bool) {
+		if residentIdx == nil {
+			return nil, CrossFileCacheMeta{}, false
+		}
+		return residentIdx, residentMeta, true
+	}
+	saver := func(idx *CodeIndex, meta CrossFileCacheMeta) {
+		residentIdx = idx
+		residentMeta = meta
+	}
+
+	// Cold build seeds the resident snapshot.
+	cold, _ := BuildIndexCachedWithPrior(cacheDir, []*File{aFile, bFile}, 2, loader, saver, nil)
+	if got, want := len(cold.Files), 2; got != want {
+		t.Fatalf("cold build len(Files) = %d, want %d", got, want)
+	}
+
+	// Repeated warm-prior overlay rebuilds: each rewrite of B.kt
+	// (different content each time) forces an overlay path, and
+	// the resident loader hands back the previously-built pointer.
+	// The bug appended the full file list on every call.
+	for i := 0; i < 5; i++ {
+		body := []byte("class B" + string(rune('0'+i)) + "\n")
+		if err := os.WriteFile(bPath, body, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		bChanged, err := ParseFile(context.Background(), bPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		idx, _ := BuildIndexCachedWithPrior(cacheDir, []*File{aFile, bChanged}, 2, loader, saver, nil)
+		if got, want := len(idx.Files), 2; got != want {
+			t.Fatalf("warm overlay iter %d: len(Files) = %d, want %d (Files grew on warm rebuild)", i, got, want)
+		}
+	}
+}
+
 func TestCrossFileFingerprintIncludesBloomLibraryVersion(t *testing.T) {
 	if bloomLibraryVersion == "" {
 		t.Fatalf("bloomLibraryVersion must be set")


### PR DESCRIPTION
## Summary
- `BuildIndexCachedWithLoaders`' warm-prior overlay path appended the full kotlin+java file slice to a daemon-resident `*CodeIndex` returned by the prior loader; the saver stored the same pointer into `WorkspaceState.codeIndexSnapshot`, so on every analyze `idx.Files` grew by `len(kotlinFiles)+len(javaFiles)` — a slow but real leak in long-lived daemons.
- Replace the slice instead of appending. Disk-fallback priors arrive with `Files == nil`, so the new behavior is also correct there. The full-payload hit path (`LoadCrossFileCacheIndex` returns a fresh struct) and the sharded-miss path (fresh `BuildIndexFromDataWithBloom`) are left alone.
- New regression test `TestWarmPriorOverlayDoesNotGrowFiles` seeds the resident snapshot via a test loader/saver, drives five consecutive content-changing overlay rebuilds, and asserts `len(idx.Files)` stays at `len(files)+len(javaFiles)`. Without the fix it fails on iteration 0 with `len(Files) = 4, want 2`.

## Test plan
- [x] `go build -o /tmp/krit ./cmd/krit/`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...`
- [x] `go test ./internal/scanner/ ./internal/pipeline/ -count=1`
- [x] Verified test fails without the fix and passes with it