### PR TITLE
test(rules): regression coverage for require* !! exemption + default args

### DIFF
--- a/internal/rules/potentialbugs_nullsafety_test.go
+++ b/internal/rules/potentialbugs_nullsafety_test.go
@@ -945,6 +945,41 @@ class State(private val username: String?) {
 	}
 }
 
+// Regression: the require* exemption only covers the `!!` in a single-expression
+// body (`fun requireXxx(): T = field!!`). A `!!` that appears in a parameter
+// default value or anywhere else in a require*-named function must still be
+// flagged — the previous text-based `=` heuristic confused the parameter's
+// `=` with an expression-body `=` and silently exempted it.
+func TestUnsafeCallOnNullableType_PositiveRequireFunctionDefaultArgBang(t *testing.T) {
+	findings := runRuleByName(t, "UnsafeCallOnNullableType", `
+package test
+class State(private val username: String?) {
+    fun requireUser(name: String = username!!): String {
+        return name
+    }
+}
+`)
+	if len(findings) == 0 {
+		t.Fatal("expected finding for !! in default argument of require* function, got none")
+	}
+}
+
+// Regression: a require*-named function with a block body and a default
+// argument containing `=` must not be exempted via the parameter `=`.
+func TestUnsafeCallOnNullableType_PositiveRequireBlockBodyWithDefaultArg(t *testing.T) {
+	findings := runRuleByName(t, "UnsafeCallOnNullableType", `
+package test
+class State(private val username: String?) {
+    fun requireUser(retries: Int = 3): String {
+        return username!!
+    }
+}
+`)
+	if len(findings) == 0 {
+		t.Fatal("expected finding for !! in block body of require* function with default arg, got none")
+	}
+}
+
 func TestUnsafeCallOnNullableType_NegativeSameBlockConstructorAssignment(t *testing.T) {
 	findings := runRuleByName(t, "UnsafeCallOnNullableType", `
 package test


### PR DESCRIPTION
## Summary

`isRequireFunctionBangBodyFlat` on main (via [#382](https://github.com/kaeawc/krit/pull/382)) already requires the enclosing function to have an **expression** body before applying the `require*` exemption to a `!!`. That means:

- A `!!` in a parameter default value falls under the outer function — if that function has a block body, no exemption.
- A `!!` inside a `require*` block body is never exempted.

So the historical "any `=` in fnText means expression body" bug is gone. This PR pins the behavior with two regression tests so a future rewrite of the helper cannot silently re-introduce it:

- \`PositiveRequireFunctionDefaultArgBang\`: `!!` in a parameter default of a `require*` function with a block body.
- \`PositiveRequireBlockBodyWithDefaultArg\`: `!!` inside the block body of a `require*` function that also has a parameter default `=`.

## Test plan

- [x] \`go test ./internal/rules/ -count=1\` — both new tests + suite green.
- [x] \`golangci-lint run ./...\` — 0 issues.
- [ ] CI green on the PR.