### PR TITLE
fix(rules): track block-comment state in CopyrightYearOutdated header walk

### DIFF
--- a/internal/rules/licensing.go
+++ b/internal/rules/licensing.go
@@ -131,17 +131,25 @@ func (r *CopyrightYearOutdatedRule) Confidence() float64 { return 0.75 }
 
 func (r *CopyrightYearOutdatedRule) check(ctx *api.Context) {
 	file := ctx.File
+	var st lineScanState
 	for i, line := range file.Lines {
+		// Snapshot state at the START of this line: a `/*` block opened
+		// on a previous line keeps us inside the header even when the
+		// continuation lines have no `*` decoration.
+		insideBlockComment := st.inBlockComment
+
 		trimmed := strings.TrimSpace(line)
 		if trimmed == "" {
+			scanLineState(line, &st)
 			continue
 		}
-		if !isHeaderCommentLine(trimmed) {
+		if !insideBlockComment && !isHeaderCommentLine(trimmed) {
 			break
 		}
 
 		match := copyrightHeaderYearRe.FindStringSubmatchIndex(line)
 		if match == nil {
+			scanLineState(line, &st)
 			continue
 		}
 

--- a/internal/rules/licensing_test.go
+++ b/internal/rules/licensing_test.go
@@ -27,6 +27,90 @@ fun currentFeature() = 42
 	}
 }
 
+// TestCopyrightYearOutdated_BlockCommentContinuationLines verifies that
+// continuation lines inside a `/* ... */` header — including lines
+// that have no `*` decoration — are still scanned for outdated
+// copyright years. The pre-fix logic relied on the leading-character
+// heuristic alone, so the first un-decorated continuation line
+// broke out of the loop and the outdated year went undetected.
+func TestCopyrightYearOutdated_BlockCommentContinuationLines(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		code string
+		want int
+	}{
+		{
+			name: "continuation line without star prefix",
+			code: `
+/*
+Copyright (c) 2018 Krit Authors
+*/
+package test
+
+fun currentFeature() = 42
+`,
+			want: 1,
+		},
+		{
+			name: "continuation line indented but no star",
+			code: `
+/*
+  Copyright 2018 Example Corp
+*/
+package test
+
+fun currentFeature() = 42
+`,
+			want: 1,
+		},
+		{
+			name: "blank line inside block then bare copyright",
+			code: `
+/*
+
+Copyright 2018 Example Corp
+
+*/
+package test
+
+fun currentFeature() = 42
+`,
+			want: 1,
+		},
+		{
+			name: "current year in unstarred continuation does not fire",
+			code: `
+/*
+Copyright 2025 Example Corp
+*/
+package test
+
+fun currentFeature() = 42
+`,
+			want: 0,
+		},
+		{
+			name: "code after closed block does not fire",
+			code: `
+/*
+License: MIT
+*/
+package test
+
+val s = "Copyright 2018 used as data, not a header"
+`,
+			want: 0,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			findings := runRuleByName(t, "CopyrightYearOutdated", tc.code)
+			if len(findings) != tc.want {
+				t.Fatalf("expected %d findings, got %d: %v", tc.want, len(findings), findings)
+			}
+		})
+	}
+}
+
 func TestCopyrightYearOutdated_Negative(t *testing.T) {
 	findings := runRuleByName(t, "CopyrightYearOutdated", `
 /*


### PR DESCRIPTION
## Root cause

`CopyrightYearOutdatedRule.check` decided whether a line was still part of the leading file header by checking only that the trimmed text started with `//`, `/*`, `*`, or `*/`. A block-comment continuation line without an explicit `*` decoration — e.g.

    /*
    Copyright (c) 2018 Krit Authors
    */

fails the heuristic, breaks out of the loop, and the outdated year is never seen. The same pattern hides outdated years separated from `/*` by a blank line or by a continuation that drops the asterisk.

## Fix

Maintain a `lineScanState` while iterating header lines so the walk knows when we are *inside* a `/* ... */` block opened on an earlier line. Lines that are already inside an open block comment are always treated as header lines; only lines that aren't inside a block AND fail `isHeaderCommentLine` break the loop. Body code after the header still ends the walk, so `val s = "Copyright 2018"` in real code doesn't mis-fire.

## Test plan

- [x] `TestCopyrightYearOutdated_BlockCommentContinuationLines` — three positive regression shapes (un-decorated continuation, indented continuation, blank-line + bare line). All three fail on the pre-fix logic and pass after.
- [x] Two confirmation subtests (current year still no-fire, post-header code still no-fire).
- [x] Pre-existing `TestCopyrightYearOutdated_Positive` / `_Negative` still pass.
- [x] `go build`, `go vet`, `golangci-lint run ./...` (0 issues), `go test ./internal/rules/ -count=1` all clean.