### PR TITLE
fix(scanner): guard CodeIndex reference maps with RWMutex

### DIFF
--- a/internal/scanner/hotspot.go
+++ b/internal/scanner/hotspot.go
@@ -53,6 +53,8 @@ func isClassLikeSymbol(kind string) bool {
 }
 
 func (idx *CodeIndex) externalReferenceFiles(name, declaringFile string, ignoreCommentRefs bool) []string {
+	idx.refMu.RLock()
+	defer idx.refMu.RUnlock()
 	var source map[string]bool
 	if ignoreCommentRefs {
 		source = idx.nonCommentRefFilesByName[name]

--- a/internal/scanner/index.go
+++ b/internal/scanner/index.go
@@ -1,6 +1,8 @@
 package scanner
 
 import (
+	"sync"
+
 	"github.com/bits-and-blooms/bloom/v3"
 
 	"github.com/kaeawc/krit/internal/perf"
@@ -76,6 +78,19 @@ type CodeIndex struct {
 	// Bloom filter for fast "is this name referenced?" checks.
 	// False positives are OK (we fall back to exact check), false negatives are not.
 	refBloom *bloom.BloomFilter
+
+	// refMu guards refCountByName, refFilesByName,
+	// nonCommentRefFilesByName, nonCommentRefCountByNameFile, and
+	// refBloom against concurrent mutation. Add/remove lookup helpers
+	// take the write lock; the read accessors (MayHaveReference,
+	// ReferenceFiles, ReferenceCount, IsReferencedOutsideFile,
+	// IsReferencedOutsideFileExcludingComments, CountNonCommentRefsInFile,
+	// externalReferenceFiles) take the read lock. The lock covers only
+	// the reference lookup state — Symbols/References/Files slices and
+	// the symbol lookup maps are still expected to be stable for the
+	// lifetime of a published index, which matches the daemon's
+	// per-project analyze mutex contract for prior-overlay mutations.
+	refMu sync.RWMutex
 }
 
 // BuildIndex constructs a cross-file index from parsed Kotlin and Java files.

--- a/internal/scanner/index_query.go
+++ b/internal/scanner/index_query.go
@@ -244,6 +244,9 @@ func (a *referenceAggregate) add(ref Reference) {
 }
 
 func (idx *CodeIndex) addReferenceLookup(ref Reference) {
+	idx.refMu.Lock()
+	defer idx.refMu.Unlock()
+
 	if idx.refCountByName == nil {
 		idx.refCountByName = make(map[string]int)
 	}
@@ -285,6 +288,9 @@ func (idx *CodeIndex) addReferenceLookup(ref Reference) {
 }
 
 func (idx *CodeIndex) removeReferenceLookup(ref Reference) {
+	idx.refMu.Lock()
+	defer idx.refMu.Unlock()
+
 	if idx.refCountByName != nil {
 		if next := idx.refCountByName[ref.Name] - 1; next > 0 {
 			idx.refCountByName[ref.Name] = next
@@ -331,7 +337,12 @@ func estimateUniqueReferenceNames(refCount int) int {
 
 // ReferenceCount returns how many times a name is referenced across all files.
 func (idx *CodeIndex) MayHaveReference(name string) bool {
-	if idx == nil || idx.refBloom == nil {
+	if idx == nil {
+		return false
+	}
+	idx.refMu.RLock()
+	defer idx.refMu.RUnlock()
+	if idx.refBloom == nil {
 		return false
 	}
 	return idx.refBloom.TestString(name)
@@ -339,12 +350,32 @@ func (idx *CodeIndex) MayHaveReference(name string) bool {
 
 // ReferenceCount returns how many times a name is referenced across all files.
 func (idx *CodeIndex) ReferenceCount(name string) int {
+	if idx == nil {
+		return 0
+	}
+	idx.refMu.RLock()
+	defer idx.refMu.RUnlock()
 	return idx.refCountByName[name]
 }
 
-// ReferenceFiles returns the set of files that reference a name.
+// ReferenceFiles returns the set of files that reference a name. The returned
+// map is a defensive copy: callers may iterate it without holding the
+// index lock and concurrent writers will not corrupt their snapshot.
 func (idx *CodeIndex) ReferenceFiles(name string) map[string]bool {
-	return idx.refFilesByName[name]
+	if idx == nil {
+		return nil
+	}
+	idx.refMu.RLock()
+	defer idx.refMu.RUnlock()
+	src := idx.refFilesByName[name]
+	if src == nil {
+		return nil
+	}
+	out := make(map[string]bool, len(src))
+	for f, v := range src {
+		out[f] = v
+	}
+	return out
 }
 
 // SymbolReferenceCount returns the total number of references that can identify
@@ -362,8 +393,13 @@ func (idx *CodeIndex) SymbolReferenceCount(sym Symbol) int {
 
 // IsReferencedOutsideFile checks if a name is referenced in any file other than the given one.
 func (idx *CodeIndex) IsReferencedOutsideFile(name, file string) bool {
+	if idx == nil {
+		return false
+	}
+	idx.refMu.RLock()
+	defer idx.refMu.RUnlock()
 	// Fast path: bloom filter says name not referenced at all
-	if !idx.refBloom.TestString(name) {
+	if idx.refBloom == nil || !idx.refBloom.TestString(name) {
 		return false
 	}
 	files := idx.refFilesByName[name]
@@ -399,8 +435,13 @@ func (idx *CodeIndex) IsSymbolReferencedOutsideFile(sym Symbol, ignoreCommentRef
 // IsReferencedOutsideFileExcludingComments checks if a name has any non-comment
 // reference in a file other than the given one.
 func (idx *CodeIndex) IsReferencedOutsideFileExcludingComments(name, file string) bool {
+	if idx == nil {
+		return false
+	}
+	idx.refMu.RLock()
+	defer idx.refMu.RUnlock()
 	// Fast path: bloom filter says name not referenced at all
-	if !idx.refBloom.TestString(name) {
+	if idx.refBloom == nil || !idx.refBloom.TestString(name) {
 		return false
 	}
 	files := idx.nonCommentRefFilesByName[name]
@@ -417,6 +458,11 @@ func (idx *CodeIndex) IsReferencedOutsideFileExcludingComments(name, file string
 
 // CountNonCommentRefsInFile counts references to a name in a file that are NOT inside comments.
 func (idx *CodeIndex) CountNonCommentRefsInFile(name, file string) int {
+	if idx == nil {
+		return 0
+	}
+	idx.refMu.RLock()
+	defer idx.refMu.RUnlock()
 	files := idx.nonCommentRefCountByNameFile[name]
 	if files == nil {
 		return 0
@@ -483,6 +529,11 @@ func symbolReferenceNames(sym Symbol) []string {
 
 // BloomStats returns the bloom filter memory usage in bytes.
 func (idx *CodeIndex) BloomStats() (refBits, crossBits uint) {
+	if idx == nil {
+		return
+	}
+	idx.refMu.RLock()
+	defer idx.refMu.RUnlock()
 	if idx.refBloom != nil {
 		refBits = idx.refBloom.Cap()
 	}

--- a/internal/scanner/index_race_test.go
+++ b/internal/scanner/index_race_test.go
@@ -1,0 +1,83 @@
+package scanner
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+)
+
+// TestCodeIndexRace exercises concurrent reads against
+// addReferenceLookup writes to catch unguarded mutations of the
+// reference lookup maps and the underlying bloom filter. Runs as part
+// of `go test -race ./internal/scanner/`; without the RWMutex on
+// CodeIndex the race detector trips on map and bloom-filter access.
+func TestCodeIndexRace(t *testing.T) {
+	t.Parallel()
+
+	const (
+		seedNames   = 64
+		writerCount = 4
+		readerCount = 8
+		opsPerLoop  = 256
+	)
+
+	symbols := make([]Symbol, 0, seedNames)
+	refs := make([]Reference, 0, seedNames)
+	for i := 0; i < seedNames; i++ {
+		name := fmt.Sprintf("seedSym%03d", i)
+		symbols = append(symbols, Symbol{
+			Name:       name,
+			Kind:       "function",
+			Visibility: "public",
+			File:       fmt.Sprintf("seed_%03d.kt", i),
+			Line:       i + 1,
+		})
+		refs = append(refs, Reference{
+			Name: name,
+			File: fmt.Sprintf("seed_%03d.kt", i),
+			Line: i + 1,
+		})
+	}
+	idx := BuildIndexFromData(symbols, refs)
+
+	var wg sync.WaitGroup
+	wg.Add(writerCount + readerCount)
+
+	for w := 0; w < writerCount; w++ {
+		go func(workerID int) {
+			defer wg.Done()
+			for i := 0; i < opsPerLoop; i++ {
+				ref := Reference{
+					Name: fmt.Sprintf("writer%d_sym%d", workerID, i%seedNames),
+					File: fmt.Sprintf("writer%d_file%d.kt", workerID, i%16),
+					Line: i + 1,
+				}
+				idx.addReferenceLookup(ref)
+				if i%3 == 0 {
+					idx.removeReferenceLookup(ref)
+				}
+			}
+		}(w)
+	}
+
+	for r := 0; r < readerCount; r++ {
+		go func(workerID int) {
+			defer wg.Done()
+			for i := 0; i < opsPerLoop; i++ {
+				name := fmt.Sprintf("seedSym%03d", i%seedNames)
+				_ = idx.MayHaveReference(name)
+				_ = idx.ReferenceCount(name)
+				for file := range idx.ReferenceFiles(name) {
+					_ = file
+				}
+				_ = idx.IsReferencedOutsideFile(name, "seed_000.kt")
+				_ = idx.IsReferencedOutsideFileExcludingComments(name, "seed_000.kt")
+				_ = idx.CountNonCommentRefsInFile(name, "seed_000.kt")
+				writerName := fmt.Sprintf("writer%d_sym%d", workerID%writerCount, i%seedNames)
+				_ = idx.MayHaveReference(writerName)
+			}
+		}(r)
+	}
+
+	wg.Wait()
+}


### PR DESCRIPTION
## Summary
- The CodeIndex reference lookup maps (refCountByName, refFilesByName, nonCommentRefFilesByName, nonCommentRefCountByNameFile) and refBloom were mutated by addReferenceLookup / removeReferenceLookup with no locking.
- LSP read sites (codelens.go, go_to_test_action.go) call ReferenceFiles / MayHaveReference etc., which can race with overlay-rebuild writes triggered by another in-flight request — `go test -race` flags this immediately.
- Add a sync.RWMutex on CodeIndex covering the lookup maps + bloom filter: write helpers take the write lock; reader accessors take the read lock; ReferenceFiles returns a defensive copy so callers can iterate after dropping the lock.

## Test plan
- [x] `go test -race ./internal/scanner/ -run TestCodeIndexRace -count=1` (new test, fails without the lock, passes with it)
- [x] `go test -race ./internal/scanner/ ./internal/lsp/ -count=1`
- [x] `go build -o /tmp/krit ./cmd/krit/`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...` (0 issues)
- [x] `go test ./... -count=1` (all packages PASS)