### PR TITLE
fix(rules): recognize Kotlin raw strings in stripKotlinComments

### DIFF
--- a/internal/rules/flat_string.go
+++ b/internal/rules/flat_string.go
@@ -7,64 +7,105 @@ import (
 	"github.com/kaeawc/krit/internal/scanner"
 )
 
+// stripKotlinComments removes Kotlin line and block comments from text
+// while preserving string-literal content. Triple-quoted raw strings
+// are recognized as a single delimiter pair so that embedded `"`, `//`,
+// and `/* */` inside the raw body are not misinterpreted as code or
+// comments.
 func stripKotlinComments(text string) string {
 	var b strings.Builder
 	b.Grow(len(text))
-	inLineComment := false
-	inBlockComment := false
-	inString := false
-	escaped := false
-	for i := 0; i < len(text); i++ {
+	n := len(text)
+	for i := 0; i < n; {
 		ch := text[i]
-		if inLineComment {
-			if ch == '\n' {
-				inLineComment = false
-				b.WriteByte(ch)
-			}
+		if ch == '/' && i+1 < n && text[i+1] == '/' {
+			i = skipLineComment(text, i)
 			continue
 		}
-		if inBlockComment {
-			if ch == '*' && i+1 < len(text) && text[i+1] == '/' {
-				inBlockComment = false
-				i++
-			}
+		if ch == '/' && i+1 < n && text[i+1] == '*' {
+			i = skipBlockComment(text, i, &b)
 			continue
 		}
-		if inString {
-			b.WriteByte(ch)
-			if escaped {
-				escaped = false
-				continue
-			}
-			if ch == '\\' {
-				escaped = true
-				continue
-			}
-			if ch == '"' {
-				inString = false
-			}
+		if ch == '"' && i+2 < n && text[i+1] == '"' && text[i+2] == '"' {
+			i = copyRawString(text, i, &b)
 			continue
 		}
 		if ch == '"' {
-			inString = true
-			b.WriteByte(ch)
+			i = copyLineString(text, i, &b)
 			continue
 		}
-		if ch == '/' && i+1 < len(text) {
-			switch text[i+1] {
-			case '/':
-				inLineComment = true
-				i++
-				continue
-			case '*':
-				inBlockComment = true
-				i++
-				continue
-			}
-		}
 		b.WriteByte(ch)
+		i++
 	}
 	return b.String()
+}
+
+func skipLineComment(text string, i int) int {
+	for i < len(text) && text[i] != '\n' {
+		i++
+	}
+	return i
+}
+
+func skipBlockComment(text string, i int, b *strings.Builder) int {
+	n := len(text)
+	i += 2
+	for i+1 < n && (text[i] != '*' || text[i+1] != '/') {
+		if text[i] == '\n' {
+			b.WriteByte('\n')
+		}
+		i++
+	}
+	if i+1 < n {
+		return i + 2
+	}
+	// Unterminated block comment: still preserve a trailing newline so
+	// downstream line counts stay stable.
+	for ; i < n; i++ {
+		if text[i] == '\n' {
+			b.WriteByte('\n')
+		}
+	}
+	return n
+}
+
+func copyRawString(text string, i int, b *strings.Builder) int {
+	n := len(text)
+	b.WriteString(`"""`)
+	i += 3
+	for i+2 < n && (text[i] != '"' || text[i+1] != '"' || text[i+2] != '"') {
+		b.WriteByte(text[i])
+		i++
+	}
+	if i+2 < n {
+		b.WriteString(`"""`)
+		return i + 3
+	}
+	for ; i < n; i++ {
+		b.WriteByte(text[i])
+	}
+	return n
+}
+
+func copyLineString(text string, i int, b *strings.Builder) int {
+	n := len(text)
+	b.WriteByte('"')
+	i++
+	for i < n {
+		c := text[i]
+		if c == '\\' && i+1 < n {
+			b.WriteByte(c)
+			b.WriteByte(text[i+1])
+			i += 2
+			continue
+		}
+		b.WriteByte(c)
+		i++
+		if c == '"' || c == '\n' {
+			break
+		}
+	}
+	return i
 }
 
 func flatContainsStringInterpolation(file *scanner.File, idx uint32) bool {

--- a/internal/rules/flat_string_test.go
+++ b/internal/rules/flat_string_test.go
@@ -1,0 +1,111 @@
+package rules
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestStripKotlinComments_StripsLineComment(t *testing.T) {
+	in := "val x = 1 // trailing\nval y = 2"
+	out := stripKotlinComments(in)
+	if strings.Contains(out, "trailing") {
+		t.Fatalf("line comment not stripped: %q", out)
+	}
+	if !strings.Contains(out, "val y = 2") {
+		t.Fatalf("code after line comment not preserved: %q", out)
+	}
+}
+
+func TestStripKotlinComments_StripsBlockComment(t *testing.T) {
+	in := "val x = /* drop me */ 1\nval y = 2"
+	out := stripKotlinComments(in)
+	if strings.Contains(out, "drop me") {
+		t.Fatalf("block comment not stripped: %q", out)
+	}
+	if !strings.Contains(out, "val y = 2") {
+		t.Fatalf("code after block comment not preserved: %q", out)
+	}
+}
+
+func TestStripKotlinComments_PreservesRegularStringContent(t *testing.T) {
+	in := `val s = "hello // world"`
+	out := stripKotlinComments(in)
+	if !strings.Contains(out, "hello // world") {
+		t.Fatalf("regular string content was stripped: %q", out)
+	}
+}
+
+func TestStripKotlinComments_TripleQuotedRawStringWithEmbeddedQuote(t *testing.T) {
+	// Inside `"""..."""` the embedded `"hi"` is part of the raw-string
+	// content. The old state machine toggled out of "string" state on
+	// the lone `"`, leaving `hi` mis-classified as code.
+	in := `val s = """he said "hi" then it"""`
+	out := stripKotlinComments(in)
+	if out != in {
+		t.Fatalf("raw-string boundary corrupted:\n input: %q\noutput: %q", in, out)
+	}
+}
+
+func TestStripKotlinComments_TripleQuotedRawStringWithEmbeddedLineComment(t *testing.T) {
+	// `//` inside a raw string must NOT be treated as a Kotlin line
+	// comment. The old state machine could exit string mode on a lone
+	// embedded `"` and then strip the following `//...` as a comment.
+	in := "val s = \"\"\"hi\"//keep me\nrest\"\"\""
+	out := stripKotlinComments(in)
+	if !strings.Contains(out, "//keep me") {
+		t.Fatalf("inner // was mis-stripped as comment: %q", out)
+	}
+	if !strings.Contains(out, "rest") {
+		t.Fatalf("raw-string body after embedded // was dropped: %q", out)
+	}
+}
+
+func TestStripKotlinComments_TripleQuotedRawStringWithEmbeddedBlockCommentMarker(t *testing.T) {
+	// `/* ... */` characters inside a raw string must not be treated as
+	// a Kotlin block comment.
+	in := "val s = \"\"\"hi\"/* keep me */tail\"\"\""
+	out := stripKotlinComments(in)
+	if !strings.Contains(out, "/* keep me */") {
+		t.Fatalf("inner /* ... */ was mis-stripped as block comment: %q", out)
+	}
+	if !strings.Contains(out, "tail") {
+		t.Fatalf("raw-string body after embedded block-comment-like text was dropped: %q", out)
+	}
+}
+
+func TestStripKotlinComments_TripleQuotedRawStringSpansMultipleLines(t *testing.T) {
+	in := "val s = \"\"\"\n    line1\n    line2\n\"\"\"\nval n = 1"
+	out := stripKotlinComments(in)
+	if !strings.Contains(out, "line1") || !strings.Contains(out, "line2") {
+		t.Fatalf("multi-line raw-string body dropped: %q", out)
+	}
+	if !strings.Contains(out, "val n = 1") {
+		t.Fatalf("code after raw string dropped: %q", out)
+	}
+}
+
+func TestStripKotlinComments_UnterminatedBlockCommentPreservesNewlines(t *testing.T) {
+	// An unterminated block comment at EOF must still flush trailing
+	// newlines so line counts downstream remain stable.
+	in := "val x = 1 /* runaway\nstill in comment\n"
+	out := stripKotlinComments(in)
+	if got, want := strings.Count(out, "\n"), strings.Count(in, "\n"); got != want {
+		t.Fatalf("newline count drifted on unterminated block comment: want %d got %d (%q)", want, got, out)
+	}
+	if strings.Contains(out, "runaway") {
+		t.Fatalf("block comment body leaked: %q", out)
+	}
+}
+
+func TestStripKotlinComments_CodeAfterRawStringTracksOutsideStringState(t *testing.T) {
+	// After `"""..."""` closes, the next `// foo` is a real line comment
+	// and must be stripped.
+	in := "val s = \"\"\"body\"\"\" // trailing\nval n = 1"
+	out := stripKotlinComments(in)
+	if strings.Contains(out, "trailing") {
+		t.Fatalf("trailing line comment after raw string was not stripped: %q", out)
+	}
+	if !strings.Contains(out, "val n = 1") {
+		t.Fatalf("code after raw string + line comment dropped: %q", out)
+	}
+}

--- a/internal/rules/style_expressions_extra_test.go
+++ b/internal/rules/style_expressions_extra_test.go
@@ -40,6 +40,28 @@ fun main() {
 	}
 }
 
+func TestMultilineLambdaItParameter_DoesNotMisparseEmbeddedQuotesInRawString(t *testing.T) {
+	// The raw-string body contains an embedded `"hi"` and a `//keep` that
+	// previously confused the comment-stripper's state machine, leaking
+	// raw-string content out and risking spurious `it.` matches once a
+	// future maintainer adds substring checks. This locks the parser
+	// behavior so the rule's downstream substring scan sees a coherent
+	// view of the lambda body even when raw strings hide special chars.
+	src := `
+package test
+fun main(items: List<String>) {
+    items.forEach { item ->
+        val s = """he said "hi"//keep me
+trailing"""
+        println(s + item)
+    }
+}
+`
+	if findings := runRuleByName(t, "MultilineLambdaItParameter", src); len(findings) != 0 {
+		t.Fatalf("expected no findings for explicit-parameter lambda with embedded-quote raw string, got %d", len(findings))
+	}
+}
+
 func TestMultilineLambdaItParameter_IgnoresCommentsAndNonProductionSources(t *testing.T) {
 	commentOnly := `
 package test


### PR DESCRIPTION
## Summary
- The per-character state machine in `stripKotlinComments` treated `"""` as three independent `"` toggles. A lone embedded `"` inside the raw body could flip the state out of "string", so a following `//` or `/* */` was then stripped as a comment, and intervening bytes were classified as code instead of string content.
- Reshape the loop around explicit token kinds (line comment, block comment, triple-quoted raw string, line string) so each delimiter pair is handled as a unit. Block comments still flush newlines so downstream line counts stay stable, including when unterminated at EOF.
- Add helper-level tests covering each token kind and one lambda-rule integration test that locks the raw-string behavior at the rule boundary.

## Test plan
- [x] `go test ./internal/rules/ -run TestStripKotlinComments -count=1`
- [x] `go test ./internal/rules/ -run TestMultilineLambdaItParameter -count=1`
- [x] `go test ./... -count=1`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...`