### PR TITLE
fix(rules): require expression body for require!! exemption

### DIFF
--- a/internal/rules/potentialbugs_nullsafety_bangbang.go
+++ b/internal/rules/potentialbugs_nullsafety_bangbang.go
@@ -42,16 +42,41 @@ func isRequireFunctionBangBodyFlat(file *scanner.File, idx uint32) bool {
 			return false
 		}
 	}
-	fnText := file.FlatNodeText(fn)
-	if !strings.Contains(fnText, "=") {
+	// The exemption is intended for `fun requireX(): T = expr!!` — the
+	// expression-body form where the function name documents the precondition.
+	// Detect this structurally via the AST: the function_body must start with
+	// `=` (expression body), not `{` (block body). A scan of `fnText` for `=`
+	// also matches default args like `requireX(x: Int = 0)` and block-body
+	// `val y = ...` assignments, silently skipping real `!!` bugs.
+	return flatFunctionHasExpressionBody(file, fn)
+}
+
+// flatFunctionHasExpressionBody reports whether the function_declaration at fn
+// uses an expression body (`fun f(): T = expr`) rather than a block body
+// (`fun f(): T { ... }`). A function with no body at all (abstract / interface)
+// returns false.
+func flatFunctionHasExpressionBody(file *scanner.File, fn uint32) bool {
+	if file == nil || fn == 0 || file.FlatType(fn) != "function_declaration" {
 		return false
 	}
-	afterEq := strings.SplitN(fnText, "=", 2)
-	if len(afterEq) != 2 {
+	body, ok := file.FlatFindChild(fn, "function_body")
+	if !ok || body == 0 {
 		return false
 	}
-	body := strings.TrimSpace(afterEq[1])
-	return !strings.HasPrefix(body, "{")
+	// The function_body's first non-named child is either `=` (expression
+	// body) or `{` (block body).
+	for child := file.FlatFirstChild(body); child != 0; child = file.FlatNextSib(child) {
+		if file.FlatIsNamed(child) {
+			continue
+		}
+		switch file.FlatType(child) {
+		case "=":
+			return true
+		case "{":
+			return false
+		}
+	}
+	return false
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/fixtures/negative/potential-bugs/UnsafeCallOnNullableType.kt
+++ b/tests/fixtures/negative/potential-bugs/UnsafeCallOnNullableType.kt
@@ -60,6 +60,10 @@ class AppInspiredSafePatterns {
 
     fun requireController(): Controller = controller!!
 
+    // Regression: expression-body `requireX` with a parameter (and therefore
+    // a `=` somewhere in the function text) must still be exempt.
+    fun requireNonNull(x: Controller?): Controller = x!!
+
     fun assignedBeforeUse() {
         if (controller == null) {
             controller = Controller()

--- a/tests/fixtures/positive/potential-bugs/UnsafeCallOnNullableType.kt
+++ b/tests/fixtures/positive/potential-bugs/UnsafeCallOnNullableType.kt
@@ -55,3 +55,22 @@ class AppInspiredUnsafePatterns {
         controller!!.start()
     }
 }
+
+// Regression: `requireX` exemption must be limited to expression bodies.
+// Block-body `requireX` with a default arg or local `val x = ...` should
+// still fire — the old `strings.SplitN(fnText, "=", 2)` heuristic incorrectly
+// matched the default-arg `=` and the assignment `=`, silently skipping these
+// real `!!` bugs.
+class RequireBlockBodyShouldFire {
+    private fun compute(): Int? = 1
+    private fun makeFoo(): String? = null
+
+    fun requireFoo(x: Int = 0): String {
+        val y = compute()
+        return y!!.toString()
+    }
+
+    fun requireBar(): String {
+        return makeFoo()!!
+    }
+}


### PR DESCRIPTION
## Summary

`UnsafeCallOnNullableType` exempts `!!` inside `fun requireX(): T = expr`, where the function name documents the precondition. The old guard accepted *any* `=` in the function's source text, so:

- a default-arg `=` (`fun requireFoo(x: Int = 0): String { ... return y!! }`), or
- a block-body assignment `=` (`fun requireBar(): String { val y = compute(); return y!! }`)

was enough to satisfy the heuristic and the rule silently dropped the `!!` finding even though the body is a real block body.

The exemption now checks the flat AST structurally: walk the `function_body` child and require its first non-named child to be `=` (expression body), not `{` (block body). A function with no body at all (abstract / interface) returns false.

## Test plan

- [x] `go build -o /tmp/krit ./cmd/krit/`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...` (clean before parallel agents grabbed the lock)
- [x] `go test ./internal/rules/ -run 'TestPositiveFixtures/positive/UnsafeCallOnNullableType|TestNegativeFixtures/negative/UnsafeCallOnNullableType' -count=1 -v` — both pass
- [x] `go test ./internal/rules/ -run "TestPositive|TestNegative|TestNullable|TestUnsafe" -count=1` — pass
- [x] New positive fixtures (block-body `requireFoo(x: Int = 0)` and `requireBar()`) now fire.
- [x] New negative fixture (`fun requireNonNull(x: Controller?): Controller = x!!`) still skipped.