### PR TITLE
fix(rules): skip xliff/annotation children in i18n CDATA rule

### DIFF
--- a/internal/rules/i18n_string_contains_html_without_cdata.go
+++ b/internal/rules/i18n_string_contains_html_without_cdata.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 
 	"github.com/kaeawc/krit/internal/android"
 	api "github.com/kaeawc/krit/internal/rules/api"
@@ -13,12 +14,55 @@ import (
 // StringContainsHTMLWithoutCDATARule flags <string> resources whose value
 // contains literal `<` or `>` markup that is neither wrapped in a
 // `<![CDATA[...]]>` section nor entity-escaped (`&lt;`, `&gt;`).
+//
+// Android i18n strings commonly contain non-HTML child elements that the
+// platform parses as placeholders or annotations rather than markup, so the
+// rule must distinguish those from real unescaped HTML:
+//
+//   - <xliff:g> wraps translator placeholders for format args and is the
+//     canonical Android i18n placeholder shape.
+//   - <annotation> spans are an Android Spanned primitive (parsed into
+//     SpannedString.Annotation by Resources.getText).
+//
+// Only children whose tag is a known HTML formatting tag (a, b, i, u, em,
+// strong, big, small, sub, sup, tt, font, br) count as evidence of literal
+// HTML markup. Strings wrapped in a CDATA section have no element children
+// and parse to empty Text once the parser strips the CDATA delimiters, so
+// they are inherently clean here.
 type StringContainsHTMLWithoutCDATARule struct {
 	ValuesStringsResourceBase
 	AndroidRule
 }
 
 func (r *StringContainsHTMLWithoutCDATARule) Confidence() float64 { return 0.9 }
+
+// htmlMarkupChildTags is the set of child element tags that, when present
+// inside a <string> resource without being wrapped in <![CDATA[...]]>,
+// indicate literal HTML markup. It mirrors htmlInlineTags from i18n_markup.go
+// and adds <a>, the canonical anchor for `Click <a href="...">here</a>`.
+var htmlMarkupChildTags = map[string]bool{
+	"a": true, "b": true, "i": true, "u": true,
+	"em": true, "strong": true,
+	"big": true, "small": true, "sub": true, "sup": true,
+	"tt": true, "font": true, "br": true,
+}
+
+// hasUnescapedHTMLChild returns true when at least one direct child element
+// of the <string> looks like an HTML formatting tag rather than a known-safe
+// Android i18n primitive (xliff:g placeholder, annotation span, etc.).
+func hasUnescapedHTMLChild(s *android.XMLNode) bool {
+	for _, child := range s.Children {
+		tag := strings.ToLower(child.Tag)
+		if idx := strings.Index(tag, ":"); idx >= 0 {
+			// Namespaced tags such as xliff:g are placeholders, not HTML.
+			continue
+		}
+		if htmlMarkupChildTags[tag] {
+			return true
+		}
+	}
+	return false
+}
 
 func (r *StringContainsHTMLWithoutCDATARule) check(ctx *api.Context) {
 	if ctx.ResourceIndex == nil {
@@ -55,7 +99,7 @@ func (r *StringContainsHTMLWithoutCDATARule) checkResourceRoot(ctx *api.Context,
 			if name == "" {
 				return
 			}
-			if len(s.Children) == 0 {
+			if !hasUnescapedHTMLChild(s) {
 				return
 			}
 			ctx.Emit(resourceFinding(path, s.Line, r.BaseRule,

--- a/internal/rules/i18n_string_contains_html_without_cdata_test.go
+++ b/internal/rules/i18n_string_contains_html_without_cdata_test.go
@@ -97,4 +97,45 @@ func TestStringContainsHtmlWithoutCDATA(t *testing.T) {
 			t.Fatalf("expected finding in values-fr, got: %s", findings[0].File)
 		}
 	})
+
+	// Regression: xliff:g placeholders are the canonical Android i18n shape
+	// and must not be flagged. The original implementation fired on every
+	// <string> that had any child element.
+	t.Run("xliff:g placeholder is clean", func(t *testing.T) {
+		resDir := filepath.Join(t.TempDir(), "res")
+		write(t, filepath.Join(resDir, "values", "strings.xml"),
+			"<resources xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\">"+
+				"<string name=\"played\">Hello <xliff:g id=\"num\" example=\"3\">%d</xliff:g> times</string>"+
+				"</resources>\n")
+		findings := runResourceRule(r, scan(t, resDir))
+		if len(findings) != 0 {
+			t.Fatalf("expected 0 findings for xliff:g placeholder, got %d: %v", len(findings), findings)
+		}
+	})
+
+	// Regression: <annotation> spans are an Android-supported markup primitive
+	// (SpannedString.Annotation) and must not be flagged.
+	t.Run("annotation span is clean", func(t *testing.T) {
+		resDir := filepath.Join(t.TempDir(), "res")
+		write(t, filepath.Join(resDir, "values", "strings.xml"),
+			"<resources><string name=\"title\">Welcome <annotation font=\"title_emphasis\">friend</annotation>!</string></resources>\n")
+		findings := runResourceRule(r, scan(t, resDir))
+		if len(findings) != 0 {
+			t.Fatalf("expected 0 findings for <annotation>, got %d: %v", len(findings), findings)
+		}
+	})
+
+	// Mixing xliff placeholder with real unescaped HTML markup should still
+	// trigger — the rule should look at the non-placeholder children.
+	t.Run("xliff:g plus inline HTML still triggers", func(t *testing.T) {
+		resDir := filepath.Join(t.TempDir(), "res")
+		write(t, filepath.Join(resDir, "values", "strings.xml"),
+			"<resources xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\">"+
+				"<string name=\"mixed\">Won <xliff:g id=\"n\">%d</xliff:g> <b>games</b></string>"+
+				"</resources>\n")
+		findings := runResourceRule(r, scan(t, resDir))
+		if len(findings) != 1 {
+			t.Fatalf("expected 1 finding for xliff + <b>, got %d: %v", len(findings), findings)
+		}
+	})
 }

--- a/tests/fixtures/negative/i18n/string-contains-html-without-cdata/src/main/res/values/strings.xml
+++ b/tests/fixtures/negative/i18n/string-contains-html-without-cdata/src/main/res/values/strings.xml
@@ -1,5 +1,9 @@
-<resources>
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="html_msg"><![CDATA[Click <a href="https://example.com">here</a>]]></string>
     <string name="entity_msg">Click &lt;a href="https://example.com"&gt;here&lt;/a&gt;</string>
     <string name="plain_msg">Hello world</string>
+    <!-- xliff:g placeholders are the canonical Android i18n shape and must not trigger. -->
+    <string name="played_count">You played <xliff:g id="num_games" example="3">%d</xliff:g> games today</string>
+    <!-- <annotation> spans are an Android Spanned primitive (SpannedString.Annotation), not HTML. -->
+    <string name="welcome_title">Welcome <annotation font="title_emphasis">friend</annotation>!</string>
 </resources>


### PR DESCRIPTION
## Summary

`StringContainsHTMLWithoutCDATA` previously flagged any `<string>` resource that had element children at all — the rule was a pure `len(s.Children) == 0` check with no inspection of what those children actually were.

That caught the two canonical Android i18n placeholder shapes:

- `<xliff:g id=\"num\">%d</xliff:g>` — translator placeholders for format args.
- `<annotation>` spans — Android Spanned primitives parsed by `Resources.getText` into `SpannedString.Annotation`.

Result: a false positive on virtually every translated string in a real Android app.

Tighten the evidence to a small whitelist of HTML formatting tags (`a`, `b`, `i`, `u`, `em`, `strong`, `big`, `small`, `sub`, `sup`, `tt`, `font`, `br`). Namespaced tags like `xliff:g` are explicitly skipped — they are placeholders, not markup. A string that mixes a placeholder with a real `<b>` still fires.

## Tests

New subtests in `TestStringContainsHtmlWithoutCDATA`:
- `xliff:g_placeholder_is_clean` — `<string><xliff:g id=\"num\">%d</xliff:g> items</string>` does not fire.
- `annotation_span_is_clean` — `<string><annotation font=\"sans\">Hello</annotation></string>` does not fire.
- `xliff:g_plus_inline_HTML_still_triggers` — mixing a placeholder with `<b>` still fires.

Updated the existing negative fixture under `tests/fixtures/negative/i18n/...` with the same shapes to cover the directory-driven fixture test.

## Test plan

- [ ] CI passes (build, vet, lint, full test suite).
- [ ] Auto-merge with squash once green.