### PR TITLE
fix(rules): require identifier-start boundary for HasPlatformType prefix match

### DIFF
--- a/internal/rules/naming.go
+++ b/internal/rules/naming.go
@@ -1095,6 +1095,33 @@ func containsIdentifierToken(text, name string) bool {
 	}
 }
 
+// containsIdentifierStart reports whether text contains an occurrence of
+// prefix where the preceding byte is not part of a Kotlin identifier,
+// so the match begins a new identifier token. Unlike
+// containsIdentifierToken this does not require a trailing boundary,
+// which lets `Java` match `JavaSerializer` while still excluding
+// `parseJavadoc`.
+func containsIdentifierStart(text, prefix string) bool {
+	if prefix == "" {
+		return false
+	}
+	start := 0
+	for {
+		idx := strings.Index(text[start:], prefix)
+		if idx < 0 {
+			return false
+		}
+		pos := start + idx
+		if pos == 0 || !isIdentByte(text[pos-1]) {
+			return true
+		}
+		start = pos + 1
+		if start >= len(text) {
+			return false
+		}
+	}
+}
+
 func isExtensionFunctionDeclFlat(file *scanner.File, idx uint32) bool {
 	if file == nil || file.FlatType(idx) != "function_declaration" {
 		return false

--- a/internal/rules/naming_helpers_internal_test.go
+++ b/internal/rules/naming_helpers_internal_test.go
@@ -1,0 +1,35 @@
+package rules
+
+import "testing"
+
+func TestContainsIdentifierStart(t *testing.T) {
+	cases := []struct {
+		text   string
+		prefix string
+		want   bool
+	}{
+		{"", "Java", false},
+		{"Java", "Java", true},
+		{"JavaSerializer.from(input)", "Java", true},
+		{"foo.JavaSerializer.from(input)", "Java", true},
+		{"parseJavadoc(content)", "Java", false},
+		{"registry.getJavadocFor(id)", "Java", false},
+		{"base64.decodeRaJava(raw)", "Java", false},
+		{"TemplateJavaxFooHelper.process(html)", "Javax", false},
+		{"return JavaxHelper.run()", "Javax", true},
+		{"Xjava.Bar()", "java", false},
+		{".java", "java", true},
+	}
+	for _, c := range cases {
+		got := containsIdentifierStart(c.text, c.prefix)
+		if got != c.want {
+			t.Errorf("containsIdentifierStart(%q, %q) = %v, want %v", c.text, c.prefix, got, c.want)
+		}
+	}
+}
+
+func TestContainsIdentifierStart_EmptyPrefix(t *testing.T) {
+	if containsIdentifierStart("anything", "") {
+		t.Fatal("empty prefix must not match")
+	}
+}

--- a/internal/rules/potentialbugs_misc_test.go
+++ b/internal/rules/potentialbugs_misc_test.go
@@ -118,6 +118,51 @@ fun name() = listOf("a", "b").first()`,
 	}
 }
 
+func TestHasPlatformType_NegativeJavaSubstringInIdentifier(t *testing.T) {
+	// "Java" appearing inside an identifier (parseJavadoc, getJavadocFor)
+	// must not trigger the rule — the substring "Java" is not at a token
+	// boundary, so it is not a Java-interop reference.
+	cases := []string{
+		`package test
+fun renderDocs(content: String) = parseJavadoc(content)`,
+		`package test
+fun lookupDoc(id: Int) = registry.getJavadocFor(id)`,
+		`package test
+fun decode(raw: String) = base64.decodeRaJava(raw)`,
+	}
+	for i, src := range cases {
+		findings := runRuleByName(t, "HasPlatformType", src)
+		if len(findings) != 0 {
+			t.Errorf("case %d: 'Java' inside identifier must not fire: got %d findings", i, len(findings))
+		}
+	}
+}
+
+func TestHasPlatformType_NegativeJavaxSubstringInIdentifier(t *testing.T) {
+	// "Javax" appearing inside an identifier must not trigger.
+	src := `
+package test
+fun render(html: String) = TemplateJavaxFooHelper.process(html)
+`
+	findings := runRuleByName(t, "HasPlatformType", src)
+	if len(findings) != 0 {
+		t.Errorf("'Javax' inside identifier must not fire: got %d findings", len(findings))
+	}
+}
+
+func TestHasPlatformType_PositiveJavaIdentifierAtTokenStart(t *testing.T) {
+	// "Java" at the start of an identifier still fires — this is the
+	// existing positive case (JavaClass.getData()) and remains intact.
+	src := `
+package test
+fun load() = JavaSerializer.from(input)
+`
+	findings := runRuleByName(t, "HasPlatformType", src)
+	if len(findings) == 0 {
+		t.Fatal("expected finding for 'JavaSerializer' at token start")
+	}
+}
+
 // --- IgnoredReturnValue ---
 
 func TestIgnoredReturnValue_Positive(t *testing.T) {

--- a/internal/rules/registry_potentialbugs_misc.go
+++ b/internal/rules/registry_potentialbugs_misc.go
@@ -163,7 +163,7 @@ func registerPotentialbugsMiscRules() {
 
 				line := file.FlatRow(idx) + 1
 				for _, prefix := range []string{"java.", "javax.", "android.", "Java", "Javax"} {
-					if strings.Contains(exprText, prefix) {
+					if containsIdentifierStart(exprText, prefix) {
 						ctx.EmitAt(line, 1,
 							"Public function with expression body should have an explicit return type to avoid platform types.")
 						return


### PR DESCRIPTION
## Summary
- The bare `Java` and `Javax` entries in HasPlatformType's prefix list were checked with `strings.Contains`, so identifiers embedding those letters (`parseJavadoc`, `getJavadocFor`, `decodeRaJava`, `TemplateJavaxFooHelper`) tripped a public-platform-type warning.
- Add `containsIdentifierStart` in `internal/rules/naming.go` — locates a prefix whose preceding byte is not an identifier byte. Differs from the existing `containsIdentifierToken` (full-token match) by intentionally allowing the match to continue into a longer identifier, which is what `JavaSerializer`-style matches need.
- Route all five prefixes (dotted and bare) through the new helper; the dotted prefixes still match because `.` is not an identifier byte.

## Test plan
- [x] `go test ./internal/rules/ -run TestHasPlatformType -count=1`
- [x] `go test ./internal/rules/ -run TestContainsIdentifierStart -count=1`
- [x] `go test ./... -count=1`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...`