### PR TITLE
fix(mcp): suppress notification responses, negotiate protocolVersion

### DIFF
--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -16,7 +16,39 @@ import (
 	"github.com/kaeawc/krit/internal/scanner"
 )
 
+// protocolVersion is the latest MCP protocol revision this server speaks.
+// It is the version returned to clients that omit `protocolVersion` or that
+// request a version the server does not recognize. Per the MCP spec
+// (https://modelcontextprotocol.io/specification/2025-06-18/basic/lifecycle),
+// when the server doesn't support the client's requested version it MUST
+// respond with another version it supports, and SHOULD pick the latest.
 const protocolVersion = "2024-11-05"
+
+// supportedProtocolVersions enumerates every MCP revision this server can
+// speak with a client, ordered newest-first. Per the spec, if the client
+// requests one of these we MUST echo it back; otherwise we respond with
+// protocolVersion (the latest). Add a new revision here when wire-level
+// compatibility is verified; do not just bump protocolVersion or older
+// clients will be told to disconnect.
+var supportedProtocolVersions = []string{
+	"2024-11-05",
+}
+
+// negotiateProtocolVersion picks the server-side response for the client's
+// requested protocolVersion. Empty client version (field omitted) is
+// treated as "client did not negotiate" and gets the server default.
+// Returns the version to send back.
+func negotiateProtocolVersion(clientVersion string) string {
+	if clientVersion == "" {
+		return protocolVersion
+	}
+	for _, v := range supportedProtocolVersions {
+		if v == clientVersion {
+			return v
+		}
+	}
+	return protocolVersion
+}
 
 // Server implements an MCP server over stdio using JSON-RPC 2.0.
 type Server struct {
@@ -137,10 +169,24 @@ func (s *Server) handleMessage(req *Request) {
 	}
 }
 
-// handleInitialize responds with server capabilities.
+// handleInitialize responds with server capabilities. Negotiates the
+// protocol version per the MCP spec: if the client's requested version
+// is one we support we echo it back; otherwise we return our latest
+// supported version and let the client decide whether to disconnect.
+// `initialize` is a request (has an id) in practice; we still gate the
+// reply on req.ID != nil so a malformed notification-style initialize
+// doesn't produce a stray `"id":null` response.
 func (s *Server) handleInitialize(req *Request) {
+	var params InitializeParams
+	if len(req.Params) > 0 {
+		// Best-effort decode: a bad params blob shouldn't break
+		// initialize, the spec only requires us to negotiate a
+		// version we can speak. An empty/invalid params falls
+		// through to the server default.
+		_ = json.Unmarshal(req.Params, &params)
+	}
 	result := InitializeResult{
-		ProtocolVersion: protocolVersion,
+		ProtocolVersion: negotiateProtocolVersion(params.ProtocolVersion),
 		Capabilities: ServerCaps{
 			Tools:     &ToolsCap{},
 			Resources: &ResourcesCap{},
@@ -151,11 +197,19 @@ func (s *Server) handleInitialize(req *Request) {
 			Version: "0.0.1",
 		},
 	}
+	if req.ID == nil {
+		return
+	}
 	s.sendResponse(req.ID, result, nil)
 }
 
 // handleToolsList returns the list of available tools.
 func (s *Server) handleToolsList(req *Request) {
+	if req.ID == nil {
+		// JSON-RPC 2.0 notifications (no id) must not get a
+		// response, even for known methods. Drop silently.
+		return
+	}
 	result := ToolsListResult{
 		Tools: toolDefinitions(),
 	}
@@ -164,6 +218,12 @@ func (s *Server) handleToolsList(req *Request) {
 
 // handleToolsCall dispatches a tool call.
 func (s *Server) handleToolsCall(req *Request) {
+	if req.ID == nil {
+		// Notification form is meaningless for tools/call (the
+		// client wants a result); drop silently rather than
+		// emitting a stray `"id":null` response.
+		return
+	}
 	var params ToolCallParams
 	if err := json.Unmarshal(req.Params, &params); err != nil {
 		s.sendResponse(req.ID, nil, &RPCError{
@@ -202,6 +262,9 @@ func (s *Server) handleToolsCall(req *Request) {
 
 // handleResourcesList returns the list of available resources.
 func (s *Server) handleResourcesList(req *Request) {
+	if req.ID == nil {
+		return
+	}
 	result := ResourcesListResult{
 		Resources: resourceDefinitions(),
 	}
@@ -210,6 +273,9 @@ func (s *Server) handleResourcesList(req *Request) {
 
 // handleResourcesRead returns the content of a resource.
 func (s *Server) handleResourcesRead(req *Request) {
+	if req.ID == nil {
+		return
+	}
 	var params ResourceReadParams
 	if err := json.Unmarshal(req.Params, &params); err != nil {
 		s.sendResponse(req.ID, nil, &RPCError{
@@ -240,6 +306,9 @@ func (s *Server) handleResourcesRead(req *Request) {
 
 // handlePromptsList returns the list of available prompts.
 func (s *Server) handlePromptsList(req *Request) {
+	if req.ID == nil {
+		return
+	}
 	result := PromptsListResult{
 		Prompts: promptDefinitions(),
 	}
@@ -248,6 +317,9 @@ func (s *Server) handlePromptsList(req *Request) {
 
 // handlePromptsGet returns a prompt with its messages.
 func (s *Server) handlePromptsGet(req *Request) {
+	if req.ID == nil {
+		return
+	}
 	var params PromptGetParams
 	if err := json.Unmarshal(req.Params, &params); err != nil {
 		s.sendResponse(req.ID, nil, &RPCError{

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -1870,3 +1870,200 @@ func mustJSON(t *testing.T, v interface{}) json.RawMessage {
 	}
 	return data
 }
+
+// runServerRaw feeds raw NDJSON lines straight at the server. Necessary
+// for notification tests because json.Marshal of Request{ID: nil} with
+// `id,omitempty` already drops the field, but constructing a request
+// with ID set to typed nil is awkward; raw lines let the test express
+// "no id field at all" unambiguously.
+func runServerRaw(t *testing.T, lines ...string) []byte {
+	t.Helper()
+	var input strings.Builder
+	for _, line := range lines {
+		input.WriteString(line)
+		if !strings.HasSuffix(line, "\n") {
+			input.WriteString("\n")
+		}
+	}
+	var output bytes.Buffer
+	reader := bufio.NewReader(strings.NewReader(input.String()))
+	server := NewServer(reader, &output)
+	server.buildDispatcher()
+	for {
+		msg, err := jsonrpc.ReadMessageNDJSON(reader)
+		if err != nil {
+			break
+		}
+		var req Request
+		if err := json.Unmarshal(msg, &req); err != nil {
+			t.Fatalf("unmarshal request: %v", err)
+		}
+		server.handleMessage(&req)
+	}
+	return output.Bytes()
+}
+
+// TestNotificationsProduceNoResponse verifies that JSON-RPC notifications
+// (messages with no `id` field) for known MCP methods never produce a
+// response. The previous implementation called sendResponse(req.ID, …)
+// unconditionally, which emitted a response with `"id":null` — a
+// violation of JSON-RPC 2.0 (responses MUST correlate to a request id,
+// and notifications MUST NOT receive a response).
+func TestNotificationsProduceNoResponse(t *testing.T) {
+	cases := []struct {
+		name string
+		line string
+	}{
+		{"tools/list notification", `{"jsonrpc":"2.0","method":"tools/list"}`},
+		{"tools/call notification", `{"jsonrpc":"2.0","method":"tools/call","params":{"name":"analyze","arguments":{"code":"fun x(){}"}}}`},
+		{"resources/list notification", `{"jsonrpc":"2.0","method":"resources/list"}`},
+		{"resources/read notification", `{"jsonrpc":"2.0","method":"resources/read","params":{"uri":"krit://rules"}}`},
+		{"prompts/list notification", `{"jsonrpc":"2.0","method":"prompts/list"}`},
+		{"prompts/get notification", `{"jsonrpc":"2.0","method":"prompts/get","params":{"name":"review_kotlin","arguments":{"code":"fun x(){}"}}}`},
+		{"initialize notification", `{"jsonrpc":"2.0","method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{}}}`},
+		{"unknown method notification", `{"jsonrpc":"2.0","method":"does/not/exist"}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out := runServerRaw(t, tc.line)
+			if len(bytes.TrimSpace(out)) != 0 {
+				t.Errorf("expected no response for notification %q, got %q", tc.name, string(out))
+			}
+		})
+	}
+}
+
+// TestNotificationDoesNotBlockSubsequentRequest pairs a notification with
+// a real request to confirm the server keeps processing after dropping
+// the notification — the fix must not accidentally break the message loop.
+func TestNotificationDoesNotBlockSubsequentRequest(t *testing.T) {
+	out := runServerRaw(t,
+		`{"jsonrpc":"2.0","method":"tools/list"}`,
+		`{"jsonrpc":"2.0","id":42,"method":"tools/list"}`,
+	)
+	outReader := bufio.NewReader(bytes.NewReader(out))
+	var responses []Response
+	for {
+		msg, err := jsonrpc.ReadMessageNDJSON(outReader)
+		if err != nil {
+			break
+		}
+		var resp Response
+		if err := json.Unmarshal(msg, &resp); err != nil {
+			t.Fatalf("unmarshal response: %v", err)
+		}
+		responses = append(responses, resp)
+	}
+	if len(responses) != 1 {
+		t.Fatalf("expected exactly 1 response (only the request, not the notification), got %d: %s", len(responses), string(out))
+	}
+	// The response id must correlate to the request, not be `null` (which
+	// is what the bug would produce for the dropped notification).
+	idFloat, ok := responses[0].ID.(float64)
+	if !ok {
+		t.Fatalf("response id has unexpected type %T (%v); should be the request id, not null", responses[0].ID, responses[0].ID)
+	}
+	if int(idFloat) != 42 {
+		t.Errorf("expected response id 42, got %v", responses[0].ID)
+	}
+}
+
+// TestInitializeNegotiatesSupportedVersion covers the spec rule: if the
+// client requests a version the server supports, the server MUST echo
+// that same version.
+func TestInitializeNegotiatesSupportedVersion(t *testing.T) {
+	// Pick the first (newest) supported version so this stays
+	// meaningful if/when the list grows.
+	supported := supportedProtocolVersions[0]
+	params := fmt.Sprintf(`{"protocolVersion":%q,"capabilities":{}}`, supported)
+	responses := runServer(t, Request{
+		JSONRPC: "2.0",
+		ID:      float64(1),
+		Method:  "initialize",
+		Params:  json.RawMessage(params),
+	})
+	if len(responses) != 1 {
+		t.Fatalf("expected 1 response, got %d", len(responses))
+	}
+	data, _ := json.Marshal(responses[0].Result)
+	var result InitializeResult
+	if err := json.Unmarshal(data, &result); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+	if result.ProtocolVersion != supported {
+		t.Errorf("server returned %q, want %q (client requested supported version, server MUST echo it)", result.ProtocolVersion, supported)
+	}
+}
+
+// TestInitializeFallsBackForUnsupportedVersion covers the spec rule: if
+// the client requests a version the server does not support (e.g. a
+// future spec revision), the server MUST respond with another version
+// it supports (we return the server's latest = protocolVersion).
+func TestInitializeFallsBackForUnsupportedVersion(t *testing.T) {
+	// "9999-12-31" is well beyond anything we will ever publish; the
+	// server cannot possibly support it.
+	params := `{"protocolVersion":"9999-12-31","capabilities":{}}`
+	responses := runServer(t, Request{
+		JSONRPC: "2.0",
+		ID:      float64(1),
+		Method:  "initialize",
+		Params:  json.RawMessage(params),
+	})
+	if len(responses) != 1 {
+		t.Fatalf("expected 1 response, got %d", len(responses))
+	}
+	data, _ := json.Marshal(responses[0].Result)
+	var result InitializeResult
+	if err := json.Unmarshal(data, &result); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+	if result.ProtocolVersion != protocolVersion {
+		t.Errorf("server returned %q for unsupported client version, want server default %q", result.ProtocolVersion, protocolVersion)
+	}
+}
+
+// TestInitializeOmittedVersionUsesServerDefault covers the case where
+// the client sends `initialize` without a `protocolVersion` field. The
+// MCP spec says the client MUST send one, but a defensive server should
+// still respond with its supported version rather than echoing the
+// empty string back as a "version".
+func TestInitializeOmittedVersionUsesServerDefault(t *testing.T) {
+	params := `{"capabilities":{}}`
+	responses := runServer(t, Request{
+		JSONRPC: "2.0",
+		ID:      float64(1),
+		Method:  "initialize",
+		Params:  json.RawMessage(params),
+	})
+	if len(responses) != 1 {
+		t.Fatalf("expected 1 response, got %d", len(responses))
+	}
+	data, _ := json.Marshal(responses[0].Result)
+	var result InitializeResult
+	if err := json.Unmarshal(data, &result); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+	if result.ProtocolVersion != protocolVersion {
+		t.Errorf("server returned %q when client omitted protocolVersion, want server default %q", result.ProtocolVersion, protocolVersion)
+	}
+}
+
+// TestNegotiateProtocolVersion exercises the pure helper directly so
+// each spec rule has a one-line regression case independent of the
+// JSON-RPC plumbing.
+func TestNegotiateProtocolVersion(t *testing.T) {
+	for _, supported := range supportedProtocolVersions {
+		if got := negotiateProtocolVersion(supported); got != supported {
+			t.Errorf("negotiate(%q) = %q, want %q (echo supported version)", supported, got, supported)
+		}
+	}
+	if got := negotiateProtocolVersion(""); got != protocolVersion {
+		t.Errorf("negotiate(\"\") = %q, want %q (server default)", got, protocolVersion)
+	}
+	if got := negotiateProtocolVersion("9999-12-31"); got != protocolVersion {
+		t.Errorf("negotiate(future) = %q, want %q (server default)", got, protocolVersion)
+	}
+	if got := negotiateProtocolVersion("1999-01-01"); got != protocolVersion {
+		t.Errorf("negotiate(past) = %q, want %q (server default)", got, protocolVersion)
+	}
+}


### PR DESCRIPTION
## Summary

- `handleToolsList` / `handleToolsCall` (and the other tools / resources / prompts handlers) called `sendResponse` unconditionally for any matching method. A JSON-RPC notification (no `id`) therefore produced a response with `"id":null` — strictly correlating clients would reject it or, worse, drop the in-flight request. Gates every `sendResponse` on `req.ID != nil`, matching the existing default-branch pattern.
- `handleInitialize` ignored `req.Params` and always returned the hardcoded `"2024-11-05"` protocolVersion. Decodes `InitializeParams` and applies the [MCP lifecycle spec](https://modelcontextprotocol.io/specification/2025-06-18/basic/lifecycle) rule: if the client's requested version is one we support, echo it back; otherwise return our latest supported version. Empty/malformed params fall back to the server default. Adds a `negotiateProtocolVersion` helper and a `supportedProtocolVersions` slice so future revisions are a one-line addition.

## Test plan

- [x] Raw-NDJSON notification cases for every known method (`tools/list`, `tools/call`, `resources/list`, `resources/read`, `prompts/list`, `prompts/get`, `initialize`, unknown) assert no response is written.
- [x] Notification followed by a real request still gets exactly one response, correlated to the request's id (not `null`).
- [x] `initialize` with a supported `protocolVersion` echoes it back.
- [x] `initialize` with an unsupported (future) `protocolVersion` returns the server's latest supported version.
- [x] `initialize` with `protocolVersion` omitted returns the server default.
- [x] Direct unit test on `negotiateProtocolVersion`.
- [x] `go build -o /tmp/krit-mcp ./cmd/krit-mcp/`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...` (0 issues)
- [x] `go test ./internal/... ./cmd/... ./pkg/... -count=1`