### PR TITLE
fix(rules): convert TrulyRandom to FlatDispatch with receiver proof

### DIFF
--- a/internal/rules/android_source_extra.go
+++ b/internal/rules/android_source_extra.go
@@ -846,31 +846,6 @@ func layoutInflationHasIntentionalNullParentContext(file *scanner.File, idx uint
 	return false
 }
 
-type TrulyRandomRule struct {
-	LineBase
-	AndroidRule
-}
-
-var secureRandomSeedRe = regexp.MustCompile(`SecureRandom\s*\(\s*(byteArrayOf|"[^"]*"|ByteArray)`)
-
-// Confidence reports a tier-2 (medium) base confidence. This is an
-// Android-lint port from AOSP; the detection relies on source-text
-// patterns (call names, string literal contents, hardcoded allow-
-// lists of API names) rather than type resolution, so project-
-// specific wrapper APIs can cause false positives or negatives.
-// Classified per roadmap/17.
-func (r *TrulyRandomRule) Confidence() float64 { return 0.75 }
-
-func (r *TrulyRandomRule) check(ctx *api.Context) {
-	file := ctx.File
-	for i, line := range file.Lines {
-		if !scanner.IsCommentLine(line) && secureRandomSeedRe.MatchString(line) {
-			ctx.Emit(r.Finding(file, i+1, 1,
-				"SecureRandom with a hardcoded seed is not secure. Use the default constructor for cryptographic randomness."))
-		}
-	}
-}
-
 type MissingPermissionRule struct {
 	FlatDispatchBase
 	AndroidRule

--- a/internal/rules/android_source_extra_test.go
+++ b/internal/rules/android_source_extra_test.go
@@ -486,8 +486,22 @@ func TestTrulyRandom_Extra(t *testing.T) {
 		findings := runRuleByName(t, "TrulyRandom", `
 package test
 
+import java.security.SecureRandom
+
 fun init() {
     val rng = SecureRandom(byteArrayOf(1, 2, 3))
+}
+`)
+		if len(findings) != 1 {
+			t.Fatalf("expected 1 finding, got %d", len(findings))
+		}
+	})
+	t.Run("positive - fully qualified seeded SecureRandom", func(t *testing.T) {
+		findings := runRuleByName(t, "TrulyRandom", `
+package test
+
+fun init() {
+    val rng = java.security.SecureRandom(byteArrayOf(1, 2, 3))
 }
 `)
 		if len(findings) != 1 {
@@ -498,8 +512,101 @@ fun init() {
 		findings := runRuleByName(t, "TrulyRandom", `
 package test
 
+import java.security.SecureRandom
+
 fun init() {
     val rng = SecureRandom()
+}
+`)
+		if len(findings) != 0 {
+			t.Fatalf("expected 0 findings, got %d", len(findings))
+		}
+	})
+	t.Run("negative - local lookalike without import", func(t *testing.T) {
+		findings := runRuleByName(t, "TrulyRandom", `
+package test
+
+class SecureRandom(seed: ByteArray)
+
+fun init() {
+    val rng = SecureRandom(byteArrayOf(1, 2, 3))
+}
+`)
+		if len(findings) != 0 {
+			t.Fatalf("expected 0 findings (local lookalike), got %d", len(findings))
+		}
+	})
+	t.Run("negative - SecureRandom mention in raw string", func(t *testing.T) {
+		findings := runRuleByName(t, "TrulyRandom", `
+package test
+
+import java.security.SecureRandom
+
+fun usage(): String {
+    return """
+        Example: SecureRandom(byteArrayOf(1, 2))
+    """.trimIndent()
+}
+`)
+		if len(findings) != 0 {
+			t.Fatalf("expected 0 findings (raw string), got %d", len(findings))
+		}
+	})
+	t.Run("negative - SecureRandom in KDoc comment", func(t *testing.T) {
+		findings := runRuleByName(t, "TrulyRandom", `
+package test
+
+import java.security.SecureRandom
+
+/**
+ * Avoid SecureRandom(byteArrayOf(1, 2)) — it's predictable.
+ */
+fun init() {
+    val rng = SecureRandom()
+}
+`)
+		if len(findings) != 0 {
+			t.Fatalf("expected 0 findings (KDoc), got %d", len(findings))
+		}
+	})
+	t.Run("positive - Java new SecureRandom with seed", func(t *testing.T) {
+		findings := runRuleByNameOnJava(t, "TrulyRandom", `
+package test;
+import java.security.SecureRandom;
+class Example {
+    SecureRandom rng() {
+        return new SecureRandom(new byte[]{1, 2, 3});
+    }
+}
+`)
+		if len(findings) != 1 {
+			t.Fatalf("expected 1 finding, got %d", len(findings))
+		}
+	})
+	t.Run("negative - Java new SecureRandom default", func(t *testing.T) {
+		findings := runRuleByNameOnJava(t, "TrulyRandom", `
+package test;
+import java.security.SecureRandom;
+class Example {
+    SecureRandom rng() {
+        return new SecureRandom();
+    }
+}
+`)
+		if len(findings) != 0 {
+			t.Fatalf("expected 0 findings, got %d", len(findings))
+		}
+	})
+	t.Run("negative - Java local lookalike", func(t *testing.T) {
+		findings := runRuleByNameOnJava(t, "TrulyRandom", `
+package test;
+class SecureRandom {
+    SecureRandom(byte[] seed) {}
+}
+class Example {
+    SecureRandom rng() {
+        return new SecureRandom(new byte[]{1, 2});
+    }
 }
 `)
 		if len(findings) != 0 {

--- a/internal/rules/android_truly_random.go
+++ b/internal/rules/android_truly_random.go
@@ -1,0 +1,61 @@
+package rules
+
+import (
+	api "github.com/kaeawc/krit/internal/rules/api"
+	"github.com/kaeawc/krit/internal/scanner"
+)
+
+// TrulyRandomRule detects SecureRandom(seed) constructor calls (Kotlin and
+// Java) where any seed argument is supplied. Per Android lint's
+// TrulyRandomDetector, a hardcoded seed defeats cryptographic randomness —
+// the default constructor should be used instead.
+//
+// SecureRandom.setSeed() with a deterministic argument is already covered by
+// SecureRandomRule. This rule covers the constructor form on both languages.
+type TrulyRandomRule struct {
+	FlatDispatchBase
+	AndroidRule
+}
+
+// Confidence reports a tier-2 (medium) base confidence. Detection is anchored
+// to an imported or fully-qualified java.security.SecureRandom reference, so
+// local lookalikes no longer fire; project-specific wrapper APIs named
+// SecureRandom can still produce false negatives when not imported.
+func (r *TrulyRandomRule) Confidence() float64 { return 0.85 }
+
+func (r *TrulyRandomRule) check(ctx *api.Context) {
+	file := ctx.File
+	switch file.FlatType(ctx.Idx) {
+	case "call_expression":
+		r.checkKotlinCall(ctx, file, ctx.Idx)
+	case "object_creation_expression":
+		r.checkJavaConstruction(ctx, file, ctx.Idx)
+	}
+}
+
+func (r *TrulyRandomRule) checkKotlinCall(ctx *api.Context, file *scanner.File, call uint32) {
+	_, args := flatCallExpressionParts(file, call)
+	if args == 0 || file.FlatNamedChildCount(args) == 0 {
+		return
+	}
+	if !secureRandomKotlinConstructorCall(file, call) {
+		return
+	}
+	r.emit(ctx, file, call)
+}
+
+func (r *TrulyRandomRule) checkJavaConstruction(ctx *api.Context, file *scanner.File, node uint32) {
+	if !secureRandomJavaObjectCreationIsSecureRandom(file, node) {
+		return
+	}
+	args, ok := file.FlatFindChild(node, "argument_list")
+	if !ok || file.FlatNamedChildCount(args) == 0 {
+		return
+	}
+	r.emit(ctx, file, node)
+}
+
+func (r *TrulyRandomRule) emit(ctx *api.Context, file *scanner.File, node uint32) {
+	ctx.Emit(r.Finding(file, file.FlatRow(node)+1, file.FlatCol(node)+1,
+		"SecureRandom with a hardcoded seed is not secure. Use the default constructor for cryptographic randomness."))
+}

--- a/internal/rules/registry_android_source_extra.go
+++ b/internal/rules/registry_android_source_extra.go
@@ -111,7 +111,9 @@ func registerAndroidSourceExtraRules() {
 		r := &TrulyRandomRule{AndroidRule: AndroidRule{BaseRule: BaseRule{RuleName: "TrulyRandom", RuleSetName: androidRuleSet, Sev: "warning"}, IssueID: "TrulyRandom", Brief: "Hardcoded seed defeats SecureRandom", Category: ALCSecurity, ALSeverity: ALSWarning, Priority: 9, Origin: "AOSP Android Lint"}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Description(), Sev: api.Severity(r.Sev),
-			Needs: api.NeedsLinePass, Confidence: r.Confidence(), Implementation: r,
+			NodeTypes:  []string{"call_expression", "object_creation_expression"},
+			Languages:  []scanner.Language{scanner.LangKotlin, scanner.LangJava},
+			Confidence: r.Confidence(), Implementation: r,
 			Check: r.check,
 		})
 	}

--- a/tests/fixtures/negative/android-lint/TrulyRandom.java
+++ b/tests/fixtures/negative/android-lint/TrulyRandom.java
@@ -1,0 +1,9 @@
+package com.example;
+
+import java.security.SecureRandom;
+
+class DefaultRandom {
+    SecureRandom create() {
+        return new SecureRandom();
+    }
+}

--- a/tests/fixtures/positive/android-lint/TrulyRandom.java
+++ b/tests/fixtures/positive/android-lint/TrulyRandom.java
@@ -1,0 +1,9 @@
+package com.example;
+
+import java.security.SecureRandom;
+
+class SeededRandom {
+    SecureRandom create() {
+        return new SecureRandom(new byte[]{1, 2, 3});
+    }
+}


### PR DESCRIPTION
## Summary

- Replace TrulyRandom's `SecureRandom\s*\(\s*(byteArrayOf|\"...|ByteArray)` line regex with a FlatDispatch rule anchored on the call AST. The old regex is the \"common method name needs receiver proof\" anti-pattern from CLAUDE.md — it would fire on `SecureRandom(byteArrayOf(...))` text inside raw strings, KDoc, or against a local lookalike `class SecureRandom`.
- Dispatch on `call_expression` and `object_creation_expression`; require the constructor to reference `java.security.SecureRandom` (imported or fully qualified) and to receive any seed argument.
- Reuses existing SecureRandom helpers (`secureRandomKotlinConstructorCall`, `secureRandomJavaObjectCreationIsSecureRandom`, `secureRandomImportsJavaSecuritySecureRandom`).

## Wins

- AST dispatch naturally skips comments and string-literal contents — no lexical-state filter needed.
- Receiver/import proof eliminates local-class false positives in both Kotlin and Java.
- Adds Java parity (`new SecureRandom(seed)`); the regex never matched Java's `new` form.
- Confidence raised 0.75 → 0.85 to reflect the stronger evidence.

## Test plan

- [x] `go build -o krit ./cmd/krit/`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...`
- [x] `make lint-rules`
- [x] `go test ./... -count=1`
- [x] New regression coverage: Kotlin FQN positive, Kotlin local-lookalike negative, raw-string negative, KDoc negative, Java positive/negative/local-lookalike
- [x] Java fixtures added at `tests/fixtures/{positive,negative}/android-lint/TrulyRandom.java`