### PR TITLE
fix(rules): walk import_header AST in GodClassOrModule

### DIFF
--- a/internal/rules/hotspot.go
+++ b/internal/rules/hotspot.go
@@ -6,6 +6,7 @@ import (
 
 	api "github.com/kaeawc/krit/internal/rules/api"
 	"github.com/kaeawc/krit/internal/scanner"
+	"github.com/kaeawc/krit/internal/sourceheader"
 )
 
 // GodClassOrModuleRule reports Kotlin source files that import from an
@@ -13,7 +14,7 @@ import (
 // side of the concept; class-level ownership can reuse the same thresholding
 // approach with AST ownership in a later iteration.
 type GodClassOrModuleRule struct {
-	LineBase
+	FlatDispatchBase
 	BaseRule
 	AllowedDistinctPackages int
 }
@@ -22,21 +23,22 @@ type GodClassOrModuleRule struct {
 // threshold is a project-sensitive heuristic. Classified per roadmap/17.
 func (r *GodClassOrModuleRule) Confidence() float64 { return 0.75 }
 
+// Walks `import_header` AST nodes instead of `file.Lines` so the count
+// excludes `import ` text inside block comments, KDoc, and raw-string
+// literals — the original line-prefix scan miscounted those.
 func (r *GodClassOrModuleRule) check(ctx *api.Context) {
 	file := ctx.File
 	packages := make(map[string]struct{})
 	firstImportLine := 0
 
-	for i, line := range file.Lines {
-		trimmed := strings.TrimSpace(line)
-		if !strings.HasPrefix(trimmed, "import ") {
-			continue
+	file.FlatWalkNodes(ctx.Idx, "import_header", func(node uint32) {
+		imp := sourceheader.FirstHeaderLine(file.FlatNodeText(node), "import")
+		if imp == "" {
+			return
 		}
 		if firstImportLine == 0 {
-			firstImportLine = i + 1
+			firstImportLine = file.FlatRow(node) + 1
 		}
-
-		imp := strings.TrimSpace(strings.TrimPrefix(trimmed, "import "))
 		if idx := strings.Index(imp, " as "); idx >= 0 {
 			imp = strings.TrimSpace(imp[:idx])
 		}
@@ -45,13 +47,13 @@ func (r *GodClassOrModuleRule) check(ctx *api.Context) {
 		} else if lastDot := strings.LastIndex(imp, "."); lastDot > 0 {
 			imp = imp[:lastDot]
 		} else {
-			continue
+			return
 		}
 		if imp == "" {
-			continue
+			return
 		}
 		packages[imp] = struct{}{}
-	}
+	})
 
 	if len(packages) <= r.AllowedDistinctPackages {
 		return

--- a/internal/rules/hotspot_test.go
+++ b/internal/rules/hotspot_test.go
@@ -78,6 +78,44 @@ class FeatureModule
 	}
 }
 
+func TestGodClassOrModuleRule_IgnoresImportTextInStringsAndComments(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "DocsHeavy.kt")
+	code := "package test\n\n" +
+		"import alpha.analytics.AnalyticsClient\n" +
+		"import beta.auth.SessionStore\n" +
+		"\n" +
+		"/*\n" +
+		" * import gamma.cache.MemoryCache\n" +
+		" * import delta.config.RuntimeConfig\n" +
+		" */\n" +
+		"\n" +
+		"val sample = \"\"\"\n" +
+		"import epsilon.fake.FakeOne\n" +
+		"import zeta.fake.FakeTwo\n" +
+		"\"\"\"\n" +
+		"\n" +
+		"class DocsHeavy\n"
+	if err := os.WriteFile(path, []byte(code), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	file, err := scanner.ParseFile(context.Background(), path)
+	if err != nil {
+		t.Fatalf("ParseFile: %v", err)
+	}
+
+	rule := &GodClassOrModuleRule{
+		BaseRule:                BaseRule{RuleName: "GodClassOrModule", RuleSetName: "architecture", Sev: "warning"},
+		AllowedDistinctPackages: 2,
+	}
+	ctx := api.FakeContext(file)
+	rule.check(ctx)
+	findings := api.ContextFindings(ctx)
+	if len(findings) != 0 {
+		t.Fatalf("expected only real imports to count, got %d findings: %+v", len(findings), findings)
+	}
+}
+
 func TestFanInFanOutHotspotRule_FlagsHighFanInClass(t *testing.T) {
 	rule := &FanInFanOutHotspotRule{
 		BaseRule:                BaseRule{RuleName: "FanInFanOutHotspot", RuleSetName: "architecture", Sev: "info"},

--- a/internal/rules/registry_hotspot.go
+++ b/internal/rules/registry_hotspot.go
@@ -14,7 +14,7 @@ func registerHotspotRules() {
 		}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			Needs: api.NeedsLinePass, Implementation: r,
+			NodeTypes: []string{"source_file"}, Confidence: r.Confidence(), Implementation: r,
 			Check: r.check,
 		})
 	}


### PR DESCRIPTION
## Summary
- Convert `GodClassOrModuleRule` from `LineBase` to `FlatDispatchBase` dispatched on `source_file`.
- Walk Kotlin `import_header` AST nodes and parse each via `sourceheader.FirstHeaderLine` instead of scanning `file.Lines` for `import ` prefixes.
- The line-prefix scan miscounted `import ` occurrences inside raw-string literals (and other multiline trivia tree-sitter attaches to header nodes). The AST walk skips strings, comments, and KDoc.

## Test plan
- [x] `go build -o krit ./cmd/krit/`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...`
- [x] `go test ./... -count=1`
- [x] `make lint-rules`
- [x] `make integration` (one unrelated flake in `cmd/krit` that passed on retry)
- [x] New regression test `TestGodClassOrModuleRule_IgnoresImportTextInStringsAndComments` covers raw-string and block-comment trivia