### PR TITLE
refactor(scanner): canonical RowForByte; absorb four parallel helpers

### DIFF
--- a/internal/android/resources.go
+++ b/internal/android/resources.go
@@ -10,12 +10,13 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"sort"
 	"strings"
 	"sync"
 	"time"
 
 	"golang.org/x/sync/errgroup"
+
+	"github.com/kaeawc/krit/internal/scanner"
 )
 
 func clampWorkers(maxWorkers, workItems int) int {
@@ -142,27 +143,13 @@ const (
 
 const ValuesScanAll = ValuesScanStrings | ValuesScanDimensions | ValuesScanPlurals | ValuesScanArrays | ValuesScanExtraText
 
-type lineIndex struct {
-	newlines []int64
-}
-
-func newLineIndex(data []byte) *lineIndex {
-	newlines := make([]int64, 0, bytes.Count(data, []byte{'\n'}))
-	for i, b := range data {
-		if b == '\n' {
-			newlines = append(newlines, int64(i))
-		}
-	}
-	return &lineIndex{newlines: newlines}
-}
-
-func (idx *lineIndex) lineAtOffset(offset int64) int {
-	if idx == nil {
+// lineAtOffset returns the 1-based line number for the given byte offset in
+// the file's content. A nil file is treated as the first line.
+func lineAtOffset(file *scanner.File, offset int64) int {
+	if file == nil {
 		return 1
 	}
-	return sort.Search(len(idx.newlines), func(i int) bool {
-		return idx.newlines[i] >= offset
-	}) + 1
+	return file.RowForByte(int(offset)) + 1
 }
 
 type resourceDirResult struct {
@@ -901,9 +888,9 @@ func (idx *ResourceIndex) parseValuesXMLKinds(path string, data []byte, kinds Va
 	needStringLines := kinds&ValuesScanStrings != 0
 	needExtraTextLines := kinds&ValuesScanExtraText != 0
 	needDimenLines := kinds&ValuesScanDimensions != 0
-	var lines *lineIndex
+	var lines *scanner.File
 	if needStringLines || needExtraTextLines || needDimenLines {
-		lines = newLineIndex(data)
+		lines = &scanner.File{Content: data, Language: scanner.LangXML, Path: path}
 	}
 	for {
 		tok, err := dec.Token()
@@ -925,7 +912,7 @@ func (idx *ResourceIndex) parseValuesXMLKinds(path string, data []byte, kinds Va
 	return fmt.Errorf("parsing XML %s: root element is not <resources>", path)
 }
 
-func (idx *ResourceIndex) parseResourcesRootKinds(dec *xml.Decoder, path string, _ []byte, root xml.StartElement, kinds ValuesScanKind, lines *lineIndex) error {
+func (idx *ResourceIndex) parseResourcesRootKinds(dec *xml.Decoder, path string, _ []byte, root xml.StartElement, kinds ValuesScanKind, lines *scanner.File) error {
 	for {
 		tok, err := dec.Token()
 		if err != nil {
@@ -944,7 +931,7 @@ func (idx *ResourceIndex) parseResourcesRootKinds(dec *xml.Decoder, path string,
 					offset := dec.InputOffset() - int64(len(t)) + int64(leadingTrimmedBytes(raw))
 					idx.ExtraTexts = append(idx.ExtraTexts, ExtraTextEntry{
 						FilePath: path,
-						Line:     lines.lineAtOffset(offset),
+						Line:     lineAtOffset(lines, offset),
 						Text:     text,
 					})
 				}
@@ -954,7 +941,7 @@ func (idx *ResourceIndex) parseResourcesRootKinds(dec *xml.Decoder, path string,
 			if lines != nil {
 				switch t.Name.Local {
 				case "string", "dimen", "style":
-					elemLine = lines.lineAtOffset(dec.InputOffset())
+					elemLine = lineAtOffset(lines, dec.InputOffset())
 				}
 			}
 			if err := idx.parseResourceElementKinds(dec, t, path, elemLine, kinds, lines); err != nil {
@@ -968,7 +955,7 @@ func (idx *ResourceIndex) parseResourcesRootKinds(dec *xml.Decoder, path string,
 	}
 }
 
-func (idx *ResourceIndex) parseResourceElementKinds(dec *xml.Decoder, start xml.StartElement, path string, line int, kinds ValuesScanKind, lines *lineIndex) error {
+func (idx *ResourceIndex) parseResourceElementKinds(dec *xml.Decoder, start xml.StartElement, path string, line int, kinds ValuesScanKind, lines *scanner.File) error {
 	switch start.Name.Local {
 	case "string":
 		return idx.parseStringElement(dec, start, path, line, kinds)
@@ -1098,7 +1085,7 @@ func (idx *ResourceIndex) parseBoolElement(dec *xml.Decoder, start xml.StartElem
 	return nil
 }
 
-func (idx *ResourceIndex) parseStyleElement(dec *xml.Decoder, start xml.StartElement, path string, line int, lines *lineIndex) error {
+func (idx *ResourceIndex) parseStyleElement(dec *xml.Decoder, start xml.StartElement, path string, line int, lines *scanner.File) error {
 	name := xmlAttr(start.Attr, "name")
 	if name == "" {
 		return skipElement(dec, start)
@@ -1128,7 +1115,7 @@ func (idx *ResourceIndex) parseStyleElement(dec *xml.Decoder, start xml.StartEle
 			itemName := xmlAttr(t.Attr, "name")
 			itemLine := 0
 			if lines != nil {
-				itemLine = lines.lineAtOffset(dec.InputOffset())
+				itemLine = lineAtOffset(lines, dec.InputOffset())
 			}
 			text, err := decodeSimpleElementText(dec, t)
 			if err != nil {

--- a/internal/harvest/harvest.go
+++ b/internal/harvest/harvest.go
@@ -96,24 +96,9 @@ func ExtractFixture(target Target, ruleName string) (Result, error) {
 		Col:       match.Col,
 		NodeType:  file.FlatType(node),
 		StartLine: file.FlatRow(node) + 1,
-		EndLine:   lineForByteOffset(file, int(file.FlatEndByte(node)-1)),
+		EndLine:   file.RowForByte(int(file.FlatEndByte(node)-1)) + 1,
 		Content:   content,
 	}, nil
-}
-
-func lineForByteOffset(file *scanner.File, offset int) int {
-	if file == nil {
-		return 1
-	}
-	offsets := file.LineOffsets()
-	line := 0
-	for i, start := range offsets {
-		if start > offset {
-			break
-		}
-		line = i
-	}
-	return line + 1
 }
 
 func WriteFixture(outPath string, result Result) error {

--- a/internal/rules/style_format.go
+++ b/internal/rules/style_format.go
@@ -3,7 +3,6 @@ package rules
 import (
 	"fmt"
 	"regexp"
-	"sort"
 	"strings"
 
 	api "github.com/kaeawc/krit/internal/rules/api"
@@ -444,7 +443,7 @@ func (r *SpacingAfterPackageAndImportsRule) check(ctx *api.Context) {
 		}
 	}
 
-	endRow := lineOfByte(file, int(preludeCodeEndByte(file, idx)))
+	endRow := file.RowForByte(int(preludeCodeEndByte(file, idx)))
 	if endRow+1 >= len(file.Lines) {
 		return
 	}
@@ -462,19 +461,6 @@ func (r *SpacingAfterPackageAndImportsRule) check(ctx *api.Context) {
 		Replacement: "\n",
 	}
 	ctx.Emit(f)
-}
-
-// lineOfByte returns the 0-based line index containing byteOffset.
-func lineOfByte(file *scanner.File, byteOffset int) int {
-	offsets := file.LineOffsets()
-	if len(offsets) == 0 {
-		return 0
-	}
-	i := sort.Search(len(offsets), func(j int) bool { return offsets[j] > byteOffset })
-	if i == 0 {
-		return 0
-	}
-	return i - 1
 }
 
 // nextPreludeSibling returns the next file-scope sibling of a package/import

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -187,6 +188,21 @@ func (f *File) LineOffset(lineIdx int) int {
 		return offsets[lineIdx]
 	}
 	return len(f.Content)
+}
+
+// RowForByte returns the 0-based line index containing the given byte offset.
+// Callers that need a 1-based line number should add 1. Returns 0 when the
+// file has no recorded line offsets.
+func (f *File) RowForByte(byteOffset int) int {
+	offsets := f.LineOffsets()
+	if len(offsets) == 0 {
+		return 0
+	}
+	i := sort.Search(len(offsets), func(j int) bool { return offsets[j] > byteOffset })
+	if i == 0 {
+		return 0
+	}
+	return i - 1
 }
 
 // ParseFile parses a Kotlin file and returns the AST. The ctx is forwarded

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -145,6 +145,41 @@ func TestLineOffset_OutOfRange(t *testing.T) {
 	}
 }
 
+func TestRowForByte(t *testing.T) {
+	// Content: "abc\ndef\nghi" → line starts at [0, 4, 8].
+	f := &File{Content: []byte("abc\ndef\nghi")}
+
+	cases := []struct {
+		byteOffset int
+		wantRow    int
+	}{
+		{0, 0},   // start of line 0
+		{2, 0},   // mid line 0
+		{3, 0},   // '\n' belongs to line 0
+		{4, 1},   // start of line 1
+		{6, 1},   // mid line 1
+		{7, 1},   // '\n' belongs to line 1
+		{8, 2},   // start of line 2
+		{10, 2},  // last byte of line 2
+		{100, 2}, // past content: clamped to last known row
+	}
+	for _, tc := range cases {
+		if got := f.RowForByte(tc.byteOffset); got != tc.wantRow {
+			t.Errorf("RowForByte(%d): expected %d, got %d", tc.byteOffset, tc.wantRow, got)
+		}
+	}
+}
+
+func TestRowForByte_EmptyContent(t *testing.T) {
+	f := &File{Content: []byte{}}
+	if got := f.RowForByte(0); got != 0 {
+		t.Errorf("RowForByte(0) on empty content: expected 0, got %d", got)
+	}
+	if got := f.RowForByte(10); got != 0 {
+		t.Errorf("RowForByte(10) on empty content: expected 0, got %d", got)
+	}
+}
+
 func parseTestKotlin(t *testing.T, src string) *sitter.Node {
 	t.Helper()
 	content := []byte(src)


### PR DESCRIPTION
## Summary

Three places computed a line index from a byte offset via \`sort.Search\` / linear scan over \`(*scanner.File).LineOffsets()\` (or an equivalent local newline table), and a fourth landed with SpacingAfterPackageAndImports in #360. Each carried its own 0-based vs 1-based convention.

Promote a single helper to the type and migrate all four callers, adding \`+ 1\` at the 1-based call sites:

\`\`\`go
// (*File).RowForByte returns the 0-based line index containing byteOffset.
func (f *File) RowForByte(byteOffset int) int { ... }  // sort.Search over LineOffsets()
\`\`\`

Migrated:
- \`internal/harvest/harvest.go\` — drops \`lineForByteOffset\` (linear scan).
- \`internal/android/resources.go\` — replaces the private \`lineIndex\` struct (over raw XML bytes, storing newline positions) with a minimal \`&scanner.File{Content, Language: LangXML, Path}\` driving a thin \`lineAtOffset\` wrapper. Picks up #373's expanded \"string\" / \"dimen\" / \"style\" element coverage.
- \`internal/rules/style_format.go\` — drops \`lineOfByte\` (from #360).

Net: 3 parallel helpers + 1 newly added local helper collapsed into one canonical method; \`sort\` imports dropped from the migrated callers; divergent newline-position vs line-start representation eliminated.

## Test plan

- [x] \`go build -o krit ./cmd/krit/\`
- [x] \`go vet ./...\`
- [x] \`golangci-lint run\` on \`internal/{scanner,harvest,android,rules}/...\` — 0 issues
- [x] \`go test ./...\` — all green
- [x] New \`TestRowForByte\` covers line starts, mid-line, the newline-belongs-to-prev-line boundary, past-content clamp, and empty content.
- [x] \`make integration\` — passes locally (cmd/krit init flake reproduces on clean main and is unrelated)