### PR TITLE
fix(pipeline): honor context cancellation at per-file boundary in dispatch

### DIFF
--- a/internal/pipeline/dispatch.go
+++ b/internal/pipeline/dispatch.go
@@ -203,12 +203,21 @@ func (d DispatchPhase) Run(ctx context.Context, in IndexResult) (DispatchResult,
 		ruleTracker = in.Tracker.Serial("ruleExecution")
 	}
 
-	g, _ := errgroup.WithContext(ctx)
+	g, gctx := errgroup.WithContext(ctx)
 	g.SetLimit(workers)
 	sourceFiles := in.SourceFiles()
 	sort.SliceStable(sourceFiles, func(i, j int) bool {
 		return len(sourceFiles[i].Content) > len(sourceFiles[j].Content)
 	})
+	dispatchState := dispatchFileState{
+		dispatcher:     dispatcher,
+		useCache:       useCache,
+		mu:             &mu,
+		allColumns:     &allColumns,
+		fileTimings:    &fileTimings,
+		findingsByFile: findingsByFile,
+		acc:            &acc,
+	}
 	for _, f := range sourceFiles {
 		if in.CacheResult != nil && in.CacheResult.CachedPaths[f.Path] {
 			continue
@@ -219,46 +228,19 @@ func (d DispatchPhase) Run(ctx context.Context, in IndexResult) (DispatchResult,
 		}
 		file, dispatched := f, dispatchedAt
 		g.Go(func() error {
-
-			var startedAt, finishedRunAt, lockedAt time.Time
-			if in.ProfileDispatch {
-				startedAt = time.Now()
+			// Honor cancellation at the per-file boundary. errgroup's
+			// SetLimit serialises submissions but does not abort
+			// already-queued goroutines; without this guard every queued
+			// file would still call into the dispatcher even after the
+			// caller cancelled ctx. RunWithStats itself does not (yet)
+			// accept a ctx, so per-rule preemption is still coarse, but
+			// skipping the remaining files turns "cancel and wait for
+			// the entire sweep to drain" into "cancel and finish the
+			// in-progress files only".
+			if err := gctx.Err(); err != nil {
+				return err
 			}
-
-			fileColumns, fileStats := dispatcher.RunWithStats(file)
-
-			if in.ProfileDispatch {
-				finishedRunAt = time.Now()
-			}
-
-			mu.Lock()
-			if in.ProfileDispatch {
-				lockedAt = time.Now()
-			}
-			if fileColumns.Len() > 0 {
-				collector := scanner.NewFindingCollector(allColumns.Len() + fileColumns.Len())
-				collector.AppendColumns(&allColumns)
-				collector.AppendColumns(&fileColumns)
-				allColumns = *collector.Columns()
-			}
-			if useCache {
-				findingsByFile[file.Path] = fileColumns
-			}
-			mergeStats(&acc, fileStats)
-			if in.ProfileDispatch {
-				endAt := time.Now()
-				fileTimings = append(fileTimings, FileTiming{
-					Path:     file.Path,
-					Size:     len(file.Content),
-					QueueMs:  startedAt.Sub(dispatched).Milliseconds(),
-					RunMs:    finishedRunAt.Sub(startedAt).Milliseconds(),
-					LockMs:   lockedAt.Sub(finishedRunAt).Milliseconds(),
-					AggMs:    endAt.Sub(lockedAt).Milliseconds(),
-					TotalMs:  endAt.Sub(dispatched).Milliseconds(),
-					Findings: fileColumns.Len(),
-				})
-			}
-			mu.Unlock()
+			dispatchState.runFile(in, file, dispatched)
 			return nil
 		})
 	}
@@ -290,6 +272,62 @@ func (d DispatchPhase) Run(ctx context.Context, in IndexResult) (DispatchResult,
 		FileTimings:    fileTimings,
 		FindingsByFile: findingsByFile,
 	}, nil
+}
+
+// dispatchFileState carries the per-Run shared state that each
+// file-level goroutine needs to consult or mutate. Extracted so the
+// per-file body lives outside (DispatchPhase).Run, keeping Run's
+// cyclomatic complexity below the project lint threshold.
+type dispatchFileState struct {
+	dispatcher     *rules.Dispatcher
+	useCache       bool
+	mu             *sync.Mutex
+	allColumns     *scanner.FindingColumns
+	fileTimings    *[]FileTiming
+	findingsByFile map[string]scanner.FindingColumns
+	acc            *rules.RunStats
+}
+
+func (s dispatchFileState) runFile(in IndexResult, file *scanner.File, dispatched time.Time) {
+	var startedAt, finishedRunAt, lockedAt time.Time
+	if in.ProfileDispatch {
+		startedAt = time.Now()
+	}
+
+	fileColumns, fileStats := s.dispatcher.RunWithStats(file)
+
+	if in.ProfileDispatch {
+		finishedRunAt = time.Now()
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if in.ProfileDispatch {
+		lockedAt = time.Now()
+	}
+	if fileColumns.Len() > 0 {
+		collector := scanner.NewFindingCollector(s.allColumns.Len() + fileColumns.Len())
+		collector.AppendColumns(s.allColumns)
+		collector.AppendColumns(&fileColumns)
+		*s.allColumns = *collector.Columns()
+	}
+	if s.useCache {
+		s.findingsByFile[file.Path] = fileColumns
+	}
+	mergeStats(s.acc, fileStats)
+	if in.ProfileDispatch {
+		endAt := time.Now()
+		*s.fileTimings = append(*s.fileTimings, FileTiming{
+			Path:     file.Path,
+			Size:     len(file.Content),
+			QueueMs:  startedAt.Sub(dispatched).Milliseconds(),
+			RunMs:    finishedRunAt.Sub(startedAt).Milliseconds(),
+			LockMs:   lockedAt.Sub(finishedRunAt).Milliseconds(),
+			AggMs:    endAt.Sub(lockedAt).Milliseconds(),
+			TotalMs:  endAt.Sub(dispatched).Milliseconds(),
+			Findings: fileColumns.Len(),
+		})
+	}
 }
 
 type oracleLookupProvider interface {

--- a/internal/pipeline/dispatch_test.go
+++ b/internal/pipeline/dispatch_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/kaeawc/krit/internal/cache"
 	api "github.com/kaeawc/krit/internal/rules/api"
@@ -303,5 +304,80 @@ func TestDispatchPhase_Run_ParallelDoesNotDeadlock(t *testing.T) {
 	}
 	if got := checked.Load(); got != n {
 		t.Errorf("check invocations = %d, want %d", got, n)
+	}
+}
+
+// TestDispatchPhase_Run_StopsQueuedFilesOnContextCancel verifies that
+// once the caller cancels the dispatch context, queued (not-yet-
+// started) file-level goroutines bail out without running the
+// dispatcher. errgroup.SetLimit serialises goroutine starts; without
+// the cancellation guard, every queued worker would still invoke
+// RunWithStats even when the caller already gave up.
+func TestDispatchPhase_Run_StopsQueuedFilesOnContextCancel(t *testing.T) {
+	dir := t.TempDir()
+	const n = 64
+	files := make([]*scanner.File, 0, n)
+	for i := 0; i < n; i++ {
+		files = append(files, writeKotlin(t, dir, fmt.Sprintf("F%d.kt", i), classDeclKotlin))
+	}
+
+	var (
+		ran     atomic.Int64
+		release = make(chan struct{})
+	)
+	rule := api.FakeRule("DispatchCancelObserver",
+		api.WithNodeTypes("class_declaration"),
+		api.WithSeverity(api.SeverityWarning),
+		api.WithCheck(func(ctx *api.Context) {
+			ran.Add(1)
+			// Block the first goroutines so the cancellation has time
+			// to fire before the queue drains. release unblocks them
+			// once the test cancels the context.
+			<-release
+		}),
+	)
+
+	in := IndexResult{
+		ParseResult: ParseResult{
+			ActiveRules: []*api.Rule{rule},
+			KotlinFiles: files,
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	type result struct {
+		out DispatchResult
+		err error
+	}
+	resultCh := make(chan result, 1)
+	go func() {
+		out, err := (DispatchPhase{}).Run(ctx, in)
+		resultCh <- result{out: out, err: err}
+	}()
+
+	// Wait for some workers to start, then cancel. The remaining queued
+	// files should never enter the rule callback after the guard sees
+	// the cancellation.
+	deadline := time.After(2 * time.Second)
+	for ran.Load() == 0 {
+		select {
+		case <-deadline:
+			cancel()
+			close(release)
+			<-resultCh
+			t.Fatalf("no workers started before deadline")
+		case <-time.After(time.Millisecond):
+		}
+	}
+	cancel()
+	close(release)
+	res := <-resultCh
+
+	if !errors.Is(res.err, context.Canceled) {
+		t.Fatalf("Run err = %v, want context.Canceled", res.err)
+	}
+	if got := ran.Load(); got >= int64(n) {
+		t.Fatalf("rule callback ran on %d/%d files; expected fewer once context was cancelled", got, n)
 	}
 }


### PR DESCRIPTION
## Root cause

`DispatchPhase.Run` spawned an errgroup but threw away the derived context (`g, _ := errgroup.WithContext(ctx)`). `errgroup.SetLimit` serialises submissions yet does not preempt already-queued goroutines, so once the caller cancelled `ctx` every remaining file in the queue still entered `dispatcher.RunWithStats` and ran to completion. The post-`g.Wait()` check for `ctx.Err()` then fired, but only after every file had been processed — defeating the point of cancellation on a large repo.

## Fix

Keep the derived `gctx`, check `gctx.Err()` at the top of each per-file goroutine, and return immediately if cancellation has been signalled. Already-running files still finish (`RunWithStats` does not accept a `ctx` yet, so per-rule preemption stays coarse), but queued files no longer pay the full dispatcher cost on a cancelled sweep.

The per-file goroutine body was extracted into a `dispatchFileState` helper to keep `Run` under the project's gocyclo threshold; behaviour is otherwise identical.

## Test plan

- [x] `TestDispatchPhase_Run_StopsQueuedFilesOnContextCancel` submits 64 files, blocks the first wave of rule callbacks until the test cancels ctx, and asserts the rule callback ran on strictly fewer than 64 files. Fails on the pre-fix code (all 64 run) and passes after. Also asserts the returned error is `context.Canceled`.
- [x] All pre-existing dispatch tests still pass.
- [x] `go test ./... -count=1`, `go vet`, `golangci-lint run ./...` (0 issues) all clean.