### PR TITLE
fix(rules): require kotlin receiver evidence for TODO() detection

### DIFF
--- a/internal/rules/exceptions.go
+++ b/internal/rules/exceptions.go
@@ -103,6 +103,31 @@ type NotImplementedDeclarationRule struct {
 // roadmap/17.
 func (r *NotImplementedDeclarationRule) Confidence() float64 { return 0.75 }
 
+// isKotlinTODOCall reports whether the call_expression at idx is a call to
+// `kotlin.TODO()` — either the unqualified `TODO(...)` (kotlin's TODO is
+// imported automatically from the `kotlin` package) or the fully-qualified
+// `kotlin.TODO(...)`. Member calls like `foo.TODO()` or `Items.TODO()` on
+// non-kotlin receivers are NOT kotlin.TODO and must not be flagged.
+func isKotlinTODOCall(file *scanner.File, idx uint32) bool {
+	if file == nil || file.FlatType(idx) != "call_expression" {
+		return false
+	}
+	for child := file.FlatFirstChild(idx); child != 0; child = file.FlatNextSib(child) {
+		switch file.FlatType(child) {
+		case "simple_identifier":
+			// Bare `TODO(...)` — kotlin.TODO is auto-imported from the
+			// `kotlin` package and is the only realistic referent for an
+			// unqualified TODO call at top-level expression position.
+			return file.FlatNodeTextEquals(child, "TODO")
+		case "navigation_expression":
+			// Qualified call. Only `kotlin.TODO(...)` counts as kotlin.TODO.
+			segments := flatNavigationChainIdentifiers(file, child)
+			return len(segments) == 2 && segments[0] == "kotlin" && segments[1] == "TODO"
+		}
+	}
+	return false
+}
+
 // RethrowCaughtExceptionRule detects catch { throw e } where e is the caught variable.
 type RethrowCaughtExceptionRule struct {
 	FlatDispatchBase

--- a/internal/rules/exceptions_test.go
+++ b/internal/rules/exceptions_test.go
@@ -304,6 +304,37 @@ fun process() {
 	}
 }
 
+// Local-lookalike: `foo.TODO()` is a member call, not kotlin.TODO. The rule
+// must require receiver/owner proof that the call resolves to the kotlin
+// stdlib TODO — bare `TODO(...)` or fully-qualified `kotlin.TODO(...)`.
+func TestExc_NotImplementedDeclaration_Negative_MemberReceiver(t *testing.T) {
+	findings := runRuleByName(t, "NotImplementedDeclaration", `
+class Tracker {
+    fun TODO(label: String) { println(label) }
+}
+
+fun useTracker() {
+    val tracker = Tracker()
+    tracker.TODO("future")
+}
+`)
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings for member call foo.TODO(), got %d", len(findings))
+	}
+}
+
+// Fully-qualified `kotlin.TODO(...)` IS kotlin.TODO and must be flagged.
+func TestExc_NotImplementedDeclaration_Positive_FullyQualified(t *testing.T) {
+	findings := runRuleByName(t, "NotImplementedDeclaration", `
+fun process() {
+    kotlin.TODO("not yet")
+}
+`)
+	if len(findings) == 0 {
+		t.Fatal("expected finding for kotlin.TODO() call")
+	}
+}
+
 // --- RethrowCaughtException ---
 
 func TestExc_RethrowCaughtException_Positive(t *testing.T) {

--- a/internal/rules/registry_exceptions.go
+++ b/internal/rules/registry_exceptions.go
@@ -84,10 +84,10 @@ func registerExceptionsRules() {
 		r := &NotImplementedDeclarationRule{BaseRule: BaseRule{RuleName: "NotImplementedDeclaration", RuleSetName: "exceptions", Sev: "warning", Desc: "Detects TODO() calls that throw NotImplementedError at runtime."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"call_expression"}, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"call_expression"}, Languages: []scanner.Language{scanner.LangKotlin}, Confidence: 0.75, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
-				if flatCallExpressionName(file, idx) != "TODO" {
+				if !isKotlinTODOCall(file, idx) {
 					return
 				}
 				ctx.EmitAt(file.FlatRow(idx)+1, file.FlatCol(idx)+1,

--- a/tests/fixtures/negative/exceptions/NotImplementedDeclaration.kt
+++ b/tests/fixtures/negative/exceptions/NotImplementedDeclaration.kt
@@ -9,3 +9,33 @@ class Example {
         println("working")
     }
 }
+
+// Local lookalikes: member functions named `TODO` on non-kotlin receivers must
+// not be flagged as kotlin.TODO() calls.
+class Tracker {
+    fun TODO(label: String) {
+        println("tracking $label")
+    }
+}
+
+object Items {
+    fun TODO() {
+        println("queued")
+    }
+}
+
+class Caller {
+    private val tracker = Tracker()
+    private val nested = Nested()
+
+    fun useReceivers() {
+        // foo.TODO() must not be treated as kotlin.TODO().
+        tracker.TODO("future")
+        Items.TODO()
+        nested.api.TODO()
+    }
+
+    class Nested {
+        val api = Tracker()
+    }
+}

--- a/tests/fixtures/positive/exceptions/NotImplementedDeclaration.kt
+++ b/tests/fixtures/positive/exceptions/NotImplementedDeclaration.kt
@@ -4,4 +4,9 @@ class Example {
     fun foo() {
         TODO("implement later")
     }
+
+    fun bar() {
+        // Fully-qualified kotlin.TODO is still a kotlin.TODO usage.
+        kotlin.TODO("not yet")
+    }
 }


### PR DESCRIPTION
## Summary

`NotImplementedDeclaration` looked at the last identifier of a `call_expression` to decide whether a call was Kotlin's `kotlin.TODO()`. With that rule, `foo.TODO()` — a member call on a non-kotlin receiver — was flagged as a kotlin.TODO() use.

## Root cause

`registry_exceptions.go` checked `flatCallExpressionName(file, idx) != "TODO"`. That helper returns the trailing identifier of a navigation chain, so `tracker.TODO(...)`, `Items.TODO()`, and `nested.api.TODO()` all looked identical to a bare `TODO(...)`.

## Fix

Introduce `isKotlinTODOCall(file, idx)` in `internal/rules/exceptions.go` and use it from the registry callback. It only returns true for:

- a bare unqualified call `TODO(...)` (kotlin's `TODO` is auto-imported from the `kotlin` package), or
- the fully-qualified form `kotlin.TODO(...)` (navigation chain of exactly `[kotlin, TODO]`).

Member calls like `tracker.TODO("future")`, `Items.TODO()`, or deeper chains like `nested.api.TODO()` are no longer flagged. The rule is also restricted to `LangKotlin` — `TODO()` has no Java equivalent.

## Regression tests

- `internal/rules/exceptions_test.go`:
  - `TestExc_NotImplementedDeclaration_Negative_MemberReceiver` — `Tracker.TODO("future")` must produce zero findings.
  - `TestExc_NotImplementedDeclaration_Positive_FullyQualified` — `kotlin.TODO("not yet")` must still be flagged.
- `tests/fixtures/negative/exceptions/NotImplementedDeclaration.kt` — adds `Tracker.TODO`, `Items.TODO`, and nested-receiver lookalikes.
- `tests/fixtures/positive/exceptions/NotImplementedDeclaration.kt` — adds a fully-qualified `kotlin.TODO("not yet")` case alongside the existing bare call.

The new negative fixture was confirmed to FAIL before the rule fix (3 false positives) and PASS after.

## Test plan

- [x] `go build -o krit ./cmd/krit/`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...`
- [x] `go test ./internal/rules/ -run "TestExc_NotImplementedDeclaration|TestPositiveFixtures/positive/NotImplementedDeclaration|TestNegativeFixtures/negative/NotImplementedDeclaration"`
- [x] `make lint-rules`
- [x] `go test ./internal/rules/ -count=1 -timeout 15m`