### PR TITLE
fix(cache): guard Cache.Files with RWMutex

### DIFF
--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 	"sync/atomic"
 
 	"github.com/kaeawc/krit/internal/config"
@@ -93,11 +94,21 @@ func (e *FileEntry) UnmarshalJSON(data []byte) error {
 }
 
 // Cache holds the entire incremental analysis cache.
+//
+// Files is guarded by filesMu: the daemon shares a single *Cache across
+// concurrent analyze RPCs (see internal/cli/serve/serve.go), and a
+// background periodic-flush goroutine may iterate the map while a
+// pipeline run mutates it. All access to Files must go through the
+// exported methods, which take filesMu read/write as appropriate.
 type Cache struct {
 	Version   string               `json:"version"`
 	RuleHash  string               `json:"ruleHash"`
 	ScanPaths []string             `json:"scanPaths,omitempty"`
 	Files     map[string]FileEntry `json:"files"`
+
+	// filesMu guards Files. Heavy I/O (file hashing, os.Stat) is performed
+	// outside the lock; only the map access is serialised.
+	filesMu sync.RWMutex
 
 	// store, when non-nil, backs all reads and writes instead of the
 	// in-memory Files map.  Entries are persisted per-file so Save becomes
@@ -202,6 +213,10 @@ func LoadFromDir(dir string) *Cache {
 // It writes to a temporary file first, then renames for crash safety
 // and safe concurrent access.  When a store is attached, Save is a no-op
 // because entries are persisted individually on each UpdateEntry call.
+//
+// Save holds Cache.filesMu read-locked across encodeBinary so concurrent
+// writers cannot tear the map mid-iteration. The compressed byte buffer
+// is written to disk after the lock is released.
 func (c *Cache) Save(cacheFilePath string) error {
 	if c.backingStore != nil {
 		return nil
@@ -210,7 +225,9 @@ func (c *Cache) Save(cacheFilePath string) error {
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		return fmt.Errorf("create cache dir: %w", err)
 	}
+	c.filesMu.RLock()
 	data, err := encodeBinary(c)
+	c.filesMu.RUnlock()
 	if err != nil {
 		return fmt.Errorf("encode cache: %w", err)
 	}
@@ -386,7 +403,9 @@ func (c *Cache) CheckFiles(filePaths []string, ruleHash string, scanPaths ...str
 
 	for _, path := range filePaths {
 		abs, _ := filepath.Abs(path)
+		c.filesMu.RLock()
 		entry, ok := c.Files[abs]
+		c.filesMu.RUnlock()
 		if !ok {
 			continue
 		}
@@ -453,7 +472,9 @@ func (c *Cache) CheckFilesIncremental(
 
 	for _, path := range filePaths {
 		abs := absPath(path)
+		c.filesMu.RLock()
 		entry, ok := c.Files[abs]
+		c.filesMu.RUnlock()
 		if !ok {
 			continue
 		}
@@ -685,20 +706,45 @@ func (c *Cache) updateEntry(path string, columns scanner.FindingColumns) {
 	if err != nil {
 		return
 	}
-	c.Files[abs] = FileEntry{
+	// Compute hash outside the lock — SHA-256 + file I/O can be tens of
+	// milliseconds on large files and would otherwise stall every reader.
+	entry := FileEntry{
 		Hash:    ComputeFileHash(path),
 		ModTime: info.ModTime().UnixMilli(),
 		Size:    info.Size(),
 		Columns: columns,
 	}
+	c.filesMu.Lock()
+	c.Files[abs] = entry
+	c.filesMu.Unlock()
 	c.mutated.Store(true)
 }
 
 // Prune removes entries for files that no longer exist.
+//
+// Stat calls are performed outside the cache lock so concurrent readers
+// and writers are not blocked on disk I/O; only the snapshot and the
+// final delete pass hold the lock.
 func (c *Cache) Prune() {
+	c.filesMu.RLock()
+	paths := make([]string, 0, len(c.Files))
 	for path := range c.Files {
+		paths = append(paths, path)
+	}
+	c.filesMu.RUnlock()
+
+	stale := make([]string, 0)
+	for _, path := range paths {
 		if _, err := os.Stat(path); err != nil {
-			delete(c.Files, path)
+			stale = append(stale, path)
 		}
 	}
+	if len(stale) == 0 {
+		return
+	}
+	c.filesMu.Lock()
+	for _, path := range stale {
+		delete(c.Files, path)
+	}
+	c.filesMu.Unlock()
 }

--- a/internal/cache/cache_race_test.go
+++ b/internal/cache/cache_race_test.go
@@ -1,0 +1,106 @@
+package cache
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/kaeawc/krit/internal/scanner"
+)
+
+// TestCacheRace hammers Cache.Files from many goroutines through the public
+// read/write/prune surface (CheckFiles, UpdateEntryColumns, Prune) to catch
+// unsynchronised map access under the race detector.
+//
+// Run with: go test -race ./internal/cache/ -count=1 -run TestCacheRace
+func TestCacheRace(t *testing.T) {
+	dir := t.TempDir()
+
+	const numFiles = 32
+	files := make([]string, numFiles)
+	for i := 0; i < numFiles; i++ {
+		p := filepath.Join(dir, fmt.Sprintf("f%d.kt", i))
+		if err := os.WriteFile(p, []byte(fmt.Sprintf("fun f%d() {}\n", i)), 0o644); err != nil {
+			t.Fatalf("seed file %d: %v", i, err)
+		}
+		files[i] = p
+	}
+
+	c := &Cache{
+		RuleHash: "samehash",
+		Files:    make(map[string]FileEntry),
+	}
+
+	// Pre-populate so readers and the pruner immediately have entries to
+	// chew on. Without this the race window between insertion and prune
+	// closes after a single iteration.
+	for _, p := range files {
+		cols := scanner.CollectFindings([]scanner.Finding{
+			{File: p, Line: 1, Col: 1, Severity: "warning", RuleSet: "race", Rule: "Seed", Message: "seed"},
+		})
+		c.UpdateEntryColumns(p, &cols)
+	}
+
+	const (
+		readers    = 8
+		writers    = 4
+		pruners    = 2
+		iterations = 200
+	)
+
+	var wg sync.WaitGroup
+
+	for r := 0; r < readers; r++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < iterations; i++ {
+				_ = c.CheckFiles(files, "samehash")
+				_ = c.CheckFilesIncremental(files, files[:numFiles/2], "samehash")
+				_ = c.MutatedSinceFlush()
+			}
+		}()
+	}
+
+	for w := 0; w < writers; w++ {
+		wg.Add(1)
+		go func(seed int) {
+			defer wg.Done()
+			for i := 0; i < iterations; i++ {
+				p := files[(seed+i)%numFiles]
+				cols := scanner.CollectFindings([]scanner.Finding{
+					{File: p, Line: 1, Col: 1, Severity: "warning", RuleSet: "race", Rule: "W", Message: "w"},
+				})
+				c.UpdateEntryColumns(p, &cols)
+				if i%16 == 0 {
+					c.MarkFlushed()
+				}
+			}
+		}(w)
+	}
+
+	for p := 0; p < pruners; p++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < iterations; i++ {
+				c.Prune()
+			}
+		}()
+	}
+
+	// Concurrent Save: exercises the read path inside encodeBinary, which
+	// iterates Files under the same RWMutex.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		savePath := filepath.Join(dir, "race.cache")
+		for i := 0; i < iterations/4; i++ {
+			_ = c.Save(savePath)
+		}
+	}()
+
+	wg.Wait()
+}


### PR DESCRIPTION
## Summary

- `Cache.Files` was read, written, and deleted across concurrent paths without synchronisation. The daemon shares a single `*cache.Cache` across analyze RPCs (`internal/cli/serve/serve.go` `analysisCacheFor`), and a background flush goroutine reads the map. Today the pipeline serialises around dispatch so the race is latent, but any future flusher tick or parallel project run would tear the map.
- Added `Cache.filesMu` (`sync.RWMutex`) and wrapped every `Files` access: `CheckFiles` / `CheckFilesIncremental` take `RLock` around the map probe; `updateEntry` does file hashing and `Stat` outside the lock and only takes `Lock` to install the entry; `Prune` snapshots paths under `RLock`, stats them lock-free, and `Lock`s only to delete dead entries; `Save` holds `RLock` across `encodeBinary` so gob iteration cannot race a writer.
- Added `TestCacheRace` that hammers `CheckFiles` / `UpdateEntryColumns` / `Prune` / `Save` from many goroutines. Race-clean with the fix, race-positive without it.

## Test plan

- [x] `go test -race ./internal/cache/ -count=1 -run TestCacheRace`
- [x] `go test -race ./internal/cache/ -count=1`
- [x] `go test ./... -count=1`
- [x] `go build -o /tmp/krit ./cmd/krit/`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...`