### PR TITLE
fix(output): trim padded negative exponent in appendJSONFloat

### DIFF
--- a/internal/output/json_finding_encoder.go
+++ b/internal/output/json_finding_encoder.go
@@ -157,13 +157,14 @@ func appendJSONEscapedByte(dst []byte, b byte) []byte {
 }
 
 // appendJSONFloat appends a float64 using the same shortest-form
-// representation encoding/json uses (strconv 'g' with -1 precision).
-// Notable cases that match json.Marshal: 0.75 → "0.75", 0.85 → "0.85",
-// 0.95 → "0.95", 1 → "1", 0.5 → "0.5".
+// representation encoding/json uses. It mirrors the encoder in the
+// standard library's encoding/json/encode.go: 'f' format for
+// magnitudes in [1e-6, 1e21), 'e' format otherwise, both with -1
+// precision; then trim a single leading zero from the exponent of
+// negative-exponent 'e' results (`1e-07` → `1e-7`) so the output is
+// byte-identical to `json.Marshal`. Notable cases: 0.75 → "0.75",
+// 1 → "1", 1e-7 → "1e-7", 1e21 → "1e+21", 1e-10 → "1e-10".
 func appendJSONFloat(dst []byte, v float64) []byte {
-	// json.Marshal for non-integer floats uses 'g' format with the
-	// shortest representation that round-trips. For integer-valued
-	// floats it omits the decimal (e.g. 1 not 1.0).
 	abs := v
 	if abs < 0 {
 		abs = -abs
@@ -172,10 +173,20 @@ func appendJSONFloat(dst []byte, v float64) []byte {
 	if abs != 0 && (abs < 1e-6 || abs >= 1e21) {
 		fmtByte = 'e'
 	}
-	// strconv emits "1.2e+05" / "1.2"; both match encoding/json's
-	// default float formatting (shortest round-trippable form, sign-
-	// prefixed exponent for 'e').
-	return strconv.AppendFloat(dst, v, fmtByte, -1, 64)
+	start := len(dst)
+	dst = strconv.AppendFloat(dst, v, fmtByte, -1, 64)
+	if fmtByte == 'e' {
+		// strconv.AppendFloat pads single-digit negative exponents to
+		// two digits ("1e-07"); encoding/json strips that pad
+		// ("1e-7"). Mirror the stdlib's last-four-byte fixup so our
+		// output round-trips byte-identically against `json.Marshal`.
+		n := len(dst)
+		if n-start >= 4 && dst[n-4] == 'e' && dst[n-3] == '-' && dst[n-2] == '0' {
+			dst[n-2] = dst[n-1]
+			dst = dst[:n-1]
+		}
+	}
+	return dst
 }
 
 // jsonSafe[b] is true when byte b can appear in a JSON string body

--- a/internal/output/json_finding_encoder_test.go
+++ b/internal/output/json_finding_encoder_test.go
@@ -171,3 +171,47 @@ func mustMarshal(t *testing.T, f JSONFinding) string {
 	}
 	return string(b)
 }
+
+// TestAppendJSONFloat_MatchesJSONMarshal locks in byte-identical
+// equivalence between our hand-rolled `appendJSONFloat` and
+// `json.Marshal` across the value ranges the encoder switches between
+// 'f' and 'e' formats and the exponent-padding boundary where the
+// stdlib trims a leading zero from negative single-digit exponents.
+func TestAppendJSONFloat_MatchesJSONMarshal(t *testing.T) {
+	values := []float64{
+		0,
+		1,
+		-1,
+		0.5,
+		-0.5,
+		0.75,
+		0.85,
+		0.95,
+		1e-5,
+		1e-6,  // boundary: just below — uses 'e' on the stdlib side too.
+		1e-7,  // strconv emits 1e-07; stdlib trims to 1e-7.
+		1e-8,  // 1e-08 → 1e-8.
+		1e-9,  // 1e-09 → 1e-9.
+		1e-10, // two-digit exponent stays 1e-10.
+		-1e-7, // negative number, negative exponent: same trim path.
+		1e20,
+		1e21, // boundary: at threshold — uses 'e'.
+		1e22,
+		1e100,
+		-1e100,
+		1234567.89,
+		1.0 / 3.0,
+	}
+	for _, v := range values {
+		t.Run(fmt.Sprintf("%g", v), func(t *testing.T) {
+			want, err := json.Marshal(v)
+			if err != nil {
+				t.Fatalf("json.Marshal(%v): %v", v, err)
+			}
+			got := appendJSONFloat(nil, v)
+			if !bytes.Equal(got, want) {
+				t.Fatalf("appendJSONFloat(%v) = %q, json.Marshal = %q", v, got, want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Root cause

`appendJSONFloat` chose `'f'` vs `'e'` format the same way as `encoding/json`, but then called `strconv.AppendFloat` straight to the output without applying the stdlib's last-four-byte fixup that trims a single leading zero from negative-exponent results:

    strconv:    1e-07    stdlib json: 1e-7
    strconv:    1e-08    stdlib json: 1e-8
    strconv:    1e-09    stdlib json: 1e-9
    strconv:    1e-10    stdlib json: 1e-10   (no trim — two-digit exponent)

Any float in `(1e-9, 1e-6)` emitted via our encoder therefore differed from `json.Marshal` by one character, breaking the encoder's documented "byte-identical to `json.Marshal`" contract and producing spurious diffs in JSON output for downstream consumers that compare against a reference produced by the stdlib.

## Fix

After `strconv.AppendFloat` when `'e'` format is in use, check whether the last four bytes are `e-0X` and collapse them to `e-X`, exactly as `encoding/json/encode.go` does. The fixup only applies when the byte before the last digit is `0` and the sign byte is `-`, so two-digit exponents like `e-10` are left alone.

## Test plan

- [x] `TestAppendJSONFloat_MatchesJSONMarshal` table-tests 21 values spanning the `'f'`/`'e'` boundaries, the single-digit-negative-exponent trim band, two-digit negative exponents, large positive exponents, and signed/unsigned variants. Each case asserts `bytes.Equal(appendJSONFloat(v), json.Marshal(v))`. The four trim-band subtests fail on the pre-fix code and pass after.
- [x] All pre-existing output tests still pass.
- [x] `go vet`, `golangci-lint run ./...` (0 issues) all clean.