### PR TITLE
fix(lsp): gate shutdown/init, drop notification responses, preserve CRLF

### DIFF
--- a/internal/lsp/jar_content_test.go
+++ b/internal/lsp/jar_content_test.go
@@ -23,6 +23,7 @@ func TestJARContentReturnsStub(t *testing.T) {
 		JARPath: "/no/such-coroutines-1.7.3.jar",
 		FQN:     "kotlinx.coroutines.CoroutineScope",
 	})
+	initializedNotif := buildRequest(nil, "initialized", map[string]interface{}{})
 	contentReq := buildRequest(2, "krit/jarContent", map[string]interface{}{
 		"uri": uri,
 	})
@@ -30,6 +31,7 @@ func TestJARContentReturnsStub(t *testing.T) {
 
 	var input, output bytes.Buffer
 	input.Write(initReq)
+	input.Write(initializedNotif)
 	input.Write(contentReq)
 	input.Write(exitReq)
 
@@ -129,6 +131,7 @@ func TestJARContentRejectsNonJARURI(t *testing.T) {
 		"rootUri":      rootURI,
 		"capabilities": map[string]interface{}{},
 	})
+	initializedNotif := buildRequest(nil, "initialized", map[string]interface{}{})
 	badReq := buildRequest(2, "krit/jarContent", map[string]interface{}{
 		"uri": "file:///tmp/Foo.kt",
 	})
@@ -136,6 +139,7 @@ func TestJARContentRejectsNonJARURI(t *testing.T) {
 
 	var input, output bytes.Buffer
 	input.Write(initReq)
+	input.Write(initializedNotif)
 	input.Write(badReq)
 	input.Write(exitReq)
 

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -167,7 +167,18 @@ func (s *Server) Run() {
 }
 
 // sendResponse sends a JSON-RPC response via the shared transport.
+//
+// Notifications (JSON-RPC 2.0 messages with no `id` member) MUST NOT receive
+// a response. The dispatcher routes notifications through the same per-method
+// handlers as requests, and several of those handlers unconditionally call
+// sendResponse with req.ID — which is nil for notifications. Gating the
+// emission here keeps every handler honest without each one needing to repeat
+// the nil-id check, and avoids emitting a response with `"id":null` that
+// strict LSP clients reject.
 func (s *Server) sendResponse(id interface{}, result interface{}, rpcErr *RPCError) {
+	if id == nil {
+		return
+	}
 	jsonrpc.SendResponse(s.writer, &s.mu, id, result, rpcErr)
 }
 
@@ -177,7 +188,41 @@ func (s *Server) sendNotification(method string, params interface{}) {
 }
 
 // handleMessage dispatches a JSON-RPC request or notification.
+//
+// Two protocol gates run before any per-method dispatch:
+//
+//   - Post-shutdown: once handleShutdown has set s.shutdown, the LSP spec
+//     requires the server to respond to every request other than `exit` with
+//     InvalidRequest (-32600). Notifications received after shutdown are
+//     silently dropped.
+//   - Pre-initialize: before the client's `initialize` request has been
+//     answered, every method other than `initialize`, `initialized`, and
+//     `exit` must be rejected with ServerNotInitialized (-32002). This
+//     prevents document handlers (didOpen / codeAction / ...) from running
+//     with a nil analyzer or unloaded config and matches the conformance
+//     behaviour modern LSP clients assume.
+//
+// Both gates only emit an error response when req.ID is non-nil; notifications
+// stay silent per JSON-RPC 2.0.
 func (s *Server) handleMessage(req *Request) {
+	if s.shutdown && req.Method != "exit" {
+		if req.ID != nil {
+			s.sendResponse(req.ID, nil, &RPCError{
+				Code:    -32600,
+				Message: "server is shutting down",
+			})
+		}
+		return
+	}
+	if !s.initialized && !isInitializationExempt(req.Method) {
+		if req.ID != nil {
+			s.sendResponse(req.ID, nil, &RPCError{
+				Code:    -32002,
+				Message: "server not initialized",
+			})
+		}
+		return
+	}
 	if s.handleLifecycleMessage(req) {
 		return
 	}
@@ -192,6 +237,19 @@ func (s *Server) handleMessage(req *Request) {
 			Code:    -32601,
 			Message: "method not found: " + req.Method,
 		})
+	}
+}
+
+// isInitializationExempt reports whether method may be processed before the
+// client has sent `initialized`. The LSP spec allows only initialize, the
+// initialized notification itself, and exit; everything else must be rejected
+// with ServerNotInitialized.
+func isInitializationExempt(method string) bool {
+	switch method {
+	case "initialize", "initialized", "exit":
+		return true
+	default:
+		return false
 	}
 }
 
@@ -703,31 +761,8 @@ func findingColumnsToCodeActions(uri string, content string, columns *scanner.Fi
 			continue
 		}
 
-		var startPos, endPos Position
-		var newText string
-
-		if fix.ByteMode {
-			startPos = byteOffsetToPosition(content, fix.StartByte)
-			endPos = byteOffsetToPosition(content, fix.EndByte)
-			newText = fix.Replacement
-		} else if fix.StartLine > 0 && fix.EndLine > 0 {
-			lines := strings.Split(content, "\n")
-			startLine := fix.StartLine - 1 // 0-based
-			endLine := fix.EndLine         // exclusive
-			if startLine < 0 {
-				startLine = 0
-			}
-			if endLine > len(lines) {
-				endLine = len(lines)
-			}
-			startPos = Position{Line: uint32(startLine), Character: 0}
-			if endLine < len(lines) {
-				endPos = Position{Line: uint32(endLine), Character: 0}
-			} else {
-				endPos = byteOffsetToPosition(content, len(content))
-			}
-			newText = fix.Replacement
-		} else {
+		startPos, endPos, newText, ok := resolveFixPositions(content, fix)
+		if !ok {
 			continue
 		}
 
@@ -765,11 +800,20 @@ func findingColumnsToCodeActions(uri string, content string, columns *scanner.Fi
 
 // resolveFixPositions converts a fix's coordinates to LSP start/end positions
 // and replacement text. Returns ok=false when the fix has no usable coordinates.
+//
+// Rules emit Replacement strings with bare "\n" line terminators. When the
+// underlying document uses CRLF (common on Windows checkouts), returning the
+// LF text verbatim writes a mixed-ending file the next time the client
+// applies the edit — the same class of corruption fixed in
+// internal/fixer/fixer.go via detectLineEnding. Rewrite the replacement to
+// match the document's existing convention so TextEdit.newText stays
+// internally consistent with the lines it surrounds.
 func resolveFixPositions(contentStr string, fix *scanner.Fix) (startPos, endPos Position, newText string, ok bool) {
+	sep := detectDocumentLineEnding(contentStr)
 	if fix.ByteMode {
 		return byteOffsetToPosition(contentStr, fix.StartByte),
 			byteOffsetToPosition(contentStr, fix.EndByte),
-			fix.Replacement,
+			normalizeLineEndings(fix.Replacement, sep),
 			true
 	}
 	if fix.StartLine > 0 && fix.EndLine > 0 {
@@ -789,9 +833,38 @@ func resolveFixPositions(contentStr string, fix *scanner.Fix) (startPos, endPos 
 		} else {
 			end = byteOffsetToPosition(contentStr, len(contentStr))
 		}
-		return start, end, fix.Replacement, true
+		return start, end, normalizeLineEndings(fix.Replacement, sep), true
 	}
 	return Position{}, Position{}, "", false
+}
+
+// detectDocumentLineEnding mirrors internal/fixer.detectLineEnding: returns
+// "\r\n" when the first newline in the document is preceded by a carriage
+// return, otherwise "\n". The fixer helper is unexported and lives in a
+// different package, so we keep this LSP-local copy rather than widening the
+// fixer API just to share one branch.
+func detectDocumentLineEnding(s string) string {
+	i := strings.IndexByte(s, '\n')
+	if i > 0 && s[i-1] == '\r' {
+		return "\r\n"
+	}
+	return "\n"
+}
+
+// normalizeLineEndings rewrites replacement to use sep as its line terminator.
+// Replacement strings come from rule code with bare "\n"; on CRLF documents
+// the dispatcher would otherwise emit LF-only edits that corrupt the buffer
+// when applied. Strips any stray trailing "\r" left on each split line so the
+// rejoined output is uniform rather than mixed.
+func normalizeLineEndings(replacement, sep string) string {
+	if sep == "\n" || !strings.Contains(replacement, "\n") {
+		return replacement
+	}
+	parts := strings.Split(replacement, "\n")
+	for i, p := range parts {
+		parts[i] = strings.TrimSuffix(p, "\r")
+	}
+	return strings.Join(parts, sep)
 }
 
 // formattingColumns returns the cached or freshly-computed findings for a

--- a/internal/lsp/server_conformance_test.go
+++ b/internal/lsp/server_conformance_test.go
@@ -1,0 +1,363 @@
+package lsp
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/kaeawc/krit/internal/scanner"
+)
+
+// TestPostShutdownRequestRejected verifies the LSP shutdown gate: after a
+// successful shutdown request, every subsequent request other than `exit`
+// must be rejected with InvalidRequest (-32600). Reproduces bug A.
+func TestPostShutdownRequestRejected(t *testing.T) {
+	initReq := buildRequest(1, "initialize", map[string]interface{}{
+		"processId":    1234,
+		"rootUri":      "file:///tmp/test",
+		"capabilities": map[string]interface{}{},
+	})
+	initializedNotif := buildRequest(nil, "initialized", map[string]interface{}{})
+	shutdownReq := buildRequest(2, "shutdown", nil)
+	codeActionReq := buildRequest(3, "textDocument/codeAction", map[string]interface{}{
+		"textDocument": map[string]interface{}{"uri": "file:///tmp/test/Test.kt"},
+		"range": map[string]interface{}{
+			"start": map[string]interface{}{"line": 0, "character": 0},
+			"end":   map[string]interface{}{"line": 0, "character": 0},
+		},
+		"context": map[string]interface{}{"diagnostics": []interface{}{}},
+	})
+
+	var input bytes.Buffer
+	input.Write(initReq)
+	input.Write(initializedNotif)
+	input.Write(shutdownReq)
+	input.Write(codeActionReq)
+
+	var output bytes.Buffer
+	server := NewServer(bufio.NewReader(&input), &output)
+	server.Run()
+
+	msgs, _ := collectMessages(output.Bytes())
+
+	// Find the response for id=3 (the post-shutdown codeAction).
+	var postShutdownResp Response
+	found := false
+	for _, msg := range msgs {
+		var resp Response
+		if err := json.Unmarshal(msg, &resp); err == nil && resp.ID == float64(3) {
+			postShutdownResp = resp
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("no response for post-shutdown request id=3 (got %d messages)", len(msgs))
+	}
+	if postShutdownResp.Error == nil {
+		t.Fatalf("expected error response after shutdown, got result=%v", postShutdownResp.Result)
+	}
+	if postShutdownResp.Error.Code != -32600 {
+		t.Errorf("expected error code -32600 (InvalidRequest), got %d", postShutdownResp.Error.Code)
+	}
+}
+
+// TestNotificationGetsNoResponse verifies that a known method sent as a
+// notification (no `id` field) does NOT trigger a JSON-RPC response. Per
+// JSON-RPC 2.0, notifications MUST NOT receive a response. Reproduces bug B.
+//
+// `textDocument/documentSymbol` is normally a request — but if a buggy client
+// (or a test) sends it without an id, the previous server would happily emit
+// `{"id":null,"result":[]}`. The fix is to gate sendResponse on a non-nil id.
+func TestNotificationGetsNoResponse(t *testing.T) {
+	initReq := buildRequest(1, "initialize", map[string]interface{}{
+		"processId":    1234,
+		"rootUri":      "file:///tmp/test",
+		"capabilities": map[string]interface{}{},
+	})
+	initializedNotif := buildRequest(nil, "initialized", map[string]interface{}{})
+	didOpenReq := buildRequest(nil, "textDocument/didOpen", map[string]interface{}{
+		"textDocument": map[string]interface{}{
+			"uri":        "file:///tmp/test/Test.kt",
+			"languageId": "kotlin",
+			"version":    1,
+			"text":       "package com.example\n",
+		},
+	})
+	// documentSymbol sent without an id → must be treated as a notification
+	// and produce no response.
+	symbolNotif := buildRequest(nil, "textDocument/documentSymbol", map[string]interface{}{
+		"textDocument": map[string]interface{}{"uri": "file:///tmp/test/Test.kt"},
+	})
+
+	var input bytes.Buffer
+	input.Write(initReq)
+	input.Write(initializedNotif)
+	input.Write(didOpenReq)
+	input.Write(symbolNotif)
+
+	var output bytes.Buffer
+	server := NewServer(bufio.NewReader(&input), &output)
+	server.Run()
+
+	msgs, _ := collectMessages(output.Bytes())
+
+	for i, msg := range msgs {
+		var resp Response
+		if err := json.Unmarshal(msg, &resp); err != nil {
+			continue
+		}
+		// A response always has a "method"-less shape; a notification has a
+		// method. Filter out the publishDiagnostics notification by checking
+		// for a non-empty Method field.
+		var probe struct {
+			Method string      `json:"method"`
+			ID     interface{} `json:"id"`
+		}
+		_ = json.Unmarshal(msg, &probe)
+		if probe.Method != "" {
+			// real notification (publishDiagnostics), ignore
+			continue
+		}
+		// Anything left is a response. None of them should have id=null —
+		// the server must never reply to a notification.
+		if probe.ID == nil {
+			t.Errorf("message %d is a response with null id, expected no response for notification: %s", i, string(msg))
+		}
+	}
+}
+
+// TestPreInitializeRequestRejected verifies the LSP initialization gate: a
+// request other than initialize/initialized/exit, sent before the client has
+// completed the initialize handshake, must be rejected with
+// ServerNotInitialized (-32002). Reproduces bug C.
+func TestPreInitializeRequestRejected(t *testing.T) {
+	// didOpen sent as a request (with an id) before any initialize. The
+	// server must respond -32002 rather than dispatching to handleDidOpen.
+	didOpenReq := buildRequest(7, "textDocument/didOpen", map[string]interface{}{
+		"textDocument": map[string]interface{}{
+			"uri":        "file:///tmp/test/Early.kt",
+			"languageId": "kotlin",
+			"version":    1,
+			"text":       "package com.example\n",
+		},
+	})
+
+	var input bytes.Buffer
+	input.Write(didOpenReq)
+
+	var output bytes.Buffer
+	server := NewServer(bufio.NewReader(&input), &output)
+	server.Run()
+
+	msgs, _ := collectMessages(output.Bytes())
+	if len(msgs) < 1 {
+		t.Fatal("expected at least 1 response to pre-initialize request")
+	}
+
+	var resp Response
+	if err := json.Unmarshal(msgs[0], &resp); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if resp.ID != float64(7) {
+		t.Errorf("response id: got %v, want 7", resp.ID)
+	}
+	if resp.Error == nil {
+		t.Fatalf("expected error response, got result=%v", resp.Result)
+	}
+	if resp.Error.Code != -32002 {
+		t.Errorf("expected error code -32002 (ServerNotInitialized), got %d", resp.Error.Code)
+	}
+}
+
+// TestPreInitializeNotificationDropped confirms that a notification arriving
+// before initialize is silently dropped — no response, no analyzer side
+// effects. The pre-init gate must not emit anything when req.ID is nil.
+func TestPreInitializeNotificationDropped(t *testing.T) {
+	didOpenNotif := buildRequest(nil, "textDocument/didOpen", map[string]interface{}{
+		"textDocument": map[string]interface{}{
+			"uri":        "file:///tmp/test/Early.kt",
+			"languageId": "kotlin",
+			"version":    1,
+			"text":       "package com.example\n",
+		},
+	})
+
+	var input bytes.Buffer
+	input.Write(didOpenNotif)
+
+	var output bytes.Buffer
+	server := NewServer(bufio.NewReader(&input), &output)
+	server.Run()
+
+	msgs, _ := collectMessages(output.Bytes())
+	if len(msgs) != 0 {
+		t.Errorf("expected no messages for pre-init notification, got %d: %v", len(msgs), msgs)
+	}
+}
+
+// TestResolveFixPositionsPreservesCRLF verifies that resolveFixPositions
+// rewrites bare-LF replacement text to match a CRLF document's line endings.
+// Reproduces bug D: rules emit Replacement with "\n", but on Windows
+// checkouts the document uses "\r\n" — returning the LF text verbatim
+// produces mixed-ending edits that corrupt the buffer.
+func TestResolveFixPositionsPreservesCRLF(t *testing.T) {
+	t.Run("byte-mode multi-line replacement", func(t *testing.T) {
+		content := "package com.example\r\n\r\nfun main() {}\r\n"
+		fix := &scanner.Fix{
+			ByteMode:    true,
+			StartByte:   0,
+			EndByte:     len(content),
+			Replacement: "package com.example\n\nfun greet() {}\n",
+		}
+		_, _, newText, ok := resolveFixPositions(content, fix)
+		if !ok {
+			t.Fatal("resolveFixPositions returned ok=false")
+		}
+		if strings.Contains(newText, "\r\n") == false && strings.Contains(newText, "\n") {
+			t.Errorf("expected CRLF in newText for CRLF document, got %q", newText)
+		}
+		// And specifically: no bare "\n" without a preceding "\r".
+		for i := 0; i < len(newText); i++ {
+			if newText[i] == '\n' && (i == 0 || newText[i-1] != '\r') {
+				t.Errorf("bare LF at offset %d in CRLF replacement: %q", i, newText)
+				break
+			}
+		}
+	})
+
+	t.Run("line-mode multi-line replacement", func(t *testing.T) {
+		content := "line1\r\nline2\r\nline3\r\n"
+		fix := &scanner.Fix{
+			ByteMode:    false,
+			StartLine:   2,
+			EndLine:     2,
+			Replacement: "replaced-a\nreplaced-b\n",
+		}
+		_, _, newText, ok := resolveFixPositions(content, fix)
+		if !ok {
+			t.Fatal("resolveFixPositions returned ok=false")
+		}
+		if !strings.Contains(newText, "\r\n") {
+			t.Errorf("expected CRLF in newText for CRLF document, got %q", newText)
+		}
+		for i := 0; i < len(newText); i++ {
+			if newText[i] == '\n' && (i == 0 || newText[i-1] != '\r') {
+				t.Errorf("bare LF at offset %d in CRLF replacement: %q", i, newText)
+				break
+			}
+		}
+	})
+
+	t.Run("LF document is untouched", func(t *testing.T) {
+		content := "line1\nline2\nline3\n"
+		fix := &scanner.Fix{
+			ByteMode:    false,
+			StartLine:   2,
+			EndLine:     2,
+			Replacement: "replaced-a\nreplaced-b\n",
+		}
+		_, _, newText, ok := resolveFixPositions(content, fix)
+		if !ok {
+			t.Fatal("resolveFixPositions returned ok=false")
+		}
+		if newText != "replaced-a\nreplaced-b\n" {
+			t.Errorf("LF document should leave Replacement intact, got %q", newText)
+		}
+	})
+
+	t.Run("single-line CRLF replacement with no newline is untouched", func(t *testing.T) {
+		content := "line1\r\nline2\r\n"
+		fix := &scanner.Fix{
+			ByteMode:    true,
+			StartByte:   0,
+			EndByte:     5,
+			Replacement: "LINE1",
+		}
+		_, _, newText, ok := resolveFixPositions(content, fix)
+		if !ok {
+			t.Fatal("resolveFixPositions returned ok=false")
+		}
+		if newText != "LINE1" {
+			t.Errorf("single-line replacement should be unchanged, got %q", newText)
+		}
+	})
+}
+
+// TestFormattingPreservesCRLFInTextEdit drives the handleFormatting path
+// end-to-end with a CRLF document and verifies the emitted TextEdit.newText
+// uses CRLF terminators, matching the document convention.
+func TestFormattingPreservesCRLFInTextEdit(t *testing.T) {
+	// Build a server with a hand-crafted document that has a CRLF body and
+	// a pre-populated fixable finding whose Replacement is bare LF.
+	server := &Server{
+		docs: make(map[string]*Document),
+	}
+	uri := "file:///tmp/test/CRLF.kt"
+	content := "package com.example\r\n\r\nval x = 1\r\n"
+	findings := []scanner.Finding{
+		{
+			File:     "/tmp/test/CRLF.kt",
+			Line:     1,
+			Col:      0,
+			RuleSet:  "style",
+			Rule:     "CRLFLineFix",
+			Severity: "warning",
+			Message:  "force LF replacement",
+			Fix: &scanner.Fix{
+				ByteMode:    false,
+				StartLine:   1,
+				EndLine:     1,
+				Replacement: "package com.example.renamed\n",
+			},
+		},
+	}
+	columns := scanner.CollectFindings(findings)
+	server.docs[uri] = &Document{
+		URI:      uri,
+		Content:  []byte(content),
+		Findings: columns,
+	}
+
+	params := DocumentFormattingParams{
+		TextDocument: TextDocumentIdentifier{URI: uri},
+		Options:      FormattingOptions{TabSize: 4, InsertSpaces: true},
+	}
+	paramsBytes, _ := json.Marshal(params)
+	req := &Request{JSONRPC: "2.0", ID: float64(10), Method: "textDocument/formatting", Params: paramsBytes}
+
+	var output bytes.Buffer
+	server.writer = &output
+	server.handleFormatting(req)
+
+	msgs, _ := collectMessages(output.Bytes())
+	if len(msgs) != 1 {
+		t.Fatalf("expected 1 response, got %d", len(msgs))
+	}
+	var resp Response
+	if err := json.Unmarshal(msgs[0], &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp.Error != nil {
+		t.Fatalf("unexpected error: %v", resp.Error)
+	}
+	resultBytes, _ := json.Marshal(resp.Result)
+	var edits []TextEdit
+	if err := json.Unmarshal(resultBytes, &edits); err != nil {
+		t.Fatalf("unmarshal edits: %v", err)
+	}
+	if len(edits) != 1 {
+		t.Fatalf("expected 1 edit, got %d", len(edits))
+	}
+	if !strings.Contains(edits[0].NewText, "\r\n") {
+		t.Errorf("expected CRLF in TextEdit.newText for CRLF document, got %q", edits[0].NewText)
+	}
+	for i := 0; i < len(edits[0].NewText); i++ {
+		if edits[0].NewText[i] == '\n' && (i == 0 || edits[0].NewText[i-1] != '\r') {
+			t.Errorf("bare LF at offset %d in TextEdit.newText: %q", i, edits[0].NewText)
+			break
+		}
+	}
+}

--- a/internal/lsp/server_test.go
+++ b/internal/lsp/server_test.go
@@ -430,11 +430,13 @@ func TestShutdownThenExit(t *testing.T) {
 		"rootUri":      "file:///tmp/test",
 		"capabilities": map[string]interface{}{},
 	})
+	initializedNotif := buildRequest(nil, "initialized", map[string]interface{}{})
 	shutdownReq := buildRequest(2, "shutdown", nil)
 	exitReq := buildRequest(nil, "exit", nil)
 
 	var input bytes.Buffer
 	input.Write(initReq)
+	input.Write(initializedNotif)
 	input.Write(shutdownReq)
 	input.Write(exitReq)
 
@@ -491,10 +493,12 @@ func TestUnknownMethodReturnsError(t *testing.T) {
 		"rootUri":      "file:///tmp/test",
 		"capabilities": map[string]interface{}{},
 	})
+	initializedNotif := buildRequest(nil, "initialized", map[string]interface{}{})
 	unknownReq := buildRequest(99, "textDocument/unknownMethod", nil)
 
 	var input bytes.Buffer
 	input.Write(initReq)
+	input.Write(initializedNotif)
 	input.Write(unknownReq)
 
 	var output bytes.Buffer


### PR DESCRIPTION
## Summary

Four LSP protocol conformance bugs in `internal/lsp/server.go`, all
landing together because they touch the same dispatch path.

- **Post-shutdown gate** (`-32600`): `handleMessage` now rejects every
  request other than `exit` once `s.shutdown` is set. Previously the
  server kept dispatching document handlers after `shutdown`, in
  violation of the LSP spec.
- **Pre-initialize gate** (`-32002`): requests other than
  `initialize` / `initialized` / `exit` arriving before the handshake
  completes are answered with `ServerNotInitialized` instead of running
  against a nil analyzer.
- **Notification responses**: `s.sendResponse` early-returns when
  `req.ID == nil`, so a known method sent as a JSON-RPC notification
  no longer triggers an `"id":null` response. Centralised in the LSP
  wrapper so each per-method handler stays unchanged.
- **CRLF preservation**: `resolveFixPositions` (used by both
  `findingColumnsToCodeActions` and `handleFormatting`) detects the
  document's line ending and rewrites bare-LF rule output to match.
  Same class of fix already shipped in `internal/fixer/`.

## Test plan

- [x] `go build -o /tmp/krit-lsp ./cmd/krit-lsp/`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...` — 0 issues
- [x] `go test ./internal/lsp/ -count=1`
- [x] `go test ./... -count=1`

New regression tests in `internal/lsp/server_conformance_test.go`:

- `TestPostShutdownRequestRejected` — `shutdown` then `codeAction`
  asserts `-32600`.
- `TestNotificationGetsNoResponse` — `documentSymbol` sent as
  notification, no response emitted.
- `TestPreInitializeRequestRejected` — `didOpen` request before
  `initialize` asserts `-32002`.
- `TestPreInitializeNotificationDropped` — pre-init notification
  produces zero output.
- `TestResolveFixPositionsPreservesCRLF` + table cases for byte-mode,
  line-mode, LF passthrough, and short-circuit on single-line text.
- `TestFormattingPreservesCRLFInTextEdit` — end-to-end formatting on a
  CRLF document, asserts `TextEdit.newText` is CRLF.

Confirmed each new test fails against the unpatched server before
applying the fixes.