### PR TITLE
fix(rules): detect safe-call operator via AST in NullableStructuredField

### DIFF
--- a/internal/rules/logging.go
+++ b/internal/rules/logging.go
@@ -773,8 +773,15 @@ func (r *NullableStructuredFieldRule) shouldFlag(file *scanner.File, idx uint32)
 	if expr == 0 {
 		return false
 	}
-	text := file.FlatNodeText(expr)
-	return strings.Contains(text, "?.") && !strings.Contains(text, "?:")
+	// An Elvis expression supplies the fallback regardless of where the
+	// safe-call sits inside its left operand.
+	if file.FlatType(expr) == "elvis_expression" {
+		return false
+	}
+	// Walk the AST looking for an actual safe-call operator node. This
+	// avoids text-level false positives where the literal substring "?."
+	// appears inside a string literal, comment, or KDoc.
+	return flatNavigationHasSafeCall(file, expr)
 }
 
 func firstCorrelationSensitiveLogCallFlat(file *scanner.File, idx uint32) uint32 {

--- a/internal/rules/observability_test.go
+++ b/internal/rules/observability_test.go
@@ -1373,6 +1373,32 @@ fun nullable(logger: Logger, user: User?) {
 	}
 }
 
+// TestNullableStructuredField_NegativeStringLiteralContainsSafeCall guards
+// against a regression where the value expression's source text was scanned
+// with strings.Contains(text, "?.") and matched the literal bytes "?."
+// appearing inside a string literal (e.g. an error message), even though
+// no actual safe-call operator was present in the AST.
+func TestNullableStructuredField_NegativeStringLiteralContainsSafeCall(t *testing.T) {
+	findings := runRuleByName(t, "NullableStructuredField", `
+package test
+
+interface Logger {
+    fun atInfo(): Event
+}
+interface Event {
+    fun addKeyValue(key: String, value: Any?): Event
+    fun log(message: String)
+}
+
+fun handle(logger: Logger) {
+    logger.atInfo().addKeyValue("hint", "use ?. operator").log("ready")
+}
+`)
+	if len(findings) != 0 {
+		t.Fatalf("expected 0 findings, got %d: %v", len(findings), findings)
+	}
+}
+
 func TestMetricTimerOutsideBlock_PositivePropertyRead(t *testing.T) {
 	findings := runRuleByName(t, "MetricTimerOutsideBlock", `
 package test

--- a/tests/fixtures/negative/observability/NullableStructuredField.kt
+++ b/tests/fixtures/negative/observability/NullableStructuredField.kt
@@ -19,3 +19,9 @@ fun handle(logger: Logger, user: User) {
 fun nullable(logger: Logger, user: User?) {
     logger.atInfo().addKeyValue("user_id", user?.id ?: "anonymous").log("ready")
 }
+
+// String literal containing the bytes "?." must not be mistaken for a real
+// safe-call operator in the AST.
+fun stringLiteralWithSafeCallBytes(logger: Logger) {
+    logger.atInfo().addKeyValue("hint", "use ?. operator").log("ready")
+}


### PR DESCRIPTION
## Root cause

`NullableStructuredFieldRule.shouldFlag` checked for the `?.` safe-call
operator with `strings.Contains(text, "?.")` on the value expression's
raw source text. That matched the literal bytes `?.` appearing inside
string literals (e.g. an error/hint message), producing false positives
even when the AST contained no safe-call.

## Fix

- Walk the navigation chain with `flatNavigationHasSafeCall`, the same
  AST-aware helper other null-safety rules use, instead of substring
  matching.
- Short-circuit when the expression is itself an `elvis_expression`:
  its right operand already supplies the fallback regardless of where
  the safe-call sits inside the left operand.

## Tests

- `TestNullableStructuredField_NegativeStringLiteralContainsSafeCall`
  in `internal/rules/observability_test.go` — Kotlin source whose value
  argument is a string literal containing the bytes `?.`; previously
  flagged, now clean.
- New case in `tests/fixtures/negative/observability/NullableStructuredField.kt`
  covering the same pattern via the positive/negative fixture harness.
- `go test ./internal/rules/ -count=1` passes.