### PR TITLE
fix(mcp): suppress responses to JSON-RPC notifications

### DIFF
--- a/internal/mcp/notification_test.go
+++ b/internal/mcp/notification_test.go
@@ -1,0 +1,90 @@
+package mcp
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/kaeawc/krit/internal/jsonrpc"
+)
+
+// TestUnknownNotificationProducesNoResponse verifies JSON-RPC 2.0 §4.1: a
+// notification (a request without an `id` member) MUST NOT receive a
+// response, even when the method is unknown to the server. Pre-fix, the
+// dispatcher's default case already guarded on req.ID, but several known-
+// method handlers (handleToolsList, handleInitialize, ...) called
+// sendResponse unconditionally and emitted `"id": null` replies for
+// notifications. The gate now lives in sendResponse itself.
+func TestUnknownNotificationProducesNoResponse(t *testing.T) {
+	notif := []byte(`{"jsonrpc":"2.0","method":"notifications/cancelled","params":{"requestId":42}}` + "\n")
+
+	var output bytes.Buffer
+	reader := bufio.NewReader(bytes.NewReader(notif))
+	server := NewServer(reader, &output)
+	server.buildDispatcher()
+
+	for {
+		msg, err := jsonrpc.ReadMessageNDJSON(reader)
+		if err != nil {
+			break
+		}
+		var req Request
+		if err := json.Unmarshal(msg, &req); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		server.handleMessage(&req)
+	}
+
+	if output.Len() != 0 {
+		t.Fatalf("notification must produce zero response bytes; got %d bytes: %s", output.Len(), output.Bytes())
+	}
+}
+
+// TestKnownMethodAsNotificationProducesNoResponse exercises the regression
+// directly: a client invokes a known request method without an id.
+// tools/list is normally a request — its handler unconditionally calls
+// sendResponse(req.ID, ...). Pre-fix that emitted a several-kilobyte
+// response with `"id": null`. Post-fix sendResponse short-circuits when
+// the id is nil.
+func TestKnownMethodAsNotificationProducesNoResponse(t *testing.T) {
+	notif := []byte(`{"jsonrpc":"2.0","method":"tools/list"}` + "\n")
+
+	var output bytes.Buffer
+	reader := bufio.NewReader(bytes.NewReader(notif))
+	server := NewServer(reader, &output)
+	server.buildDispatcher()
+
+	for {
+		msg, err := jsonrpc.ReadMessageNDJSON(reader)
+		if err != nil {
+			break
+		}
+		var req Request
+		if err := json.Unmarshal(msg, &req); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		server.handleMessage(&req)
+	}
+
+	if output.Len() != 0 {
+		t.Fatalf("known method sent as notification must produce zero response bytes; got %d bytes: %s", output.Len(), output.Bytes())
+	}
+}
+
+// TestRequestStillGetsResponseAfterNotificationFix is a sanity check that
+// ordinary requests still get replies — the notification gate must not
+// affect the request path.
+func TestRequestStillGetsResponseAfterNotificationFix(t *testing.T) {
+	out := runServer(t, Request{
+		JSONRPC: "2.0",
+		ID:      float64(7),
+		Method:  "tools/list",
+	})
+	if len(out) != 1 {
+		t.Fatalf("expected 1 response, got %d", len(out))
+	}
+	if out[0].ID == nil {
+		t.Errorf("expected non-null id in response, got null")
+	}
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -103,7 +103,18 @@ func (s *Server) buildDispatcher() {
 }
 
 // sendResponse sends a JSON-RPC 2.0 response via the shared transport.
+//
+// Notifications (JSON-RPC 2.0 messages with no `id` member) MUST NOT receive
+// a response. The dispatcher routes notifications through the same per-method
+// handlers as requests, and several of those handlers unconditionally call
+// sendResponse with req.ID — which is nil for notifications. Gating the
+// emission here keeps every handler honest without each one needing to repeat
+// the nil-id check, and avoids emitting a response with `"id":null` that
+// strict clients reject. Mirrors the LSP-side gate in internal/lsp/server.go.
 func (s *Server) sendResponse(id interface{}, result interface{}, rpcErr *RPCError) {
+	if id == nil {
+		return
+	}
 	jsonrpc.SendResponseNDJSON(s.writer, &s.mu, id, result, rpcErr)
 }
 


### PR DESCRIPTION
## Summary

JSON-RPC 2.0 §4.1 forbids responses to notifications (requests with no `id` member). PR #385 already added an `id == nil` gate inside the LSP server's `sendResponse`; this PR applies the matching gate to the MCP server. Several MCP handlers (`handleInitialize`, `handleToolsList`, `handleResourcesList`, `handlePromptsList`, `handlePromptsGet`) call `sendResponse` unconditionally with `req.ID` — which is `nil` when the client sent the method as a notification — and the previous code emitted a several-kilobyte `{"id":null, "result":...}` reply that strict MCP clients reject.

## Test plan

- [x] `go build -o krit ./cmd/krit/`
- [x] `go vet ./...`
- [x] `golangci-lint run ./internal/mcp/`
- [x] `go test ./internal/lsp/ ./internal/mcp/ ./internal/jsonrpc/ ./cmd/krit-lsp/ ./cmd/krit-mcp/ -count=1`
- [x] Verified the new regression tests fail without the fix — `TestKnownMethodAsNotificationProducesNoResponse` observed the bug emitting an 11 KB `{"jsonrpc":"2.0","id":null,"result":{"tools":[...]}}` reply to a `tools/list` notification.

### New regression tests

- `TestUnknownNotificationProducesNoResponse` — `notifications/cancelled` produces zero response bytes.
- `TestKnownMethodAsNotificationProducesNoResponse` — `tools/list` sent as a notification produces zero response bytes (the case that exposed the bug pre-fix).
- `TestRequestStillGetsResponseAfterNotificationFix` — sanity check that ordinary requests are unaffected by the gate.