### PR TITLE
fix(oracle): tighten daemon shutdown, Close locking, PID cleanup, and parallel exit

### DIFF
--- a/internal/cli/serve/oracle_daemon_parallel_close_test.go
+++ b/internal/cli/serve/oracle_daemon_parallel_close_test.go
@@ -1,0 +1,120 @@
+package serve
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// fakeBlockingEntry produces an oracleDaemonEntry whose close blocks
+// for `closeDelay`, recording invocation count via gotClose. Used by
+// the parallel-shutdown assertions below.
+func fakeBlockingEntry(closeDelay time.Duration, gotClose *atomic.Int32) *oracleDaemonEntry {
+	return &oracleDaemonEntry{
+		jarPath:    "fake.jar",
+		sourceDirs: []string{},
+		closeFn: func() error {
+			gotClose.Add(1)
+			time.Sleep(closeDelay)
+			return nil
+		},
+	}
+}
+
+// TestCloseOracleDaemons_ShutsDownInParallel proves fix D: N owned
+// daemons close concurrently rather than serially under the registry
+// mutex. With the old implementation N×closeDelay was the lower bound;
+// the fix collapses to ~closeDelay + scheduler slack.
+func TestCloseOracleDaemons_ShutsDownInParallel(t *testing.T) {
+	state := newDaemonState(t.TempDir())
+
+	const N = 4
+	const closeDelay = 200 * time.Millisecond
+	var calls atomic.Int32
+	for i := 0; i < N; i++ {
+		state.oracleDaemonByKey["k"+string(rune('a'+i))] = fakeBlockingEntry(closeDelay, &calls)
+	}
+
+	start := time.Now()
+	state.closeOracleDaemons()
+	elapsed := time.Since(start)
+
+	if got := calls.Load(); got != int32(N) {
+		t.Fatalf("close invoked %d times; want %d", got, N)
+	}
+
+	// Parallel: ~closeDelay + slack. Serial would be N×closeDelay = 800ms.
+	// Use a 1.5× single-delay ceiling: gives plenty of room for slow CI
+	// without admitting the serial path.
+	maxParallel := closeDelay * 3 / 2
+	if elapsed > maxParallel {
+		t.Errorf("closeOracleDaemons elapsed %s; expected <%s (parallel close)", elapsed, maxParallel)
+	}
+	// Also assert we did at least one delay's worth — guards against a
+	// future refactor that accidentally skips Close entirely.
+	if elapsed < closeDelay/2 {
+		t.Errorf("closeOracleDaemons elapsed %s; expected ≥%s (proves we waited)", elapsed, closeDelay/2)
+	}
+
+	if got := len(state.oracleDaemonByKey); got != 0 {
+		t.Errorf("after close, cache has %d entries; want 0", got)
+	}
+}
+
+// TestCloseOracleDaemons_DoesNotHoldRegistryMutexAcrossClose is a
+// complementary check: while closeOracleDaemons is mid-flight (i.e.
+// blocked inside one of the parallel Close goroutines), the registry
+// mutex must already be available to a concurrent reader. With the
+// old implementation, the reader would block for N×closeDelay.
+func TestCloseOracleDaemons_DoesNotHoldRegistryMutexAcrossClose(t *testing.T) {
+	state := newDaemonState(t.TempDir())
+
+	const N = 4
+	const closeDelay = 250 * time.Millisecond
+	var calls atomic.Int32
+
+	// Block one of the closes so the goroutines are mid-flight when
+	// we probe the registry mutex.
+	probeStart := make(chan struct{})
+	probeDone := make(chan struct{})
+	for i := 0; i < N; i++ {
+		state.oracleDaemonByKey["k"+string(rune('a'+i))] = &oracleDaemonEntry{
+			jarPath: "fake.jar",
+			closeFn: func() error {
+				calls.Add(1)
+				time.Sleep(closeDelay)
+				return nil
+			},
+		}
+	}
+
+	go func() {
+		<-probeStart
+		// Should be able to acquire the registry mutex immediately —
+		// the parallel-close fix releases it once entries are
+		// snapshotted, well before any Close completes.
+		state.oracleDaemonMu.Lock()
+		_ = state.oracleDaemonByKey
+		state.oracleDaemonMu.Unlock()
+		close(probeDone)
+	}()
+
+	go func() {
+		// Let the probe race against closeOracleDaemons; small sleep
+		// to make sure closeOracleDaemons has had a chance to acquire
+		// & release the mutex before the probe asks for it.
+		time.Sleep(20 * time.Millisecond)
+		close(probeStart)
+	}()
+
+	state.closeOracleDaemons()
+
+	// Probe must finish promptly (the registry mutex was released
+	// quickly inside closeOracleDaemons even though Close goroutines
+	// were still blocked).
+	select {
+	case <-probeDone:
+	case <-time.After(closeDelay):
+		t.Fatalf("registry mutex was held across the Close path; probe blocked >%s", closeDelay)
+	}
+}

--- a/internal/cli/serve/serve.go
+++ b/internal/cli/serve/serve.go
@@ -456,6 +456,26 @@ type oracleDaemonEntry struct {
 	daemon     *oracle.Daemon
 	jarPath    string
 	sourceDirs []string
+	// closeFn, when non-nil, replaces entry.daemon.Close() in
+	// closeOracleDaemons. Used by tests to inject a controllable
+	// close — production code leaves it nil.
+	closeFn func() error
+}
+
+// close routes to closeFn when set (tests) and to daemon.Close()
+// otherwise (production). nil-receiver and nil-daemon are no-ops so
+// closeOracleDaemons can safely call this on every cached entry.
+func (e *oracleDaemonEntry) close() error {
+	if e == nil {
+		return nil
+	}
+	if e.closeFn != nil {
+		return e.closeFn()
+	}
+	if e.daemon == nil {
+		return nil
+	}
+	return e.daemon.Close()
 }
 
 // ensureOracleDaemon lazy-starts (or reuses) a krit-types JVM daemon
@@ -534,19 +554,41 @@ func (s *daemonState) pingOracleDaemon() {
 // TCP connections closed but the underlying process is left alive
 // for the next krit invocation to find. Daemons started by serve
 // (shared=false) get a graceful Shutdown→Kill via Daemon.Close.
+//
+// The registry mutex is held only long enough to snapshot the entry
+// list and clear the map; Daemon.Close (which can block for the
+// 10s shutdown grace period per daemon) runs after the mutex is
+// released. Closes run concurrently so N daemons shut down in
+// ~one grace period rather than N×grace period, and the registry
+// mutex never blocks an insertion path during exit.
 func (s *daemonState) closeOracleDaemons() {
 	if s == nil {
 		return
 	}
 	s.oracleDaemonMu.Lock()
-	defer s.oracleDaemonMu.Unlock()
+	entries := make([]*oracleDaemonEntry, 0, len(s.oracleDaemonByKey))
 	for _, entry := range s.oracleDaemonByKey {
-		if entry == nil || entry.daemon == nil {
+		if entry == nil {
 			continue
 		}
-		_ = entry.daemon.Close()
+		if entry.daemon == nil && entry.closeFn == nil {
+			continue
+		}
+		entries = append(entries, entry)
 	}
 	s.oracleDaemonByKey = map[string]*oracleDaemonEntry{}
+	s.oracleDaemonMu.Unlock()
+
+	var wg sync.WaitGroup
+	wg.Add(len(entries))
+	for _, entry := range entries {
+		entry := entry
+		go func() {
+			defer wg.Done()
+			_ = entry.close()
+		}()
+	}
+	wg.Wait()
 }
 
 // analysisCacheEntry holds a lazily-loaded *cache.Cache and the file

--- a/internal/oracle/daemon.go
+++ b/internal/oracle/daemon.go
@@ -484,31 +484,66 @@ func (d *Daemon) Rebuild() error {
 	return err
 }
 
-// Shutdown gracefully stops the daemon.
+// shutdownGracePeriod bounds how long Shutdown waits for the JVM to
+// exit cleanly after the "shutdown" request before issuing Kill(). Tests
+// override the package-level variable so the goroutine-leak coverage
+// doesn't take 10s.
+var shutdownGracePeriod = 10 * time.Second
+
+// Shutdown gracefully stops the daemon. The wait goroutine is guaranteed
+// to return — on grace-period expiry we Kill() the process so cmd.Wait()
+// returns deterministically rather than leaking. The grace-period wait
+// runs outside d.mu so concurrent callers (Close, sendOnce timeout) are
+// not blocked behind a stuck JVM. The started→false flip is atomic with
+// the started check so two racing Shutdowns / Closes do not both attempt
+// to send the shutdown verb and wait.
 func (d *Daemon) Shutdown() error {
 	d.mu.Lock()
-	defer d.mu.Unlock()
-
 	if !d.started {
+		d.mu.Unlock()
 		return nil
 	}
-
-	// Send shutdown request — ignore errors since the process may close immediately
-	d.sendResult("shutdown", nil) //nolint:errcheck
-
+	// Claim the shutdown before we release the lock so a concurrent
+	// caller observes started=false and short-circuits.
 	d.started = false
+	cmd := d.cmd
+	// Send shutdown request while we still hold the lock — sendOnce
+	// would otherwise reject the call (started=false). Errors are
+	// ignored because the JVM may close the pipe before responding.
+	_, _ = d.sendOnce("shutdown", nil)
+	d.mu.Unlock()
 
-	// Wait for process to exit with a timeout
+	return waitForCmdExit(cmd)
+}
+
+// waitForCmdExit waits for cmd to exit. On grace-period expiry it
+// issues Kill() so cmd.Wait() returns and the inner goroutine never
+// leaks; without the Kill the goroutine would outlive the function,
+// holding a reference to cmd indefinitely while the JVM (zombie or
+// otherwise) refuses to reap. nil cmd is a no-op.
+func waitForCmdExit(cmd *exec.Cmd) error {
+	if cmd == nil {
+		return nil
+	}
 	done := make(chan error, 1)
 	go func() {
-		done <- d.cmd.Wait()
+		done <- cmd.Wait()
 	}()
 
+	timer := time.NewTimer(shutdownGracePeriod)
+	defer timer.Stop()
 	select {
 	case err := <-done:
 		return err
-	case <-time.After(10 * time.Second):
-		d.cmd.Process.Kill()
+	case <-timer.C:
+		if cmd.Process != nil {
+			_ = cmd.Process.Kill()
+		}
+		// Block until the goroutine observes the Kill and returns; the
+		// kernel reaps the SIGKILLed process promptly so this never
+		// hangs in practice, but the deterministic join is the whole
+		// point of the fix.
+		<-done
 		return fmt.Errorf("daemon did not exit within timeout, killed")
 	}
 }
@@ -545,12 +580,14 @@ func (d *Daemon) Checkpoint() error {
 func (d *Daemon) Release() error {
 	d.mu.Lock()
 	d.started = false
+	conn := d.conn
+	logFile := d.logFile
 	d.mu.Unlock()
-	if d.conn != nil {
-		d.conn.Close()
+	if conn != nil {
+		conn.Close()
 	}
-	if d.logFile != nil {
-		d.logFile.Close()
+	if logFile != nil {
+		logFile.Close()
 	}
 	return nil
 }
@@ -558,39 +595,65 @@ func (d *Daemon) Release() error {
 // Close shuts down and cleans up. For shared (reused) daemons, only the TCP
 // connection is closed — the daemon process keeps running for future clients.
 // For owned daemons, the process is shut down and PID files are removed.
+//
+// All field reads happen under d.mu; the started flag is consumed
+// atomically (claim-and-flip under the lock) so concurrent Close /
+// Shutdown calls only run the heavy shutdown path once instead of
+// racing into a double-Wait + double-PID-remove. Callers that lose
+// the started claim still get conn/logFile cleanup, but skip the
+// shutdown handshake and PID-file removal that the winning caller
+// has already performed (or is performing).
 func (d *Daemon) Close() error {
-	if d.shared {
+	d.mu.Lock()
+	claimedShutdown := d.started
+	d.started = false
+	shared := d.shared
+	cmd := d.cmd
+	conn := d.conn
+	logFile := d.logFile
+	port := d.port
+	srcHash := d.sourcesHash
+	slot := d.slot
+	// Send the shutdown verb under the lock so sendOnce doesn't reject
+	// it (we just flipped started=false). Only the caller that won the
+	// claim gets to talk to the JVM here.
+	if claimedShutdown && !shared {
+		_, _ = d.sendOnce("shutdown", nil)
+	}
+	d.mu.Unlock()
+
+	if shared {
 		// We connected to an existing daemon — just close the TCP connection.
 		// The daemon keeps running for the next client.
-		d.mu.Lock()
-		d.started = false
-		d.mu.Unlock()
-		if d.conn != nil {
-			d.conn.Close()
+		if conn != nil {
+			conn.Close()
 		}
 		return nil
 	}
 
-	if d.started {
-		if err := d.Shutdown(); err != nil {
-			// Force kill as fallback
-			if d.cmd != nil && d.cmd.Process != nil {
-				d.cmd.Process.Kill()
+	if claimedShutdown {
+		if err := waitForCmdExit(cmd); err != nil {
+			// waitForCmdExit already issued Kill on the grace-period
+			// path; this is the belt-and-suspenders fallback for a
+			// non-timeout error (e.g., Wait returned immediately with
+			// a transport error).
+			if cmd != nil && cmd.Process != nil {
+				_ = cmd.Process.Kill()
 			}
 		}
 	}
 	// Clean up PID files if this was a persistent daemon we started.
-	// Use the Daemon's own sourcesHash so we only touch this repo's
-	// PID file entries — other repos' daemons under daemons/ are
-	// left alone.
-	if d.port != 0 && d.sourcesHash != "" {
-		removePIDFileSlot(d.sourcesHash, d.slot)
+	// Only the caller that won the started claim removes the PID file
+	// so the loser doesn't tear down a successor daemon that took the
+	// slot in between.
+	if claimedShutdown && port != 0 && srcHash != "" {
+		removePIDFileSlot(srcHash, slot)
 	}
-	if d.conn != nil {
-		d.conn.Close()
+	if conn != nil {
+		conn.Close()
 	}
-	if d.logFile != nil {
-		d.logFile.Close()
+	if logFile != nil {
+		logFile.Close()
 	}
 	return nil
 }

--- a/internal/oracle/daemon_lifecycle_test.go
+++ b/internal/oracle/daemon_lifecycle_test.go
@@ -1,0 +1,367 @@
+package oracle
+
+import (
+	"bufio"
+	"encoding/json"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// ---------------------------------------------------------------------------
+// Bug A — Shutdown grace-period: the wait goroutine must always return.
+// ---------------------------------------------------------------------------
+
+// startSleepCmd starts a child process that will not exit on its own
+// within the test's lifetime. Used to simulate a stuck JVM so we can
+// exercise the Shutdown grace-period → Kill → Wait path. The "sleep"
+// binary is available on every supported developer platform; if not
+// found the test skips rather than fails.
+func startSleepCmd(t *testing.T) *exec.Cmd {
+	t.Helper()
+	sleepBin, err := exec.LookPath("sleep")
+	if err != nil {
+		t.Skipf("sleep not available: %v", err)
+	}
+	cmd := exec.Command(sleepBin, "300")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start sleep: %v", err)
+	}
+	return cmd
+}
+
+// pipeStdio returns an in-memory pipe pair to use as stdin/stdout
+// stand-ins on a Daemon. A background helper reads each request line
+// off stdin and writes a canned `{"id": N, "result": {}}` response to
+// stdout, so sendOnce sees a successful round-trip (does NOT time out
+// and so does NOT pre-kill the test process). This lets Shutdown's
+// grace-period path own the Kill decision.
+func pipeStdio(t *testing.T) (io.WriteCloser, *bufio.Scanner) {
+	t.Helper()
+	stdinR, stdinW := io.Pipe()
+	stdoutR, stdoutW := io.Pipe()
+	go func() {
+		sc := bufio.NewScanner(stdinR)
+		sc.Buffer(make([]byte, 0, 64*1024), 64*1024*1024)
+		for sc.Scan() {
+			var req daemonRequest
+			if err := json.Unmarshal([]byte(sc.Text()), &req); err != nil {
+				continue
+			}
+			resp := []byte(`{"id":` + strconv.Itoa(req.ID) + `,"result":{}}` + "\n")
+			if _, err := stdoutW.Write(resp); err != nil {
+				return
+			}
+		}
+	}()
+	t.Cleanup(func() {
+		_ = stdinW.Close()
+		_ = stdoutW.Close()
+	})
+	sc := bufio.NewScanner(stdoutR)
+	sc.Buffer(make([]byte, 0, 64*1024), 64*1024*1024)
+	return stdinW, sc
+}
+
+// withShortShutdownGrace shortens the grace period so the test exercises
+// the Kill→Wait join in well under a second.
+func withShortShutdownGrace(t *testing.T, d time.Duration) {
+	t.Helper()
+	orig := shutdownGracePeriod
+	shutdownGracePeriod = d
+	t.Cleanup(func() { shutdownGracePeriod = orig })
+}
+
+// withShortRequestTimeout shortens daemonRequestTimeout so the in-Shutdown
+// sendOnce call returns quickly when the fake "JVM" never responds.
+func withShortRequestTimeout(t *testing.T, d time.Duration) {
+	t.Helper()
+	t.Setenv("KRIT_TYPES_REQUEST_TIMEOUT", d.String())
+}
+
+// TestShutdown_KillsStuckProcess_AndJoinsWaitGoroutine verifies fix A:
+// when the JVM doesn't exit on its own, Shutdown issues Kill() and waits
+// for the wait goroutine to return. We assert (a) Shutdown returns
+// promptly and (b) no goroutine leak compared to the pre-Shutdown baseline.
+func TestShutdown_KillsStuckProcess_AndJoinsWaitGoroutine(t *testing.T) {
+	withShortShutdownGrace(t, 200*time.Millisecond)
+	withShortRequestTimeout(t, 100*time.Millisecond)
+
+	stdinW, stdoutSc := pipeStdio(t)
+	cmd := startSleepCmd(t)
+	t.Cleanup(func() { _ = cmd.Process.Kill() })
+
+	d := &Daemon{
+		cmd:     cmd,
+		stdin:   stdinW,
+		stdout:  stdoutSc,
+		nextID:  1,
+		started: true,
+	}
+
+	// Let the runtime settle so the goroutine baseline is stable.
+	runtime.Gosched()
+	baseline := runtime.NumGoroutine()
+
+	start := time.Now()
+	err := d.Shutdown()
+	elapsed := time.Since(start)
+
+	if err == nil || !strings.Contains(err.Error(), "did not exit within timeout") {
+		t.Fatalf("expected timeout-killed error, got %v", err)
+	}
+	// Grace 200ms + request timeout 100ms + slack. Anything past 2s
+	// means we leaked the wait goroutine and timed out somewhere else.
+	if elapsed > 2*time.Second {
+		t.Errorf("Shutdown took %s; expected <2s", elapsed)
+	}
+
+	// Confirm the sleep process was actually reaped (Kill→Wait join).
+	if cmd.ProcessState == nil {
+		t.Errorf("cmd.ProcessState is nil; Wait() never observed exit")
+	}
+
+	// Wait a moment for any unrelated goroutines to settle, then check
+	// the leak. We allow a small +/- slack because Go's runtime keeps a
+	// few worker goroutines hot.
+	time.Sleep(50 * time.Millisecond)
+	runtime.Gosched()
+	after := runtime.NumGoroutine()
+	if after > baseline+1 {
+		// Print stack on failure for debuggability.
+		buf := make([]byte, 1<<16)
+		n := runtime.Stack(buf, true)
+		t.Errorf("goroutine leak: before=%d after=%d delta=%d\n%s",
+			baseline, after, after-baseline, buf[:n])
+	}
+}
+
+// TestShutdown_NotStarted_NoOp confirms the early-return path still
+// works after the started-flag claim refactor.
+func TestShutdown_NotStarted_NoOp(t *testing.T) {
+	d := &Daemon{started: false}
+	if err := d.Shutdown(); err != nil {
+		t.Errorf("Shutdown(not started) = %v; want nil", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Bug B — Close + Shutdown concurrent calls must be race-free and idempotent.
+// ---------------------------------------------------------------------------
+
+// TestCloseShutdownConcurrent_NoRaceAndIdempotent calls Close and
+// Shutdown from N goroutines concurrently and asserts no races
+// (caught only under `go test -race`) and that the underlying process
+// is killed exactly once with no double-Wait panic.
+func TestCloseShutdownConcurrent_NoRaceAndIdempotent(t *testing.T) {
+	withShortShutdownGrace(t, 200*time.Millisecond)
+	withShortRequestTimeout(t, 100*time.Millisecond)
+
+	stdinW, stdoutSc := pipeStdio(t)
+	cmd := startSleepCmd(t)
+	t.Cleanup(func() { _ = cmd.Process.Kill() })
+
+	d := &Daemon{
+		cmd:     cmd,
+		stdin:   stdinW,
+		stdout:  stdoutSc,
+		nextID:  1,
+		started: true,
+	}
+
+	const N = 8
+	var wg sync.WaitGroup
+	wg.Add(N * 2)
+	var closeOK, shutdownOK atomic.Int32
+	for i := 0; i < N; i++ {
+		go func() {
+			defer wg.Done()
+			if err := d.Close(); err == nil {
+				closeOK.Add(1)
+			}
+		}()
+		go func() {
+			defer wg.Done()
+			_ = d.Shutdown()
+			shutdownOK.Add(1)
+		}()
+	}
+	wg.Wait()
+
+	// Confirm the started flag is false and the process is reaped.
+	d.mu.Lock()
+	if d.started {
+		t.Errorf("expected started=false after concurrent shutdown/close")
+	}
+	d.mu.Unlock()
+	if cmd.ProcessState == nil {
+		t.Errorf("cmd.ProcessState nil; the winning caller did not Wait()")
+	}
+	// Every Shutdown must have returned (closeOK/shutdownOK counts are
+	// only a sanity gate; the real assertion is "no -race report").
+	if shutdownOK.Load() != N {
+		t.Errorf("Shutdown called %d times; %d returned", N, shutdownOK.Load())
+	}
+}
+
+// TestClose_ReadsAllFieldsUnderLock is a focused regression: Close used
+// to read d.cmd / d.conn / d.started without holding d.mu. The fix
+// snapshots those fields under the lock; this test uses -race to
+// detect any remaining unsynchronised access.
+func TestClose_ReadsAllFieldsUnderLock(t *testing.T) {
+	withShortShutdownGrace(t, 50*time.Millisecond)
+	withShortRequestTimeout(t, 30*time.Millisecond)
+
+	stdinW, stdoutSc := pipeStdio(t)
+	cmd := startSleepCmd(t)
+	t.Cleanup(func() { _ = cmd.Process.Kill() })
+
+	d := &Daemon{
+		cmd:     cmd,
+		stdin:   stdinW,
+		stdout:  stdoutSc,
+		nextID:  1,
+		started: true,
+	}
+
+	// Concurrently mutate d.started under the lock while Close runs;
+	// without the locked snapshot in Close this would race.
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				d.mu.Lock()
+				_ = d.started
+				d.mu.Unlock()
+			}
+		}
+	}()
+
+	_ = d.Close()
+	close(stop)
+	wg.Wait()
+}
+
+// ---------------------------------------------------------------------------
+// Bug C — writePIDFileSlot must clean up the .pid on .port write failure.
+// ---------------------------------------------------------------------------
+
+// TestWritePIDFileSlot_RollsBackPIDOnPortFailure proves that when the
+// .port write fails (we force this by making the daemons dir
+// read-only after the .pid write would have happened), the .pid file
+// is removed so a stale entry is never left behind.
+func TestWritePIDFileSlot_RollsBackPIDOnPortFailure(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("running as root; chmod 0500 won't block writes")
+	}
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	srcHash := hashSources([]string{"/fake/repo/rollback"})
+	daemonDir := filepath.Join(tmpHome, ".krit", "cache", "daemons")
+	if err := os.MkdirAll(daemonDir, 0755); err != nil {
+		t.Fatalf("mkdir daemons: %v", err)
+	}
+
+	// Strategy: pre-create the .port file as a directory so os.WriteFile
+	// can't replace it. The .pid write still succeeds (a sibling new
+	// file). We then assert .pid does not survive after the rollback.
+	portPath := daemonPortPathForSlot(srcHash, 0)
+	if err := os.Mkdir(portPath, 0755); err != nil {
+		t.Fatalf("seed bogus .port directory: %v", err)
+	}
+
+	err := writePIDFileSlot(1234, 5678, srcHash, 0)
+	if err == nil {
+		t.Fatal("expected writePIDFileSlot to fail when .port path is a directory")
+	}
+	if !strings.Contains(err.Error(), "write port file") {
+		t.Fatalf("expected 'write port file' error, got %v", err)
+	}
+
+	pidPath := daemonPIDPathForSlot(srcHash, 0)
+	if _, statErr := os.Stat(pidPath); !os.IsNotExist(statErr) {
+		t.Errorf("expected .pid to be rolled back; stat err = %v", statErr)
+	}
+}
+
+// TestWritePIDFileSlot_NoOrphanAfterRollback exercises the same fix
+// via the readPIDFileSlot consumer: after a failed write, readPIDFile
+// must return an error (no orphan) so the connect-existing-daemon
+// flow doesn't see a stale PID pointing at a process we never
+// successfully wired up.
+func TestWritePIDFileSlot_NoOrphanAfterRollback(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("running as root; chmod 0500 won't block writes")
+	}
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	srcHash := hashSources([]string{"/fake/repo/orphan"})
+	daemonDir := filepath.Join(tmpHome, ".krit", "cache", "daemons")
+	if err := os.MkdirAll(daemonDir, 0755); err != nil {
+		t.Fatalf("mkdir daemons: %v", err)
+	}
+	// Make the .port path a directory so the .port write fails.
+	if err := os.Mkdir(daemonPortPathForSlot(srcHash, 0), 0755); err != nil {
+		t.Fatalf("seed bogus .port directory: %v", err)
+	}
+
+	_ = writePIDFileSlot(99, 100, srcHash, 0)
+
+	if _, err := readPIDFileSlot(srcHash, 0); err == nil {
+		t.Errorf("expected readPIDFileSlot to fail after rollback")
+	}
+}
+
+// TestStartupCachePathHelperUnchanged ensures the daemon PID path
+// constants didn't drift; the rollback fix touches the writer but
+// must not change the on-disk shape that older daemons rely on.
+func TestStartupCachePathHelperUnchanged(t *testing.T) {
+	got := daemonPIDFileName("deadbeef00000000", 0)
+	if got != "deadbeef00000000.pid" {
+		t.Errorf("legacy slot 0 pid name = %q; want deadbeef00000000.pid", got)
+	}
+	got = daemonPIDFileName("deadbeef00000000", 3)
+	if got != "deadbeef00000000.3.pid" {
+		t.Errorf("slot 3 pid name = %q; want deadbeef00000000.3.pid", got)
+	}
+}
+
+// TestWritePIDFileSlot_HappyPathStillWorks regression-tests that the
+// rollback addition didn't accidentally break the success path.
+func TestWritePIDFileSlot_HappyPathStillWorks(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	srcHash := hashSources([]string{"/fake/repo/happy"})
+	if err := writePIDFileSlot(4242, 9999, srcHash, 0); err != nil {
+		t.Fatalf("writePIDFileSlot: %v", err)
+	}
+	t.Cleanup(func() { removePIDFileSlot(srcHash, 0) })
+
+	info, err := readPIDFileSlot(srcHash, 0)
+	if err != nil {
+		t.Fatalf("readPIDFileSlot: %v", err)
+	}
+	if info.PID != 4242 {
+		t.Errorf("PID = %d; want 4242", info.PID)
+	}
+	if info.Port != 9999 {
+		t.Errorf("Port = %d; want 9999", info.Port)
+	}
+}

--- a/internal/oracle/daemon_registry.go
+++ b/internal/oracle/daemon_registry.go
@@ -151,6 +151,11 @@ func writePIDFileSlot(pid, port int, sourcesHash string, slot int) error {
 	}
 	portPath := daemonPortPathForSlot(sourcesHash, slot)
 	if err := os.WriteFile(portPath, []byte(strconv.Itoa(port)+"\n"), 0644); err != nil {
+		// Roll back the .pid we just wrote so future invocations don't
+		// see an orphan .pid pointing at the now-killed daemon process
+		// and waste a connect attempt before falling through to
+		// cleanStaleDaemon.
+		_ = os.Remove(pidPath)
 		return fmt.Errorf("write port file: %w", err)
 	}
 	return nil
@@ -507,6 +512,12 @@ func startDaemonWithPortSlotOnce(jarPath string, sourceDirs []string, classpath 
 
 	if err := writePIDFileSlot(cmd.Process.Pid, ready.Port, srcHash, slot); err != nil {
 		cmd.Process.Kill()
+		// writePIDFileSlot already rolls back .pid on .port failure,
+		// but defensively remove both here so a partial write from a
+		// future writer (e.g. .pid+.port both written, then a
+		// follow-on bookkeeping step fails) can't leave stale entries
+		// pointing at a daemon we just killed.
+		removePIDFileSlot(srcHash, slot)
 		return nil, fmt.Errorf("write PID file: %w", err)
 	}
 


### PR DESCRIPTION
## Summary

Closes four overlapping JVM-daemon lifecycle bugs that all manifest on `serve` exit. They live in adjacent files (`internal/oracle/daemon.go`, `internal/oracle/daemon_registry.go`, `internal/cli/serve/serve.go`) so they ship together.

- **A) Daemon.Shutdown** now Kills the JVM on grace-period expiry and joins the wait goroutine before returning — a stuck child no longer leaks the `cmd.Wait()` goroutine. The wait runs outside `d.mu` so concurrent callers aren't blocked behind a hung process.
- **B) Daemon.Close** acquires `d.mu` for every field read and atomically claim-and-flips `d.started` under the lock. Concurrent `Close`/`Shutdown` callers no longer race into double-Wait or double-PID-remove; only the winner runs the shutdown handshake and PID-file cleanup, while losers still close `conn`/`logFile` safely.
- **C) writePIDFileSlot** rolls back the `.pid` on `.port` write failure, and the caller in `startDaemonWithPortSlotOnce` defensively removes both files after `cmd.Process.Kill()`. An orphan `.pid` no longer points at a daemon we just killed.
- **D) closeOracleDaemons** snapshots cached entries under `oracleDaemonMu`, releases the lock, and runs each `daemon.Close()` concurrently via `sync.WaitGroup`. N daemons now shut down in ~one grace period rather than N x grace period, and the registry mutex never blocks an insertion path during exit.

## Regression tests

- `internal/oracle/daemon_lifecycle_test.go`
  - `TestShutdown_KillsStuckProcess_AndJoinsWaitGoroutine` runs `Shutdown` against a real `sleep` child, asserts the timeout-killed error, confirms `cmd.ProcessState != nil` (Wait actually returned), and checks `runtime.NumGoroutine` for the leak.
  - `TestCloseShutdownConcurrent_NoRaceAndIdempotent` and `TestClose_ReadsAllFieldsUnderLock` exercise the started-claim TOCTOU under `-race`.
  - `TestWritePIDFileSlot_RollsBackPIDOnPortFailure` + `_NoOrphanAfterRollback` force `.port` write failure (pre-creating the path as a directory) and assert `.pid` is removed.
- `internal/cli/serve/oracle_daemon_parallel_close_test.go`
  - `TestCloseOracleDaemons_ShutsDownInParallel` injects a `closeFn` shim and asserts N=4 daemons close in <1.5 x single-close time.
  - `TestCloseOracleDaemons_DoesNotHoldRegistryMutexAcrossClose` confirms the registry mutex is free while parallel closes are mid-flight.

## Test plan

- [x] `go build -o /tmp/krit ./cmd/krit/`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...` (0 issues)
- [x] `go test -race ./internal/oracle/ ./internal/cli/serve/ -count=1`
- [x] `go test ./... -count=1` (all packages pass)
- [x] `make lint-rules`