### PR TITLE
fix(fixer): propagate context to cwebp / optipng / pngcrush subprocesses

### DIFF
--- a/internal/fixer/binary.go
+++ b/internal/fixer/binary.go
@@ -64,7 +64,10 @@ func ValidateBinaryFix(fix *scanner.BinaryFix, searchDirs []string) ([]android.F
 
 // ApplyBinaryFixesBatchColumns applies binary fixes from columnar findings in the
 // same safe order as ApplyBinaryFixesBatch, working directly with columnar data.
-func ApplyBinaryFixesBatchColumns(columns *scanner.FindingColumns, dryRun bool, searchDirs ...[]string) (applied int, errors []error) {
+// `ctx` is propagated to every external subprocess (cwebp, optipng, pngcrush)
+// so the caller can apply a timeout or honor cancellation — a stuck
+// converter no longer hangs the LSP/MCP server or CLI run.
+func ApplyBinaryFixesBatchColumns(ctx context.Context, columns *scanner.FindingColumns, dryRun bool, searchDirs ...[]string) (applied int, errors []error) {
 	if columns == nil || columns.Len() == 0 {
 		return 0, nil
 	}
@@ -75,12 +78,15 @@ func ApplyBinaryFixesBatchColumns(columns *scanner.FindingColumns, dryRun bool, 
 			fixes = append(fixes, bf)
 		}
 	})
-	return applyBinaryFixesBatchRaw(fixes, dryRun, searchDirs...)
+	return applyBinaryFixesBatchRaw(ctx, fixes, dryRun, searchDirs...)
 }
 
 // applyBinaryFixesBatchRaw is the core implementation shared by ApplyBinaryFixesBatch
 // and ApplyBinaryFixesBatchColumns, operating on raw *BinaryFix pointers.
-func applyBinaryFixesBatchRaw(fixes []*scanner.BinaryFix, dryRun bool, searchDirs ...[]string) (applied int, errors []error) {
+func applyBinaryFixesBatchRaw(ctx context.Context, fixes []*scanner.BinaryFix, dryRun bool, searchDirs ...[]string) (applied int, errors []error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	var refDirs []string
 	if len(searchDirs) > 0 {
 		refDirs = searchDirs[0]
@@ -103,21 +109,22 @@ func applyBinaryFixesBatchRaw(fixes []*scanner.BinaryFix, dryRun bool, searchDir
 			optimizations = append(optimizations, bf)
 		}
 	}
-	return applyBinaryFixPartitions(conversions, creates, moves, deletions, optimizations, dryRun, refDirs)
+	return applyBinaryFixPartitions(ctx, conversions, creates, moves, deletions, optimizations, dryRun, refDirs)
 }
 
 // applyBinaryFixPartitions runs the 6-pass ordered apply logic on pre-partitioned fix slices.
 // Order: conversions → optimizations → creates → moves → (delete-source for conversions) → explicit deletions.
 func applyBinaryFixPartitions(
+	ctx context.Context,
 	conversions, creates, moves, deletions, optimizations []*scanner.BinaryFix,
 	dryRun bool,
 	refDirs []string,
 ) (applied int, errors []error) {
-	n, errs, converted := applyWebPConversions(conversions, dryRun, refDirs)
+	n, errs, converted := applyWebPConversions(ctx, conversions, dryRun, refDirs)
 	applied += n
 	errors = append(errors, errs...)
 
-	n, errs = applyPNGOptimizations(optimizations, dryRun)
+	n, errs = applyPNGOptimizations(ctx, optimizations, dryRun)
 	applied += n
 	errors = append(errors, errs...)
 
@@ -139,7 +146,7 @@ func applyBinaryFixPartitions(
 	return
 }
 
-func applyWebPConversions(conversions []*scanner.BinaryFix, dryRun bool, refDirs []string) (int, []error, map[string]bool) {
+func applyWebPConversions(ctx context.Context, conversions []*scanner.BinaryFix, dryRun bool, refDirs []string) (int, []error, map[string]bool) {
 	applied := 0
 	var errors []error
 	converted := make(map[string]bool)
@@ -157,7 +164,7 @@ func applyWebPConversions(conversions []*scanner.BinaryFix, dryRun bool, refDirs
 			errors = append(errors, fmt.Errorf("skipped conversion of %s: %d direct file reference(s) found", bf.SourcePath, len(refs)))
 			continue
 		}
-		if err := convertToWebP(bf.SourcePath, bf.TargetPath, dryRun); err != nil {
+		if err := convertToWebP(ctx, bf.SourcePath, bf.TargetPath, dryRun); err != nil {
 			errors = append(errors, err)
 			continue
 		}
@@ -167,11 +174,11 @@ func applyWebPConversions(conversions []*scanner.BinaryFix, dryRun bool, refDirs
 	return applied, errors, converted
 }
 
-func applyPNGOptimizations(optimizations []*scanner.BinaryFix, dryRun bool) (int, []error) {
+func applyPNGOptimizations(ctx context.Context, optimizations []*scanner.BinaryFix, dryRun bool) (int, []error) {
 	applied := 0
 	var errors []error
 	for _, bf := range optimizations {
-		if err := optimizePNG(bf.SourcePath, dryRun); err != nil {
+		if err := optimizePNG(ctx, bf.SourcePath, dryRun); err != nil {
 			errors = append(errors, err)
 		} else {
 			applied++
@@ -257,7 +264,8 @@ func applyExplicitDeletions(deletions []*scanner.BinaryFix, dryRun bool) (int, [
 // convertToWebP converts an image file to WebP format using cwebp.
 // If dst is empty, generates the target path by replacing the file extension with .webp.
 // In dry-run mode, validates that cwebp is available but does not perform conversion.
-func convertToWebP(src, dst string, dryRun bool) error {
+// `ctx` bounds the subprocess so a wedged cwebp does not block the caller.
+func convertToWebP(ctx context.Context, src, dst string, dryRun bool) error {
 	if dst == "" {
 		dst = strings.TrimSuffix(src, filepath.Ext(src)) + ".webp"
 	}
@@ -268,7 +276,7 @@ func convertToWebP(src, dst string, dryRun bool) error {
 	if dryRun {
 		return nil
 	}
-	cmd := exec.CommandContext(context.Background(), cwebp, "-q", "80", src, "-o", dst)
+	cmd := exec.CommandContext(ctx, cwebp, "-q", "80", src, "-o", dst)
 	if output, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("cwebp failed: %w: %s", err, string(output))
 	}
@@ -277,14 +285,15 @@ func convertToWebP(src, dst string, dryRun bool) error {
 
 // optimizePNG runs optipng (or pngcrush as fallback) for lossless PNG optimization.
 // In dry-run mode, validates that a tool is available but does not perform optimization.
-func optimizePNG(src string, dryRun bool) error {
+// `ctx` bounds the subprocess so a wedged optimizer does not block the caller.
+func optimizePNG(ctx context.Context, src string, dryRun bool) error {
 	// Try optipng first, then pngcrush as fallback.
 	optipng, err := exec.LookPath("optipng")
 	if err == nil {
 		if dryRun {
 			return nil
 		}
-		cmd := exec.CommandContext(context.Background(), optipng, "-o2", "-quiet", src)
+		cmd := exec.CommandContext(ctx, optipng, "-o2", "-quiet", src)
 		if output, err := cmd.CombinedOutput(); err != nil {
 			return fmt.Errorf("optipng failed on %s: %w: %s", src, err, string(output))
 		}
@@ -297,7 +306,7 @@ func optimizePNG(src string, dryRun bool) error {
 			return nil
 		}
 		tmp := src + ".crush"
-		cmd := exec.CommandContext(context.Background(), pngcrush, "-q", src, tmp)
+		cmd := exec.CommandContext(ctx, pngcrush, "-q", src, tmp)
 		if output, err := cmd.CombinedOutput(); err != nil {
 			os.Remove(tmp) // clean up on failure
 			return fmt.Errorf("pngcrush failed on %s: %w: %s", src, err, string(output))

--- a/internal/fixer/binary_slice_test.go
+++ b/internal/fixer/binary_slice_test.go
@@ -1,6 +1,7 @@
 package fixer
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -15,7 +16,9 @@ import (
 
 // ApplyBinaryFixes processes binary fix findings one at a time in the order
 // they appear. Retained for tests that exercise per-finding error semantics.
-func ApplyBinaryFixes(findings []scanner.Finding, dryRun bool) (applied int, errors []error) {
+// `ctx` bounds the external subprocesses spawned for WebP conversion and
+// PNG optimization; tests typically pass context.Background().
+func ApplyBinaryFixes(ctx context.Context, findings []scanner.Finding, dryRun bool) (applied int, errors []error) {
 	for _, f := range findings {
 		if f.BinaryFix == nil {
 			continue
@@ -25,7 +28,7 @@ func ApplyBinaryFixes(findings []scanner.Finding, dryRun bool) (applied int, err
 		}
 		switch f.BinaryFix.Type {
 		case scanner.BinaryFixConvertWebP:
-			err := convertToWebP(f.BinaryFix.SourcePath, f.BinaryFix.TargetPath, dryRun)
+			err := convertToWebP(ctx, f.BinaryFix.SourcePath, f.BinaryFix.TargetPath, dryRun)
 			if err != nil {
 				errors = append(errors, err)
 				continue
@@ -77,7 +80,7 @@ func ApplyBinaryFixes(findings []scanner.Finding, dryRun bool) (applied int, err
 				applied++
 			}
 		case scanner.BinaryFixOptimizePNG:
-			err := optimizePNG(f.BinaryFix.SourcePath, dryRun)
+			err := optimizePNG(ctx, f.BinaryFix.SourcePath, dryRun)
 			if err != nil {
 				errors = append(errors, err)
 			} else {
@@ -91,14 +94,14 @@ func ApplyBinaryFixes(findings []scanner.Finding, dryRun bool) (applied int, err
 // ApplyBinaryFixesBatch processes all binary fix findings in a safe order:
 // first all conversions and optimizations, then file creates/moves, then all
 // deletions. Slice counterpart of ApplyBinaryFixesBatchColumns.
-func ApplyBinaryFixesBatch(findings []scanner.Finding, dryRun bool, searchDirs ...[]string) (applied int, errors []error) {
+func ApplyBinaryFixesBatch(ctx context.Context, findings []scanner.Finding, dryRun bool, searchDirs ...[]string) (applied int, errors []error) {
 	var fixes []*scanner.BinaryFix
 	for i := range findings {
 		if findings[i].BinaryFix != nil {
 			fixes = append(fixes, findings[i].BinaryFix)
 		}
 	}
-	return applyBinaryFixesBatchRaw(fixes, dryRun, searchDirs...)
+	return applyBinaryFixesBatchRaw(ctx, fixes, dryRun, searchDirs...)
 }
 
 // Slice-taking key/meta extractors for deduplicateFixesReverse. Exercised

--- a/internal/fixer/binary_test.go
+++ b/internal/fixer/binary_test.go
@@ -1,6 +1,7 @@
 package fixer
 
 import (
+	"context"
 	"image"
 	"image/color"
 	"image/gif"
@@ -10,6 +11,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/kaeawc/krit/internal/scanner"
 )
@@ -79,7 +81,7 @@ func TestApplyBinaryFixes_SkipsNilBinaryFix(t *testing.T) {
 		},
 	}
 
-	applied, errors := ApplyBinaryFixes(findings, false)
+	applied, errors := ApplyBinaryFixes(context.Background(), findings, false)
 	if applied != 0 {
 		t.Errorf("expected 0 applied, got %d", applied)
 	}
@@ -89,7 +91,7 @@ func TestApplyBinaryFixes_SkipsNilBinaryFix(t *testing.T) {
 }
 
 func TestApplyBinaryFixes_EmptyFindings(t *testing.T) {
-	applied, errors := ApplyBinaryFixes(nil, false)
+	applied, errors := ApplyBinaryFixes(context.Background(), nil, false)
 	if applied != 0 {
 		t.Errorf("expected 0 applied, got %d", applied)
 	}
@@ -116,7 +118,7 @@ func TestApplyBinaryFixes_CwebpNotFound(t *testing.T) {
 		},
 	}
 
-	applied, errors := ApplyBinaryFixes(findings, false)
+	applied, errors := ApplyBinaryFixes(context.Background(), findings, false)
 	if applied != 0 {
 		t.Errorf("expected 0 applied when cwebp missing, got %d", applied)
 	}
@@ -150,7 +152,7 @@ func TestApplyBinaryFixes_DryRunWithCwebp(t *testing.T) {
 		},
 	}
 
-	applied, errors := ApplyBinaryFixes(findings, true)
+	applied, errors := ApplyBinaryFixes(context.Background(), findings, true)
 	if applied != 1 {
 		t.Errorf("expected 1 applied in dry-run, got %d", applied)
 	}
@@ -187,7 +189,7 @@ func TestApplyBinaryFixes_MultipleFindingsMixed(t *testing.T) {
 		},
 	}
 
-	applied, errors := ApplyBinaryFixes(findings, false)
+	applied, errors := ApplyBinaryFixes(context.Background(), findings, false)
 	if applied != 0 {
 		t.Errorf("expected 0 applied (cwebp missing), got %d", applied)
 	}
@@ -200,7 +202,7 @@ func TestConvertToWebP_TargetPathGeneration(t *testing.T) {
 	// Override PATH to ensure cwebp is not found so we get a predictable error
 	t.Setenv("PATH", t.TempDir())
 
-	err := convertToWebP("/some/path/icon.png", "", false)
+	err := convertToWebP(context.Background(), "/some/path/icon.png", "", false)
 	if err == nil {
 		t.Fatal("expected error when cwebp not found")
 	}
@@ -212,12 +214,50 @@ func TestConvertToWebP_TargetPathGeneration(t *testing.T) {
 func TestConvertToWebP_CustomTargetPath(t *testing.T) {
 	t.Setenv("PATH", t.TempDir())
 
-	err := convertToWebP("/some/path/icon.png", "/other/path/icon.webp", false)
+	err := convertToWebP(context.Background(), "/some/path/icon.png", "/other/path/icon.webp", false)
 	if err == nil {
 		t.Fatal("expected error when cwebp not found")
 	}
 	if !containsStr(err.Error(), "cwebp not found") {
 		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+// TestConvertToWebP_HonorsContextCancellation drops a fake `cwebp`
+// shim onto PATH that sleeps indefinitely, then invokes convertToWebP
+// with a context that is cancelled almost immediately. On the pre-fix
+// code (context.Background hard-coded) the call would hang for the
+// full sleep duration; with the ctx parameter threaded through, the
+// wedged subprocess is killed and the call returns promptly.
+func TestConvertToWebP_HonorsContextCancellation(t *testing.T) {
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skip("sh not available")
+	}
+	dir := t.TempDir()
+	fake := filepath.Join(dir, "cwebp")
+	if err := os.WriteFile(fake, []byte("#!/bin/sh\nsleep 3600\n"), 0o755); err != nil {
+		t.Fatalf("write fake cwebp: %v", err)
+	}
+	t.Setenv("PATH", dir)
+	src := filepath.Join(dir, "in.png")
+	writeStaticPNG(t, src)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- convertToWebP(ctx, src, "", false)
+	}()
+	// Give the subprocess a moment to start before cancelling.
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("expected convertToWebP to return an error once the subprocess is killed")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("convertToWebP did not return after cancellation; context was not propagated to the cwebp subprocess")
 	}
 }
 
@@ -244,7 +284,7 @@ func TestApplyBinaryFixes_DeleteFile(t *testing.T) {
 		},
 	}
 
-	applied, errors := ApplyBinaryFixes(findings, false)
+	applied, errors := ApplyBinaryFixes(context.Background(), findings, false)
 	if applied != 1 {
 		t.Errorf("expected 1 applied, got %d", applied)
 	}
@@ -276,7 +316,7 @@ func TestApplyBinaryFixes_DeleteFile_DryRun(t *testing.T) {
 		},
 	}
 
-	applied, errors := ApplyBinaryFixes(findings, true)
+	applied, errors := ApplyBinaryFixes(context.Background(), findings, true)
 	if applied != 1 {
 		t.Errorf("expected 1 applied in dry-run, got %d", applied)
 	}
@@ -303,7 +343,7 @@ func TestApplyBinaryFixes_DeleteFile_Missing(t *testing.T) {
 		},
 	}
 
-	applied, errors := ApplyBinaryFixes(findings, false)
+	applied, errors := ApplyBinaryFixes(context.Background(), findings, false)
 	if applied != 0 {
 		t.Errorf("expected 0 applied for missing file, got %d", applied)
 	}
@@ -339,7 +379,7 @@ func TestApplyBinaryFixes_DeleteSourceAfterConvert_NoCwebp(t *testing.T) {
 		},
 	}
 
-	applied, errors := ApplyBinaryFixes(findings, false)
+	applied, errors := ApplyBinaryFixes(context.Background(), findings, false)
 	if applied != 0 {
 		t.Errorf("expected 0 applied (cwebp missing), got %d", applied)
 	}
@@ -353,7 +393,7 @@ func TestApplyBinaryFixes_DeleteSourceAfterConvert_NoCwebp(t *testing.T) {
 }
 
 func TestApplyBinaryFixesBatch_EmptyFindings(t *testing.T) {
-	applied, errors := ApplyBinaryFixesBatch(nil, false)
+	applied, errors := ApplyBinaryFixesBatch(context.Background(), nil, false)
 	if applied != 0 {
 		t.Errorf("expected 0 applied, got %d", applied)
 	}
@@ -384,7 +424,7 @@ func TestApplyBinaryFixesBatch_DeletesOnly(t *testing.T) {
 		},
 	}
 
-	applied, errors := ApplyBinaryFixesBatch(findings, false)
+	applied, errors := ApplyBinaryFixesBatch(context.Background(), findings, false)
 	if applied != 2 {
 		t.Errorf("expected 2 applied, got %d", applied)
 	}
@@ -412,7 +452,7 @@ func TestApplyBinaryFixesBatch_DryRunDeletesPreserved(t *testing.T) {
 		},
 	}
 
-	applied, errors := ApplyBinaryFixesBatch(findings, true)
+	applied, errors := ApplyBinaryFixesBatch(context.Background(), findings, true)
 	if applied != 1 {
 		t.Errorf("expected 1 applied in dry-run, got %d", applied)
 	}
@@ -454,7 +494,7 @@ func TestApplyBinaryFixesBatch_OrderConvertBeforeDelete(t *testing.T) {
 		},
 	}
 
-	applied, errors := ApplyBinaryFixesBatch(findings, false)
+	applied, errors := ApplyBinaryFixesBatch(context.Background(), findings, false)
 	// Conversion fails (no cwebp) -> 0 from conversion.
 	// Explicit delete should still succeed -> 1.
 	if applied != 1 {
@@ -475,7 +515,7 @@ func TestApplyBinaryFixesBatch_SkipsNilBinaryFix(t *testing.T) {
 		{File: "test.kt", Rule: "SomeRule", Message: "no fix"},
 	}
 
-	applied, errors := ApplyBinaryFixesBatch(findings, false)
+	applied, errors := ApplyBinaryFixesBatch(context.Background(), findings, false)
 	if applied != 0 {
 		t.Errorf("expected 0 applied, got %d", applied)
 	}
@@ -504,7 +544,7 @@ func TestApplyBinaryFixes_CreateFile(t *testing.T) {
 		},
 	}
 
-	applied, errors := ApplyBinaryFixes(findings, false)
+	applied, errors := ApplyBinaryFixes(context.Background(), findings, false)
 	if applied != 1 {
 		t.Errorf("expected 1 applied, got %d", applied)
 	}
@@ -537,7 +577,7 @@ func TestApplyBinaryFixes_CreateFile_DryRun(t *testing.T) {
 		},
 	}
 
-	applied, errors := ApplyBinaryFixes(findings, true)
+	applied, errors := ApplyBinaryFixes(context.Background(), findings, true)
 	if applied != 1 {
 		t.Errorf("expected 1 applied in dry-run, got %d", applied)
 	}
@@ -571,7 +611,7 @@ func TestApplyBinaryFixes_MoveFile(t *testing.T) {
 		},
 	}
 
-	applied, errors := ApplyBinaryFixes(findings, false)
+	applied, errors := ApplyBinaryFixes(context.Background(), findings, false)
 	if applied != 1 {
 		t.Errorf("expected 1 applied, got %d", applied)
 	}
@@ -613,7 +653,7 @@ func TestApplyBinaryFixes_MoveFile_DryRun(t *testing.T) {
 		},
 	}
 
-	applied, errors := ApplyBinaryFixes(findings, true)
+	applied, errors := ApplyBinaryFixes(context.Background(), findings, true)
 	if applied != 1 {
 		t.Errorf("expected 1 applied in dry-run, got %d", applied)
 	}
@@ -645,7 +685,7 @@ func TestApplyBinaryFixes_MoveFile_MissingSource(t *testing.T) {
 		},
 	}
 
-	applied, errors := ApplyBinaryFixes(findings, false)
+	applied, errors := ApplyBinaryFixes(context.Background(), findings, false)
 	if applied != 0 {
 		t.Errorf("expected 0 applied, got %d", applied)
 	}
@@ -679,7 +719,7 @@ func TestApplyBinaryFixes_OptimizePNG_NoTool(t *testing.T) {
 		},
 	}
 
-	applied, errors := ApplyBinaryFixes(findings, false)
+	applied, errors := ApplyBinaryFixes(context.Background(), findings, false)
 	if applied != 0 {
 		t.Errorf("expected 0 applied when no PNG optimizer, got %d", applied)
 	}
@@ -707,7 +747,7 @@ func TestApplyBinaryFixes_OptimizePNG_DryRun_NoTool(t *testing.T) {
 		},
 	}
 
-	applied, errors := ApplyBinaryFixes(findings, true)
+	applied, errors := ApplyBinaryFixes(context.Background(), findings, true)
 	if applied != 0 {
 		t.Errorf("expected 0 applied, got %d", applied)
 	}
@@ -732,7 +772,7 @@ func TestApplyBinaryFixes_HintOnly_Skipped(t *testing.T) {
 		},
 	}
 
-	applied, errors := ApplyBinaryFixes(findings, false)
+	applied, errors := ApplyBinaryFixes(context.Background(), findings, false)
 	if applied != 0 {
 		t.Errorf("expected 0 applied for hint-only fix, got %d", applied)
 	}
@@ -756,7 +796,7 @@ func TestApplyBinaryFixesBatch_HintOnly_Skipped(t *testing.T) {
 		},
 	}
 
-	applied, errors := ApplyBinaryFixesBatch(findings, false)
+	applied, errors := ApplyBinaryFixesBatch(context.Background(), findings, false)
 	if applied != 0 {
 		t.Errorf("expected 0 applied for hint-only fix, got %d", applied)
 	}
@@ -782,7 +822,7 @@ func TestApplyBinaryFixesBatch_CreateFile(t *testing.T) {
 		},
 	}
 
-	applied, errors := ApplyBinaryFixesBatch(findings, false)
+	applied, errors := ApplyBinaryFixesBatch(context.Background(), findings, false)
 	if applied != 1 {
 		t.Errorf("expected 1 applied, got %d", applied)
 	}
@@ -818,7 +858,7 @@ func TestApplyBinaryFixesBatch_MoveFile(t *testing.T) {
 		},
 	}
 
-	applied, errors := ApplyBinaryFixesBatch(findings, false)
+	applied, errors := ApplyBinaryFixesBatch(context.Background(), findings, false)
 	if applied != 1 {
 		t.Errorf("expected 1 applied, got %d", applied)
 	}
@@ -871,7 +911,7 @@ func TestApplyBinaryFixesBatch_MixedTypes(t *testing.T) {
 		},
 	}
 
-	applied, errors := ApplyBinaryFixesBatch(findings, false)
+	applied, errors := ApplyBinaryFixesBatch(context.Background(), findings, false)
 	if applied != 3 {
 		t.Errorf("expected 3 applied, got %d", applied)
 	}
@@ -935,13 +975,13 @@ func TestApplyBinaryFixesBatchColumns_MatchesSliceBehavior(t *testing.T) {
 	}
 
 	sliceFindings, _, wantDeleted, wantMoved, wantCreated := makeFixture(t)
-	wantApplied, wantErrors := ApplyBinaryFixesBatch(sliceFindings, false)
+	wantApplied, wantErrors := ApplyBinaryFixesBatch(context.Background(), sliceFindings, false)
 	if len(wantErrors) != 0 {
 		t.Fatalf("slice ApplyBinaryFixesBatch errors: %v", wantErrors)
 	}
 
 	_, columns, gotDeleted, gotMoved, gotCreated := makeFixture(t)
-	gotApplied, gotErrors := ApplyBinaryFixesBatchColumns(&columns, false)
+	gotApplied, gotErrors := ApplyBinaryFixesBatchColumns(context.Background(), &columns, false)
 	if len(gotErrors) != 0 {
 		t.Fatalf("columnar ApplyBinaryFixesBatchColumns errors: %v", gotErrors)
 	}
@@ -1001,7 +1041,7 @@ func TestApplyBinaryFixesBatch_DryRun_MixedTypes(t *testing.T) {
 		},
 	}
 
-	applied, errors := ApplyBinaryFixesBatch(findings, true)
+	applied, errors := ApplyBinaryFixesBatch(context.Background(), findings, true)
 	if applied != 3 {
 		t.Errorf("expected 3 applied in dry-run, got %d", applied)
 	}
@@ -1121,7 +1161,7 @@ func TestApplyBinaryFixesBatch_SkipsConversionWithDirectRefs(t *testing.T) {
 		},
 	}
 
-	applied, errors := ApplyBinaryFixesBatch(findings, false, []string{srcDir})
+	applied, errors := ApplyBinaryFixesBatch(context.Background(), findings, false, []string{srcDir})
 
 	// Conversion should be skipped due to direct references.
 	if applied != 0 {
@@ -1169,7 +1209,7 @@ func TestApplyBinaryFixesBatch_AllowsConversionWithNoRefs(t *testing.T) {
 		},
 	}
 
-	_, errors := ApplyBinaryFixesBatch(findings, false, []string{srcDir})
+	_, errors := ApplyBinaryFixesBatch(context.Background(), findings, false, []string{srcDir})
 
 	// Should attempt conversion (fail because no cwebp, not because of refs).
 	if len(errors) != 1 {
@@ -1337,7 +1377,7 @@ func TestApplyBinaryFixesBatch_SkipsAnimatedGIF(t *testing.T) {
 		},
 	}
 
-	applied, errors := ApplyBinaryFixesBatch(findings, false)
+	applied, errors := ApplyBinaryFixesBatch(context.Background(), findings, false)
 	if applied != 0 {
 		t.Errorf("expected 0 applied for animated GIF, got %d", applied)
 	}
@@ -1375,7 +1415,7 @@ func TestApplyBinaryFixesBatch_SkipsLowMinSdk(t *testing.T) {
 		},
 	}
 
-	applied, errors := ApplyBinaryFixesBatch(findings, false)
+	applied, errors := ApplyBinaryFixesBatch(context.Background(), findings, false)
 	if applied != 0 {
 		t.Errorf("expected 0 applied for low minSdk, got %d", applied)
 	}

--- a/internal/pipeline/fixup.go
+++ b/internal/pipeline/fixup.go
@@ -114,7 +114,7 @@ func (FixupPhase) Run(ctx context.Context, in FixupInput) (FixupResult, error) {
 
 	var binaryErrs []error
 	if in.ApplyBinary {
-		applied, errs := fixer.ApplyBinaryFixesBatchColumns(&columns, in.DryRunBinary)
+		applied, errs := fixer.ApplyBinaryFixesBatchColumns(ctx, &columns, in.DryRunBinary)
 		binaryFixes = applied
 		binaryErrs = errs
 		fixErrs = append(fixErrs, errs...)


### PR DESCRIPTION
## Root cause

`convertToWebP` and `optimizePNG` both launched their external converters with `exec.CommandContext(context.Background(), ...)`, giving the subprocess a context that can never be cancelled. A stalled `cwebp`, `optipng`, or `pngcrush` blocked the entire fixer batch — and by extension the LSP/MCP server or CLI run that was driving it. The public batch API `ApplyBinaryFixesBatchColumns` did not even accept a `ctx`, so callers had no way to thread their existing cancellation signal in.

## Fix

Add `context.Context` as the first parameter to `ApplyBinaryFixesBatchColumns`, `applyBinaryFixesBatchRaw`, `applyBinaryFixPartitions`, `applyWebPConversions`, `applyPNGOptimizations`, `convertToWebP`, and `optimizePNG`. The ctx is handed straight into `exec.CommandContext`, so cancellation kills the subprocess via SIGKILL and returns to the caller promptly.

The existing caller in `pipeline/fixup.go` now forwards the dispatch ctx it already has in scope; tests pass `context.Background()`.

## Test plan

- [x] `TestConvertToWebP_HonorsContextCancellation` drops a fake `cwebp` shim on `PATH` that sleeps for an hour, then cancels the context. The call returns within seconds; on the pre-fix code the test would have had to wait out the sleep.
- [x] All pre-existing binary-fixer tests still pass.
- [x] `go test ./... -count=1`, `go vet`, `golangci-lint run ./...` (0 issues) all clean.