### PR TITLE
test(rules): expand NotImplementedDeclaration fixtures and tests

### DIFF
--- a/internal/rules/exceptions_test.go
+++ b/internal/rules/exceptions_test.go
@@ -304,34 +304,49 @@ fun process() {
 	}
 }
 
-// Local-lookalike: `foo.TODO()` is a member call, not kotlin.TODO. The rule
-// must require receiver/owner proof that the call resolves to the kotlin
-// stdlib TODO — bare `TODO(...)` or fully-qualified `kotlin.TODO(...)`.
-func TestExc_NotImplementedDeclaration_Negative_MemberReceiver(t *testing.T) {
+// Regression: flatCallExpressionName returns the rightmost identifier of a
+// navigation chain, so `svc.TODO()` would otherwise be reported as
+// `kotlin.TODO`. Only bare TODO() and the explicitly-qualified kotlin.TODO()
+// should fire.
+func TestExc_NotImplementedDeclaration_IgnoresNavigationReceivers(t *testing.T) {
 	findings := runRuleByName(t, "NotImplementedDeclaration", `
-class Tracker {
-    fun TODO(label: String) { println(label) }
+class Service {
+    fun TODO(): String = "x"
 }
 
-fun useTracker() {
-    val tracker = Tracker()
-    tracker.TODO("future")
+class Caller(private val svc: Service) {
+    fun a(): String = svc.TODO()
+    fun b(): String = this.svc.TODO()
 }
+
+object Registry {
+    fun TODO(): String = "y"
+}
+
+fun obj(): String = Registry.TODO()
 `)
 	if len(findings) != 0 {
-		t.Fatalf("expected no findings for member call foo.TODO(), got %d", len(findings))
+		t.Fatalf("expected no findings for non-kotlin receivers, got %d:\n%v", len(findings), findings)
 	}
 }
 
-// Fully-qualified `kotlin.TODO(...)` IS kotlin.TODO and must be flagged.
-func TestExc_NotImplementedDeclaration_Positive_FullyQualified(t *testing.T) {
+func TestExc_NotImplementedDeclaration_FiresOnKotlinQualified(t *testing.T) {
 	findings := runRuleByName(t, "NotImplementedDeclaration", `
-fun process() {
-    kotlin.TODO("not yet")
-}
+fun a(): Nothing = kotlin.TODO()
+fun b(): Nothing = kotlin.TODO("not yet")
 `)
-	if len(findings) == 0 {
-		t.Fatal("expected finding for kotlin.TODO() call")
+	if len(findings) != 2 {
+		t.Fatalf("expected 2 findings for kotlin.TODO() calls, got %d:\n%v", len(findings), findings)
+	}
+}
+
+func TestExc_NotImplementedDeclaration_FiresOnBareCall(t *testing.T) {
+	findings := runRuleByName(t, "NotImplementedDeclaration", `
+fun a(): Nothing = TODO()
+fun b(): Nothing = TODO("not yet")
+`)
+	if len(findings) != 2 {
+		t.Fatalf("expected 2 findings for bare TODO() calls, got %d:\n%v", len(findings), findings)
 	}
 }
 

--- a/tests/fixtures/negative/exceptions/NotImplementedDeclaration.kt
+++ b/tests/fixtures/negative/exceptions/NotImplementedDeclaration.kt
@@ -1,13 +1,44 @@
 package exceptions
 
-class Example {
-    fun foo() {
-        doWork()
+// Bare TODO() and kotlin.TODO() are the only forms that resolve to
+// kotlin.TODO; navigation calls on user types must not be flagged just
+// because the rightmost identifier happens to be TODO.
+
+class Service {
+    fun TODO(): String = "user-defined TODO"
+    fun other(): String = "x"
+}
+
+class Caller(private val svc: Service) {
+    fun a(): String = svc.TODO()
+    fun b(): String = svc.other()
+}
+
+object Registry {
+    fun TODO(): String = "object-defined TODO"
+}
+
+fun useObjectMember(): String = Registry.TODO()
+
+class Nested {
+    inner class Inner {
+        fun TODO(): String = "inner TODO"
     }
 
-    private fun doWork() {
-        println("working")
+    fun useInner(): String {
+        val inner = Inner()
+        return inner.TODO()
     }
+
+    fun useDeepChain(c: Caller): String = c.svc.TODO()
+}
+
+fun ordinaryWork() {
+    doWork()
+}
+
+private fun doWork() {
+    println("working")
 }
 
 // Local lookalikes: member functions named `TODO` on non-kotlin receivers must

--- a/tests/fixtures/positive/exceptions/NotImplementedDeclaration.kt
+++ b/tests/fixtures/positive/exceptions/NotImplementedDeclaration.kt
@@ -1,12 +1,19 @@
 package exceptions
 
 class Example {
-    fun foo() {
+    fun bareNoMessage() {
+        TODO()
+    }
+
+    fun bareWithMessage() {
         TODO("implement later")
     }
 
-    fun bar() {
-        // Fully-qualified kotlin.TODO is still a kotlin.TODO usage.
+    fun fullyQualified() {
+        kotlin.TODO()
+    }
+
+    fun fullyQualifiedWithMessage() {
         kotlin.TODO("not yet")
     }
 }


### PR DESCRIPTION
## Summary

The `isKotlinTODOCall` helper already on `main` ([#405](https://github.com/kaeawc/krit/pull/405)) requires either a bare `TODO(...)` or an explicit `kotlin.TODO(...)` qualification before `NotImplementedDeclaration` fires, so the original fix this PR proposed is no longer needed.

What remains, after rebasing onto `main`, is a denser fixture and test surface for the same behavior:

- **Negative fixture**: user-defined `TODO` members on a class, an `object`, a nested `inner class`, plus a deep navigation chain (`c.svc.TODO()`).
- **Positive fixture**: separate cases for bare `TODO()`, bare `TODO("…")`, `kotlin.TODO()`, and `kotlin.TODO("…")`.
- **Tests**: one navigation-receiver negative covering svc / `this.svc` / `object` receivers; per-shape positives that pin the expected finding counts (rather than `len(findings) == 0`).

## Test plan

- [x] \`go test ./... -count=1\` — full suite green locally.
- [x] \`golangci-lint run ./...\` — 0 issues.
- [ ] CI green on the PR.