### PR TITLE
test(rules): UnnecessarySafeCall fixture for safe-call with mid-call comment

### DIFF
--- a/tests/fixtures/fixable/per-rule/UnnecessarySafeCall.kt
+++ b/tests/fixtures/fixable/per-rule/UnnecessarySafeCall.kt
@@ -5,4 +5,11 @@ class UnnecessarySafeCall {
         val x: String = "hello"
         val len = x?.length
     }
+
+    fun exampleWithMisleadingComment() {
+        val y: String = "world"
+        // Regression: a comment containing "?." between the receiver and
+        // the real safe-call operator must not confuse the autofix.
+        val len = y /* ?.fake */ ?.length
+    }
 }

--- a/tests/fixtures/fixable/per-rule/UnnecessarySafeCall.kt.expected
+++ b/tests/fixtures/fixable/per-rule/UnnecessarySafeCall.kt.expected
@@ -5,4 +5,11 @@ class UnnecessarySafeCall {
         val x: String = "hello"
         val len = x.length
     }
+
+    fun exampleWithMisleadingComment() {
+        val y: String = "world"
+        // Regression: a comment containing "?." between the receiver and
+        // the real safe-call operator must not confuse the autofix.
+        val len = y /* ?.fake */ .length
+    }
 }


### PR DESCRIPTION
## Summary

[#404](https://github.com/kaeawc/krit/pull/404) anchored the \`UnnecessarySafeCall\` autofix on the AST \`?.\` token, so a \`?.\` appearing in a comment or string between the receiver and the navigation suffix can no longer move the rewrite's edit point. Add a fixable fixture pair that pins this behavior so a future text-scan regression turns red.

The fixture adds a method whose body contains an inline block comment \`/* ?.fake */\` between the receiver and the real safe-call operator. The \`.expected\` file confirms the autofix rewrites the real operator, not the comment.

## Test plan

- [x] \`go test ./internal/rules/ -count=1\` — green, fixable fixture honored.
- [x] \`golangci-lint run ./...\` — 0 issues.
- [ ] CI green on the PR.