### PR TITLE
fix(rules): require JDBC receiver token boundary for close() detection

### DIFF
--- a/internal/rules/database.go
+++ b/internal/rules/database.go
@@ -169,6 +169,9 @@ func jdbcPreparedStatementCallFlat(file *scanner.File, idx uint32) bool {
 }
 
 func jdbcPreparedStatementHasCleanupFlat(file *scanner.File, idx uint32, stmtName string) bool {
+	if stmtName == "" {
+		return false
+	}
 	scope, ok := file.FlatParent(idx)
 	if !ok {
 		return false
@@ -182,11 +185,37 @@ func jdbcPreparedStatementHasCleanupFlat(file *scanner.File, idx uint32, stmtNam
 		}
 
 		childText := file.FlatNodeText(child)
-		if strings.Contains(childText, stmtName+".close(") || strings.Contains(childText, stmtName+".use") {
+		if jdbcCloseReceiverPresent(childText, stmtName) {
 			return true
 		}
 	}
 
+	return false
+}
+
+// jdbcCloseReceiverPresent reports whether text contains a `<stmtName>.close(`
+// or `<stmtName>.use` call where stmtName matches as a whole identifier token
+// (not just a trailing substring of an unrelated identifier such as
+// `apsCloser.close(` for a stmtName of `Closer`, or `xstmt.close(` for `stmt`).
+func jdbcCloseReceiverPresent(text, stmtName string) bool {
+	if stmtName == "" {
+		return false
+	}
+	for _, suffix := range []string{".close(", ".use"} {
+		needle := stmtName + suffix
+		start := 0
+		for {
+			rel := strings.Index(text[start:], needle)
+			if rel < 0 {
+				break
+			}
+			pos := start + rel
+			if pos == 0 || !isIdentChar(text[pos-1]) {
+				return true
+			}
+			start = pos + 1
+		}
+	}
 	return false
 }
 

--- a/internal/rules/database_test.go
+++ b/internal/rules/database_test.go
@@ -1077,6 +1077,63 @@ fun querySafely(connection: Connection) {
 	}
 }
 
+// TestJdbcPreparedStatementNotClosed_PositiveLookalikeReceiver guards against
+// the substring-matching regression where an unrelated sibling identifier
+// (e.g. `apsCloser.close(` or `mystmt.close(`) whose name happens to end with
+// the statement variable name was mistaken as cleanup for the real
+// PreparedStatement, suppressing the leak finding.
+func TestJdbcPreparedStatementNotClosed_PositiveLookalikeReceiver(t *testing.T) {
+	findings := runRuleByName(t, "JdbcPreparedStatementNotClosed", `
+package test
+
+interface Connection {
+    fun prepareStatement(sql: String): PreparedStatement
+}
+
+interface PreparedStatement {
+    fun executeQuery(): ResultSet
+    fun close()
+}
+
+interface ResultSet
+
+class Closer {
+    fun close() {}
+}
+
+fun query(connection: Connection, apsCloser: Closer, mystmt: Closer) {
+    val stmt = connection.prepareStatement("SELECT 1")
+    stmt.executeQuery()
+    apsCloser.close()
+    mystmt.close()
+}
+`)
+	if len(findings) == 0 {
+		t.Fatal("expected leak finding for stmt; lookalike receivers apsCloser/mystmt must not suppress it")
+	}
+}
+
+// TestJdbcPreparedStatementNotClosed_NegativeLookalikeReceiverOnly verifies
+// that a sibling identifier whose name only suffix-matches the statement
+// variable does not, on its own, trigger spurious detection logic when no
+// real PreparedStatement is being leaked.
+func TestJdbcPreparedStatementNotClosed_NegativeLookalikeReceiverOnly(t *testing.T) {
+	findings := runRuleByName(t, "JdbcPreparedStatementNotClosed", `
+package test
+
+class Closer {
+    fun close() {}
+}
+
+fun query(apsCloser: Closer) {
+    apsCloser.close()
+}
+`)
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings when no PreparedStatement is present, got %v", findings)
+	}
+}
+
 func TestRoomExportSchemaDisabled_Positive(t *testing.T) {
 	findings := runRuleByName(t, "RoomExportSchemaDisabled", `
 package test


### PR DESCRIPTION
## Summary
- `jdbcPreparedStatementHasCleanupFlat` (shared by `JdbcPreparedStatementNotClosed` and `SqliteCursorWithoutClose`) used `strings.Contains(childText, stmtName+".close(")` / `+".use"`, so any sibling expression whose text happened to contain that substring was treated as cleanup.
- Real Statement/Cursor leaks were silently suppressed when an unrelated identifier in the same scope ended with the statement variable name (e.g. `xstmt.close(` masked a leak of `stmt`, `apsCloser.close(` masked a leak of `ps`).
- Fix: introduce `jdbcCloseReceiverPresent`, which requires a non-identifier byte (or start-of-text) immediately before `stmtName` so the receiver must match as a whole identifier token. Behavior is unchanged for genuine `stmt.close(` / `stmt.use` cleanup.

## Test plan
- [x] `TestJdbcPreparedStatementNotClosed_PositiveLookalikeReceiver` — added; fails on `main`, passes after the fix.
- [x] `TestJdbcPreparedStatementNotClosed_NegativeLookalikeReceiverOnly` — added.
- [x] Existing `TestJdbcPreparedStatementNotClosed_Positive`/`_Negative`, `TestSqliteCursorWithoutClose_*` still pass.
- [x] `go build`, `go vet`, `golangci-lint run ./...` (0 issues), `go test ./...`, `make lint-rules`.