### PR TITLE
fix(scanner): clamp out-of-range line to last byte for suppression lookup

### DIFF
--- a/internal/scanner/suppress.go
+++ b/internal/scanner/suppress.go
@@ -124,15 +124,37 @@ func (f *SuppressionFilter) IsSuppressed(ruleID, ruleSet string, line int) bool 
 		}
 	}
 	if f.annotations != nil && f.file != nil {
-		byteOffset := 0
-		if line > 0 {
-			byteOffset = f.file.LineOffset(line - 1)
-		}
+		byteOffset := suppressionByteOffsetForLine(f.file, line)
 		if f.annotations.isSuppressedWithAliases(byteOffset, ruleID, ruleSet, aliases) {
 			return true
 		}
 	}
 	return false
+}
+
+// suppressionByteOffsetForLine maps a 1-based finding line to a byte
+// offset inside `file` that suppression-range checks can use.
+//
+//   - `line >= 1` and within the file: returns the byte offset of the
+//     start of that line.
+//   - `line <= 0`: treats the finding as file-level (line is unknown
+//     or the rule reports on the whole file) and returns 0. With
+//     `EndByte` exclusive, a `@file:Suppress(...)` covering [0,
+//     fileSize) still matches byte 0.
+//   - `line` past the last line: clamps to the last byte in the file
+//     so file-level suppressions still apply. `f.file.LineOffset`
+//     returns `len(Content)` for out-of-range indices, which is past
+//     the exclusive `EndByte` and would silently miss file-level
+//     suppressions.
+func suppressionByteOffsetForLine(file *File, line int) int {
+	if line <= 0 {
+		return 0
+	}
+	offset := file.LineOffset(line - 1)
+	if n := len(file.Content); n > 0 && offset >= n {
+		return n - 1
+	}
+	return offset
 }
 
 // IsFileExcluded reports whether the given rule is globally excluded

--- a/internal/scanner/suppress_filter_test.go
+++ b/internal/scanner/suppress_filter_test.go
@@ -496,3 +496,66 @@ func TestFlatWalkSuppressions_NestedClasses(t *testing.T) {
 		t.Error("@Suppress on Inner class must not bleed to outerFun")
 	}
 }
+
+// TestSuppressionFilter_FileLevelAppliesToInvalidLineNumbers verifies
+// that an `@file:Suppress(...)` annotation still matches when the
+// caller passes an out-of-range line number. The pre-fix
+// IsSuppressed converted line<=0 to byteOffset=0 (file-level was
+// preserved) but converted line>lastLine to byteOffset=len(Content),
+// which sits past the exclusive `EndByte` of every annotation —
+// silently losing the file-level suppression for findings reported
+// on stale or otherwise out-of-range line numbers.
+func TestSuppressionFilter_FileLevelAppliesToInvalidLineNumbers(t *testing.T) {
+	src := "@file:Suppress(\"MagicNumber\")\nclass A {\n    val x = 42\n}\n"
+	f := parsedFileForFilter(t, "A.kt", src)
+	sf := BuildSuppressionFilter(f, nil, nil, "")
+
+	cases := []struct {
+		name string
+		line int
+	}{
+		{name: "line zero treated as file-level finding", line: 0},
+		{name: "negative line still falls back to file-level", line: -1},
+		{name: "line past last line still sees file-level suppression", line: 1_000_000},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if !sf.IsSuppressed("MagicNumber", "", tc.line) {
+				t.Fatalf("@file:Suppress(\"MagicNumber\") should suppress findings reported with line=%d", tc.line)
+			}
+			// Sanity: a different rule must not be silenced.
+			if sf.IsSuppressed("OtherRule", "", tc.line) {
+				t.Fatalf("@file:Suppress(\"MagicNumber\") must not silence OtherRule (line=%d)", tc.line)
+			}
+		})
+	}
+}
+
+// TestSuppressionByteOffsetForLine pins the conversion contract:
+// invalid line numbers map to file-level lookups, valid lines map to
+// the start byte of that line, and lines past EOF clamp to the last
+// in-file byte so file-level suppression still applies.
+func TestSuppressionByteOffsetForLine(t *testing.T) {
+	src := "line1\nline2\nline3\n" // 18 bytes total
+	f := parsedFileForFilter(t, "A.kt", src)
+
+	cases := []struct {
+		name string
+		line int
+		want int
+	}{
+		{name: "line zero", line: 0, want: 0},
+		{name: "negative line", line: -5, want: 0},
+		{name: "first line", line: 1, want: 0},
+		{name: "second line", line: 2, want: len("line1\n")},
+		{name: "third line", line: 3, want: len("line1\nline2\n")},
+		{name: "past last line clamps to last in-file byte", line: 999, want: len(src) - 1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := suppressionByteOffsetForLine(f, tc.line); got != tc.want {
+				t.Fatalf("suppressionByteOffsetForLine(line=%d) = %d, want %d", tc.line, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Root cause

`SuppressionFilter.IsSuppressed` converted a 1-based finding line to a byte offset with:

    if line > 0 {
        byteOffset = f.file.LineOffset(line - 1)
    }

Two edge cases silently mishandled file-level suppressions:

1. `line <= 0` (file-level finding, unknown line) kept `byteOffset` at 0, which after [#419](https://github.com/kaeawc/krit/pull/419)'s exclusive-end fix still matches a `@file:Suppress(...)` covering `[0, fileSize)`. Correct in practice, but undocumented.

2. `line > lastLine` (out-of-range, e.g. stale baseline or a rule that miscalculates a row) clamped via `LineOffset` to `len(file.Content)`. That byte sits past every annotation's exclusive `EndByte`, so a file-level `@file:Suppress(...)` was silently dropped and the finding surfaced.

## Fix

Extract `suppressionByteOffsetForLine(file, line)` and document the contract — invalid or zero lines map to 0 (file-level); valid lines map to the start byte of that line; lines past EOF clamp to the last in-file byte so file-level suppression still applies.

## Test plan

- [x] `TestSuppressionFilter_FileLevelAppliesToInvalidLineNumbers` exercises `line=0`, `line=-1`, and `line=1_000_000` against an `@file:Suppress(...)` and asserts all three are silenced. The `line=1_000_000` subtest fails on the pre-fix code; the `line<=0` cases were already correct but are pinned here so future refactors don't regress.
- [x] `TestSuppressionByteOffsetForLine` table-tests the helper directly across zero, negative, valid, and past-EOF lines.
- [x] All pre-existing scanner tests still pass.
- [x] `go test ./... -count=1`, `go vet`, `golangci-lint run ./...` (0 issues) all clean.