### PR TITLE
feat(plugin-sdk): plumb remaining 4 capabilities into RuleContext (#357)

### DIFF
--- a/docs/external-rules.md
+++ b/docs/external-rules.md
@@ -310,33 +310,31 @@ may not be known to the binary at config-load time.
 `@KritRuleInfo.needs` declares which project-scope facts the rule
 expects. The daemon either delivers the requested fact into
 `RuleContext` or refuses to load the jar — there is no third "advisory"
-state. The list below is the supported surface today; the unsupported
-entries stay in the enum so existing source continues to compile, but
-the values are `@Deprecated` (warn) and a rule that declares one fails
-at jar load with a clear, copy-pasteable diagnostic. Tracked on
-[#357](https://github.com/kaeawc/krit/issues/357).
+state. A rule that declares a capability the daemon does not recognise
+(typo, ahead-of-daemon SDK) fails at jar load with a clear,
+copy-pasteable diagnostic.
 
 | Capability | Status | What it gives you |
 | --- | --- | --- |
 | `NEEDS_RESOLVER` | **supported** | Populates `RuleContext.resolver` with the [`Resolver`](#) bridge. Methods: `isSuspendCall`, `resolvedCallFqName`, `isLambdaSuspend`, `expressionType`. Each call opens a Kotlin Analysis API session — expect microsecond-class overhead per query. |
 | `NEEDS_PARSED_FILES` | **supported (implicit)** | The daemon always parses the Kotlin file before invoking `check()` and exposes the result on `KritFile.ktFile`. Declaring it is a forward-compatible hint; omitting it changes nothing today. |
-| `NEEDS_CROSS_FILE` | `@Deprecated` — fails load | Cross-file declaration index (decl → references, references → decl). Not yet plumbed. |
-| `NEEDS_MODULE_INDEX` | `@Deprecated` — fails load | Gradle module identity + per-module dependency graph. Not yet plumbed. |
-| `NEEDS_MANIFEST` | `@Deprecated` — fails load | Android `AndroidManifest.xml` view. Not yet plumbed. |
-| `NEEDS_RESOURCES` | `@Deprecated` — fails load | Parsed `res/` tree (strings, drawables, layouts). Not yet plumbed. |
 | `NEEDS_GRADLE` | **supported** | Populates `RuleContext.gradle` with a `GradleContext`. Properties: `minSdk`, `targetSdk`, `compileSdk`, `kotlinVersion`, `javaTargetVersion`, `agpVersion`. Methods: `hasDependency(group, name)`, `dependencyVersion(group, name)`. Null when the project has no Gradle build files. |
+| `NEEDS_MANIFEST` | **supported** | Populates `RuleContext.manifest` with a `ManifestContext`. Properties: `packageName`, `minSdk`, `targetSdk`. Methods: `hasPermission(name)`, `hasActivity(name)`, `isActivityExported(name)`, plus the matching `hasService`/`isServiceExported`/`hasReceiver`/`isReceiverExported` pairs. Null when the project has no `AndroidManifest.xml`. |
+| `NEEDS_RESOURCES` | **supported** | Populates `RuleContext.resources` with a `ResourcesContext`. Methods: `stringValue(name)`, `hasString(name)`, `colorValue(name)`, `dimensionValue(name)`, `hasDrawable(name)`, `hasLayout(name)`, `hasId(name)`. Null when the project has no Android `res/` directory. |
+| `NEEDS_MODULE_INDEX` | **supported** | Populates `RuleContext.moduleIndex` with a `ModuleIndexContext`. Properties: `modulePaths`. Methods: `directoryOf(modulePath)`, `dependenciesOf(modulePath)`, `sourceRootsOf(modulePath)`. Null when the project has no Gradle modules. |
+| `NEEDS_CROSS_FILE` | **supported** | Populates `RuleContext.crossFile` with a `CrossFileContext`. Methods: `declarationByFqn(fqn)`, `referenceFiles(name)`, `isReferenced(name)` (non-comment references only). Null when the daemon's cross-file pass did not run. The wire payload can be sizable on large projects — declare this capability only when the rule genuinely needs whole-project visibility. |
 
 ### What a load failure looks like
 
-A jar that declares an unsupported capability is rejected at
-`listPlugins` time, before any rule from that jar runs:
+A jar that declares an unrecognised capability (typo, ahead-of-daemon
+SDK) is rejected at `listPlugins` time, before any rule from that jar
+runs:
 
 ```
 error: krit-rule-api: /tmp/acme-rules.jar: rule jar declares capabilities
 the daemon does not yet provide to plugin rules; the rule would run
 without the facts it asked for. Remove the declaration(s) or wait for
-support (tracked on https://github.com/kaeawc/krit/issues/357).
-Unsupported: [acme.NoTodo: NEEDS_GRADLE]
+support. Unsupported: [acme.NoTodo: NEEDS_TIME_TRAVEL]
 ```
 
 The diagnostic surfaces on the same channels as the SDK-compat verdict:
@@ -346,15 +344,45 @@ remediation is to either delete the bad enum from `@KritRuleInfo.needs`
 or — once the corresponding hook lands — rebuild against a daemon that
 moves the entry into the supported set.
 
-### Promoting a capability from deprecated to supported
+### Wire payload cost
 
-When the daemon learns to deliver one of the deprecated capabilities
-(e.g. `NEEDS_GRADLE`), promotion is a minor-version change on
-`krit-rule-api`: the `@Deprecated` marker is removed, `RuleContext`
-grows the new accessor, the daemon adds the entry to
-`PluginCapabilities.SUPPORTED`, and the matrix above flips. Existing
-rule jars that already declared the capability start running with the
-new fact wired in — no rule-jar rebuild required.
+Project-scope payloads ride on every `analyzeFile` RPC the Go pipeline
+issues — one per Kotlin file. For payloads that are at most a few KB
+(gradle, manifest, module index, most projects' resources) the per-file
+re-serialisation is negligible. `NEEDS_CROSS_FILE` is different: on a
+100 KLOC project the declarations + references payload can run into
+the megabytes, and shipping it ~1000 times per scan is wasteful.
+
+A future change will hoist project-scope payloads onto a separate
+`setProjectContext` RPC the daemon caches per session; until then,
+declare `NEEDS_CROSS_FILE` only when the rule genuinely needs
+whole-project visibility, and prefer narrower lookups (`isReferenced`,
+`declarationByFqn`) over walking the full lists. Tracked alongside the
+per-file pattern in
+[#357](https://github.com/kaeawc/krit/issues/357).
+
+### Project facts can be null
+
+The project-scope accessors (`gradle`, `manifest`, `resources`,
+`moduleIndex`, `crossFile`) are non-null only when the rule declared
+the matching `@KritRuleInfo.needs` value AND the Go pipeline assembled
+a payload for that fact. A pure-Kotlin library project with no
+`AndroidManifest.xml` leaves `manifest` and `resources` null even when
+the rule declared them. Rules should defensively null-check before
+dereferencing.
+
+### Adding a new capability
+
+Adding a new capability is a minor-version change on `krit-rule-api`:
+extend the `Capability` enum, grow `RuleContext` with the matching
+`XxxContext` interface, mirror the wire payload on both sides
+(`PluginXxxProfile` in `internal/oracle/daemon.go`,
+`XxxProfilePayload` in `tools/krit-types/.../Main.kt`), wire the
+extractor and the `PayloadXxxContext` impl in `PluginRules.kt`, add
+the per-project builder in `internal/pipeline/custom_kotlin_rules.go`,
+add the value to `PluginCapabilities.SUPPORTED`, and update the matrix
+above. Existing rule jars that already declared the capability start
+running with the new fact wired in — no rule-jar rebuild required.
 
 ## FixSafety levels
 

--- a/internal/oracle/daemon.go
+++ b/internal/oracle/daemon.go
@@ -340,13 +340,82 @@ type PluginGradleProfile struct {
 	Deps              []string `json:"deps,omitempty"`
 }
 
-// AnalyzePluginFile runs selected Kotlin custom rules against one source file.
-// ruleConfigs maps each rule ID to its configured `options` map; an empty
-// or nil map is omitted from the request so the daemon's RuleContext.config
-// stays empty for those rules. gradle is forwarded only when at least one
-// selected rule declared NEEDS_GRADLE — keeps wire size minimal for the
-// common case.
-func (d *Daemon) AnalyzePluginFile(jars []string, path string, source []byte, ruleIDs []string, ruleConfigs map[string]map[string]interface{}, gradle *PluginGradleProfile) (AnalyzePluginFileResult, error) {
+// PluginManifestProfile is the wire payload that backs `RuleContext.manifest`
+// on the Kotlin side. See `ManifestContext` in tools/krit-rule-api for the
+// rule-facing surface and `ManifestProfilePayload` in tools/krit-types for
+// the daemon-side mirror. ExportedActivities / ExportedServices /
+// ExportedReceivers are the subsets of the corresponding name lists that
+// declare `android:exported="true"`; the Kotlin side builds a HashSet on
+// first lookup.
+type PluginManifestProfile struct {
+	Package            string   `json:"package,omitempty"`
+	MinSdk             int      `json:"minSdk,omitempty"`
+	TargetSdk          int      `json:"targetSdk,omitempty"`
+	Permissions        []string `json:"permissions,omitempty"`
+	Activities         []string `json:"activities,omitempty"`
+	ExportedActivities []string `json:"exportedActivities,omitempty"`
+	Services           []string `json:"services,omitempty"`
+	ExportedServices   []string `json:"exportedServices,omitempty"`
+	Receivers          []string `json:"receivers,omitempty"`
+	ExportedReceivers  []string `json:"exportedReceivers,omitempty"`
+}
+
+// PluginResourcesProfile is the wire payload that backs
+// `RuleContext.resources`. See `ResourcesContext` in tools/krit-rule-api
+// for the rule-facing surface. Strings/Colors/Dimensions are flat
+// `"name=value"` lists so the daemon-side parser can lean on the same
+// `extractJsonStringArray` it uses for the gradle deps list; the parser
+// splits on the first `=` so values containing `=` round-trip cleanly.
+type PluginResourcesProfile struct {
+	Strings    []string `json:"strings,omitempty"`
+	Drawables  []string `json:"drawables,omitempty"`
+	Layouts    []string `json:"layouts,omitempty"`
+	Colors     []string `json:"colors,omitempty"`
+	Dimensions []string `json:"dimensions,omitempty"`
+	IDs        []string `json:"ids,omitempty"`
+}
+
+// PluginModulesProfile is the wire payload that backs
+// `RuleContext.moduleIndex`. See `ModuleIndexContext` in tools/krit-rule-api
+// for the rule-facing surface. Each module is encoded as a single
+// `"path|directory|dependsOn,..|sourceRoots,..."` pipe-delimited string
+// — Gradle module paths never contain pipes or commas, so the encoding
+// stays unambiguous without escaping.
+type PluginModulesProfile struct {
+	Modules []string `json:"modules,omitempty"`
+}
+
+// PluginCrossFileProfile is the wire payload that backs
+// `RuleContext.crossFile`. See `CrossFileContext` in tools/krit-rule-api
+// for the rule-facing surface. Declarations are encoded as
+// `"fqn|kind|file|line|visibility"` strings; NonCommentRefsByName as
+// `"name|file1,file2,..."` strings (non-comment references only) so the
+// daemon can answer the two query methods without rehashing every entry.
+type PluginCrossFileProfile struct {
+	Declarations         []string `json:"declarations,omitempty"`
+	NonCommentRefsByName []string `json:"nonCommentRefsByName,omitempty"`
+}
+
+// AnalyzePluginFile runs selected Kotlin custom rules against one source
+// file. ruleConfigs maps each rule ID to its configured `options` map; an
+// empty or nil map is omitted from the request so the daemon's
+// RuleContext.config stays empty for those rules. Each project-scope
+// payload (gradle / manifest / resources / moduleIndex / crossFile) is
+// forwarded only when at least one selected rule declared the matching
+// capability — keeps wire size minimal for the common case where most
+// rules only need source.
+func (d *Daemon) AnalyzePluginFile(
+	jars []string,
+	path string,
+	source []byte,
+	ruleIDs []string,
+	ruleConfigs map[string]map[string]interface{},
+	gradle *PluginGradleProfile,
+	manifest *PluginManifestProfile,
+	resources *PluginResourcesProfile,
+	modules *PluginModulesProfile,
+	crossFile *PluginCrossFileProfile,
+) (AnalyzePluginFileResult, error) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
@@ -361,6 +430,18 @@ func (d *Daemon) AnalyzePluginFile(jars []string, path string, source []byte, ru
 	}
 	if gradle != nil {
 		params["gradle"] = gradle
+	}
+	if manifest != nil {
+		params["manifest"] = manifest
+	}
+	if resources != nil {
+		params["resources"] = resources
+	}
+	if modules != nil {
+		params["moduleIndex"] = modules
+	}
+	if crossFile != nil {
+		params["crossFile"] = crossFile
 	}
 	result, err := d.sendResult("analyzeFile", params)
 	if err != nil {

--- a/internal/pipeline/custom_kotlin_rules.go
+++ b/internal/pipeline/custom_kotlin_rules.go
@@ -4,20 +4,29 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 
+	"github.com/kaeawc/krit/internal/android"
 	"github.com/kaeawc/krit/internal/config"
 	"github.com/kaeawc/krit/internal/diag"
 	"github.com/kaeawc/krit/internal/librarymodel"
+	"github.com/kaeawc/krit/internal/module"
 	"github.com/kaeawc/krit/internal/oracle"
 	"github.com/kaeawc/krit/internal/rules"
 	"github.com/kaeawc/krit/internal/scanner"
 )
 
-// capabilityNeedsGradle mirrors `Capability.NEEDS_GRADLE.name` from
-// tools/krit-rule-api. Kept as a const so a typo can't silently turn
-// the gradle plumb into a no-op.
-const capabilityNeedsGradle = "NEEDS_GRADLE"
+// capabilityNeeds* mirror the `Capability.NEEDS_*.name` values from
+// tools/krit-rule-api. Kept as constants so a typo can't silently turn
+// the plumbing into a no-op.
+const (
+	capabilityNeedsGradle      = "NEEDS_GRADLE"
+	capabilityNeedsManifest    = "NEEDS_MANIFEST"
+	capabilityNeedsResources   = "NEEDS_RESOURCES"
+	capabilityNeedsModuleIndex = "NEEDS_MODULE_INDEX"
+	capabilityNeedsCrossFile   = "NEEDS_CROSS_FILE"
+)
 
 func runKotlinPluginRulesAndMerge(ctx context.Context, args ProjectArgs, host ProjectHostState, indexResult IndexResult, crossFileResult *CrossFileResult, bundleHit bool) error {
 	if len(args.CustomRuleJars) == 0 || bundleHit {
@@ -44,8 +53,24 @@ func runKotlinPluginRulesAndMerge(ctx context.Context, args ProjectArgs, host Pr
 	}
 
 	var gradlePayload *oracle.PluginGradleProfile
-	if anyRuleNeedsGradle(list.Rules, ruleIDs) && indexResult.LibraryFacts != nil {
+	if anyRuleNeedsCapability(list.Rules, ruleIDs, capabilityNeedsGradle) && indexResult.LibraryFacts != nil {
 		gradlePayload = buildGradlePayload(&indexResult.LibraryFacts.Profile)
+	}
+	var manifestPayload *oracle.PluginManifestProfile
+	if anyRuleNeedsCapability(list.Rules, ruleIDs, capabilityNeedsManifest) {
+		manifestPayload = buildManifestPayload(indexResult.AndroidProject)
+	}
+	var resourcesPayload *oracle.PluginResourcesProfile
+	if anyRuleNeedsCapability(list.Rules, ruleIDs, capabilityNeedsResources) {
+		resourcesPayload = buildResourcesPayload(indexResult.AndroidProject)
+	}
+	var modulesPayload *oracle.PluginModulesProfile
+	if anyRuleNeedsCapability(list.Rules, ruleIDs, capabilityNeedsModuleIndex) {
+		modulesPayload = buildModulesPayload(indexResult.Graph)
+	}
+	var crossFilePayload *oracle.PluginCrossFileProfile
+	if anyRuleNeedsCapability(list.Rules, ruleIDs, capabilityNeedsCrossFile) {
+		crossFilePayload = buildCrossFilePayload(indexResult.CodeIndex)
 	}
 
 	collector := scanner.NewFindingCollector(crossFileResult.Findings.Len())
@@ -59,7 +84,7 @@ func runKotlinPluginRulesAndMerge(ctx context.Context, args ProjectArgs, host Pr
 			return ctx.Err()
 		default:
 		}
-		result, err := daemon.AnalyzePluginFile(args.CustomRuleJars, file.Path, file.Content, ruleIDs, ruleOptions, gradlePayload)
+		result, err := daemon.AnalyzePluginFile(args.CustomRuleJars, file.Path, file.Content, ruleIDs, ruleOptions, gradlePayload, manifestPayload, resourcesPayload, modulesPayload, crossFilePayload)
 		if err != nil {
 			return fmt.Errorf("run Kotlin custom rules on %s: %w", file.Path, err)
 		}
@@ -74,11 +99,11 @@ func runKotlinPluginRulesAndMerge(ctx context.Context, args ProjectArgs, host Pr
 	return nil
 }
 
-// anyRuleNeedsGradle reports whether any of the selected rules declared
-// NEEDS_GRADLE. Callers use this to skip building the Gradle wire
-// payload when no rule will read it — keeps the wire size minimal for
-// the common case where rules only need source.
-func anyRuleNeedsGradle(loaded []oracle.PluginRuleDescriptor, selected []string) bool {
+// anyRuleNeedsCapability reports whether any of the selected rules
+// declared the named capability. Callers use this to skip building the
+// matching wire payload when no rule will read it — keeps the wire
+// size minimal for the common case where rules only need source.
+func anyRuleNeedsCapability(loaded []oracle.PluginRuleDescriptor, selected []string, capability string) bool {
 	if len(selected) == 0 {
 		return false
 	}
@@ -91,7 +116,7 @@ func anyRuleNeedsGradle(loaded []oracle.PluginRuleDescriptor, selected []string)
 			continue
 		}
 		for _, need := range rule.Needs {
-			if need == capabilityNeedsGradle {
+			if need == capability {
 				return true
 			}
 		}
@@ -145,6 +170,226 @@ func uniqueStrings(in []string) []string {
 		}
 	}
 	return in[:w]
+}
+
+// buildManifestPayload parses the first AndroidManifest.xml the
+// AndroidProject detector found and projects it into the narrow wire
+// schema the krit-types daemon expects. Returns nil when no manifest
+// path is known or the file cannot be parsed — the daemon then leaves
+// `RuleContext.manifest` null for the rule.
+func buildManifestPayload(project *android.Project) *oracle.PluginManifestProfile {
+	if project == nil || len(project.ManifestPaths) == 0 {
+		return nil
+	}
+	var manifest *android.Manifest
+	for _, path := range project.ManifestPaths {
+		parsed, err := android.ParseManifest(path)
+		if err == nil && parsed != nil {
+			manifest = parsed
+			break
+		}
+	}
+	if manifest == nil {
+		return nil
+	}
+	out := &oracle.PluginManifestProfile{
+		Package:   manifest.Package,
+		MinSdk:    parseSdkInt(manifest.UsesSdk.MinSdkVersion),
+		TargetSdk: parseSdkInt(manifest.UsesSdk.TargetSdkVersion),
+	}
+	for _, p := range manifest.UsesPermissions {
+		if p.Name != "" {
+			out.Permissions = append(out.Permissions, p.Name)
+		}
+	}
+	for _, a := range manifest.Application.Activities {
+		if a.Name == "" {
+			continue
+		}
+		out.Activities = append(out.Activities, a.Name)
+		if android.IsExported(android.Component{Name: a.Name, Exported: a.Exported, Permission: a.Permission}, len(a.IntentFilters) > 0) {
+			out.ExportedActivities = append(out.ExportedActivities, a.Name)
+		}
+	}
+	for _, s := range manifest.Application.Services {
+		if s.Name == "" {
+			continue
+		}
+		out.Services = append(out.Services, s.Name)
+		if android.IsExported(android.Component{Name: s.Name, Exported: s.Exported, Permission: s.Permission}, len(s.IntentFilters) > 0) {
+			out.ExportedServices = append(out.ExportedServices, s.Name)
+		}
+	}
+	for _, r := range manifest.Application.Receivers {
+		if r.Name == "" {
+			continue
+		}
+		out.Receivers = append(out.Receivers, r.Name)
+		if android.IsExported(android.Component{Name: r.Name, Exported: r.Exported, Permission: r.Permission}, len(r.IntentFilters) > 0) {
+			out.ExportedReceivers = append(out.ExportedReceivers, r.Name)
+		}
+	}
+	return out
+}
+
+func parseSdkInt(raw string) int {
+	if raw == "" {
+		return 0
+	}
+	v, err := strconv.Atoi(raw)
+	if err != nil || v < 0 {
+		return 0
+	}
+	return v
+}
+
+// buildResourcesPayload scans every res/ directory the AndroidProject
+// detector found and projects the merged ResourceIndex into the wire
+// schema. Strings/colors/dimensions are encoded as `"name=value"`
+// strings so the daemon-side parser can lean on `extractJsonStringArray`.
+// Returns nil when no res/ dir is known or scanning fails entirely.
+func buildResourcesPayload(project *android.Project) *oracle.PluginResourcesProfile {
+	if project == nil || len(project.ResDirs) == 0 {
+		return nil
+	}
+	merged := &android.ResourceIndex{}
+	for _, dir := range project.ResDirs {
+		idx, err := android.ScanResourceDir(dir)
+		if err != nil || idx == nil {
+			continue
+		}
+		merged = android.MergeResourceIndexes(merged, idx)
+	}
+	out := &oracle.PluginResourcesProfile{}
+	for name, value := range merged.Strings {
+		out.Strings = append(out.Strings, name+"="+value)
+	}
+	for name, value := range merged.Colors {
+		out.Colors = append(out.Colors, name+"="+value)
+	}
+	for name, value := range merged.Dimensions {
+		out.Dimensions = append(out.Dimensions, name+"="+value)
+	}
+	for name := range merged.Layouts {
+		out.Layouts = append(out.Layouts, name)
+	}
+	for name := range merged.IDs {
+		out.IDs = append(out.IDs, name)
+	}
+	out.Drawables = append(out.Drawables, merged.Drawables...)
+	sort.Strings(out.Strings)
+	sort.Strings(out.Drawables)
+	sort.Strings(out.Layouts)
+	sort.Strings(out.Colors)
+	sort.Strings(out.Dimensions)
+	sort.Strings(out.IDs)
+	// Drawables is the only field built from a slice (across multi-res/
+	// configurations), so only it can carry true duplicates after merge;
+	// the map-sourced fields are unique by construction.
+	out.Drawables = uniqueStrings(out.Drawables)
+	if len(out.Strings) == 0 && len(out.Drawables) == 0 && len(out.Layouts) == 0 &&
+		len(out.Colors) == 0 && len(out.Dimensions) == 0 && len(out.IDs) == 0 {
+		return nil
+	}
+	return out
+}
+
+// buildModulesPayload encodes each Gradle module as a single
+// pipe-delimited `"path|directory|dependsOn,..|sourceRoots,..."` string.
+// Gradle module paths never contain pipes or commas, so the encoding
+// stays unambiguous without escaping.
+func buildModulesPayload(graph *module.Graph) *oracle.PluginModulesProfile {
+	if graph == nil || len(graph.Modules) == 0 {
+		return nil
+	}
+	paths := make([]string, 0, len(graph.Modules))
+	for path := range graph.Modules {
+		paths = append(paths, path)
+	}
+	sort.Strings(paths)
+	out := &oracle.PluginModulesProfile{}
+	for _, path := range paths {
+		mod := graph.Modules[path]
+		if mod == nil {
+			continue
+		}
+		deps := make([]string, 0, len(mod.Dependencies))
+		for _, dep := range mod.Dependencies {
+			if dep.ModulePath != "" {
+				deps = append(deps, dep.ModulePath)
+			}
+		}
+		out.Modules = append(out.Modules, strings.Join([]string{
+			mod.Path,
+			mod.Dir,
+			strings.Join(deps, ","),
+			strings.Join(mod.SourceRoots, ","),
+		}, "|"))
+	}
+	if len(out.Modules) == 0 {
+		return nil
+	}
+	return out
+}
+
+// buildCrossFilePayload projects the scanner.CodeIndex into the wire
+// schema: declarations as `"fqn|kind|file|line|visibility"` and
+// references pre-grouped by name as `"name|file1,file2,..."` (only
+// non-comment references count, mirroring the dead-code use case the
+// index is most often used for).
+func buildCrossFilePayload(index *scanner.CodeIndex) *oracle.PluginCrossFileProfile {
+	if index == nil {
+		return nil
+	}
+	out := &oracle.PluginCrossFileProfile{}
+	if len(index.Symbols) > 0 {
+		out.Declarations = make([]string, 0, len(index.Symbols))
+		for _, sym := range index.Symbols {
+			if sym.FQN == "" {
+				continue
+			}
+			out.Declarations = append(out.Declarations, strings.Join([]string{
+				sym.FQN,
+				sym.Kind,
+				sym.File,
+				strconv.Itoa(sym.Line),
+				sym.Visibility,
+			}, "|"))
+		}
+		sort.Strings(out.Declarations)
+	}
+	if len(index.References) > 0 {
+		filesByName := map[string][]string{}
+		seenPerName := map[string]map[string]struct{}{}
+		for _, ref := range index.References {
+			if ref.Name == "" || ref.InComment {
+				continue
+			}
+			if seenPerName[ref.Name] == nil {
+				seenPerName[ref.Name] = map[string]struct{}{}
+			}
+			if _, ok := seenPerName[ref.Name][ref.File]; ok {
+				continue
+			}
+			seenPerName[ref.Name][ref.File] = struct{}{}
+			filesByName[ref.Name] = append(filesByName[ref.Name], ref.File)
+		}
+		names := make([]string, 0, len(filesByName))
+		for name := range filesByName {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		out.NonCommentRefsByName = make([]string, 0, len(names))
+		for _, name := range names {
+			files := filesByName[name]
+			sort.Strings(files)
+			out.NonCommentRefsByName = append(out.NonCommentRefsByName, name+"|"+strings.Join(files, ","))
+		}
+	}
+	if len(out.Declarations) == 0 && len(out.NonCommentRefsByName) == 0 {
+		return nil
+	}
+	return out
 }
 
 // selectPluginRules picks which jar-loaded rules to dispatch and collects

--- a/internal/pipeline/custom_kotlin_rules_test.go
+++ b/internal/pipeline/custom_kotlin_rules_test.go
@@ -9,9 +9,11 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/kaeawc/krit/internal/android"
 	"github.com/kaeawc/krit/internal/config"
 	"github.com/kaeawc/krit/internal/diag"
 	"github.com/kaeawc/krit/internal/librarymodel"
+	"github.com/kaeawc/krit/internal/module"
 	"github.com/kaeawc/krit/internal/oracle"
 	"github.com/kaeawc/krit/internal/rules"
 	api "github.com/kaeawc/krit/internal/rules/api"
@@ -483,20 +485,20 @@ func TestAnyRuleNeedsGradleHonorsSelection(t *testing.T) {
 	// acme.GradleButInactive is loaded but the user disabled it via
 	// krit.yml; the gradle payload should not be built just because a
 	// loaded-but-unselected rule declares NEEDS_GRADLE.
-	if anyRuleNeedsGradle(loaded, []string{"acme.Resolver"}) {
+	if anyRuleNeedsCapability(loaded, []string{"acme.Resolver"}, capabilityNeedsGradle) {
 		t.Errorf("unselected NEEDS_GRADLE rule must not trigger plumb")
 	}
 	// acme.Gradle is selected → true.
-	if !anyRuleNeedsGradle(loaded, []string{"acme.Resolver", "acme.Gradle"}) {
+	if !anyRuleNeedsCapability(loaded, []string{"acme.Resolver", "acme.Gradle"}, capabilityNeedsGradle) {
 		t.Errorf("acme.Gradle declares NEEDS_GRADLE; gradle plumb required")
 	}
 	// Empty selection → false.
-	if anyRuleNeedsGradle(loaded, nil) {
+	if anyRuleNeedsCapability(loaded, nil, capabilityNeedsGradle) {
 		t.Errorf("empty selection should not trigger gradle plumb")
 	}
 	// Rules with no needs → false.
 	plain := []oracle.PluginRuleDescriptor{{RuleID: "x", Needs: nil}}
-	if anyRuleNeedsGradle(plain, []string{"x"}) {
+	if anyRuleNeedsCapability(plain, []string{"x"}, capabilityNeedsGradle) {
 		t.Errorf("rule without NEEDS_GRADLE should not trigger plumb")
 	}
 }
@@ -537,5 +539,195 @@ func TestBuildGradlePayloadProjectsSubsetOfProfile(t *testing.T) {
 func TestBuildGradlePayloadNilProfileReturnsNil(t *testing.T) {
 	if got := buildGradlePayload(nil); got != nil {
 		t.Errorf("nil profile must yield nil payload, got %+v", got)
+	}
+}
+
+func TestAnyRuleNeedsCapabilityHandlesAllCapabilityValues(t *testing.T) {
+	// The five capability constants must each be recognized by name —
+	// a typo in the const string would silently skip the plumb.
+	tests := []struct{ capability, need string }{
+		{capabilityNeedsGradle, "NEEDS_GRADLE"},
+		{capabilityNeedsManifest, "NEEDS_MANIFEST"},
+		{capabilityNeedsResources, "NEEDS_RESOURCES"},
+		{capabilityNeedsModuleIndex, "NEEDS_MODULE_INDEX"},
+		{capabilityNeedsCrossFile, "NEEDS_CROSS_FILE"},
+	}
+	for _, tc := range tests {
+		if tc.capability != tc.need {
+			t.Errorf("capability const %q drifted from Capability.%s.name", tc.capability, tc.need)
+		}
+		loaded := []oracle.PluginRuleDescriptor{{RuleID: "r", Needs: []string{tc.need}}}
+		if !anyRuleNeedsCapability(loaded, []string{"r"}, tc.capability) {
+			t.Errorf("%s should be detected as needed", tc.capability)
+		}
+	}
+}
+
+func TestBuildManifestPayloadParsesXMLAndProjectsToWire(t *testing.T) {
+	dir := t.TempDir()
+	manifestPath := filepath.Join(dir, "AndroidManifest.xml")
+	const xml = `<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.acme.app">
+    <uses-sdk android:minSdkVersion="24" android:targetSdkVersion="34"/>
+    <uses-permission android:name="android.permission.INTERNET"/>
+    <application>
+        <activity android:name="com.acme.MainActivity" android:exported="true"/>
+        <activity android:name="com.acme.HiddenActivity"/>
+        <service android:name="com.acme.MyService" android:exported="false"/>
+        <receiver android:name="com.acme.BootReceiver" android:exported="true"/>
+    </application>
+</manifest>`
+	if err := os.WriteFile(manifestPath, []byte(xml), 0o644); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+	project := &android.Project{ManifestPaths: []string{manifestPath}}
+	got := buildManifestPayload(project)
+	if got == nil {
+		t.Fatal("expected non-nil payload")
+	}
+	if got.Package != "com.acme.app" {
+		t.Errorf("Package = %q", got.Package)
+	}
+	if got.MinSdk != 24 || got.TargetSdk != 34 {
+		t.Errorf("Sdk = %+v", got)
+	}
+	if !reflect.DeepEqual(got.Permissions, []string{"android.permission.INTERNET"}) {
+		t.Errorf("Permissions = %v", got.Permissions)
+	}
+	if !reflect.DeepEqual(got.Activities, []string{"com.acme.MainActivity", "com.acme.HiddenActivity"}) {
+		t.Errorf("Activities = %v", got.Activities)
+	}
+	if !reflect.DeepEqual(got.ExportedActivities, []string{"com.acme.MainActivity"}) {
+		t.Errorf("ExportedActivities = %v", got.ExportedActivities)
+	}
+	if len(got.ExportedServices) != 0 {
+		t.Errorf("ExportedServices should be empty for exported=false service: %v", got.ExportedServices)
+	}
+	if !reflect.DeepEqual(got.ExportedReceivers, []string{"com.acme.BootReceiver"}) {
+		t.Errorf("ExportedReceivers = %v", got.ExportedReceivers)
+	}
+}
+
+func TestBuildManifestPayloadReturnsNilWhenAndroidProjectAbsent(t *testing.T) {
+	if got := buildManifestPayload(nil); got != nil {
+		t.Errorf("nil project must yield nil payload, got %+v", got)
+	}
+	if got := buildManifestPayload(&android.Project{}); got != nil {
+		t.Errorf("empty manifest paths must yield nil payload, got %+v", got)
+	}
+}
+
+func TestBuildResourcesPayloadEncodesNameValuePairs(t *testing.T) {
+	dir := t.TempDir()
+	valuesDir := filepath.Join(dir, "values")
+	if err := os.MkdirAll(valuesDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	const stringsXml = `<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">Acme</string>
+    <string name="ok">OK</string>
+    <color name="primary">#FF0000</color>
+    <dimen name="margin_default">16dp</dimen>
+</resources>`
+	if err := os.WriteFile(filepath.Join(valuesDir, "strings.xml"), []byte(stringsXml), 0o644); err != nil {
+		t.Fatalf("write strings.xml: %v", err)
+	}
+	project := &android.Project{ResDirs: []string{dir}}
+	got := buildResourcesPayload(project)
+	if got == nil {
+		t.Fatal("expected non-nil payload")
+	}
+	// Order is enforced by sort.Strings in buildResourcesPayload.
+	if !reflect.DeepEqual(got.Strings, []string{"app_name=Acme", "ok=OK"}) {
+		t.Errorf("Strings = %v", got.Strings)
+	}
+	if !reflect.DeepEqual(got.Colors, []string{"primary=#FF0000"}) {
+		t.Errorf("Colors = %v", got.Colors)
+	}
+	if !reflect.DeepEqual(got.Dimensions, []string{"margin_default=16dp"}) {
+		t.Errorf("Dimensions = %v", got.Dimensions)
+	}
+}
+
+func TestBuildResourcesPayloadReturnsNilForEmptyProject(t *testing.T) {
+	if got := buildResourcesPayload(nil); got != nil {
+		t.Errorf("nil project must yield nil payload, got %+v", got)
+	}
+	if got := buildResourcesPayload(&android.Project{}); got != nil {
+		t.Errorf("empty res dirs must yield nil payload, got %+v", got)
+	}
+}
+
+func TestBuildModulesPayloadEncodesPipeDelimitedEntries(t *testing.T) {
+	graph := module.NewModuleGraph("/abs/root")
+	graph.Modules[":app"] = &module.Module{
+		Path: ":app",
+		Dir:  "/abs/app",
+		Dependencies: []module.Dependency{
+			{ModulePath: ":core", Configuration: "implementation"},
+			{ModulePath: ":data", Configuration: "implementation"},
+		},
+		SourceRoots: []string{"/abs/app/src/main/kotlin"},
+	}
+	graph.Modules[":core"] = &module.Module{Path: ":core", Dir: "/abs/core"}
+	got := buildModulesPayload(graph)
+	if got == nil {
+		t.Fatal("expected non-nil payload")
+	}
+	// Sorted by path: :app, :core.
+	wantApp := ":app|/abs/app|:core,:data|/abs/app/src/main/kotlin"
+	wantCore := ":core|/abs/core||"
+	if got.Modules[0] != wantApp {
+		t.Errorf("modules[0] = %q, want %q", got.Modules[0], wantApp)
+	}
+	if got.Modules[1] != wantCore {
+		t.Errorf("modules[1] = %q, want %q", got.Modules[1], wantCore)
+	}
+}
+
+func TestBuildModulesPayloadReturnsNilForEmptyGraph(t *testing.T) {
+	if got := buildModulesPayload(nil); got != nil {
+		t.Errorf("nil graph must yield nil payload, got %+v", got)
+	}
+	if got := buildModulesPayload(module.NewModuleGraph("/abs")); got != nil {
+		t.Errorf("empty modules must yield nil payload, got %+v", got)
+	}
+}
+
+func TestBuildCrossFilePayloadEncodesDeclarationsAndReferences(t *testing.T) {
+	index := &scanner.CodeIndex{
+		Symbols: []scanner.Symbol{
+			{FQN: "com.acme.Foo", Kind: "class", File: "/abs/Foo.kt", Line: 10, Visibility: "public"},
+			{FQN: "", Kind: "function"}, // skipped — no FQN
+		},
+		References: []scanner.Reference{
+			{Name: "Foo", File: "/abs/Bar.kt", Line: 5},
+			{Name: "Foo", File: "/abs/Baz.kt", Line: 7},
+			{Name: "Foo", File: "/abs/CommentRef.kt", Line: 3, InComment: true}, // skipped — comment
+			{Name: ""}, // skipped — no name
+		},
+	}
+	got := buildCrossFilePayload(index)
+	if got == nil {
+		t.Fatal("expected non-nil payload")
+	}
+	wantDecls := []string{"com.acme.Foo|class|/abs/Foo.kt|10|public"}
+	if !reflect.DeepEqual(got.Declarations, wantDecls) {
+		t.Errorf("Declarations = %v, want %v", got.Declarations, wantDecls)
+	}
+	wantRefs := []string{"Foo|/abs/Bar.kt,/abs/Baz.kt"}
+	if !reflect.DeepEqual(got.NonCommentRefsByName, wantRefs) {
+		t.Errorf("NonCommentRefsByName = %v, want %v", got.NonCommentRefsByName, wantRefs)
+	}
+}
+
+func TestBuildCrossFilePayloadReturnsNilForEmptyIndex(t *testing.T) {
+	if got := buildCrossFilePayload(nil); got != nil {
+		t.Errorf("nil index must yield nil payload, got %+v", got)
+	}
+	if got := buildCrossFilePayload(&scanner.CodeIndex{}); got != nil {
+		t.Errorf("empty index must yield nil payload, got %+v", got)
 	}
 }

--- a/tools/krit-rule-api/src/main/kotlin/dev/jasonpearson/krit/api/KritRule.kt
+++ b/tools/krit-rule-api/src/main/kotlin/dev/jasonpearson/krit/api/KritRule.kt
@@ -145,6 +145,174 @@ interface GradleContext {
 }
 
 /**
+ * Parsed `AndroidManifest.xml` view. Available on [RuleContext.manifest]
+ * when the rule declares [Capability.NEEDS_MANIFEST] and the daemon
+ * detected an `AndroidManifest.xml` in the project (a pure Kotlin
+ * library project leaves this null).
+ *
+ * The surface is intentionally narrow: scalar attributes for the most
+ * common access patterns, plus query methods for the unbounded
+ * collections (`<uses-permission>`, components). Walk the file directly
+ * via `KritFile` if a rule needs richer manifest evidence than this
+ * exposes.
+ */
+interface ManifestContext {
+    /** `<manifest package="...">`, or null when unparseable. */
+    val packageName: String?
+
+    /** `<uses-sdk android:minSdkVersion="...">`, or null when unset. */
+    val minSdk: Int?
+
+    /** `<uses-sdk android:targetSdkVersion="...">`, or null when unset. */
+    val targetSdk: Int?
+
+    /** Returns true when the manifest lists `<uses-permission android:name="[name]"/>`. */
+    fun hasPermission(name: String): Boolean
+
+    /** Returns true when an `<activity android:name="[name]"/>` is declared. */
+    fun hasActivity(name: String): Boolean
+
+    /**
+     * Returns true when the named activity is exported. A component is
+     * considered exported when `android:exported="true"`, or when the
+     * attribute is unset and the component declares at least one
+     * `<intent-filter>` (the pre-API-31 implicit-export default).
+     * Returns false when the activity is not declared.
+     */
+    fun isActivityExported(name: String): Boolean
+
+    /** Returns true when a `<service android:name="[name]"/>` is declared. */
+    fun hasService(name: String): Boolean
+
+    /**
+     * Returns true when the named service is exported (same semantics
+     * as [isActivityExported]).
+     */
+    fun isServiceExported(name: String): Boolean
+
+    /** Returns true when a `<receiver android:name="[name]"/>` is declared. */
+    fun hasReceiver(name: String): Boolean
+
+    /**
+     * Returns true when the named receiver is exported (same semantics
+     * as [isActivityExported]).
+     */
+    fun isReceiverExported(name: String): Boolean
+}
+
+/**
+ * Parsed `res/` tree. Available on [RuleContext.resources] when the
+ * rule declares [Capability.NEEDS_RESOURCES] and the daemon detected
+ * at least one Android `res/` directory.
+ *
+ * Lookups are by resource name (the identifier you'd reference as
+ * `R.string.foo` / `R.drawable.bar` from code). Values are the rendered
+ * resource value (translatable string, hex color, dimension literal).
+ * `hasXxx(name)` is cheaper than `xxxValue(name) != null` because it
+ * skips the rendered-value lookup.
+ */
+interface ResourcesContext {
+    /** Returns the `@string/[name]` value, or null when undeclared. */
+    fun stringValue(name: String): String?
+
+    /** Returns true when `@string/[name]` is declared. */
+    fun hasString(name: String): Boolean
+
+    /** Returns true when `@drawable/[name]` is declared. */
+    fun hasDrawable(name: String): Boolean
+
+    /** Returns true when `@layout/[name]` is declared. */
+    fun hasLayout(name: String): Boolean
+
+    /** Returns the `@color/[name]` value (hex), or null when undeclared. */
+    fun colorValue(name: String): String?
+
+    /** Returns true when `@color/[name]` is declared. */
+    fun hasColor(name: String): Boolean
+
+    /** Returns the `@dimen/[name]` value (e.g. `"16dp"`), or null when undeclared. */
+    fun dimensionValue(name: String): String?
+
+    /** Returns true when `@dimen/[name]` is declared. */
+    fun hasDimension(name: String): Boolean
+
+    /** Returns true when `@+id/[name]` is declared in any layout. */
+    fun hasId(name: String): Boolean
+}
+
+/**
+ * Gradle module identity + per-module dependency graph. Available on
+ * [RuleContext.moduleIndex] when the rule declares
+ * [Capability.NEEDS_MODULE_INDEX] and the daemon discovered at least
+ * one Gradle module.
+ *
+ * `modulePaths` is the list of Gradle paths (`:app`, `:core:util`) in
+ * the order the daemon discovered them. Use the lookup methods rather
+ * than walking the list directly when you only care about one module.
+ */
+interface ModuleIndexContext {
+    /** Discovered Gradle module paths, in daemon-discovery order. */
+    val modulePaths: List<String>
+
+    /** Returns the absolute filesystem directory for `[modulePath]`, or null. */
+    fun directoryOf(modulePath: String): String?
+
+    /**
+     * Returns the Gradle paths the named module declares as project
+     * dependencies (any configuration). Empty list when the module has
+     * no project deps or is not in the index.
+     */
+    fun dependenciesOf(modulePath: String): List<String>
+
+    /**
+     * Returns the source-root directories for `[modulePath]`. Empty
+     * list when the module has no declared source roots or is not in
+     * the index.
+     */
+    fun sourceRootsOf(modulePath: String): List<String>
+}
+
+/**
+ * Cross-file declaration / reference index. Available on
+ * [RuleContext.crossFile] when the rule declares
+ * [Capability.NEEDS_CROSS_FILE] and the daemon's cross-file pass ran.
+ *
+ * The wire payload can be sizable on large projects — declare this
+ * capability only when the rule genuinely needs whole-project
+ * visibility. The query API stays narrow: FQN → declaration site, and
+ * unqualified name → list of files that mention it.
+ */
+interface CrossFileContext {
+    /** Returns the declaration site for `[fqn]` (e.g. `com.acme.Foo`), or null. */
+    fun declarationByFqn(fqn: String): CrossFileDeclaration?
+
+    /**
+     * Returns the list of files that contain at least one non-comment
+     * reference to the unqualified identifier `[name]`. Returns an
+     * empty list when the name is unreferenced.
+     */
+    fun referenceFiles(name: String): List<String>
+
+    /**
+     * Returns true when at least one non-comment file references the
+     * unqualified identifier `[name]`.
+     */
+    fun isReferenced(name: String): Boolean
+}
+
+/**
+ * One declaration site surfaced through [CrossFileContext]. `kind` is
+ * one of `class`, `interface`, `object`, `function`, `property`.
+ */
+data class CrossFileDeclaration(
+    val fqn: String,
+    val kind: String,
+    val file: String,
+    val line: Int,
+    val visibility: String? = null,
+)
+
+/**
  * Per-invocation context passed to custom rules.
  *
  * `config` is the per-rule options map from the consumer's `krit.yml`:
@@ -173,6 +341,30 @@ class RuleContext(
      * facts for the project.
      */
     val gradle: GradleContext? = null,
+    /**
+     * Parsed `AndroidManifest.xml` view. Non-null only when the rule
+     * declared [Capability.NEEDS_MANIFEST] and the project ships a
+     * parseable `AndroidManifest.xml`.
+     */
+    val manifest: ManifestContext? = null,
+    /**
+     * Parsed `res/` tree. Non-null only when the rule declared
+     * [Capability.NEEDS_RESOURCES] and the project ships at least one
+     * Android `res/` directory.
+     */
+    val resources: ResourcesContext? = null,
+    /**
+     * Gradle module identity + dependency graph. Non-null only when
+     * the rule declared [Capability.NEEDS_MODULE_INDEX] and the daemon
+     * discovered at least one Gradle module.
+     */
+    val moduleIndex: ModuleIndexContext? = null,
+    /**
+     * Cross-file declaration / reference index. Non-null only when the
+     * rule declared [Capability.NEEDS_CROSS_FILE] and the daemon's
+     * cross-file pass ran.
+     */
+    val crossFile: CrossFileContext? = null,
 ) {
     /** Returns the [key] option as a String, or [default] if absent / wrong type. */
     fun stringOption(key: String, default: String = ""): String =
@@ -243,18 +435,14 @@ enum class Maturity { STABLE, EXPERIMENTAL, DEPRECATED }
 /**
  * Capabilities a custom rule needs from the Krit daemon.
  *
- * Each value documents which `RuleContext` hook the daemon wires up when
- * the rule declares it. Capabilities marked `@Deprecated` are not yet
- * delivered to plugin rules — declaring one of those fails the jar at
- * load time with a clear message (see `PluginRules.kt`). The
- * load-time gate exists so a typo or a too-optimistic declaration
- * cannot silently degrade to "rule runs without the facts it asked
- * for". Tracked on https://github.com/kaeawc/krit/issues/357.
+ * Each value documents which `RuleContext` hook the daemon wires up
+ * when the rule declares it. The daemon either delivers the fact into
+ * `RuleContext` or refuses to load the jar — there is no third
+ * "advisory" state. See `docs/external-rules.md#capability-semantics`
+ * for the user-facing matrix.
  *
  * Adding a new capability is a minor-version change (additive, default
- * not-required). Promoting a deprecated entry to "supported" is also a
- * minor-version change. Removing a deprecated entry is a major-version
- * change.
+ * not-required). Removing a capability is a major-version change.
  */
 enum class Capability {
     /**
@@ -264,20 +452,17 @@ enum class Capability {
      */
     NEEDS_RESOLVER,
 
-    @Deprecated(
-        message = "NEEDS_CROSS_FILE is not yet delivered to plugin rules. " +
-            "Declaring it causes the rule jar to fail at load time. Tracked " +
-            "on https://github.com/kaeawc/krit/issues/357.",
-        level = DeprecationLevel.WARNING,
-    )
+    /**
+     * Populates [RuleContext.crossFile] with a [CrossFileContext] view
+     * of declarations and references indexed across the project.
+     */
     NEEDS_CROSS_FILE,
 
-    @Deprecated(
-        message = "NEEDS_MODULE_INDEX is not yet delivered to plugin rules. " +
-            "Declaring it causes the rule jar to fail at load time. Tracked " +
-            "on https://github.com/kaeawc/krit/issues/357.",
-        level = DeprecationLevel.WARNING,
-    )
+    /**
+     * Populates [RuleContext.moduleIndex] with a [ModuleIndexContext]
+     * view of every discovered Gradle module and its declared
+     * project-dependency edges.
+     */
     NEEDS_MODULE_INDEX,
 
     /**
@@ -289,20 +474,17 @@ enum class Capability {
      */
     NEEDS_PARSED_FILES,
 
-    @Deprecated(
-        message = "NEEDS_MANIFEST is not yet delivered to plugin rules. " +
-            "Declaring it causes the rule jar to fail at load time. Tracked " +
-            "on https://github.com/kaeawc/krit/issues/357.",
-        level = DeprecationLevel.WARNING,
-    )
+    /**
+     * Populates [RuleContext.manifest] with a [ManifestContext] view
+     * of the project's parsed `AndroidManifest.xml`.
+     */
     NEEDS_MANIFEST,
 
-    @Deprecated(
-        message = "NEEDS_RESOURCES is not yet delivered to plugin rules. " +
-            "Declaring it causes the rule jar to fail at load time. Tracked " +
-            "on https://github.com/kaeawc/krit/issues/357.",
-        level = DeprecationLevel.WARNING,
-    )
+    /**
+     * Populates [RuleContext.resources] with a [ResourcesContext] view
+     * of the project's parsed `res/` tree (strings, drawables,
+     * layouts, colors, dimens, ids).
+     */
     NEEDS_RESOURCES,
 
     /**

--- a/tools/krit-types/src/main/kotlin/dev/jasonpearson/krit/types/Main.kt
+++ b/tools/krit-types/src/main/kotlin/dev/jasonpearson/krit/types/Main.kt
@@ -719,6 +719,19 @@ data class DaemonRequest(
     // any selected rule declares NEEDS_GRADLE. Null when no rule asked
     // for it (the common case — keeps wire size minimal).
     val gradleProfile: GradleProfilePayload? = null,
+    // Parsed AndroidManifest.xml facts. Null when no rule asked for
+    // NEEDS_MANIFEST or the project has no AndroidManifest.xml.
+    val manifestProfile: ManifestProfilePayload? = null,
+    // Parsed res/ tree facts. Null when no rule asked for NEEDS_RESOURCES
+    // or the project has no Android resource directories.
+    val resourcesProfile: ResourcesProfilePayload? = null,
+    // Per-module identity + dependency edges. Null when no rule asked
+    // for NEEDS_MODULE_INDEX or the project has no Gradle modules.
+    val modulesProfile: ModulesProfilePayload? = null,
+    // Cross-file declaration + reference index. Null when no rule
+    // asked for NEEDS_CROSS_FILE or the daemon's cross-file pass did
+    // not run for the project.
+    val crossFileProfile: CrossFileProfilePayload? = null,
 )
 
 /**
@@ -738,6 +751,66 @@ data class GradleProfilePayload(
     val javaTargetVersion: String?,
     val agpVersion: String?,
     val deps: List<String>,
+)
+
+/**
+ * Wire-format `AndroidManifest.xml` facts handed to plugin rules via
+ * `ManifestContext`. `exportedActivities` / `exportedServices` /
+ * `exportedReceivers` are flat string lists rather than per-component
+ * booleans so the wire payload can lean on `extractJsonStringArray`;
+ * the Kotlin-side `PayloadManifestContext` rebuilds the lookup sets
+ * lazily.
+ */
+data class ManifestProfilePayload(
+    val packageName: String?,
+    val minSdk: Int?,
+    val targetSdk: Int?,
+    val permissions: List<String>,
+    val activities: List<String>,
+    val exportedActivities: List<String>,
+    val services: List<String>,
+    val exportedServices: List<String>,
+    val receivers: List<String>,
+    val exportedReceivers: List<String>,
+)
+
+/**
+ * Wire-format Android `res/` tree handed to plugin rules via
+ * `ResourcesContext`. Strings/colors/dimensions are flat
+ * `"name=value"` lists so the wire format reuses the same `String[]`
+ * extractor — the daemon parses them back into maps on construction.
+ */
+data class ResourcesProfilePayload(
+    val strings: List<String>,
+    val drawables: List<String>,
+    val layouts: List<String>,
+    val colors: List<String>,
+    val dimensions: List<String>,
+    val ids: List<String>,
+)
+
+/**
+ * Wire-format Gradle-module identity + per-module dependency graph
+ * handed to plugin rules via `ModuleIndexContext`. Encoded as
+ * `path|directory|dependsOn,...|sourceRoots,...` strings so the wire
+ * can reuse `extractJsonStringArray`. Commas inside paths/directories
+ * are not supported — Gradle module paths never contain them.
+ */
+data class ModulesProfilePayload(
+    val modules: List<String>,
+)
+
+/**
+ * Wire-format cross-file index handed to plugin rules via
+ * `CrossFileContext`. Declarations are encoded as
+ * `fqn|kind|file|line|visibility` strings. References are pre-grouped
+ * by name as `name|file1,file2,...` strings (non-comment references
+ * only) so the daemon can answer `referenceFiles(name)` and
+ * `isReferenced(name)` without rehashing every entry.
+ */
+data class CrossFileProfilePayload(
+    val declarations: List<String>,
+    val nonCommentRefsByName: List<String>,
 )
 
 /** 1-based line/col tuple used in resolveExpressionTypes requests. */
@@ -773,7 +846,11 @@ fun parseRequest(json: String): DaemonRequest {
     val source = extractJsonString(json, "source")
     val ruleConfigs = extractJsonNestedObjectMap(json, "ruleConfigs")
     val gradleProfile = extractGradleProfilePayload(json)
-    return DaemonRequest(id, method, files, timings, callFilter, declarationProfile, expressionPositions, jarPath, fqn, pluginJars, ruleIds, path, source, ruleConfigs, gradleProfile)
+    val manifestProfile = extractManifestProfilePayload(json)
+    val resourcesProfile = extractResourcesProfilePayload(json)
+    val modulesProfile = extractModulesProfilePayload(json)
+    val crossFileProfile = extractCrossFileProfilePayload(json)
+    return DaemonRequest(id, method, files, timings, callFilter, declarationProfile, expressionPositions, jarPath, fqn, pluginJars, ruleIds, path, source, ruleConfigs, gradleProfile, manifestProfile, resourcesProfile, modulesProfile, crossFileProfile)
 }
 
 private fun extractGradleProfilePayload(json: String): GradleProfilePayload? {
@@ -786,6 +863,49 @@ private fun extractGradleProfilePayload(json: String): GradleProfilePayload? {
         javaTargetVersion = extractJsonString(outer, "javaTargetVersion"),
         agpVersion = extractJsonString(outer, "agpVersion"),
         deps = extractJsonStringArray(outer, "deps").orEmpty(),
+    )
+}
+
+private fun extractManifestProfilePayload(json: String): ManifestProfilePayload? {
+    val outer = extractJsonObjectBlock(json, "manifest") ?: return null
+    return ManifestProfilePayload(
+        packageName = extractJsonString(outer, "package"),
+        minSdk = extractJsonLong(outer, "minSdk")?.toInt()?.takeIf { it >= 0 },
+        targetSdk = extractJsonLong(outer, "targetSdk")?.toInt()?.takeIf { it >= 0 },
+        permissions = extractJsonStringArray(outer, "permissions").orEmpty(),
+        activities = extractJsonStringArray(outer, "activities").orEmpty(),
+        exportedActivities = extractJsonStringArray(outer, "exportedActivities").orEmpty(),
+        services = extractJsonStringArray(outer, "services").orEmpty(),
+        exportedServices = extractJsonStringArray(outer, "exportedServices").orEmpty(),
+        receivers = extractJsonStringArray(outer, "receivers").orEmpty(),
+        exportedReceivers = extractJsonStringArray(outer, "exportedReceivers").orEmpty(),
+    )
+}
+
+private fun extractResourcesProfilePayload(json: String): ResourcesProfilePayload? {
+    val outer = extractJsonObjectBlock(json, "resources") ?: return null
+    return ResourcesProfilePayload(
+        strings = extractJsonStringArray(outer, "strings").orEmpty(),
+        drawables = extractJsonStringArray(outer, "drawables").orEmpty(),
+        layouts = extractJsonStringArray(outer, "layouts").orEmpty(),
+        colors = extractJsonStringArray(outer, "colors").orEmpty(),
+        dimensions = extractJsonStringArray(outer, "dimensions").orEmpty(),
+        ids = extractJsonStringArray(outer, "ids").orEmpty(),
+    )
+}
+
+private fun extractModulesProfilePayload(json: String): ModulesProfilePayload? {
+    val outer = extractJsonObjectBlock(json, "moduleIndex") ?: return null
+    return ModulesProfilePayload(
+        modules = extractJsonStringArray(outer, "modules").orEmpty(),
+    )
+}
+
+private fun extractCrossFileProfilePayload(json: String): CrossFileProfilePayload? {
+    val outer = extractJsonObjectBlock(json, "crossFile") ?: return null
+    return CrossFileProfilePayload(
+        declarations = extractJsonStringArray(outer, "declarations").orEmpty(),
+        nonCommentRefsByName = extractJsonStringArray(outer, "nonCommentRefsByName").orEmpty(),
     )
 }
 

--- a/tools/krit-types/src/main/kotlin/dev/jasonpearson/krit/types/PluginRules.kt
+++ b/tools/krit-types/src/main/kotlin/dev/jasonpearson/krit/types/PluginRules.kt
@@ -1,13 +1,18 @@
 package dev.jasonpearson.krit.types
 
 import dev.jasonpearson.krit.api.Capability
+import dev.jasonpearson.krit.api.CrossFileContext
+import dev.jasonpearson.krit.api.CrossFileDeclaration
 import dev.jasonpearson.krit.api.Finding
 import dev.jasonpearson.krit.api.FixSafety
 import dev.jasonpearson.krit.api.GradleContext
 import dev.jasonpearson.krit.api.KritFile
 import dev.jasonpearson.krit.api.KritRule
 import dev.jasonpearson.krit.api.KritRuleInfo
+import dev.jasonpearson.krit.api.ManifestContext
+import dev.jasonpearson.krit.api.ModuleIndexContext
 import dev.jasonpearson.krit.api.Resolver
+import dev.jasonpearson.krit.api.ResourcesContext
 import dev.jasonpearson.krit.api.RuleApiVersion
 import dev.jasonpearson.krit.api.RuleContext
 import org.jetbrains.kotlin.analysis.api.KaExperimentalApi
@@ -165,11 +170,17 @@ internal object PluginCapabilities {
         // rather than rejected, so existing rules that opt in stay
         // forward-compatible.
         Capability.NEEDS_PARSED_FILES.name,
-        // NEEDS_GRADLE delivers RuleContext.gradle when the Go-side
-        // caller forwards a GradleProfilePayload — see
-        // `runKotlinPluginRulesAndMerge` in
-        // internal/pipeline/custom_kotlin_rules.go.
+        // Project-scope facts are delivered through the per-call
+        // analyzeFile payload by `runKotlinPluginRulesAndMerge` in
+        // internal/pipeline/custom_kotlin_rules.go. A rule that
+        // declares one of these but runs against a project that has
+        // no matching fact (e.g. NEEDS_MANIFEST on a pure-Kotlin
+        // library) sees the corresponding RuleContext field as null.
         Capability.NEEDS_GRADLE.name,
+        Capability.NEEDS_MANIFEST.name,
+        Capability.NEEDS_RESOURCES.name,
+        Capability.NEEDS_MODULE_INDEX.name,
+        Capability.NEEDS_CROSS_FILE.name,
     )
 
     fun unsupported(needs: List<String>): List<String> =
@@ -392,20 +403,29 @@ fun DaemonSession.handleAnalyzeFileWithPlugins(request: DaemonRequest): String {
         val findings = mutableListOf<PluginFinding>()
         val errors = linkedMapOf<String, String>()
         val gradleContext = request.gradleProfile?.let(::PayloadGradleContext)
+        val manifestContext = request.manifestProfile?.let(::PayloadManifestContext)
+        val resourcesContext = request.resourcesProfile?.let(::PayloadResourcesContext)
+        val moduleIndexContext = request.modulesProfile?.let(::PayloadModuleIndexContext)
+        val crossFileContext = request.crossFileProfile?.let(::PayloadCrossFileContext)
         for (loaded in PluginRuleRegistry.selected(request.ruleIds)) {
             try {
                 val options = request.ruleConfigs?.get(loaded.descriptor.ruleId).orEmpty()
-                val resolver = if (ktFile != null && loaded.descriptor.needs.contains(Capability.NEEDS_RESOLVER.name)) {
+                val needs = loaded.descriptor.needs
+                val resolver = if (ktFile != null && needs.contains(Capability.NEEDS_RESOLVER.name)) {
                     AnalysisApiResolver(ktFile)
                 } else {
                     null
                 }
-                val gradle = if (loaded.descriptor.needs.contains(Capability.NEEDS_GRADLE.name)) {
-                    gradleContext
-                } else {
-                    null
-                }
-                val ctx = RuleContext(loaded.descriptor.ruleId, options, resolver, gradle)
+                val ctx = RuleContext(
+                    ruleId = loaded.descriptor.ruleId,
+                    config = options,
+                    resolver = resolver,
+                    gradle = gradleContext.takeIf { needs.contains(Capability.NEEDS_GRADLE.name) },
+                    manifest = manifestContext.takeIf { needs.contains(Capability.NEEDS_MANIFEST.name) },
+                    resources = resourcesContext.takeIf { needs.contains(Capability.NEEDS_RESOURCES.name) },
+                    moduleIndex = moduleIndexContext.takeIf { needs.contains(Capability.NEEDS_MODULE_INDEX.name) },
+                    crossFile = crossFileContext.takeIf { needs.contains(Capability.NEEDS_CROSS_FILE.name) },
+                )
                 for (finding in loaded.rule.check(file, ctx)) {
                     findings.add(toPluginFinding(file.path, loaded.descriptor, finding))
                 }
@@ -585,6 +605,143 @@ internal class PayloadGradleContext(payload: GradleProfilePayload) : GradleConte
 
     override fun dependencyVersion(group: String, name: String): String? =
         versionByCoord["$group:$name"]
+}
+
+/**
+ * [ManifestContext] view backed by the [ManifestProfilePayload]
+ * forwarded over the wire. Per-component lookup sets are built lazily
+ * on first query — rules that only read scalar attributes (package,
+ * SDK versions) skip the set construction entirely.
+ */
+internal class PayloadManifestContext(payload: ManifestProfilePayload) : ManifestContext {
+    override val packageName: String? = payload.packageName
+    override val minSdk: Int? = payload.minSdk
+    override val targetSdk: Int? = payload.targetSdk
+
+    private val permissionSet: Set<String> by lazy { payload.permissions.toHashSet() }
+    private val activitySet: Set<String> by lazy { payload.activities.toHashSet() }
+    private val exportedActivitySet: Set<String> by lazy { payload.exportedActivities.toHashSet() }
+    private val serviceSet: Set<String> by lazy { payload.services.toHashSet() }
+    private val exportedServiceSet: Set<String> by lazy { payload.exportedServices.toHashSet() }
+    private val receiverSet: Set<String> by lazy { payload.receivers.toHashSet() }
+    private val exportedReceiverSet: Set<String> by lazy { payload.exportedReceivers.toHashSet() }
+
+    override fun hasPermission(name: String): Boolean = name in permissionSet
+    override fun hasActivity(name: String): Boolean = name in activitySet
+    override fun isActivityExported(name: String): Boolean = name in exportedActivitySet
+    override fun hasService(name: String): Boolean = name in serviceSet
+    override fun isServiceExported(name: String): Boolean = name in exportedServiceSet
+    override fun hasReceiver(name: String): Boolean = name in receiverSet
+    override fun isReceiverExported(name: String): Boolean = name in exportedReceiverSet
+}
+
+/**
+ * [ResourcesContext] view backed by the [ResourcesProfilePayload]
+ * forwarded over the wire. Maps are built lazily by parsing the flat
+ * `"name=value"` wire format — splitting on the first `=` so values
+ * containing `=` (e.g. URL-encoded strings) round-trip cleanly.
+ */
+internal class PayloadResourcesContext(payload: ResourcesProfilePayload) : ResourcesContext {
+    private val stringMap: Map<String, String> by lazy { parseNameValueList(payload.strings) }
+    private val colorMap: Map<String, String> by lazy { parseNameValueList(payload.colors) }
+    private val dimensionMap: Map<String, String> by lazy { parseNameValueList(payload.dimensions) }
+    private val drawableSet: Set<String> by lazy { payload.drawables.toHashSet() }
+    private val layoutSet: Set<String> by lazy { payload.layouts.toHashSet() }
+    private val idSet: Set<String> by lazy { payload.ids.toHashSet() }
+
+    override fun stringValue(name: String): String? = stringMap[name]
+    override fun hasString(name: String): Boolean = stringMap.containsKey(name)
+    override fun hasDrawable(name: String): Boolean = name in drawableSet
+    override fun hasLayout(name: String): Boolean = name in layoutSet
+    override fun colorValue(name: String): String? = colorMap[name]
+    override fun hasColor(name: String): Boolean = colorMap.containsKey(name)
+    override fun dimensionValue(name: String): String? = dimensionMap[name]
+    override fun hasDimension(name: String): Boolean = dimensionMap.containsKey(name)
+    override fun hasId(name: String): Boolean = name in idSet
+
+    private fun parseNameValueList(entries: List<String>): Map<String, String> {
+        val out = HashMap<String, String>(entries.size)
+        for (entry in entries) {
+            val eq = entry.indexOf('=')
+            if (eq <= 0) continue
+            out[entry.substring(0, eq)] = entry.substring(eq + 1)
+        }
+        return out
+    }
+}
+
+/**
+ * [ModuleIndexContext] view backed by the [ModulesProfilePayload]
+ * forwarded over the wire. Each module is encoded as the
+ * `path|directory|dependsOn-comma-list|sourceRoots-comma-list` shape
+ * documented on the payload; the parser splits and indexes on first
+ * query.
+ */
+internal class PayloadModuleIndexContext(payload: ModulesProfilePayload) : ModuleIndexContext {
+    private data class Entry(
+        val directory: String,
+        val dependsOn: List<String>,
+        val sourceRoots: List<String>,
+    )
+
+    private val byPath: Map<String, Entry> by lazy {
+        val out = LinkedHashMap<String, Entry>(payload.modules.size)
+        for (line in payload.modules) {
+            val parts = line.split('|')
+            if (parts.size < 4 || parts[0].isEmpty()) continue
+            val deps = parts[2].takeIf { it.isNotEmpty() }?.split(',') ?: emptyList()
+            val roots = parts[3].takeIf { it.isNotEmpty() }?.split(',') ?: emptyList()
+            out[parts[0]] = Entry(parts[1], deps, roots)
+        }
+        out
+    }
+
+    override val modulePaths: List<String> get() = byPath.keys.toList()
+    override fun directoryOf(modulePath: String): String? = byPath[modulePath]?.directory
+    override fun dependenciesOf(modulePath: String): List<String> =
+        byPath[modulePath]?.dependsOn.orEmpty()
+    override fun sourceRootsOf(modulePath: String): List<String> =
+        byPath[modulePath]?.sourceRoots.orEmpty()
+}
+
+/**
+ * [CrossFileContext] view backed by the [CrossFileProfilePayload]
+ * forwarded over the wire. Both the FQN→declaration map and the
+ * name→reference-files map are built lazily — many cross-file rules
+ * only query one direction.
+ */
+internal class PayloadCrossFileContext(payload: CrossFileProfilePayload) : CrossFileContext {
+    private val byFqn: Map<String, CrossFileDeclaration> by lazy {
+        val out = HashMap<String, CrossFileDeclaration>(payload.declarations.size)
+        for (entry in payload.declarations) {
+            val parts = entry.split('|')
+            if (parts.size < 4 || parts[0].isEmpty()) continue
+            val line = parts[3].toIntOrNull() ?: continue
+            val visibility = parts.getOrNull(4)?.takeIf { it.isNotEmpty() }
+            out[parts[0]] = CrossFileDeclaration(parts[0], parts[1], parts[2], line, visibility)
+        }
+        out
+    }
+
+    private val refFilesByName: Map<String, List<String>> by lazy {
+        val out = HashMap<String, List<String>>(payload.nonCommentRefsByName.size)
+        for (entry in payload.nonCommentRefsByName) {
+            val sep = entry.indexOf('|')
+            if (sep <= 0) continue
+            val name = entry.substring(0, sep)
+            val files = entry.substring(sep + 1)
+                .split(',')
+                .filter { it.isNotEmpty() }
+            if (files.isNotEmpty()) {
+                out[name] = files
+            }
+        }
+        out
+    }
+
+    override fun declarationByFqn(fqn: String): CrossFileDeclaration? = byFqn[fqn]
+    override fun referenceFiles(name: String): List<String> = refFilesByName[name].orEmpty()
+    override fun isReferenced(name: String): Boolean = refFilesByName.containsKey(name)
 }
 
 @OptIn(KaExperimentalApi::class)

--- a/tools/krit-types/src/test/kotlin/dev/jasonpearson/krit/types/CrossFileContextTest.kt
+++ b/tools/krit-types/src/test/kotlin/dev/jasonpearson/krit/types/CrossFileContextTest.kt
@@ -1,0 +1,90 @@
+package dev.jasonpearson.krit.types
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class CrossFileContextTest {
+
+    private fun ctx(
+        declarations: List<String> = emptyList(),
+        nonCommentRefsByName: List<String> = emptyList(),
+    ) = PayloadCrossFileContext(
+        CrossFileProfilePayload(
+            declarations = declarations,
+            nonCommentRefsByName = nonCommentRefsByName,
+        ),
+    )
+
+    @Test
+    fun declarationLookupParsesPipeDelimitedEntries() {
+        val crossFile = ctx(declarations = listOf("com.acme.Foo|class|/abs/Foo.kt|10|public"))
+        val decl = assertNotNull(crossFile.declarationByFqn("com.acme.Foo"))
+        assertEquals("com.acme.Foo", decl.fqn)
+        assertEquals("class", decl.kind)
+        assertEquals("/abs/Foo.kt", decl.file)
+        assertEquals(10, decl.line)
+        assertEquals("public", decl.visibility)
+    }
+
+    @Test
+    fun missingDeclarationReturnsNull() {
+        val crossFile = ctx(declarations = listOf("com.acme.Foo|class|/F.kt|1|"))
+        assertNull(crossFile.declarationByFqn("com.acme.Missing"))
+    }
+
+    @Test
+    fun declarationWithEmptyVisibilityNormalisesToNull() {
+        val crossFile = ctx(declarations = listOf("com.acme.Foo|class|/abs/Foo.kt|10|"))
+        val decl = assertNotNull(crossFile.declarationByFqn("com.acme.Foo"))
+        assertNull(decl.visibility)
+    }
+
+    @Test
+    fun malformedDeclarationEntriesAreIgnored() {
+        val crossFile = ctx(
+            declarations = listOf(
+                "no-pipes",
+                "two|pipes|only",
+                "ok|class|/F.kt|not-an-int|",
+                "com.acme.Good|class|/G.kt|5|",
+            ),
+        )
+        assertNotNull(crossFile.declarationByFqn("com.acme.Good"))
+        assertNull(crossFile.declarationByFqn("ok"))
+    }
+
+    @Test
+    fun referenceLookupReturnsFileListInWireOrder() {
+        val crossFile = ctx(
+            nonCommentRefsByName = listOf("Foo|/abs/Bar.kt,/abs/Baz.kt"),
+        )
+        assertEquals(listOf("/abs/Bar.kt", "/abs/Baz.kt"), crossFile.referenceFiles("Foo"))
+        assertTrue(crossFile.isReferenced("Foo"))
+    }
+
+    @Test
+    fun unreferencedNameReturnsEmptyList() {
+        val crossFile = ctx(nonCommentRefsByName = listOf("Foo|/abs/Bar.kt"))
+        assertEquals(emptyList(), crossFile.referenceFiles("Missing"))
+        assertFalse(crossFile.isReferenced("Missing"))
+    }
+
+    @Test
+    fun parsesCrossFileProfileViaParseRequest() {
+        val json = """{"id":1,"method":"analyzeFile","params":{"path":"X.kt","crossFile":{"declarations":["c.D|class|/D.kt|1|"],"nonCommentRefsByName":["D|/U.kt"]}}}"""
+        val req = parseRequest(json)
+        val crossFile = req.crossFileProfile ?: error("crossFileProfile must round-trip")
+        assertEquals(listOf("c.D|class|/D.kt|1|"), crossFile.declarations)
+        assertEquals(listOf("D|/U.kt"), crossFile.nonCommentRefsByName)
+    }
+
+    @Test
+    fun parseRequestLeavesCrossFileProfileNullWhenAbsent() {
+        val json = """{"id":1,"method":"analyzeFile","params":{"path":"X.kt"}}"""
+        assertNull(parseRequest(json).crossFileProfile)
+    }
+}

--- a/tools/krit-types/src/test/kotlin/dev/jasonpearson/krit/types/ManifestContextTest.kt
+++ b/tools/krit-types/src/test/kotlin/dev/jasonpearson/krit/types/ManifestContextTest.kt
@@ -1,0 +1,117 @@
+package dev.jasonpearson.krit.types
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class ManifestContextTest {
+
+    private fun ctx(
+        packageName: String? = null,
+        minSdk: Int? = null,
+        targetSdk: Int? = null,
+        permissions: List<String> = emptyList(),
+        activities: List<String> = emptyList(),
+        exportedActivities: List<String> = emptyList(),
+        services: List<String> = emptyList(),
+        exportedServices: List<String> = emptyList(),
+        receivers: List<String> = emptyList(),
+        exportedReceivers: List<String> = emptyList(),
+    ) = PayloadManifestContext(
+        ManifestProfilePayload(
+            packageName = packageName,
+            minSdk = minSdk,
+            targetSdk = targetSdk,
+            permissions = permissions,
+            activities = activities,
+            exportedActivities = exportedActivities,
+            services = services,
+            exportedServices = exportedServices,
+            receivers = receivers,
+            exportedReceivers = exportedReceivers,
+        ),
+    )
+
+    @Test
+    fun scalarsPassThroughVerbatim() {
+        val manifest = ctx(packageName = "com.acme.app", minSdk = 24, targetSdk = 34)
+        assertEquals("com.acme.app", manifest.packageName)
+        assertEquals(24, manifest.minSdk)
+        assertEquals(34, manifest.targetSdk)
+    }
+
+    @Test
+    fun absentScalarsRemainNull() {
+        val manifest = ctx()
+        assertNull(manifest.packageName)
+        assertNull(manifest.minSdk)
+        assertNull(manifest.targetSdk)
+    }
+
+    @Test
+    fun hasPermissionMatchesByName() {
+        val manifest = ctx(permissions = listOf("android.permission.INTERNET", "android.permission.CAMERA"))
+        assertTrue(manifest.hasPermission("android.permission.INTERNET"))
+        assertTrue(manifest.hasPermission("android.permission.CAMERA"))
+        assertFalse(manifest.hasPermission("android.permission.WAKE_LOCK"))
+    }
+
+    @Test
+    fun activityComponentsTrackNameAndExportedSubsetSeparately() {
+        val manifest = ctx(
+            activities = listOf("com.acme.MainActivity", "com.acme.HiddenActivity"),
+            exportedActivities = listOf("com.acme.MainActivity"),
+        )
+        assertTrue(manifest.hasActivity("com.acme.MainActivity"))
+        assertTrue(manifest.hasActivity("com.acme.HiddenActivity"))
+        assertFalse(manifest.hasActivity("com.acme.MissingActivity"))
+        assertTrue(manifest.isActivityExported("com.acme.MainActivity"))
+        assertFalse(manifest.isActivityExported("com.acme.HiddenActivity"))
+        assertFalse(manifest.isActivityExported("com.acme.MissingActivity"))
+    }
+
+    @Test
+    fun serviceComponentsTrackExportedSubset() {
+        val manifest = ctx(
+            services = listOf("com.acme.MyService", "com.acme.OtherService"),
+            exportedServices = listOf("com.acme.MyService"),
+        )
+        assertTrue(manifest.isServiceExported("com.acme.MyService"))
+        assertFalse(manifest.isServiceExported("com.acme.OtherService"))
+        assertTrue(manifest.hasService("com.acme.OtherService"))
+    }
+
+    @Test
+    fun receiverComponentsTrackExportedSubset() {
+        val manifest = ctx(
+            receivers = listOf("com.acme.BootReceiver"),
+            exportedReceivers = listOf("com.acme.BootReceiver"),
+        )
+        assertTrue(manifest.hasReceiver("com.acme.BootReceiver"))
+        assertTrue(manifest.isReceiverExported("com.acme.BootReceiver"))
+        assertFalse(manifest.hasReceiver("com.acme.Missing"))
+    }
+
+    @Test
+    fun parsesManifestProfileViaParseRequest() {
+        val json = """{"id":1,"method":"analyzeFile","params":{"path":"X.kt","manifest":{"package":"com.acme.app","minSdk":24,"targetSdk":34,"permissions":["android.permission.INTERNET"],"activities":["com.acme.MainActivity"],"exportedActivities":["com.acme.MainActivity"],"services":[],"receivers":["com.acme.R"]}}}"""
+        val req = parseRequest(json)
+        val manifest = req.manifestProfile ?: error("manifestProfile must round-trip")
+        assertEquals("com.acme.app", manifest.packageName)
+        assertEquals(24, manifest.minSdk)
+        assertEquals(34, manifest.targetSdk)
+        assertEquals(listOf("android.permission.INTERNET"), manifest.permissions)
+        assertEquals(listOf("com.acme.MainActivity"), manifest.activities)
+        assertEquals(listOf("com.acme.MainActivity"), manifest.exportedActivities)
+        assertEquals(emptyList(), manifest.services)
+        assertEquals(listOf("com.acme.R"), manifest.receivers)
+    }
+
+    @Test
+    fun parseRequestLeavesManifestProfileNullWhenAbsent() {
+        val json = """{"id":1,"method":"analyzeFile","params":{"path":"X.kt"}}"""
+        assertNull(parseRequest(json).manifestProfile)
+    }
+}

--- a/tools/krit-types/src/test/kotlin/dev/jasonpearson/krit/types/ModuleIndexContextTest.kt
+++ b/tools/krit-types/src/test/kotlin/dev/jasonpearson/krit/types/ModuleIndexContextTest.kt
@@ -1,0 +1,66 @@
+package dev.jasonpearson.krit.types
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class ModuleIndexContextTest {
+
+    private fun ctx(vararg entries: String) = PayloadModuleIndexContext(ModulesProfilePayload(entries.toList()))
+
+    @Test
+    fun modulePathsAreDiscoveredInWireOrder() {
+        val moduleIndex = ctx(
+            ":app|/abs/app||",
+            ":core:util|/abs/core/util||",
+        )
+        assertEquals(listOf(":app", ":core:util"), moduleIndex.modulePaths)
+    }
+
+    @Test
+    fun directoryAndDependsOnAreParsedFromPipeDelimitedEntry() {
+        val moduleIndex = ctx(":app|/abs/app|:core,:data|/abs/app/src/main/kotlin")
+        assertEquals("/abs/app", moduleIndex.directoryOf(":app"))
+        assertEquals(listOf(":core", ":data"), moduleIndex.dependenciesOf(":app"))
+        assertEquals(listOf("/abs/app/src/main/kotlin"), moduleIndex.sourceRootsOf(":app"))
+    }
+
+    @Test
+    fun missingModuleReturnsNullDirectoryAndEmptyLists() {
+        val moduleIndex = ctx(":app|/abs/app||")
+        assertNull(moduleIndex.directoryOf(":missing"))
+        assertTrue(moduleIndex.dependenciesOf(":missing").isEmpty())
+        assertTrue(moduleIndex.sourceRootsOf(":missing").isEmpty())
+    }
+
+    @Test
+    fun moduleWithNoDependenciesOrSourceRootsReturnsEmptyLists() {
+        val moduleIndex = ctx(":core|/abs/core||")
+        assertTrue(moduleIndex.dependenciesOf(":core").isEmpty())
+        assertTrue(moduleIndex.sourceRootsOf(":core").isEmpty())
+    }
+
+    @Test
+    fun malformedEntriesAreIgnoredNotThrown() {
+        // Defensive — a stray entry without a pipe must not corrupt the
+        // map or throw on lookup. Go-side caller emits well-formed
+        // entries; this guards against future regressions.
+        val moduleIndex = ctx("no-pipe", "|empty-path", ":app|/abs/app||")
+        assertEquals(listOf(":app"), moduleIndex.modulePaths)
+    }
+
+    @Test
+    fun parsesModulesProfileViaParseRequest() {
+        val json = """{"id":1,"method":"analyzeFile","params":{"path":"X.kt","moduleIndex":{"modules":[":app|/abs/app|:core|/abs/app/src/main/kotlin"]}}}"""
+        val req = parseRequest(json)
+        val modules = req.modulesProfile ?: error("modulesProfile must round-trip")
+        assertEquals(listOf(":app|/abs/app|:core|/abs/app/src/main/kotlin"), modules.modules)
+    }
+
+    @Test
+    fun parseRequestLeavesModulesProfileNullWhenAbsent() {
+        val json = """{"id":1,"method":"analyzeFile","params":{"path":"X.kt"}}"""
+        assertNull(parseRequest(json).modulesProfile)
+    }
+}

--- a/tools/krit-types/src/test/kotlin/dev/jasonpearson/krit/types/PluginCapabilitiesTest.kt
+++ b/tools/krit-types/src/test/kotlin/dev/jasonpearson/krit/types/PluginCapabilitiesTest.kt
@@ -10,34 +10,18 @@ class PluginCapabilitiesTest {
     private val jar = "/tmp/acme-rules.jar"
 
     @Test
-    fun resolverAndParsedFilesAreSupported() {
-        assertTrue(PluginCapabilities.unsupported(listOf(Capability.NEEDS_RESOLVER.name)).isEmpty())
-        assertTrue(PluginCapabilities.unsupported(listOf(Capability.NEEDS_PARSED_FILES.name)).isEmpty())
-    }
-
-    @Suppress("DEPRECATION")
-    @Test
-    fun unsupportedListsEveryDeprecatedCapability() {
-        val unsupported = PluginCapabilities.unsupported(
-            listOf(
-                Capability.NEEDS_RESOLVER.name,
-                Capability.NEEDS_CROSS_FILE.name,
-                Capability.NEEDS_MODULE_INDEX.name,
-                Capability.NEEDS_PARSED_FILES.name,
-                Capability.NEEDS_MANIFEST.name,
-                Capability.NEEDS_RESOURCES.name,
-                Capability.NEEDS_GRADLE.name,
-            ),
-        )
-        assertEquals(
-            listOf(
-                Capability.NEEDS_CROSS_FILE.name,
-                Capability.NEEDS_MODULE_INDEX.name,
-                Capability.NEEDS_MANIFEST.name,
-                Capability.NEEDS_RESOURCES.name,
-            ),
-            unsupported,
-        )
+    fun everyEnumValueIsSupported() {
+        // Issue #357 promotes the final four `@Deprecated` capabilities
+        // (MANIFEST, RESOURCES, MODULE_INDEX, CROSS_FILE) to supported.
+        // A Capability enum value must be either in SUPPORTED or
+        // removed from the enum entirely — there is no third
+        // "advisory" state.
+        for (capability in Capability.values()) {
+            assertTrue(
+                PluginCapabilities.unsupported(listOf(capability.name)).isEmpty(),
+                "$capability should be supported but unsupported() returned a non-empty list",
+            )
+        }
     }
 
     @Test
@@ -56,7 +40,6 @@ class PluginCapabilitiesTest {
         assertEquals(listOf("NEEDS_TIME_TRAVEL"), unsupported)
     }
 
-    @Suppress("DEPRECATION")
     @Test
     fun loadDiagnosticIsErrorLevelWithRuleIdAndCapability() {
         val diagnostic = PluginCapabilities.buildLoadDiagnostic(
@@ -64,10 +47,10 @@ class PluginCapabilitiesTest {
             ruleSdkVersion = "1.2.3",
             daemonSdkVersion = "1.2.3",
             violations = listOf(
-                CapabilityViolation("acme.NoTodo", listOf(Capability.NEEDS_GRADLE.name)),
+                CapabilityViolation("acme.NoTodo", listOf("NEEDS_TIME_TRAVEL")),
                 CapabilityViolation(
                     "acme.NoFixme",
-                    listOf(Capability.NEEDS_MANIFEST.name, Capability.NEEDS_RESOURCES.name),
+                    listOf("NEEDS_QUANTUM_TUNNEL", "NEEDS_WORMHOLE"),
                 ),
             ),
         )
@@ -77,16 +60,15 @@ class PluginCapabilitiesTest {
         assertEquals("1.2.3", diagnostic.daemonSdkVersion)
         assertTrue(diagnostic.message.contains("acme.NoTodo"), diagnostic.message)
         assertTrue(diagnostic.message.contains("acme.NoFixme"), diagnostic.message)
-        assertTrue(diagnostic.message.contains(Capability.NEEDS_GRADLE.name), diagnostic.message)
-        assertTrue(diagnostic.message.contains(Capability.NEEDS_MANIFEST.name), diagnostic.message)
-        assertTrue(diagnostic.message.contains(Capability.NEEDS_RESOURCES.name), diagnostic.message)
+        assertTrue(diagnostic.message.contains("NEEDS_TIME_TRAVEL"), diagnostic.message)
+        assertTrue(diagnostic.message.contains("NEEDS_QUANTUM_TUNNEL"), diagnostic.message)
+        assertTrue(diagnostic.message.contains("NEEDS_WORMHOLE"), diagnostic.message)
         assertTrue(
             diagnostic.message.contains(PluginCapabilities.TRACKING_ISSUE_URL),
             diagnostic.message,
         )
     }
 
-    @Suppress("DEPRECATION")
     @Test
     fun loadDiagnosticOrdersRulesAlphabeticallyForDeterminism() {
         val diagnostic = PluginCapabilities.buildLoadDiagnostic(
@@ -94,8 +76,8 @@ class PluginCapabilitiesTest {
             ruleSdkVersion = "1.2.3",
             daemonSdkVersion = "1.2.3",
             violations = listOf(
-                CapabilityViolation("z.RuleZ", listOf(Capability.NEEDS_GRADLE.name)),
-                CapabilityViolation("a.RuleA", listOf(Capability.NEEDS_MANIFEST.name)),
+                CapabilityViolation("z.RuleZ", listOf("NEEDS_TIME_TRAVEL")),
+                CapabilityViolation("a.RuleA", listOf("NEEDS_QUANTUM_TUNNEL")),
             ),
         )
         val idxA = diagnostic.message.indexOf("a.RuleA")

--- a/tools/krit-types/src/test/kotlin/dev/jasonpearson/krit/types/ResourcesContextTest.kt
+++ b/tools/krit-types/src/test/kotlin/dev/jasonpearson/krit/types/ResourcesContextTest.kt
@@ -1,0 +1,99 @@
+package dev.jasonpearson.krit.types
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class ResourcesContextTest {
+
+    private fun ctx(
+        strings: List<String> = emptyList(),
+        drawables: List<String> = emptyList(),
+        layouts: List<String> = emptyList(),
+        colors: List<String> = emptyList(),
+        dimensions: List<String> = emptyList(),
+        ids: List<String> = emptyList(),
+    ) = PayloadResourcesContext(
+        ResourcesProfilePayload(
+            strings = strings,
+            drawables = drawables,
+            layouts = layouts,
+            colors = colors,
+            dimensions = dimensions,
+            ids = ids,
+        ),
+    )
+
+    @Test
+    fun stringValueLookupHonorsNameEqualsValueEncoding() {
+        val resources = ctx(strings = listOf("app_name=Acme", "ok=OK"))
+        assertEquals("Acme", resources.stringValue("app_name"))
+        assertEquals("OK", resources.stringValue("ok"))
+        assertNull(resources.stringValue("missing"))
+        assertTrue(resources.hasString("app_name"))
+        assertFalse(resources.hasString("missing"))
+    }
+
+    @Test
+    fun colorAndDimensionValuesParseSimilarly() {
+        val resources = ctx(
+            colors = listOf("primary=#FF0000"),
+            dimensions = listOf("margin_default=16dp"),
+        )
+        assertEquals("#FF0000", resources.colorValue("primary"))
+        assertEquals("16dp", resources.dimensionValue("margin_default"))
+        assertTrue(resources.hasColor("primary"))
+        assertTrue(resources.hasDimension("margin_default"))
+        assertFalse(resources.hasColor("missing"))
+    }
+
+    @Test
+    fun stringValueWithEqualsSignPreservesEverythingAfterFirstEquals() {
+        // Defensive — i18n strings may include `=` characters; the
+        // parser splits on the first `=` only so values containing `=`
+        // round-trip cleanly.
+        val resources = ctx(strings = listOf("encoded_url=a=b&c=d"))
+        assertEquals("a=b&c=d", resources.stringValue("encoded_url"))
+    }
+
+    @Test
+    fun drawableLayoutIdLookupsAreSetBased() {
+        val resources = ctx(
+            drawables = listOf("ic_launcher"),
+            layouts = listOf("activity_main", "fragment_home"),
+            ids = listOf("root_view"),
+        )
+        assertTrue(resources.hasDrawable("ic_launcher"))
+        assertFalse(resources.hasDrawable("missing"))
+        assertTrue(resources.hasLayout("activity_main"))
+        assertTrue(resources.hasLayout("fragment_home"))
+        assertTrue(resources.hasId("root_view"))
+        assertFalse(resources.hasId("missing"))
+    }
+
+    @Test
+    fun malformedStringEntriesAreIgnored() {
+        val resources = ctx(strings = listOf("no-equals", "=empty-name", "ok=OK"))
+        assertEquals("OK", resources.stringValue("ok"))
+        assertFalse(resources.hasString("no-equals"))
+        assertFalse(resources.hasString(""))
+    }
+
+    @Test
+    fun parsesResourcesProfileViaParseRequest() {
+        val json = """{"id":1,"method":"analyzeFile","params":{"path":"X.kt","resources":{"strings":["app_name=Acme"],"drawables":["ic_launcher"],"layouts":["activity_main"],"colors":["primary=#FF0000"],"dimensions":["margin=16dp"],"ids":["root"]}}}"""
+        val req = parseRequest(json)
+        val resources = req.resourcesProfile ?: error("resourcesProfile must round-trip")
+        assertEquals(listOf("app_name=Acme"), resources.strings)
+        assertEquals(listOf("ic_launcher"), resources.drawables)
+        assertEquals(listOf("activity_main"), resources.layouts)
+    }
+
+    @Test
+    fun parseRequestLeavesResourcesProfileNullWhenAbsent() {
+        val json = """{"id":1,"method":"analyzeFile","params":{"path":"X.kt"}}"""
+        assertNull(parseRequest(json).resourcesProfile)
+    }
+}


### PR DESCRIPTION
## Summary

Closes the loop on [#357](https://github.com/kaeawc/krit/issues/357) by
promoting the last four `@Deprecated` `Capability` values
(`NEEDS_MANIFEST`, `NEEDS_RESOURCES`, `NEEDS_MODULE_INDEX`,
`NEEDS_CROSS_FILE`) to supported. Rules can now read project-wide
manifest / resource / module / cross-file facts via
`RuleContext.manifest` / `.resources` / `.moduleIndex` / `.crossFile`.

Mirrors the per-capability pattern established by
[#371](https://github.com/kaeawc/krit/pull/371)'s `NEEDS_GRADLE`
plumb:

- One `XxxContext` interface per capability in `krit-rule-api`, with a
  narrow surface (scalar properties + `hasXxx` / `xxxValue` query
  methods).
- One `PluginXxxProfile` struct (Go) / `XxxProfilePayload` data class
  (Kotlin) carrying the wire format.
- Each payload forwarded on `analyzeFile` only when at least one
  selected rule declared the matching capability — keeps the wire
  minimal for the common case.
- `PayloadXxxContext` impls hydrate the interface from the wire
  payload, lazy-building lookup sets so rules that read only a few
  queries skip the construction cost.
- `PluginCapabilities.SUPPORTED` gains all four; jars that previously
  failed load now run with the facts wired in.

Manifest export semantics honour the pre-API-31 implicit
`<intent-filter>` rule via `android.IsExported`, so a rule asking
`isActivityExported("X")` gets the same answer the Krit built-in
manifest rules see (case-insensitive, intent-filter-aware).

`anyRuleNeedsGradle` was generalised to `anyRuleNeedsCapability` driven
by `capabilityNeedsXxx` constants; a regression test asserts each
constant matches its `Capability.NEEDS_*.name`.

Docs flipped the capability matrix and added a per-file wire-payload
cost section — `NEEDS_CROSS_FILE` payloads can be sizable on big
projects; a future `setProjectContext` RPC will hoist project-scope
payloads out of the per-file loop.

## Test plan

- [x] `go build ./... && go vet ./... && go test ./internal/pipeline/ ./internal/oracle/ -count=1`
- [x] `golangci-lint run ./internal/oracle/... ./internal/pipeline/...` (0 issues)
- [x] `make lint-rules` (passes)
- [x] `cd tools/krit-types && ./gradlew --no-daemon test` (all tests pass)
- [x] New Go tests: `TestAnyRuleNeedsCapabilityHandlesAllCapabilityValues`, `TestBuildManifestPayloadParsesXMLAndProjectsToWire`, `TestBuildManifestPayloadReturnsNilWhenAndroidProjectAbsent`, `TestBuildResourcesPayloadEncodesNameValuePairs`, `TestBuildResourcesPayloadReturnsNilForEmptyProject`, `TestBuildModulesPayloadEncodesPipeDelimitedEntries`, `TestBuildModulesPayloadReturnsNilForEmptyGraph`, `TestBuildCrossFilePayloadEncodesDeclarationsAndReferences`, `TestBuildCrossFilePayloadReturnsNilForEmptyIndex`
- [x] New Kotlin tests: `ManifestContextTest`, `ResourcesContextTest`, `ModuleIndexContextTest`, `CrossFileContextTest` (each with parseRequest round-trip + lookup/edge-case coverage)
- [x] `PluginCapabilitiesTest` now asserts every `Capability` enum value is in `SUPPORTED`