### PR TITLE
feat(gradle): collapse krit DSL onto common-path knobs, nest escape hatches

### DIFF
--- a/docs/external-rules.md
+++ b/docs/external-rules.md
@@ -396,7 +396,7 @@ replacement, safety)`. `FixSafety` mirrors the built-in tiers:
 | `SEMANTIC` | Behavior change that a human must review. | Replacing `==` with `equals(..., ignoreCase = true)`, swapping deprecated API for a non-equivalent replacement. |
 
 The consumer caps which tiers apply via `--fix-level` (CLI) or the
-`krit { fixLevel.set("...") }` Gradle DSL. The flag default is
+`krit { advanced { fixLevel = "..." } }` Gradle DSL. The flag default is
 `idiomatic`, and the cap is inclusive moving up the table:
 
 - `--fix-level=cosmetic` applies only `COSMETIC` fixes.

--- a/krit-gradle-plugin/README.md
+++ b/krit-gradle-plugin/README.md
@@ -10,74 +10,77 @@ Add the plugin to your `build.gradle.kts`:
 plugins {
     id("dev.jasonpearson.krit") version "0.2.0"
 }
+```
 
+That's it for most projects — drop a `krit.yml` next to the build file and
+`./gradlew kritCheck` works.
+
+### Common configuration
+
+```kotlin
 krit {
-    // Krit binary version (downloaded automatically from GitHub Releases)
-    toolVersion.set("0.2.0")
+    config = file("krit.yml")               // optional; auto-discovered when omitted
+    baseline = file("krit-baseline.xml")    // optional
+    ignoreFailures = false                  // fail the build on findings
 
-    // Path to krit.yml configuration file
-    config.set(file("krit.yml"))
-
-    // Source directories to analyze (defaults to src/main/kotlin + src/test/kotlin)
-    source.setFrom("src/main/kotlin", "src/test/kotlin")
-
-    // Fail the build on findings (default: false)
-    ignoreFailures.set(false)
-
-    // Enable all rules including opt-in ones
-    allRules.set(false)
-
-    // Auto-fix level: "cosmetic", "idiomatic" (default), or "semantic"
-    fixLevel.set("idiomatic")
-
-    // Baseline file for suppressing known issues
-    baseline.set(file("krit-baseline.xml"))
-
-    // Number of parallel analysis jobs (default: CPU count)
-    parallel.set(Runtime.getRuntime().availableProcessors())
-
-    // Use a local krit binary instead of downloading
-    // binary.set(file("/usr/local/bin/krit"))
-
-    // Configure report outputs
     reports {
-        sarif {
-            required.set(true)  // enabled by default
-            outputLocation.set(file("build/reports/krit/krit.sarif"))
-        }
-        json {
-            required.set(true)
-            outputLocation.set(file("build/reports/krit/krit.json"))
-        }
-        plain {
-            required.set(false)  // disabled by default
-        }
-        checkstyle {
-            required.set(false)  // disabled by default
-        }
+        sarif.required = true               // default
+        json.required = true
+    }
+}
+```
+
+### Custom rules
+
+Wire a sibling rule project through the standard `dependencies` block:
+
+```kotlin
+dependencies {
+    kritCustomRules(project(":my-rules"))
+}
+```
+
+See [`krit-custom-rule-plugin`](../krit-custom-rule-plugin/README.md) for
+authoring the rule module itself.
+
+### Advanced / escape hatches
+
+For overrides most projects never need:
+
+```kotlin
+krit {
+    advanced {
+        toolVersion = "0.2.0"                       // pin the binary version
+        binary = file("/usr/local/bin/krit")        // skip the download entirely
+        parallel = 4                                // -j
+        noCache = false                             // --no-cache
+        typeInference = true
+        allRules = false
+        fixLevel = "idiomatic"                      // cosmetic | idiomatic | semantic
+        source.setFrom("src/main/kotlin")           // override auto-detection
+        reportsDir = layout.buildDirectory.dir("reports/krit")
     }
 }
 ```
 
 ### Reports
 
-The plugin supports four report formats: SARIF (default), JSON, plain text, and Checkstyle. Each format can be independently enabled or disabled, and output locations can be customized.
-
-By default, only the SARIF report is enabled. Reports are written to `build/reports/krit/` unless overridden.
+Four formats are supported: SARIF (the default), JSON, plain text, and Checkstyle. Each can be toggled independently, and output locations can be customized:
 
 ```kotlin
 krit {
     reports {
-        // Enable multiple formats
-        sarif { required.set(true) }
-        json { required.set(true) }
+        sarif.required = true                                   // default
+        json.required = true
         checkstyle {
-            required.set(true)
-            outputLocation.set(file("build/reports/checkstyle/krit.xml"))
+            required = true
+            outputLocation = file("build/reports/checkstyle/krit.xml")
         }
     }
 }
 ```
+
+Reports are written to `build/reports/krit/` unless overridden via `advanced.reportsDir`.
 
 ### Per-Source-Set Tasks
 
@@ -127,27 +130,13 @@ Then reference the baseline in your configuration:
 
 ```kotlin
 krit {
-    baseline.set(file("build/reports/krit/baseline.xml"))
+    baseline = file("build/reports/krit/baseline.xml")
 }
 ```
 
 ## Binary Resolution
 
-The plugin automatically downloads the correct platform-specific krit binary from GitHub Releases and caches it in `~/.gradle/krit/`. Supported platforms:
-
-- `darwin-arm64` (macOS Apple Silicon)
-- `darwin-amd64` (macOS Intel)
-- `linux-arm64`
-- `linux-amd64`
-- `windows-amd64`
-
-To use a locally installed binary instead:
-
-```kotlin
-krit {
-    binary.set(file("/usr/local/bin/krit"))
-}
-```
+The plugin downloads the correct platform-specific krit binary from GitHub Releases and caches it in `~/.gradle/krit/`. Supported platforms: `darwin-arm64`, `darwin-amd64`, `linux-arm64`, `linux-amd64`, `windows-amd64`. To skip the download and use a local binary, set `advanced.binary` (see [Advanced / escape hatches](#advanced--escape-hatches) above).
 
 ## Requirements
 

--- a/krit-gradle-plugin/src/main/kotlin/dev/jasonpearson/krit/gradle/KritAdvanced.kt
+++ b/krit-gradle-plugin/src/main/kotlin/dev/jasonpearson/krit/gradle/KritAdvanced.kt
@@ -1,0 +1,56 @@
+package dev.jasonpearson.krit.gradle
+
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
+
+/**
+ * Escape-hatch settings for projects that need to override krit's automatic
+ * configuration. The common path (Kotlin/Android plugin applied, default
+ * `build/reports/krit` output, bundled binary) does not need any of these.
+ *
+ * Access via:
+ * ```
+ * krit {
+ *     advanced {
+ *         parallel = 4
+ *         binary = file("/path/to/krit")
+ *     }
+ * }
+ * ```
+ */
+interface KritAdvanced {
+    /** Krit binary version to download. Defaults to the plugin's bundled version. */
+    val toolVersion: Property<String>
+
+    /** Local krit binary path. Overrides the downloaded binary when set. */
+    val binary: RegularFileProperty
+
+    /** Number of parallel jobs (maps to `-j`). Defaults to CPU count. */
+    val parallel: Property<Int>
+
+    /** Disable the incremental analysis cache (maps to `--no-cache`). Default: false. */
+    val noCache: Property<Boolean>
+
+    /** Enable source-level type inference. Default: true. */
+    val typeInference: Property<Boolean>
+
+    /** Auto-fix safety level: `cosmetic`, `idiomatic` (default), or `semantic`. */
+    val fixLevel: Property<String>
+
+    /** Enable all rules including opt-in (maps to `--all-rules`). Default: false. */
+    val allRules: Property<Boolean>
+
+    /**
+     * Source directories scanned by the aggregate `kritCheck` task. Auto-derived
+     * from the Kotlin JVM / Android source sets; only override for non-standard
+     * layouts. Default: `src/main/kotlin`, `src/test/kotlin`.
+     */
+    val source: ConfigurableFileCollection
+
+    /** Reports output directory. Default: `build/reports/krit`. */
+    val reportsDir: DirectoryProperty
+}
+
+abstract class DefaultKritAdvanced : KritAdvanced

--- a/krit-gradle-plugin/src/main/kotlin/dev/jasonpearson/krit/gradle/KritExtension.kt
+++ b/krit-gradle-plugin/src/main/kotlin/dev/jasonpearson/krit/gradle/KritExtension.kt
@@ -4,7 +4,6 @@ import org.gradle.api.Action
 import org.gradle.api.Project
 import org.gradle.api.UnknownTaskException
 import org.gradle.api.file.ConfigurableFileCollection
-import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
@@ -14,62 +13,42 @@ import javax.inject.Inject
 /**
  * DSL extension for configuring the krit Kotlin static analysis plugin.
  *
- * Usage in build.gradle.kts:
+ * The common-path surface is intentionally small — apply the plugin, drop a
+ * `krit.yml` next to the build file, and that's enough for most projects.
+ * The few settings most users want:
+ *
  * ```
  * krit {
- *     toolVersion.set("0.2.0")
- *     config.set(file("krit.yml"))
- *     ignoreFailures.set(false)
+ *     config = file("krit.yml")          // optional; auto-discovered when omitted
+ *     baseline = file("krit-baseline.xml")
+ *     ignoreFailures = false             // gate the build on findings
  *     reports {
- *         sarif { required.set(true) }
- *         json { required.set(false) }
+ *         sarif.required = true
+ *         json.required = true
  *     }
  * }
  * ```
+ *
+ * Escape hatches (binary path, parallelism, cache toggles, fix level, etc.)
+ * live under [advanced]. Project-level custom-rule wiring goes through the
+ * `kritCustomRules` configuration in the `dependencies` block.
  */
 abstract class KritExtension @Inject constructor(
     private val project: Project,
     objects: ObjectFactory,
 ) {
 
-    /** Krit binary version to download. Default: plugin's bundled version constant. */
-    abstract val toolVersion: Property<String>
-
-    /** Path to krit.yml config file. */
+    /** Path to krit.yml. Optional — when unset, the CLI auto-discovers from the project root. */
     abstract val config: RegularFileProperty
 
-    /** Severity threshold -- fail the build if findings at or above this level exist. */
+    /** Fail the build when findings exceed the configured severity threshold. Default: false. */
     abstract val ignoreFailures: Property<Boolean>
-
-    /** Enable all rules including opt-in (maps to --all-rules). */
-    abstract val allRules: Property<Boolean>
 
     /** Baseline file for suppressing known issues. */
     abstract val baseline: RegularFileProperty
 
-    /** Source directories to analyze. */
-    abstract val source: ConfigurableFileCollection
-
-    /** Kotlin custom-rule jars to load through krit-types. */
+    /** Kotlin custom-rule jars to load through krit-types. Populated by `kritCustomRules` deps. */
     abstract val customRuleJars: ConfigurableFileCollection
-
-    /** Reports output directory. */
-    abstract val reportsDir: DirectoryProperty
-
-    /** Auto-fix level: cosmetic, idiomatic, or semantic. */
-    abstract val fixLevel: Property<String>
-
-    /** Path to a local krit binary (skips download). */
-    abstract val binary: RegularFileProperty
-
-    /** Number of parallel jobs (maps to -j). Default: CPU count. */
-    abstract val parallel: Property<Int>
-
-    /** Disable incremental analysis cache (maps to --no-cache). */
-    abstract val noCache: Property<Boolean>
-
-    /** Enable type inference (default true). */
-    abstract val typeInference: Property<Boolean>
 
     /** Report format configuration. */
     val reports: KritReports = objects.newInstance(DefaultKritReports::class.java)
@@ -77,6 +56,14 @@ abstract class KritExtension @Inject constructor(
     /** Configure reports via DSL block. */
     fun reports(action: Action<KritReports>) {
         action.execute(reports)
+    }
+
+    /** Advanced/escape-hatch settings — see [KritAdvanced]. */
+    val advanced: KritAdvanced = objects.newInstance(DefaultKritAdvanced::class.java)
+
+    /** Configure advanced settings via DSL block. */
+    fun advanced(action: Action<KritAdvanced>) {
+        action.execute(advanced)
     }
 
     /**

--- a/krit-gradle-plugin/src/main/kotlin/dev/jasonpearson/krit/gradle/KritPlugin.kt
+++ b/krit-gradle-plugin/src/main/kotlin/dev/jasonpearson/krit/gradle/KritPlugin.kt
@@ -61,20 +61,20 @@ class KritPlugin : Plugin<Project> {
         extension.customRuleJars.from(customRulesConfiguration)
 
         // Set conventions (defaults)
-        extension.toolVersion.convention(KRIT_DEFAULT_VERSION)
-        extension.allRules.convention(false)
         extension.ignoreFailures.convention(false)
-        extension.fixLevel.convention("idiomatic")
-        extension.parallel.convention(Runtime.getRuntime().availableProcessors())
-        extension.noCache.convention(false)
-        extension.typeInference.convention(true)
-        extension.source.setFrom("src/main/kotlin", "src/test/kotlin")
-        extension.reportsDir.convention(
+        extension.advanced.toolVersion.convention(KRIT_DEFAULT_VERSION)
+        extension.advanced.allRules.convention(false)
+        extension.advanced.fixLevel.convention("idiomatic")
+        extension.advanced.parallel.convention(Runtime.getRuntime().availableProcessors())
+        extension.advanced.noCache.convention(false)
+        extension.advanced.typeInference.convention(true)
+        extension.advanced.source.setFrom("src/main/kotlin", "src/test/kotlin")
+        extension.advanced.reportsDir.convention(
             project.layout.buildDirectory.dir("reports/krit")
         )
 
         // Set report conventions
-        val reportsDir = extension.reportsDir
+        val reportsDir = extension.advanced.reportsDir
         extension.reports.sarif.required.convention(true)
         extension.reports.sarif.outputLocation.convention(
             reportsDir.map { it.file("krit.sarif") }
@@ -97,7 +97,7 @@ class KritPlugin : Plugin<Project> {
             "kritBinaryResolver",
             KritBinaryResolver::class.java,
         ) {
-            parameters.version.set(extension.toolVersion)
+            parameters.version.set(extension.advanced.toolVersion)
             parameters.cacheDir.set(
                 project.layout.dir(
                     project.provider {
@@ -109,20 +109,22 @@ class KritPlugin : Plugin<Project> {
         }
 
         // Shared convention for resolving the krit binary
-        val kritBinaryFile = extension.binary.orElse(
+        val kritBinaryFile = extension.advanced.binary.orElse(
             project.layout.file(project.provider { binaryResolver.get().resolve() })
         )
+
+        val advanced = extension.advanced
 
         // Wire task defaults for all KritCheckTask instances
         project.tasks.withType(KritCheckTask::class.java).configureEach {
             kritBinary.convention(kritBinaryFile)
-            allRules.convention(extension.allRules)
+            allRules.convention(advanced.allRules)
             ignoreFailures.convention(extension.ignoreFailures)
             config.convention(extension.config)
             baseline.convention(extension.baseline)
-            parallel.convention(extension.parallel)
-            noCache.convention(extension.noCache)
-            typeInference.convention(extension.typeInference)
+            parallel.convention(advanced.parallel)
+            noCache.convention(advanced.noCache)
+            typeInference.convention(advanced.typeInference)
             customRuleJars.from(extension.customRuleJars)
             // Wire reports from extension
             sarifRequired.convention(extension.reports.sarif.required)
@@ -139,39 +141,39 @@ class KritPlugin : Plugin<Project> {
         project.tasks.withType(KritFormatTask::class.java).configureEach {
             kritBinary.convention(kritBinaryFile)
             config.convention(extension.config)
-            fixLevel.convention(extension.fixLevel)
-            parallel.convention(extension.parallel)
-            noCache.convention(extension.noCache)
-            typeInference.convention(extension.typeInference)
+            fixLevel.convention(advanced.fixLevel)
+            parallel.convention(advanced.parallel)
+            noCache.convention(advanced.noCache)
+            typeInference.convention(advanced.typeInference)
         }
 
         // Wire task defaults for all KritBaselineTask instances
         project.tasks.withType(KritBaselineTask::class.java).configureEach {
             kritBinary.convention(kritBinaryFile)
             config.convention(extension.config)
-            allRules.convention(extension.allRules)
-            parallel.convention(extension.parallel)
-            noCache.convention(extension.noCache)
-            typeInference.convention(extension.typeInference)
+            allRules.convention(advanced.allRules)
+            parallel.convention(advanced.parallel)
+            noCache.convention(advanced.noCache)
+            typeInference.convention(advanced.typeInference)
             customRuleJars.from(extension.customRuleJars)
         }
 
         // Register the aggregate kritCheck task
         project.tasks.register("kritCheck", KritCheckTask::class.java) {
-            setSource(extension.source)
-            sourceRoots.from(extension.source)
+            setSource(advanced.source)
+            sourceRoots.from(advanced.source)
             description = "Run krit analysis on all Kotlin sources"
         }
 
         // Register the kritFormat task
         project.tasks.register("kritFormat", KritFormatTask::class.java) {
-            source.setFrom(extension.source)
+            source.setFrom(advanced.source)
             description = "Apply krit auto-fixes to Kotlin sources"
         }
 
         // Register the kritBaseline task
         project.tasks.register("kritBaseline", KritBaselineTask::class.java) {
-            source.setFrom(extension.source)
+            source.setFrom(advanced.source)
             baselineFile.convention(
                 project.layout.buildDirectory.file("reports/krit/baseline.xml")
             )

--- a/krit-gradle-plugin/src/test/kotlin/dev/jasonpearson/krit/gradle/KritPluginTest.kt
+++ b/krit-gradle-plugin/src/test/kotlin/dev/jasonpearson/krit/gradle/KritPluginTest.kt
@@ -62,45 +62,105 @@ class KritPluginTest {
     }
 
     @Test
-    fun `extension has correct default values`() {
+    fun `top-level extension defaults are minimal and focused on user-facing knobs`() {
         val project = newProject()
 
         val extension = project.extensions.getByType(KritExtension::class.java)
-        assertEquals(KritPlugin.KRIT_DEFAULT_VERSION, extension.toolVersion.get())
-        assertEquals(false, extension.allRules.get())
         assertEquals(false, extension.ignoreFailures.get())
-        assertEquals("idiomatic", extension.fixLevel.get())
-        assertEquals(true, extension.typeInference.get())
-        assertEquals(false, extension.noCache.get())
-        assertEquals(Runtime.getRuntime().availableProcessors(), extension.parallel.get())
+        // config, baseline, customRuleJars are unset by default (user-provided or
+        // populated via the kritCustomRules configuration).
+        assertFalse(extension.config.isPresent, "config should default unset for auto-discovery")
+        assertFalse(extension.baseline.isPresent, "baseline should default unset")
     }
 
     @Test
-    fun `extension properties are configurable`() {
+    fun `ignoreFailures is configurable at the top level`() {
         val project = newProject()
-
         val extension = project.extensions.getByType(KritExtension::class.java)
-
-        extension.toolVersion.set("1.0.0")
-        assertEquals("1.0.0", extension.toolVersion.get())
-
-        extension.allRules.set(true)
-        assertEquals(true, extension.allRules.get())
 
         extension.ignoreFailures.set(true)
         assertEquals(true, extension.ignoreFailures.get())
+    }
 
-        extension.fixLevel.set("semantic")
-        assertEquals("semantic", extension.fixLevel.get())
+    @Test
+    fun `advanced extension exposes escape-hatch defaults`() {
+        val project = newProject()
 
-        extension.parallel.set(4)
-        assertEquals(4, extension.parallel.get())
+        val advanced = project.extensions.getByType(KritExtension::class.java).advanced
+        assertEquals(KritPlugin.KRIT_DEFAULT_VERSION, advanced.toolVersion.get())
+        assertEquals(false, advanced.allRules.get())
+        assertEquals("idiomatic", advanced.fixLevel.get())
+        assertEquals(true, advanced.typeInference.get())
+        assertEquals(false, advanced.noCache.get())
+        assertEquals(Runtime.getRuntime().availableProcessors(), advanced.parallel.get())
+    }
 
-        extension.noCache.set(true)
-        assertEquals(true, extension.noCache.get())
+    @Test
+    fun `advanced extension is configurable`() {
+        val project = newProject()
+        val advanced = project.extensions.getByType(KritExtension::class.java).advanced
 
-        extension.typeInference.set(false)
-        assertEquals(false, extension.typeInference.get())
+        advanced.toolVersion.set("1.0.0")
+        advanced.allRules.set(true)
+        advanced.fixLevel.set("semantic")
+        advanced.parallel.set(4)
+        advanced.noCache.set(true)
+        advanced.typeInference.set(false)
+
+        assertEquals("1.0.0", advanced.toolVersion.get())
+        assertEquals(true, advanced.allRules.get())
+        assertEquals("semantic", advanced.fixLevel.get())
+        assertEquals(4, advanced.parallel.get())
+        assertEquals(true, advanced.noCache.get())
+        assertEquals(false, advanced.typeInference.get())
+    }
+
+    @Test
+    fun `advanced block is configurable via action`() {
+        val project = newProject()
+        val extension = project.extensions.getByType(KritExtension::class.java)
+
+        extension.advanced {
+            parallel.set(7)
+            noCache.set(true)
+        }
+
+        assertEquals(7, extension.advanced.parallel.get())
+        assertEquals(true, extension.advanced.noCache.get())
+    }
+
+    @Test
+    fun `advanced settings flow through to task conventions`() {
+        val project = newProject()
+        val extension = project.extensions.getByType(KritExtension::class.java)
+
+        extension.advanced.parallel.set(11)
+        extension.advanced.allRules.set(true)
+        extension.advanced.fixLevel.set("semantic")
+
+        val check = project.tasks.getByName("kritCheck") as KritCheckTask
+        val fmt = project.tasks.getByName("kritFormat") as KritFormatTask
+        val baseline = project.tasks.getByName("kritBaseline") as KritBaselineTask
+
+        assertEquals(11, check.parallel.get())
+        assertEquals(true, check.allRules.get())
+        assertEquals("semantic", fmt.fixLevel.get())
+        assertEquals(true, baseline.allRules.get())
+    }
+
+    @Test
+    fun `top-level extension does not expose escape-hatch properties`() {
+        // Compile-time guard: KritExtension must NOT carry these knobs anymore.
+        // Reflection check keeps the regression test honest without re-introducing
+        // imports of the moved Property<*> APIs.
+        val publicMembers = KritExtension::class.java.methods.map { it.name }.toSet()
+        listOf("getToolVersion", "getAllRules", "getFixLevel", "getParallel",
+               "getNoCache", "getTypeInference", "getBinary", "getReportsDir",
+               "getSource")
+            .forEach { accessor ->
+                assertFalse(accessor in publicMembers,
+                    "KritExtension still exposes $accessor — it should live under `advanced`")
+            }
     }
 
     @Test

--- a/playground/kotlin-webservice/build.gradle.kts
+++ b/playground/kotlin-webservice/build.gradle.kts
@@ -27,18 +27,22 @@ dependencies {
 }
 
 krit {
-    config.set(file("krit.yml"))
-    ignoreFailures.set(true)
+    config = file("krit.yml")
+    ignoreFailures = true
 
-    // Use the krit binary built from this checkout (`make build` or
-    // `go build -o krit ./cmd/krit/` at the repo root) so the demo does not
-    // depend on a published release. Drop this line to fall back to the
-    // version downloaded from GitHub Releases.
-    val localKrit = rootDir.resolve("../../krit")
-    if (localKrit.isFile) {
-        binary.set(localKrit)
+    reports {
+        plain.required = true
+        json.required = true
     }
 
-    reports.plain.required.set(true)
-    reports.json.required.set(true)
+    advanced {
+        // Use the krit binary built from this checkout (`make build` or
+        // `go build -o krit ./cmd/krit/` at the repo root) so the demo does
+        // not depend on a published release. Drop this block to fall back to
+        // the version downloaded from GitHub Releases.
+        val localKrit = rootDir.resolve("../../krit")
+        if (localKrit.isFile) {
+            binary = localKrit
+        }
+    }
 }


### PR DESCRIPTION
## Summary

- Slims `KritExtension` top-level to the settings most projects actually configure: `config`, `ignoreFailures`, `baseline`, `reports`, `customRuleJars`.
- Moves escape hatches (`toolVersion`, `binary`, `parallel`, `noCache`, `typeInference`, `fixLevel`, `allRules`, `source`, `reportsDir`) under a new nested `advanced { }` block that mirrors the existing `reports { }` DSL.
- Adds a reflection-based regression test (`top-level extension does not expose escape-hatch properties`) so future contributors cannot accidentally re-add an escape hatch to the primary DSL.
- Updates README + `docs/external-rules.md` + playground to use Kotlin property-assignment form (`foo = value`) throughout instead of `foo.set(value)`.

For most consumers the happy path is now:

```kotlin
krit {
    config = file(\"krit.yml\")
    baseline = file(\"krit-baseline.xml\")
    reports { sarif.required = true }
}
```

## Follow-ups (out of scope for this PR)

- `KritAdvanced.fixLevel: Property<String>` → enum. Stringly-typed today.
- Extract a shared task-wiring helper from `KritPlugin`'s three `withType().configureEach { }` blocks (\`KritCheckTask\`, \`KritFormatTask\`, \`KritBaselineTask\` share ~5 conventions).
- Settings plugin (\`dev.jasonpearson.krit.settings\`) for root-applied configuration across all subprojects — next PR in this series.

## Test plan

- [x] \`./gradlew test\` in \`krit-gradle-plugin\` (existing + new tests for advanced DSL pass)
- [x] \`go build -o krit ./cmd/krit/\`
- [x] \`go vet ./...\`
- [x] \`golangci-lint run ./...\` — 0 issues
- [x] \`go test ./... -count=1\` — full suite green
- [x] Playground (\`playground/kotlin-webservice\`) configures + \`kritCustomRules\` resolution still works end-to-end