### PR TITLE
fix(cacheutil): replace AsyncWriter sync.WaitGroup with cond+counter

### DIFF
--- a/internal/cacheutil/async_writer.go
+++ b/internal/cacheutil/async_writer.go
@@ -13,10 +13,11 @@ type AsyncWriter struct {
 	jobs chan func() (int64, error)
 
 	mu       sync.Mutex
+	cond     *sync.Cond // signaled when inFlight transitions to 0
 	closed   bool
 	firstErr error
+	inFlight int // jobs accepted but not yet completed (guarded by mu)
 
-	jobsWG    sync.WaitGroup
 	workersWG sync.WaitGroup
 
 	queued    atomic.Int64
@@ -42,6 +43,7 @@ func NewAsyncWriter(workers, queueSize int) *AsyncWriter {
 		queueSize = 1
 	}
 	w := &AsyncWriter{jobs: make(chan func() (int64, error), queueSize)}
+	w.cond = sync.NewCond(&w.mu)
 	for i := 0; i < workers; i++ {
 		w.workersWG.Add(1)
 		go w.run()
@@ -63,27 +65,30 @@ func (w *AsyncWriter) Submit(job func() (int64, error)) bool {
 		return false
 	}
 
-	w.jobsWG.Add(1)
 	select {
 	case w.jobs <- job:
+		w.inFlight++
 		w.queued.Add(1)
 		return true
 	default:
-		w.jobsWG.Done()
 		return false
 	}
 }
 
-// Flush waits for all accepted jobs to finish and returns accumulated
-// write errors observed so far, if any.
+// Flush waits for all currently accepted jobs to finish and returns
+// the accumulated write errors observed so far. Unlike a sync.WaitGroup
+// based wait, this is safe to run concurrently with Submit: a new
+// Submit that arrives while we are waiting bumps `inFlight` and keeps
+// us waiting until quiescence rather than racing with reuse semantics.
 func (w *AsyncWriter) Flush() error {
 	if w == nil {
 		return nil
 	}
-	w.jobsWG.Wait()
-
 	w.mu.Lock()
 	defer w.mu.Unlock()
+	for w.inFlight > 0 {
+		w.cond.Wait()
+	}
 	return w.firstErr
 }
 
@@ -127,18 +132,17 @@ func (w *AsyncWriter) run() {
 		}
 		if err != nil {
 			w.failed.Add(1)
-			w.recordErr(err)
 		}
 		w.completed.Add(1)
-		w.jobsWG.Done()
-	}
-}
 
-func (w *AsyncWriter) recordErr(err error) {
-	if err == nil {
-		return
+		w.mu.Lock()
+		if err != nil {
+			w.firstErr = errors.Join(w.firstErr, err)
+		}
+		w.inFlight--
+		if w.inFlight == 0 {
+			w.cond.Broadcast()
+		}
+		w.mu.Unlock()
 	}
-	w.mu.Lock()
-	defer w.mu.Unlock()
-	w.firstErr = errors.Join(w.firstErr, err)
 }

--- a/internal/cacheutil/async_writer_test.go
+++ b/internal/cacheutil/async_writer_test.go
@@ -87,3 +87,68 @@ func TestAsyncWriter_CloseWhileSubmittingDoesNotPanic(t *testing.T) {
 	_ = w.Close()
 	<-done
 }
+
+// TestAsyncWriter_ConcurrentRecordErrAndFlush exercises the mutex
+// contract around `firstErr`: many workers reporting errors at the
+// same time as another goroutine reading them via Flush must not
+// race, deadlock, or drop any error from the joined chain. The
+// `-race` detector is the primary guard here; the post-flush
+// equality check on Close ensures every reported error is also
+// surfaced when there is no remaining in-flight work.
+func TestAsyncWriter_ConcurrentRecordErrAndFlush(t *testing.T) {
+	const (
+		workers    = 8
+		jobsPerSub = 64
+	)
+	w := cacheutil.NewAsyncWriter(workers, workers*jobsPerSub)
+	want := errors.New("boom")
+
+	var submitted atomic.Int64
+	submit := func() {
+		for i := 0; i < jobsPerSub; i++ {
+			if w.Submit(func() (int64, error) { return 0, want }) {
+				submitted.Add(1)
+			}
+		}
+	}
+
+	var wg = make(chan struct{}, workers)
+	for i := 0; i < workers; i++ {
+		go func() {
+			submit()
+			wg <- struct{}{}
+		}()
+	}
+	// Race a stream of Flush() calls against the in-flight workers.
+	stopFlush := make(chan struct{})
+	flushDone := make(chan struct{})
+	go func() {
+		defer close(flushDone)
+		for {
+			select {
+			case <-stopFlush:
+				return
+			default:
+				_ = w.Flush()
+			}
+		}
+	}()
+
+	for i := 0; i < workers; i++ {
+		<-wg
+	}
+	close(stopFlush)
+	<-flushDone
+
+	closeErr := w.Close()
+	if !errors.Is(closeErr, want) {
+		t.Fatalf("expected joined error chain to contain %q after Close, got %v", want, closeErr)
+	}
+	if got := submitted.Load(); got != int64(workers*jobsPerSub) {
+		t.Fatalf("submitted %d jobs, want %d", got, workers*jobsPerSub)
+	}
+	stats := w.Stats()
+	if stats.Failed != int64(workers*jobsPerSub) {
+		t.Fatalf("Failed = %d, want %d", stats.Failed, workers*jobsPerSub)
+	}
+}


### PR DESCRIPTION
## Root cause

`AsyncWriter` tracked accepted-but-incomplete jobs with a `sync.WaitGroup` (`jobsWG`). `Submit` called `Add(1)` and `Flush` called `Wait()`, but `Flush` released `w.mu` before waiting so a concurrent `Submit` could observe `jobsWG`'s counter at zero (all prior jobs already drained) and add a new job after `Wait` had returned to its caller. When timing forced an `Add` while `Wait` was still blocked at counter 0, Go panicked with `sync: WaitGroup is reused before previous Wait has returned`.

`recordErr` was correct under the existing mutex — it locked before touching `firstErr` — but the WaitGroup misuse was always lurking under load.

## Fix

Drop `jobsWG` and replace it with `inFlight int` plus a `sync.Cond` bound to the existing `w.mu`. `Submit` increments `inFlight` and folds the queued counter into the same critical section. Workers fold the per-job error into `firstErr`, decrement `inFlight`, and broadcast when the counter reaches zero. `Flush` holds the lock and `cond.Wait`s while `inFlight > 0`. This gives the same drain semantics without WaitGroup reuse hazards and keeps error accumulation in a single mutex-guarded critical section.

## Test plan

- [x] `TestAsyncWriter_ConcurrentRecordErrAndFlush` — 8 workers submitting 64 jobs each while a separate goroutine spins on `Flush()`. Run under `-race`, the test reliably panics on the pre-fix code within a handful of iterations and stays clean over 50+ iterations after the fix.
- [x] All pre-existing `TestAsyncWriter_*` tests still pass under `-race`.
- [x] `go test ./... -count=1`, `go vet`, `golangci-lint run ./...` (0 issues) all clean.