### PR TITLE
refactor(rules): dispatch MixedAssertionLibraries on source_file via ImportFacts

### DIFF
--- a/internal/rules/registry_testing_quality.go
+++ b/internal/rules/registry_testing_quality.go
@@ -115,8 +115,11 @@ func registerTestingQualityMixedAssertionLibraries() {
 	}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		Needs: api.NeedsLinePass, Implementation: r,
-		Check: r.check,
+		NodeTypes:      []string{"source_file"},
+		Languages:      []scanner.Language{scanner.LangKotlin},
+		Confidence:     r.Confidence(),
+		Implementation: r,
+		Check:          r.check,
 	})
 }
 

--- a/internal/rules/testing_quality.go
+++ b/internal/rules/testing_quality.go
@@ -197,7 +197,7 @@ func (r *AssertTrueOnComparisonRule) Confidence() float64 { return 0.75 }
 // MixedAssertionLibrariesRule detects files that import both JUnit Assert and
 // Truth APIs in the import header.
 type MixedAssertionLibrariesRule struct {
-	LineBase
+	FlatDispatchBase
 	BaseRule
 }
 
@@ -208,41 +208,12 @@ func (r *MixedAssertionLibrariesRule) Confidence() float64 { return 0.75 }
 
 func (r *MixedAssertionLibrariesRule) check(ctx *api.Context) {
 	file := ctx.File
-	var hasJUnitAssertImport bool
-	var hasTruthImport bool
-
-	for i, line := range file.Lines {
-		trimmed := strings.TrimSpace(line)
-
-		switch {
-		case trimmed == "", scanner.IsCommentLine(line):
-			continue
-		case strings.HasPrefix(trimmed, "@file:"):
-			continue
-		case strings.HasPrefix(trimmed, "package "):
-			continue
-		case strings.HasPrefix(trimmed, "import "):
-			if strings.HasPrefix(trimmed, "import org.junit.Assert.") {
-				hasJUnitAssertImport = true
-				if hasTruthImport {
-					ctx.Emit(r.Finding(file, i+1, 1,
-						"Avoid mixing JUnit Assert and Truth imports in the same file; pick one assertion library."))
-					return
-				}
-			}
-			if strings.HasPrefix(trimmed, "import com.google.common.truth.Truth.") {
-				hasTruthImport = true
-				if hasJUnitAssertImport {
-					ctx.Emit(r.Finding(file, i+1, 1,
-						"Avoid mixing JUnit Assert and Truth imports in the same file; pick one assertion library."))
-					return
-				}
-			}
-			continue
-		default:
-			return
-		}
+	imports := fileFactsCache().Imports(file)
+	if !imports.HasAnyPrefix("org.junit.Assert.") || !imports.HasAnyPrefix("com.google.common.truth.Truth.") {
+		return
 	}
+	ctx.Emit(r.Finding(file, file.FlatRow(ctx.Idx)+1, 1,
+		"Avoid mixing JUnit Assert and Truth imports in the same file; pick one assertion library."))
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/rules/testing_quality_test.go
+++ b/internal/rules/testing_quality_test.go
@@ -169,6 +169,112 @@ fun testCompute() {
 	}
 }
 
+// Single emit per file even when many imports of both libraries are
+// present — source_file dispatches once, regardless of import count.
+func TestMixedAssertionLibraries_EmitsOnce(t *testing.T) {
+	findings := runRuleByName(t, "MixedAssertionLibraries", `
+package test
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import com.google.common.truth.Truth.assertThat
+import com.google.common.truth.Truth.assertWithMessage
+
+fun testCompute() {
+    val actual = compute()
+    assertEquals(42, actual)
+    assertNotNull(actual)
+    assertThat(actual).isEqualTo(42)
+    assertWithMessage("x").that(actual).isEqualTo(42)
+}
+`)
+	if len(findings) != 1 {
+		t.Fatalf("expected exactly one finding, got %d", len(findings))
+	}
+}
+
+// Wildcard imports for both libraries trigger the rule via ImportFacts'
+// Wildcards prefix match.
+func TestMixedAssertionLibraries_WildcardImports(t *testing.T) {
+	findings := runRuleByName(t, "MixedAssertionLibraries", `
+package test
+
+import org.junit.Assert.*
+import com.google.common.truth.Truth.*
+
+fun testCompute() {
+    val actual = compute()
+    assertEquals(42, actual)
+    assertThat(actual).isEqualTo(42)
+}
+`)
+	if len(findings) != 1 {
+		t.Fatalf("expected one finding for wildcard mixed imports, got %d", len(findings))
+	}
+}
+
+// Aliased imports still match — ImportFacts indexes the alias-stripped FQN.
+func TestMixedAssertionLibraries_AliasedImports(t *testing.T) {
+	findings := runRuleByName(t, "MixedAssertionLibraries", `
+package test
+
+import org.junit.Assert.assertEquals as junitEquals
+import com.google.common.truth.Truth.assertThat as truthAssertThat
+
+fun testCompute() {
+    val actual = compute()
+    junitEquals(42, actual)
+    truthAssertThat(actual).isEqualTo(42)
+}
+`)
+	if len(findings) != 1 {
+		t.Fatalf("expected one finding for aliased mixed imports, got %d", len(findings))
+	}
+}
+
+// Comments and KDoc that mention the FQNs but never import them must not
+// trigger the rule — ImportFacts only inspects import_header AST nodes.
+func TestMixedAssertionLibraries_CommentMentionsOnly(t *testing.T) {
+	findings := runRuleByName(t, "MixedAssertionLibraries", `
+package test
+
+// Not actually importing: org.junit.Assert.assertEquals
+/* Block comment referencing com.google.common.truth.Truth.assertThat */
+/**
+ * KDoc that mentions org.junit.Assert.assertEquals and
+ * com.google.common.truth.Truth.assertThat.
+ */
+import com.google.common.truth.Truth.assertThat
+
+fun testCompute() {
+    val actual = compute()
+    assertThat(actual).isEqualTo(42)
+}
+`)
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings for comment-only mentions, got %d", len(findings))
+	}
+}
+
+// Only one library imported is the common case and must stay clean.
+func TestMixedAssertionLibraries_OnlyJUnit(t *testing.T) {
+	findings := runRuleByName(t, "MixedAssertionLibraries", `
+package test
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+
+fun testCompute() {
+    val actual = compute()
+    assertEquals(42, actual)
+    assertNotNull(actual)
+}
+`)
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(findings))
+	}
+}
+
 func TestAssertNullableWithNotNullAssertion_Positive(t *testing.T) {
 	findings := runRuleByName(t, "AssertNullableWithNotNullAssertion", `
 package test


### PR DESCRIPTION
## Summary

- Converts `MixedAssertionLibrariesRule` from a `LineBase` (per-line scan) to `FlatDispatchBase` that fires once per Kotlin file on the `source_file` AST node.
- Consults the cached `ImportFacts` (`fileFactsCache().Imports(file).HasAnyPrefix(...)`) instead of re-scanning `file.Lines` per rule, amortizing import inspection across the import-sensitive rule set via `filefacts.Cache`'s `sync.Map`.
- Expands regression coverage: wildcard imports, aliased imports, comment/KDoc mentions, single-library negatives, and the multi-import emit-once guarantee.

## Why

`ImportFacts` is the canonical AST-driven import index for the codebase (used by `android.go`, `logging.go`, `accessibility.go`, etc.). The previous line scan re-tokenized the file header per rule activation, missed wildcard imports unless their trailing `.*` happened to match the prefix, and used text matching that couldn't distinguish a real import from a KDoc mention. The new path reuses the shared cache and uses `HasAnyPrefix` (which already handles `FQNs` + `Wildcards` + alias stripping).

## Performance

Net-faster on warm caches: `ImportFacts` is memoized per `*scanner.File` via `sync.Map` (`internal/filefacts/filefacts.go:181-196`) and shared with other import-sensitive rules. Two `HasAnyPrefix` calls iterate the imports map; the trade vs. a fused single pass is intentional for readability (savings would be tens of ns). The rule remains `DefaultActive: false`, so impact on the default config is zero.

## Test plan

- [x] `go test ./internal/rules/ -run TestMixedAssertion -count=1`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...`
- [x] `make lint-rules`
- [x] `go test ./... -count=1`