### PR TITLE
fix(config): autoDetect krit.yml relative to analyzed root

### DIFF
--- a/cmd/krit/main_test.go
+++ b/cmd/krit/main_test.go
@@ -243,6 +243,130 @@ func TestConfigDisablesRule(t *testing.T) {
 	}
 }
 
+// TestConfigAutoDetectFromAnalyzedRoot is the CLI-level regression for
+// the autoDetect-relative-to-CWD bug. Invokes the krit binary from a
+// foreign CWD with the analyzed path pointing at a directory whose
+// krit.yml disables UnusedVariable. The config must take effect even
+// though the binary's CWD has no krit.yml of its own and --config is
+// not passed.
+func TestConfigAutoDetectFromAnalyzedRoot(t *testing.T) {
+	analyzed := writeTempKt(t, "AutoDetect.kt", "package test\n\nfun example() {\n    val x = 1\n}\n")
+	configPath := filepath.Join(analyzed, "krit.yml")
+	if err := os.WriteFile(configPath, []byte("style:\n  UnusedVariable:\n    active: false\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Run from a CWD that does not contain a krit.yml so the buggy
+	// CWD-relative autoDetect would silently fall back to defaults.
+	foreignCwd := t.TempDir()
+	cmd := exec.Command(binPath, "--no-cache", "--no-type-inference", "--no-type-oracle", "-q", "-f", "json", analyzed)
+	cmd.Dir = foreignCwd
+	var stdout, stderr strings.Builder
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		var exitErr *exec.ExitError
+		if !errors.As(err, &exitErr) {
+			t.Fatalf("unexpected error running krit: %v\nstderr: %s", err, stderr.String())
+		}
+	}
+
+	var result map[string]interface{}
+	if err := json.Unmarshal([]byte(stdout.String()), &result); err != nil {
+		t.Fatalf("invalid JSON: %v\nstdout: %s\nstderr: %s", err, stdout.String(), stderr.String())
+	}
+	findings, _ := result["findings"].([]interface{})
+	for _, f := range findings {
+		fm := f.(map[string]interface{})
+		if fm["rule"] == "UnusedVariable" {
+			t.Fatalf("UnusedVariable should be disabled by analyzed-root krit.yml (CWD=%s, analyzed=%s); config silently ignored. findings=%v", foreignCwd, analyzed, findings)
+		}
+	}
+}
+
+// TestConfigExplicitOverridesAnalyzedRoot — when both a krit.yml in
+// the analyzed root and an explicit --config are present, --config
+// wins.
+func TestConfigExplicitOverridesAnalyzedRoot(t *testing.T) {
+	analyzed := writeTempKt(t, "Override.kt", "package test\n\nfun example() {\n    val x = 1\n}\n")
+	// Root config would disable UnusedVariable…
+	rootCfg := filepath.Join(analyzed, "krit.yml")
+	if err := os.WriteFile(rootCfg, []byte("style:\n  UnusedVariable:\n    active: false\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	// …but --config points at a different file that re-enables it.
+	explicitDir := t.TempDir()
+	explicitCfg := filepath.Join(explicitDir, "explicit.yml")
+	if err := os.WriteFile(explicitCfg, []byte("style:\n  UnusedVariable:\n    active: true\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	foreignCwd := t.TempDir()
+	cmd := exec.Command(binPath, "--no-cache", "--no-type-inference", "--no-type-oracle", "-q", "-f", "json", "--config", explicitCfg, analyzed)
+	cmd.Dir = foreignCwd
+	var stdout, stderr strings.Builder
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		var exitErr *exec.ExitError
+		if !errors.As(err, &exitErr) {
+			t.Fatalf("unexpected error: %v\nstderr: %s", err, stderr.String())
+		}
+	}
+
+	var result map[string]interface{}
+	if err := json.Unmarshal([]byte(stdout.String()), &result); err != nil {
+		t.Fatalf("invalid JSON: %v\nstdout: %s", err, stdout.String())
+	}
+	findings, _ := result["findings"].([]interface{})
+	found := false
+	for _, f := range findings {
+		fm := f.(map[string]interface{})
+		if fm["rule"] == "UnusedVariable" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("explicit --config should override analyzed-root krit.yml: expected UnusedVariable finding, got: %v", findings)
+	}
+}
+
+// TestConfigAutoDetectFromCwdNoArgs locks in the legacy CWD-relative
+// behaviour: invoking krit with no path arguments still picks up a
+// krit.yml in the current working directory.
+func TestConfigAutoDetectFromCwdNoArgs(t *testing.T) {
+	dir := writeTempKt(t, "Cwd.kt", "package test\n\nfun example() {\n    val x = 1\n}\n")
+	configPath := filepath.Join(dir, "krit.yml")
+	if err := os.WriteFile(configPath, []byte("style:\n  UnusedVariable:\n    active: false\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := exec.Command(binPath, "--no-cache", "--no-type-inference", "--no-type-oracle", "-q", "-f", "json", ".")
+	cmd.Dir = dir
+	var stdout, stderr strings.Builder
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		var exitErr *exec.ExitError
+		if !errors.As(err, &exitErr) {
+			t.Fatalf("unexpected error: %v\nstderr: %s", err, stderr.String())
+		}
+	}
+
+	var result map[string]interface{}
+	if err := json.Unmarshal([]byte(stdout.String()), &result); err != nil {
+		t.Fatalf("invalid JSON: %v\nstdout: %s", err, stdout.String())
+	}
+	findings, _ := result["findings"].([]interface{})
+	for _, f := range findings {
+		fm := f.(map[string]interface{})
+		if fm["rule"] == "UnusedVariable" {
+			t.Fatalf("CWD-relative krit.yml should disable UnusedVariable, but rule fired: %v", findings)
+		}
+	}
+}
+
 func TestRunAndroidProjectAnalysisColumns_EmptyProject(t *testing.T) {
 	project := &android.Project{}
 	result, err := (pipeline.AndroidPhase{}).Run(context.Background(), pipeline.AndroidInput{Project: project})

--- a/internal/cli/scan/runner_state.go
+++ b/internal/cli/scan/runner_state.go
@@ -246,7 +246,13 @@ func loadScanConfig(f *scanFlags) *config.Config {
 	if userCfgPath == "" {
 		userCfgPath = detectConfigForScanArgs(flag.Args())
 	}
-	cfg, cfgErr := config.LoadAndMerge(userCfgPath, defaultCfgPath)
+	// Pass the analyzed-path roots so config auto-detection works when
+	// invoked from a different CWD (e.g. `krit /some/path` from $HOME).
+	// detectConfigForScanArgs probes only the immediate dir of arg[0];
+	// threading the full arg list into LoadAndMerge keeps detection
+	// working when other arg shapes (multiple roots, file paths) are
+	// passed without --config.
+	cfg, cfgErr := config.LoadAndMerge(userCfgPath, defaultCfgPath, flag.Args()...)
 	if cfgErr != nil {
 		fmt.Fprintf(os.Stderr, "warning: config: %v\n", cfgErr)
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -113,19 +113,27 @@ func lookupMap(data map[string]interface{}, path ...string) (map[string]interfac
 }
 
 // LoadConfig loads a YAML config file and returns a Config.
-// If path is empty, it auto-detects krit.yml or .krit.yml from the project root,
+// If path is empty, it auto-detects krit.yml or .krit.yml from the supplied
+// search roots (or the current working directory when no roots are passed),
 // falling back to config/default-krit.yml relative to the executable.
-func LoadConfig(path string) (*Config, error) {
+//
+// Pass the analyzed-project root(s) so detection is independent of where
+// `krit` was invoked from: `krit /some/path` must find /some/path/krit.yml
+// even when the user's CWD is elsewhere.
+func LoadConfig(path string, roots ...string) (*Config, error) {
 	if path != "" {
 		return loadFile(path)
 	}
-	return autoDetect()
+	return autoDetect(roots...)
 }
 
 // LoadAndMerge loads defaults first, then merges user config on top.
-// If userPath is empty, auto-detection is used for the user config.
+// If userPath is empty, auto-detection is used for the user config and
+// `roots` controls which directories are probed (the analyzed project
+// root(s)). When no roots are supplied, the current working directory is
+// used as a last resort — preserving the legacy single-arg call shape.
 // If no user config is found, defaults alone are returned.
-func LoadAndMerge(userPath string, defaultPath string) (*Config, error) {
+func LoadAndMerge(userPath string, defaultPath string, roots ...string) (*Config, error) {
 	var base *Config
 	if defaultPath != "" {
 		var err error
@@ -146,7 +154,7 @@ func LoadAndMerge(userPath string, defaultPath string) (*Config, error) {
 			return nil, fmt.Errorf("loading config %s: %w", userPath, err)
 		}
 	} else {
-		user, err = autoDetect()
+		user, err = autoDetect(roots...)
 		if err != nil || user == nil {
 			// No user config found, return defaults only
 			return base, nil //nolint:nilerr // autoDetect failure is non-fatal: krit.yml is optional, caller proceeds with built-in defaults
@@ -178,13 +186,62 @@ func loadFile(path string) (*Config, error) {
 // (e.g. krit.yaml) is a one-line change.
 var Filenames = []string{"krit.yml", ".krit.yml"}
 
-func autoDetect() (*Config, error) {
-	for _, name := range Filenames {
-		if _, err := os.Stat(name); err == nil {
-			return loadFile(name)
+// autoDetect probes the supplied search roots for the first krit.yml /
+// .krit.yml present and loads it. Each root may be a directory, a file
+// (in which case its parent directory is probed), or an empty string
+// (skipped). When no roots are supplied, the current working directory
+// is probed — preserving legacy callers that invoke LoadConfig with no
+// path and no analyzed-project context.
+//
+// First match wins, in caller order. Returns (nil, nil) when no config
+// is found; non-existence is a normal outcome, not an error.
+func autoDetect(roots ...string) (*Config, error) {
+	candidates := autoDetectDirs(roots)
+	seen := make(map[string]struct{}, len(candidates))
+	for _, dir := range candidates {
+		if dir == "" {
+			continue
+		}
+		if _, ok := seen[dir]; ok {
+			continue
+		}
+		seen[dir] = struct{}{}
+		for _, name := range Filenames {
+			candidate := filepath.Join(dir, name)
+			fi, err := os.Stat(candidate)
+			if err != nil {
+				continue
+			}
+			if fi.IsDir() {
+				continue
+			}
+			return loadFile(candidate)
 		}
 	}
 	return nil, nil
+}
+
+// autoDetectDirs normalises raw search-root entries to a list of
+// directories to probe. Files contribute their parent directory; empty
+// entries are dropped. When the resulting list is empty, the current
+// working directory is used so legacy `autoDetect()` calls (no roots)
+// keep finding `./krit.yml`.
+func autoDetectDirs(roots []string) []string {
+	out := make([]string, 0, len(roots)+1)
+	for _, root := range roots {
+		if root == "" {
+			continue
+		}
+		dir := root
+		if fi, err := os.Stat(root); err == nil && !fi.IsDir() {
+			dir = filepath.Dir(root)
+		}
+		out = append(out, dir)
+	}
+	if len(out) == 0 {
+		out = append(out, ".")
+	}
+	return out
 }
 
 // FindDefaultConfig locates the default config file.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1265,3 +1265,268 @@ func TestTypedSectionsNilConfig(t *testing.T) {
 		t.Errorf("nil cfg Oracle().Classpath = %v, want nil", got)
 	}
 }
+
+// withCwd runs fn with the process working directory temporarily set
+// to dir. Restores the prior working directory before returning (even
+// on failure) so neighbouring tests are unaffected.
+func withCwd(t *testing.T, dir string, fn func()) {
+	t.Helper()
+	prev, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir %s: %v", dir, err)
+	}
+	defer func() {
+		if cerr := os.Chdir(prev); cerr != nil {
+			t.Fatalf("restore cwd: %v", cerr)
+		}
+	}()
+	fn()
+}
+
+// TestLoadConfigAutoDetectFromAnalyzedRoot is the regression test for
+// the CWD-relative autoDetect bug: invoking `krit /some/path` from a
+// different working directory must still find /some/path/krit.yml when
+// the analyzed root is threaded through to LoadConfig.
+func TestLoadConfigAutoDetectFromAnalyzedRoot(t *testing.T) {
+	analyzed := t.TempDir()
+	configPath := filepath.Join(analyzed, "krit.yml")
+	if err := os.WriteFile(configPath, []byte(`
+style:
+  MagicNumber:
+    active: true
+    threshold: 999
+`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Force CWD to a directory with no krit.yml so the CWD fallback can
+	// not accidentally succeed.
+	other := t.TempDir()
+	withCwd(t, other, func() {
+		cfg, err := LoadConfig("", analyzed)
+		if err != nil {
+			t.Fatalf("LoadConfig from analyzed root: %v", err)
+		}
+		if cfg == nil {
+			t.Fatal("expected config loaded from analyzed root, got nil (silent fallback to defaults)")
+		}
+		if got := cfg.GetInt("style", "MagicNumber", "threshold", 0); got != 999 {
+			t.Errorf("expected threshold=999 from analyzed root krit.yml, got %d", got)
+		}
+	})
+}
+
+// TestLoadConfigAutoDetectFromAnalyzedFile mirrors the directory case
+// for a file argument (`krit /some/path/Foo.kt`): the file's parent
+// directory should be probed for krit.yml.
+func TestLoadConfigAutoDetectFromAnalyzedFile(t *testing.T) {
+	analyzed := t.TempDir()
+	configPath := filepath.Join(analyzed, ".krit.yml")
+	if err := os.WriteFile(configPath, []byte("style:\n  MagicNumber:\n    active: false\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	filePath := filepath.Join(analyzed, "Example.kt")
+	if err := os.WriteFile(filePath, []byte("class Example\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	other := t.TempDir()
+	withCwd(t, other, func() {
+		cfg, err := LoadConfig("", filePath)
+		if err != nil {
+			t.Fatalf("LoadConfig from analyzed file: %v", err)
+		}
+		if cfg == nil {
+			t.Fatal("expected config loaded from analyzed file's dir, got nil")
+		}
+		active := cfg.IsRuleActive("style", "MagicNumber")
+		if active == nil || *active != false {
+			t.Errorf("expected MagicNumber active=false from .krit.yml, got %v", active)
+		}
+	})
+}
+
+// TestLoadConfigCwdFallbackWithoutRoots locks in the legacy behaviour:
+// when no roots are supplied (`LoadConfig("")` from the project root
+// with no analyzed paths), the current working directory is still
+// probed. The arity-preserving variadic must not regress this.
+func TestLoadConfigCwdFallbackWithoutRoots(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "krit.yml")
+	if err := os.WriteFile(configPath, []byte("style:\n  MagicNumber:\n    active: true\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	withCwd(t, dir, func() {
+		cfg, err := LoadConfig("")
+		if err != nil {
+			t.Fatalf("LoadConfig CWD fallback: %v", err)
+		}
+		if cfg == nil {
+			t.Fatal("expected CWD-relative krit.yml to load, got nil")
+		}
+		active := cfg.IsRuleActive("style", "MagicNumber")
+		if active == nil || !*active {
+			t.Errorf("expected MagicNumber active=true from CWD krit.yml, got %v", active)
+		}
+	})
+}
+
+// TestLoadConfigExplicitPathOverridesRoots makes the precedence
+// explicit: an explicit path always wins, regardless of any analyzed
+// roots passed alongside it.
+func TestLoadConfigExplicitPathOverridesRoots(t *testing.T) {
+	rootDir := t.TempDir()
+	rootCfg := filepath.Join(rootDir, "krit.yml")
+	if err := os.WriteFile(rootCfg, []byte("style:\n  MagicNumber:\n    threshold: 1\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	explicitDir := t.TempDir()
+	explicitCfg := filepath.Join(explicitDir, "explicit.yml")
+	if err := os.WriteFile(explicitCfg, []byte("style:\n  MagicNumber:\n    threshold: 42\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadConfig(explicitCfg, rootDir)
+	if err != nil {
+		t.Fatalf("LoadConfig explicit: %v", err)
+	}
+	if got := cfg.GetInt("style", "MagicNumber", "threshold", 0); got != 42 {
+		t.Errorf("expected explicit threshold=42 to win over root threshold=1, got %d", got)
+	}
+}
+
+// TestLoadAndMergeAutoDetectFromAnalyzedRoot is the LoadAndMerge twin
+// of the LoadConfig regression: defaults plus root-relative krit.yml,
+// invoked from a foreign CWD.
+func TestLoadAndMergeAutoDetectFromAnalyzedRoot(t *testing.T) {
+	defaultsDir := t.TempDir()
+	defaultPath := filepath.Join(defaultsDir, "defaults.yml")
+	if err := os.WriteFile(defaultPath, []byte(`
+style:
+  MaxLineLength:
+    active: true
+    maxLineLength: 120
+  MagicNumber:
+    active: true
+    threshold: 5
+`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	analyzed := t.TempDir()
+	userPath := filepath.Join(analyzed, "krit.yml")
+	if err := os.WriteFile(userPath, []byte(`
+style:
+  MagicNumber:
+    threshold: 99
+`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	other := t.TempDir()
+	withCwd(t, other, func() {
+		cfg, err := LoadAndMerge("", defaultPath, analyzed)
+		if err != nil {
+			t.Fatalf("LoadAndMerge: %v", err)
+		}
+		if cfg == nil {
+			t.Fatal("expected merged config, got nil")
+		}
+		// User override pulled from analyzed root.
+		if got := cfg.GetInt("style", "MagicNumber", "threshold", 0); got != 99 {
+			t.Errorf("expected user override threshold=99, got %d (user krit.yml silently ignored?)", got)
+		}
+		// Default still present for unrelated keys.
+		if got := cfg.GetInt("style", "MaxLineLength", "maxLineLength", 0); got != 120 {
+			t.Errorf("expected default maxLineLength=120, got %d", got)
+		}
+	})
+}
+
+// TestLoadAndMergeExplicitPathOverridesRoots — `--config FILE` wins
+// over both the analyzed root probe and the CWD fallback.
+func TestLoadAndMergeExplicitPathOverridesRoots(t *testing.T) {
+	defaultsDir := t.TempDir()
+	defaultPath := filepath.Join(defaultsDir, "defaults.yml")
+	_ = os.WriteFile(defaultPath, []byte("style:\n  MagicNumber:\n    threshold: 1\n"), 0644)
+
+	rootDir := t.TempDir()
+	_ = os.WriteFile(filepath.Join(rootDir, "krit.yml"), []byte("style:\n  MagicNumber:\n    threshold: 2\n"), 0644)
+
+	explicitDir := t.TempDir()
+	explicitPath := filepath.Join(explicitDir, "explicit.yml")
+	_ = os.WriteFile(explicitPath, []byte("style:\n  MagicNumber:\n    threshold: 42\n"), 0644)
+
+	cfg, err := LoadAndMerge(explicitPath, defaultPath, rootDir)
+	if err != nil {
+		t.Fatalf("LoadAndMerge: %v", err)
+	}
+	if got := cfg.GetInt("style", "MagicNumber", "threshold", 0); got != 42 {
+		t.Errorf("expected explicit threshold=42 (overrides root=2 and default=1), got %d", got)
+	}
+}
+
+// TestAutoDetectFirstRootWins covers multi-root precedence: when more
+// than one root has a krit.yml, the first root in caller order wins.
+func TestAutoDetectFirstRootWins(t *testing.T) {
+	first := t.TempDir()
+	second := t.TempDir()
+	_ = os.WriteFile(filepath.Join(first, "krit.yml"), []byte("style:\n  MagicNumber:\n    threshold: 1\n"), 0644)
+	_ = os.WriteFile(filepath.Join(second, "krit.yml"), []byte("style:\n  MagicNumber:\n    threshold: 2\n"), 0644)
+
+	other := t.TempDir()
+	withCwd(t, other, func() {
+		cfg, err := LoadConfig("", first, second)
+		if err != nil {
+			t.Fatalf("LoadConfig: %v", err)
+		}
+		if got := cfg.GetInt("style", "MagicNumber", "threshold", 0); got != 1 {
+			t.Errorf("expected first-root threshold=1 to win, got %d", got)
+		}
+	})
+}
+
+// TestAutoDetectSkipsEmptyAndMissingRoots — empty strings and roots
+// that don't exist are silently skipped; the next root is probed.
+func TestAutoDetectSkipsEmptyAndMissingRoots(t *testing.T) {
+	good := t.TempDir()
+	_ = os.WriteFile(filepath.Join(good, "krit.yml"), []byte("style:\n  MagicNumber:\n    threshold: 7\n"), 0644)
+
+	other := t.TempDir()
+	withCwd(t, other, func() {
+		cfg, err := LoadConfig("", "", "/no/such/dir", good)
+		if err != nil {
+			t.Fatalf("LoadConfig: %v", err)
+		}
+		if cfg == nil {
+			t.Fatal("expected hit on third root")
+		}
+		if got := cfg.GetInt("style", "MagicNumber", "threshold", 0); got != 7 {
+			t.Errorf("expected threshold=7 from good root, got %d", got)
+		}
+	})
+}
+
+// TestAutoDetectKritYmlPrecedence — when both krit.yml and .krit.yml
+// exist in the same root, krit.yml wins (the order in Filenames).
+func TestAutoDetectKritYmlPrecedence(t *testing.T) {
+	dir := t.TempDir()
+	_ = os.WriteFile(filepath.Join(dir, "krit.yml"), []byte("style:\n  MagicNumber:\n    threshold: 1\n"), 0644)
+	_ = os.WriteFile(filepath.Join(dir, ".krit.yml"), []byte("style:\n  MagicNumber:\n    threshold: 2\n"), 0644)
+
+	other := t.TempDir()
+	withCwd(t, other, func() {
+		cfg, err := LoadConfig("", dir)
+		if err != nil {
+			t.Fatalf("LoadConfig: %v", err)
+		}
+		if got := cfg.GetInt("style", "MagicNumber", "threshold", 0); got != 1 {
+			t.Errorf("expected krit.yml threshold=1 to win, got %d", got)
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- `internal/config.autoDetect` called `os.Stat("krit.yml")` (CWD-relative). Running `krit /some/path` from a different working directory silently missed `/some/path/krit.yml` and fell back to built-in defaults, with no warning — the user believed their config was in effect.
- Thread the analyzed paths into `LoadConfig` / `LoadAndMerge` via a variadic `roots` parameter and probe each root (directories directly, files via their parent dir) before falling back to CWD. First match wins. Explicit `--config FILE` still overrides everything.
- Scan runner now passes `flag.Args()` through. Existing verb helpers (snapshot, serve daemon, LSP) already resolve their root via `FindConfigInDir` and continue to work unchanged.

## Test plan
- [x] `go build -o /tmp/krit ./cmd/krit/`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...` (0 issues on this branch)
- [x] `go test ./internal/config/ ./cmd/krit/ -count=1`
- [x] `go test ./... -count=1`
- [x] New unit tests in `internal/config/config_test.go` cover analyzed-root detection from a foreign CWD (directory + file args), the CWD fallback, `--config` precedence, multi-root order, and skip-empty/missing roots
- [x] New integration tests in `cmd/krit/main_test.go` exercise the same scenarios end-to-end against the built binary (`TestConfigAutoDetectFromAnalyzedRoot`, `TestConfigExplicitOverridesAnalyzedRoot`, `TestConfigAutoDetectFromCwdNoArgs`)