### PR TITLE
fix(rules): receiver-boundary cleanup for Android Recycle resource leak

### DIFF
--- a/internal/rules/android_performance.go
+++ b/internal/rules/android_performance.go
@@ -679,6 +679,15 @@ func extractPropertyTypeFlat(file *scanner.File, idx uint32) string {
 	return ""
 }
 
+// recycleCleanupMethodNames is the set of callees that finalize a recyclable
+// Android resource (TypedArray, Cursor, VelocityTracker, Parcel) when invoked
+// on the resource itself.
+var recycleCleanupMethodNames = map[string]bool{
+	"recycle": true,
+	"close":   true,
+	"use":     true,
+}
+
 func recycleVariableHasCleanupFlat(file *scanner.File, idx uint32, varName string) bool {
 	scope, ok := file.FlatParent(idx)
 	if !ok {
@@ -692,10 +701,7 @@ func recycleVariableHasCleanupFlat(file *scanner.File, idx uint32, varName strin
 			continue
 		}
 
-		childText := file.FlatNodeText(child)
-		if strings.Contains(childText, varName+".recycle()") ||
-			strings.Contains(childText, varName+".close()") ||
-			strings.Contains(childText, varName+".use") {
+		if subtreeHasCallOnReceiver(file, child, varName, recycleCleanupMethodNames) {
 			return true
 		}
 	}

--- a/internal/rules/database_test.go
+++ b/internal/rules/database_test.go
@@ -1245,3 +1245,75 @@ class NotARoomDb : Base()
 		t.Fatalf("expected no findings for non-@Database annotation, got %v", findings)
 	}
 }
+
+// Regression: jdbcPreparedStatementHasCleanupFlat used to call
+// strings.Contains on the source text, so `vs.close()` falsely "closed"
+// a sibling statement named `s`. The fix requires an identifier-boundary
+// match by walking the AST.
+func TestJdbcPreparedStatementNotClosed_LookalikeReceiverDoesNotSuppress(t *testing.T) {
+	findings := runRuleByName(t, "JdbcPreparedStatementNotClosed", `
+package test
+
+interface Connection {
+    fun prepareStatement(sql: String): PreparedStatement
+}
+
+interface PreparedStatement {
+    fun executeQuery(): ResultSet
+    fun close()
+}
+
+interface ResultSet
+
+fun query(connection: Connection) {
+    val s = connection.prepareStatement("SELECT 1")
+    val vs = connection.prepareStatement("SELECT 2")
+    s.executeQuery()
+    vs.executeQuery()
+    vs.close()
+    // s is never closed
+}
+`)
+	leaked := false
+	for _, f := range findings {
+		if strings.Contains(f.Message, "'s'") {
+			leaked = true
+		}
+	}
+	if !leaked {
+		t.Fatalf("expected leaked statement 's' to be reported even though sibling 'vs' was closed; got %v", findings)
+	}
+}
+
+// Regression: the negative side — a short-named statement that *is*
+// closed must continue to be recognised as cleaned-up.
+func TestJdbcPreparedStatementNotClosed_ShortNameClosedIsRecognised(t *testing.T) {
+	findings := runRuleByName(t, "JdbcPreparedStatementNotClosed", `
+package test
+
+interface Connection {
+    fun prepareStatement(sql: String): PreparedStatement
+}
+
+interface PreparedStatement {
+    fun executeQuery(): ResultSet
+    fun close()
+}
+
+interface ResultSet
+
+fun query(connection: Connection) {
+    val s = connection.prepareStatement("SELECT 1")
+    try {
+        s.executeQuery()
+    } finally {
+        s.close()
+    }
+}
+`)
+	for _, f := range findings {
+		if strings.Contains(f.Message, "'s'") {
+			t.Fatalf("expected no finding for statement 's' that is explicitly closed; got %v", f)
+		}
+	}
+}

--- a/internal/rules/flat_call.go
+++ b/internal/rules/flat_call.go
@@ -508,6 +508,43 @@ func ancestorCallNameIn(file *scanner.File, idx uint32, names map[string]bool) b
 	return false
 }
 
+// subtreeHasCallOnReceiver walks every call_expression inside `root`
+// (including root itself) and reports whether any call is invoked on a
+// bare receiver identifier exactly equal to `receiverName` with a callee
+// in `methodNames`. The receiver must be a simple_identifier — qualified
+// chains like `wrapper.s.close()` do not match `receiverName == "s"`,
+// and longer-name lookalikes like `vs.close()` do not match
+// `receiverName == "s"`. Used by resource-leak rules that previously
+// scanned source text with `strings.Contains` and incorrectly matched
+// longer identifiers ending in the same suffix.
+func subtreeHasCallOnReceiver(file *scanner.File, root uint32, receiverName string, methodNames map[string]bool) bool {
+	if file == nil || root == 0 || receiverName == "" || len(methodNames) == 0 {
+		return false
+	}
+	found := false
+	file.FlatWalkNodes(root, "call_expression", func(call uint32) {
+		if found {
+			return
+		}
+		if !methodNames[flatCallExpressionName(file, call)] {
+			return
+		}
+		navExpr, _ := flatCallExpressionParts(file, call)
+		if navExpr == 0 || file.FlatNamedChildCount(navExpr) == 0 {
+			return
+		}
+		first := file.FlatNamedChild(navExpr, 0)
+		if file.FlatType(first) != "simple_identifier" {
+			return
+		}
+		if !file.FlatNodeTextEquals(first, receiverName) {
+			return
+		}
+		found = true
+	})
+	return found
+}
+
 // functionHasReceiverCallAfter reports whether fn contains a call after target
 // whose receiver name and callee match. accept can reject same-name calls that
 // are not the API being searched for, such as Kotlin scope-function apply.

--- a/tests/fixtures/negative/android-lint/Recycle.kt
+++ b/tests/fixtures/negative/android-lint/Recycle.kt
@@ -10,4 +10,22 @@ class StyleHelper(private val context: Context) {
         ta.recycle()
         return color
     }
+
+    // Regression: a short-named TypedArray `ta` is properly recycled; the
+    // receiver-bound identifier-boundary check must recognise `ta.recycle()`
+    // (and must not be confused into thinking some longer-named sibling
+    // closed it).
+    fun getColorWithSiblingResource(attrs: IntArray, other: IntArray): Int {
+        val ta: TypedArray = context.obtainStyledAttributes(attrs)
+        val vta: TypedArray = context.obtainStyledAttributes(other)
+        val color = ta.getColor(0, 0)
+        try {
+            // do something with vta
+            vta.getColor(0, 0)
+        } finally {
+            ta.recycle()
+            vta.recycle()
+        }
+        return color
+    }
 }

--- a/tests/fixtures/negative/database/JdbcPreparedStatementNotClosed.kt
+++ b/tests/fixtures/negative/database/JdbcPreparedStatementNotClosed.kt
@@ -24,3 +24,16 @@ fun querySafely(connection: Connection) {
         stmt.executeQuery()
     }
 }
+
+// Regression: a short-named statement `s` is properly closed; the
+// receiver-bound identifier-boundary check must recognise `s.close()`
+// (and must not be confused into thinking some other identifier ending
+// in 's' closed it).
+fun queryShortName(connection: Connection) {
+    val s = connection.prepareStatement("SELECT 1")
+    try {
+        s.executeQuery()
+    } finally {
+        s.close()
+    }
+}

--- a/tests/fixtures/negative/database/SqliteCursorWithoutClose.kt
+++ b/tests/fixtures/negative/database/SqliteCursorWithoutClose.kt
@@ -27,3 +27,18 @@ fun loadUsersExplicitClose(db: SQLiteDatabase) {
     }
     cursor.close()
 }
+
+// Regression: a short-named cursor `c` is properly closed; the
+// receiver-bound identifier-boundary check must recognise `c.close()`
+// (and must not be confused into thinking some longer-named sibling
+// closed it).
+fun loadUsersShortName(db: SQLiteDatabase) {
+    val c = db.rawQuery("SELECT * FROM users", null)
+    try {
+        while (c.moveToNext()) {
+            // ...
+        }
+    } finally {
+        c.close()
+    }
+}

--- a/tests/fixtures/positive/android-lint/Recycle.kt
+++ b/tests/fixtures/positive/android-lint/Recycle.kt
@@ -10,4 +10,17 @@ class StyleHelper(private val context: Context) {
         // Missing cleanup call
         return color
     }
+
+    // Regression: a leaked short-named TypedArray `ta` must FIRE even when a
+    // longer-named sibling `vta.recycle()` is present in the same scope.
+    // The substring scan that this rule used to use matched `vta.recycle()`
+    // as evidence that `ta` had been recycled.
+    fun getColorsWithLookalike(attrs: IntArray, other: IntArray): Int {
+        val ta: TypedArray = context.obtainStyledAttributes(attrs)
+        val vta: TypedArray = context.obtainStyledAttributes(other)
+        val color = ta.getColor(0, 0)
+        vta.recycle()
+        // ta is never recycled
+        return color
+    }
 }

--- a/tests/fixtures/positive/database/JdbcPreparedStatementNotClosed.kt
+++ b/tests/fixtures/positive/database/JdbcPreparedStatementNotClosed.kt
@@ -16,3 +16,19 @@ fun query(connection: Connection) {
     val rs = stmt.executeQuery()
     println(rs)
 }
+
+// Regression: a leaked short-named statement `s` must FIRE even when a
+// longer-named sibling `vs.close()` is present in the same scope. The
+// substring scan that this rule used to use was matching `vs.close(`
+// as evidence that `s` had been closed.
+fun queryWithLookalike(connection: Connection) {
+    val s = connection.prepareStatement("SELECT 1")
+    val vs = connection.prepareStatement("SELECT 2")
+    val rs = s.executeQuery()
+    try {
+        vs.close()
+    } finally {
+        // s is never closed
+        println(rs)
+    }
+}

--- a/tests/fixtures/positive/database/SqliteCursorWithoutClose.kt
+++ b/tests/fixtures/positive/database/SqliteCursorWithoutClose.kt
@@ -23,3 +23,17 @@ fun loadAccounts(db: SQLiteDatabase) {
         // ...
     }
 }
+
+// Regression: a leaked short-named cursor `c` must FIRE even when a
+// longer-named sibling `vc.close()` is present in the same scope. The
+// substring scan that this rule used to use matched `vc.close(` as
+// evidence that `c` had been closed.
+fun loadUsersWithLookalike(db: SQLiteDatabase) {
+    val c = db.rawQuery("SELECT * FROM users", null)
+    val vc = db.rawQuery("SELECT * FROM admins", null)
+    while (c.moveToNext()) {
+        // ...
+    }
+    vc.close()
+    // c is never closed
+}


### PR DESCRIPTION
## Summary

[#388](https://github.com/kaeawc/krit/pull/388) fixed the receiver-boundary lookalike bug for the JDBC / SQLite resource-leak rules, but the Android \`Recycle\` rule still calls \`strings.Contains(childText, varName+\".close()\")\` (and \`.recycle()\`, \`.use\`). So:

- A sibling variable like \`vs.close()\` falsely "closes" a short-named sibling \`s\`.
- Longer-name lookalikes (\`thisRecycler\`) silently suppress findings on \`Recycler\`.

This PR replaces the text scan in \`recycleVariableHasCleanupFlat\` with a small AST helper, \`subtreeHasCallOnReceiver\`, that walks every \`call_expression\` in the subtree and only accepts a bare receiver \`simple_identifier\` exactly equal to the variable name. The helper sits next to the existing \`flat_call\` helpers and is reusable by any other resource-leak rule with the same pattern.

Also adds positive + negative Kotlin fixtures for Recycle, JdbcPreparedStatementNotClosed, and SqliteCursorWithoutClose, plus two regression tests on the JDBC rule (added in #388 but not regression-pinned) for short-name suppress + lookalike scenarios.

## Test plan

- [x] \`go test ./internal/rules/ -count=1\` — green.
- [x] \`golangci-lint run ./...\` — 0 issues.
- [ ] CI green on the PR.