### PR TITLE
fix(rules): skip PrintlnInProduction on bare calls when the builtin is shadowed

### DIFF
--- a/internal/rules/filefacts.go
+++ b/internal/rules/filefacts.go
@@ -42,4 +42,5 @@ const (
 	slotTestQualityMockNames        = "testQualityMockNames"
 	slotTestQualityAssertionHelpers = "testQualityAssertionHelpers"
 	slotUnusedImportRefs            = "unusedImportRefs"
+	slotPrintBuiltinShadows         = "printBuiltinShadows"
 )

--- a/internal/rules/release_engineering.go
+++ b/internal/rules/release_engineering.go
@@ -613,7 +613,133 @@ func isProductionPrintCallFlat(file *scanner.File, idx uint32, name, receiver st
 			(segs[1] == "out" || segs[1] == "err") &&
 			segs[2] == name
 	}
-	return receiver == ""
+	if receiver != "" {
+		return false
+	}
+	// Bare `println(...)` resolves to kotlin.io.println only when nothing
+	// in the file shadows the built-in name: no top-level/member/local
+	// function_declaration named `println`, and no non-kotlin.io import
+	// (or alias) that brings a same-named symbol into scope.
+	return !kotlinFileShadowsBuiltinPrint(file, name)
+}
+
+// printBuiltinShadowFacts records, per file, whether the kotlin.io
+// built-in `println` and/or `print` are shadowed by a same-file
+// declaration or non-kotlin.io import. PrintlnInProduction calls into
+// this once per check; the dispatcher invokes the check per matching
+// call_expression, so without memoization a file with N bare
+// println/print calls would re-walk the entire AST and import header N
+// times.
+type printBuiltinShadowFacts struct {
+	println bool
+	print   bool
+}
+
+func (f printBuiltinShadowFacts) shadows(name string) bool {
+	switch name {
+	case "println":
+		return f.println
+	case "print":
+		return f.print
+	}
+	return false
+}
+
+// kotlinFileShadowsBuiltinPrint returns true when the file declares a
+// function named `name` at any scope, or imports a non-kotlin.io symbol
+// that would resolve before kotlin.io.<name> for a bare call. Result is
+// cached per-file via filefacts; only one AST walk and one import scan
+// run per file regardless of how many bare-call sites the rule visits.
+func kotlinFileShadowsBuiltinPrint(file *scanner.File, name string) bool {
+	if file == nil || name == "" {
+		return false
+	}
+	return printBuiltinShadowFactsFor(file).shadows(name)
+}
+
+func printBuiltinShadowFactsFor(file *scanner.File) printBuiltinShadowFacts {
+	return filefacts.FileFact(fileFactsCache(), file, slotPrintBuiltinShadows, func() printBuiltinShadowFacts {
+		return computePrintBuiltinShadowFacts(file)
+	})
+}
+
+func computePrintBuiltinShadowFacts(file *scanner.File) printBuiltinShadowFacts {
+	var facts printBuiltinShadowFacts
+	file.FlatWalkAllNodes(0, func(idx uint32) {
+		if facts.println && facts.print {
+			return
+		}
+		if file.FlatType(idx) != "function_declaration" {
+			return
+		}
+		switch flatFunctionName(file, idx) {
+		case "println":
+			facts.println = true
+		case "print":
+			facts.print = true
+		}
+	})
+	if facts.println && facts.print {
+		return facts
+	}
+	// One import-header pass detects shadowing for both names.
+	kotlinScanImportsForPrintShadow(file, &facts)
+	return facts
+}
+
+// kotlinScanImportsForPrintShadow walks the file's import header and
+// sets facts.println / facts.print whenever an import statement (or
+// `as` alias) brings a same-named symbol into scope, other than an
+// explicit `import kotlin.io.<name>` re-import of the built-in.
+// Comments are stripped so a commented-out import does not register.
+func kotlinScanImportsForPrintShadow(file *scanner.File, facts *printBuiltinShadowFacts) {
+	inBlockComment := false
+	for _, line := range file.Lines {
+		if facts.println && facts.print {
+			return
+		}
+		stripped, stillInBlock := stripBlockComments(line, inBlockComment)
+		inBlockComment = stillInBlock
+		if i := strings.Index(stripped, "//"); i >= 0 {
+			stripped = stripped[:i]
+		}
+		trimmed := strings.TrimSpace(stripped)
+		if trimmed == "" {
+			continue
+		}
+		if !strings.HasPrefix(trimmed, "import ") {
+			if strings.HasPrefix(trimmed, "package ") {
+				continue
+			}
+			// Imports must precede the first declaration; stop scanning.
+			return
+		}
+		spec := strings.TrimSpace(strings.TrimPrefix(trimmed, "import "))
+		// Alias takes precedence: `import a.b.X as <name>` shadows.
+		if _, after, ok := strings.Cut(spec, " as "); ok {
+			alias := strings.TrimSpace(strings.TrimSuffix(after, ";"))
+			markPrintShadow(facts, alias)
+			continue
+		}
+		spec = strings.TrimSpace(strings.TrimSuffix(spec, ";"))
+		switch spec {
+		case "kotlin.io.println", "kotlin.io.print":
+			// Re-import of the built-in does not shadow.
+			continue
+		}
+		if i := strings.LastIndex(spec, "."); i >= 0 {
+			markPrintShadow(facts, spec[i+1:])
+		}
+	}
+}
+
+func markPrintShadow(facts *printBuiltinShadowFacts, name string) {
+	switch name {
+	case "println":
+		facts.println = true
+	case "print":
+		facts.print = true
+	}
 }
 
 func printlnNonProductionPath(path string) bool {

--- a/internal/rules/release_engineering_test.go
+++ b/internal/rules/release_engineering_test.go
@@ -1503,6 +1503,126 @@ fun logIt() {
 	}
 }
 
+// TestPrintlnInProduction_SkipsShadowedBareCalls verifies that the rule
+// no longer reports bare `println(...)` calls when a same-file
+// declaration or import could resolve them to a user-defined symbol
+// instead of kotlin.io.println. Each case constructs the minimum source
+// that the pre-fix code would have flagged.
+func TestPrintlnInProduction_SkipsShadowedBareCalls(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		code string
+	}{
+		{
+			name: "top-level fun println shadows builtin",
+			code: `
+package test
+
+fun println(label: String): String = label
+
+fun usesShadowed() {
+    val recorded = println("ignored")
+    require(recorded.isNotEmpty())
+}
+`,
+		},
+		{
+			name: "member fun println shadows for bare call inside class",
+			code: `
+package test
+
+class Reporter {
+    fun println(label: String): String = label
+    fun emit() {
+        val recorded = println("ignored")
+        require(recorded.isNotEmpty())
+    }
+}
+`,
+		},
+		{
+			name: "local fun println shadows in enclosing scope",
+			code: `
+package test
+
+fun emit() {
+    fun println(label: String): String = label
+    val recorded = println("ignored")
+    require(recorded.isNotEmpty())
+}
+`,
+		},
+		{
+			name: "non-kotlin.io import of println shadows builtin",
+			code: `
+package test
+
+import com.example.io.println
+
+fun emit() {
+    val recorded = println("ignored")
+    require(recorded.isNotEmpty())
+}
+
+fun com.example.io.println(label: String): String = label
+`,
+		},
+		{
+			name: "import alias mapped to println shadows builtin",
+			code: `
+package test
+
+import com.example.io.write as println
+
+fun emit() {
+    val recorded = println("ignored")
+    require(recorded.isNotEmpty())
+}
+
+fun com.example.io.write(label: String): String = label
+`,
+		},
+		{
+			name: "top-level fun print shadows builtin print",
+			code: `
+package test
+
+fun print(label: String): String = label
+
+fun emit() {
+    val recorded = print("ignored")
+    require(recorded.isNotEmpty())
+}
+`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			findings := runRuleByName(t, "PrintlnInProduction", tc.code)
+			if len(findings) != 0 {
+				t.Fatalf("expected 0 findings, got %d: %v", len(findings), findings)
+			}
+		})
+	}
+}
+
+// TestPrintlnInProduction_ExplicitKotlinIoImportStillFlags ensures that
+// the shadow check does NOT swallow a legitimate finding when the file
+// only re-imports the kotlin.io built-in.
+func TestPrintlnInProduction_ExplicitKotlinIoImportStillFlags(t *testing.T) {
+	findings := runRuleByName(t, "PrintlnInProduction", `
+package test
+
+import kotlin.io.println
+
+fun emit() {
+    println("debug")
+}
+`)
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding (re-import of builtin should not shadow), got %d: %v", len(findings), findings)
+	}
+}
+
 func TestPrintStackTraceInProduction(t *testing.T) {
 	rule := buildRuleIndex()["PrintStackTraceInProduction"]
 	if rule == nil {

--- a/tests/fixtures/negative/release-engineering/PrintlnInProduction.kt
+++ b/tests/fixtures/negative/release-engineering/PrintlnInProduction.kt
@@ -3,3 +3,15 @@ package com.example.releaseengineering
 fun main() {
     println("script entry point")
 }
+
+// Bare `println(...)` resolves to a same-file top-level declaration
+// rather than kotlin.io.println, so the rule must not flag it. Member-
+// and local-function shadowing cases are exercised by direct unit tests
+// rather than fixture files: the fixture harness ties one rule per
+// .kt file, so we can only express one shadowing flavour here.
+fun println(label: String): String = label
+
+fun usesShadowed() {
+    val recorded = println("ignored: shadowed by the top-level fun above")
+    require(recorded.isNotEmpty())
+}


### PR DESCRIPTION
## Root cause

`isProductionPrintCallFlat` returned `receiver == ""` for any bare-receiver call named `println` or `print`, which mis-fired on any file that shadowed the built-in with its own declaration or import. A top-level `fun println(...)`, a member `fun println(...)` called from inside its class, a local `fun println(...)` nested in another function, or an `import some.pkg.println` (or `import some.pkg.write as println`) all resolve before `kotlin.io.println` — but the rule was reporting them as production logging violations.

## Fix

Before reporting a bare-call site, consult per-file facts that:

1. Walk the file's `function_declaration` nodes once for a same-name declaration at any scope (top-level, member, or local).
2. Scan the import header for a same-name terminal segment or `as` alias.

An explicit `import kotlin.io.println` re-imports the built-in and does **not** shadow. The result is memoized via `filefacts.FileFact` so a file with many bare println/print sites pays the AST walk and import scan once total per file, not once per call_expression — important because the dispatcher invokes the rule check per matching call.

## Test plan

- [x] `TestPrintlnInProduction_SkipsShadowedBareCalls` — top-level, member, local, raw import, alias, and `print` (not `println`) shadow variants. All six subtests fail on the pre-fix code.
- [x] `TestPrintlnInProduction_ExplicitKotlinIoImportStillFlags` — explicit `import kotlin.io.println` must still be treated as the built-in.
- [x] Negative fixture extended with a top-level `fun println(...)` shadow case so the fixture harness exercises the same regression.
- [x] Pre-existing tests (`TestPrintlnInProduction_FlagsBareAndSystemPrints`, `TestPrintlnInProduction_IgnoresGradleAndCustomReceivers`, `TestPrintlnInProduction_StructuralReceiver`) still pass.
- [x] `go build`, `go vet`, `golangci-lint run ./...` (0 issues), `go test ./internal/rules/ -count=1`, `go test ./... -count=1` all clean.