### PR TITLE
fix(output): URI-encode SARIF artifactLocation paths

### DIFF
--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/url"
 	"os"
 	"strings"
 
@@ -270,7 +271,7 @@ func FormatSARIFColumns(w io.Writer, columns *scanner.FindingColumns, version st
 			Message: sarifText{Text: cols.MessageAt(row)},
 			Locations: []sarifLocation{{
 				PhysicalLocation: sarifPhysicalLocation{
-					ArtifactLocation: sarifArtifactLocation{URI: cols.FileAt(row)},
+					ArtifactLocation: sarifArtifactLocation{URI: pathToSARIFURI(cols.FileAt(row))},
 					Region:           sarifRegion{StartLine: cols.LineAt(row), StartColumn: cols.ColumnAt(row)},
 				},
 			}},
@@ -439,6 +440,82 @@ func FormatCheckstyleColumns(w io.Writer, columns *scanner.FindingColumns) {
 		fmt.Fprintln(w, `  </file>`)
 	}
 	fmt.Fprintln(w, `</checkstyle>`)
+}
+
+// pathToSARIFURI converts a filesystem path into a SARIF-safe
+// artifactLocation.uri reference. SARIF 2.1.0 requires the value to be a
+// valid URI reference per RFC 3986, so spaces, '#', '?', other reserved
+// characters, and non-ASCII scalars must be percent-encoded. Windows
+// backslashes are normalised to forward slashes.
+//
+// Encoding rules:
+//   - Empty input returns "" unchanged.
+//   - Absolute POSIX paths ("/foo/bar") become "file:///foo/bar" with each
+//     path segment percent-encoded.
+//   - Windows drive paths ("C:\\foo\\bar") become "file:///C:/foo/bar".
+//   - Windows UNC paths ("\\\\srv\\share\\foo") become
+//     "file://srv/share/foo".
+//   - Relative paths stay relative (no file:// scheme is prepended) so that
+//     SARIF consumers can resolve them against their own uriBaseId — but
+//     reserved characters in each path segment are still percent-encoded.
+//
+// Slashes between segments are preserved verbatim; url.PathEscape is applied
+// per segment to keep them as path separators rather than encoding them.
+func pathToSARIFURI(path string) string {
+	if path == "" {
+		return ""
+	}
+	// UNC path: \\server\share\rest
+	if strings.HasPrefix(path, `\\`) {
+		rest := strings.TrimPrefix(path, `\\`)
+		rest = strings.ReplaceAll(rest, `\`, "/")
+		parts := strings.SplitN(rest, "/", 2)
+		host := parts[0]
+		tail := ""
+		if len(parts) == 2 {
+			tail = parts[1]
+		}
+		return "file://" + encodeURIHost(host) + "/" + encodeURIPath(tail)
+	}
+	// Windows drive: C:\foo or C:/foo
+	if len(path) >= 2 && path[1] == ':' && isASCIILetter(path[0]) {
+		drive := string(path[0]) + ":"
+		rest := strings.TrimLeft(path[2:], `\/`)
+		rest = strings.ReplaceAll(rest, `\`, "/")
+		return "file:///" + drive + "/" + encodeURIPath(rest)
+	}
+	// POSIX absolute path.
+	if strings.HasPrefix(path, "/") {
+		rest := strings.TrimPrefix(path, "/")
+		return "file:///" + encodeURIPath(rest)
+	}
+	// Relative path: keep relative, normalise backslashes, encode segments.
+	normalized := strings.ReplaceAll(path, `\`, "/")
+	return encodeURIPath(normalized)
+}
+
+// encodeURIPath percent-encodes each '/'-separated segment with
+// url.PathEscape while preserving the slashes themselves.
+func encodeURIPath(p string) string {
+	if p == "" {
+		return ""
+	}
+	segs := strings.Split(p, "/")
+	for i, s := range segs {
+		segs[i] = url.PathEscape(s)
+	}
+	return strings.Join(segs, "/")
+}
+
+// encodeURIHost percent-encodes a host component for use in a file:// URI
+// authority (UNC hosts). url.PathEscape is conservative enough — '/' and
+// '?' would terminate the host but neither appears after our SplitN.
+func encodeURIHost(h string) string {
+	return url.PathEscape(h)
+}
+
+func isASCIILetter(b byte) bool {
+	return (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z')
 }
 
 func xmlEscape(s string) string {

--- a/internal/output/sarif_uri_test.go
+++ b/internal/output/sarif_uri_test.go
@@ -1,0 +1,133 @@
+package output
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/kaeawc/krit/internal/scanner"
+)
+
+// TestSARIFArtifactLocationURI verifies SARIF artifactLocation.uri is a valid
+// URI reference per RFC 3986: reserved characters (space, '#', '?'), unicode
+// scalars, and Windows backslashes are encoded/normalised. Strict consumers
+// such as GitHub code scanning reject runs that embed raw paths.
+func TestSARIFArtifactLocationURI(t *testing.T) {
+	cases := []struct {
+		name    string
+		path    string
+		wantURI string
+	}{
+		{
+			name:    "posix-absolute-with-spaces",
+			path:    "/tmp/My Project/Foo.kt",
+			wantURI: "file:///tmp/My%20Project/Foo.kt",
+		},
+		{
+			name:    "posix-absolute-with-hash",
+			path:    "/tmp/proj/Bug#123.kt",
+			wantURI: "file:///tmp/proj/Bug%23123.kt",
+		},
+		{
+			name:    "posix-absolute-with-question",
+			path:    "/tmp/proj/Maybe?.kt",
+			wantURI: "file:///tmp/proj/Maybe%3F.kt",
+		},
+		{
+			name:    "posix-absolute-with-unicode",
+			path:    "/tmp/проект/Файл.kt",
+			wantURI: "file:///tmp/%D0%BF%D1%80%D0%BE%D0%B5%D0%BA%D1%82/%D0%A4%D0%B0%D0%B9%D0%BB.kt",
+		},
+		{
+			name:    "windows-drive-with-backslashes",
+			path:    `C:\Users\Jane\My Project\Foo.kt`,
+			wantURI: "file:///C:/Users/Jane/My%20Project/Foo.kt",
+		},
+		{
+			name:    "relative-with-spaces",
+			path:    "app/My Module/Foo.kt",
+			wantURI: "app/My%20Module/Foo.kt",
+		},
+		{
+			name:    "relative-with-backslashes",
+			path:    `app\sub dir\Foo.kt`,
+			wantURI: "app/sub%20dir/Foo.kt",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			findings := []scanner.Finding{
+				{
+					File:     tc.path,
+					Line:     1,
+					Col:      1,
+					Severity: "warning",
+					RuleSet:  "style",
+					Rule:     "Demo",
+					Message:  "demo",
+				},
+			}
+
+			var buf bytes.Buffer
+			if err := FormatSARIF(&buf, findings, "0.0.0"); err != nil {
+				t.Fatalf("FormatSARIF: %v", err)
+			}
+
+			var log sarifLog
+			if err := json.Unmarshal(buf.Bytes(), &log); err != nil {
+				t.Fatalf("invalid SARIF JSON: %v\n%s", err, buf.String())
+			}
+			if len(log.Runs) != 1 || len(log.Runs[0].Results) != 1 {
+				t.Fatalf("expected 1 run with 1 result; got %s", buf.String())
+			}
+			got := log.Runs[0].Results[0].Locations[0].PhysicalLocation.ArtifactLocation.URI
+			if got != tc.wantURI {
+				t.Fatalf("artifactLocation.uri = %q, want %q", got, tc.wantURI)
+			}
+
+			// Belt-and-suspenders: no raw spaces, '#', '?', backslashes, or
+			// non-ASCII bytes should leak into the URI string.
+			if strings.ContainsAny(got, " \\") {
+				t.Errorf("URI contains forbidden char (space/backslash): %q", got)
+			}
+			for i := 0; i < len(got); i++ {
+				if got[i] > 0x7E || got[i] < 0x20 {
+					t.Errorf("URI contains non-printable/non-ASCII byte 0x%02x: %q", got[i], got)
+					break
+				}
+			}
+		})
+	}
+}
+
+// TestPathToSARIFURI exercises the helper directly so the URI convention is
+// pinned independent of the formatter wiring.
+func TestPathToSARIFURI(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"", ""},
+		{"/tmp/foo.kt", "file:///tmp/foo.kt"},
+		{"/tmp/My Project/Foo.kt", "file:///tmp/My%20Project/Foo.kt"},
+		{"/tmp/проект/Файл.kt", "file:///tmp/%D0%BF%D1%80%D0%BE%D0%B5%D0%BA%D1%82/%D0%A4%D0%B0%D0%B9%D0%BB.kt"},
+		{"/tmp/has?and#.kt", "file:///tmp/has%3Fand%23.kt"},
+		{"app/Foo.kt", "app/Foo.kt"},
+		{"app/My Module/Foo.kt", "app/My%20Module/Foo.kt"},
+		{`C:\Users\Jane\Foo.kt`, "file:///C:/Users/Jane/Foo.kt"},
+		{`C:\Users\Jane\My Project\Foo.kt`, "file:///C:/Users/Jane/My%20Project/Foo.kt"},
+		{`app\sub\Foo.kt`, "app/sub/Foo.kt"},
+		// UNC: \\server\share\Foo.kt → file://server/share/Foo.kt per the
+		// MS-recommended file URI form for UNC paths.
+		{`\\server\share\Foo.kt`, "file://server/share/Foo.kt"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			if got := pathToSARIFURI(tc.in); got != tc.want {
+				t.Fatalf("pathToSARIFURI(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- SARIF `artifactLocation.uri` now goes through a `pathToSARIFURI` helper instead of receiving the raw OS path. Spaces, `#`, `?`, unicode scalars, and Windows backslashes were causing strict consumers (GitHub code scanning, some IDEs) to reject runs as malformed.
- Helper convention: absolute POSIX paths become `file:///…`, Windows drive paths become `file:///C:/…`, UNC paths become `file://srv/share/…`, and relative paths stay relative so SARIF consumers can resolve them against their own `uriBaseId`. Every segment is percent-encoded with `url.PathEscape` so reserved characters and non-ASCII bytes are preserved as valid URI references.

## Test plan
- [x] `go test ./internal/output/ -count=1` — new `TestSARIFArtifactLocationURI` exercises the formatter end-to-end with paths containing space, `#`, `?`, unicode, Windows backslashes, and relative inputs; new `TestPathToSARIFURI` pins the helper directly (POSIX absolute, relative, Windows drive, UNC, mixed separators).
- [x] `go build -o /tmp/krit ./cmd/krit/`
- [x] `go vet ./...`
- [x] `golangci-lint run ./internal/output/...` (full-tree lint was also clean for this change; unrelated linter warnings in other worktrees are not from this PR).
- [x] `go test ./... -count=1`