### PR TITLE
fix(schema): reject non-integer float and non-string slice elements

### DIFF
--- a/config/default-krit.yml
+++ b/config/default-krit.yml
@@ -633,10 +633,8 @@ style:
   ForbiddenMethodCall:
     active: false
     methods:
-      - reason: 'print writes directly to standard output; prefer a logger for application code.'
-        value: 'kotlin.io.print'
-      - reason: 'println writes directly to standard output; prefer a logger for application code.'
-        value: 'kotlin.io.println'
+      - 'kotlin.io.print'
+      - 'kotlin.io.println'
   MandatoryBracesLoops:
     active: false
   MaxChainedCallsOnSameLine:
@@ -889,8 +887,7 @@ style:
   ForbiddenAnnotation:
     active: false
     annotations:
-      - value: 'SuppressWarnings'
-        reason: 'Use @Suppress instead.'
+      - 'SuppressWarnings'
   ForbiddenNamedParam:
     active: false
     methods:

--- a/config/profiles/balanced.yml
+++ b/config/profiles/balanced.yml
@@ -617,10 +617,8 @@ style:
   ForbiddenMethodCall:
     active: false
     methods:
-      - reason: 'print writes directly to standard output; prefer a logger for application code.'
-        value: 'kotlin.io.print'
-      - reason: 'println writes directly to standard output; prefer a logger for application code.'
-        value: 'kotlin.io.println'
+      - 'kotlin.io.print'
+      - 'kotlin.io.println'
   MandatoryBracesLoops:
     active: false
   MaxChainedCallsOnSameLine:
@@ -871,8 +869,7 @@ style:
   ForbiddenAnnotation:
     active: false
     annotations:
-      - value: 'SuppressWarnings'
-        reason: 'Use @Suppress instead.'
+      - 'SuppressWarnings'
   ForbiddenNamedParam:
     active: false
     methods:

--- a/internal/schema/schema_test.go
+++ b/internal/schema/schema_test.go
@@ -369,6 +369,137 @@ func TestValidateConfig_WrongType(t *testing.T) {
 	}
 }
 
+func TestValidateConfig_IntAcceptsIntegerValues(t *testing.T) {
+	cases := []struct {
+		name  string
+		value interface{}
+	}{
+		{"int", 42},
+		{"int64", int64(42)},
+		{"integral float64", float64(42)},
+		{"zero", 0},
+		{"negative int", -3},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := config.NewConfig()
+			cfg.Set("complexity", "LongMethod", "allowedLines", tc.value)
+			errs := ValidateConfig(cfg)
+			for _, e := range errs {
+				if e.Path == "complexity.LongMethod.allowedLines" && e.Level == "error" {
+					t.Errorf("unexpected error for %v: %s", tc.value, e)
+				}
+			}
+		})
+	}
+}
+
+func TestValidateConfig_IntRejectsNonIntegralFloat(t *testing.T) {
+	cfg := config.NewConfig()
+	cfg.Set("complexity", "LongMethod", "allowedLines", 2.5)
+
+	errs := ValidateConfig(cfg)
+	found := false
+	for _, e := range errs {
+		if e.Path == "complexity.LongMethod.allowedLines" && e.Level == "error" {
+			found = true
+			if !strings.Contains(e.Message, "allowedLines") {
+				t.Errorf("error message missing option name: %q", e.Message)
+			}
+			if !strings.Contains(e.Message, "2.5") {
+				t.Errorf("error message missing offending value: %q", e.Message)
+			}
+			break
+		}
+	}
+	if !found {
+		t.Error("expected error for non-integral float where int expected")
+	}
+}
+
+func TestValidateConfig_IntRejectsStringValue(t *testing.T) {
+	cfg := config.NewConfig()
+	cfg.Set("complexity", "LongMethod", "allowedLines", "2")
+
+	errs := ValidateConfig(cfg)
+	found := false
+	for _, e := range errs {
+		if e.Path == "complexity.LongMethod.allowedLines" && e.Level == "error" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected error for string where int expected")
+	}
+}
+
+func TestValidateConfig_IntRejectsOutOfRangeFloat(t *testing.T) {
+	cfg := config.NewConfig()
+	// 2^63 exceeds the range of int64; cannot represent as int
+	cfg.Set("complexity", "LongMethod", "allowedLines", float64(1e20))
+
+	errs := ValidateConfig(cfg)
+	found := false
+	for _, e := range errs {
+		if e.Path == "complexity.LongMethod.allowedLines" && e.Level == "error" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected error for out-of-range float where int expected")
+	}
+}
+
+func TestValidateConfig_StringSliceAcceptsStrings(t *testing.T) {
+	cfg := config.NewConfig()
+	cfg.Data()["testSourcePaths"] = []interface{}{"a", "b"}
+
+	errs := ValidateConfig(cfg)
+	for _, e := range errs {
+		if e.Path == "testSourcePaths" && e.Level == "error" {
+			t.Errorf("unexpected error: %s", e)
+		}
+	}
+}
+
+func TestValidateConfig_StringSliceAcceptsEmpty(t *testing.T) {
+	cfg := config.NewConfig()
+	cfg.Data()["testSourcePaths"] = []interface{}{}
+
+	errs := ValidateConfig(cfg)
+	for _, e := range errs {
+		if e.Path == "testSourcePaths" && e.Level == "error" {
+			t.Errorf("unexpected error: %s", e)
+		}
+	}
+}
+
+func TestValidateConfig_StringSliceRejectsNonStringElement(t *testing.T) {
+	cfg := config.NewConfig()
+	cfg.Data()["testSourcePaths"] = []interface{}{"a", 1}
+
+	errs := ValidateConfig(cfg)
+	found := false
+	for _, e := range errs {
+		if e.Path == "testSourcePaths" && e.Level == "error" {
+			found = true
+			if !strings.Contains(e.Message, "testSourcePaths") && !strings.Contains(e.Message, "index 1") && !strings.Contains(e.Message, "[1]") {
+				t.Errorf("error message missing index/name context: %q", e.Message)
+			}
+			if !strings.Contains(e.Message, "int") {
+				t.Errorf("error message missing offending type: %q", e.Message)
+			}
+			break
+		}
+	}
+	if !found {
+		t.Error("expected error for non-string element in string slice")
+	}
+}
+
 func TestValidateConfig_InvalidNamingRegex(t *testing.T) {
 	cfg := config.NewConfig()
 	cfg.Set("naming", "ClassNaming", "classPattern", "[unclosed")

--- a/internal/schema/validate.go
+++ b/internal/schema/validate.go
@@ -2,6 +2,7 @@ package schema
 
 import (
 	"fmt"
+	"math"
 	"sort"
 
 	"github.com/kaeawc/krit/internal/config"
@@ -322,11 +323,7 @@ func validateRuleFields(setName, ruleName string, ruleMap map[string]interface{}
 func checkType(path string, val interface{}, expected OptionType) *ValidationError {
 	switch expected {
 	case OptionTypeInt:
-		switch val.(type) {
-		case int, int64, float64:
-			return nil
-		}
-		return &ValidationError{Path: path, Message: fmt.Sprintf("expected integer, got %T", val), Level: "error"}
+		return checkInt(path, val)
 	case OptionTypeBool:
 		if _, ok := val.(bool); !ok {
 			return &ValidationError{Path: path, Message: fmt.Sprintf("expected boolean, got %T", val), Level: "error"}
@@ -344,14 +341,56 @@ func checkType(path string, val interface{}, expected OptionType) *ValidationErr
 			return &ValidationError{Path: path, Message: fmt.Sprintf("invalid regex: %v", err), Level: "error"}
 		}
 	case OptionTypeStringSlice:
-		if _, ok := val.([]interface{}); !ok {
-			if _, ok := val.([]string); !ok {
-				// Also accept a single string as a one-element list
-				if _, ok := val.(string); !ok {
-					return &ValidationError{Path: path, Message: fmt.Sprintf("expected array of strings, got %T", val), Level: "error"}
+		return checkStringSlice(path, val)
+	}
+	return nil
+}
+
+// checkInt validates an OptionTypeInt value. YAML decodes plain integer
+// literals like `2` as float64, so an integral float that fits in int64 is
+// accepted. Fractional values, non-finite floats, and floats outside int64
+// range are rejected with a message that names the option and the value.
+func checkInt(path string, val interface{}) *ValidationError {
+	switch v := val.(type) {
+	case int, int64:
+		return nil
+	case float64:
+		if math.IsNaN(v) || math.IsInf(v, 0) {
+			return &ValidationError{Path: path, Message: fmt.Sprintf("expected integer for %q, got non-finite float %v", path, v), Level: "error"}
+		}
+		if math.Trunc(v) != v {
+			return &ValidationError{Path: path, Message: fmt.Sprintf("expected integer for %q, got non-integer float %v", path, v), Level: "error"}
+		}
+		if v < math.MinInt64 || v > math.MaxInt64 {
+			return &ValidationError{Path: path, Message: fmt.Sprintf("expected integer for %q, value %v exceeds int64 range", path, v), Level: "error"}
+		}
+		return nil
+	}
+	return &ValidationError{Path: path, Message: fmt.Sprintf("expected integer, got %T", val), Level: "error"}
+}
+
+// checkStringSlice validates an OptionTypeStringSlice value. YAML decodes
+// arrays as []interface{}, so each element must be checked individually.
+// A bare string is also accepted as a one-element list to match historic
+// loader behavior.
+func checkStringSlice(path string, val interface{}) *ValidationError {
+	switch v := val.(type) {
+	case []interface{}:
+		for i, elem := range v {
+			if _, ok := elem.(string); !ok {
+				return &ValidationError{
+					Path:    path,
+					Message: fmt.Sprintf("expected string element in %q at index %d, got %T", path, i, elem),
+					Level:   "error",
 				}
 			}
 		}
+	case []string:
+		// Already typed as []string by the loader; nothing to verify.
+	case string:
+		// Also accept a single string as a one-element list.
+	default:
+		return &ValidationError{Path: path, Message: fmt.Sprintf("expected array of strings, got %T", val), Level: "error"}
 	}
 	return nil
 }

--- a/schemas/krit-config.schema.json
+++ b/schemas/krit-config.schema.json
@@ -2277,7 +2277,7 @@
           }
         },
         "LocaleFolder": {
-          "description": "Wrong locale folder naming [precision: heuristic/text-backed] [noisiness: noisy] [capabilities: line-pass]",
+          "description": "Wrong locale folder naming [precision: project-structure-aware] [noisiness: normal] [capabilities: resources]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -4635,7 +4635,7 @@
           }
         },
         "UseAlpha2": {
-          "description": "3-letter ISO code in locale folder [precision: heuristic/text-backed] [noisiness: noisy] [capabilities: line-pass]",
+          "description": "3-letter ISO code in locale folder [precision: project-structure-aware] [noisiness: normal] [capabilities: resources]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -15165,7 +15165,7 @@
           }
         },
         "SpacingAfterPackageAndImports": {
-          "description": "Detects missing blank lines after package and import declarations. [fixable: cosmetic] [precision: heuristic/text-backed] [noisiness: noisy] [capabilities: line-pass]",
+          "description": "Detects missing blank lines after package and import declarations. [fixable: cosmetic] [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {


### PR DESCRIPTION
## Summary
- `OptionTypeInt` no longer silently accepts fractional `float64` values like `2.5`. YAML integer literals (which decode as float64) are still accepted when integral and within int64 range; fractional, non-finite, or out-of-range floats fail with a message naming the option and value.
- `OptionTypeStringSlice` now validates each element of `[]interface{}` and reports the option name, index, and offending type when a non-string slips in.
- Updated `config/default-krit.yml` and `config/profiles/balanced.yml` to drop the unsupported `{value, reason}` object form under `ForbiddenMethodCall.methods` and `ForbiddenAnnotation.annotations` so the bundled configs conform to the declared `string[]` schema.
- Regenerated `schemas/krit-config.schema.json` to pick up unrelated descriptor drift surfaced by `make schema`.

## Test plan
- [x] `go test ./internal/schema/ -count=1`
- [x] `go test ./... -count=1`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...`
- [x] `go build -o /tmp/krit ./cmd/krit/`