### PR TITLE
fix(rules): require single-arg call shape in callBoolArgIsTrue

### DIFF
--- a/internal/rules/android_webview_allow_file_access.go
+++ b/internal/rules/android_webview_allow_file_access.go
@@ -32,14 +32,19 @@ func (r *WebViewAllowFileAccessRule) check(ctx *api.Context) {
 	})
 }
 
-// callBoolArgIsTrue reports whether the first argument of a call (Kotlin
-// call_expression or Java method_invocation) is the literal `true` after
-// unwrapping parentheses.
+// callBoolArgIsTrue reports whether `call` is a single-argument call
+// (Kotlin call_expression or Java method_invocation) whose only
+// argument is the literal `true` after unwrapping parentheses. Every
+// WebSettings rule that consumes this helper targets a Setter with
+// exactly one boolean parameter (`setAllowFileAccess(boolean)` and
+// friends), so insisting on arity-1 here avoids fooling the rules
+// with a same-named multi-arg overload like
+// `setAllowFileAccess(domain, true)`.
 func callBoolArgIsTrue(file *scanner.File, call uint32) bool {
 	switch file.FlatType(call) {
 	case "call_expression":
 		_, args := flatCallExpressionParts(file, call)
-		if args == 0 {
+		if args == 0 || file.FlatNamedChildCount(args) != 1 {
 			return false
 		}
 		first := file.FlatNamedChild(args, 0)
@@ -59,7 +64,7 @@ func callBoolArgIsTrue(file *scanner.File, call uint32) bool {
 		if !ok {
 			return false
 		}
-		if file.FlatNamedChildCount(args) == 0 {
+		if file.FlatNamedChildCount(args) != 1 {
 			return false
 		}
 		first := file.FlatNamedChild(args, 0)

--- a/internal/rules/android_webview_allow_file_access_test.go
+++ b/internal/rules/android_webview_allow_file_access_test.go
@@ -114,3 +114,52 @@ fun describe(): String = "webView.settings.setAllowFileAccess(true)"
 		t.Fatalf("expected 0 findings, got %d: %v", len(findings), findings)
 	}
 }
+
+// TestWebViewAllowFileAccess_NegativeMultiArgOverload locks in the
+// callBoolArgIsTrue arity check: a same-named custom 2-arg method that
+// happens to pass `true` as its second argument must not be reported
+// as an Android WebSettings violation. The pre-fix helper only looked
+// at the first argument, so a call like `setAllowFileAccess(domain,
+// true)` would not fire — but a flipped-argument call
+// `setAllowFileAccess(true, domain)` on a WebSettings-like receiver
+// would. Requiring arity == 1 closes both forms.
+func TestWebViewAllowFileAccess_NegativeMultiArgOverload(t *testing.T) {
+	findings := runRuleByName(t, "WebViewAllowFileAccess", `
+import android.webkit.WebSettings
+import android.webkit.WebView
+
+// A custom WebSettings-shaped wrapper with a multi-arg overload.
+class WebSettingsWrapper {
+    var settings: WebSettingsWrapper = this
+    fun setAllowFileAccess(value: Boolean, audit: String) {}
+}
+
+fun configure(webView: WebView, settings: WebSettingsWrapper) {
+    settings.setAllowFileAccess(true, "audit-tag")
+}
+`)
+	if len(findings) != 0 {
+		t.Fatalf("expected 0 findings on multi-arg overload, got %d: %v", len(findings), findings)
+	}
+}
+
+func TestWebViewAllowFileAccess_JavaNegativeMultiArgOverload(t *testing.T) {
+	findings := runRuleByNameOnJava(t, "WebViewAllowFileAccess", `
+import android.webkit.WebSettings;
+import android.webkit.WebView;
+
+class WebSettingsWrapper {
+    public WebSettingsWrapper getSettings() { return this; }
+    public void setAllowFileAccess(boolean value, String audit) {}
+}
+
+class Page {
+    void bind(WebSettingsWrapper s) {
+        s.getSettings().setAllowFileAccess(true, "audit-tag");
+    }
+}
+`)
+	if len(findings) != 0 {
+		t.Fatalf("expected 0 Java findings on multi-arg overload, got %d: %v", len(findings), findings)
+	}
+}


### PR DESCRIPTION
## Root cause

`callBoolArgIsTrue` only inspected the first argument, so a same-named multi-arg call like `setAllowFileAccess(true, "audit")` on a WebSettings-shaped receiver matched even though the real Android setter has a single boolean parameter. Five WebView rules (`WebViewAllowFileAccess`, `WebViewAllowFileAccessFromFileURLs`, `WebViewUniversalAccessFromFileURLs`, `WebContentsDebuggingEnabled`, and the shared `WebSettings` toggle dispatch) all relied on this helper, so any custom multi-arg overload risked a false positive.

## Fix

Tighten `callBoolArgIsTrue` to require exactly one named argument in both the Kotlin and Java paths before accepting the literal-`true` check. Existing call sites already verify the call name and the WebSettings-like receiver, so adding the arity guard adds defense in depth without changing real-Android behaviour.

## Test plan

- [x] `TestWebViewAllowFileAccess_NegativeMultiArgOverload` (Kotlin) and `TestWebViewAllowFileAccess_JavaNegativeMultiArgOverload` (Java) construct a custom WebSettings-shaped receiver with a 2-arg `setAllowFileAccess(value, audit)` method and call it with `true` as the first argument. Both subtests fire one false-positive on the pre-fix code and pass with the arity check in place.
- [x] Pre-existing positive and negative cases still pass.
- [x] `go build`, `go vet`, `golangci-lint run ./...` (0 issues), `go test ./internal/rules/ -count=1` all clean.