### PR TITLE
fix(output): make SARIF severity mapping explicit with a defensive default

### DIFF
--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -258,13 +258,7 @@ func FormatSARIFColumns(w io.Writer, columns *scanner.FindingColumns, version st
 		}
 
 		severity := cols.SeverityAt(row)
-		level := "note"
-		switch severity {
-		case "error":
-			level = "error"
-		case "warning":
-			level = "warning"
-		}
+		level := sarifLevelForSeverity(severity)
 		r := sarifResult{
 			RuleID:  ruleID,
 			Level:   level,
@@ -306,6 +300,28 @@ func FormatSARIFColumns(w io.Writer, columns *scanner.FindingColumns, version st
 
 // buildResultProperties returns the per-finding sarifProperties payload,
 // or nil when the finding has no metadata worth emitting.
+// sarifLevelForSeverity returns the SARIF 2.1.0 `level` value (one of
+// "error", "warning", "note", "none") that corresponds to a krit
+// severity string. SARIF rejects out-of-domain level values, so every
+// krit-emitted severity must map to one of the four spec values.
+//
+// The mapping is explicit (no silent fallthrough): unknown severity
+// strings default to "warning" instead of being collapsed to "note",
+// so an upstream typo or a newly-introduced severity surfaces as a
+// loud finding rather than being silently downgraded.
+func sarifLevelForSeverity(severity string) string {
+	switch severity {
+	case "error":
+		return "error"
+	case "warning":
+		return "warning"
+	case "info", "informational":
+		return "note"
+	default:
+		return "warning"
+	}
+}
+
 func buildResultProperties(confidence float64, precision, effort string, caps []string, sec *api.SecurityTaxonomy) *sarifProperties {
 	if confidence <= 0 && precision == "" && effort == "" && len(caps) == 0 && sec == nil {
 		return nil

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -1169,3 +1169,101 @@ func TestIsTerminal_ReturnsFalseForBuffer(t *testing.T) {
 		t.Error("isTerminal should return false for bytes.Buffer")
 	}
 }
+
+// TestSarifLevelForSeverity locks in the SARIF level mapping for every
+// severity string krit currently emits, plus an unknown value to
+// guard against silent collapse. Adding a new severity string should
+// either land here explicitly or fall through to the "warning"
+// default so SARIF consumers see it instead of having it quietly
+// downgraded to "note".
+func TestSarifLevelForSeverity(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{in: "error", want: "error"},
+		{in: "warning", want: "warning"},
+		{in: "info", want: "note"},
+		{in: "informational", want: "note"},
+		{in: "", want: "warning"},
+		{in: "hint", want: "warning"},
+		{in: "ERROR", want: "warning"}, // case-sensitive: capitalised must not silently match.
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			if got := sarifLevelForSeverity(tc.in); got != tc.want {
+				t.Fatalf("sarifLevelForSeverity(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestFormatSARIFColumns_LevelForInfoSeverity verifies that an info
+// finding renders as SARIF level "note" via the FormatSARIFColumns
+// pipeline (not just the helper in isolation), so any future
+// refactor that bypasses sarifLevelForSeverity is caught.
+func TestFormatSARIFColumns_LevelForInfoSeverity(t *testing.T) {
+	cols := buildSarifSeverityFixture("info")
+	var buf bytes.Buffer
+	if err := FormatSARIFColumns(&buf, &cols, "test"); err != nil {
+		t.Fatalf("FormatSARIFColumns: %v", err)
+	}
+	if level := firstSarifResultLevel(t, buf.Bytes()); level != "note" {
+		t.Fatalf("info severity rendered as level %q, want %q", level, "note")
+	}
+}
+
+// TestFormatSARIFColumns_LevelForUnknownSeverityNormalisesToInfo
+// documents the current end-to-end behaviour: the scanner's
+// `severityIDFromString` collapses any severity that is not exactly
+// "error" or "warning" to the internal `info` ID before it reaches
+// SARIF, so an out-of-domain severity ("hint") renders as level
+// "note" — the SARIF equivalent of "info". If a future change
+// preserves the original severity string instead of collapsing to
+// "info", `sarifLevelForSeverity`'s defensive default surfaces it
+// as "warning" instead of silently being downgraded; the unit test
+// on the helper itself covers that contract.
+func TestFormatSARIFColumns_LevelForUnknownSeverityNormalisesToInfo(t *testing.T) {
+	cols := buildSarifSeverityFixture("hint")
+	var buf bytes.Buffer
+	if err := FormatSARIFColumns(&buf, &cols, "test"); err != nil {
+		t.Fatalf("FormatSARIFColumns: %v", err)
+	}
+	if level := firstSarifResultLevel(t, buf.Bytes()); level != "note" {
+		t.Fatalf("unknown severity rendered as level %q, want %q (scanner collapses to info)", level, "note")
+	}
+}
+
+func buildSarifSeverityFixture(severity string) scanner.FindingColumns {
+	c := scanner.NewFindingCollector(1)
+	c.Append(scanner.Finding{
+		File:     "Sample.kt",
+		Rule:     "SeverityFixtureRule",
+		RuleSet:  "test",
+		Severity: severity,
+		Message:  "fixture",
+		Line:     1,
+		Col:      1,
+	})
+	return *c.Columns()
+}
+
+func firstSarifResultLevel(t *testing.T, raw []byte) string {
+	t.Helper()
+	var doc map[string]interface{}
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("unmarshal SARIF: %v\n%s", err, raw)
+	}
+	runs, _ := doc["runs"].([]interface{})
+	if len(runs) == 0 {
+		t.Fatalf("no runs in SARIF output:\n%s", raw)
+	}
+	run, _ := runs[0].(map[string]interface{})
+	results, _ := run["results"].([]interface{})
+	if len(results) == 0 {
+		t.Fatalf("no results in SARIF output:\n%s", raw)
+	}
+	first, _ := results[0].(map[string]interface{})
+	level, _ := first["level"].(string)
+	return level
+}


### PR DESCRIPTION
## Root cause

The SARIF formatter mapped krit severities to SARIF `level` values inline:

    level := "note"
    switch severity {
    case "error":   level = "error"
    case "warning": level = "warning"
    }

`info` (the third severity the scanner currently emits) flowed through to the implicit `note` default by coincidence, and any unknown severity that future code might introduce would silently collapse to `note` too. The mapping intent was not documented and the helper was not unit-testable.

Today the scanner's `severityIDFromString` collapses everything that isn't `"error"` or `"warning"` into the internal `info` ID before the finding reaches the SARIF formatter, so the silent-collapse risk is latent rather than active. Making the mapping explicit defends the formatter against any future change that preserves the original severity string.

## Fix

Extract `sarifLevelForSeverity` with explicit cases for `"error"`, `"warning"`, and `"info"` / `"informational"` → `"note"`, and a defensive `"warning"` fallback for anything else. Document the rationale on the helper.

## Test plan

- [x] `TestSarifLevelForSeverity` table-tests every known severity plus empty, lowercase-unknown (`"hint"`), and the case-sensitive miss (`"ERROR"`) that the defensive default surfaces as `"warning"`.
- [x] `TestFormatSARIFColumns_LevelForInfoSeverity` and `TestFormatSARIFColumns_LevelForUnknownSeverityNormalisesToInfo` pin the end-to-end behaviour through `FormatSARIFColumns`, including the documented scanner-side normalisation of unknown severities to `info`.
- [x] All pre-existing output tests still pass.
- [x] `go test ./... -count=1`, `go vet`, `golangci-lint run ./...` (0 issues) all clean.