### PR TITLE
fix(oracle): bound preloadByPath cache to avoid daemon memory growth

### DIFF
--- a/internal/oracle/lazy.go
+++ b/internal/oracle/lazy.go
@@ -1,6 +1,7 @@
 package oracle
 
 import (
+	"container/list"
 	"sync"
 	"sync/atomic"
 
@@ -15,9 +16,25 @@ type preloadState struct {
 	err    error
 }
 
+// preloadCacheCap bounds the number of distinct oracle JSON paths the
+// package-level preload cache retains. Each entry pins an *Oracle (tens
+// of MB for large repos) so an unbounded map leaks memory in long-running
+// daemons (`krit serve`, LSP) that touch a stream of distinct paths.
+// The cap is generous for realistic multi-project daemon use; once a
+// LazyLookup resolves it holds its own oracle pointer, so evicting a
+// completed entry only forces a re-Load on a future first lookup for
+// the same path.
+const preloadCacheCap = 64
+
+type preloadEntry struct {
+	path  string
+	state *preloadState
+}
+
 var (
 	preloadMu     sync.Mutex
-	preloadByPath = map[string]*preloadState{}
+	preloadByPath = map[string]*list.Element{}
+	preloadLRU    = list.New() // front = most-recently-used; back = LRU
 )
 
 // PreloadPath kicks off oracle JSON deserialization for path and keeps the
@@ -33,12 +50,31 @@ func PreloadPath(path string) {
 func preloadStateFor(path string) *preloadState {
 	preloadMu.Lock()
 	defer preloadMu.Unlock()
-	if state := preloadByPath[path]; state != nil {
-		return state
+	if elem := preloadByPath[path]; elem != nil {
+		preloadLRU.MoveToFront(elem)
+		return elem.Value.(*preloadEntry).state
 	}
 	state := &preloadState{done: make(chan struct{})}
-	preloadByPath[path] = state
+	entry := &preloadEntry{path: path, state: state}
+	elem := preloadLRU.PushFront(entry)
+	preloadByPath[path] = elem
+	for preloadLRU.Len() > preloadCacheCap {
+		oldest := preloadLRU.Back()
+		if oldest == nil {
+			break
+		}
+		preloadLRU.Remove(oldest)
+		delete(preloadByPath, oldest.Value.(*preloadEntry).path)
+	}
 	return state
+}
+
+// preloadCacheLen returns the current number of cached entries. Test-only
+// helper; not exported.
+func preloadCacheLen() int {
+	preloadMu.Lock()
+	defer preloadMu.Unlock()
+	return preloadLRU.Len()
 }
 
 func (s *preloadState) load(path string) {

--- a/internal/oracle/lazy_test.go
+++ b/internal/oracle/lazy_test.go
@@ -1,9 +1,12 @@
 package oracle
 
 import (
+	"container/list"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 )
@@ -116,4 +119,110 @@ func TestLazyLookupPreload_NilSafe(t *testing.T) {
 		t.Fatalf("empty path should not load; Loaded() = %v", got)
 	}
 	(&LazyLookup{}).Preload() // path == "" — must not panic or load
+}
+
+// resetPreloadCache drops every entry from the package-level preload LRU
+// so cap assertions are not perturbed by earlier tests in the same
+// process. Mirrors the locking discipline of preloadStateFor.
+func resetPreloadCache() {
+	preloadMu.Lock()
+	defer preloadMu.Unlock()
+	preloadByPath = map[string]*list.Element{}
+	preloadLRU.Init()
+}
+
+// TestPreloadCache_EvictsOldestPastCap is the regression test for the
+// unbounded preloadByPath map leak: writing more than preloadCacheCap
+// distinct paths used to grow the map without bound. The cap must hold
+// and the oldest entry must be evicted.
+func TestPreloadCache_EvictsOldestPastCap(t *testing.T) {
+	resetPreloadCache()
+
+	// Insert cap+overflow distinct paths. They never need to exist on
+	// disk — preloadStateFor only reserves the cache slot.
+	overflow := 10
+	total := preloadCacheCap + overflow
+	for i := 0; i < total; i++ {
+		_ = preloadStateFor(fmt.Sprintf("/fake/oracle/path-%d.json", i))
+	}
+
+	if got := preloadCacheLen(); got != preloadCacheCap {
+		t.Fatalf("preload cache len = %d after %d inserts; want cap %d",
+			got, total, preloadCacheCap)
+	}
+
+	// The first `overflow` paths must have been evicted; the most
+	// recent `preloadCacheCap` must remain.
+	preloadMu.Lock()
+	for i := 0; i < overflow; i++ {
+		path := fmt.Sprintf("/fake/oracle/path-%d.json", i)
+		if _, ok := preloadByPath[path]; ok {
+			preloadMu.Unlock()
+			t.Fatalf("expected evicted path %q to be absent", path)
+		}
+	}
+	for i := overflow; i < total; i++ {
+		path := fmt.Sprintf("/fake/oracle/path-%d.json", i)
+		if _, ok := preloadByPath[path]; !ok {
+			preloadMu.Unlock()
+			t.Fatalf("expected retained path %q to remain", path)
+		}
+	}
+	preloadMu.Unlock()
+}
+
+// TestPreloadCache_TouchPromotesToFront confirms LRU recency: re-asking
+// for an existing path must protect it from eviction even as new paths
+// stream in.
+func TestPreloadCache_TouchPromotesToFront(t *testing.T) {
+	resetPreloadCache()
+
+	// Fill to cap.
+	for i := 0; i < preloadCacheCap; i++ {
+		_ = preloadStateFor(fmt.Sprintf("/fake/oracle/old-%d.json", i))
+	}
+	// Touch the oldest entry so it becomes most-recent.
+	hotPath := "/fake/oracle/old-0.json"
+	_ = preloadStateFor(hotPath)
+
+	// Push a fresh path; the now-LRU entry (old-1) should be evicted,
+	// not the touched hot entry.
+	_ = preloadStateFor("/fake/oracle/fresh.json")
+
+	preloadMu.Lock()
+	defer preloadMu.Unlock()
+	if _, ok := preloadByPath[hotPath]; !ok {
+		t.Fatalf("touched path %q was evicted; LRU recency broken", hotPath)
+	}
+	if _, ok := preloadByPath["/fake/oracle/old-1.json"]; ok {
+		t.Fatalf("expected LRU entry old-1.json to be evicted")
+	}
+}
+
+// TestPreloadCache_ConcurrentInsertsRespectCap is the -race friendly
+// stress test: many goroutines racing through preloadStateFor must
+// neither corrupt the map nor blow past the cap.
+func TestPreloadCache_ConcurrentInsertsRespectCap(t *testing.T) {
+	resetPreloadCache()
+
+	const workers = 16
+	const perWorker = 64
+
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for w := 0; w < workers; w++ {
+		go func(id int) {
+			defer wg.Done()
+			for i := 0; i < perWorker; i++ {
+				path := fmt.Sprintf("/fake/oracle/w%d-p%d.json", id, i)
+				_ = preloadStateFor(path)
+			}
+		}(w)
+	}
+	wg.Wait()
+
+	if got := preloadCacheLen(); got > preloadCacheCap {
+		t.Fatalf("preload cache len = %d after concurrent inserts; want <= %d",
+			got, preloadCacheCap)
+	}
 }


### PR DESCRIPTION
## Summary
- `internal/oracle/lazy.go` kept a package-level `preloadByPath` map keyed by absolute oracle JSON path that grew unbounded for the lifetime of every `krit serve` / LSP daemon. Each entry pinned an `*Oracle` (tens of MB on large repos), so daemons that touched a stream of distinct projects or invalidated oracle paths leaked memory indefinitely with no eviction path.
- Replaces the unbounded map with a 64-entry in-memory LRU built on `container/list`. The cap is comfortably above realistic multi-project daemon working sets, and the LRU lives behind the existing `preloadMu` so callers see no API change.
- Each `LazyLookup.load()` already copies `state.loaded` / `state.err` into its own `lazyResult` before returning, so evicting a *completed* cache entry only forces a re-`Load` on a future first lookup for the same path — never on a `LazyLookup` already in flight.

## Policy chosen
Option (a) — a bounded in-memory LRU — over the daemon-scoped (option c) refactor or a goroutine-driven TTL (option b). Rationale: `PreloadPath` and `NewLazyLookup` are called from per-scan `runner` and pipeline code that have no handle on `daemonState`, so plumbing the cache into the daemon would touch many files for marginal benefit. The LRU is the smallest, surgical, race-safe change that bounds memory growth without changing the public surface or eviction timing semantics. 64 entries is large enough that daily multi-project use never thrashes the cap.

## Tests
- `TestPreloadCache_EvictsOldestPastCap` — insert `cap + overflow` distinct paths, assert len == cap and the oldest `overflow` paths are evicted.
- `TestPreloadCache_TouchPromotesToFront` — verifies LRU recency: touching the oldest entry protects it from eviction when a fresh path arrives.
- `TestPreloadCache_ConcurrentInsertsRespectCap` — 16 goroutines × 64 inserts under `-race`; cache must stay at or below cap and not corrupt the map.

## Test plan
- [x] `go build -o /tmp/krit ./cmd/krit/`
- [x] `go vet ./...`
- [x] `golangci-lint run ./internal/oracle/...` (0 issues; the 6 issues from `./...` come from a sibling worktree's stale files)
- [x] `go test -race ./internal/oracle/ -count=1`
- [x] `go test ./... -count=1`