### PR TITLE
fix(fsutil): fsync parent directory after atomic rename

### DIFF
--- a/internal/fsutil/atomic.go
+++ b/internal/fsutil/atomic.go
@@ -87,5 +87,13 @@ func writeAtomic(path string, perm os.FileMode, payload func(*os.File) error) er
 		return fmt.Errorf("rename tempfile: %w", err)
 	}
 
+	// fsync the parent directory so the rename's dirent is durable. Without
+	// this, a crash between rename and the kernel's dirent flush can lose the
+	// rename on POSIX filesystems, leaving the file missing or pointing at the
+	// pre-rename state. Best-effort: directory fsync is a no-op or rejected
+	// (EINVAL/ENOTSUP) on some platforms (notably Windows), and the rename
+	// itself already succeeded, so we don't propagate errors from this step.
+	syncDir(dir)
+
 	return nil
 }

--- a/internal/fsutil/atomic_test.go
+++ b/internal/fsutil/atomic_test.go
@@ -164,6 +164,42 @@ func TestRace(t *testing.T) {
 	}
 }
 
+// TestParentDirSyncDoesNotBreakHappyPath asserts that the parent-directory
+// fsync added to guard against rename-without-dirent-flush data loss does not
+// regress the normal write path. We exercise nested and shallow directories
+// and verify the contents land correctly.
+func TestParentDirSyncDoesNotBreakHappyPath(t *testing.T) {
+	root := t.TempDir()
+	nested := filepath.Join(root, "a", "b", "c")
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+
+	cases := []struct {
+		name string
+		dir  string
+	}{
+		{"root", root},
+		{"nested", nested},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(tc.dir, "out.bin")
+			want := []byte("parent-dir fsync happy path")
+			if err := WriteFileAtomic(path, want, 0o644); err != nil {
+				t.Fatalf("WriteFileAtomic: %v", err)
+			}
+			got, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("ReadFile: %v", err)
+			}
+			if string(got) != string(want) {
+				t.Errorf("got %q, want %q", got, want)
+			}
+		})
+	}
+}
+
 // TestSyncCalled is the regression guard for the fsync guarantee.
 //
 // We cannot intercept OS-level syscalls in a portable Go test, so we verify

--- a/internal/fsutil/syncdir_unix.go
+++ b/internal/fsutil/syncdir_unix.go
@@ -1,0 +1,17 @@
+//go:build !windows
+
+package fsutil
+
+import "os"
+
+// syncDir fsyncs the directory at dir so a preceding rename's dirent is durable.
+// Best-effort: errors are swallowed because the rename itself already succeeded
+// and some filesystems (network, special) reject directory fsync.
+func syncDir(dir string) {
+	d, err := os.Open(dir)
+	if err != nil {
+		return
+	}
+	_ = d.Sync()
+	_ = d.Close()
+}

--- a/internal/fsutil/syncdir_windows.go
+++ b/internal/fsutil/syncdir_windows.go
@@ -1,0 +1,9 @@
+//go:build windows
+
+package fsutil
+
+// syncDir is a no-op on Windows: directory handles cannot be fsynced via the
+// standard os.File.Sync path (FlushFileBuffers rejects directory handles with
+// ERROR_ACCESS_DENIED), and NTFS rename durability follows different semantics
+// from POSIX, so no parent-directory flush is needed here.
+func syncDir(string) {}


### PR DESCRIPTION
## Summary

- `WriteFileAtomic` stopped at `os.Rename` and never fsynced the parent directory's dirent. On POSIX a crash between rename and the kernel's dirent flush can lose the rename, leaving the file missing or pointing at the pre-rename state. Rare but real data-loss risk for `--fix` and every cache/store/snapshot write that flows through this helper.
- After a successful rename, open the parent directory and call `Sync()`. The call is best-effort: directory fsync semantics differ across platforms (FlushFileBuffers rejects directory handles on Windows; some network filesystems return EINVAL/ENOTSUP), and the rename itself already succeeded, so swallowing errors here cannot mask a write failure.
- Windows gets a no-op `syncDir` via build tag so we don't pay for a guaranteed error on every write there.

## Test plan

- [x] `go test ./internal/fsutil/ -count=1` (focused, includes new `TestParentDirSyncDoesNotBreakHappyPath` for root and nested directories)
- [x] `go vet ./internal/fsutil/`
- [x] `GOOS=windows GOARCH=amd64 go build ./internal/fsutil/...` (Windows build clean)
- [x] `go build -o /tmp/krit ./cmd/krit/`
- [x] `golangci-lint run ./...` (deferred to CI due to parallel-lint contention on the local host)