### PR TITLE
fix(applysuggestion): report post-dedup edit count and surface dropped fixes

### DIFF
--- a/internal/cli/applysuggestion/applysuggestion.go
+++ b/internal/cli/applysuggestion/applysuggestion.go
@@ -109,15 +109,27 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	}
 
 	cols := buildFindingColumns(finding, sug, edits)
-	applied, _, errs := fixer.ApplyAllFixesColumns(context.Background(), &cols, "")
+	applied, _, dropped, errs := fixer.ApplyAllFixesColumnsDetailed(context.Background(), &cols, "")
 	for _, e := range errs {
 		fmt.Fprintf(stderr, "apply-suggestion: %v\n", e)
 	}
 	if len(errs) > 0 {
 		return 1
 	}
+	for _, d := range dropped {
+		reason := d.Reason
+		if reason == "" {
+			reason = "overlapping conflict"
+		}
+		fmt.Fprintf(stderr, "apply-suggestion: warning: dropped edit from %s at %s:%d because %s\n",
+			d.Rule, d.File, d.Line, reason)
+	}
+	appliedTargets := summarizeAppliedTargets(edits, dropped)
 	fmt.Fprintf(stdout, "applied suggestion %q for finding %q (%d edit(s) across %s)\n",
-		sug.ID, *findingID, applied, summarizeTargets(edits))
+		sug.ID, *findingID, applied, appliedTargets)
+	if len(dropped) > 0 {
+		fmt.Fprintf(stdout, "  %d edit(s) dropped due to overlap; see warnings above\n", len(dropped))
+	}
 	return 0
 }
 
@@ -305,4 +317,34 @@ func summarizeTargets(edits []output.JSONSuggestedEdit) string {
 	}
 	sort.Strings(out)
 	return strings.Join(out, ", ")
+}
+
+// summarizeAppliedTargets is summarizeTargets minus any file whose only
+// edits were all dropped. This keeps the "applied … across X" string in
+// sync with the post-dedup count: if a file's sole edit was dropped, it
+// did not actually get touched, so reporting it as a target would be
+// just as misleading as the inflated edit count we're fixing.
+func summarizeAppliedTargets(edits []output.JSONSuggestedEdit, dropped []fixer.DroppedFix) string {
+	if len(dropped) == 0 {
+		return summarizeTargets(edits)
+	}
+	droppedPerFile := make(map[string]int, len(dropped))
+	for _, d := range dropped {
+		droppedPerFile[d.File]++
+	}
+	editsPerFile := make(map[string]int, len(edits))
+	for _, e := range edits {
+		editsPerFile[e.TargetFile]++
+	}
+	kept := make([]output.JSONSuggestedEdit, 0, len(edits))
+	for _, e := range edits {
+		if droppedPerFile[e.TargetFile] >= editsPerFile[e.TargetFile] {
+			continue
+		}
+		kept = append(kept, e)
+	}
+	if len(kept) == 0 {
+		return "no files"
+	}
+	return summarizeTargets(kept)
 }

--- a/internal/cli/applysuggestion/applysuggestion_test.go
+++ b/internal/cli/applysuggestion/applysuggestion_test.go
@@ -278,6 +278,108 @@ func TestApply_crossFileEdit(t *testing.T) {
 	}
 }
 
+// TestApply_overlappingEditsReportPostDedupCount is the regression for
+// the apply-suggestion reporting bug: when two edits in the same
+// suggestion overlap, fixer.deduplicateFixesReverse drops one, but the
+// CLI used to report the full submitted count. The success line must
+// report the post-dedup applied count, and the dropped edit must be
+// surfaced as a warning with a clear reason on stderr.
+func TestApply_overlappingEditsReportPostDedupCount(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "a.kt")
+	if err := os.WriteFile(src, []byte("abcdefghij"), 0o644); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	// Two byte-mode edits that overlap at bytes 2-8 — dedup keeps the
+	// longer span (rule emits two via the same suggestion id).
+	report := output.JSONReport{
+		Findings: []output.JSONFinding{{
+			File: "a.kt", Line: 1, Column: 1, RuleSet: "demo", Rule: "OverlapRule",
+			Message: "overlap",
+			SuggestedFixes: []output.JSONSuggestedFix{{
+				ID: "overlap", Title: "overlapping edits",
+				Edits: []output.JSONSuggestedEdit{
+					{StartByte: 2, EndByte: 5, ByteMode: true, Replacement: "Z"},
+					{StartByte: 2, EndByte: 8, ByteMode: true, Replacement: "A"},
+				},
+			}},
+		}},
+	}
+	path := reportFile(t, report)
+	var stdout, stderr bytes.Buffer
+	rc := run([]string{
+		"--finding", "OverlapRule:a.kt:1:1",
+		"--suggestion", "overlap",
+		"--base", dir,
+		path,
+	}, nil, &stdout, &stderr)
+	if rc != 0 {
+		t.Fatalf("rc=%d stderr=%s", rc, stderr.String())
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "1 edit(s) across") {
+		t.Errorf("expected post-dedup applied count of 1, got: %s", out)
+	}
+	if strings.Contains(out, "2 edit(s) across") {
+		t.Errorf("output still reports inflated submitted count: %s", out)
+	}
+	if !strings.Contains(out, "1 edit(s) dropped") {
+		t.Errorf("expected dropped summary on stdout, got: %s", out)
+	}
+	errOut := stderr.String()
+	if !strings.Contains(errOut, "dropped edit") || !strings.Contains(errOut, "because") {
+		t.Errorf("expected dropped-edit warning with reason on stderr, got: %s", errOut)
+	}
+	got, err := os.ReadFile(src)
+	if err != nil {
+		t.Fatalf("read modified source: %v", err)
+	}
+	if string(got) != "abAij" {
+		t.Errorf("file content: got %q want %q", got, "abAij")
+	}
+}
+
+// TestApply_droppedReasonIsSurfaced asserts the canonical overlap
+// reason string flows through to user-visible output, so the user can
+// understand why an edit was skipped without re-reading the fixer
+// source.
+func TestApply_droppedReasonIsSurfaced(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "a.kt")
+	if err := os.WriteFile(src, []byte("abcdefghij"), 0o644); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	report := output.JSONReport{
+		Findings: []output.JSONFinding{{
+			File: "a.kt", Line: 1, Column: 1, Rule: "OverlapRule",
+			SuggestedFixes: []output.JSONSuggestedFix{{
+				ID: "overlap",
+				Edits: []output.JSONSuggestedEdit{
+					{StartByte: 2, EndByte: 5, ByteMode: true, Replacement: "Z"},
+					{StartByte: 2, EndByte: 8, ByteMode: true, Replacement: "A"},
+				},
+			}},
+		}},
+	}
+	path := reportFile(t, report)
+	var stdout, stderr bytes.Buffer
+	rc := run([]string{
+		"--finding", "OverlapRule:a.kt:1:1",
+		"--suggestion", "overlap",
+		"--base", dir,
+		path,
+	}, nil, &stdout, &stderr)
+	if rc != 0 {
+		t.Fatalf("rc=%d stderr=%s", rc, stderr.String())
+	}
+	errOut := stderr.String()
+	// The reason text comes from internal/fixer; require a substring
+	// from the canonical message so a typo there fails the test.
+	if !strings.Contains(errOut, "overlaps with") {
+		t.Errorf("expected canonical overlap reason in warning, got: %s", errOut)
+	}
+}
+
 // TestFix_doesNotApplySuggestedEdits guards the mutual exclusion between
 // --fix and suggested fixes. A finding with no autofix (Fix=nil) but a
 // suggested fix carrying edits must not be touched by the

--- a/internal/fixer/fixer.go
+++ b/internal/fixer/fixer.go
@@ -78,6 +78,12 @@ func countParseErrors(ctx context.Context, content []byte) int {
 }
 
 // FixResult holds the result of applying fixes to a file.
+//
+// Applied counts text edits that actually made it into the rewritten
+// file — i.e. the input fix count minus any fixes removed by overlap
+// dedup. DroppedFixes carries the rejected fixes (with a Reason) so
+// user-facing callers can explain why an edit was skipped instead of
+// silently inflating the "applied" total.
 type FixResult struct {
 	Applied      int
 	DroppedFixes []DroppedFix
@@ -86,9 +92,23 @@ type FixResult struct {
 // ApplyAllFixesColumns applies text fixes from columnar findings across all files.
 // It reconstructs only rows that carry text fixes, preserving the existing file-level
 // fixer behavior without materializing the entire finding set.
+//
+// totalFixes counts only fixes that were actually written to disk
+// (overlap-dropped fixes are excluded). Callers that need the
+// dropped-fix detail to surface as user-visible warnings should use
+// ApplyAllFixesColumnsDetailed.
 func ApplyAllFixesColumns(ctx context.Context, columns *scanner.FindingColumns, suffix string) (totalFixes int, filesModified int, errors []error) {
+	totalFixes, filesModified, _, errors = ApplyAllFixesColumnsDetailed(ctx, columns, suffix)
+	return
+}
+
+// ApplyAllFixesColumnsDetailed is the same as ApplyAllFixesColumns but
+// also returns the aggregate list of fixes dropped due to overlap
+// conflicts (with their Reason populated). The returned dropped slice
+// is ordered by file path so callers can render stable diagnostics.
+func ApplyAllFixesColumnsDetailed(ctx context.Context, columns *scanner.FindingColumns, suffix string) (totalFixes int, filesModified int, dropped []DroppedFix, errors []error) {
 	if columns == nil || columns.Len() == 0 {
-		return 0, 0, nil
+		return 0, 0, nil, nil
 	}
 
 	byFile := make(map[string][]int)
@@ -113,6 +133,9 @@ func ApplyAllFixesColumns(ctx context.Context, columns *scanner.FindingColumns, 
 		if res.Applied > 0 {
 			totalFixes += res.Applied
 			filesModified++
+		}
+		if len(res.DroppedFixes) > 0 {
+			dropped = append(dropped, res.DroppedFixes...)
 		}
 	}
 	return
@@ -180,7 +203,7 @@ func applyFixesDetailedColumns(ctx context.Context, path string, columns *scanne
 		return FixResult{DroppedFixes: droppedFixes}, err
 	}
 
-	return FixResult{Applied: len(fixes), DroppedFixes: droppedFixes}, nil
+	return FixResult{Applied: len(fixes) - len(droppedFixes), DroppedFixes: droppedFixes}, nil
 }
 
 // filePerm returns the existing file's permission bits so atomic overwrite
@@ -378,10 +401,17 @@ func uniqueNames(n int, get func(int) string) []string {
 
 // DroppedFix records a fix that was dropped due to overlap conflict.
 type DroppedFix struct {
-	Rule string
-	File string
-	Line int
+	Rule   string
+	File   string
+	Line   int
+	Reason string
 }
+
+// overlapDropReason is the canonical reason string used when
+// deduplicateFixesReverse rejects an overlapping fix. Surfaced through
+// FixResult.DroppedFixes / ApplyAllFixesColumnsDetailed so user-facing
+// CLIs (e.g. apply-suggestion) can explain why an edit was skipped.
+const overlapDropReason = "overlaps with a higher-priority fix at the same target range"
 
 // deduplicateFixesReverse removes overlapping fixes from a reverse-sorted
 // slice. The caller supplies key extractors that return the start and end
@@ -411,6 +441,6 @@ func textFixRowLineEnd(f textFixRow) int   { return f.fix.EndLine }
 func textFixRowLineStart(f textFixRow) int { return f.fix.StartLine }
 func textFixRowDroppedFor(path string) func(textFixRow) DroppedFix {
 	return func(f textFixRow) DroppedFix {
-		return DroppedFix{Rule: f.rule, File: path, Line: f.line}
+		return DroppedFix{Rule: f.rule, File: path, Line: f.line, Reason: overlapDropReason}
 	}
 }

--- a/internal/fixer/fixer_test.go
+++ b/internal/fixer/fixer_test.go
@@ -257,9 +257,9 @@ func TestByteModeFix_OverlappingDedup(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	// Both findings are counted even though one is deduplicated
-	if n != 2 {
-		t.Fatalf("expected 2 fixes counted, got %d", n)
+	// Only the surviving (non-overlapping) fix is counted.
+	if n != 1 {
+		t.Fatalf("expected 1 fix applied after overlap dedup, got %d", n)
 	}
 	got := readFile(t, path)
 	// The fix with higher StartByte (4-8) is applied first in reverse order.
@@ -1031,14 +1031,18 @@ func TestByteConflictDetection_DroppedFixReported(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if res.Applied != 2 {
-		t.Fatalf("expected 2 fixes counted, got %d", res.Applied)
+	// Applied is the post-dedup count: 2 submitted - 1 dropped = 1.
+	if res.Applied != 1 {
+		t.Fatalf("expected 1 fix applied (post-dedup), got %d", res.Applied)
 	}
 	if len(res.DroppedFixes) != 1 {
 		t.Fatalf("expected 1 dropped fix, got %d", len(res.DroppedFixes))
 	}
 	if res.DroppedFixes[0].Rule != "rule-A" {
 		t.Fatalf("expected dropped rule 'rule-A', got %q", res.DroppedFixes[0].Rule)
+	}
+	if res.DroppedFixes[0].Reason == "" {
+		t.Fatalf("expected non-empty Reason on dropped fix, got %#v", res.DroppedFixes[0])
 	}
 }
 


### PR DESCRIPTION
## Summary
- `krit apply-suggestion` previously reported the count of *submitted* edits as `applied N edit(s)`. When the fixer's overlap dedup dropped one or more edits, the count was inflated and the dropped edits were never surfaced.
- Fix `FixResult.Applied` to mean the post-dedup count (subtract `len(droppedFixes)`), add `ApplyAllFixesColumnsDetailed` so callers can recover the aggregate dropped list, and attach a canonical `Reason` to each `DroppedFix`.
- `apply-suggestion` now prints a per-dropped-edit warning with the reason on stderr, an accurate "applied N edit(s) across …" line, and a "M edit(s) dropped due to overlap" summary on stdout. `summarizeAppliedTargets` excludes files whose only edit was dropped so the targets list matches reality.
- Updated the two existing tests that locked in the inflated-count behavior (`TestByteModeFix_OverlappingDedup`, `TestByteConflictDetection_DroppedFixReported`); pipeline `TextApplied` / `AppliedFixes` reporting now benefits from the same semantic fix without any test changes there.

## Test plan
- [x] `go build -o /tmp/krit ./cmd/krit/`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...` (0 issues)
- [x] `go test ./internal/cli/applysuggestion/ -count=1` (passes, including two new regression tests covering overlap reporting + dropped-reason surfacing)
- [x] `go test ./... -count=1 -timeout 15m`
- [x] `make lint-rules`