### PR TITLE
fix(rules): stop MdcPutNoRemove scope walk at lambdas and local funs

### DIFF
--- a/internal/rules/flat_node.go
+++ b/internal/rules/flat_node.go
@@ -24,6 +24,57 @@ func flatEnclosingFunction(file *scanner.File, idx uint32) (uint32, bool) {
 	return flatEnclosingAncestor(file, idx, "function_declaration")
 }
 
+// localScopeBoundaryTypes lists node types that begin a new local
+// execution context. A walker that wants to inspect only the same
+// synchronous scope as `root` should refuse to descend into these
+// subtrees:
+//
+//   - function_declaration: nested local funs run only when called.
+//   - lambda_literal / anonymous_function: bodies run when invoked,
+//     often on a different thread (coroutine builders, callbacks).
+//   - class_declaration / object_declaration: nested type bodies and
+//     `object : I { ... }` expressions execute their member code on
+//     method invocation, not as part of the enclosing function.
+//
+// Sibling constructs that DO share the enclosing function's frame
+// (init/`anonymous_initializer`, `secondary_constructor` calls into
+// the primary, property getters/setters reachable through expressions)
+// are intentionally absent so an in-scope cleanup is still seen.
+var localScopeBoundaryTypes = map[string]struct{}{
+	"function_declaration": {},
+	"lambda_literal":       {},
+	"anonymous_function":   {},
+	"class_declaration":    {},
+	"object_declaration":   {},
+}
+
+// flatWalkLocalScope visits every descendant of `root` that lives in
+// the same local scope as `root` itself, stopping at any node listed
+// in localScopeBoundaryTypes. The callback is invoked for `root` and
+// for each in-scope descendant in pre-order. Use when a rule needs to
+// reason about the synchronous execution of a function body — e.g.
+// MDC.put/clear/remove pairing — without being misled by clean-up
+// calls inside coroutine builders, callbacks, or local helper
+// functions whose execution context is unknown.
+func flatWalkLocalScope(file *scanner.File, root uint32, fn func(uint32)) {
+	if file == nil || file.FlatTree == nil || root == 0 || fn == nil {
+		return
+	}
+	var walk func(uint32)
+	walk = func(idx uint32) {
+		if idx != root {
+			if _, isBoundary := localScopeBoundaryTypes[file.FlatType(idx)]; isBoundary {
+				return
+			}
+		}
+		fn(idx)
+		for child := file.FlatFirstChild(idx); child != 0; child = file.FlatNextSib(child) {
+			walk(child)
+		}
+	}
+	walk(root)
+}
+
 func flatLastNamedChild(file *scanner.File, idx uint32) uint32 {
 	if file == nil || idx == 0 || file.FlatNamedChildCount(idx) == 0 {
 		return 0

--- a/internal/rules/logging.go
+++ b/internal/rules/logging.go
@@ -1501,14 +1501,20 @@ func mdcStaticKeyFlat(file *scanner.File, call uint32) (string, bool) {
 }
 
 // mdcRemoveOrClearMatchesFlat reports whether `fn`'s body contains an
-// MDC.remove(key) for the given key, or an MDC.clear() call. When the key is
-// not a static literal, any MDC.remove(...) call counts as a match.
+// MDC.remove(key) for the given key, or an MDC.clear() call, within
+// the same synchronous scope as the matching MDC.put. Calls that live
+// inside a nested lambda, anonymous function, or local class/object —
+// e.g. `launch { MDC.clear() }` — execute on a different thread or
+// at a different time and do not actually clean up the put we paired
+// against, so flatWalkLocalScope stops at those boundaries. When the
+// key is not a static literal, any in-scope MDC.remove(...) call
+// counts as a match.
 func mdcRemoveOrClearMatchesFlat(file *scanner.File, fn uint32, key string, keyKnown bool) bool {
 	if file == nil || fn == 0 {
 		return false
 	}
 	matched := false
-	file.FlatWalkAllNodes(fn, func(candidate uint32) {
+	flatWalkLocalScope(file, fn, func(candidate uint32) {
 		if matched {
 			return
 		}

--- a/internal/rules/observability_test.go
+++ b/internal/rules/observability_test.go
@@ -2161,3 +2161,114 @@ fun ping(logger: Logger, a: Int, b: Int) {
 		t.Fatalf("expected 0 findings on numeric concat outside arg, got %d: %v", len(findings), findings)
 	}
 }
+
+// TestMdcPutNoRemove_StopsAtLocalScopeBoundaries verifies that
+// MDC.clear() or MDC.remove() inside a nested lambda, local function,
+// or anonymous object is NOT treated as a matching cleanup for an
+// MDC.put on the enclosing function — those bodies run at a different
+// time or on a different thread, so the MDC value still leaks out of
+// the put's scope.
+func TestMdcPutNoRemove_StopsAtLocalScopeBoundaries(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		code string
+		want int
+	}{
+		{
+			name: "clear inside coroutine launch lambda does not match",
+			code: `
+package test
+
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
+import org.slf4j.MDC
+
+fun emit(req: String) {
+    MDC.put("reqId", req)
+    GlobalScope.launch {
+        MDC.clear()
+    }
+}
+`,
+			want: 1,
+		},
+		{
+			name: "remove inside nested local fun does not match",
+			code: `
+package test
+
+import org.slf4j.MDC
+
+fun emit(req: String) {
+    MDC.put("reqId", req)
+    fun cleanup() {
+        MDC.remove("reqId")
+    }
+}
+`,
+			want: 1,
+		},
+		{
+			name: "clear inside anonymous object does not match",
+			code: `
+package test
+
+import org.slf4j.MDC
+
+interface Hook {
+    fun run()
+}
+
+fun emit(req: String) {
+    MDC.put("reqId", req)
+    val hook = object : Hook {
+        override fun run() {
+            MDC.clear()
+        }
+    }
+    hook.run()
+}
+`,
+			want: 1,
+		},
+		{
+			name: "remove in same scope still matches",
+			code: `
+package test
+
+import org.slf4j.MDC
+
+fun emit(req: String) {
+    MDC.put("reqId", req)
+    try {
+        // ...
+    } finally {
+        MDC.remove("reqId")
+    }
+}
+`,
+			want: 0,
+		},
+		{
+			name: "clear in same scope still matches",
+			code: `
+package test
+
+import org.slf4j.MDC
+
+fun emit(req: String) {
+    MDC.put("reqId", req)
+    MDC.clear()
+}
+`,
+			want: 0,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			findings := runRuleByName(t, "MdcPutNoRemove", tc.code)
+			if len(findings) != tc.want {
+				t.Fatalf("expected %d findings, got %d: %v", tc.want, len(findings), findings)
+			}
+		})
+	}
+}

--- a/tests/fixtures/positive/observability/MdcPutNoRemove.kt
+++ b/tests/fixtures/positive/observability/MdcPutNoRemove.kt
@@ -1,5 +1,7 @@
 package observability
 
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
 import org.slf4j.MDC
 
 data class Request(val id: String)
@@ -11,4 +13,30 @@ fun process(req: Request) {
 fun handle(req: Request) {
     MDC.put("reqId", req.id)
     process(req)
+}
+
+// The MDC.clear() call below lives inside a coroutine builder lambda,
+// which runs on a different thread/time than the caller. A scope-blind
+// walker would treat it as a matching cleanup and silently swallow the
+// real leak. The scope-aware walker stops at the lambda boundary so
+// this function is still flagged.
+fun handleLeaksAcrossLambda(req: Request) {
+    MDC.put("reqId", req.id)
+    GlobalScope.launch {
+        process(req)
+        MDC.clear()
+    }
+}
+
+// Same shape with MDC.remove inside a local helper function rather
+// than a lambda. The helper's body is its own scope and may never be
+// invoked from this function, so the scope-aware walker treats it as
+// a boundary and the put is still flagged as leaking.
+fun handleLeaksAcrossLocalFun(req: Request) {
+    MDC.put("reqId", req.id)
+    fun cleanup() {
+        MDC.remove("reqId")
+    }
+    process(req)
+    // cleanup() is defined but never invoked.
 }


### PR DESCRIPTION
## Root cause

`mdcRemoveOrClearMatchesFlat` used `FlatWalkAllNodes` to look for an `MDC.clear()` or `MDC.remove(key)` inside the function holding the matching `MDC.put`. The walk descended into nested `function_declaration`, `lambda_literal`, `anonymous_function`, `class_declaration`, and `object_declaration` subtrees, so a cleanup call inside a coroutine builder lambda — `launch { MDC.clear() }`, the documented failure mode — silently swallowed the real leak. Local helper funs and anonymous-object members had the same effect.

## Fix

Add `flatWalkLocalScope(file, root, fn)` next to the existing flat-node helpers and route `MdcPutNoRemove` through it. The walker descends in pre-order but refuses to enter nested function bodies, lambda bodies, anonymous functions, and anonymous class/object expressions, so only same-scope cleanup is credited.

`init` blocks, secondary constructors, and property accessors are intentionally absent from the boundary set because they share the enclosing function's MDC stack.

## Test plan

- [x] `TestMdcPutNoRemove_StopsAtLocalScopeBoundaries` — three new failure shapes (coroutine launch lambda, nested local fun, anonymous object). All three subtests fail on the pre-fix code.
- [x] Same test also locks in two confirmation cases (same-scope `MDC.remove` and `MDC.clear` still match).
- [x] Positive fixture extended with `handleLeaksAcrossLambda` and `handleLeaksAcrossLocalFun` for end-to-end coverage.
- [x] `go build`, `go vet`, `golangci-lint run ./...` (0 issues), `go test ./internal/rules/ -count=1` all clean.