### PR TITLE
fix(scanner): synchronize CodeIndex mutable state

### DIFF
--- a/internal/scanner/index.go
+++ b/internal/scanner/index.go
@@ -1,6 +1,8 @@
 package scanner
 
 import (
+	"sync"
+
 	"github.com/bits-and-blooms/bloom/v3"
 
 	"github.com/kaeawc/krit/internal/perf"
@@ -76,6 +78,19 @@ type CodeIndex struct {
 	// Bloom filter for fast "is this name referenced?" checks.
 	// False positives are OK (we fall back to exact check), false negatives are not.
 	refBloom *bloom.BloomFilter
+
+	// mu guards the lookup maps (symbolsByName, symbolsByFQN,
+	// refCountByName, refFilesByName, nonCommentRefFilesByName,
+	// nonCommentRefCountByNameFile) and refBloom against concurrent
+	// mutation. The pipeline today serializes BuildIndexIncremental
+	// externally, but the contract is defended here so a future
+	// background flush / parallel indexer / concurrent reader cannot
+	// tear state. Read paths take an RLock; mutation paths
+	// (addSymbolToLookups, removeSymbolFromLookups, addReferenceLookup,
+	// removeReferenceLookup) take the write lock. Initial construction
+	// in buildCodeIndexWithBloom runs before any caller has a pointer
+	// to the index, so it does not lock.
+	mu sync.RWMutex
 }
 
 // BuildIndex constructs a cross-file index from parsed Kotlin and Java files.
@@ -268,19 +283,24 @@ func BuildIndexIncremental(base *CodeIndex, removePaths map[string]bool, addSymb
 	if base == nil {
 		return BuildIndexFromData(addSymbols, addRefs)
 	}
+	// Hold the write lock for the whole delta so readers either see the
+	// full pre-update or full post-update state — never a half-applied
+	// mix of removed symbols and unwritten adds.
+	base.mu.Lock()
+	defer base.mu.Unlock()
 	if len(removePaths) > 0 {
-		base.removeFileContributions(removePaths)
+		base.removeFileContributionsLocked(removePaths)
 	}
 	if len(addSymbols) > 0 {
 		base.Symbols = append(base.Symbols, addSymbols...)
 		for _, sym := range addSymbols {
-			base.addSymbolToLookups(sym)
+			base.addSymbolToLookupsLocked(sym)
 		}
 	}
 	if len(addRefs) > 0 {
 		base.References = append(base.References, addRefs...)
 		for _, ref := range addRefs {
-			base.addReferenceLookup(ref)
+			base.addReferenceLookupLocked(ref)
 		}
 	}
 	return base
@@ -341,18 +361,21 @@ func buildCodeIndexWithBloom(symbols []Symbol, refs []Reference, prebuilt *bloom
 	}
 
 	for _, sym := range idx.Symbols {
-		idx.addSymbolToLookups(sym)
+		idx.addSymbolToLookupsLocked(sym)
 	}
-	idx.buildReferenceLookups(prebuilt == nil)
+	idx.buildReferenceLookupsLocked(prebuilt == nil)
 
 	return idx
 }
 
-// addSymbolToLookups inserts sym into symbolsByName + symbolsByFQN.
+// addSymbolToLookupsLocked inserts sym into symbolsByName + symbolsByFQN.
 // Used by both the initial buildCodeIndexWithBloom loop and the
 // incremental BuildIndexIncremental path so both produce identical
 // map state for the same input set.
-func (idx *CodeIndex) addSymbolToLookups(sym Symbol) {
+//
+// Caller must hold idx.mu for writing (or be the constructor — initial
+// build runs before any pointer to idx escapes).
+func (idx *CodeIndex) addSymbolToLookupsLocked(sym Symbol) {
 	idx.symbolsByName[sym.Name] = append(idx.symbolsByName[sym.Name], sym)
 	if sym.FQN != "" {
 		idx.symbolsByFQN[sym.FQN] = sym
@@ -362,11 +385,13 @@ func (idx *CodeIndex) addSymbolToLookups(sym Symbol) {
 	}
 }
 
-// removeSymbolFromLookups deletes sym's entries from symbolsByName +
-// symbolsByFQN. Inverse of addSymbolToLookups — symbol equality is
+// removeSymbolFromLookupsLocked deletes sym's entries from symbolsByName +
+// symbolsByFQN. Inverse of addSymbolToLookupsLocked — symbol equality is
 // by full struct value, which matches how rebuildSymbolLookups
 // originally inserted them.
-func (idx *CodeIndex) removeSymbolFromLookups(sym Symbol) {
+//
+// Caller must hold idx.mu for writing.
+func (idx *CodeIndex) removeSymbolFromLookupsLocked(sym Symbol) {
 	dropSymbolFromSlice(idx.symbolsByName, sym.Name, sym)
 	if sym.FQN != "" {
 		if existing, ok := idx.symbolsByFQN[sym.FQN]; ok && existing == sym {
@@ -400,7 +425,9 @@ func dropSymbolFromSlice(m map[string][]Symbol, key string, target Symbol) {
 	}
 }
 
-func (idx *CodeIndex) removeFileContributions(paths map[string]bool) {
+// removeFileContributionsLocked drops all symbols and references that
+// originated from any of paths. Caller must hold idx.mu for writing.
+func (idx *CodeIndex) removeFileContributionsLocked(paths map[string]bool) {
 	if len(paths) == 0 {
 		return
 	}
@@ -421,14 +448,14 @@ func (idx *CodeIndex) removeFileContributions(paths map[string]bool) {
 		}
 		idx.Symbols = dst
 		for _, sym := range removed {
-			idx.removeSymbolFromLookups(sym)
+			idx.removeSymbolFromLookupsLocked(sym)
 		}
 	}
 	if len(idx.References) > 0 {
 		dst := idx.References[:0]
 		for _, ref := range idx.References {
 			if paths[ref.File] {
-				idx.removeReferenceLookup(ref)
+				idx.removeReferenceLookupLocked(ref)
 				continue
 			}
 			dst = append(dst, ref)

--- a/internal/scanner/index_query.go
+++ b/internal/scanner/index_query.go
@@ -11,11 +11,23 @@ var sourceImportRe = regexp.MustCompile(`(?m)^\s*import\s+(?:static\s+)?([A-Za-z
 
 // SymbolsNamed returns declarations indexed under a simple or fully-qualified
 // name. A nil result means no matching declaration is known.
+//
+// The returned slice is a snapshot — concurrent mutation via
+// BuildIndexIncremental cannot tear it.
 func (idx *CodeIndex) SymbolsNamed(name string) []Symbol {
 	if idx == nil || name == "" {
 		return nil
 	}
-	return idx.symbolsByName[name]
+	idx.mu.RLock()
+	syms := idx.symbolsByName[name]
+	if syms == nil {
+		idx.mu.RUnlock()
+		return nil
+	}
+	out := make([]Symbol, len(syms))
+	copy(out, syms)
+	idx.mu.RUnlock()
+	return out
 }
 
 // SymbolByFQN returns the declaration with the exact fully-qualified name.
@@ -23,7 +35,9 @@ func (idx *CodeIndex) SymbolByFQN(fqn string) (Symbol, bool) {
 	if idx == nil || fqn == "" {
 		return Symbol{}, false
 	}
+	idx.mu.RLock()
 	sym, ok := idx.symbolsByFQN[fqn]
+	idx.mu.RUnlock()
 	return sym, ok
 }
 
@@ -175,7 +189,10 @@ func sourceImports(file *File) (map[string]string, []string) {
 	return explicit, wildcards
 }
 
-func (idx *CodeIndex) buildReferenceLookups(addToBloom bool) {
+// buildReferenceLookupsLocked rebuilds the per-name reference aggregates
+// from idx.References. Caller must hold idx.mu for writing (or be the
+// constructor — initial build runs before any pointer to idx escapes).
+func (idx *CodeIndex) buildReferenceLookupsLocked(addToBloom bool) {
 	if len(idx.References) == 0 {
 		idx.refCountByName = make(map[string]int)
 		idx.refFilesByName = make(map[string]map[string]bool)
@@ -243,7 +260,9 @@ func (a *referenceAggregate) add(ref Reference) {
 	a.nonCommentCounts[ref.File]++
 }
 
-func (idx *CodeIndex) addReferenceLookup(ref Reference) {
+// addReferenceLookupLocked records a single reference into the per-name
+// maps and bloom filter. Caller must hold idx.mu for writing.
+func (idx *CodeIndex) addReferenceLookupLocked(ref Reference) {
 	if idx.refCountByName == nil {
 		idx.refCountByName = make(map[string]int)
 	}
@@ -284,7 +303,10 @@ func (idx *CodeIndex) addReferenceLookup(ref Reference) {
 	idx.refBloom.AddString(ref.Name)
 }
 
-func (idx *CodeIndex) removeReferenceLookup(ref Reference) {
+// removeReferenceLookupLocked removes a single reference from the per-name
+// maps. The bloom filter is left untouched — it tolerates extra bits as
+// false positives. Caller must hold idx.mu for writing.
+func (idx *CodeIndex) removeReferenceLookupLocked(ref Reference) {
 	if idx.refCountByName != nil {
 		if next := idx.refCountByName[ref.Name] - 1; next > 0 {
 			idx.refCountByName[ref.Name] = next
@@ -329,9 +351,15 @@ func estimateUniqueReferenceNames(refCount int) int {
 	return estimated
 }
 
-// ReferenceCount returns how many times a name is referenced across all files.
+// MayHaveReference reports whether name appears in the bloom filter. False
+// positives are possible; false negatives are not.
 func (idx *CodeIndex) MayHaveReference(name string) bool {
-	if idx == nil || idx.refBloom == nil {
+	if idx == nil {
+		return false
+	}
+	idx.mu.RLock()
+	defer idx.mu.RUnlock()
+	if idx.refBloom == nil {
 		return false
 	}
 	return idx.refBloom.TestString(name)
@@ -339,12 +367,32 @@ func (idx *CodeIndex) MayHaveReference(name string) bool {
 
 // ReferenceCount returns how many times a name is referenced across all files.
 func (idx *CodeIndex) ReferenceCount(name string) int {
+	if idx == nil {
+		return 0
+	}
+	idx.mu.RLock()
+	defer idx.mu.RUnlock()
 	return idx.refCountByName[name]
 }
 
-// ReferenceFiles returns the set of files that reference a name.
+// ReferenceFiles returns a snapshot of the set of files that reference a
+// name. The returned map is owned by the caller — mutating it does not
+// affect the index, and concurrent index mutation cannot tear it.
 func (idx *CodeIndex) ReferenceFiles(name string) map[string]bool {
-	return idx.refFilesByName[name]
+	if idx == nil {
+		return nil
+	}
+	idx.mu.RLock()
+	defer idx.mu.RUnlock()
+	files := idx.refFilesByName[name]
+	if len(files) == 0 {
+		return nil
+	}
+	out := make(map[string]bool, len(files))
+	for f, v := range files {
+		out[f] = v
+	}
+	return out
 }
 
 // SymbolReferenceCount returns the total number of references that can identify
@@ -362,8 +410,13 @@ func (idx *CodeIndex) SymbolReferenceCount(sym Symbol) int {
 
 // IsReferencedOutsideFile checks if a name is referenced in any file other than the given one.
 func (idx *CodeIndex) IsReferencedOutsideFile(name, file string) bool {
+	if idx == nil {
+		return false
+	}
+	idx.mu.RLock()
+	defer idx.mu.RUnlock()
 	// Fast path: bloom filter says name not referenced at all
-	if !idx.refBloom.TestString(name) {
+	if idx.refBloom == nil || !idx.refBloom.TestString(name) {
 		return false
 	}
 	files := idx.refFilesByName[name]
@@ -399,8 +452,13 @@ func (idx *CodeIndex) IsSymbolReferencedOutsideFile(sym Symbol, ignoreCommentRef
 // IsReferencedOutsideFileExcludingComments checks if a name has any non-comment
 // reference in a file other than the given one.
 func (idx *CodeIndex) IsReferencedOutsideFileExcludingComments(name, file string) bool {
+	if idx == nil {
+		return false
+	}
+	idx.mu.RLock()
+	defer idx.mu.RUnlock()
 	// Fast path: bloom filter says name not referenced at all
-	if !idx.refBloom.TestString(name) {
+	if idx.refBloom == nil || !idx.refBloom.TestString(name) {
 		return false
 	}
 	files := idx.nonCommentRefFilesByName[name]
@@ -417,6 +475,11 @@ func (idx *CodeIndex) IsReferencedOutsideFileExcludingComments(name, file string
 
 // CountNonCommentRefsInFile counts references to a name in a file that are NOT inside comments.
 func (idx *CodeIndex) CountNonCommentRefsInFile(name, file string) int {
+	if idx == nil {
+		return 0
+	}
+	idx.mu.RLock()
+	defer idx.mu.RUnlock()
 	files := idx.nonCommentRefCountByNameFile[name]
 	if files == nil {
 		return 0
@@ -434,11 +497,13 @@ func (idx *CodeIndex) countRefsInFileForSymbol(sym Symbol, file string, ignoreCo
 			count += idx.CountNonCommentRefsInFile(name, file)
 			continue
 		}
+		idx.mu.RLock()
 		for _, ref := range idx.References {
 			if ref.Name == name && ref.File == file {
 				count++
 			}
 		}
+		idx.mu.RUnlock()
 	}
 	return count
 }
@@ -446,8 +511,19 @@ func (idx *CodeIndex) countRefsInFileForSymbol(sym Symbol, file string, ignoreCo
 // UnusedSymbols returns symbols that are never referenced from any other file.
 // If ignoreCommentRefs is true, references inside comments don't count as usage.
 func (idx *CodeIndex) UnusedSymbols(ignoreCommentRefs bool) []Symbol {
+	if idx == nil {
+		return nil
+	}
+	// Snapshot the symbol slice under the read lock so the iteration is
+	// not racing with concurrent BuildIndexIncremental adds (which
+	// append-with-may-realloc into idx.Symbols).
+	idx.mu.RLock()
+	symbols := make([]Symbol, len(idx.Symbols))
+	copy(symbols, idx.Symbols)
+	idx.mu.RUnlock()
+
 	var unused []Symbol
-	for _, sym := range idx.Symbols {
+	for _, sym := range symbols {
 		if sym.IsOverride || sym.IsMain || sym.IsTest {
 			continue
 		}
@@ -483,6 +559,11 @@ func symbolReferenceNames(sym Symbol) []string {
 
 // BloomStats returns the bloom filter memory usage in bytes.
 func (idx *CodeIndex) BloomStats() (refBits, crossBits uint) {
+	if idx == nil {
+		return
+	}
+	idx.mu.RLock()
+	defer idx.mu.RUnlock()
 	if idx.refBloom != nil {
 		refBits = idx.refBloom.Cap()
 	}

--- a/internal/scanner/index_race_test.go
+++ b/internal/scanner/index_race_test.go
@@ -1,0 +1,97 @@
+package scanner
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+)
+
+// TestCodeIndex_ConcurrentReadWrite exercises CodeIndex's public lookup API
+// under concurrent mutation. It must run cleanly under `go test -race` —
+// without internal synchronization, concurrent writers (BuildIndexIncremental)
+// racing with readers (MayHaveReference, ReferenceCount, ReferenceFiles,
+// IsReferencedOutsideFile, SymbolsNamed, SymbolByFQN) tear bloom/map state.
+//
+// The pipeline currently serializes mutations, so this test defends the
+// contract for future callers (background flush, parallel indexer) rather
+// than reproducing a live bug.
+func TestCodeIndex_ConcurrentReadWrite(t *testing.T) {
+	t.Parallel()
+
+	const initialSymbols = 64
+	const initialRefs = 256
+
+	symbols := make([]Symbol, 0, initialSymbols)
+	refs := make([]Reference, 0, initialRefs)
+	for i := 0; i < initialSymbols; i++ {
+		name := fmt.Sprintf("Sym%d", i)
+		symbols = append(symbols, Symbol{
+			Name:       name,
+			Kind:       "function",
+			Visibility: "public",
+			File:       fmt.Sprintf("file_%d.kt", i),
+			FQN:        "com.example." + name,
+		})
+	}
+	for i := 0; i < initialRefs; i++ {
+		refs = append(refs, Reference{
+			Name: fmt.Sprintf("Sym%d", i%initialSymbols),
+			File: fmt.Sprintf("ref_%d.kt", i%32),
+		})
+	}
+
+	idx := BuildIndexFromData(symbols, refs)
+
+	const readers = 8
+	const writers = 2
+	const opsPerGoroutine = 200
+
+	var wg sync.WaitGroup
+
+	// Readers: hit every public read path concurrently.
+	for r := 0; r < readers; r++ {
+		wg.Add(1)
+		go func(seed int) {
+			defer wg.Done()
+			for i := 0; i < opsPerGoroutine; i++ {
+				name := fmt.Sprintf("Sym%d", (seed+i)%initialSymbols)
+				_ = idx.MayHaveReference(name)
+				_ = idx.ReferenceCount(name)
+				for range idx.ReferenceFiles(name) {
+				}
+				_ = idx.IsReferencedOutsideFile(name, "ref_0.kt")
+				_ = idx.IsReferencedOutsideFileExcludingComments(name, "ref_0.kt")
+				_ = idx.CountNonCommentRefsInFile(name, "ref_0.kt")
+				_ = idx.SymbolsNamed(name)
+				_, _ = idx.SymbolByFQN("com.example." + name)
+			}
+		}(r)
+	}
+
+	// Writers: feed BuildIndexIncremental adds (the documented mutation path)
+	// concurrently with readers. The pipeline today serializes this externally,
+	// but the test asserts that the index's internal state is itself safe.
+	for w := 0; w < writers; w++ {
+		wg.Add(1)
+		go func(seed int) {
+			defer wg.Done()
+			for i := 0; i < opsPerGoroutine; i++ {
+				name := fmt.Sprintf("NewSym%d_%d", seed, i)
+				addSyms := []Symbol{{
+					Name:       name,
+					Kind:       "function",
+					Visibility: "public",
+					File:       fmt.Sprintf("added_%d_%d.kt", seed, i),
+					FQN:        "com.example." + name,
+				}}
+				addRefs := []Reference{{
+					Name: name,
+					File: fmt.Sprintf("added_%d_%d.kt", seed, i),
+				}}
+				BuildIndexIncremental(idx, nil, addSyms, addRefs)
+			}
+		}(w)
+	}
+
+	wg.Wait()
+}


### PR DESCRIPTION
## Summary

- `CodeIndex`'s lookup maps (`symbolsByName`, `symbolsByFQN`, `refCountByName`, `refFilesByName`, `nonCommentRefFilesByName`, `nonCommentRefCountByNameFile`) and `refBloom` were mutated by `BuildIndexIncremental` without any synchronization, while readers (`MayHaveReference`, `ReferenceCount`, `ReferenceFiles`, `IsReferencedOutsideFile`, `SymbolsNamed`, `SymbolByFQN`, etc.) read them concurrently. The pipeline serializes mutations externally today, but the index's own contract was unsafe — a future background flush, parallel indexer, or concurrent reader would tear state.
- Guard the lookup maps and `refBloom` with a `sync.RWMutex`. Mutation paths (`BuildIndexIncremental`, the `*Locked` symbol/reference helpers, `removeFileContributionsLocked`, `buildReferenceLookupsLocked`) take the write lock; read paths take the read lock and return defensive copies for slice/map returns so callers cannot observe torn state. Initial construction in `buildCodeIndexWithBloom` runs before any pointer to the index escapes, so it does not lock.
- Add `internal/scanner/index_race_test.go`: concurrent readers across every public lookup API racing concurrent `BuildIndexIncremental` writers. Must pass under `go test -race`.

## Test plan

- [x] `go vet ./...`
- [x] `golangci-lint run ./...` (0 issues)
- [x] `go test -race -count=1 ./internal/scanner/...`
- [x] `go test ./... -count=1`