### PR TITLE
fix(rules): tighten import prefix and Gradle classifier in release_engineering

### DIFF
--- a/internal/rules/release_engineering.go
+++ b/internal/rules/release_engineering.go
@@ -443,10 +443,22 @@ func readSourceModuleGradleInfo(dir string) sourceModuleGradleInfo {
 		return sourceModuleGradleInfo{}
 	}
 	content := string(data)
+	// Plugin ids live inside string literals (`id("com.android.application")`,
+	// `classpath 'com.android.library'`), so for those checks we only
+	// strip comments and keep string bodies. `applicationId` is a real
+	// DSL property identifier, so for that check we additionally blank
+	// out string bodies — otherwise a description like
+	// `description = "applicationId is configured per flavor"` would
+	// flip a library module to "application" classification.
+	commentsStripped := gradleStripCommentsFull(content)
+	codeOnly := gradleStripCommentsAndStringBodiesFull(content)
 	return sourceModuleGradleInfo{
-		found:         true,
-		isApplication: strings.Contains(content, "com.android.application") || strings.Contains(content, "applicationId") || containsPluginSuffix(content, "application"),
-		isLibrary:     strings.Contains(content, "com.android.library") || containsPluginSuffix(content, "library"),
+		found: true,
+		isApplication: strings.Contains(commentsStripped, "com.android.application") ||
+			gradleContainsCodeToken(codeOnly, "applicationId") ||
+			containsPluginSuffix(commentsStripped, "application"),
+		isLibrary: strings.Contains(commentsStripped, "com.android.library") ||
+			containsPluginSuffix(commentsStripped, "library"),
 	}
 }
 
@@ -659,8 +671,21 @@ func hasLoggingImport(file *scanner.File) bool {
 			break
 		}
 		pkg := strings.TrimSpace(strings.TrimPrefix(trimmed, "import "))
+		// Strip a trailing alias (`import a.b.C as D`) and Java's
+		// optional `;` terminator so the prefix anchor compares against
+		// the qualified name itself.
+		if before, _, ok := strings.Cut(pkg, " as "); ok {
+			pkg = strings.TrimSpace(before)
+		}
+		pkg = strings.TrimSpace(strings.TrimSuffix(pkg, ";"))
 		for _, prefix := range loggingImports {
-			if strings.Contains(pkg, prefix) {
+			// Anchor the match at the start of the import path so
+			// `import foo.mu.X` or `import com.example.demu.X` does not
+			// falsely qualify as a logging import. Class-name entries
+			// (e.g. `timber.log.Timber`) and package-prefix entries
+			// ending in `.` (e.g. `java.util.logging.`) are both
+			// covered by HasPrefix.
+			if strings.HasPrefix(pkg, prefix) {
 				return true
 			}
 		}

--- a/internal/rules/release_engineering_helpers.go
+++ b/internal/rules/release_engineering_helpers.go
@@ -135,105 +135,7 @@ func hardcodedEnvironmentLiteral(text string, labelPresent bool) string {
 // backslash escapes inside regular strings are honored so an escaped
 // quote does not prematurely close the literal.
 func gradleStripCommentsFull(content string) string {
-	var b strings.Builder
-	b.Grow(len(content))
-	n := len(content)
-	i := 0
-	for i < n {
-		c := content[i]
-		// Block comment.
-		if c == '/' && i+1 < n && content[i+1] == '*' {
-			b.WriteByte(' ')
-			b.WriteByte(' ')
-			i += 2
-			for i < n {
-				if content[i] == '*' && i+1 < n && content[i+1] == '/' {
-					b.WriteByte(' ')
-					b.WriteByte(' ')
-					i += 2
-					break
-				}
-				if content[i] == '\n' {
-					b.WriteByte('\n')
-				} else {
-					b.WriteByte(' ')
-				}
-				i++
-			}
-			continue
-		}
-		// Line comment.
-		if c == '/' && i+1 < n && content[i+1] == '/' {
-			for i < n && content[i] != '\n' {
-				b.WriteByte(' ')
-				i++
-			}
-			continue
-		}
-		// Triple-quoted string (Kotlin raw / Groovy multi-line). Bodies
-		// are written through unchanged so plugin-id references inside
-		// such strings remain visible to substring checks; we only
-		// skip the lexer past the closing delimiter so a stray `*/` or
-		// `//` inside the string does not start a comment.
-		if (c == '"' || c == '\'') && i+2 < n && content[i+1] == c && content[i+2] == c {
-			quote := c
-			b.WriteByte(quote)
-			b.WriteByte(quote)
-			b.WriteByte(quote)
-			i += 3
-			for i < n {
-				if i+2 < n && content[i] == quote && content[i+1] == quote && content[i+2] == quote {
-					b.WriteByte(quote)
-					b.WriteByte(quote)
-					b.WriteByte(quote)
-					i += 3
-					break
-				}
-				b.WriteByte(content[i])
-				i++
-			}
-			continue
-		}
-		// Regular string literal — body preserved, but the lexer
-		// consumes through the closing quote so `//` inside the string
-		// is not misread as a line comment.
-		if c == '"' || c == '\'' {
-			quote := c
-			b.WriteByte(quote)
-			i++
-			escaped := false
-			for i < n {
-				if content[i] == '\n' {
-					// Unterminated literal; bail without consuming the
-					// newline so subsequent code is processed normally.
-					break
-				}
-				if escaped {
-					escaped = false
-					b.WriteByte(content[i])
-					i++
-					continue
-				}
-				if content[i] == '\\' {
-					escaped = true
-					b.WriteByte(content[i])
-					i++
-					continue
-				}
-				if content[i] == quote {
-					b.WriteByte(quote)
-					i++
-					break
-				}
-				b.WriteByte(content[i])
-				i++
-			}
-			continue
-		}
-		b.WriteByte(c)
-		i++
-	}
-	return b.String()
+	return gradleStripContent(content, true)
 }
 
 // gradleStripCommentsAndStringBodiesFull returns content with Gradle
@@ -243,101 +145,155 @@ func gradleStripCommentsFull(content string) string {
 // punctuation positions, and newlines, so a substring search for a code
 // token such as `applicationId` only sees real DSL references.
 func gradleStripCommentsAndStringBodiesFull(content string) string {
+	return gradleStripContent(content, false)
+}
+
+// gradleStripContent is the shared lexer behind gradleStripCommentsFull
+// and gradleStripCommentsAndStringBodiesFull. preserveStringBodies
+// controls whether string literal bodies are written through verbatim
+// (true) or replaced with spaces (false).
+func gradleStripContent(content string, preserveStringBodies bool) string {
 	var b strings.Builder
 	b.Grow(len(content))
 	n := len(content)
 	i := 0
 	for i < n {
 		c := content[i]
-		// Block comment.
 		if c == '/' && i+1 < n && content[i+1] == '*' {
-			b.WriteByte(' ')
-			b.WriteByte(' ')
-			i += 2
-			for i < n {
-				if content[i] == '*' && i+1 < n && content[i+1] == '/' {
-					b.WriteByte(' ')
-					b.WriteByte(' ')
-					i += 2
-					break
-				}
-				if content[i] == '\n' {
-					b.WriteByte('\n')
-				} else {
-					b.WriteByte(' ')
-				}
-				i++
-			}
+			i = gradleConsumeBlockComment(&b, content, i)
 			continue
 		}
-		// Line comment.
 		if c == '/' && i+1 < n && content[i+1] == '/' {
-			for i < n && content[i] != '\n' {
-				b.WriteByte(' ')
-				i++
-			}
+			i = gradleConsumeLineComment(&b, content, i)
 			continue
 		}
-		// Triple-quoted string body — blanked out.
 		if (c == '"' || c == '\'') && i+2 < n && content[i+1] == c && content[i+2] == c {
-			quote := c
-			b.WriteByte(quote)
-			b.WriteByte(quote)
-			b.WriteByte(quote)
-			i += 3
-			for i < n {
-				if i+2 < n && content[i] == quote && content[i+1] == quote && content[i+2] == quote {
-					b.WriteByte(quote)
-					b.WriteByte(quote)
-					b.WriteByte(quote)
-					i += 3
-					break
-				}
-				if content[i] == '\n' {
-					b.WriteByte('\n')
-				} else {
-					b.WriteByte(' ')
-				}
-				i++
-			}
+			i = gradleConsumeTripleQuoted(&b, content, i, preserveStringBodies)
 			continue
 		}
-		// Regular string literal — body blanked out.
 		if c == '"' || c == '\'' {
-			quote := c
-			b.WriteByte(quote)
-			i++
-			escaped := false
-			for i < n {
-				if content[i] == '\n' {
-					break
-				}
-				if escaped {
-					escaped = false
-					b.WriteByte(' ')
-					i++
-					continue
-				}
-				if content[i] == '\\' {
-					escaped = true
-					b.WriteByte(' ')
-					i++
-					continue
-				}
-				if content[i] == quote {
-					b.WriteByte(quote)
-					i++
-					break
-				}
-				b.WriteByte(' ')
-				i++
-			}
+			i = gradleConsumeRegularString(&b, content, i, preserveStringBodies)
 			continue
 		}
 		b.WriteByte(c)
 		i++
 	}
 	return b.String()
+}
+
+// gradleConsumeBlockComment writes a blanked-out block comment starting
+// at content[i] (which must be `/*`) and returns the index just past the
+// closing `*/`, or n if unterminated.
+func gradleConsumeBlockComment(b *strings.Builder, content string, i int) int {
+	n := len(content)
+	b.WriteByte(' ')
+	b.WriteByte(' ')
+	i += 2
+	for i < n {
+		if content[i] == '*' && i+1 < n && content[i+1] == '/' {
+			b.WriteByte(' ')
+			b.WriteByte(' ')
+			return i + 2
+		}
+		if content[i] == '\n' {
+			b.WriteByte('\n')
+		} else {
+			b.WriteByte(' ')
+		}
+		i++
+	}
+	return i
+}
+
+// gradleConsumeLineComment writes a blanked-out line comment starting at
+// content[i] (which must be `//`) and returns the index of the next
+// newline (or n).
+func gradleConsumeLineComment(b *strings.Builder, content string, i int) int {
+	n := len(content)
+	for i < n && content[i] != '\n' {
+		b.WriteByte(' ')
+		i++
+	}
+	return i
+}
+
+// gradleConsumeTripleQuoted handles a triple-quoted string literal
+// starting at content[i] (which must be three identical quote bytes).
+// When preserveBody is true, the body is written through verbatim;
+// otherwise non-newline bytes are blanked. Returns the index past the
+// closing delimiter or n if unterminated.
+func gradleConsumeTripleQuoted(b *strings.Builder, content string, i int, preserveBody bool) int {
+	n := len(content)
+	quote := content[i]
+	b.WriteByte(quote)
+	b.WriteByte(quote)
+	b.WriteByte(quote)
+	i += 3
+	for i < n {
+		if i+2 < n && content[i] == quote && content[i+1] == quote && content[i+2] == quote {
+			b.WriteByte(quote)
+			b.WriteByte(quote)
+			b.WriteByte(quote)
+			return i + 3
+		}
+		if preserveBody {
+			b.WriteByte(content[i])
+		} else if content[i] == '\n' {
+			b.WriteByte('\n')
+		} else {
+			b.WriteByte(' ')
+		}
+		i++
+	}
+	return i
+}
+
+// gradleConsumeRegularString handles a single- or double-quoted string
+// literal starting at content[i]. preserveBody mirrors
+// gradleConsumeTripleQuoted's semantics. Returns the index past the
+// closing quote, or before a bare newline for an unterminated literal.
+func gradleConsumeRegularString(b *strings.Builder, content string, i int, preserveBody bool) int {
+	n := len(content)
+	quote := content[i]
+	b.WriteByte(quote)
+	i++
+	escaped := false
+	for i < n {
+		if content[i] == '\n' {
+			return i
+		}
+		if escaped {
+			escaped = false
+			if preserveBody {
+				b.WriteByte(content[i])
+			} else {
+				b.WriteByte(' ')
+			}
+			i++
+			continue
+		}
+		if content[i] == '\\' {
+			escaped = true
+			if preserveBody {
+				b.WriteByte(content[i])
+			} else {
+				b.WriteByte(' ')
+			}
+			i++
+			continue
+		}
+		if content[i] == quote {
+			b.WriteByte(quote)
+			return i + 1
+		}
+		if preserveBody {
+			b.WriteByte(content[i])
+		} else {
+			b.WriteByte(' ')
+		}
+		i++
+	}
+	return i
 }
 
 // gradleContainsCodeToken reports whether content contains needle as a

--- a/internal/rules/release_engineering_helpers.go
+++ b/internal/rules/release_engineering_helpers.go
@@ -124,6 +124,252 @@ func hardcodedEnvironmentLiteral(text string, labelPresent bool) string {
 	return unquoted
 }
 
+// gradleStripCommentsFull returns content with Gradle (Groovy /
+// Kotlin DSL) line comments and block comments replaced by spaces
+// (preserving newlines). String literal bodies are preserved verbatim,
+// which lets classifier substring checks see plugin-id strings like
+// `'com.android.library'` while ignoring `// classpath
+// 'com.android.application'` and `/* ... applicationId ... */` blocks.
+// Triple-quoted Kotlin / Groovy strings are recognised so a `*/`
+// embedded inside a raw string does not falsely close a comment, and
+// backslash escapes inside regular strings are honored so an escaped
+// quote does not prematurely close the literal.
+func gradleStripCommentsFull(content string) string {
+	var b strings.Builder
+	b.Grow(len(content))
+	n := len(content)
+	i := 0
+	for i < n {
+		c := content[i]
+		// Block comment.
+		if c == '/' && i+1 < n && content[i+1] == '*' {
+			b.WriteByte(' ')
+			b.WriteByte(' ')
+			i += 2
+			for i < n {
+				if content[i] == '*' && i+1 < n && content[i+1] == '/' {
+					b.WriteByte(' ')
+					b.WriteByte(' ')
+					i += 2
+					break
+				}
+				if content[i] == '\n' {
+					b.WriteByte('\n')
+				} else {
+					b.WriteByte(' ')
+				}
+				i++
+			}
+			continue
+		}
+		// Line comment.
+		if c == '/' && i+1 < n && content[i+1] == '/' {
+			for i < n && content[i] != '\n' {
+				b.WriteByte(' ')
+				i++
+			}
+			continue
+		}
+		// Triple-quoted string (Kotlin raw / Groovy multi-line). Bodies
+		// are written through unchanged so plugin-id references inside
+		// such strings remain visible to substring checks; we only
+		// skip the lexer past the closing delimiter so a stray `*/` or
+		// `//` inside the string does not start a comment.
+		if (c == '"' || c == '\'') && i+2 < n && content[i+1] == c && content[i+2] == c {
+			quote := c
+			b.WriteByte(quote)
+			b.WriteByte(quote)
+			b.WriteByte(quote)
+			i += 3
+			for i < n {
+				if i+2 < n && content[i] == quote && content[i+1] == quote && content[i+2] == quote {
+					b.WriteByte(quote)
+					b.WriteByte(quote)
+					b.WriteByte(quote)
+					i += 3
+					break
+				}
+				b.WriteByte(content[i])
+				i++
+			}
+			continue
+		}
+		// Regular string literal — body preserved, but the lexer
+		// consumes through the closing quote so `//` inside the string
+		// is not misread as a line comment.
+		if c == '"' || c == '\'' {
+			quote := c
+			b.WriteByte(quote)
+			i++
+			escaped := false
+			for i < n {
+				if content[i] == '\n' {
+					// Unterminated literal; bail without consuming the
+					// newline so subsequent code is processed normally.
+					break
+				}
+				if escaped {
+					escaped = false
+					b.WriteByte(content[i])
+					i++
+					continue
+				}
+				if content[i] == '\\' {
+					escaped = true
+					b.WriteByte(content[i])
+					i++
+					continue
+				}
+				if content[i] == quote {
+					b.WriteByte(quote)
+					i++
+					break
+				}
+				b.WriteByte(content[i])
+				i++
+			}
+			continue
+		}
+		b.WriteByte(c)
+		i++
+	}
+	return b.String()
+}
+
+// gradleStripCommentsAndStringBodiesFull returns content with Gradle
+// (Groovy / Kotlin DSL) comments and string literal bodies replaced by
+// spaces (preserving newlines). Both regular and triple-quoted strings
+// are handled. The output preserves quote characters, comment-start
+// punctuation positions, and newlines, so a substring search for a code
+// token such as `applicationId` only sees real DSL references.
+func gradleStripCommentsAndStringBodiesFull(content string) string {
+	var b strings.Builder
+	b.Grow(len(content))
+	n := len(content)
+	i := 0
+	for i < n {
+		c := content[i]
+		// Block comment.
+		if c == '/' && i+1 < n && content[i+1] == '*' {
+			b.WriteByte(' ')
+			b.WriteByte(' ')
+			i += 2
+			for i < n {
+				if content[i] == '*' && i+1 < n && content[i+1] == '/' {
+					b.WriteByte(' ')
+					b.WriteByte(' ')
+					i += 2
+					break
+				}
+				if content[i] == '\n' {
+					b.WriteByte('\n')
+				} else {
+					b.WriteByte(' ')
+				}
+				i++
+			}
+			continue
+		}
+		// Line comment.
+		if c == '/' && i+1 < n && content[i+1] == '/' {
+			for i < n && content[i] != '\n' {
+				b.WriteByte(' ')
+				i++
+			}
+			continue
+		}
+		// Triple-quoted string body — blanked out.
+		if (c == '"' || c == '\'') && i+2 < n && content[i+1] == c && content[i+2] == c {
+			quote := c
+			b.WriteByte(quote)
+			b.WriteByte(quote)
+			b.WriteByte(quote)
+			i += 3
+			for i < n {
+				if i+2 < n && content[i] == quote && content[i+1] == quote && content[i+2] == quote {
+					b.WriteByte(quote)
+					b.WriteByte(quote)
+					b.WriteByte(quote)
+					i += 3
+					break
+				}
+				if content[i] == '\n' {
+					b.WriteByte('\n')
+				} else {
+					b.WriteByte(' ')
+				}
+				i++
+			}
+			continue
+		}
+		// Regular string literal — body blanked out.
+		if c == '"' || c == '\'' {
+			quote := c
+			b.WriteByte(quote)
+			i++
+			escaped := false
+			for i < n {
+				if content[i] == '\n' {
+					break
+				}
+				if escaped {
+					escaped = false
+					b.WriteByte(' ')
+					i++
+					continue
+				}
+				if content[i] == '\\' {
+					escaped = true
+					b.WriteByte(' ')
+					i++
+					continue
+				}
+				if content[i] == quote {
+					b.WriteByte(quote)
+					i++
+					break
+				}
+				b.WriteByte(' ')
+				i++
+			}
+			continue
+		}
+		b.WriteByte(c)
+		i++
+	}
+	return b.String()
+}
+
+// gradleContainsCodeToken reports whether content contains needle as a
+// whole token outside string literals or comments. Caller should pass
+// the output of gradleStripCommentsAndStringBodiesFull as content so
+// the check only sees real code. Word-boundary matching uses
+// isGradleIdentByte so `myApplicationIdSuffix` won't be reported for
+// `applicationId`, and `com.android.application2` won't be reported
+// for `com.android.application`.
+func gradleContainsCodeToken(content, needle string) bool {
+	for offset := 0; ; {
+		idx := strings.Index(content[offset:], needle)
+		if idx < 0 {
+			return false
+		}
+		idx += offset
+		offset = idx + len(needle)
+		if idx > 0 && isGradleIdentByte(content[idx-1]) {
+			continue
+		}
+		end := idx + len(needle)
+		if end < len(content) && isGradleIdentByte(content[end]) {
+			continue
+		}
+		return true
+	}
+}
+
+func isGradleIdentByte(c byte) bool {
+	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '_' || c == '$'
+}
+
 // stripBlockComments removes /* ... */ regions from line, threading the
 // open-block state across lines. The returned bool reports whether the
 // line ends still inside an unclosed block comment.

--- a/internal/rules/release_engineering_internal_test.go
+++ b/internal/rules/release_engineering_internal_test.go
@@ -1,6 +1,13 @@
 package rules
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kaeawc/krit/internal/scanner"
+)
 
 func TestDebugToastPrefixRegex(t *testing.T) {
 	cases := []struct {
@@ -23,5 +30,300 @@ func TestDebugToastPrefixRegex(t *testing.T) {
 		if got != tc.want {
 			t.Errorf("debugToastPrefixRe.MatchString(%q) = %v, want %v", tc.text, got, tc.want)
 		}
+	}
+}
+
+// TestHasLoggingImportPrefixAnchored regresses bug A: the previous
+// implementation used strings.Contains for matching a logging-package
+// prefix, so non-logging imports whose path happened to include "mu." or
+// "java.util.logging." as a substring were incorrectly classified as
+// logging imports.
+func TestHasLoggingImportPrefixAnchored(t *testing.T) {
+	cases := []struct {
+		name   string
+		source string
+		want   bool
+	}{
+		{
+			name: "java.util.logging positive",
+			source: "package com.example\n" +
+				"\n" +
+				"import java.util.logging.Logger\n",
+			want: true,
+		},
+		{
+			name: "demu lookalike negative",
+			source: "package com.example\n" +
+				"\n" +
+				"import com.example.demu.LoggerFacade\n",
+			want: false,
+		},
+		{
+			name: "foo.mu lookalike negative",
+			source: "package com.example\n" +
+				"\n" +
+				"import foo.mu.X\n",
+			want: false,
+		},
+		{
+			name: "java.util.logging substring negative",
+			source: "package com.example\n" +
+				"\n" +
+				"import org.example.java.util.logging.X\n",
+			want: false,
+		},
+		{
+			name: "timber positive",
+			source: "package com.example\n" +
+				"\n" +
+				"import timber.log.Timber\n",
+			want: true,
+		},
+		{
+			name: "java import with semicolon positive",
+			source: "package com.example;\n" +
+				"\n" +
+				"import java.util.logging.Logger;\n",
+			want: true,
+		},
+		{
+			name: "kotlin import with alias positive",
+			source: "package com.example\n" +
+				"\n" +
+				"import java.util.logging.Logger as JLogger\n",
+			want: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			file := &scanner.File{Lines: strings.Split(tc.source, "\n")}
+			got := hasLoggingImport(file)
+			if got != tc.want {
+				t.Fatalf("hasLoggingImport = %v, want %v\nsource:\n%s", got, tc.want, tc.source)
+			}
+		})
+	}
+}
+
+// TestReadSourceModuleGradleInfoLexical regresses bug B: a commented-out
+// plugin id or a string literal containing "applicationId" must not flip
+// a library module's classification to "application".
+func TestReadSourceModuleGradleInfoLexical(t *testing.T) {
+	cases := []struct {
+		name          string
+		filename      string
+		content       string
+		isApplication bool
+		isLibrary     bool
+	}{
+		{
+			name:     "kts plugin id is application",
+			filename: "build.gradle.kts",
+			content: `plugins {
+    id("com.android.application")
+}
+`,
+			isApplication: true,
+			isLibrary:     false,
+		},
+		{
+			name:     "kts plugin id is library",
+			filename: "build.gradle.kts",
+			content: `plugins {
+    id("com.android.library")
+}
+`,
+			isApplication: false,
+			isLibrary:     true,
+		},
+		{
+			name:     "commented classpath does not classify as application",
+			filename: "build.gradle",
+			content: `// classpath 'com.android.application'
+
+plugins {
+    id 'com.android.library'
+}
+`,
+			isApplication: false,
+			isLibrary:     true,
+		},
+		{
+			name:     "applicationId inside string description does not classify as application",
+			filename: "build.gradle.kts",
+			content: `plugins {
+    id("com.android.library")
+}
+
+description = "applicationId is configured per flavor"
+`,
+			isApplication: false,
+			isLibrary:     true,
+		},
+		{
+			name:     "block-commented application plugin id does not classify as application",
+			filename: "build.gradle.kts",
+			content: `/*
+ * plugins {
+ *     id("com.android.application")
+ * }
+ */
+plugins {
+    id("com.android.library")
+}
+`,
+			isApplication: false,
+			isLibrary:     true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			if err := os.WriteFile(filepath.Join(dir, tc.filename), []byte(tc.content), 0o644); err != nil {
+				t.Fatalf("write %s: %v", tc.filename, err)
+			}
+			info := readSourceModuleGradleInfo(dir)
+			if !info.found {
+				t.Fatalf("expected info.found=true for %s", tc.filename)
+			}
+			if info.isApplication != tc.isApplication {
+				t.Errorf("isApplication = %v, want %v", info.isApplication, tc.isApplication)
+			}
+			if info.isLibrary != tc.isLibrary {
+				t.Errorf("isLibrary = %v, want %v", info.isLibrary, tc.isLibrary)
+			}
+		})
+	}
+}
+
+// TestGradleStripCommentsFullPreservesStrings asserts that the
+// comments-only stripper removes line and block comments but leaves
+// string literal bodies intact — Gradle plugin ids live inside string
+// literals, and the classifier still needs to see them.
+func TestGradleStripCommentsFullPreservesStrings(t *testing.T) {
+	cases := []struct {
+		name      string
+		input     string
+		keepToken string
+		dropToken string
+	}{
+		{
+			name:      "line comment is stripped, plugin string kept",
+			input:     "// id 'com.android.application'\nid 'com.android.library'\n",
+			keepToken: "com.android.library",
+			dropToken: "com.android.application",
+		},
+		{
+			name:      "block comment is stripped",
+			input:     "/* id 'com.android.application' */\nid 'com.android.library'\n",
+			keepToken: "com.android.library",
+			dropToken: "com.android.application",
+		},
+		{
+			name:      "string body is preserved",
+			input:     "id 'com.android.library'\n",
+			keepToken: "com.android.library",
+			dropToken: "com.android.application",
+		},
+		{
+			name:      "double-slash inside string is not a comment",
+			input:     "val url = \"http://example.com\"\nid 'com.android.library'\n",
+			keepToken: "http://example.com",
+			dropToken: "TOKEN_NOT_PRESENT",
+		},
+		{
+			name:      "block-comment terminator inside raw string does not close a non-existent comment",
+			input:     "val s = \"\"\"*/keep_me*/\"\"\"\nid 'com.android.library'\n",
+			keepToken: "keep_me",
+			dropToken: "TOKEN_NOT_PRESENT",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := gradleStripCommentsFull(tc.input)
+			if !strings.Contains(got, tc.keepToken) {
+				t.Errorf("expected %q to remain in stripped output, got %q", tc.keepToken, got)
+			}
+			if tc.dropToken != "TOKEN_NOT_PRESENT" && strings.Contains(got, tc.dropToken) {
+				t.Errorf("expected %q to be removed from stripped output, got %q", tc.dropToken, got)
+			}
+		})
+	}
+}
+
+// TestGradleStripCommentsAndStringBodiesFullBlanksLiterals asserts the
+// stricter stripper used for identifier-style classifier tokens: both
+// comments and string literal bodies are blanked out so a substring
+// like "applicationId" only matches real DSL property references.
+func TestGradleStripCommentsAndStringBodiesFullBlanksLiterals(t *testing.T) {
+	cases := []struct {
+		name      string
+		input     string
+		keepToken string
+		dropToken string
+	}{
+		{
+			name:      "applicationId inside double-quoted string is blanked",
+			input:     "description = \"applicationId is configured per flavor\"\napplicationId = \"com.example.app\"\n",
+			keepToken: "description",
+			dropToken: "configured",
+		},
+		{
+			name:      "applicationId inside single-quoted string is blanked",
+			input:     "description = 'applicationId is configured'\n",
+			keepToken: "description",
+			dropToken: "applicationId",
+		},
+		{
+			name:      "applicationId inside triple-quoted string is blanked",
+			input:     "val s = \"\"\"applicationId is configured\"\"\"\n",
+			keepToken: "val s",
+			dropToken: "applicationId",
+		},
+		{
+			name:      "escaped quote keeps lexer inside literal",
+			input:     "val s = \"applicationId is \\\"x\\\"\"\n",
+			keepToken: "val s",
+			dropToken: "applicationId",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := gradleStripCommentsAndStringBodiesFull(tc.input)
+			if !strings.Contains(got, tc.keepToken) {
+				t.Errorf("expected %q to remain in stripped output, got %q", tc.keepToken, got)
+			}
+			if strings.Contains(got, tc.dropToken) {
+				t.Errorf("expected %q to be removed from stripped output, got %q", tc.dropToken, got)
+			}
+		})
+	}
+}
+
+// TestGradleContainsCodeToken covers the word-boundary lookup used to
+// confirm an Android DSL property identifier appears outside string
+// literals. Inputs are pre-stripped by
+// gradleStripCommentsAndStringBodiesFull so this test feeds already-
+// stripped content.
+func TestGradleContainsCodeToken(t *testing.T) {
+	cases := []struct {
+		name   string
+		input  string
+		needle string
+		want   bool
+	}{
+		{"bare property assignment", "applicationId = \"x\"", "applicationId", true},
+		{"trailing call paren", "applicationId(\"x\")", "applicationId", true},
+		{"property at end of file", "applicationId", "applicationId", true},
+		{"longer identifier rejected", "myApplicationIdSuffix", "applicationId", false},
+		{"prefix-only identifier rejected", "applicationIdentity = 1", "applicationId", false},
+		{"completely absent", "id = 1", "applicationId", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := gradleContainsCodeToken(tc.input, tc.needle); got != tc.want {
+				t.Fatalf("gradleContainsCodeToken(%q, %q) = %v, want %v", tc.input, tc.needle, got, tc.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

Two related false-positive sources in `internal/rules/release_engineering.go`.

### Bug A: `hasLoggingImport` substring match

Used `strings.Contains(pkg, prefix)` to detect logging-package imports for prefixes like `mu.` and `java.util.logging.`. That matches anywhere in the import path, so `import com.example.demu.X` falsely qualifies as a logging import and triggers `PrintStackTraceInProduction` and friends. Fix: anchor with `strings.HasPrefix` after trimming the leading `import` keyword and any whitespace.

### Bug B: `sourceModuleGradleInfo` not lexically aware

Used `strings.Contains(content, \"com.android.application\")` and `applicationId` against the whole Gradle file as a flat string. A commented-out plugin id (`// com.android.application`) or a string literal mentioning `applicationId` in an unrelated description flipped a library module into the \"application\" classification, causing downstream Android-only rules to misfire on library modules. Fix: add a small lexical scan that strips `//` line comments, `/* ... */` block comments, and skips `\"...\"` / `'...'` string literals before testing the markers.

## Tests

- `TestPrintStackTraceInProduction_LoggingImportPrefix` — `import com.example.demu.X` no longer matches; `import java.util.logging.Logger` still does.
- `TestPrintStackTraceInProduction_LoggingImportCommentForms` — line/block comments around the import path no longer false-match.
- `TestSourceModuleGradleInfo_*` — commented-out plugin id, string-literal mentions, and live plugin blocks now classify correctly.

## Test plan

- [ ] CI passes (build, vet, lint, full test suite).
- [ ] Auto-merge with squash once green.