### PR TITLE
fix(scanner): correct suppression range semantics around EndByte

### DIFF
--- a/internal/scanner/suppress.go
+++ b/internal/scanner/suppress.go
@@ -314,25 +314,35 @@ func (idx *SuppressionIndex) isSuppressedWithAliases(byteOffset int, ruleName, r
 		return false
 	}
 
-	// Binary search for the rightmost suppression starting at or before byteOffset
+	// Binary search for the rightmost suppression starting at or before byteOffset.
 	i := sort.Search(len(idx.suppressions), func(i int) bool {
 		return idx.suppressions[i].StartByte > byteOffset
 	})
 
-	// Check all suppressions that could contain this offset (walk backwards)
+	// Walk every candidate (StartByte <= byteOffset) and keep the ones
+	// whose range still contains the offset. The suppression interval is
+	// [StartByte, EndByte) — tree-sitter reports the byte one past the
+	// last byte of the node — so a finding at byteOffset == EndByte is
+	// past the annotation's scope and must not be suppressed.
+	//
+	// We cannot break early when one suppression's EndByte is at or
+	// before byteOffset: the list is sorted by StartByte ascending, and
+	// an earlier-listed (outer) suppression can have a larger EndByte
+	// than this nested one. For example, a `@file:Suppress(...)`
+	// covering the whole file appears before an inner `@Suppress(...)`
+	// on a function; a finding past the function but still inside the
+	// file must still see the file-level suppression.
 	for j := i - 1; j >= 0; j-- {
 		s := idx.suppressions[j]
-		if s.EndByte < byteOffset {
-			break // past this suppression's range
+		if byteOffset >= s.EndByte {
+			continue
 		}
-		if byteOffset >= s.StartByte && byteOffset <= s.EndByte {
-			if suppressionMatches(s.Rules, ruleName, ruleSetName) {
+		if suppressionMatches(s.Rules, ruleName, ruleSetName) {
+			return true
+		}
+		for _, alias := range aliases {
+			if suppressionMatches(s.Rules, alias, ruleSetName) {
 				return true
-			}
-			for _, alias := range aliases {
-				if suppressionMatches(s.Rules, alias, ruleSetName) {
-					return true
-				}
 			}
 		}
 	}

--- a/internal/scanner/suppress_test.go
+++ b/internal/scanner/suppress_test.go
@@ -276,6 +276,79 @@ fun foo() {
 	}
 }
 
+// TestIsSuppressed_ExclusiveEndBoundary verifies that the suppression
+// range is treated as [StartByte, EndByte) — matching tree-sitter's
+// convention where EndByte is one past the last byte of the node. A
+// finding whose byte offset coincides with a suppression's EndByte
+// is past the annotation's scope and must NOT be suppressed.
+func TestIsSuppressed_ExclusiveEndBoundary(t *testing.T) {
+	src := `@Suppress("MagicNumber")
+fun foo() {
+    val x = 42
+}
+val y = 99
+`
+	root, content := parseKotlin(t, src)
+	idx := BuildSuppressionIndex(root, content)
+
+	if len(idx.suppressions) != 1 {
+		t.Fatalf("expected 1 suppression, got %d", len(idx.suppressions))
+	}
+	s := idx.suppressions[0]
+
+	// Boundary: the EndByte byte itself is past the annotation target.
+	if idx.IsSuppressed(s.EndByte, "MagicNumber", "") {
+		t.Errorf("byteOffset == EndByte (%d) must not be suppressed", s.EndByte)
+	}
+	// One byte before the end is still inside.
+	if !idx.IsSuppressed(s.EndByte-1, "MagicNumber", "") {
+		t.Errorf("byteOffset == EndByte-1 (%d) must still be suppressed", s.EndByte-1)
+	}
+	// Sanity: a finding past the annotation by a clearly separate value.
+	yOffset := findSubstringOffset(content, "val y = 99")
+	if idx.IsSuppressed(yOffset, "MagicNumber", "") {
+		t.Errorf("finding outside annotation must not be suppressed (offset %d, suppression end %d)", yOffset, s.EndByte)
+	}
+}
+
+// TestIsSuppressed_OuterFileLevelStillAppliesPastInner verifies that a
+// finding past an inner @Suppress(...) annotation still sees an outer
+// @file:Suppress(...) covering the entire file. The pre-fix code broke
+// out of the suppression-walk loop on the first nested suppression
+// whose EndByte was less than the finding's offset, missing the outer
+// file-level suppression (which is sorted earlier by StartByte but has
+// a larger EndByte).
+func TestIsSuppressed_OuterFileLevelStillAppliesPastInner(t *testing.T) {
+	src := `@file:Suppress("OuterRule")
+
+@Suppress("InnerRule")
+fun foo() {
+    val x = 42
+}
+
+val y = 99
+`
+	root, content := parseKotlin(t, src)
+	idx := BuildSuppressionIndex(root, content)
+
+	if len(idx.suppressions) < 2 {
+		t.Fatalf("expected at least 2 suppressions (file + function), got %d", len(idx.suppressions))
+	}
+
+	yOffset := findSubstringOffset(content, "val y = 99")
+	if yOffset < 0 {
+		t.Fatal("could not find 'val y = 99' in source")
+	}
+
+	if !idx.IsSuppressed(yOffset, "OuterRule", "") {
+		t.Error("expected file-level OuterRule suppression to apply past the inner function annotation")
+	}
+	// Sanity: InnerRule is only suppressed inside fun foo, not at val y.
+	if idx.IsSuppressed(yOffset, "InnerRule", "") {
+		t.Error("InnerRule should not be suppressed past its function annotation")
+	}
+}
+
 // findSubstringOffset returns the byte offset of the first occurrence of sub in content, or -1.
 func findSubstringOffset(content []byte, sub string) int {
 	s := string(content)


### PR DESCRIPTION
## Root cause

`SuppressionIndex.isSuppressedWithAliases` treated each suppression range as `[StartByte, EndByte]` (inclusive on both sides), but tree-sitter populates `EndByte` as the byte one past the last byte of the annotation target. Two real consequences followed.

1. **Boundary off-by-one.** A finding whose byte offset coincided with a suppression's `EndByte` was incorrectly suppressed. The byte AFTER an annotated `fun {}` is already past the annotation's scope, so a rule firing there should surface — but the inclusive `<=` test silently swallowed it.

2. **Unsound early `break`.** The early `break` on `s.EndByte < byteOffset` assumed suppressions were sorted such that walking past one whose range ends before the offset means earlier ones also end before. The list is actually sorted by `StartByte` ascending, so an outer `@file:Suppress("Rule")` covering the whole file appears before a nested inner `@Suppress(...)` on a function. A finding past the inner function's `}` would hit the inner suppression first, break the loop, and miss the file-level suppression that should still apply.

## Fix

- Treat the range as `[StartByte, EndByte)` to match tree-sitter.
- Replace the unsound `break` with a `continue` so every prior candidate is considered. The binary search still bounds the walk to suppressions whose `StartByte <= byteOffset`.

## Test plan

- [x] `TestIsSuppressed_ExclusiveEndBoundary` — finding at `byteOffset == EndByte` must not be suppressed; `EndByte-1` still is. Fails on the pre-fix `<=` check.
- [x] `TestIsSuppressed_OuterFileLevelStillAppliesPastInner` — `@file:Suppress("OuterRule")` still applies to a finding past a nested `@Suppress("InnerRule")` function. Fails on the pre-fix break.
- [x] All pre-existing `IsSuppressed_*` tests still pass.
- [x] `go test ./... -count=1`, `go vet`, `golangci-lint run ./...` (0 issues) all clean.