### PR TITLE
fix(rules): skip comment text when detecting embedded private keys

### DIFF
--- a/internal/rules/android.go
+++ b/internal/rules/android.go
@@ -384,9 +384,12 @@ func (r *PrivateKeyRule) Confidence() float64 { return 0.75 }
 
 func (r *PrivateKeyRule) check(ctx *api.Context) {
 	file := ctx.File
+	var st lineScanState
 	for i, line := range file.Lines {
-		if strings.Contains(line, "BEGIN RSA PRIVATE KEY") || strings.Contains(line, "BEGIN PRIVATE KEY") ||
-			strings.Contains(line, "BEGIN EC PRIVATE KEY") {
+		scrubbed := stripCommentsKeepStrings(line, &st)
+		if strings.Contains(scrubbed, "BEGIN RSA PRIVATE KEY") ||
+			strings.Contains(scrubbed, "BEGIN PRIVATE KEY") ||
+			strings.Contains(scrubbed, "BEGIN EC PRIVATE KEY") {
 			ctx.Emit(r.Finding(file, i+1, 1,
 				"Private key detected in source code. Remove and use secure key storage."))
 		}

--- a/internal/rules/android_base_test.go
+++ b/internal/rules/android_base_test.go
@@ -500,6 +500,94 @@ val key = KeyStore.getInstance("AndroidKeyStore")
 	}
 }
 
+// TestPackagedPrivateKey_IgnoresKeyMarkerInComments confirms that the
+// rule no longer reports private-key markers that appear only inside
+// line comments, block comments, or KDoc — those are documentation, not
+// embedded secrets. Each case fails on the pre-fix `strings.Contains`
+// implementation.
+func TestPackagedPrivateKey_IgnoresKeyMarkerInComments(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		code string
+	}{
+		{
+			name: "line comment mentions key marker",
+			code: `
+package test
+
+// Example header format: -----BEGIN RSA PRIVATE KEY-----
+val keystoreAlias = "AndroidKeyStore"
+`,
+		},
+		{
+			name: "single-line block comment mentions key marker",
+			code: `
+package test
+
+/* The PEM payload starts with -----BEGIN PRIVATE KEY----- */
+val keystoreAlias = "AndroidKeyStore"
+`,
+		},
+		{
+			name: "multi-line block comment mentions key marker",
+			code: `
+package test
+
+/*
+ * Documentation:
+ *   -----BEGIN EC PRIVATE KEY-----
+ *   <base64 here>
+ *   -----END EC PRIVATE KEY-----
+ */
+val keystoreAlias = "AndroidKeyStore"
+`,
+		},
+		{
+			name: "kdoc mentions key marker",
+			code: `
+package test
+
+/**
+ * Loads a key whose PEM header is -----BEGIN RSA PRIVATE KEY-----.
+ */
+fun load(): String = "AndroidKeyStore"
+`,
+		},
+		{
+			name: "trailing line comment after code mentions key marker",
+			code: `
+package test
+
+val keystoreAlias = "AndroidKeyStore" // headers like -----BEGIN PRIVATE KEY----- are PEM
+`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			findings := runRuleByName(t, "PackagedPrivateKey", tc.code)
+			if len(findings) != 0 {
+				t.Fatalf("expected 0 findings, got %d: %v", len(findings), findings)
+			}
+		})
+	}
+}
+
+// TestPackagedPrivateKey_FlagsKeyInRawString locks in that triple-quoted
+// raw strings — a natural place to paste a real PEM block — still
+// trigger the rule on every line that contains a header marker.
+func TestPackagedPrivateKey_FlagsKeyInRawString(t *testing.T) {
+	findings := runRuleByName(t, "PackagedPrivateKey", "\n"+`package test
+
+val key = """
+    -----BEGIN RSA PRIVATE KEY-----
+    MIIEowIBAAKCAQEA...
+    -----END RSA PRIVATE KEY-----
+""".trimIndent()
+`)
+	if len(findings) == 0 {
+		t.Fatal("expected at least 1 finding for raw-string PEM block")
+	}
+}
+
 // --- ObsoleteLayoutParamsRule (ObsoleteLayoutParam) ---
 
 func TestObsoleteLayoutParam_Positive(t *testing.T) {

--- a/internal/rules/complexity.go
+++ b/internal/rules/complexity.go
@@ -352,7 +352,7 @@ type lineScanState struct {
 // raw-string state — occurrences inside comments or regular strings are
 // ignored.
 func scanLineState(line string, st *lineScanState) {
-	scanLineLexical(line, st, nil)
+	scanLineLexical(line, st, nil, true)
 }
 
 // stripCommentsAndRawStrings returns a copy of `line` where every byte
@@ -387,102 +387,145 @@ func stripCommentsAndRawStrings(line string, st *lineScanState) string {
 		return line
 	}
 	out := []byte(line)
-	scanLineLexical(line, st, out)
+	scanLineLexical(line, st, out, true)
 	return string(out)
 }
 
-// scanLineLexical is the shared body of scanLineState and
-// stripCommentsAndRawStrings. It advances `st` across `line` and, when
-// `mask` is non-nil, overwrites every byte that falls inside a line
-// comment, block comment, or raw string with a space. Regular `"..."`
-// strings advance the lexer's state (so `\"` and inner `"` are handled
-// correctly) but their bytes are never masked.
-func scanLineLexical(line string, st *lineScanState, mask []byte) {
-	i := 0
+// stripCommentsKeepStrings is the sibling of stripCommentsAndRawStrings
+// for rules whose patterns may legitimately appear inside both regular
+// and raw string literals (e.g. a private-key marker pasted into a
+// triple-quoted string). It masks only line-comment and block-comment
+// bytes; regular and raw string bytes are preserved verbatim. Length
+// preservation and state semantics match the other helper.
+func stripCommentsKeepStrings(line string, st *lineScanState) string {
+	if line == "" {
+		return ""
+	}
+	if !st.inBlockComment &&
+		!strings.Contains(line, "//") &&
+		!strings.Contains(line, "/*") {
+		// Lex still has to advance for the in-line content (raw and
+		// regular string toggles), so any raw string that opens on this
+		// line is recorded for the next call. No bytes are masked.
+		scanLineLexical(line, st, nil, false)
+		return line
+	}
+	out := []byte(line)
+	scanLineLexical(line, st, out, false)
+	return string(out)
+}
+
+// scanLineLexical is the shared body of scanLineState and the
+// stripComments* helpers. It advances `st` across `line` and, when
+// `mask` is non-nil, overwrites every byte that falls inside a line or
+// block comment with a space. Raw `"""..."""` strings are also masked
+// when `maskRaw` is true; otherwise their bytes are preserved (the lex
+// still advances `st.inRawString`). Regular `"..."` strings advance
+// the lexer's state (so `\"` and inner `"` are handled correctly) but
+// their bytes are never masked.
+func scanLineLexical(line string, st *lineScanState, mask []byte, maskRaw bool) {
 	n := len(line)
 	inLineComment := false
 	inRegString := false
-	scrub := func(j int) {
-		if mask != nil {
-			mask[j] = ' '
-		}
-	}
-	for i < n {
-		if inLineComment {
+	for i := 0; i < n; {
+		switch {
+		case inLineComment:
 			if mask == nil {
 				return
 			}
-			scrub(i)
+			mask[i] = ' '
 			i++
-			continue
+		case st.inBlockComment:
+			i = lexAdvanceBlockComment(line, i, n, st, mask)
+		case st.inRawString:
+			i = lexAdvanceRawString(line, i, n, st, mask, maskRaw)
+		case inRegString:
+			i, inRegString = lexAdvanceRegString(line, i, n)
+		default:
+			i, inLineComment, inRegString = lexAdvanceCodePos(
+				line, i, n, st, mask, maskRaw, inRegString)
 		}
-		if st.inBlockComment {
-			if i+1 < n && line[i] == '*' && line[i+1] == '/' {
-				scrub(i)
-				scrub(i + 1)
-				st.inBlockComment = false
-				i += 2
-				continue
-			}
-			scrub(i)
-			i++
-			continue
+	}
+}
+
+// lexAdvanceBlockComment masks the current byte (and the closing `*/`
+// when present) and returns the next index. Caller ensures we are
+// inside a block comment.
+func lexAdvanceBlockComment(line string, i, n int, st *lineScanState, mask []byte) int {
+	if i+1 < n && line[i] == '*' && line[i+1] == '/' {
+		maskByte(mask, i)
+		maskByte(mask, i+1)
+		st.inBlockComment = false
+		return i + 2
+	}
+	maskByte(mask, i)
+	return i + 1
+}
+
+// lexAdvanceRawString masks (when maskRaw is true) the current raw-
+// string byte and the closing `"""` when present. Caller ensures we
+// are inside a raw string.
+func lexAdvanceRawString(line string, i, n int, st *lineScanState, mask []byte, maskRaw bool) int {
+	if i+2 < n && line[i] == '"' && line[i+1] == '"' && line[i+2] == '"' {
+		if maskRaw {
+			maskByte(mask, i)
+			maskByte(mask, i+1)
+			maskByte(mask, i+2)
 		}
-		if st.inRawString {
-			if i+2 < n && line[i] == '"' && line[i+1] == '"' && line[i+2] == '"' {
-				scrub(i)
-				scrub(i + 1)
-				scrub(i + 2)
-				st.inRawString = false
-				i += 3
-				continue
-			}
-			scrub(i)
-			i++
-			continue
+		st.inRawString = false
+		return i + 3
+	}
+	if maskRaw {
+		maskByte(mask, i)
+	}
+	return i + 1
+}
+
+// lexAdvanceRegString advances past one byte inside a regular `"..."`
+// string, honouring `\"` escapes and the closing `"`.
+func lexAdvanceRegString(line string, i, n int) (int, bool) {
+	if line[i] == '\\' && i+1 < n {
+		return i + 2, true
+	}
+	if line[i] == '"' {
+		return i + 1, false
+	}
+	return i + 1, true
+}
+
+// lexAdvanceCodePos consumes one code-position byte and returns the
+// new index plus the updated `inLineComment` and `inRegString` flags.
+// State transitions (`//`, `/*`, `"""`, `"`) are recognized here.
+func lexAdvanceCodePos(line string, i, n int, st *lineScanState, mask []byte, maskRaw, inRegString bool) (int, bool, bool) {
+	if i+1 < n && line[i] == '/' && line[i+1] == '/' {
+		maskByte(mask, i)
+		maskByte(mask, i+1)
+		return i + 2, true, inRegString
+	}
+	if i+1 < n && line[i] == '/' && line[i+1] == '*' {
+		st.inBlockComment = true
+		maskByte(mask, i)
+		maskByte(mask, i+1)
+		return i + 2, false, inRegString
+	}
+	if i+2 < n && line[i] == '"' && line[i+1] == '"' && line[i+2] == '"' {
+		st.inRawString = true
+		if maskRaw {
+			maskByte(mask, i)
+			maskByte(mask, i+1)
+			maskByte(mask, i+2)
 		}
-		if inRegString {
-			if line[i] == '\\' && i+1 < n {
-				i += 2
-				continue
-			}
-			if line[i] == '"' {
-				inRegString = false
-				i++
-				continue
-			}
-			i++
-			continue
-		}
-		// Code position.
-		if i+1 < n && line[i] == '/' && line[i+1] == '/' {
-			inLineComment = true
-			scrub(i)
-			scrub(i + 1)
-			i += 2
-			continue
-		}
-		if i+1 < n && line[i] == '/' && line[i+1] == '*' {
-			st.inBlockComment = true
-			scrub(i)
-			scrub(i + 1)
-			i += 2
-			continue
-		}
-		if i+2 < n && line[i] == '"' && line[i+1] == '"' && line[i+2] == '"' {
-			st.inRawString = true
-			scrub(i)
-			scrub(i + 1)
-			scrub(i + 2)
-			i += 3
-			continue
-		}
-		if line[i] == '"' {
-			inRegString = true
-			i++
-			continue
-		}
-		i++
+		return i + 3, false, inRegString
+	}
+	if line[i] == '"' {
+		return i + 1, false, true
+	}
+	return i + 1, false, inRegString
+}
+
+func maskByte(mask []byte, i int) {
+	if mask != nil {
+		mask[i] = ' '
 	}
 }
 

--- a/internal/rules/complexity_internal_test.go
+++ b/internal/rules/complexity_internal_test.go
@@ -2,6 +2,7 @@ package rules
 
 import (
 	"regexp"
+	"strings"
 	"testing"
 )
 
@@ -116,8 +117,9 @@ func TestStripCommentsAndRawStrings_PreservesCodeAndMasksNonCode(t *testing.T) {
 }
 
 // TestScanLineStateMatchesStrip ensures the original scanLineState advance
-// path used by complexity rules stays in sync with the new shared lexer
-// body. Drift would silently corrupt LongMethod and friends.
+// path used by complexity rules stays in sync with the shared lexer
+// body across both strip variants. Drift would silently corrupt
+// LongMethod and friends.
 func TestScanLineStateMatchesStrip(t *testing.T) {
 	lines := []string{
 		`fun f() {`,
@@ -129,13 +131,107 @@ func TestScanLineStateMatchesStrip(t *testing.T) {
 		`    val r = "regular \"quoted\" string"`,
 		`}`,
 	}
-	var stripState lineScanState
+	var rawStripState lineScanState
+	var keepStripState lineScanState
 	var scanState lineScanState
 	for i, line := range lines {
-		_ = stripCommentsAndRawStrings(line, &stripState)
+		_ = stripCommentsAndRawStrings(line, &rawStripState)
+		_ = stripCommentsKeepStrings(line, &keepStripState)
 		scanLineState(line, &scanState)
-		if stripState != scanState {
-			t.Fatalf("line %d (%q): state drift: strip=%+v scan=%+v", i, line, stripState, scanState)
+		if rawStripState != scanState {
+			t.Fatalf("line %d (%q): state drift between stripCommentsAndRawStrings and scanLineState: strip=%+v scan=%+v", i, line, rawStripState, scanState)
 		}
+		if keepStripState != scanState {
+			t.Fatalf("line %d (%q): state drift between stripCommentsKeepStrings and scanLineState: strip=%+v scan=%+v", i, line, keepStripState, scanState)
+		}
+	}
+}
+
+// TestStripCommentsKeepStrings_MasksOnlyComments locks in that the
+// keep-strings variant scrubs line- and block-comment bytes while
+// leaving regular and raw string bytes verbatim, which is what
+// PackagedPrivateKey and similar rules require to detect markers
+// pasted into PEM-style string literals.
+func TestStripCommentsKeepStrings_MasksOnlyComments(t *testing.T) {
+	cases := []struct {
+		name      string
+		lines     []string
+		marker    string // must appear in scrubbed output where expected
+		expectOn  []int  // 0-based lines that must still contain marker
+		expectOff []int  // 0-based lines that must NOT contain marker
+	}{
+		{
+			name: "marker in line comment is masked",
+			lines: []string{
+				`// header: -----BEGIN RSA PRIVATE KEY-----`,
+				`val key = "-----BEGIN RSA PRIVATE KEY-----..."`,
+			},
+			marker:    "BEGIN RSA PRIVATE KEY",
+			expectOn:  []int{1},
+			expectOff: []int{0},
+		},
+		{
+			name: "marker in block comment is masked",
+			lines: []string{
+				`/* -----BEGIN PRIVATE KEY----- example */`,
+				`val key = "-----BEGIN PRIVATE KEY-----..."`,
+			},
+			marker:    "BEGIN PRIVATE KEY",
+			expectOn:  []int{1},
+			expectOff: []int{0},
+		},
+		{
+			name: "marker in multi-line block comment is masked across lines",
+			lines: []string{
+				`/*`,
+				` * -----BEGIN EC PRIVATE KEY-----`,
+				` */`,
+				`val key = "-----BEGIN EC PRIVATE KEY-----..."`,
+			},
+			marker:    "BEGIN EC PRIVATE KEY",
+			expectOn:  []int{3},
+			expectOff: []int{1},
+		},
+		{
+			name: "marker in raw string is preserved",
+			lines: []string{
+				`val key = """`,
+				`-----BEGIN RSA PRIVATE KEY-----`,
+				`"""`,
+			},
+			marker:   "BEGIN RSA PRIVATE KEY",
+			expectOn: []int{1},
+		},
+		{
+			name: "marker in regular string is preserved",
+			lines: []string{
+				`val key = "-----BEGIN RSA PRIVATE KEY-----..."`,
+			},
+			marker:   "BEGIN RSA PRIVATE KEY",
+			expectOn: []int{0},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var st lineScanState
+			scrubbed := make([]string, len(tc.lines))
+			for i, line := range tc.lines {
+				out := stripCommentsKeepStrings(line, &st)
+				if len(out) != len(line) {
+					t.Fatalf("line %d: scrubbed length %d != input length %d", i, len(out), len(line))
+				}
+				scrubbed[i] = out
+			}
+			for _, idx := range tc.expectOn {
+				if !strings.Contains(scrubbed[idx], tc.marker) {
+					t.Fatalf("line %d: expected marker %q to remain in scrubbed %q", idx, tc.marker, scrubbed[idx])
+				}
+			}
+			for _, idx := range tc.expectOff {
+				if strings.Contains(scrubbed[idx], tc.marker) {
+					t.Fatalf("line %d: expected marker %q to be masked, but it survived in %q", idx, tc.marker, scrubbed[idx])
+				}
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Root cause

`PrivateKeyRule.check` ran `strings.Contains` on each raw line looking for `-----BEGIN RSA PRIVATE KEY-----`, `-----BEGIN PRIVATE KEY-----`, or `-----BEGIN EC PRIVATE KEY-----`. Any line, block, or KDoc comment that mentioned the PEM header — for example a brief `// Documentation: -----BEGIN EC PRIVATE KEY-----` — produced a PackagedPrivateKey finding even though there was no real key in code.

## Fix

Add `stripCommentsKeepStrings(line, st)` next to the existing `stripCommentsAndRawStrings`. It masks line- and block-comment bytes while leaving both regular and raw string contents verbatim, which is what this rule needs: a real key pasted into a `String` constant or a `"""..."""` raw string still has to be flagged.

The shared lexer body gains a `maskRaw bool` flag; the existing helper passes `true` and behaves exactly as before. To keep the lexer under `gocyclo`'s 20 threshold, the per-state advance was split into small helpers (`lexAdvanceBlockComment`, `lexAdvanceRawString`, `lexAdvanceRegString`, `lexAdvanceCodePos`).

## Test plan

- [x] `TestPackagedPrivateKey_IgnoresKeyMarkerInComments` — line comment, single-line block comment, multi-line block comment, KDoc, and trailing-line-comment shapes. All five subtests fail on the pre-fix `strings.Contains` path.
- [x] `TestPackagedPrivateKey_FlagsKeyInRawString` — PEM block pasted into a `"""..."""` raw string still triggers the rule.
- [x] `TestStripCommentsKeepStrings_MasksOnlyComments` — direct unit test on the new helper.
- [x] `TestScanLineStateMatchesStrip` extended so both strip variants must stay in lock-step with `scanLineState`.
- [x] `go build`, `go vet`, `golangci-lint run ./...` (0 issues), `go test ./internal/rules/ -count=1` all clean.