### PR TITLE
fix(rules): use AST tokens for nullsafety_redundant offsets and checks

### DIFF
--- a/internal/rules/potentialbugs_nullsafety_redundant.go
+++ b/internal/rules/potentialbugs_nullsafety_redundant.go
@@ -408,6 +408,34 @@ func flatNavigationHasSafeCall(file *scanner.File, nav uint32) bool {
 	return found
 }
 
+// flatNavigationSafeCallOperator returns the AST node index of the top-level
+// `?.` token for a navigation_expression — i.e. the operator that joins this
+// expression's receiver to its suffix. Returns 0 if no `?.` token is present
+// directly on the expression (chained `?.` inside the receiver is ignored).
+//
+// Kotlin tree-sitter shapes the operator as either a direct `?.` child of
+// `navigation_expression` or as a `?.` child inside its `navigation_suffix`.
+// Using the AST node's byte range avoids the text-scan footgun of locating
+// `?.` inside a receiver-side string literal (e.g. `x.contains("?.")?.bar`).
+func flatNavigationSafeCallOperator(file *scanner.File, nav uint32) uint32 {
+	if file == nil || nav == 0 {
+		return 0
+	}
+	for child := file.FlatFirstChild(nav); child != 0; child = file.FlatNextSib(child) {
+		switch file.FlatType(child) {
+		case "?.":
+			return child
+		case "navigation_suffix":
+			for gc := file.FlatFirstChild(child); gc != 0; gc = file.FlatNextSib(gc) {
+				if file.FlatType(gc) == "?." {
+					return gc
+				}
+			}
+		}
+	}
+	return 0
+}
+
 func flatNullCheckNavigationReceiver(file *scanner.File, idx uint32) uint32 {
 	if file == nil || idx == 0 {
 		return 0
@@ -940,7 +968,6 @@ func (r *UnnecessarySafeCallRule) check(ctx *api.Context) {
 	if !flatNavigationHasSafeCall(file, idx) {
 		return
 	}
-	text := file.FlatNodeText(idx)
 
 	// The navigation_expression has children: receiver, navigation_suffix
 	// The ?. operator is in the navigation_suffix
@@ -975,16 +1002,30 @@ func (r *UnnecessarySafeCallRule) check(ctx *api.Context) {
 		return
 	}
 
+	// Locate the ?. operator via the AST so the fix range is correct even when
+	// the receiver text itself contains the literal `?.` substring (e.g. inside
+	// a string argument to a chained call).
+	safeOp := flatNavigationSafeCallOperator(file, idx)
+	makeFix := func() *scanner.Fix {
+		if safeOp == 0 {
+			return nil
+		}
+		return &scanner.Fix{
+			ByteMode:    true,
+			StartByte:   int(file.FlatStartByte(safeOp)),
+			EndByte:     int(file.FlatEndByte(safeOp)),
+			Replacement: ".",
+		}
+	}
+
 	// If the receiver is a function parameter with an explicit non-null type,
 	// the safe call is always unnecessary — emit directly without waiting for
 	// the resolver or the val-only heuristic (which won't find params).
 	if unnecessarySafeCallNonNullFunctionParamFlat(file, idx, name) {
 		f := r.Finding(file, file.FlatRow(idx)+1, file.FlatCol(idx)+1,
 			fmt.Sprintf("Unnecessary safe call (?.) on non-nullable parameter '%s'.", name))
-		qIdx := strings.Index(text, "?.")
-		if qIdx >= 0 {
-			start := int(file.FlatStartByte(idx))
-			f.Fix = &scanner.Fix{ByteMode: true, StartByte: start + qIdx, EndByte: start + qIdx + 2, Replacement: "."}
+		if fix := makeFix(); fix != nil {
+			f.Fix = fix
 		}
 		ctx.Emit(f)
 		return
@@ -1000,11 +1041,8 @@ func (r *UnnecessarySafeCallRule) check(ctx *api.Context) {
 			// Known non-null (possibly via smart cast) — flag
 			f := r.Finding(file, file.FlatRow(idx)+1, file.FlatCol(idx)+1,
 				fmt.Sprintf("Unnecessary safe call (?.) on non-nullable '%s'.", name))
-			// Find the ?. in the text and replace with .
-			qIdx := strings.Index(text, "?.")
-			if qIdx >= 0 {
-				start := int(file.FlatStartByte(idx))
-				f.Fix = &scanner.Fix{ByteMode: true, StartByte: start + qIdx, EndByte: start + qIdx + 2, Replacement: "."}
+			if fix := makeFix(); fix != nil {
+				f.Fix = fix
 			}
 			ctx.Emit(f)
 			return
@@ -1014,10 +1052,8 @@ func (r *UnnecessarySafeCallRule) check(ctx *api.Context) {
 	if sameFileExplicitNonNullValueDeclaration(file, idx, name) {
 		f := r.Finding(file, file.FlatRow(idx)+1, file.FlatCol(idx)+1,
 			fmt.Sprintf("Unnecessary safe call (?.) on non-nullable val '%s'.", name))
-		qIdx := strings.Index(text, "?.")
-		if qIdx >= 0 {
-			start := int(file.FlatStartByte(idx))
-			f.Fix = &scanner.Fix{ByteMode: true, StartByte: start + qIdx, EndByte: start + qIdx + 2, Replacement: "."}
+		if fix := makeFix(); fix != nil {
+			f.Fix = fix
 		}
 		ctx.Emit(f)
 	}
@@ -1188,20 +1224,24 @@ func unnecessarySafeCallLambdaHasRepeatedThisSafeCalls(file *scanner.File, lambd
 	if file == nil || lambda == 0 {
 		return false
 	}
-	text := file.FlatNodeText(lambda)
+	// Count navigation_expressions whose receiver is a `this_expression` and
+	// whose operator is `?.`. Walking the AST avoids the text-scan footgun of
+	// matching `this?.` inside a string literal argument.
 	count := 0
-	for start := 0; start < len(text); {
-		idx := strings.Index(text[start:], "this?.")
-		if idx < 0 {
-			return false
+	file.FlatWalkAllNodes(lambda, func(candidate uint32) {
+		if count >= 2 || file.FlatType(candidate) != "navigation_expression" {
+			return
+		}
+		receiver := file.FlatChild(candidate, 0)
+		if receiver == 0 || file.FlatType(receiver) != "this_expression" {
+			return
+		}
+		if flatNavigationSafeCallOperator(file, candidate) == 0 {
+			return
 		}
 		count++
-		if count >= 2 {
-			return true
-		}
-		start += idx + len("this?.")
-	}
-	return false
+	})
+	return count >= 2
 }
 
 func unnecessarySafeCallLambdaHasNullableImplicitItReceiver(file *scanner.File, lambda uint32) bool {
@@ -1281,11 +1321,26 @@ func getterNullableReceiverFlat(file *scanner.File, getter uint32, structural bo
 				}
 			}
 		}
-		text := file.FlatNodeText(candidate)
-		if colonIdx := strings.Index(text, ":"); colonIdx > 0 && strings.Contains(text[:colonIdx], "?.") {
-			return true
+		// Fallback: scan the receiver-type prefix for `?.`. Anchor the prefix
+		// to the start of the `variable_declaration` AST child rather than the
+		// first `:` in the property text, so a backtick-quoted property name
+		// containing `:` (`val `foo:bar`: Foo = ...`) does not shift the
+		// boundary into the name itself.
+		varDecl, _ := file.FlatFindChild(candidate, "variable_declaration")
+		if varDecl == 0 {
+			return false
 		}
-		return false
+		propStart := file.FlatStartByte(candidate)
+		varStart := file.FlatStartByte(varDecl)
+		if varStart <= propStart {
+			return false
+		}
+		prefix := file.FlatNodeText(candidate)
+		offset := int(varStart - propStart)
+		if offset > len(prefix) {
+			offset = len(prefix)
+		}
+		return strings.Contains(prefix[:offset], "?.")
 	}
 	return false
 }

--- a/internal/rules/potentialbugs_nullsafety_redundant_internal_test.go
+++ b/internal/rules/potentialbugs_nullsafety_redundant_internal_test.go
@@ -1,0 +1,205 @@
+package rules
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/kaeawc/krit/internal/scanner"
+)
+
+// parseInlineForInternalTest parses the given Kotlin source into a *scanner.File
+// using a temporary .kt file so internal tests can exercise helpers without
+// going through the rules_test wrappers.
+func parseInlineForInternalTest(t *testing.T, code string) *scanner.File {
+	t.Helper()
+	tmp, err := os.CreateTemp("", "krit_nullsafety_*.kt")
+	if err != nil {
+		t.Fatalf("temp file: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Remove(tmp.Name()) })
+	if _, err := tmp.WriteString(code); err != nil {
+		t.Fatalf("write temp: %v", err)
+	}
+	if err := tmp.Close(); err != nil {
+		t.Fatalf("close temp: %v", err)
+	}
+	file, err := scanner.ParseFile(context.Background(), tmp.Name())
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	return file
+}
+
+// TestFlatNavigationSafeCallOperator_LocatesAstToken confirms the helper
+// returns the AST node index of the top-level `?.` operator regardless of
+// whether the receiver text contains the literal `?.` substring (e.g. in a
+// string argument to a chained call). Using AST byte ranges is what keeps
+// the autofix from corrupting source containing such literals.
+func TestFlatNavigationSafeCallOperator_LocatesAstToken(t *testing.T) {
+	file := parseInlineForInternalTest(t, "fun f(): Int { val s: String = \"\"; return s?.length ?: 0 }\n")
+	var nav uint32
+	file.FlatWalkNodes(0, "navigation_expression", func(idx uint32) {
+		if nav == 0 {
+			nav = idx
+		}
+	})
+	if nav == 0 {
+		t.Fatal("expected to find a navigation_expression")
+	}
+	op := flatNavigationSafeCallOperator(file, nav)
+	if op == 0 {
+		t.Fatal("expected flatNavigationSafeCallOperator to find the ?. token")
+	}
+	if got := file.FlatType(op); got != "?." {
+		t.Fatalf("operator type = %q, want %q", got, "?.")
+	}
+	span := file.FlatEndByte(op) - file.FlatStartByte(op)
+	if span != 2 {
+		t.Fatalf("operator byte span = %d, want 2", span)
+	}
+}
+
+// TestFlatNavigationSafeCallOperator_ReceiverStringLiteralWithSafeCall
+// covers the Bug A scenario: a receiver call whose string-literal argument
+// contains the literal substring `?.`. The AST locator must point at the
+// real `?.` operator token, not at the first text occurrence (which lies
+// inside the string literal). The old `strings.Index(text, "?.")` approach
+// would have produced an offset inside the literal, corrupting the source
+// when the autofix replaces the byte range with `.`.
+func TestFlatNavigationSafeCallOperator_ReceiverStringLiteralWithSafeCall(t *testing.T) {
+	src := "fun f(lookup: (String) -> String): Int { return lookup(\"?.\")?.length ?: 0 }\n"
+	file := parseInlineForInternalTest(t, src)
+	var nav uint32
+	// Pick the outermost navigation_expression (the one immediately holding
+	// the top-level ?. operator).
+	file.FlatWalkNodes(0, "navigation_expression", func(idx uint32) {
+		if nav == 0 {
+			nav = idx
+		}
+	})
+	if nav == 0 {
+		t.Fatal("expected to find a navigation_expression")
+	}
+	op := flatNavigationSafeCallOperator(file, nav)
+	if op == 0 {
+		t.Fatal("expected flatNavigationSafeCallOperator to find the ?. token")
+	}
+	// Confirm the AST locator landed AFTER the string literal "?.": the
+	// text-search alternative would have returned the first `?.` occurrence,
+	// which is inside the literal.
+	astStart := int(file.FlatStartByte(op))
+	textStart := -1
+	// Search inside the navigation_expression text for "?." — replicate the
+	// old behavior to prove the AST locator differs.
+	navText := file.FlatNodeText(nav)
+	for i := 0; i+1 < len(navText); i++ {
+		if navText[i] == '?' && navText[i+1] == '.' {
+			textStart = int(file.FlatStartByte(nav)) + i
+			break
+		}
+	}
+	if textStart < 0 {
+		t.Fatal("test setup error: expected `?.` substring inside the navigation_expression text")
+	}
+	if astStart <= textStart {
+		t.Fatalf("AST operator start (%d) must lie strictly after the first textual `?.` occurrence (%d); the AST locator should skip past the string literal", astStart, textStart)
+	}
+	// Quick sanity: the byte range should bracket the real `?.` operator.
+	got := navText[astStart-int(file.FlatStartByte(nav)) : astStart-int(file.FlatStartByte(nav))+2]
+	if got != "?." {
+		t.Fatalf("AST operator bytes = %q, want %q", got, "?.")
+	}
+}
+
+// TestUnnecessarySafeCallLambdaHasRepeatedThisSafeCalls_IgnoresStringLiteral
+// is the Bug B regression: the heuristic must count navigation_expression
+// nodes whose receiver is `this_expression` and whose operator is `?.`, not
+// raw text occurrences of `this?.`. A string literal containing
+// `"this?.foo this?.bar"` and a single real `this?.X` should yield count==1,
+// so the helper must return false.
+func TestUnnecessarySafeCallLambdaHasRepeatedThisSafeCalls_IgnoresStringLiteral(t *testing.T) {
+	file := parseInlineForInternalTest(t, `
+package test
+fun addKeyValue(k: String, v: String) { println(k + v) }
+fun example() {
+    val obj: String = "hello"
+    with(obj) {
+        addKeyValue("k", "this?.foo this?.bar")
+        val len = this?.length
+        println(len)
+    }
+}
+`)
+	var lambda uint32
+	file.FlatWalkNodes(0, "lambda_literal", func(idx uint32) {
+		if lambda == 0 {
+			lambda = idx
+		}
+	})
+	if lambda == 0 {
+		t.Fatal("expected to find a lambda_literal")
+	}
+	if unnecessarySafeCallLambdaHasRepeatedThisSafeCalls(file, lambda) {
+		t.Fatal("heuristic must not trip on string-literal occurrences of `this?.`; only real AST navigation should count")
+	}
+}
+
+// TestUnnecessarySafeCallLambdaHasRepeatedThisSafeCalls_CountsRealCalls
+// confirms the AST-based count still trips when the lambda actually has two
+// or more `this?.X` navigations.
+func TestUnnecessarySafeCallLambdaHasRepeatedThisSafeCalls_CountsRealCalls(t *testing.T) {
+	file := parseInlineForInternalTest(t, `
+package test
+fun example() {
+    val obj: String = "hello"
+    with(obj) {
+        val a = this?.length
+        val b = this?.hashCode()
+        println(a.toString() + b.toString())
+    }
+}
+`)
+	var lambda uint32
+	file.FlatWalkNodes(0, "lambda_literal", func(idx uint32) {
+		if lambda == 0 {
+			lambda = idx
+		}
+	})
+	if lambda == 0 {
+		t.Fatal("expected to find a lambda_literal")
+	}
+	if !unnecessarySafeCallLambdaHasRepeatedThisSafeCalls(file, lambda) {
+		t.Fatal("heuristic should trip when the lambda has two real this?.X navigations")
+	}
+}
+
+// TestGetterNullableReceiverFlat_BacktickColonInPropertyName_Internal pins
+// Bug C: the receiver-type-prefix fallback must anchor to the
+// variable_declaration child of the property_declaration, not the first `:`
+// in the text (which can land inside a backtick-quoted property name).
+//
+// A backtick-quoted property name containing both `?.` and `:` (where the
+// `:` appears AFTER the `?.`) must not be misread as an extension property
+// with a nullable receiver. With the old `strings.Index(text, ":")`
+// fallback, the `:` inside backticks shifts the boundary so that the
+// apparent "receiver-type prefix" includes the `?.` from the name,
+// falsely classifying the property as having a nullable receiver.
+func TestGetterNullableReceiverFlat_BacktickColonInPropertyName_Internal(t *testing.T) {
+	file := parseInlineForInternalTest(t, "val `?.weird:name`: String\n  get() = \"\"\n")
+	var getter uint32
+	file.FlatWalkNodes(0, "getter", func(idx uint32) {
+		if getter == 0 {
+			getter = idx
+		}
+	})
+	if getter == 0 {
+		t.Fatal("expected to find a getter")
+	}
+	if getterNullableReceiverFlat(file, getter, false) {
+		t.Fatal("getterNullableReceiverFlat must not return true when `?.` appears only inside a backtick-quoted property name")
+	}
+	if getterNullableReceiverFlat(file, getter, true) {
+		t.Fatal("getterNullableReceiverFlat (structural) must not return true when `?.` appears only inside a backtick-quoted property name")
+	}
+}

--- a/internal/rules/potentialbugs_nullsafety_test.go
+++ b/internal/rules/potentialbugs_nullsafety_test.go
@@ -1947,3 +1947,69 @@ fun update(tp: TextPaint?) {
 		t.Fatalf("expected no findings for nullable apply receiver this!!, got %d", len(findings))
 	}
 }
+
+// --- Regression tests for AST-based locators in nullsafety_redundant ---
+
+// TestUnnecessarySafeCall_FixUsesAstOperatorOffset confirms the autofix
+// targets the AST `?.` token's byte range. A regression where the rule used
+// strings.Index over the navigation_expression text would corrupt the source
+// if the receiver text contained `?.` (e.g. inside a string literal); the
+// AST-based locator is immune to that. This test simply pins the fix range
+// to the exact bytes of the operator token.
+func TestUnnecessarySafeCall_FixUsesAstOperatorOffset(t *testing.T) {
+	findings := runRuleByNameWithResolver(t, "UnnecessarySafeCall", `
+package test
+fun example(s: String) {
+    val len = s?.length
+    println(len)
+}
+`)
+	if len(findings) == 0 {
+		t.Fatal("expected at least one finding for s?.length on non-null param")
+	}
+	var found bool
+	for _, f := range findings {
+		if f.Fix == nil {
+			continue
+		}
+		if f.Fix.Replacement != "." {
+			continue
+		}
+		span := f.Fix.EndByte - f.Fix.StartByte
+		if span != 2 {
+			t.Fatalf("fix span = %d, want 2 (length of `?.`)", span)
+		}
+		found = true
+	}
+	if !found {
+		t.Fatal("expected a fix with replacement `.` and 2-byte span over `?.`")
+	}
+}
+
+// TestGetterNullableReceiverFlat_BacktickColonBoundary confirms the
+// receiver-type prefix scan in getterNullableReceiverFlat is anchored to
+// the variable_declaration AST child, not the first `:` in the property
+// text. A backtick-quoted property name containing `:` must not shift the
+// boundary into the name itself.
+func TestGetterNullableReceiverFlat_BacktickColonBoundary(t *testing.T) {
+	// The rule under test is UnnecessarySafeCall. The getter helper is
+	// invoked when checking `this?.X` inside a property's getter; the
+	// preceding property declaration here uses a backtick-quoted name
+	// containing `:`. If the boundary leaks into the name, the heuristic
+	// is consulted on text that does not contain the receiver-type prefix
+	// and the rule's behavior on the getter must remain correct
+	// (specifically: the safe-call inside the getter of a non-receiver
+	// property must NOT be flagged as unnecessary just because the
+	// preceding declaration's text gets misparsed).
+	findings := runRuleByNameWithResolver(t, "UnnecessarySafeCall", "\n"+
+		"package test\n"+
+		"class Foo { fun uppercase(): String = \"\" }\n"+
+		"val `foo:bar`: Foo? = null\n"+
+		"val String?.thing: String\n"+
+		"  get() = this?.uppercase() ?: \"\"\n")
+	for _, f := range findings {
+		if strings.Contains(f.Message, "this") {
+			t.Fatalf("did not expect a finding on this?.uppercase() inside an extension property with nullable receiver; got: %+v", f)
+		}
+	}
+}

--- a/tests/fixtures/negative/potential-bugs/UnnecessarySafeCall.kt
+++ b/tests/fixtures/negative/potential-bugs/UnnecessarySafeCall.kt
@@ -19,4 +19,19 @@ class UnnecessarySafeCall {
     fun withNullableDefault(s: String? = null) {
         val len = s?.length
     }
+
+    // String literals containing "this?." inside a lambda body must NOT
+    // trip the repeated-`this?.` heuristic that suppresses findings on
+    // `this?.X` in scope-function lambdas. The rule already does not flag
+    // `this?.X` directly, but downstream callers consult the helper to
+    // decide whether the receiver-this is nullable; an AST-based count
+    // ensures only real navigation_expressions contribute.
+    fun lambdaWithStringLiteralLookingLikeThisSafeCalls(obj: String?) {
+        obj?.let {
+            // Two textual occurrences of "this?." inside a single literal —
+            // must not count as repeated AST navigations.
+            val msg = "doc: this?.foo and this?.bar are not real calls"
+            println(msg)
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Three locations in `internal/rules/potentialbugs_nullsafety_redundant.go` located the `?.` operator or the property-type `:` boundary with `strings.Index` over a parent node's text. That is fragile when the surrounding text legitimately contains those substrings — and could either corrupt source via the `UnnecessarySafeCall` autofix or falsely trip a receiver-nullability heuristic.

Switched all three to AST traversal:

- A new `flatNavigationSafeCallOperator` helper returns the AST node index of the top-level `?.` token on a `navigation_expression` (handles both direct `?.` children and `?.` nested in a `navigation_suffix`). The three `UnnecessarySafeCallRule` fix builders now derive `StartByte` / `EndByte` from that node, immune to a receiver-side string literal containing `?.`.
- `unnecessarySafeCallLambdaHasRepeatedThisSafeCalls` now counts `navigation_expression` nodes whose receiver is `this_expression` and whose operator is `?.`, instead of scanning lambda text for `"this?."`. A string literal containing repeated `this?.` no longer trips the heuristic.
- `getterNullableReceiverFlat`'s receiver-type-prefix fallback now anchors to the `variable_declaration` AST child of the `property_declaration`, not the first textual `:`, so backtick-quoted property names like `` `?.weird:name` `` do not shift the boundary.

## Test plan

- [x] `go build -o /tmp/krit ./cmd/krit/`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...`
- [x] `go test ./internal/rules/ -count=1`
- [x] `go test ./... -count=1`
- [x] `make regression`
- [x] New internal tests directly exercise each helper with inputs that fail the old text-scan path; restored verifications confirm they fail before the fix.