### PR TITLE
fix(rules): detect safe-call/Elvis via AST in NullableStructuredFieldRule

### DIFF
--- a/internal/rules/logging.go
+++ b/internal/rules/logging.go
@@ -773,8 +773,58 @@ func (r *NullableStructuredFieldRule) shouldFlag(file *scanner.File, idx uint32)
 	if expr == 0 {
 		return false
 	}
-	text := file.FlatNodeText(expr)
-	return strings.Contains(text, "?.") && !strings.Contains(text, "?:")
+	return nullableSafeCallWithoutElvis(file, expr)
+}
+
+// nullableSafeCallWithoutElvis reports whether the expression rooted at idx
+// contains an actual `?.` safe-navigation token outside any string literal
+// and is not the receiver of an `?:` Elvis expression that supplies a
+// fallback. Detection runs over the flat AST rather than raw text so that
+// string-literal contents such as `"use ?. operator"` cannot trigger a
+// false positive.
+func nullableSafeCallWithoutElvis(file *scanner.File, idx uint32) bool {
+	if file == nil || idx == 0 {
+		return false
+	}
+	// An Elvis expression at the top supplies the fallback; any safe call
+	// inside is paired with `?:` so the rule should not fire.
+	if file.FlatType(idx) == "elvis_expression" {
+		return false
+	}
+	return flatExpressionHasSafeCallOutsideStrings(file, idx)
+}
+
+// flatExpressionHasSafeCallOutsideStrings walks the flat AST rooted at idx
+// and returns true when it finds a `?.` token node that is not nested inside
+// a string literal. It also returns false if any enclosing/descendant Elvis
+// expression provides a fallback for the safe call.
+func flatExpressionHasSafeCallOutsideStrings(file *scanner.File, idx uint32) bool {
+	if file == nil || idx == 0 {
+		return false
+	}
+	hasSafe := false
+	hasElvis := false
+	var walk func(uint32)
+	walk = func(node uint32) {
+		if node == 0 || hasSafe && hasElvis {
+			return
+		}
+		switch file.FlatType(node) {
+		case "string_literal", "line_string_literal", "multi_line_string_literal",
+			"raw_string_literal", "character_literal",
+			"line_comment", "multiline_comment":
+			return
+		case "?.":
+			hasSafe = true
+		case "elvis_expression":
+			hasElvis = true
+		}
+		for i := 0; i < file.FlatChildCount(node); i++ {
+			walk(file.FlatChild(node, i))
+		}
+	}
+	walk(idx)
+	return hasSafe && !hasElvis
 }
 
 func firstCorrelationSensitiveLogCallFlat(file *scanner.File, idx uint32) uint32 {

--- a/internal/rules/observability_test.go
+++ b/internal/rules/observability_test.go
@@ -1373,6 +1373,31 @@ fun nullable(logger: Logger, user: User?) {
 	}
 }
 
+// TestNullableStructuredField_NegativeSafeCallInStringLiteral is a regression
+// test for the prior raw-text scan that flagged any value-expression text
+// containing "?." even when those bytes appeared inside a string literal.
+func TestNullableStructuredField_NegativeSafeCallInStringLiteral(t *testing.T) {
+	findings := runRuleByName(t, "NullableStructuredField", `
+package test
+
+interface Logger {
+    fun atInfo(): Event
+}
+interface Event {
+    fun addKeyValue(key: String, value: Any?): Event
+    fun log(message: String)
+}
+
+fun documented(logger: Logger) {
+    logger.atInfo().addKeyValue("note", "use ?. operator when nullable").log("ready")
+    logger.atInfo().addKeyValue("hint", "x?.y").log("ready")
+}
+`)
+	if len(findings) != 0 {
+		t.Fatalf("expected 0 findings, got %d: %v", len(findings), findings)
+	}
+}
+
 func TestMetricTimerOutsideBlock_PositivePropertyRead(t *testing.T) {
 	findings := runRuleByName(t, "MetricTimerOutsideBlock", `
 package test

--- a/tests/fixtures/negative/observability/NullableStructuredField.kt
+++ b/tests/fixtures/negative/observability/NullableStructuredField.kt
@@ -19,3 +19,8 @@ fun handle(logger: Logger, user: User) {
 fun nullable(logger: Logger, user: User?) {
     logger.atInfo().addKeyValue("user_id", user?.id ?: "anonymous").log("ready")
 }
+
+fun documented(logger: Logger) {
+    logger.atInfo().addKeyValue("note", "use ?. operator when nullable").log("ready")
+    logger.atInfo().addKeyValue("hint", "x?.y").log("ready")
+}


### PR DESCRIPTION
## Summary

- `NullableStructuredFieldRule.shouldFlag` scanned the raw text of an `addKeyValue` value-argument for `?.` and `?:`, so any call whose value literal contained those characters (e.g. `addKeyValue("note", "use ?. operator when nullable")`) produced a false "nullable safe-call without Elvis fallback" finding.
- Replace the text scan with a flat-AST walk that recognises actual `?.` token nodes and `elvis_expression` nodes, while skipping descent into string/character literals and comments so byte-level occurrences inside string content can no longer trip the rule.
- Extend the negative fixture and add a focused regression test that would have fired under the old text-based detector.

## Test plan

- [x] `go build -o /tmp/krit ./cmd/krit/`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...` (0 issues)
- [x] `go test ./internal/rules/ -run 'NullableStructuredField' -count=1`
- [x] `go test ./internal/rules/ -run 'TestPositiveFixtures|TestNegativeFixtures|TestFixableFixtures' -count=1`