### PR TITLE
refactor(rules): dispatch MissingPackageDeclaration on AST root

### DIFF
--- a/internal/rules/potentialbugs_lifecycle.go
+++ b/internal/rules/potentialbugs_lifecycle.go
@@ -301,34 +301,28 @@ func (r *LateinitUsageRule) Confidence() float64 { return 0.75 }
 // MissingPackageDeclarationRule detects Kotlin/Java source files without package statements.
 // ---------------------------------------------------------------------------
 type MissingPackageDeclarationRule struct {
-	LineBase
+	FlatDispatchBase
 	BaseRule
 }
 
-// Confidence bumps this line rule from the 0.75 line-rule default to
-// 0.95 — the check walks the first non-blank, non-comment line and
-// verifies it starts with "package ". Deterministic with no
-// heuristic path.
+// Confidence bumps this rule from the line-rule default to 0.95 — the
+// check asks tree-sitter whether the file's root has a package_header
+// (Kotlin) or package_declaration (Java) child. Deterministic with no
+// heuristic path and no dependence on line-level comment detection.
 func (r *MissingPackageDeclarationRule) Confidence() float64 { return 0.95 }
 
 func (r *MissingPackageDeclarationRule) check(ctx *api.Context) {
-	file := ctx.File
-	if !strings.HasSuffix(file.Path, ".kt") && !strings.HasSuffix(file.Path, ".java") {
+	idx, file := ctx.Idx, ctx.File
+	var pkgType string
+	switch {
+	case strings.HasSuffix(file.Path, ".java"):
+		pkgType = "package_declaration"
+	case strings.HasSuffix(file.Path, ".kt"):
+		pkgType = "package_header"
+	default:
 		return
 	}
-	for _, line := range file.Lines {
-		trimmed := strings.TrimSpace(line)
-		if trimmed == "" || scanner.IsCommentLine(line) {
-			continue
-		}
-		if strings.HasPrefix(trimmed, "package ") {
-			return
-		}
-		// First non-comment, non-blank line is not a package declaration
-		f := r.Finding(file, 1, 1,
-			"Missing package declaration in source file.")
-		f.Fix = derivePackageFix(file)
-		ctx.Emit(f)
+	if _, ok := file.FlatFindChild(idx, pkgType); ok {
 		return
 	}
 	f := r.Finding(file, 1, 1,

--- a/internal/rules/registry_potentialbugs_lifecycle.go
+++ b/internal/rules/registry_potentialbugs_lifecycle.go
@@ -227,7 +227,7 @@ func registerPotentialbugsLifecycleRules() {
 		r := &MissingPackageDeclarationRule{BaseRule: BaseRule{RuleName: "MissingPackageDeclaration", RuleSetName: "potential-bugs", Sev: "warning", Desc: "Detects Kotlin or Java source files that are missing a package declaration."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			Needs: api.NeedsLinePass, Languages: []scanner.Language{scanner.LangKotlin, scanner.LangJava}, Fix: api.FixCosmetic, Implementation: r,
+			NodeTypes: []string{"source_file", "program"}, Languages: []scanner.Language{scanner.LangKotlin, scanner.LangJava}, Fix: api.FixCosmetic, Implementation: r,
 			Check: r.check,
 		})
 	}

--- a/tests/fixtures/negative/potential-bugs/MissingPackageDeclaration.kt
+++ b/tests/fixtures/negative/potential-bugs/MissingPackageDeclaration.kt
@@ -1,3 +1,7 @@
+/* Copyright (c) 2026
+   All rights reserved. */
+@file:Suppress("UNUSED")
+
 package com.example
 
 class WithPackage {


### PR DESCRIPTION
## Summary
- Convert `MissingPackageDeclarationRule` from `LineBase` to `FlatDispatchBase`. The rule now fires once per `source_file` (Kotlin) / `program` (Java) and checks for a direct `package_header` / `package_declaration` child instead of scanning lines and asking `scanner.IsCommentLine` whether each prefix looks like a comment.
- Drops the brittle line-level comment heuristic. The previous implementation false-positived on:
  - Multi-line block comments whose continuation lines do not start with `*` or `/*` (e.g. a `/* license\n   notice */` header).
  - Top-of-file annotations such as `@file:Suppress(...)` preceding the package declaration — `IsCommentLine` returns false, so the line scanner emitted at the annotation.
- The negative fixture is extended to lock in both regressions in one file.

## Wins
- **Correctness:** tree-sitter handles comments, shebangs, file annotations, and string literals correctly; no more reliance on string-prefix heuristics.
- **Performance:** one `FlatFindChild` lookup on the root node replaces a per-file line scan with `TrimSpace` / prefix checks. The tree-sitter parse already happens for every file regardless.
- **Simpler control flow:** the redundant emit branch at the end of the previous function (empty file / all-comment file) is gone — the single-node check covers it.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `golangci-lint run ./...`
- [x] `go test ./... -count=1`
- [x] Focused: `TestPositiveFixtures/positive/MissingPackageDeclaration`, `TestNegativeFixtures/negative/MissingPackageDeclaration`
- [x] `make lint-rules`