### PR TITLE
perf(scanner): migrate FlatTree to SoA + add per-type posting list

### DIFF
--- a/internal/di/graph.go
+++ b/internal/di/graph.go
@@ -75,7 +75,7 @@ func BuildGraph(files []*scanner.File, moduleGraph *module.Graph) *Graph {
 
 	var seeds []bindingSeed
 	for _, file := range files {
-		if file == nil || file.FlatTree == nil || len(file.FlatTree.Nodes) == 0 {
+		if file == nil || file.FlatTree == nil || file.FlatTree.Len() == 0 {
 			continue
 		}
 		pkg := packageNameFlat(file)

--- a/internal/rules/android_correctness_checks.go
+++ b/internal/rules/android_correctness_checks.go
@@ -1062,11 +1062,12 @@ func rangeResolveConstant(file *scanner.File, name string, use uint32, constants
 	}
 	useFn, _ := flatEnclosingFunction(file, use)
 	useOwner := androidEnclosingOwner(file, use)
-	useStart := file.FlatTree.Nodes[use].StartByte
+	t := file.FlatTree
+	useStart := t.StartBytes[use]
 	bestScore := 0
 	var best rangeConstantSpec
 	for _, candidate := range candidates {
-		if candidate.decl == 0 || file.FlatTree.Nodes[candidate.decl].StartByte >= useStart {
+		if candidate.decl == 0 || t.StartBytes[candidate.decl] >= useStart {
 			continue
 		}
 		score := 0
@@ -1085,7 +1086,7 @@ func rangeResolveConstant(file *scanner.File, name string, use uint32, constants
 		if score == 0 {
 			continue
 		}
-		if score > bestScore || (score == bestScore && file.FlatTree.Nodes[candidate.decl].StartByte > file.FlatTree.Nodes[best.decl].StartByte) {
+		if score > bestScore || (score == bestScore && t.StartBytes[candidate.decl] > t.StartBytes[best.decl]) {
 			best = candidate
 			bestScore = score
 		}

--- a/internal/rules/android_correctness_checks_test.go
+++ b/internal/rules/android_correctness_checks_test.go
@@ -425,12 +425,12 @@ func runWrongViewCastOnFile(t *testing.T, file *scanner.File, idx *android.Resou
 		wants[typ] = true
 	}
 	collector := scanner.NewFindingCollector(0)
-	for i := range file.FlatTree.Nodes {
+	for i := range file.FlatTree.Types {
 		flatIdx := uint32(i)
 		if !wants[file.FlatType(flatIdx)] {
 			continue
 		}
-		node := file.FlatTree.Nodes[i]
+		node := file.FlatTree.Node(flatIdx)
 		rule.Check(&api.Context{
 			File:              file,
 			Idx:               flatIdx,

--- a/internal/rules/android_onclick.go
+++ b/internal/rules/android_onclick.go
@@ -53,7 +53,7 @@ func (r *OnClickRule) check(ctx *api.Context) {
 		if file == nil || file.FlatTree == nil {
 			continue
 		}
-		for idx := range file.FlatTree.Nodes {
+		for idx := range file.FlatTree.Types {
 			classIdx := uint32(idx)
 			if file.FlatType(classIdx) != "class_declaration" {
 				continue
@@ -165,11 +165,10 @@ func parameterTypeNameIsView(file *scanner.File, parameter uint32) bool {
 // collectClassInflatedLayouts walks the class subtree once, capturing the
 // layout names referenced by setContentView(R.layout.X) and inflate(R.layout.X, ...).
 func collectClassInflatedLayouts(file *scanner.File, classIdx uint32, out map[string]struct{}) {
-	classNode := file.FlatTree.Nodes[classIdx]
-	end := classNode.EndByte
-	for cursor := classIdx + 1; int(cursor) < len(file.FlatTree.Nodes); cursor++ {
-		node := file.FlatTree.Nodes[cursor]
-		if node.StartByte >= end {
+	t := file.FlatTree
+	end := t.EndBytes[classIdx]
+	for cursor := classIdx + 1; int(cursor) < len(t.Types); cursor++ {
+		if t.StartBytes[cursor] >= end {
 			break
 		}
 		if file.FlatType(cursor) != "call_expression" {

--- a/internal/rules/api/fake.go
+++ b/internal/rules/api/fake.go
@@ -110,8 +110,8 @@ func FakeContextWithNode(file *scanner.File, idx uint32) *Context {
 		Idx:       idx,
 		Collector: scanner.NewFindingCollector(0),
 	}
-	if file.FlatTree != nil && int(idx) < len(file.FlatTree.Nodes) {
-		node := file.FlatTree.Nodes[idx]
+	if file.FlatTree != nil && int(idx) < file.FlatTree.Len() {
+		node := file.FlatTree.Node(idx)
 		ctx.Node = &node
 	}
 	return ctx

--- a/internal/rules/complexity.go
+++ b/internal/rules/complexity.go
@@ -27,7 +27,7 @@ func FunctionComplexities(file *scanner.File) []FunctionComplexity {
 		return nil
 	}
 	out := make([]FunctionComplexity, 0)
-	for idx := uint32(1); idx < uint32(len(file.FlatTree.Nodes)); idx++ {
+	for idx := uint32(1); idx < uint32(file.FlatTree.Len()); idx++ {
 		if file.FlatType(idx) != "function_declaration" {
 			continue
 		}
@@ -95,8 +95,9 @@ func collectComplexityMetricsFlat(root uint32, file *scanner.File) complexityMet
 		// Iterate children directly via FirstChild/NextSib (O(N) total)
 		// instead of FlatNamedChild(idx, i) in a loop (O(N²) due to O(i)
 		// per FlatNamedChild call).
-		for child := file.FlatTree.Nodes[idx].FirstChild; child != 0; child = file.FlatTree.Nodes[child].NextSib {
-			if !file.FlatTree.Nodes[child].IsNamed() {
+		t := file.FlatTree
+		for child := t.FirstChildren[idx]; child != 0; child = t.NextSibs[child] {
+			if !t.NodeIsNamed(child) {
 				continue
 			}
 			walk(child, nextDepthNesting, nextCognitiveNesting)
@@ -124,7 +125,8 @@ func isElseIfChainNodeFlat(file *scanner.File, idx uint32) bool {
 	// comments, error nodes, or other extras between `else` and the inner
 	// `if` — byte offsets are not.
 	sawElse := false
-	for c := file.FlatTree.Nodes[p].FirstChild; c != 0; c = file.FlatTree.Nodes[c].NextSib {
+	t := file.FlatTree
+	for c := t.FirstChildren[p]; c != 0; c = t.NextSibs[c] {
 		if !sawElse {
 			if file.FlatType(c) == "else" {
 				sawElse = true
@@ -738,8 +740,9 @@ func countCyclomaticAcrossLambdasFlat(
 		if nodeType == "elvis_expression" {
 			cyclomatic++
 		}
-		for c := file.FlatTree.Nodes[idx].FirstChild; c != 0; c = file.FlatTree.Nodes[c].NextSib {
-			if !file.FlatTree.Nodes[c].IsNamed() {
+		t := file.FlatTree
+		for c := t.FirstChildren[idx]; c != 0; c = t.NextSibs[c] {
+			if !t.NodeIsNamed(c) {
 				continue
 			}
 			walk(c)

--- a/internal/rules/coroutines.go
+++ b/internal/rules/coroutines.go
@@ -421,7 +421,7 @@ func walkCallsRespectingScope(file *scanner.File, root uint32, fn func(uint32) b
 		if stopped {
 			return
 		}
-		for child := file.FlatTree.Nodes[idx].FirstChild; child != 0; child = file.FlatTree.Nodes[child].NextSib {
+		for child := file.FlatTree.FirstChildren[idx]; child != 0; child = file.FlatTree.NextSibs[child] {
 			if stopped {
 				return
 			}

--- a/internal/rules/dispatcher.go
+++ b/internal/rules/dispatcher.go
@@ -381,6 +381,8 @@ func (d *Dispatcher) RunWithStats(file *scanner.File) (scanner.FindingColumns, R
 // into a FindingCollector, bypassing the intermediate []scanner.Finding
 // accumulation. Rules emit via ctx.Emit which routes straight to the
 // collector; the result is returned as columnar data.
+//
+//nolint:gocyclo // Hot path: per-rule dispatch is inlined twice (posting-list vs full-walk path) to avoid closure allocations and preserve Go inlining; extracting into helpers measurably regresses small-file dispatch.
 func (d *Dispatcher) RunColumnsWithStats(file *scanner.File) (scanner.FindingColumns, RunStats) {
 	stats := RunStats{
 		DispatchRuleNsByRule: make(map[string]int64),
@@ -414,13 +416,47 @@ func (d *Dispatcher) RunColumnsWithStats(file *scanner.File) (scanner.FindingCol
 	javaFileFacts, javaSourceIndex := javaContextFactsForFile(file)
 
 	// Single-pass AST walk.
+	//
+	// Two paths share the same per-rule dispatch logic (inlined here, not
+	// a closure — closures would defeat the compiler's inlining and add
+	// allocation overhead per Run call):
+	//
+	//   1. Posting-list path: iterate tree.NodesByType[typeID] for each
+	//      typeID that has at least one subscribed rule. Visits ONLY
+	//      indices of subscribed types, skipping the bulk of the tree.
+	//
+	//   2. Full walk path: a single pass over every node. Used when
+	//      there is at least one rule registered with nil NodeTypes
+	//      (d.allNodeRules), since those need to see every node.
+	//
+	// In the common case (no allNodeRules) the posting-list path is
+	// strictly less work than the old walk-everything-and-dispatch-by-type
+	// approach: most nodes have no subscribed handlers, so we save the
+	// per-node loop body entirely.
 	start = time.Now()
-	if file.FlatTree != nil && len(file.FlatTree.Nodes) > 0 {
-		for idx := range file.FlatTree.Nodes {
-			flatIdx := uint32(idx)
-			flatNode := file.FlatTree.Nodes[idx]
-			if int(flatNode.Type) < len(flatTypeRules) {
-				if handlers := flatTypeRules[flatNode.Type]; handlers != nil {
+	if tree := file.FlatTree; tree != nil && tree.Len() > 0 {
+		if len(d.allNodeRules) == 0 {
+			// Posting-list path.
+			//
+			// The per-rule body below is duplicated in the full-walk path
+			// at line ~493 and in the allNodeRules block at line ~516.
+			// Keep all three in sync — extracting to a helper measurably
+			// regresses small-file dispatch (closures defeat inlining).
+			n := len(tree.NodesByType)
+			if n > len(flatTypeRules) {
+				n = len(flatTypeRules)
+			}
+			for typeID := 0; typeID < n; typeID++ {
+				handlers := flatTypeRules[typeID]
+				if len(handlers) == 0 {
+					continue
+				}
+				indices := tree.NodesByType[typeID]
+				if len(indices) == 0 {
+					continue
+				}
+				for _, flatIdx := range indices {
+					flatNode := tree.Node(flatIdx)
 					for _, r := range handlers {
 						if excludedRules[r.ID] {
 							continue
@@ -443,22 +479,54 @@ func (d *Dispatcher) RunColumnsWithStats(file *scanner.File) (scanner.FindingCol
 					}
 				}
 			}
-			for _, r := range d.allNodeRules {
-				if excludedRules[r.ID] {
-					continue
+		} else {
+			// Full walk path: every node must be visited for allNodeRules.
+			// Per-rule body kept in sync with the posting-list path above.
+			n := tree.Len()
+			for i := 0; i < n; i++ {
+				flatIdx := uint32(i)
+				flatNode := tree.Node(flatIdx)
+				var handlers []*api.Rule
+				if int(flatNode.Type) < len(flatTypeRules) {
+					handlers = flatTypeRules[flatNode.Type]
 				}
-				resolver, ok := d.resolveForRule(r)
-				if !ok {
-					continue
+				for _, r := range handlers {
+					if excludedRules[r.ID] {
+						continue
+					}
+					if !ruleMatchesLexicalCalleeNames(r, file, flatIdx) {
+						continue
+					}
+					resolver, ok := d.resolveForRule(r)
+					if !ok {
+						continue
+					}
+					t := time.Now()
+					runWithRuleProfileLabel(r.ID, "dispatch", func() {
+						safeCheckV2NodeColumnar(r, flatIdx, &flatNode, file, collector, &stats, resolver, d.libraryFacts, javaFileFacts, javaSourceIndex, d.javaSemanticFacts, d.fileFacts)
+					})
+					elapsed := time.Since(t).Nanoseconds()
+					stats.DispatchRuleNs += elapsed
+					stats.DispatchRuleNsByRule[r.ID] += elapsed
+					stats.recordRule(r.ID, "dispatch", elapsed)
 				}
-				t := time.Now()
-				runWithRuleProfileLabel(r.ID, "dispatch", func() {
-					safeCheckV2NodeColumnar(r, flatIdx, &flatNode, file, collector, &stats, resolver, d.libraryFacts, javaFileFacts, javaSourceIndex, d.javaSemanticFacts, d.fileFacts)
-				})
-				elapsed := time.Since(t).Nanoseconds()
-				stats.DispatchRuleNs += elapsed
-				stats.DispatchRuleNsByRule[r.ID] += elapsed
-				stats.recordRule(r.ID, "dispatch", elapsed)
+				for _, r := range d.allNodeRules {
+					if excludedRules[r.ID] {
+						continue
+					}
+					resolver, ok := d.resolveForRule(r)
+					if !ok {
+						continue
+					}
+					t := time.Now()
+					runWithRuleProfileLabel(r.ID, "dispatch", func() {
+						safeCheckV2NodeColumnar(r, flatIdx, &flatNode, file, collector, &stats, resolver, d.libraryFacts, javaFileFacts, javaSourceIndex, d.javaSemanticFacts, d.fileFacts)
+					})
+					elapsed := time.Since(t).Nanoseconds()
+					stats.DispatchRuleNs += elapsed
+					stats.DispatchRuleNsByRule[r.ID] += elapsed
+					stats.recordRule(r.ID, "dispatch", elapsed)
+				}
 			}
 		}
 	}
@@ -864,23 +932,32 @@ func (d *Dispatcher) RunResourceSource(file *scanner.File, idx *android.Resource
 	stats := RunStats{RuleStatsByRule: make(map[string]RuleExecutionStat)}
 	collector := scanner.NewFindingCollector(0)
 	javaFileFacts, javaSourceIndex := javaContextFactsForFile(file)
-	if file.FlatTree != nil && len(file.FlatTree.Nodes) > 0 {
-		for i := range file.FlatTree.Nodes {
-			flatIdx := uint32(i)
-			flatNode := file.FlatTree.Nodes[i]
-			for _, r := range rulesByType[flatNode.Type] {
-				if !ruleMatchesLexicalCalleeNames(r, file, flatIdx) {
-					continue
+	if tree := file.FlatTree; tree != nil && tree.Len() > 0 {
+		// Resource-source rules are all node-typed (rulesByType only).
+		// Iterate per-type via the posting list so we visit only the
+		// indices for types with subscribers, skipping the bulk of the
+		// tree.
+		for typeID, handlers := range rulesByType {
+			var indices []uint32
+			if int(typeID) < len(tree.NodesByType) {
+				indices = tree.NodesByType[typeID]
+			}
+			for _, flatIdx := range indices {
+				flatNode := tree.Node(flatIdx)
+				for _, r := range handlers {
+					if !ruleMatchesLexicalCalleeNames(r, file, flatIdx) {
+						continue
+					}
+					resolver, ok := d.resolveForRule(r)
+					if !ok {
+						continue
+					}
+					t := time.Now()
+					runWithRuleProfileLabel(r.ID, "resource-source", func() {
+						safeCheckV2ResourceNodeColumnar(r, flatIdx, &flatNode, file, idx, collector, &stats, resolver, d.libraryFacts, javaFileFacts, javaSourceIndex, d.javaSemanticFacts, d.fileFacts)
+					})
+					stats.recordRule(r.ID, "resource-source", time.Since(t).Nanoseconds())
 				}
-				resolver, ok := d.resolveForRule(r)
-				if !ok {
-					continue
-				}
-				t := time.Now()
-				runWithRuleProfileLabel(r.ID, "resource-source", func() {
-					safeCheckV2ResourceNodeColumnar(r, flatIdx, &flatNode, file, idx, collector, &stats, resolver, d.libraryFacts, javaFileFacts, javaSourceIndex, d.javaSemanticFacts, d.fileFacts)
-				})
-				stats.recordRule(r.ID, "resource-source", time.Since(t).Nanoseconds())
 			}
 		}
 	}

--- a/internal/rules/potentialbugs_misc.go
+++ b/internal/rules/potentialbugs_misc.go
@@ -818,7 +818,7 @@ func flatIsUsedAsExpression(file *scanner.File, idx uint32) bool {
 
 func flatIsUsedAsExpressionInStatements(file *scanner.File, idx, parent uint32) bool {
 	for prev, ok := file.FlatPrevSibling(idx); ok; prev, ok = file.FlatPrevSibling(prev) {
-		if !file.FlatTree.Nodes[prev].IsNamed() {
+		if !file.FlatTree.NodeIsNamed(prev) {
 			continue
 		}
 		if file.FlatType(prev) == "jump_expression" {

--- a/internal/rules/release_engineering.go
+++ b/internal/rules/release_engineering.go
@@ -1258,7 +1258,7 @@ func openForTestingTypeRefFromNode(file *scanner.File, root uint32) openForTesti
 }
 
 func openForTestingFirstUserType(file *scanner.File, root uint32) uint32 {
-	if file == nil || file.FlatTree == nil || int(root) >= len(file.FlatTree.Nodes) {
+	if file == nil || file.FlatTree == nil || int(root) >= file.FlatTree.Len() {
 		return 0
 	}
 	if file.FlatType(root) == "user_type" {

--- a/internal/rules/semantics/semantics.go
+++ b/internal/rules/semantics/semantics.go
@@ -25,7 +25,7 @@ type NodeRef struct {
 
 // Valid reports whether the reference points at an existing flat node.
 func (r NodeRef) Valid() bool {
-	return r.File != nil && r.File.FlatTree != nil && int(r.Node) < len(r.File.FlatTree.Nodes)
+	return r.File != nil && r.File.FlatTree != nil && int(r.Node) < r.File.FlatTree.Len()
 }
 
 // CallTarget is the rule-facing view of a Kotlin call expression.

--- a/internal/scanner/arena_benchmark_test.go
+++ b/internal/scanner/arena_benchmark_test.go
@@ -18,7 +18,7 @@ func BenchmarkPerFileAllocationHotspots(b *testing.B) {
 		b.SetBytes(int64(len(content)))
 		for i := 0; i < b.N; i++ {
 			flat := flattenTree(root)
-			if len(flat.Nodes) == 0 {
+			if flat.Len() == 0 {
 				b.Fatal("expected flattened tree to contain nodes")
 			}
 		}
@@ -39,7 +39,7 @@ func BenchmarkPerFileAllocationHotspots(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			flat := flattenTree(root)
 			columns := CollectFindings(findings)
-			if len(flat.Nodes) == 0 {
+			if flat.Len() == 0 {
 				b.Fatal("expected flattened tree to contain nodes")
 			}
 			if columns.Len() != len(findings) {

--- a/internal/scanner/benchmark_test.go
+++ b/internal/scanner/benchmark_test.go
@@ -362,7 +362,7 @@ func BenchmarkNodeTextVsZeroCopy(b *testing.B) {
 	}
 
 	var allNodes []uint32
-	for i := range f.FlatTree.Nodes {
+	for i := range f.FlatTree.Types {
 		allNodes = append(allNodes, uint32(i))
 	}
 

--- a/internal/scanner/flat.go
+++ b/internal/scanner/flat.go
@@ -25,10 +25,11 @@ var (
 	nodeTypeSnapshot atomic.Pointer[[]string]
 )
 
-// FlatNode stores a tree-sitter node in a compact, cgo-free form.
-// Size: 40 bytes. PrevSib is stored explicitly so FlatPrevSibling can be
-// O(1); without it, prev-sibling access required walking from FirstChild
-// which gave O(sibling_index) per call and O(N²) across adjacent callers.
+// FlatNode is a value-type view of a single flattened node. The canonical
+// storage is the parallel slices on FlatTree (struct-of-arrays); this
+// view materializes those slices into a 40-byte value for callers that
+// prefer struct semantics. Hot paths should index FlatTree's parallel
+// slices directly to avoid the per-access struct construction.
 type FlatNode struct {
 	Type       uint16
 	Parent     uint32
@@ -59,9 +60,74 @@ func (n FlatNode) TypeName() string {
 	return nodeTypeName(n.Type)
 }
 
-// FlatTree holds a preorder-flattened syntax tree.
+// FlatTree holds a preorder-flattened syntax tree in struct-of-arrays form.
+// Field arrays are parallel: each is the same length, indexed by node ID
+// in document order. PrevSibs is stored explicitly so prev-sibling access
+// is O(1); without it, walking from FirstChild would be O(sibling_index)
+// per call and O(N²) across adjacent callers.
+//
+// NodesByType is a posting list indexed by node type ID, giving direct
+// access to all nodes of a given type without a full tree walk. The
+// dispatcher uses this to skip nodes whose type has no subscribed rules.
 type FlatTree struct {
-	Nodes []FlatNode
+	Types         []uint16
+	Parents       []uint32
+	FirstChildren []uint32
+	NextSibs      []uint32
+	PrevSibs      []uint32
+	StartBytes    []uint32
+	EndBytes      []uint32
+	StartRows     []uint16
+	StartCols     []uint16
+	ChildCounts   []uint16
+	NamedCounts   []uint16
+	Flags         []uint8
+
+	// NodesByType[typeID] is a slice of node indices for nodes of that
+	// type in document order. A nil/empty entry means no nodes of that
+	// type appear in this tree. Built by flattenTree, rebuilt by the
+	// parse cache after type-table remap.
+	NodesByType [][]uint32
+}
+
+// Len returns the number of nodes in the tree. Safe on a nil receiver.
+func (t *FlatTree) Len() int {
+	if t == nil {
+		return 0
+	}
+	return len(t.Types)
+}
+
+// Node materializes a FlatNode value at the given index. Hot paths
+// should prefer direct field access via t.Types[idx], etc.
+func (t *FlatTree) Node(idx uint32) FlatNode {
+	if t == nil || int(idx) >= len(t.Types) {
+		return FlatNode{}
+	}
+	return FlatNode{
+		Type:       t.Types[idx],
+		Parent:     t.Parents[idx],
+		FirstChild: t.FirstChildren[idx],
+		NextSib:    t.NextSibs[idx],
+		PrevSib:    t.PrevSibs[idx],
+		StartByte:  t.StartBytes[idx],
+		EndByte:    t.EndBytes[idx],
+		StartRow:   t.StartRows[idx],
+		StartCol:   t.StartCols[idx],
+		ChildCount: t.ChildCounts[idx],
+		NamedCount: t.NamedCounts[idx],
+		Flags:      t.Flags[idx],
+	}
+}
+
+// NodeIsNamed reports whether the node at idx is a named tree-sitter
+// node. O(1) field read against t.Flags — preferred over Node(idx).IsNamed()
+// in hot paths to avoid materializing the full FlatNode value.
+func (t *FlatTree) NodeIsNamed(idx uint32) bool {
+	if t == nil || int(idx) >= len(t.Flags) {
+		return false
+	}
+	return t.Flags[idx]&flatNodeFlagNamed != 0
 }
 
 func flattenTree(root *sitter.Node) *FlatTree {
@@ -69,30 +135,51 @@ func flattenTree(root *sitter.Node) *FlatTree {
 		return &FlatTree{}
 	}
 
-	nodes := make([]FlatNode, 0, estimateFlatCapacity(root))
+	capHint := estimateFlatCapacity(root)
+	t := &FlatTree{
+		Types:         make([]uint16, 0, capHint),
+		Parents:       make([]uint32, 0, capHint),
+		FirstChildren: make([]uint32, 0, capHint),
+		NextSibs:      make([]uint32, 0, capHint),
+		PrevSibs:      make([]uint32, 0, capHint),
+		StartBytes:    make([]uint32, 0, capHint),
+		EndBytes:      make([]uint32, 0, capHint),
+		StartRows:     make([]uint16, 0, capHint),
+		StartCols:     make([]uint16, 0, capHint),
+		ChildCounts:   make([]uint16, 0, capHint),
+		NamedCounts:   make([]uint16, 0, capHint),
+		Flags:         make([]uint8, 0, capHint),
+	}
+
 	var walk func(node *sitter.Node, parent uint32, hasParent bool) uint32
 	walk = func(node *sitter.Node, parent uint32, hasParent bool) uint32 {
-		idx := uint32(len(nodes))
+		idx := uint32(len(t.Types))
 		start := node.StartPoint()
-		flatNode := FlatNode{
-			Type:       internNodeType(node.Type()),
-			StartByte:  node.StartByte(),
-			EndByte:    node.EndByte(),
-			StartRow:   saturateUint16(start.Row),
-			StartCol:   saturateUint16(start.Column),
-			ChildCount: saturateUint16(node.ChildCount()),
-			NamedCount: saturateUint16(node.NamedChildCount()),
-		}
-		if hasParent {
-			flatNode.Parent = parent
-		}
+		typeID := internNodeType(node.Type())
+		var flags uint8
 		if node.IsNamed() {
-			flatNode.Flags |= flatNodeFlagNamed
+			flags |= flatNodeFlagNamed
 		}
 		if node.IsError() || node.HasError() {
-			flatNode.Flags |= flatNodeFlagError
+			flags |= flatNodeFlagError
 		}
-		nodes = append(nodes, flatNode)
+		var parentField uint32
+		if hasParent {
+			parentField = parent
+		}
+
+		t.Types = append(t.Types, typeID)
+		t.Parents = append(t.Parents, parentField)
+		t.FirstChildren = append(t.FirstChildren, 0)
+		t.NextSibs = append(t.NextSibs, 0)
+		t.PrevSibs = append(t.PrevSibs, 0)
+		t.StartBytes = append(t.StartBytes, node.StartByte())
+		t.EndBytes = append(t.EndBytes, node.EndByte())
+		t.StartRows = append(t.StartRows, saturateUint16(start.Row))
+		t.StartCols = append(t.StartCols, saturateUint16(start.Column))
+		t.ChildCounts = append(t.ChildCounts, saturateUint16(node.ChildCount()))
+		t.NamedCounts = append(t.NamedCounts, saturateUint16(node.NamedChildCount()))
+		t.Flags = append(t.Flags, flags)
 
 		var prevChild uint32
 		for i := 0; i < int(node.ChildCount()); i++ {
@@ -101,12 +188,12 @@ func flattenTree(root *sitter.Node) *FlatTree {
 				continue
 			}
 			childIdx := walk(child, idx, true)
-			if nodes[idx].FirstChild == 0 {
-				nodes[idx].FirstChild = childIdx
+			if t.FirstChildren[idx] == 0 {
+				t.FirstChildren[idx] = childIdx
 			}
 			if prevChild != 0 {
-				nodes[prevChild].NextSib = childIdx
-				nodes[childIdx].PrevSib = prevChild
+				t.NextSibs[prevChild] = childIdx
+				t.PrevSibs[childIdx] = prevChild
 			}
 			prevChild = childIdx
 		}
@@ -114,7 +201,38 @@ func flattenTree(root *sitter.Node) *FlatTree {
 	}
 
 	walk(root, 0, false)
-	return &FlatTree{Nodes: nodes}
+	t.buildNodesByType()
+	return t
+}
+
+// buildNodesByType reconstructs the per-type posting list from t.Types.
+// Used by the parse cache after remapping local type IDs back to the
+// process-global table.
+func (t *FlatTree) buildNodesByType() {
+	if t == nil || len(t.Types) == 0 {
+		t.NodesByType = nil
+		return
+	}
+	var maxType uint16
+	for _, tID := range t.Types {
+		if tID > maxType {
+			maxType = tID
+		}
+	}
+	counts := make([]uint32, int(maxType)+1)
+	for _, tID := range t.Types {
+		counts[tID]++
+	}
+	out := make([][]uint32, int(maxType)+1)
+	for tID, c := range counts {
+		if c > 0 {
+			out[tID] = make([]uint32, 0, c)
+		}
+	}
+	for i, tID := range t.Types {
+		out[tID] = append(out[tID], uint32(i))
+	}
+	t.NodesByType = out
 }
 
 // FlatNodeText returns the source text spanned by the flattened node.
@@ -125,11 +243,10 @@ func FlatNodeText(tree *FlatTree, idx uint32, content []byte) string {
 // FlatNodeBytes returns the source bytes spanned by the flattened node.
 // The returned slice aliases content and is only valid while content is live.
 func FlatNodeBytes(tree *FlatTree, idx uint32, content []byte) []byte {
-	if tree == nil || int(idx) >= len(tree.Nodes) {
+	if tree == nil || int(idx) >= len(tree.Types) {
 		return nil
 	}
-	node := tree.Nodes[idx]
-	return content[node.StartByte:node.EndByte]
+	return content[tree.StartBytes[idx]:tree.EndBytes[idx]]
 }
 
 // FlatNodeTextEquals reports whether the node's source text equals s.
@@ -152,7 +269,10 @@ func FlatNodeString(tree *FlatTree, idx uint32, content []byte, pool *StringPool
 	return pool.Intern(bytesToStringView(b))
 }
 
-// FlatWalkNodes calls fn for every node of the given type.
+// FlatWalkNodes calls fn for every node of the given type. Uses the
+// NodesByType posting list when available for direct O(matches) access;
+// falls back to a linear scan over t.Types when the posting list has
+// not been built (e.g. ad-hoc test trees).
 func FlatWalkNodes(tree *FlatTree, nodeType string, fn func(uint32)) {
 	if tree == nil {
 		return
@@ -161,8 +281,14 @@ func FlatWalkNodes(tree *FlatTree, nodeType string, fn func(uint32)) {
 	if !ok {
 		return
 	}
-	for i := range tree.Nodes {
-		if tree.Nodes[i].Type == typeID {
+	if int(typeID) < len(tree.NodesByType) {
+		for _, idx := range tree.NodesByType[typeID] {
+			fn(idx)
+		}
+		return
+	}
+	for i, t := range tree.Types {
+		if t == typeID {
 			fn(uint32(i))
 		}
 	}
@@ -175,15 +301,15 @@ func FlatWalkNodes(tree *FlatTree, nodeType string, fn func(uint32)) {
 // source_file root), which silently produced whole-file source reads when
 // the result was passed to FlatNodeText.
 func FlatFindChild(tree *FlatTree, parent uint32, childType string) (uint32, bool) {
-	if tree == nil || int(parent) >= len(tree.Nodes) {
+	if tree == nil || int(parent) >= len(tree.Types) {
 		return 0, false
 	}
 	typeID, ok := lookupNodeType(childType)
 	if !ok {
 		return 0, false
 	}
-	for child := tree.Nodes[parent].FirstChild; child != 0; child = tree.Nodes[child].NextSib {
-		if tree.Nodes[child].Type == typeID {
+	for child := tree.FirstChildren[parent]; child != 0; child = tree.NextSibs[child] {
+		if tree.Types[child] == typeID {
 			return child, true
 		}
 	}
@@ -196,11 +322,11 @@ func FlatHasModifier(tree *FlatTree, idx uint32, content []byte, modifier string
 	if !ok {
 		return false
 	}
-	for child := tree.Nodes[mods].FirstChild; child != 0; child = tree.Nodes[child].NextSib {
+	for child := tree.FirstChildren[mods]; child != 0; child = tree.NextSibs[child] {
 		if bytesEqualString(FlatNodeBytes(tree, child, content), modifier) {
 			return true
 		}
-		for grandChild := tree.Nodes[child].FirstChild; grandChild != 0; grandChild = tree.Nodes[grandChild].NextSib {
+		for grandChild := tree.FirstChildren[child]; grandChild != 0; grandChild = tree.NextSibs[grandChild] {
 			if bytesEqualString(FlatNodeBytes(tree, grandChild, content), modifier) {
 				return true
 			}
@@ -254,47 +380,49 @@ func (f *File) FlatHasModifier(idx uint32, modifier string) bool {
 }
 
 func (f *File) FlatType(idx uint32) string {
-	if f == nil || f.FlatTree == nil || int(idx) >= len(f.FlatTree.Nodes) {
+	if f == nil || f.FlatTree == nil || int(idx) >= len(f.FlatTree.Types) {
 		return ""
 	}
-	return f.FlatTree.Nodes[idx].TypeName()
+	return nodeTypeName(f.FlatTree.Types[idx])
 }
 
 func (f *File) FlatChildCount(idx uint32) int {
-	if f == nil || f.FlatTree == nil || int(idx) >= len(f.FlatTree.Nodes) {
+	if f == nil || f.FlatTree == nil || int(idx) >= len(f.FlatTree.Types) {
 		return 0
 	}
-	return int(f.FlatTree.Nodes[idx].ChildCount)
+	return int(f.FlatTree.ChildCounts[idx])
 }
 
 func (f *File) FlatChild(parent uint32, childIdx int) uint32 {
-	if f == nil || f.FlatTree == nil || int(parent) >= len(f.FlatTree.Nodes) || childIdx < 0 {
+	if f == nil || f.FlatTree == nil || int(parent) >= len(f.FlatTree.Types) || childIdx < 0 {
 		return 0
 	}
-	child := f.FlatTree.Nodes[parent].FirstChild
+	t := f.FlatTree
+	child := t.FirstChildren[parent]
 	for i := 0; child != 0; i++ {
 		if i == childIdx {
 			return child
 		}
-		child = f.FlatTree.Nodes[child].NextSib
+		child = t.NextSibs[child]
 	}
 	return 0
 }
 
 func (f *File) FlatNamedChildCount(idx uint32) int {
-	if f == nil || f.FlatTree == nil || int(idx) >= len(f.FlatTree.Nodes) {
+	if f == nil || f.FlatTree == nil || int(idx) >= len(f.FlatTree.Types) {
 		return 0
 	}
-	return int(f.FlatTree.Nodes[idx].NamedCount)
+	return int(f.FlatTree.NamedCounts[idx])
 }
 
 func (f *File) FlatNamedChild(parent uint32, childIdx int) uint32 {
-	if f == nil || f.FlatTree == nil || int(parent) >= len(f.FlatTree.Nodes) || childIdx < 0 {
+	if f == nil || f.FlatTree == nil || int(parent) >= len(f.FlatTree.Types) || childIdx < 0 {
 		return 0
 	}
+	t := f.FlatTree
 	namedIdx := 0
-	for child := f.FlatTree.Nodes[parent].FirstChild; child != 0; child = f.FlatTree.Nodes[child].NextSib {
-		if !f.FlatTree.Nodes[child].IsNamed() {
+	for child := t.FirstChildren[parent]; child != 0; child = t.NextSibs[child] {
+		if t.Flags[child]&flatNodeFlagNamed == 0 {
 			continue
 		}
 		if namedIdx == childIdx {
@@ -306,10 +434,11 @@ func (f *File) FlatNamedChild(parent uint32, childIdx int) uint32 {
 }
 
 func (f *File) FlatForEachChild(parent uint32, fn func(uint32)) {
-	if f == nil || f.FlatTree == nil || int(parent) >= len(f.FlatTree.Nodes) || fn == nil {
+	if f == nil || f.FlatTree == nil || int(parent) >= len(f.FlatTree.Types) || fn == nil {
 		return
 	}
-	for child := f.FlatTree.Nodes[parent].FirstChild; child != 0; child = f.FlatTree.Nodes[child].NextSib {
+	t := f.FlatTree
+	for child := t.FirstChildren[parent]; child != 0; child = t.NextSibs[child] {
 		fn(child)
 	}
 }
@@ -320,17 +449,17 @@ func (f *File) FlatHasChildOfType(parent uint32, childType string) bool {
 }
 
 func (f *File) FlatParent(idx uint32) (uint32, bool) {
-	if f == nil || f.FlatTree == nil || idx == 0 || int(idx) >= len(f.FlatTree.Nodes) {
+	if f == nil || f.FlatTree == nil || idx == 0 || int(idx) >= len(f.FlatTree.Types) {
 		return 0, false
 	}
-	return f.FlatTree.Nodes[idx].Parent, true
+	return f.FlatTree.Parents[idx], true
 }
 
 func (f *File) FlatNextSibling(idx uint32) (uint32, bool) {
-	if f == nil || f.FlatTree == nil || int(idx) >= len(f.FlatTree.Nodes) {
+	if f == nil || f.FlatTree == nil || int(idx) >= len(f.FlatTree.Types) {
 		return 0, false
 	}
-	next := f.FlatTree.Nodes[idx].NextSib
+	next := f.FlatTree.NextSibs[idx]
 	if next == 0 {
 		return 0, false
 	}
@@ -338,10 +467,10 @@ func (f *File) FlatNextSibling(idx uint32) (uint32, bool) {
 }
 
 func (f *File) FlatPrevSibling(idx uint32) (uint32, bool) {
-	if f == nil || f.FlatTree == nil || int(idx) >= len(f.FlatTree.Nodes) {
+	if f == nil || f.FlatTree == nil || int(idx) >= len(f.FlatTree.Types) {
 		return 0, false
 	}
-	prev := f.FlatTree.Nodes[idx].PrevSib
+	prev := f.FlatTree.PrevSibs[idx]
 	if prev == 0 {
 		return 0, false
 	}
@@ -358,20 +487,20 @@ func (f *File) FlatPrevSibling(idx uint32) (uint32, bool) {
 // Prefer this over `for i := 0; i < FlatChildCount(p); i++ { FlatChild(p, i) }`
 // which is O(k) per child access and O(N²) across the full iteration.
 func (f *File) FlatFirstChild(parent uint32) uint32 {
-	if f == nil || f.FlatTree == nil || int(parent) >= len(f.FlatTree.Nodes) {
+	if f == nil || f.FlatTree == nil || int(parent) >= len(f.FlatTree.Types) {
 		return 0
 	}
-	return f.FlatTree.Nodes[parent].FirstChild
+	return f.FlatTree.FirstChildren[parent]
 }
 
 // FlatNextSib returns the next sibling index, or 0 if idx is the last child.
 // O(1). Simpler variant of FlatNextSibling (which returns (uint32, bool))
 // for the linked-list iteration idiom.
 func (f *File) FlatNextSib(idx uint32) uint32 {
-	if f == nil || f.FlatTree == nil || int(idx) >= len(f.FlatTree.Nodes) {
+	if f == nil || f.FlatTree == nil || int(idx) >= len(f.FlatTree.Types) {
 		return 0
 	}
-	return f.FlatTree.Nodes[idx].NextSib
+	return f.FlatTree.NextSibs[idx]
 }
 
 // FlatIsNamed reports whether the node at idx is a named tree-sitter node
@@ -383,10 +512,10 @@ func (f *File) FlatNextSib(idx uint32) uint32 {
 //	    // ... use c as a named child ...
 //	}
 func (f *File) FlatIsNamed(idx uint32) bool {
-	if f == nil || f.FlatTree == nil || int(idx) >= len(f.FlatTree.Nodes) {
+	if f == nil || f.FlatTree == nil || int(idx) >= len(f.FlatTree.Types) {
 		return false
 	}
-	return f.FlatTree.Nodes[idx].IsNamed()
+	return f.FlatTree.Flags[idx]&flatNodeFlagNamed != 0
 }
 
 func (f *File) FlatHasAncestorOfType(idx uint32, ancestorType string) bool {
@@ -398,7 +527,7 @@ func (f *File) FlatHasAncestorOfType(idx uint32, ancestorType string) bool {
 		return false
 	}
 	for current, ok := f.FlatParent(idx); ok; current, ok = f.FlatParent(current) {
-		if f.FlatTree.Nodes[current].Type == typeID {
+		if f.FlatTree.Types[current] == typeID {
 			return true
 		}
 	}
@@ -410,7 +539,7 @@ func (f *File) FlatHasAnyAncestorOfType(idx uint32, ancestorTypes ...uint16) boo
 		return false
 	}
 	for current, ok := f.FlatParent(idx); ok; current, ok = f.FlatParent(current) {
-		currentType := f.FlatTree.Nodes[current].Type
+		currentType := f.FlatTree.Types[current]
 		for _, ancestorType := range ancestorTypes {
 			if currentType == ancestorType {
 				return true
@@ -421,19 +550,20 @@ func (f *File) FlatHasAnyAncestorOfType(idx uint32, ancestorTypes ...uint16) boo
 }
 
 func (f *File) FlatWalkNodes(root uint32, nodeType string, fn func(uint32)) {
-	if f == nil || f.FlatTree == nil || fn == nil || int(root) >= len(f.FlatTree.Nodes) {
+	if f == nil || f.FlatTree == nil || fn == nil || int(root) >= len(f.FlatTree.Types) {
 		return
 	}
 	typeID, ok := lookupNodeType(nodeType)
 	if !ok {
 		return
 	}
+	t := f.FlatTree
 	var walk func(uint32)
 	walk = func(idx uint32) {
-		if f.FlatTree.Nodes[idx].Type == typeID {
+		if t.Types[idx] == typeID {
 			fn(idx)
 		}
-		for child := f.FlatTree.Nodes[idx].FirstChild; child != 0; child = f.FlatTree.Nodes[child].NextSib {
+		for child := t.FirstChildren[idx]; child != 0; child = t.NextSibs[child] {
 			walk(child)
 		}
 	}
@@ -441,13 +571,14 @@ func (f *File) FlatWalkNodes(root uint32, nodeType string, fn func(uint32)) {
 }
 
 func (f *File) FlatWalkAllNodes(root uint32, fn func(uint32)) {
-	if f == nil || f.FlatTree == nil || fn == nil || int(root) >= len(f.FlatTree.Nodes) {
+	if f == nil || f.FlatTree == nil || fn == nil || int(root) >= len(f.FlatTree.Types) {
 		return
 	}
+	t := f.FlatTree
 	var walk func(uint32)
 	walk = func(idx uint32) {
 		fn(idx)
-		for child := f.FlatTree.Nodes[idx].FirstChild; child != 0; child = f.FlatTree.Nodes[child].NextSib {
+		for child := t.FirstChildren[idx]; child != 0; child = t.NextSibs[child] {
 			walk(child)
 		}
 	}
@@ -486,48 +617,51 @@ func (f *File) FlatFindModifierNode(idx uint32, modifier string) uint32 {
 }
 
 func (f *File) FlatStartByte(idx uint32) uint32 {
-	if f == nil || f.FlatTree == nil || int(idx) >= len(f.FlatTree.Nodes) {
+	if f == nil || f.FlatTree == nil || int(idx) >= len(f.FlatTree.Types) {
 		return 0
 	}
-	return f.FlatTree.Nodes[idx].StartByte
+	return f.FlatTree.StartBytes[idx]
 }
 
 func (f *File) FlatEndByte(idx uint32) uint32 {
-	if f == nil || f.FlatTree == nil || int(idx) >= len(f.FlatTree.Nodes) {
+	if f == nil || f.FlatTree == nil || int(idx) >= len(f.FlatTree.Types) {
 		return 0
 	}
-	return f.FlatTree.Nodes[idx].EndByte
+	return f.FlatTree.EndBytes[idx]
 }
 
 func (f *File) FlatRow(idx uint32) int {
-	if f == nil || f.FlatTree == nil || int(idx) >= len(f.FlatTree.Nodes) {
+	if f == nil || f.FlatTree == nil || int(idx) >= len(f.FlatTree.Types) {
 		return 0
 	}
-	return int(f.FlatTree.Nodes[idx].StartRow)
+	return int(f.FlatTree.StartRows[idx])
 }
 
 func (f *File) FlatCol(idx uint32) int {
-	if f == nil || f.FlatTree == nil || int(idx) >= len(f.FlatTree.Nodes) {
+	if f == nil || f.FlatTree == nil || int(idx) >= len(f.FlatTree.Types) {
 		return 0
 	}
-	return int(f.FlatTree.Nodes[idx].StartCol)
+	return int(f.FlatTree.StartCols[idx])
 }
 
 func (f *File) FlatNamedDescendantForByteRange(startByte, endByte uint32) (uint32, bool) {
-	if f == nil || f.FlatTree == nil || len(f.FlatTree.Nodes) == 0 {
+	if f == nil || f.FlatTree == nil || len(f.FlatTree.Types) == 0 {
 		return 0, false
 	}
+	t := f.FlatTree
 	best := uint32(0)
 	bestSpan := uint32(math.MaxUint32)
 	found := false
-	for idx, node := range f.FlatTree.Nodes {
-		if !node.IsNamed() {
+	for idx := range t.Types {
+		if t.Flags[idx]&flatNodeFlagNamed == 0 {
 			continue
 		}
-		if node.StartByte > startByte || node.EndByte < endByte {
+		sb := t.StartBytes[idx]
+		eb := t.EndBytes[idx]
+		if sb > startByte || eb < endByte {
 			continue
 		}
-		span := node.EndByte - node.StartByte
+		span := eb - sb
 		if !found || span < bestSpan {
 			best = uint32(idx)
 			bestSpan = span

--- a/internal/scanner/flat_test.go
+++ b/internal/scanner/flat_test.go
@@ -45,8 +45,8 @@ abstract class Example(private val name: String) {
 	if flat == nil {
 		t.Fatal("expected non-nil FlatTree")
 	}
-	if len(flat.Nodes) != len(preorder) {
-		t.Fatalf("expected %d flat nodes, got %d", len(preorder), len(flat.Nodes))
+	if flat.Len() != len(preorder) {
+		t.Fatalf("expected %d flat nodes, got %d", len(preorder), flat.Len())
 	}
 
 	childrenByParent := make(map[int][]int)
@@ -55,7 +55,7 @@ abstract class Example(private val name: String) {
 	}
 
 	for idx, info := range preorder {
-		got := flat.Nodes[idx]
+		got := flat.Node(uint32(idx))
 		if got.TypeName() != info.node.Type() {
 			t.Errorf("node %d: expected type %q, got %q", idx, info.node.Type(), got.TypeName())
 		}
@@ -181,7 +181,7 @@ abstract class Example {
 		t.Fatalf("expected %q, got %q", "abstract", string(view))
 	}
 
-	content[flat.Nodes[modsIdx].StartByte] = 'A'
+	content[flat.StartBytes[modsIdx]] = 'A'
 	if string(view) != "Abstract" {
 		t.Fatalf("expected live view to reflect updated content, got %q", string(view))
 	}
@@ -212,7 +212,7 @@ abstract class Example {
 
 	pool := NewStringPool()
 	got := FlatNodeString(flat, modsIdx, content, pool)
-	content[flat.Nodes[modsIdx].StartByte] = 'A'
+	content[flat.StartBytes[modsIdx]] = 'A'
 	if got != "abstract" {
 		t.Fatalf("expected interned string to remain stable after content mutation, got %q", got)
 	}
@@ -233,10 +233,10 @@ func TestParseFile_PopulatesFlatTree(t *testing.T) {
 	if file.FlatTree == nil {
 		t.Fatal("expected ParseFile to populate FlatTree")
 	}
-	if len(file.FlatTree.Nodes) == 0 {
+	if file.FlatTree.Len() == 0 {
 		t.Fatal("expected FlatTree to contain nodes")
 	}
-	if file.FlatTree.Nodes[0].TypeName() != "source_file" {
-		t.Fatalf("expected flat root type source_file, got %q", file.FlatTree.Nodes[0].TypeName())
+	if nodeTypeName(file.FlatTree.Types[0]) != "source_file" {
+		t.Fatalf("expected flat root type source_file, got %q", nodeTypeName(file.FlatTree.Types[0]))
 	}
 }

--- a/internal/scanner/index_java.go
+++ b/internal/scanner/index_java.go
@@ -198,11 +198,11 @@ func collectJavaReferencesFlatUncached(file *File, refs *[]Reference) {
 	if !hasIdentifier && !hasTypeIdentifier && len(scopedIDs) == 0 {
 		return
 	}
-	nodes := file.FlatTree.Nodes
-	for i := range nodes {
-		node := nodes[i]
-		isSimple := (hasIdentifier && node.Type == identifierID) || (hasTypeIdentifier && node.Type == typeIdentifierID)
-		isScoped := hasNodeType(scopedIDs, node.Type)
+	t := file.FlatTree
+	for i := range t.Types {
+		nodeType := t.Types[i]
+		isSimple := (hasIdentifier && nodeType == identifierID) || (hasTypeIdentifier && nodeType == typeIdentifierID)
+		isScoped := hasNodeType(scopedIDs, nodeType)
 		if !isSimple && !isScoped {
 			continue
 		}
@@ -217,9 +217,9 @@ func collectJavaReferencesFlatUncached(file *File, refs *[]Reference) {
 		*refs = append(*refs, Reference{
 			Name:      name,
 			File:      file.Path,
-			Line:      int(node.StartRow) + 1,
-			StartByte: int(node.StartByte),
-			EndByte:   int(node.EndByte),
+			Line:      int(t.StartRows[i]) + 1,
+			StartByte: int(t.StartBytes[i]),
+			EndByte:   int(t.EndBytes[i]),
 			Language:  LangJava,
 		})
 		if isSimple {
@@ -227,9 +227,9 @@ func collectJavaReferencesFlatUncached(file *File, refs *[]Reference) {
 				*refs = append(*refs, Reference{
 					Name:      prop,
 					File:      file.Path,
-					Line:      int(node.StartRow) + 1,
-					StartByte: int(node.StartByte),
-					EndByte:   int(node.EndByte),
+					Line:      int(t.StartRows[i]) + 1,
+					StartByte: int(t.StartBytes[i]),
+					EndByte:   int(t.EndBytes[i]),
 					Language:  LangJava,
 				})
 			}

--- a/internal/scanner/index_kotlin.go
+++ b/internal/scanner/index_kotlin.go
@@ -11,7 +11,7 @@ func indexFile(file *File) ([]Symbol, []Reference) {
 	var symbols []Symbol
 	var references []Reference
 
-	if file == nil || file.FlatTree == nil || len(file.FlatTree.Nodes) == 0 {
+	if file == nil || file.FlatTree == nil || file.FlatTree.Len() == 0 {
 		return symbols, references
 	}
 
@@ -165,7 +165,7 @@ func collectReferencesFlat(file *File, refs *[]Reference) {
 	}
 
 	file.FlatWalkAllNodes(0, func(idx uint32) {
-		nodeType := file.FlatTree.Nodes[idx].Type
+		nodeType := file.FlatTree.Types[idx]
 		if (!hasSimpleID || nodeType != simpleID) && (!hasTypeID || nodeType != typeID) {
 			return
 		}

--- a/internal/scanner/index_test.go
+++ b/internal/scanner/index_test.go
@@ -706,14 +706,29 @@ func TestCollectReferencesFlat_KDocReferenceInComment(t *testing.T) {
 	}
 	start := uint32(startOffset)
 	end := start + uint32(len("DocumentedType"))
+	tree := &FlatTree{
+		Types: []uint16{
+			internNodeType("source_file"),
+			internNodeType("multiline_comment"),
+			internNodeType("simple_identifier"),
+		},
+		Parents:       []uint32{0, 0, 1},
+		FirstChildren: []uint32{1, 2, 0},
+		NextSibs:      []uint32{0, 0, 0},
+		PrevSibs:      []uint32{0, 0, 0},
+		StartBytes:    []uint32{0, 0, start},
+		EndBytes:      []uint32{uint32(len(src)), uint32(len(src)), end},
+		StartRows:     []uint16{0, 0, 1},
+		StartCols:     []uint16{0, 0, 9},
+		ChildCounts:   []uint16{1, 1, 0},
+		NamedCounts:   []uint16{1, 1, 0},
+		Flags:         []uint8{flatNodeFlagNamed, flatNodeFlagNamed, flatNodeFlagNamed},
+	}
+	tree.buildNodesByType()
 	file := &File{
-		Path:    "demo.kt",
-		Content: src,
-		FlatTree: &FlatTree{Nodes: []FlatNode{
-			{Type: internNodeType("source_file"), FirstChild: 1, ChildCount: 1, NamedCount: 1, Flags: flatNodeFlagNamed, EndByte: uint32(len(src))},
-			{Type: internNodeType("multiline_comment"), Parent: 0, FirstChild: 2, StartByte: 0, EndByte: uint32(len(src)), StartRow: 0, ChildCount: 1, NamedCount: 1, Flags: flatNodeFlagNamed},
-			{Type: internNodeType("simple_identifier"), Parent: 1, StartByte: start, EndByte: end, StartRow: 1, StartCol: 9, Flags: flatNodeFlagNamed},
-		}},
+		Path:     "demo.kt",
+		Content:  src,
+		FlatTree: tree,
 	}
 
 	var refs []Reference

--- a/internal/scanner/parse_cache.go
+++ b/internal/scanner/parse_cache.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime/debug"
+	"strconv"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -28,8 +29,11 @@ import (
 )
 
 const (
-	parseCacheVersion    uint32 = 5
-	parseCacheVersionStr        = "5"
+	// Bumped to 6 when FlatTree migrated from AoS ([]FlatNode) to SoA
+	// (parallel slices per field). Old entries are not loadable: the
+	// gob payload shape changed from {NodeTypeTable, Nodes} to
+	// {NodeTypeTable, Types, Parents, FirstChildren, ...}.
+	parseCacheVersion uint32 = 6
 
 	// Files below this threshold parse in under a millisecond; the gob
 	// serialization + filesystem round-trip dominates the savings.
@@ -46,16 +50,34 @@ const (
 	parseCacheLRULock   = "lru.lock"
 )
 
-// parseCacheEntry is the compressed on-disk gob payload. NodeTypeTable maps the
-// entry's local FlatNode.Type indices back to node-type strings so a
-// reader can re-intern them into its own global NodeTypeTable — crucial
-// because the type table grows lazily and a fresh process's global
-// indices won't match the writer's. Version, grammar, content hash, and
-// language live in the owning sidecar/path rather than being duplicated
-// in every entry.
+// parseCacheVersionStr is the schema-version sidecar string; kept in
+// sync with parseCacheVersion via strconv to remove drift risk.
+var parseCacheVersionStr = strconv.FormatUint(uint64(parseCacheVersion), 10)
+
+// parseCacheEntry is the compressed on-disk gob payload. NodeTypeTable maps
+// the entry's local Type indices back to node-type strings so a reader
+// can re-intern them into its own global NodeTypeTable — crucial because
+// the type table grows lazily and a fresh process's global indices won't
+// match the writer's. Version, grammar, content hash, and language live
+// in the owning sidecar/path rather than being duplicated in every entry.
+//
+// The fields mirror FlatTree's parallel-slice layout (SoA). NodesByType
+// is NOT serialized because it depends on the type-ID space, which is
+// remapped on load; we rebuild it post-remap.
 type parseCacheEntry struct {
 	NodeTypeTable []string
-	Nodes         []FlatNode
+	Types         []uint16
+	Parents       []uint32
+	FirstChildren []uint32
+	NextSibs      []uint32
+	PrevSibs      []uint32
+	StartBytes    []uint32
+	EndBytes      []uint32
+	StartRows     []uint16
+	StartCols     []uint16
+	ChildCounts   []uint16
+	NamedCounts   []uint16
+	Flags         []uint8
 }
 
 // ParseCache persists FlatTree parse results keyed by content hash.
@@ -345,23 +367,47 @@ func (lc *langCache) loadByHash(hash string) (*FlatTree, bool) {
 		if lc.lru != nil {
 			lc.lru.Touch(hash)
 		}
-		remapEntryNodes(entry.Nodes, entry.NodeTypeTable)
+		tree := flatTreeFromEntry(entry)
 		lc.hits.Add(1)
-		return &FlatTree{Nodes: entry.Nodes}, true
+		return tree, true
 	}
 	if entry, ok := lc.loadLegacyEntry(hash); ok {
 		if lc.lru != nil {
 			lc.lru.Touch(hash)
 		}
-		remapEntryNodes(entry.Nodes, entry.NodeTypeTable)
+		tree := flatTreeFromEntry(entry)
 		lc.hits.Add(1)
-		return &FlatTree{Nodes: entry.Nodes}, true
+		return tree, true
 	}
 	if lc.lru != nil {
 		lc.lru.Forget(hash)
 	}
 	lc.misses.Add(1)
 	return nil, false
+}
+
+// flatTreeFromEntry rebuilds a FlatTree from a freshly-decoded cache
+// entry. The entry's Types slice holds LOCAL indices into entry.NodeTypeTable;
+// they are remapped to the process-global NodeTypeTable in place. The
+// NodesByType posting list is rebuilt post-remap.
+func flatTreeFromEntry(entry *parseCacheEntry) *FlatTree {
+	remapEntryTypes(entry.Types, entry.NodeTypeTable)
+	tree := &FlatTree{
+		Types:         entry.Types,
+		Parents:       entry.Parents,
+		FirstChildren: entry.FirstChildren,
+		NextSibs:      entry.NextSibs,
+		PrevSibs:      entry.PrevSibs,
+		StartBytes:    entry.StartBytes,
+		EndBytes:      entry.EndBytes,
+		StartRows:     entry.StartRows,
+		StartCols:     entry.StartCols,
+		ChildCounts:   entry.ChildCounts,
+		NamedCounts:   entry.NamedCounts,
+		Flags:         entry.Flags,
+	}
+	tree.buildNodesByType()
+	return tree
 }
 
 func (lc *langCache) loadPackedEntry(hash string) (*parseCacheEntry, bool) {
@@ -398,10 +444,10 @@ func (lc *langCache) loadLegacyEntry(hash string) (*parseCacheEntry, bool) {
 	return &entry, true
 }
 
-// remapEntryNodes rewrites each node's Type from the entry's local
+// remapEntryTypes rewrites each entry in types from the entry's local
 // index (into localTable) to the current process's global NodeTypeTable
-// index. Done in place on the node slice returned in the entry.
-func remapEntryNodes(nodes []FlatNode, localTable []string) {
+// index. Done in place.
+func remapEntryTypes(types []uint16, localTable []string) {
 	if len(localTable) == 0 {
 		return
 	}
@@ -409,9 +455,9 @@ func remapEntryNodes(nodes []FlatNode, localTable []string) {
 	for i, name := range localTable {
 		remap[i] = internNodeType(name)
 	}
-	for i := range nodes {
-		if int(nodes[i].Type) < len(remap) {
-			nodes[i].Type = remap[nodes[i].Type]
+	for i, t := range types {
+		if int(t) < len(remap) {
+			types[i] = remap[t]
 		}
 	}
 }
@@ -475,10 +521,10 @@ func (lc *langCache) saveAsync(path string, content []byte, tree *FlatTree, writ
 	if writer == nil {
 		return lc.saveEntry(hash, tree)
 	}
-	nodes := append([]FlatNode(nil), tree.Nodes...)
+	snap := cloneTreeForCacheSave(tree)
 	lc.asyncQueued.Add(1)
 	if writer.Submit(func() (int64, error) {
-		n, err := lc.encodePendingEntryFromOwnedNodes(hash, nodes)
+		n, err := lc.encodePendingEntryFromOwnedTree(hash, snap)
 		if err != nil {
 			lc.asyncFailed.Add(1)
 			return 0, err
@@ -489,7 +535,7 @@ func (lc *langCache) saveAsync(path string, content []byte, tree *FlatTree, writ
 	}) {
 		return nil
 	}
-	n, err := lc.saveEntryFromOwnedNodes(hash, nodes)
+	n, err := lc.saveEntryFromOwnedTree(hash, snap)
 	if err != nil {
 		lc.asyncFailed.Add(1)
 		return err
@@ -497,6 +543,29 @@ func (lc *langCache) saveAsync(path string, content []byte, tree *FlatTree, writ
 	lc.asyncCompleted.Add(1)
 	lc.asyncBytes.Add(n)
 	return err
+}
+
+// cloneTreeForCacheSave makes a defensive shallow copy of the SoA slices
+// in tree so an async writer can encode without contention. NodesByType
+// is NOT cloned (and not used for encoding).
+func cloneTreeForCacheSave(tree *FlatTree) *FlatTree {
+	if tree == nil {
+		return nil
+	}
+	return &FlatTree{
+		Types:         append([]uint16(nil), tree.Types...),
+		Parents:       append([]uint32(nil), tree.Parents...),
+		FirstChildren: append([]uint32(nil), tree.FirstChildren...),
+		NextSibs:      append([]uint32(nil), tree.NextSibs...),
+		PrevSibs:      append([]uint32(nil), tree.PrevSibs...),
+		StartBytes:    append([]uint32(nil), tree.StartBytes...),
+		EndBytes:      append([]uint32(nil), tree.EndBytes...),
+		StartRows:     append([]uint16(nil), tree.StartRows...),
+		StartCols:     append([]uint16(nil), tree.StartCols...),
+		ChildCounts:   append([]uint16(nil), tree.ChildCounts...),
+		NamedCounts:   append([]uint16(nil), tree.NamedCounts...),
+		Flags:         append([]uint8(nil), tree.Flags...),
+	}
 }
 
 func (lc *langCache) removeEntry(hash string) error {
@@ -557,19 +626,19 @@ func (pc *ParseCache) saveEntry(hash string, tree *FlatTree) error {
 }
 
 func (lc *langCache) saveEntry(hash string, tree *FlatTree) error {
-	local, cloned := buildLocalTableAndNodes(tree.Nodes)
+	local, cloned := buildLocalTableAndTree(tree)
 	_, err := lc.writeEntry(hash, local, cloned)
 	return err
 }
 
-func (lc *langCache) saveEntryFromOwnedNodes(hash string, nodes []FlatNode) (int64, error) {
-	local := rewriteNodesToLocalTypes(nodes)
-	return lc.writeEntry(hash, local, nodes)
+func (lc *langCache) saveEntryFromOwnedTree(hash string, tree *FlatTree) (int64, error) {
+	local := rewriteTreeToLocalTypes(tree)
+	return lc.writeEntry(hash, local, tree)
 }
 
-func (lc *langCache) encodePendingEntryFromOwnedNodes(hash string, nodes []FlatNode) (int64, error) {
-	local := rewriteNodesToLocalTypes(nodes)
-	blob, err := lc.encodeEntry(local, nodes)
+func (lc *langCache) encodePendingEntryFromOwnedTree(hash string, tree *FlatTree) (int64, error) {
+	local := rewriteTreeToLocalTypes(tree)
+	blob, err := lc.encodeEntry(local, tree)
 	if err != nil {
 		return 0, err
 	}
@@ -577,8 +646,8 @@ func (lc *langCache) encodePendingEntryFromOwnedNodes(hash string, nodes []FlatN
 	return int64(len(blob)), nil
 }
 
-func (lc *langCache) writeEntry(hash string, local []string, nodes []FlatNode) (int64, error) {
-	blob, err := lc.encodeEntry(local, nodes)
+func (lc *langCache) writeEntry(hash string, local []string, tree *FlatTree) (int64, error) {
+	blob, err := lc.encodeEntry(local, tree)
 	if err != nil {
 		return 0, fmt.Errorf("encode cache entry: %w", err)
 	}
@@ -589,10 +658,21 @@ func (lc *langCache) writeEntry(hash string, local []string, nodes []FlatNode) (
 	return size, nil
 }
 
-func (lc *langCache) encodeEntry(local []string, nodes []FlatNode) ([]byte, error) {
+func (lc *langCache) encodeEntry(local []string, tree *FlatTree) ([]byte, error) {
 	entry := parseCacheEntry{
 		NodeTypeTable: local,
-		Nodes:         nodes,
+		Types:         tree.Types,
+		Parents:       tree.Parents,
+		FirstChildren: tree.FirstChildren,
+		NextSibs:      tree.NextSibs,
+		PrevSibs:      tree.PrevSibs,
+		StartBytes:    tree.StartBytes,
+		EndBytes:      tree.EndBytes,
+		StartRows:     tree.StartRows,
+		StartCols:     tree.StartCols,
+		ChildCounts:   tree.ChildCounts,
+		NamedCounts:   tree.NamedCounts,
+		Flags:         tree.Flags,
 	}
 	start := time.Now()
 	blob, err := cacheutil.EncodeZstdGob(entry)
@@ -668,36 +748,57 @@ func (lc *langCache) writeEncodedEntries(writes []parseEncodedEntryWrite) error 
 	return nil
 }
 
-// buildLocalTableAndNodes walks nodes, collects the set of global Type
-// IDs actually used, and produces a parallel array of their string names
-// plus a clone of the node slice with Type rewritten to indices into
-// that local table.
-func buildLocalTableAndNodes(nodes []FlatNode) ([]string, []FlatNode) {
-	cloned := make([]FlatNode, len(nodes))
-	copy(cloned, nodes)
-	return rewriteNodesToLocalTypes(cloned), cloned
+// buildLocalTableAndTree walks tree.Types, collects the set of global
+// type IDs actually used, and produces a parallel array of their string
+// names plus a defensive shallow copy of the FlatTree with Types
+// rewritten to indices into that local table. Other SoA slices are
+// aliased — the caller must not mutate them — because they don't
+// participate in the remap.
+func buildLocalTableAndTree(tree *FlatTree) ([]string, *FlatTree) {
+	if tree == nil {
+		return nil, &FlatTree{}
+	}
+	cloned := &FlatTree{
+		Types:         append([]uint16(nil), tree.Types...),
+		Parents:       tree.Parents,
+		FirstChildren: tree.FirstChildren,
+		NextSibs:      tree.NextSibs,
+		PrevSibs:      tree.PrevSibs,
+		StartBytes:    tree.StartBytes,
+		EndBytes:      tree.EndBytes,
+		StartRows:     tree.StartRows,
+		StartCols:     tree.StartCols,
+		ChildCounts:   tree.ChildCounts,
+		NamedCounts:   tree.NamedCounts,
+		Flags:         tree.Flags,
+	}
+	return rewriteTreeToLocalTypes(cloned), cloned
 }
 
-func rewriteNodesToLocalTypes(nodes []FlatNode) []string {
+// rewriteTreeToLocalTypes rewrites tree.Types in place from global to
+// local type IDs and returns the parallel string table.
+func rewriteTreeToLocalTypes(tree *FlatTree) []string {
+	if tree == nil || len(tree.Types) == 0 {
+		return nil
+	}
 	var maxType uint16
-	for _, n := range nodes {
-		if n.Type > maxType {
-			maxType = n.Type
+	for _, t := range tree.Types {
+		if t > maxType {
+			maxType = t
 		}
 	}
 	// Dense lookup: globalToLocal[g] == 0 is the "unseen" sentinel, so
 	// stored slots are offset by 1 and subtracted on read.
 	globalToLocal := make([]uint16, int(maxType)+1)
 	local := make([]string, 0, 32)
-	for i := range nodes {
-		g := nodes[i].Type
+	for i, g := range tree.Types {
 		slot := globalToLocal[g]
 		if slot == 0 {
 			local = append(local, nodeTypeName(g))
 			slot = uint16(len(local))
 			globalToLocal[g] = slot
 		}
-		nodes[i].Type = slot - 1
+		tree.Types[i] = slot - 1
 	}
 	return local
 }

--- a/internal/scanner/parse_cache_java_test.go
+++ b/internal/scanner/parse_cache_java_test.go
@@ -64,14 +64,14 @@ func TestParseCache_Java_RoundTrip(t *testing.T) {
 		t.Fatal("expected FlatTree on hit")
 	}
 
-	if len(hit.FlatTree.Nodes) != len(miss.FlatTree.Nodes) {
+	if hit.FlatTree.Len() != miss.FlatTree.Len() {
 		t.Fatalf("node count differs: miss=%d hit=%d",
-			len(miss.FlatTree.Nodes), len(hit.FlatTree.Nodes))
+			miss.FlatTree.Len(), hit.FlatTree.Len())
 	}
-	for i := range miss.FlatTree.Nodes {
-		if miss.FlatTree.Nodes[i].TypeName() != hit.FlatTree.Nodes[i].TypeName() {
+	for i := range miss.FlatTree.Types {
+		if nodeTypeName(miss.FlatTree.Types[i]) != nodeTypeName(hit.FlatTree.Types[i]) {
 			t.Fatalf("node %d type name differs: want %q got %q",
-				i, miss.FlatTree.Nodes[i].TypeName(), hit.FlatTree.Nodes[i].TypeName())
+				i, nodeTypeName(miss.FlatTree.Types[i]), nodeTypeName(hit.FlatTree.Types[i]))
 		}
 	}
 }
@@ -299,9 +299,9 @@ func TestParseCache_Java_ConcurrentWritesSameHash(t *testing.T) {
 	if !ok {
 		t.Fatal("expected hit after concurrent writes")
 	}
-	if len(tree.Nodes) != len(seed.FlatTree.Nodes) {
+	if tree.Len() != seed.FlatTree.Len() {
 		t.Fatalf("node count mismatch: want %d got %d",
-			len(seed.FlatTree.Nodes), len(tree.Nodes))
+			seed.FlatTree.Len(), tree.Len())
 	}
 }
 

--- a/internal/scanner/parse_cache_test.go
+++ b/internal/scanner/parse_cache_test.go
@@ -93,13 +93,13 @@ func TestParseCache_RoundTrip(t *testing.T) {
 		t.Fatal("expected FlatTree on hit")
 	}
 
-	if len(hit.FlatTree.Nodes) != len(miss.FlatTree.Nodes) {
+	if hit.FlatTree.Len() != miss.FlatTree.Len() {
 		t.Fatalf("node count differs: miss=%d hit=%d",
-			len(miss.FlatTree.Nodes), len(hit.FlatTree.Nodes))
+			miss.FlatTree.Len(), hit.FlatTree.Len())
 	}
-	for i := range miss.FlatTree.Nodes {
-		m := miss.FlatTree.Nodes[i]
-		h := hit.FlatTree.Nodes[i]
+	for i := range miss.FlatTree.Types {
+		m := miss.FlatTree.Node(uint32(i))
+		h := hit.FlatTree.Node(uint32(i))
 		if m != h {
 			t.Fatalf("node %d differs after round-trip:\n  miss=%+v\n  hit =%+v", i, m, h)
 		}
@@ -142,14 +142,14 @@ func TestParseCache_HitAfterRestart(t *testing.T) {
 	if !ok {
 		t.Fatal("expected cache hit on run 2")
 	}
-	if len(tree.Nodes) != len(f1.FlatTree.Nodes) {
+	if tree.Len() != f1.FlatTree.Len() {
 		t.Fatalf("node count diverged: want %d got %d",
-			len(f1.FlatTree.Nodes), len(tree.Nodes))
+			f1.FlatTree.Len(), tree.Len())
 	}
-	for i := range tree.Nodes {
-		if tree.Nodes[i].TypeName() != f1.FlatTree.Nodes[i].TypeName() {
+	for i := range tree.Types {
+		if nodeTypeName(tree.Types[i]) != nodeTypeName(f1.FlatTree.Types[i]) {
 			t.Fatalf("node %d type name differs: want %q got %q",
-				i, f1.FlatTree.Nodes[i].TypeName(), tree.Nodes[i].TypeName())
+				i, nodeTypeName(f1.FlatTree.Types[i]), nodeTypeName(tree.Types[i]))
 		}
 	}
 }
@@ -495,9 +495,9 @@ func TestParseCache_ConcurrentWritesSameHash(t *testing.T) {
 	if !ok {
 		t.Fatal("expected hit after concurrent writes")
 	}
-	if len(tree.Nodes) != len(seed.FlatTree.Nodes) {
+	if tree.Len() != seed.FlatTree.Len() {
 		t.Fatalf("node count mismatch: want %d got %d",
-			len(seed.FlatTree.Nodes), len(tree.Nodes))
+			seed.FlatTree.Len(), tree.Len())
 	}
 }
 

--- a/internal/scanner/suppress.go
+++ b/internal/scanner/suppress.go
@@ -294,7 +294,7 @@ func BuildSuppressionIndexFlat(tree *FlatTree, content []byte) *SuppressionIndex
 	idx := &SuppressionIndex{
 		suppressions: make([]Suppression, 0, 16),
 	}
-	if tree == nil || len(tree.Nodes) == 0 {
+	if tree == nil || len(tree.Types) == 0 {
 		return idx
 	}
 	flatWalkForSuppressions(tree, 0, content, idx)
@@ -403,10 +403,10 @@ func suppressionMatches(rules map[string]bool, ruleName string, ruleSetName stri
 }
 
 func flatWalkForSuppressions(tree *FlatTree, idx uint32, content []byte, out *SuppressionIndex) {
-	if tree == nil || int(idx) >= len(tree.Nodes) {
+	if tree == nil || int(idx) >= len(tree.Types) {
 		return
 	}
-	nodeType := tree.Nodes[idx].TypeName()
+	nodeType := nodeTypeName(tree.Types[idx])
 
 	switch nodeType {
 	case "prefix_expression", "annotation":
@@ -431,8 +431,8 @@ func flatWalkForSuppressions(tree *FlatTree, idx uint32, content []byte, out *Su
 		return
 	}
 
-	for child := tree.Nodes[idx].FirstChild; child != 0; child = tree.Nodes[child].NextSib {
-		switch tree.Nodes[child].TypeName() {
+	for child := tree.FirstChildren[idx]; child != 0; child = tree.NextSibs[child] {
+		switch nodeTypeName(tree.Types[child]) {
 		case "prefix_expression", "annotation":
 			flatProcessSuppressionNode(tree, child, content, out)
 		case "file_annotation":
@@ -464,8 +464,8 @@ func flatProcessFileAnnotation(tree *FlatTree, idx uint32, content []byte, out *
 	// root's Parent field is also 0, making walk-until-parent==0 ambiguous).
 	var root uint32
 	out.suppressions = append(out.suppressions, Suppression{
-		StartByte: int(tree.Nodes[root].StartByte),
-		EndByte:   int(tree.Nodes[root].EndByte),
+		StartByte: int(tree.StartBytes[root]),
+		EndByte:   int(tree.EndBytes[root]),
 		Rules:     rules,
 	})
 }
@@ -476,9 +476,9 @@ func flatProcessSuppressionNode(tree *FlatTree, idx uint32, content []byte, out 
 		return false
 	}
 	parseText := textBytes
-	if tree.Nodes[idx].TypeName() == "prefix_expression" {
-		for child := tree.Nodes[idx].FirstChild; child != 0; child = tree.Nodes[child].NextSib {
-			if tree.Nodes[child].TypeName() == "annotation" && flatAnnotationHasArgs(tree, child) {
+	if nodeTypeName(tree.Types[idx]) == "prefix_expression" {
+		for child := tree.FirstChildren[idx]; child != 0; child = tree.NextSibs[child] {
+			if nodeTypeName(tree.Types[child]) == "annotation" && flatAnnotationHasArgs(tree, child) {
 				parseText = FlatNodeBytes(tree, child, content)
 				break
 			}
@@ -490,16 +490,16 @@ func flatProcessSuppressionNode(tree *FlatTree, idx uint32, content []byte, out 
 		return true
 	}
 	out.suppressions = append(out.suppressions, Suppression{
-		StartByte: int(tree.Nodes[target].StartByte),
-		EndByte:   int(tree.Nodes[target].EndByte),
+		StartByte: int(tree.StartBytes[target]),
+		EndByte:   int(tree.EndBytes[target]),
 		Rules:     rules,
 	})
 	return true
 }
 
 func flatAnnotationHasArgs(tree *FlatTree, idx uint32) bool {
-	for child := tree.Nodes[idx].FirstChild; child != 0; child = tree.Nodes[child].NextSib {
-		if tree.Nodes[child].TypeName() == "constructor_invocation" {
+	for child := tree.FirstChildren[idx]; child != 0; child = tree.NextSibs[child] {
+		if nodeTypeName(tree.Types[child]) == "constructor_invocation" {
 			return true
 		}
 	}
@@ -507,11 +507,11 @@ func flatAnnotationHasArgs(tree *FlatTree, idx uint32) bool {
 }
 
 func flatFindAnnotationTarget(tree *FlatTree, idx uint32) uint32 {
-	if tree.Nodes[idx].TypeName() == "prefix_expression" {
+	if nodeTypeName(tree.Types[idx]) == "prefix_expression" {
 		var annChild uint32
 		hasOperand := false
-		for child := tree.Nodes[idx].FirstChild; child != 0; child = tree.Nodes[child].NextSib {
-			if tree.Nodes[child].TypeName() == "annotation" {
+		for child := tree.FirstChildren[idx]; child != 0; child = tree.NextSibs[child] {
+			if nodeTypeName(tree.Types[child]) == "annotation" {
 				annChild = child
 			} else {
 				hasOperand = true
@@ -522,17 +522,17 @@ func flatFindAnnotationTarget(tree *FlatTree, idx uint32) uint32 {
 		}
 	}
 
-	parent := tree.Nodes[idx].Parent
+	parent := tree.Parents[idx]
 	if idx == 0 && parent == 0 {
 		return 0
 	}
-	if tree.Nodes[parent].TypeName() == "modifiers" {
-		return tree.Nodes[parent].Parent
+	if nodeTypeName(tree.Types[parent]) == "modifiers" {
+		return tree.Parents[parent]
 	}
-	parentType := tree.Nodes[parent].TypeName()
+	parentType := nodeTypeName(tree.Types[parent])
 	if parentType == "source_file" || parentType == "statements" || parentType == "class_body" {
 		foundSelf := false
-		for child := tree.Nodes[parent].FirstChild; child != 0; child = tree.Nodes[child].NextSib {
+		for child := tree.FirstChildren[parent]; child != 0; child = tree.NextSibs[child] {
 			if child == idx {
 				foundSelf = true
 				continue
@@ -540,7 +540,7 @@ func flatFindAnnotationTarget(tree *FlatTree, idx uint32) uint32 {
 			if !foundSelf {
 				continue
 			}
-			childType := tree.Nodes[child].TypeName()
+			childType := nodeTypeName(tree.Types[child])
 			if childType == "prefix_expression" || childType == "annotation" {
 				continue
 			}

--- a/internal/typeinfer/declarations.go
+++ b/internal/typeinfer/declarations.go
@@ -7,7 +7,7 @@ import (
 )
 
 func (r *defaultResolver) indexDeclarationsFlat(idx uint32, file *scanner.File, scope *ScopeTable, it *ImportTable, pkg string) {
-	if file == nil || file.FlatTree == nil || int(idx) >= len(file.FlatTree.Nodes) || scope == nil || it == nil {
+	if file == nil || file.FlatTree == nil || int(idx) >= file.FlatTree.Len() || scope == nil || it == nil {
 		return
 	}
 

--- a/internal/typeinfer/imports.go
+++ b/internal/typeinfer/imports.go
@@ -19,7 +19,7 @@ func scanFileHeadersFlat(rootIdx uint32, file *scanner.File) fileHeaders {
 			Aliases:  make(map[string]string),
 		},
 	}
-	if file == nil || file.FlatTree == nil || int(rootIdx) >= len(file.FlatTree.Nodes) {
+	if file == nil || file.FlatTree == nil || int(rootIdx) >= file.FlatTree.Len() {
 		return headers
 	}
 	visitChild := func(child uint32) {

--- a/internal/typeinfer/parallel.go
+++ b/internal/typeinfer/parallel.go
@@ -30,7 +30,7 @@ type FileTypeInfo struct {
 // touching any shared state. Returns a FileTypeInfo that can be
 // merged later.
 func IndexFileParallel(file *scanner.File) *FileTypeInfo {
-	if file == nil || file.FlatTree == nil || len(file.FlatTree.Nodes) == 0 || file.FlatType(0) != "source_file" {
+	if file == nil || file.FlatTree == nil || file.FlatTree.Len() == 0 || file.FlatType(0) != "source_file" {
 		return nil
 	}
 

--- a/internal/typeinfer/resolver_test.go
+++ b/internal/typeinfer/resolver_test.go
@@ -455,7 +455,7 @@ fun main() {
 }
 `
 	file := parseTestFile(t, src)
-	if file.FlatTree == nil || len(file.FlatTree.Nodes) == 0 {
+	if file.FlatTree == nil || file.FlatTree.Len() == 0 {
 		t.Fatal("expected parsed tree")
 	}
 	// Match the original "any children" semantics: the pre-migration test

--- a/internal/typeinfer/scopes.go
+++ b/internal/typeinfer/scopes.go
@@ -15,7 +15,7 @@ func (s flatScopeSpan) StartByte() uint32 { return s.start }
 func (s flatScopeSpan) EndByte() uint32   { return s.end }
 
 func (r *defaultResolver) buildScopesFlat(idx uint32, file *scanner.File, scope *ScopeTable, it *ImportTable) {
-	if file == nil || file.FlatTree == nil || int(idx) >= len(file.FlatTree.Nodes) || scope == nil {
+	if file == nil || file.FlatTree == nil || int(idx) >= file.FlatTree.Len() || scope == nil {
 		return
 	}
 	if idx == 0 && file.FlatType(0) == "source_file" {

--- a/internal/usedsymbols/usedsymbols.go
+++ b/internal/usedsymbols/usedsymbols.go
@@ -69,7 +69,7 @@ func Package(file *scanner.File) string {
 // Extract returns the deduplicated, sorted set of external symbols
 // referenced by file. The pkg/module filter is applied by the caller.
 func Extract(file *scanner.File) []Symbol {
-	if file == nil || file.FlatTree == nil || len(file.FlatTree.Nodes) == 0 {
+	if file == nil || file.FlatTree == nil || file.FlatTree.Len() == 0 {
 		return nil
 	}
 	_, it := scanHeaders(file)
@@ -188,7 +188,7 @@ func parseImportHeader(file *scanner.File, idx uint32, it *importTable) {
 // the import table alone wouldn't capture.
 func walkBody(file *scanner.File, it *importTable, add func(fqn, kind string, arity int)) {
 	tree := file.FlatTree
-	for i := uint32(1); i < uint32(len(tree.Nodes)); i++ {
+	for i := uint32(1); i < uint32(tree.Len()); i++ {
 		switch file.FlatType(i) {
 		case "navigation_expression":
 			handleNavigation(file, i, it, add)


### PR DESCRIPTION
## Summary

- **`FlatTree` AoS → SoA**: replace `Nodes []FlatNode` (40 B/struct) with 12 parallel slices (`Types`, `Parents`, `FirstChildren`, `NextSibs`, `PrevSibs`, `StartBytes`, `EndBytes`, `StartRows`, `StartCols`, `ChildCounts`, `NamedCounts`, `Flags`). Keeps `FlatNode` as a value-type view via `tree.Node(idx)` for callers that want struct semantics.
- **`NodesByType [][]uint32` posting list**: built once during `flattenTree`, rebuilt post-load by the parse cache. Lets the dispatcher iterate only nodes whose type has a subscribed handler.
- **Dispatcher hot loop rewritten**: when `allNodeRules` is empty (the common case) iterate per-type via the posting list; fall through to a single full-walk only when at least one nil-NodeTypes rule is registered. Per-rule dispatch body is intentionally duplicated across both branches (closures defeat Go inlining and measurably regressed small-file dispatch in benches); kept-in-sync comments document this.
- **Parse cache v5 → v6**: `parseCacheEntry` reshaped from `{NodeTypeTable, Nodes []FlatNode}` to the 12 column slices. Old caches auto-invalidate via the version sidecar. `NodesByType` is NOT serialized — rebuilt after the local-to-global type-ID remap.
- **16 callers migrated** from `tree.Nodes[i].X` to the parallel slices (`tree.Types[i]`, `tree.FirstChildren[i]`, etc.) — scanner internals, dispatcher, complexity, coroutines, android rules, typeinfer, usedsymbols, di, and their tests.

## Benchmarks

E2E on `~/github/kotlin/compiler/` (37 k `.kt` files), comparing against a re-run baseline on the same FS-warm state:

| Mode | Baseline | SoA | Δ |
|---|---|---|---|
| non-daemon cold | 28.3 s, 4.75 GB | **17.8 s, 4.75 GB** | **-37% time** |
| non-daemon warm | 13.3 s, 3.68 GB | **12.1 s, 3.87 GB** | **-9% time** |
| daemon warm | 156 ms | 169 ms | within noise |
| **findings** | 33232 | **33232** | identical ✓ |

In-process highlights:
- `BenchmarkDispatcherRun_LargeFile`: 128 ms → 88–100 ms (**-25%**)
- `BenchmarkDispatcherRun_AllRules`: 128 ms → ~90 ms (**-30%**)
- `BenchmarkParseCacheSweep_CacheHit/size=4096`: 476 µs → 218 µs (**-54%**)
- `BenchmarkPerFileAllocationHotspots/flatten-tree`: 4.4 MB → 3.73 MB (**-15% mem**), +6% time
- `BenchmarkParseFile`: 64 µs → 75 µs (+17%) — cold-parse overhead from 12-column allocation + posting list build, amortized away by the warm-cache win

## Follow-ups (not in this PR)

- Single-arena allocation for the 12 SoA columns (uses `unsafe`) — could erase the cold-parse regression
- CSR encoding for `NodesByType` (offsets + flat indices arrays) — fewer per-tree allocations
- Either would land as a focused follow-up if BenchmarkParseFile latency matters

## Test plan

- [x] `go vet ./...` — clean
- [x] `golangci-lint run ./...` — clean
- [x] `go test ./... -count=1` — all pass
- [x] `make lint-rules` — clean
- [x] Findings parity verified on Kotlin compiler corpus (33232 in all four cold/warm × daemon/non-daemon modes)