### PR TITLE
fix(fixer): inclusive line-range dedup and enable parse-safety net

### DIFF
--- a/internal/fixer/binary_slice_test.go
+++ b/internal/fixer/binary_slice_test.go
@@ -102,11 +102,14 @@ func ApplyBinaryFixesBatch(findings []scanner.Finding, dryRun bool, searchDirs .
 }
 
 // Slice-taking key/meta extractors for deduplicateFixesReverse. Exercised
-// only from the fixer_test.go suite's generic dedup tests.
+// only from the fixer_test.go suite's generic dedup tests. The line-end
+// extractor mirrors textFixRowLineEnd by returning EndLine + 1 so the
+// inclusive line range matches the half-open semantics deduplicateFixesReverse
+// expects.
 
 func findingByteEnd(f scanner.Finding) int   { return f.Fix.EndByte }
 func findingByteStart(f scanner.Finding) int { return f.Fix.StartByte }
-func findingLineEnd(f scanner.Finding) int   { return f.Fix.EndLine }
+func findingLineEnd(f scanner.Finding) int   { return f.Fix.EndLine + 1 }
 func findingLineStart(f scanner.Finding) int { return f.Fix.StartLine }
 func findingDropped(f scanner.Finding) DroppedFix {
 	return DroppedFix{Rule: f.Rule, File: f.File, Line: f.Line}

--- a/internal/fixer/fixer.go
+++ b/internal/fixer/fixer.go
@@ -55,7 +55,16 @@ func ValidateFixResult(ctx context.Context, path string, original, fixed []byte)
 	return nil
 }
 
-// countParseErrors parses content as Kotlin and counts ERROR nodes in the flat tree.
+// countParseErrors parses content as Kotlin and counts ERROR nodes in the
+// flat tree. Known grammar gaps in tree-sitter-kotlin are filtered so the
+// validation safety net does not reject legal, modern Kotlin output:
+//
+//   - The rangeUntil operator (`..<`, Kotlin 1.7.20+) is not in the
+//     tree-sitter grammar yet and surfaces as an ERROR node containing
+//     just `<` immediately after the `..` token. Treating it as a real
+//     parse error would block any autofix that emits `..<`, e.g.
+//     RangeUntilInsteadOfRangeTo, even though the output is valid
+//     Kotlin and compiles cleanly.
 func countParseErrors(ctx context.Context, content []byte) int {
 	parser := scanner.GetKotlinParser()
 	defer scanner.PutKotlinParser(parser)
@@ -70,11 +79,29 @@ func countParseErrors(ctx context.Context, content []byte) int {
 
 	count := 0
 	file.FlatWalkAllNodes(0, func(idx uint32) {
-		if file.FlatType(idx) == "ERROR" {
-			count++
+		if file.FlatType(idx) != "ERROR" {
+			return
 		}
+		if isRangeUntilGrammarGap(file, content, idx) {
+			return
+		}
+		count++
 	})
 	return count
+}
+
+// isRangeUntilGrammarGap reports whether the ERROR node at idx is the
+// `<` portion of a Kotlin rangeUntil operator (`..<`), which the
+// tree-sitter grammar models as a parse error.
+func isRangeUntilGrammarGap(file *scanner.File, content []byte, idx uint32) bool {
+	if file.FlatNodeText(idx) != "<" {
+		return false
+	}
+	start := int(file.FlatStartByte(idx))
+	if start < 2 || start > len(content) {
+		return false
+	}
+	return content[start-2] == '.' && content[start-1] == '.'
 }
 
 // FixResult holds the result of applying fixes to a file.
@@ -105,7 +132,13 @@ func ApplyAllFixesColumns(ctx context.Context, columns *scanner.FindingColumns, 
 	// of CI log diff noise — see #27.
 	for _, path := range iterutil.SortedKeys(byFile) {
 		rows := byFile[path]
-		res, err := applyFixesDetailedColumns(ctx, path, columns, rows, suffix, false)
+		// validate=true engages the post-fix Kotlin parse safety net for
+		// .kt/.kts files. Fixes that introduce new parse errors are
+		// dropped (file untouched, entries surface in DroppedFixes)
+		// instead of being silently written to disk. Non-Kotlin files
+		// short-circuit inside ValidateFixResult so the safety net has
+		// no measurable cost for Java/XML/Gradle batches.
+		res, err := applyFixesDetailedColumns(ctx, path, columns, rows, suffix, true)
 		if err != nil {
 			errors = append(errors, fmt.Errorf("%s: %w", path, err))
 			continue
@@ -168,7 +201,26 @@ func applyFixesDetailedColumns(ctx context.Context, path string, columns *scanne
 
 	if validate {
 		if err := ValidateFixResult(ctx, path, content, []byte(result)); err != nil {
-			return FixResult{DroppedFixes: droppedFixes}, fmt.Errorf("fix validation failed for %s: %w", path, err)
+			// Treat validation failure as a soft drop rather than a
+			// catastrophic error: the file stays untouched on disk and
+			// every fix that contributed to the rejected output is
+			// reported via DroppedFixes so callers (CLI, LSP, pipeline
+			// output) can surface why nothing was written. Returning an
+			// error here would abort the file's fix batch and the
+			// dropped fixes would be invisible to the user.
+			reason := fmt.Sprintf("fix validation failed: %v", err)
+			validationDrops := make([]DroppedFix, 0, len(fixes))
+			for _, f := range fixes {
+				validationDrops = append(validationDrops, DroppedFix{
+					Rule:   f.rule,
+					File:   path,
+					Line:   f.line,
+					Reason: reason,
+				})
+			}
+			pkgLog.Warn("dropped fix batch due to parse-validation failure",
+				"file", path, "fixes", len(fixes), "error", err)
+			return FixResult{DroppedFixes: append(droppedFixes, validationDrops...)}, nil
 		}
 	}
 
@@ -376,17 +428,27 @@ func uniqueNames(n int, get func(int) string) []string {
 	return out
 }
 
-// DroppedFix records a fix that was dropped due to overlap conflict.
+// DroppedFix records a fix that was dropped before being written to disk.
+// Reason describes why the fix was dropped (overlap conflict, parse-error
+// safety net, etc.) and is empty for overlap drops, which are the historic
+// default.
 type DroppedFix struct {
-	Rule string
-	File string
-	Line int
+	Rule   string
+	File   string
+	Line   int
+	Reason string
 }
 
 // deduplicateFixesReverse removes overlapping fixes from a reverse-sorted
-// slice. The caller supplies key extractors that return the start and end
-// offsets (byte or line depending on the fix mode) and a meta extractor
-// that shapes the DroppedFix entry for conflicts.
+// slice. The caller supplies key extractors that return the start and the
+// half-open end of each fix (byte or line depending on the fix mode) and
+// a meta extractor that shapes the DroppedFix entry for conflicts.
+//
+// The endKey extractor MUST return an exclusive end offset so the overlap
+// test (`endKey(f) > lastStart`) correctly rejects fixes whose range
+// touches the previously kept fix's start. Byte ranges are already
+// half-open in scanner.Fix; line ranges are inclusive on both ends, so
+// the line-mode extractor returns `EndLine + 1` to normalize.
 func deduplicateFixesReverse[T any](fixes []T, endKey, startKey func(T) int, meta func(T) DroppedFix) ([]T, []DroppedFix) {
 	if len(fixes) <= 1 {
 		return fixes, nil
@@ -407,7 +469,16 @@ func deduplicateFixesReverse[T any](fixes []T, endKey, startKey func(T) int, met
 
 func textFixRowByteEnd(f textFixRow) int   { return f.fix.EndByte }
 func textFixRowByteStart(f textFixRow) int { return f.fix.StartByte }
-func textFixRowLineEnd(f textFixRow) int   { return f.fix.EndLine }
+
+// textFixRowLineEnd returns an exclusive end-line key for the dedup pass.
+// applyLineFixes treats Fix.EndLine as inclusive (slicing lines[start:end]
+// where end == fix.EndLine), so two adjacent fixes like [5..7] and [7..7]
+// both touch line 7. The dedup uses `endKey > lastStart` with half-open
+// semantics, so we add 1 here to make the inclusive line range register
+// as overlapping with a later fix that starts on the same line. Without
+// this conversion the dedup would keep both fixes and applyLineFixes
+// would garble line 7 by editing it twice.
+func textFixRowLineEnd(f textFixRow) int   { return f.fix.EndLine + 1 }
 func textFixRowLineStart(f textFixRow) int { return f.fix.StartLine }
 func textFixRowDroppedFor(path string) func(textFixRow) DroppedFix {
 	return func(f textFixRow) DroppedFix {

--- a/internal/fixer/fixer_test.go
+++ b/internal/fixer/fixer_test.go
@@ -950,18 +950,25 @@ func TestApplyFixesWithValidation_RejectsInvalidFix(t *testing.T) {
 		}),
 	}
 
-	_, err := ApplyFixesWithValidation(t.Context(), path, findings, "", true)
-	if err == nil {
-		t.Fatal("expected validation error")
+	res, err := ApplyFixesDetailed(t.Context(), path, findings, "", true)
+	if err != nil {
+		t.Fatalf("unexpected catastrophic error: %v", err)
 	}
-	if !strings.Contains(err.Error(), "fix validation failed") {
-		t.Fatalf("expected validation failure message, got: %v", err)
+	if res.Applied != 0 {
+		t.Fatalf("applied = %d, want 0 when validation rejects the fix", res.Applied)
+	}
+	if len(res.DroppedFixes) != 1 {
+		t.Fatalf("DroppedFixes len = %d, want 1", len(res.DroppedFixes))
+	}
+	if !strings.Contains(res.DroppedFixes[0].Reason, "fix validation failed") {
+		t.Fatalf("DroppedFixes[0].Reason = %q, want it to mention fix validation failed",
+			res.DroppedFixes[0].Reason)
 	}
 
-	// Original file should be unchanged since validation failed before write
+	// Original file should be unchanged since validation rejected the fix
 	got := readFile(t, path)
 	if got != original {
-		t.Fatalf("original file should be unchanged after validation failure, got %q", got)
+		t.Fatalf("original file should be unchanged after validation rejection, got %q", got)
 	}
 }
 
@@ -1274,5 +1281,155 @@ func TestDeduplicateLineFixesReverse_SingleFix(t *testing.T) {
 	}
 	if len(dropped) != 0 {
 		t.Fatalf("expected 0 dropped, got %d", len(dropped))
+	}
+}
+
+// TestLineConflictDetection_AdjacentInclusiveEnd_DropsSecondFix is the
+// regression test for the off-by-one bug in deduplicateFixesReverse for
+// inclusive line ranges. Fix [5..7] and fix [7..7] both touch line 7
+// because applyLineFixes treats EndLine as inclusive (slicing
+// lines[start:end] where end == fix.EndLine). The dedup previously used
+// `endKey(f) > lastStart` with the raw EndLine and so kept both fixes;
+// the subsequent application loop then walked line 7 twice and garbled
+// output. After the fix one of the two fixes must be dropped.
+func TestLineConflictDetection_AdjacentInclusiveEnd_DropsSecondFix(t *testing.T) {
+	path := writeTestFile(t, "line1\nline2\nline3\nline4\nline5\nline6\nline7\nline8\n")
+	findings := []scanner.Finding{
+		findingWithRule(path, "rule-A", &scanner.Fix{
+			StartLine:   5,
+			EndLine:     7,
+			Replacement: "REPLACED-A",
+		}),
+		findingWithRule(path, "rule-B", &scanner.Fix{
+			StartLine:   7,
+			EndLine:     7,
+			Replacement: "REPLACED-B",
+		}),
+	}
+
+	res, err := ApplyFixesDetailed(t.Context(), path, findings, "", false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(res.DroppedFixes) != 1 {
+		t.Fatalf("expected exactly one dropped fix (both touch line 7), got %d: %#v",
+			len(res.DroppedFixes), res.DroppedFixes)
+	}
+
+	// Higher StartLine sorts first in the reverse-walk: rule-B (7..7) is
+	// kept; rule-A (5..7) overlaps line 7 and must be dropped.
+	if res.DroppedFixes[0].Rule != "rule-A" {
+		t.Fatalf("expected dropped rule 'rule-A', got %q", res.DroppedFixes[0].Rule)
+	}
+
+	got := readFile(t, path)
+	want := "line1\nline2\nline3\nline4\nline5\nline6\nREPLACED-B\nline8\n"
+	if got != want {
+		t.Fatalf("file content garbled by overlapping fixes:\n got:  %q\n want: %q", got, want)
+	}
+}
+
+// TestLineConflictDetection_AdjacentNonOverlapping_BothApply confirms
+// that the inclusive-to-half-open conversion in textFixRowLineEnd does
+// not over-drop. Fix [5..7] and fix [8..8] are adjacent but do NOT touch
+// any line in common, so both must apply.
+func TestLineConflictDetection_AdjacentNonOverlapping_BothApply(t *testing.T) {
+	path := writeTestFile(t, "line1\nline2\nline3\nline4\nline5\nline6\nline7\nline8\nline9\n")
+	findings := []scanner.Finding{
+		findingWithRule(path, "rule-A", &scanner.Fix{
+			StartLine:   5,
+			EndLine:     7,
+			Replacement: "REPLACED-A",
+		}),
+		findingWithRule(path, "rule-B", &scanner.Fix{
+			StartLine:   8,
+			EndLine:     8,
+			Replacement: "REPLACED-B",
+		}),
+	}
+
+	res, err := ApplyFixesDetailed(t.Context(), path, findings, "", false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(res.DroppedFixes) != 0 {
+		t.Fatalf("expected zero dropped fixes for adjacent-but-non-overlapping ranges, got %#v",
+			res.DroppedFixes)
+	}
+	if res.Applied != 2 {
+		t.Fatalf("applied = %d, want 2", res.Applied)
+	}
+
+	got := readFile(t, path)
+	want := "line1\nline2\nline3\nline4\nREPLACED-A\nREPLACED-B\nline9\n"
+	if got != want {
+		t.Fatalf("unexpected content:\n got:  %q\n want: %q", got, want)
+	}
+}
+
+// TestApplyAllFixesColumns_ValidationDropsBadFix is the integration-level
+// regression for the parse-validation safety net being engaged in
+// production. A fix that introduces new Kotlin parse errors must be
+// dropped: the file stays untouched on disk and DroppedFixes carries the
+// entry with a useful reason. Before this fix, ApplyAllFixesColumns
+// passed validate=false to applyFixesDetailedColumns, so broken output
+// was silently written.
+func TestApplyAllFixesColumns_ValidationDropsBadFix(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.kt")
+	original := "fun main() { println(\"hello\") }\n"
+	if err := os.WriteFile(path, []byte(original), 0o644); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+
+	// Replacement strips the closing brace + paren so the result no
+	// longer parses as Kotlin.
+	findings := []scanner.Finding{
+		findingWithRule(path, "broken-rule", &scanner.Fix{
+			StartByte:   0,
+			EndByte:     len(original) - 1,
+			Replacement: "fun main() { println(\"hello\"",
+			ByteMode:    true,
+		}),
+	}
+	cols := scanner.CollectFindings(findings)
+
+	applied, modified, errs := ApplyAllFixesColumns(t.Context(), &cols, "")
+	if len(errs) > 0 {
+		t.Fatalf("ApplyAllFixesColumns returned errors: %v", errs)
+	}
+	if applied != 0 {
+		t.Fatalf("applied = %d, want 0 when validation rejects fix", applied)
+	}
+	if modified != 0 {
+		t.Fatalf("modified = %d, want 0 when validation rejects fix", modified)
+	}
+
+	// File on disk must be unchanged.
+	got := readFile(t, path)
+	if got != original {
+		t.Fatalf("file modified despite validation rejection: got %q, want %q", got, original)
+	}
+
+	// Use applyFixesDetailedColumns directly to inspect the DroppedFix
+	// payload — ApplyAllFixesColumns intentionally throws the result
+	// away. validate=true mirrors the production behavior we just
+	// asserted above.
+	cols2 := scanner.CollectFindings(findings)
+	rows := []int{0}
+	res, err := applyFixesDetailedColumns(t.Context(), path, &cols2, rows, "", true)
+	if err != nil {
+		t.Fatalf("applyFixesDetailedColumns error: %v", err)
+	}
+	if len(res.DroppedFixes) != 1 {
+		t.Fatalf("DroppedFixes len = %d, want 1: %#v", len(res.DroppedFixes), res.DroppedFixes)
+	}
+	if res.DroppedFixes[0].Rule != "broken-rule" {
+		t.Fatalf("DroppedFixes[0].Rule = %q, want %q", res.DroppedFixes[0].Rule, "broken-rule")
+	}
+	if !strings.Contains(res.DroppedFixes[0].Reason, "fix validation failed") {
+		t.Fatalf("DroppedFixes[0].Reason = %q, want it to mention fix validation failed",
+			res.DroppedFixes[0].Reason)
 	}
 }


### PR DESCRIPTION
## Summary

Two bugs in the autofix path that combined to let bad output reach disk:

- **Off-by-one in `deduplicateFixesReverse` for line ranges.** The dedup
  used a half-open overlap test (`endKey(f) > lastStart`), but
  `applyLineFixes` treats `Fix.EndLine` as inclusive. Two adjacent fixes
  like `[5..7]` and `[7..7]` both touched line 7 yet both survived
  dedup; the apply loop then rewrote line 7 twice and garbled output.
  Fix: normalize the line-mode end key to `EndLine + 1` so the existing
  half-open check stays correct for both byte and line modes. Byte-mode
  semantics are unchanged.

- **Post-fix parse-validation safety net was dead in production.**
  `ApplyAllFixesColumns` passed `validate=false`, so any autofix that
  introduced new Kotlin ERROR nodes was silently written. Production
  now sets `validate=true`. `applyFixesDetailedColumns` treats
  validation failures as soft drops — the file stays untouched on disk,
  every contributing fix appears in `DroppedFixes` with a `Reason`
  field explaining why, and no catastrophic error aborts the batch.
  `countParseErrors` skips the tree-sitter-kotlin grammar gap around
  the rangeUntil operator (`..<`) so legal modern Kotlin output is not
  falsely rejected.

## Test plan

- [x] `TestLineConflictDetection_AdjacentInclusiveEnd_DropsSecondFix` — `[5..7]` and `[7..7]` regression
- [x] `TestLineConflictDetection_AdjacentNonOverlapping_BothApply` — `[5..7]` and `[8..8]` confirms no over-drop
- [x] `TestApplyAllFixesColumns_ValidationDropsBadFix` — bad fix is dropped via `DroppedFixes` (with reason), file unchanged on disk, no error returned
- [x] Updated `TestApplyFixesWithValidation_RejectsInvalidFix` to the new dropped-fix contract
- [x] `go build ./cmd/krit/`, `go vet ./...`, `golangci-lint run ./...`, `go test ./internal/fixer/ ./internal/cli/applysuggestion/ -count=1`, `go test ./... -count=1`