### PR TITLE
fix(cache): lock c.Files in encodeBinary

### DIFF
--- a/internal/cache/binary.go
+++ b/internal/cache/binary.go
@@ -72,6 +72,7 @@ func hasBinaryMagic(data []byte) bool {
 }
 
 func encodeBinary(c *Cache) ([]byte, error) {
+	c.filesMu.RLock()
 	entries := make([]binaryEntry, 0, len(c.Files))
 	for path, entry := range c.Files {
 		entries = append(entries, binaryEntry{
@@ -82,6 +83,7 @@ func encodeBinary(c *Cache) ([]byte, error) {
 			Columns: entry.Columns,
 		})
 	}
+	c.filesMu.RUnlock()
 	sort.Slice(entries, func(i, j int) bool {
 		return entries[i].Path < entries[j].Path
 	})


### PR DESCRIPTION
## Summary

[#393](https://github.com/kaeawc/krit/pull/393) introduced \`filesMu\` to guard \`Cache.Files\`, but \`encodeBinary\` in \`internal/cache/binary.go\` still ranges the map without acquiring the read lock. Concurrent serialization during cache writes can race with mutating callers and trips \`-race\` intermittently.

This PR adds the missing \`RLock\` / \`RUnlock\` around the map iteration. The lock is released before sorting, which only touches the local \`entries\` slice copy.

## Test plan

- [x] \`go test ./internal/cache/ -count=1 -race\` — green.
- [x] \`golangci-lint run ./...\` — 0 issues.
- [ ] CI green on the PR.