### PR TITLE
fix(rules): scrub comments and raw strings in StructuredLogKeyMixedCase

### DIFF
--- a/internal/rules/complexity.go
+++ b/internal/rules/complexity.go
@@ -352,29 +352,92 @@ type lineScanState struct {
 // raw-string state — occurrences inside comments or regular strings are
 // ignored.
 func scanLineState(line string, st *lineScanState) {
+	scanLineLexical(line, st, nil)
+}
+
+// stripCommentsAndRawStrings returns a copy of `line` where every byte
+// inside a line comment, block comment, or raw `"""..."""` string
+// literal is replaced with a single space. Regular `"..."` string
+// literals are preserved verbatim — they typically hold real call
+// arguments that line-based rules want to inspect, and Kotlin's
+// requirement to escape inner `"` characters makes it hard for a
+// regular string's body to fabricate a false positive for patterns
+// that need a `"` boundary.
+//
+// The returned string has the same length as the input so column
+// positions are stable; callers can run regex matches against the
+// scrubbed line and reject hits that originated in non-code regions
+// without losing positional information.
+//
+// `st` carries multi-line block-comment and raw-string state across
+// calls; callers iterating over `file.Lines` should declare one
+// lineScanState outside the loop and reuse it.
+func stripCommentsAndRawStrings(line string, st *lineScanState) string {
+	if line == "" {
+		return ""
+	}
+	// Fast path: when no multi-line construct is open and the line cannot
+	// start one (no `//`, `/*`, or `"""`), the scrub is a no-op and state
+	// stays clean. Regular `"..."` strings are preserved verbatim and do
+	// not carry state across lines, so we don't need to detect them here.
+	if !st.inBlockComment && !st.inRawString &&
+		!strings.Contains(line, "//") &&
+		!strings.Contains(line, "/*") &&
+		!strings.Contains(line, `"""`) {
+		return line
+	}
+	out := []byte(line)
+	scanLineLexical(line, st, out)
+	return string(out)
+}
+
+// scanLineLexical is the shared body of scanLineState and
+// stripCommentsAndRawStrings. It advances `st` across `line` and, when
+// `mask` is non-nil, overwrites every byte that falls inside a line
+// comment, block comment, or raw string with a space. Regular `"..."`
+// strings advance the lexer's state (so `\"` and inner `"` are handled
+// correctly) but their bytes are never masked.
+func scanLineLexical(line string, st *lineScanState, mask []byte) {
 	i := 0
 	n := len(line)
 	inLineComment := false
 	inRegString := false
+	scrub := func(j int) {
+		if mask != nil {
+			mask[j] = ' '
+		}
+	}
 	for i < n {
 		if inLineComment {
-			return
+			if mask == nil {
+				return
+			}
+			scrub(i)
+			i++
+			continue
 		}
 		if st.inBlockComment {
 			if i+1 < n && line[i] == '*' && line[i+1] == '/' {
+				scrub(i)
+				scrub(i + 1)
 				st.inBlockComment = false
 				i += 2
 				continue
 			}
+			scrub(i)
 			i++
 			continue
 		}
 		if st.inRawString {
 			if i+2 < n && line[i] == '"' && line[i+1] == '"' && line[i+2] == '"' {
+				scrub(i)
+				scrub(i + 1)
+				scrub(i + 2)
 				st.inRawString = false
 				i += 3
 				continue
 			}
+			scrub(i)
 			i++
 			continue
 		}
@@ -394,16 +457,23 @@ func scanLineState(line string, st *lineScanState) {
 		// Code position.
 		if i+1 < n && line[i] == '/' && line[i+1] == '/' {
 			inLineComment = true
+			scrub(i)
+			scrub(i + 1)
 			i += 2
 			continue
 		}
 		if i+1 < n && line[i] == '/' && line[i+1] == '*' {
 			st.inBlockComment = true
+			scrub(i)
+			scrub(i + 1)
 			i += 2
 			continue
 		}
 		if i+2 < n && line[i] == '"' && line[i+1] == '"' && line[i+2] == '"' {
 			st.inRawString = true
+			scrub(i)
+			scrub(i + 1)
+			scrub(i + 2)
 			i += 3
 			continue
 		}

--- a/internal/rules/complexity_internal_test.go
+++ b/internal/rules/complexity_internal_test.go
@@ -1,0 +1,141 @@
+package rules
+
+import (
+	"regexp"
+	"testing"
+)
+
+var testAddKeyValueRe = regexp.MustCompile(`\baddKeyValue\s*\(\s*"([^"]+)"`)
+
+// TestStripCommentsAndRawStrings_PreservesCodeAndMasksNonCode locks in the
+// invariants used by line-pass rules (e.g. StructuredLogKeyMixedCase):
+// real call expressions remain intact, while pattern occurrences inside
+// comments and raw strings are scrubbed so they cannot drive a false
+// positive.
+func TestStripCommentsAndRawStrings_PreservesCodeAndMasksNonCode(t *testing.T) {
+	cases := []struct {
+		name     string
+		lines    []string
+		wantKeys map[int]string // line index → captured key after scrub
+	}{
+		{
+			name:     "real call preserved",
+			lines:    []string{`addKeyValue("user_id", id)`},
+			wantKeys: map[int]string{0: "user_id"},
+		},
+		{
+			name: "line comment ignored",
+			lines: []string{
+				`x() // addKeyValue("requestId", id)`,
+				`addKeyValue("user_id", id)`,
+			},
+			wantKeys: map[int]string{1: "user_id"},
+		},
+		{
+			name: "block comment ignored single line",
+			lines: []string{
+				`x() /* addKeyValue("requestId", id) */ y()`,
+				`addKeyValue("user_id", id)`,
+			},
+			wantKeys: map[int]string{1: "user_id"},
+		},
+		{
+			name: "block comment ignored across lines",
+			lines: []string{
+				`/* docs:`,
+				` * addKeyValue("requestId", id)`,
+				` */`,
+				`addKeyValue("user_id", id)`,
+			},
+			wantKeys: map[int]string{3: "user_id"},
+		},
+		{
+			name: "raw string ignored single line",
+			lines: []string{
+				`val s = """addKeyValue("requestId", id)"""`,
+				`addKeyValue("user_id", id)`,
+			},
+			wantKeys: map[int]string{1: "user_id"},
+		},
+		{
+			name: "raw string ignored across lines",
+			lines: []string{
+				`val s = """`,
+				`  addKeyValue("requestId", id)`,
+				`"""`,
+				`addKeyValue("user_id", id)`,
+			},
+			wantKeys: map[int]string{3: "user_id"},
+		},
+		{
+			// Escaped inner quotes break the regex's `"([^"]+)"` boundary,
+			// so the regular string body cannot fabricate a match even
+			// though we deliberately do NOT scrub regular-string bytes.
+			name: "regular string with escaped quotes does not false-positive",
+			lines: []string{
+				`err("addKeyValue(\"requestId\", v)")`,
+				`addKeyValue("user_id", id)`,
+			},
+			wantKeys: map[int]string{1: "user_id"},
+		},
+		{
+			name: "triple-quote inside line comment does not enter raw mode",
+			lines: []string{
+				`// snippet: """raw with addKeyValue("requestId", id)"""`,
+				`addKeyValue("user_id", id)`,
+			},
+			wantKeys: map[int]string{1: "user_id"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var st lineScanState
+			gotKeys := map[int]string{}
+			for i, line := range tc.lines {
+				out := stripCommentsAndRawStrings(line, &st)
+				if len(out) != len(line) {
+					t.Fatalf("line %d: scrubbed length %d != input length %d (%q vs %q)", i, len(out), len(line), out, line)
+				}
+				if m := testAddKeyValueRe.FindStringSubmatch(out); m != nil {
+					gotKeys[i] = m[1]
+				}
+			}
+			for idx, want := range tc.wantKeys {
+				if gotKeys[idx] != want {
+					t.Fatalf("line %d: got captured key %q, want %q (scrubbed line: %q)", idx, gotKeys[idx], want, tc.lines[idx])
+				}
+			}
+			for idx, got := range gotKeys {
+				if _, ok := tc.wantKeys[idx]; !ok {
+					t.Fatalf("line %d: unexpected captured key %q from %q", idx, got, tc.lines[idx])
+				}
+			}
+		})
+	}
+}
+
+// TestScanLineStateMatchesStrip ensures the original scanLineState advance
+// path used by complexity rules stays in sync with the new shared lexer
+// body. Drift would silently corrupt LongMethod and friends.
+func TestScanLineStateMatchesStrip(t *testing.T) {
+	lines := []string{
+		`fun f() {`,
+		`    val s = """`,
+		`      multi-line raw`,
+		`    """`,
+		`    /* block`,
+		`       comment */`,
+		`    val r = "regular \"quoted\" string"`,
+		`}`,
+	}
+	var stripState lineScanState
+	var scanState lineScanState
+	for i, line := range lines {
+		_ = stripCommentsAndRawStrings(line, &stripState)
+		scanLineState(line, &scanState)
+		if stripState != scanState {
+			t.Fatalf("line %d (%q): state drift: strip=%+v scan=%+v", i, line, stripState, scanState)
+		}
+	}
+}

--- a/internal/rules/logging.go
+++ b/internal/rules/logging.go
@@ -1359,14 +1359,24 @@ func (r *StructuredLogKeyMixedCaseRule) check(ctx *api.Context) {
 
 func collectStructuredLogKeys(file *scanner.File) []structuredLogKeyOccurrence {
 	var keys []structuredLogKeyOccurrence
+	var st lineScanState
 	for i, line := range file.Lines {
-		for _, match := range structuredAddKeyValueRe.FindAllStringSubmatch(line, -1) {
+		// Pre-filter: skip the lexical scrub and regex scans when the
+		// line cannot match either pattern. State still needs to advance
+		// so a subsequent line that does contain a candidate sees an
+		// accurate `inBlockComment` / `inRawString`.
+		if !strings.Contains(line, "addKeyValue") && !strings.Contains(line, "MDC") {
+			scanLineState(line, &st)
+			continue
+		}
+		scrubbed := stripCommentsAndRawStrings(line, &st)
+		for _, match := range structuredAddKeyValueRe.FindAllStringSubmatch(scrubbed, -1) {
 			if len(match) < 2 {
 				continue
 			}
 			keys = appendStructuredLogKey(keys, match[1], i+1)
 		}
-		for _, match := range structuredMDCPutRe.FindAllStringSubmatch(line, -1) {
+		for _, match := range structuredMDCPutRe.FindAllStringSubmatch(scrubbed, -1) {
 			if len(match) < 2 {
 				continue
 			}

--- a/tests/fixtures/negative/observability/StructuredLogKeyMixedCase.kt
+++ b/tests/fixtures/negative/observability/StructuredLogKeyMixedCase.kt
@@ -14,10 +14,44 @@ class MapLike {
 }
 
 fun record(logger: Logger, map: MapLike, id: String) {
+    // Real code uses three snake_case keys. The migration note below
+    // mentions a camelCase key inside a line comment. A lexical scanner
+    // that ignores comment state would count that as a real key, push
+    // snake_case past the 70% majority threshold, and flag the
+    // camelCase entry as a false-positive mixed-case finding.
+    // Migration note: addKeyValue("requestId", id) was renamed to "request_id".
     logger.atInfo()
         .addKeyValue("user_id", id)
         .addKeyValue("account_id", id)
-        .addKeyValue("request_id", id)
+        .addKeyValue("session_id", id)
         .log("done")
-    map.put("requestId", id)
+    map.put("requestId", id) // map.put is not MDC.put; ignored by the regex either way.
+}
+
+fun recordWithRawStringNote(logger: Logger, id: String) {
+    // Same shape as `record`, but the camelCase example lives inside a
+    // triple-quoted raw string. A scanner that does not track raw-string
+    // state would still treat it as a real call.
+    val migrationNote = """
+        Legacy usage:
+          addKeyValue("requestId", id)
+    """.trimIndent()
+    println(migrationNote)
+    logger.atInfo()
+        .addKeyValue("user_id", id)
+        .addKeyValue("account_id", id)
+        .addKeyValue("session_id", id)
+        .log("done")
+}
+
+fun recordWithBlockCommentNote(logger: Logger, id: String) {
+    /*
+     * Example camelCase usage from the SDK README:
+     *   addKeyValue("requestId", id)
+     */
+    logger.atInfo()
+        .addKeyValue("user_id", id)
+        .addKeyValue("account_id", id)
+        .addKeyValue("session_id", id)
+        .log("done")
 }


### PR DESCRIPTION
## Root cause

`collectStructuredLogKeys` matched `addKeyValue("…")` and `MDC.put("…")` against each raw line, so a `// addKeyValue("requestId", id)` line comment, a `/* … */` block comment, or a `"""…addKeyValue("requestId", id)…"""` raw string fabricated structured-log keys. Three real snake_case keys plus one fake camelCase key from a comment was enough to push snake_case past the 70% majority and emit a spurious mixed-case finding on the camelCase fake.

## Fix

Add `stripCommentsAndRawStrings(line, st)` next to the existing `scanLineState` (they now share a `scanLineLexical` body). It returns a length-preserving copy of the line with line/block-comment and raw-string bytes replaced by spaces; regular `"…"` strings stay verbatim because their content is typically the call argument we want to inspect, and Kotlin's escape rules keep them from forging the regex anchor.

`collectStructuredLogKeys` runs the regexes on the scrubbed copy, with a fast path that skips both the scrub and the regex when the line cannot contain either pattern. State still advances on the skipped lines so a later trigger sees an accurate `inBlockComment` / `inRawString`.

## Test plan

- [x] `TestStripCommentsAndRawStrings_PreservesCodeAndMasksNonCode` — locks the helper against line comment, block comment (single- and multi-line), raw string (single- and multi-line), escaped-quote regular string, and triple-quote-inside-line-comment cases.
- [x] `TestScanLineStateMatchesStrip` — guards against drift between the old `scanLineState` advance path (used by complexity rules) and the new shared lexer body.
- [x] Negative fixture extended with three regression functions, each exercising one of the three lexical false-positive sources; each tuned so the snake_case majority crosses the 70% threshold under the pre-fix logic. Verified the fixture fails (3 spurious findings) without the `logging.go` change and passes with it.
- [x] `go build ./... && go vet ./... && golangci-lint run ./...` clean.
- [x] `go test ./... -count=1` passes.