### PR TITLE
perf(scanner): CSR-encode FlatTree per-type posting list

### DIFF
--- a/internal/rules/dispatcher.go
+++ b/internal/rules/dispatcher.go
@@ -421,9 +421,10 @@ func (d *Dispatcher) RunColumnsWithStats(file *scanner.File) (scanner.FindingCol
 	// a closure — closures would defeat the compiler's inlining and add
 	// allocation overhead per Run call):
 	//
-	//   1. Posting-list path: iterate tree.NodesByType[typeID] for each
-	//      typeID that has at least one subscribed rule. Visits ONLY
-	//      indices of subscribed types, skipping the bulk of the tree.
+	//   1. Posting-list path: iterate the CSR posting list
+	//      (tree.NodeTypeOffsets / NodeTypeIndices) for each typeID that
+	//      has at least one subscribed rule. Visits ONLY indices of
+	//      subscribed types, skipping the bulk of the tree.
 	//
 	//   2. Full walk path: a single pass over every node. Used when
 	//      there is at least one rule registered with nil NodeTypes
@@ -442,7 +443,16 @@ func (d *Dispatcher) RunColumnsWithStats(file *scanner.File) (scanner.FindingCol
 			// at line ~493 and in the allNodeRules block at line ~516.
 			// Keep all three in sync — extracting to a helper measurably
 			// regresses small-file dispatch (closures defeat inlining).
-			n := len(tree.NodesByType)
+			// Hoist the CSR arrays into locals so the compiler can
+			// keep them in registers across the loop and prove that
+			// offsets[typeID] / offsets[typeID+1] are in-bounds from
+			// the n bound below (n == len(offsets)-1).
+			offsets := tree.NodeTypeOffsets
+			postingIndices := tree.NodeTypeIndices
+			n := len(offsets) - 1
+			if n < 0 {
+				n = 0
+			}
 			if n > len(flatTypeRules) {
 				n = len(flatTypeRules)
 			}
@@ -451,7 +461,7 @@ func (d *Dispatcher) RunColumnsWithStats(file *scanner.File) (scanner.FindingCol
 				if len(handlers) == 0 {
 					continue
 				}
-				indices := tree.NodesByType[typeID]
+				indices := postingIndices[offsets[typeID]:offsets[typeID+1]]
 				if len(indices) == 0 {
 					continue
 				}
@@ -938,10 +948,7 @@ func (d *Dispatcher) RunResourceSource(file *scanner.File, idx *android.Resource
 		// indices for types with subscribers, skipping the bulk of the
 		// tree.
 		for typeID, handlers := range rulesByType {
-			var indices []uint32
-			if int(typeID) < len(tree.NodesByType) {
-				indices = tree.NodesByType[typeID]
-			}
+			indices := tree.NodesOfType(typeID)
 			for _, flatIdx := range indices {
 				flatNode := tree.Node(flatIdx)
 				for _, r := range handlers {

--- a/internal/rules/dispatcher.go
+++ b/internal/rules/dispatcher.go
@@ -443,10 +443,9 @@ func (d *Dispatcher) RunColumnsWithStats(file *scanner.File) (scanner.FindingCol
 			// at line ~493 and in the allNodeRules block at line ~516.
 			// Keep all three in sync — extracting to a helper measurably
 			// regresses small-file dispatch (closures defeat inlining).
-			// Hoist the CSR arrays into locals so the compiler can
-			// keep them in registers across the loop and prove that
-			// offsets[typeID] / offsets[typeID+1] are in-bounds from
-			// the n bound below (n == len(offsets)-1).
+			// Hoist the CSR arrays into locals so the compiler keeps
+			// them in registers across the loop and can prove the
+			// two-index slice expression in-bounds from the n clamp.
 			offsets := tree.NodeTypeOffsets
 			postingIndices := tree.NodeTypeIndices
 			n := len(offsets) - 1

--- a/internal/rules/logging.go
+++ b/internal/rules/logging.go
@@ -1325,10 +1325,10 @@ func (r *StructuredLogKeyMixedCaseRule) decisionFor(ctx *api.Context) structured
 		snake, camel := 0, 0
 		tree := file.FlatTree
 		callTypeID, ok := scanner.LookupFlatNodeType("call_expression")
-		if !ok || tree == nil || int(callTypeID) >= len(tree.NodesByType) {
+		if !ok || tree == nil {
 			return structuredLogKeyDecision{}
 		}
-		for _, flatIdx := range tree.NodesByType[callTypeID] {
+		for _, flatIdx := range tree.NodesOfType(callTypeID) {
 			key, ok := structuredLogKeyAtCall(file, flatIdx)
 			if !ok {
 				continue

--- a/internal/scanner/flat.go
+++ b/internal/scanner/flat.go
@@ -66,9 +66,10 @@ func (n FlatNode) TypeName() string {
 // is O(1); without it, walking from FirstChild would be O(sibling_index)
 // per call and O(N²) across adjacent callers.
 //
-// NodesByType is a posting list indexed by node type ID, giving direct
-// access to all nodes of a given type without a full tree walk. The
-// dispatcher uses this to skip nodes whose type has no subscribed rules.
+// NodeTypeOffsets/NodeTypeIndices form a CSR (compressed sparse row)
+// posting list indexed by node type ID, giving direct access to all
+// nodes of a given type without a full tree walk. The dispatcher uses
+// this to skip nodes whose type has no subscribed rules.
 type FlatTree struct {
 	Types         []uint16
 	Parents       []uint32
@@ -83,11 +84,38 @@ type FlatTree struct {
 	NamedCounts   []uint16
 	Flags         []uint8
 
-	// NodesByType[typeID] is a slice of node indices for nodes of that
-	// type in document order. A nil/empty entry means no nodes of that
-	// type appear in this tree. Built by flattenTree, rebuilt by the
-	// parse cache after type-table remap.
-	NodesByType [][]uint32
+	// NodeTypeOffsets and NodeTypeIndices form a CSR posting list:
+	// nodes of type t are at NodeTypeIndices[NodeTypeOffsets[t]:NodeTypeOffsets[t+1]]
+	// in document order. NodeTypeOffsets has length maxType+2 with the
+	// trailing entry equal to len(NodeTypeIndices) so [t:t+1] slicing
+	// works for every valid typeID. Both are nil for an empty tree or
+	// an ad-hoc tree that never had the posting list built.
+	NodeTypeOffsets []uint32
+	NodeTypeIndices []uint32
+}
+
+// NodesOfType returns the indices of every node with the given type ID
+// in document order. Zero-allocation: the result is a slice view into
+// NodeTypeIndices. Returns nil when the posting list is absent or
+// typeID is out of range.
+func (t *FlatTree) NodesOfType(typeID uint16) []uint32 {
+	if t == nil {
+		return nil
+	}
+	off := t.NodeTypeOffsets
+	if int(typeID)+1 >= len(off) {
+		return nil
+	}
+	return t.NodeTypeIndices[off[typeID]:off[typeID+1]]
+}
+
+// NumNodeTypes returns the number of type buckets in the posting list
+// (maxType+1). Zero when the posting list has not been built.
+func (t *FlatTree) NumNodeTypes() int {
+	if t == nil || len(t.NodeTypeOffsets) == 0 {
+		return 0
+	}
+	return len(t.NodeTypeOffsets) - 1
 }
 
 // Len returns the number of nodes in the tree. Safe on a nil receiver.
@@ -205,12 +233,19 @@ func flattenTree(root *sitter.Node) *FlatTree {
 	return t
 }
 
-// buildNodesByType reconstructs the per-type posting list from t.Types.
+// buildNodesByType reconstructs the CSR posting list from t.Types.
 // Used by the parse cache after remapping local type IDs back to the
-// process-global table.
+// process-global table. Allocates exactly two slices; the alloc-budget
+// regression test in flat_csr_test.go locks the budget.
+//
+// Counting sort with offsets-as-write-cursor. Forward iteration over
+// Types in the scatter pass outperforms the textbook reverse-scatter
+// variant (better branch prediction / instruction-level parallelism on
+// real workloads), at the cost of a final right-shift restore pass.
 func (t *FlatTree) buildNodesByType() {
 	if t == nil || len(t.Types) == 0 {
-		t.NodesByType = nil
+		t.NodeTypeOffsets = nil
+		t.NodeTypeIndices = nil
 		return
 	}
 	var maxType uint16
@@ -219,20 +254,33 @@ func (t *FlatTree) buildNodesByType() {
 			maxType = tID
 		}
 	}
-	counts := make([]uint32, int(maxType)+1)
+	// Length maxType+2 so the trailing entry is the closing bound and
+	// callers can slice indices[offsets[t]:offsets[t+1]] for any
+	// valid typeID without a length check.
+	offsets := make([]uint32, int(maxType)+2)
 	for _, tID := range t.Types {
-		counts[tID]++
+		offsets[int(tID)+1]++
 	}
-	out := make([][]uint32, int(maxType)+1)
-	for tID, c := range counts {
-		if c > 0 {
-			out[tID] = make([]uint32, 0, c)
-		}
+	for i := 1; i < len(offsets); i++ {
+		offsets[i] += offsets[i-1]
 	}
+	indices := make([]uint32, len(t.Types))
+	// Use offsets as a write cursor; restore by shifting right one
+	// slot after the scatter. Post-scatter offsets[t-1] equals the
+	// original offsets[t], so a right shift recovers the bucket
+	// starts. Trailing offsets[maxType+1] stays put — no bucket
+	// maxType+1 exists, so it was never advanced.
 	for i, tID := range t.Types {
-		out[tID] = append(out[tID], uint32(i))
+		slot := offsets[tID]
+		indices[slot] = uint32(i)
+		offsets[tID] = slot + 1
 	}
-	t.NodesByType = out
+	for i := len(offsets) - 1; i > 0; i-- {
+		offsets[i] = offsets[i-1]
+	}
+	offsets[0] = 0
+	t.NodeTypeOffsets = offsets
+	t.NodeTypeIndices = indices
 }
 
 // FlatNodeText returns the source text spanned by the flattened node.
@@ -270,9 +318,9 @@ func FlatNodeString(tree *FlatTree, idx uint32, content []byte, pool *StringPool
 }
 
 // FlatWalkNodes calls fn for every node of the given type. Uses the
-// NodesByType posting list when available for direct O(matches) access;
-// falls back to a linear scan over t.Types when the posting list has
-// not been built (e.g. ad-hoc test trees).
+// CSR posting list when available for direct O(matches) access; falls
+// back to a linear scan over t.Types when the posting list has not
+// been built (e.g. ad-hoc test trees).
 func FlatWalkNodes(tree *FlatTree, nodeType string, fn func(uint32)) {
 	if tree == nil {
 		return
@@ -281,8 +329,8 @@ func FlatWalkNodes(tree *FlatTree, nodeType string, fn func(uint32)) {
 	if !ok {
 		return
 	}
-	if int(typeID) < len(tree.NodesByType) {
-		for _, idx := range tree.NodesByType[typeID] {
+	if len(tree.NodeTypeOffsets) > 0 {
+		for _, idx := range tree.NodesOfType(typeID) {
 			fn(idx)
 		}
 		return

--- a/internal/scanner/flat.go
+++ b/internal/scanner/flat.go
@@ -235,13 +235,12 @@ func flattenTree(root *sitter.Node) *FlatTree {
 
 // buildNodesByType reconstructs the CSR posting list from t.Types.
 // Used by the parse cache after remapping local type IDs back to the
-// process-global table. Allocates exactly two slices; the alloc-budget
-// regression test in flat_csr_test.go locks the budget.
+// process-global table.
 //
-// Counting sort with offsets-as-write-cursor. Forward iteration over
-// Types in the scatter pass outperforms the textbook reverse-scatter
-// variant (better branch prediction / instruction-level parallelism on
-// real workloads), at the cost of a final right-shift restore pass.
+// Counting sort with offsets-as-write-cursor. Forward iteration in the
+// scatter pass outperformed the textbook reverse-scatter variant in
+// benchmarks (better branch prediction / instruction-level parallelism),
+// at the cost of a final right-shift restore pass.
 func (t *FlatTree) buildNodesByType() {
 	if t == nil || len(t.Types) == 0 {
 		t.NodeTypeOffsets = nil

--- a/internal/scanner/flat_csr_test.go
+++ b/internal/scanner/flat_csr_test.go
@@ -1,0 +1,297 @@
+package scanner
+
+import (
+	"slices"
+	"sort"
+	"testing"
+)
+
+// TestBuildNodesByType_EmptyTree asserts that an empty tree leaves the
+// CSR posting list nil — callers rely on len(NodeTypeOffsets) == 0 to
+// detect "no posting list" (e.g. FlatWalkNodes' fallback path).
+func TestBuildNodesByType_EmptyTree(t *testing.T) {
+	tree := &FlatTree{}
+	tree.buildNodesByType()
+	if tree.NodeTypeOffsets != nil {
+		t.Errorf("expected nil NodeTypeOffsets for empty tree, got %v", tree.NodeTypeOffsets)
+	}
+	if tree.NodeTypeIndices != nil {
+		t.Errorf("expected nil NodeTypeIndices for empty tree, got %v", tree.NodeTypeIndices)
+	}
+	if got := tree.NumNodeTypes(); got != 0 {
+		t.Errorf("expected NumNodeTypes()=0 for empty tree, got %d", got)
+	}
+}
+
+func TestBuildNodesByType_SingleType(t *testing.T) {
+	typeID := internNodeType("identifier")
+	tree := &FlatTree{Types: []uint16{typeID, typeID, typeID}}
+	tree.buildNodesByType()
+	if got := len(tree.NodeTypeOffsets); got != int(typeID)+2 {
+		t.Fatalf("expected NodeTypeOffsets length %d, got %d", int(typeID)+2, got)
+	}
+	got := tree.NodesOfType(typeID)
+	want := []uint32{0, 1, 2}
+	if !slices.Equal(got, want) {
+		t.Errorf("expected indices %v, got %v", want, got)
+	}
+}
+
+// TestBuildNodesByType_DocumentOrderPreserved is the core correctness
+// guard for the CSR scatter pass. The order of indices within a bucket
+// must match document order — rules depend on this for stable dispatch
+// ordering and reproducible findings.
+func TestBuildNodesByType_DocumentOrderPreserved(t *testing.T) {
+	aID := internNodeType("identifier")
+	bID := internNodeType("integer_literal")
+	cID := internNodeType("string_literal")
+	tree := &FlatTree{Types: []uint16{
+		aID, bID, aID, cID, aID, bID, cID, aID, bID,
+	}}
+	tree.buildNodesByType()
+
+	cases := []struct {
+		name   string
+		typeID uint16
+		want   []uint32
+	}{
+		{"identifier", aID, []uint32{0, 2, 4, 7}},
+		{"integer_literal", bID, []uint32{1, 5, 8}},
+		{"string_literal", cID, []uint32{3, 6}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tree.NodesOfType(tc.typeID)
+			if !slices.Equal(got, tc.want) {
+				t.Errorf("expected indices %v in document order, got %v", tc.want, got)
+			}
+		})
+	}
+}
+
+// TestNodesOfType_OutOfRange asserts that NodesOfType is safe for
+// typeIDs that do not appear in this tree. FlatWalkNodes relies on
+// this when looking up a node type that was interned by another
+// parser pass but doesn't appear in this particular file.
+func TestNodesOfType_OutOfRange(t *testing.T) {
+	typeID := internNodeType("identifier")
+	tree := &FlatTree{Types: []uint16{typeID}}
+	tree.buildNodesByType()
+
+	beyond := uint16(len(tree.NodeTypeOffsets))
+	if got := tree.NodesOfType(beyond); got != nil {
+		t.Errorf("expected nil for typeID past max, got %v", got)
+	}
+	if got := tree.NodesOfType(^uint16(0)); got != nil {
+		t.Errorf("expected nil for max uint16 typeID, got %v", got)
+	}
+
+	var nilTree *FlatTree
+	if got := nilTree.NodesOfType(0); got != nil {
+		t.Errorf("expected nil for nil tree, got %v", got)
+	}
+}
+
+// TestBuildNodesByType_PartitionsTypes confirms that every node index
+// appears in exactly one bucket and the union of buckets covers all
+// nodes. This is the property a tree walk relies on: dispatching by
+// type visits each node once and only once.
+func TestBuildNodesByType_PartitionsTypes(t *testing.T) {
+	root, _ := parseKotlin(t, `
+package com.example
+
+import kotlin.collections.List
+
+class Container(val items: List<String>) {
+    fun describe(): String {
+        val parts = items.map { it.uppercase() }
+        return parts.joinToString(", ")
+    }
+}
+`)
+	tree := flattenTree(root)
+	if tree.Len() == 0 {
+		t.Fatal("expected non-empty tree")
+	}
+
+	seen := make(map[uint32]bool, tree.Len())
+	for typeID := uint16(0); int(typeID) < tree.NumNodeTypes(); typeID++ {
+		for _, idx := range tree.NodesOfType(typeID) {
+			if seen[idx] {
+				t.Fatalf("index %d appears in multiple buckets", idx)
+			}
+			seen[idx] = true
+			if got := tree.Types[idx]; got != typeID {
+				t.Errorf("bucket %d contains index %d with type %d", typeID, idx, got)
+			}
+		}
+	}
+	if len(seen) != tree.Len() {
+		t.Fatalf("expected every node (%d) covered by buckets, got %d", tree.Len(), len(seen))
+	}
+}
+
+// TestBuildNodesByType_MatchesLinearScan checks the posting list
+// against a brute-force linear scan over t.Types for every typeID,
+// ensuring complete behavioural equivalence with the prior [][]uint32
+// shape and with FlatWalkNodes' fallback path.
+func TestBuildNodesByType_MatchesLinearScan(t *testing.T) {
+	root, _ := parseKotlin(t, `
+fun fizzbuzz(n: Int): String = when {
+    n % 15 == 0 -> "FizzBuzz"
+    n % 3 == 0 -> "Fizz"
+    n % 5 == 0 -> "Buzz"
+    else -> n.toString()
+}
+`)
+	tree := flattenTree(root)
+	if tree.Len() == 0 {
+		t.Fatal("expected non-empty tree")
+	}
+
+	for typeID := uint16(0); int(typeID) < tree.NumNodeTypes(); typeID++ {
+		var want []uint32
+		for i, tID := range tree.Types {
+			if tID == typeID {
+				want = append(want, uint32(i))
+			}
+		}
+		got := tree.NodesOfType(typeID)
+		if !slices.Equal(got, want) {
+			t.Errorf("typeID %d (%s): got %v, want %v",
+				typeID, nodeTypeName(typeID), got, want)
+		}
+	}
+}
+
+// TestFlatWalkNodes_FallbackWithoutPostingList asserts the fallback
+// path still works for ad-hoc trees that skip buildNodesByType. Rule
+// authors hand-construct FlatTrees in unit tests; this path must keep
+// working.
+func TestFlatWalkNodes_FallbackWithoutPostingList(t *testing.T) {
+	typeID := internNodeType("identifier")
+	tree := &FlatTree{Types: []uint16{typeID, typeID + 1, typeID, typeID + 1, typeID}}
+	// Deliberately do NOT call buildNodesByType.
+	if len(tree.NodeTypeOffsets) != 0 {
+		t.Fatal("preconditions violated: posting list should be empty")
+	}
+
+	var got []uint32
+	FlatWalkNodes(tree, nodeTypeName(typeID), func(idx uint32) {
+		got = append(got, idx)
+	})
+	want := []uint32{0, 2, 4}
+	if !slices.Equal(got, want) {
+		t.Errorf("expected fallback to yield %v, got %v", want, got)
+	}
+}
+
+// TestFlatWalkNodes_PostingListMatchesFallback runs both code paths on
+// the same tree and verifies the results match. Catches future drift
+// between the posting-list and fallback dispatch paths.
+func TestFlatWalkNodes_PostingListMatchesFallback(t *testing.T) {
+	root, _ := parseKotlin(t, `
+class A {
+    fun b() = c().d()
+    fun e() = f()
+}
+`)
+	tree := flattenTree(root)
+
+	allTypeNames := make([]string, 0, tree.NumNodeTypes())
+	for typeID := uint16(0); int(typeID) < tree.NumNodeTypes(); typeID++ {
+		if len(tree.NodesOfType(typeID)) == 0 {
+			continue
+		}
+		allTypeNames = append(allTypeNames, nodeTypeName(typeID))
+	}
+	sort.Strings(allTypeNames)
+
+	fallback := &FlatTree{Types: append([]uint16(nil), tree.Types...)}
+
+	for _, name := range allTypeNames {
+		var fastResult, slowResult []uint32
+		FlatWalkNodes(tree, name, func(idx uint32) { fastResult = append(fastResult, idx) })
+		FlatWalkNodes(fallback, name, func(idx uint32) { slowResult = append(slowResult, idx) })
+		if !slices.Equal(fastResult, slowResult) {
+			t.Errorf("type %q: posting-list %v vs fallback %v", name, fastResult, slowResult)
+		}
+	}
+}
+
+// TestBuildNodesByType_AllocBudget locks in the 2-alloc-per-rebuild
+// budget. Before CSR this was 2 + distinct_types (≈50 for typical
+// Kotlin files); regressing back would reintroduce GC pressure on
+// every warm cache hit. If this test starts failing, look for code
+// that re-introduces per-bucket [][]uint32 slices or a third
+// per-rebuild scratch slice.
+func TestBuildNodesByType_AllocBudget(t *testing.T) {
+	root, _ := parseKotlin(t, `
+package com.example
+
+import kotlin.collections.List
+
+class Repository(
+    private val items: List<String>,
+    private val onChange: (String) -> Unit,
+) {
+    fun add(value: String) {
+        if (value.isNotBlank()) {
+            onChange(value.trim())
+        }
+    }
+
+    fun describe(): String {
+        return items.joinToString(prefix = "[", postfix = "]", separator = ", ") {
+            it.uppercase()
+        }
+    }
+}
+`)
+	tree := flattenTree(root)
+	// Drop the posting list so each AllocsPerRun iteration starts cold.
+	tree.NodeTypeOffsets = nil
+	tree.NodeTypeIndices = nil
+
+	avg := testing.AllocsPerRun(50, func() {
+		tree.buildNodesByType()
+		// Reset so the next call also allocates fresh slices, otherwise
+		// AllocsPerRun would only measure the first iteration's allocs.
+		tree.NodeTypeOffsets = nil
+		tree.NodeTypeIndices = nil
+	})
+	const budget = 2
+	if avg > budget {
+		t.Errorf("buildNodesByType allocated %.2f allocs/op, budget is %d", avg, budget)
+	}
+}
+
+// BenchmarkBuildNodesByType reports allocs/op and ns/op so CI dashboards
+// can track regressions over time. Pairs with the alloc-budget test
+// above as a softer signal — the test is the hard gate.
+func BenchmarkBuildNodesByType(b *testing.B) {
+	root, _ := parseKotlinBench(b, `
+package com.example
+
+class Service(
+    private val items: List<String>,
+    private val cache: MutableMap<String, Int>,
+) {
+    fun process(input: String): String {
+        val tokens = input.split(",").map { it.trim() }
+        for (token in tokens) {
+            cache[token] = (cache[token] ?: 0) + 1
+        }
+        return tokens.joinToString(separator = "|") { it.uppercase() }
+    }
+}
+`)
+	tree := flattenTree(root)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		tree.NodeTypeOffsets = nil
+		tree.NodeTypeIndices = nil
+		tree.buildNodesByType()
+	}
+}

--- a/internal/scanner/flat_csr_test.go
+++ b/internal/scanner/flat_csr_test.go
@@ -2,7 +2,6 @@ package scanner
 
 import (
 	"slices"
-	"sort"
 	"testing"
 )
 
@@ -197,19 +196,13 @@ class A {
 }
 `)
 	tree := flattenTree(root)
+	fallback := &FlatTree{Types: append([]uint16(nil), tree.Types...)}
 
-	allTypeNames := make([]string, 0, tree.NumNodeTypes())
 	for typeID := uint16(0); int(typeID) < tree.NumNodeTypes(); typeID++ {
 		if len(tree.NodesOfType(typeID)) == 0 {
 			continue
 		}
-		allTypeNames = append(allTypeNames, nodeTypeName(typeID))
-	}
-	sort.Strings(allTypeNames)
-
-	fallback := &FlatTree{Types: append([]uint16(nil), tree.Types...)}
-
-	for _, name := range allTypeNames {
+		name := nodeTypeName(typeID)
 		var fastResult, slowResult []uint32
 		FlatWalkNodes(tree, name, func(idx uint32) { fastResult = append(fastResult, idx) })
 		FlatWalkNodes(fallback, name, func(idx uint32) { slowResult = append(slowResult, idx) })
@@ -249,16 +242,8 @@ class Repository(
 }
 `)
 	tree := flattenTree(root)
-	// Drop the posting list so each AllocsPerRun iteration starts cold.
-	tree.NodeTypeOffsets = nil
-	tree.NodeTypeIndices = nil
-
 	avg := testing.AllocsPerRun(50, func() {
 		tree.buildNodesByType()
-		// Reset so the next call also allocates fresh slices, otherwise
-		// AllocsPerRun would only measure the first iteration's allocs.
-		tree.NodeTypeOffsets = nil
-		tree.NodeTypeIndices = nil
 	})
 	const budget = 2
 	if avg > budget {

--- a/internal/scanner/parse_cache.go
+++ b/internal/scanner/parse_cache.go
@@ -61,9 +61,10 @@ var parseCacheVersionStr = strconv.FormatUint(uint64(parseCacheVersion), 10)
 // match the writer's. Version, grammar, content hash, and language live
 // in the owning sidecar/path rather than being duplicated in every entry.
 //
-// The fields mirror FlatTree's parallel-slice layout (SoA). NodesByType
-// is NOT serialized because it depends on the type-ID space, which is
-// remapped on load; we rebuild it post-remap.
+// The fields mirror FlatTree's parallel-slice layout (SoA). The CSR
+// posting list (NodeTypeOffsets/NodeTypeIndices) is NOT serialized
+// because it depends on the type-ID space, which is remapped on load;
+// we rebuild it post-remap.
 type parseCacheEntry struct {
 	NodeTypeTable []string
 	Types         []uint16
@@ -389,7 +390,7 @@ func (lc *langCache) loadByHash(hash string) (*FlatTree, bool) {
 // flatTreeFromEntry rebuilds a FlatTree from a freshly-decoded cache
 // entry. The entry's Types slice holds LOCAL indices into entry.NodeTypeTable;
 // they are remapped to the process-global NodeTypeTable in place. The
-// NodesByType posting list is rebuilt post-remap.
+// CSR posting list is rebuilt post-remap.
 func flatTreeFromEntry(entry *parseCacheEntry) *FlatTree {
 	remapEntryTypes(entry.Types, entry.NodeTypeTable)
 	tree := &FlatTree{
@@ -546,8 +547,8 @@ func (lc *langCache) saveAsync(path string, content []byte, tree *FlatTree, writ
 }
 
 // cloneTreeForCacheSave makes a defensive shallow copy of the SoA slices
-// in tree so an async writer can encode without contention. NodesByType
-// is NOT cloned (and not used for encoding).
+// in tree so an async writer can encode without contention. The CSR
+// posting list is NOT cloned (and not used for encoding).
 func cloneTreeForCacheSave(tree *FlatTree) *FlatTree {
 	if tree == nil {
 		return nil


### PR DESCRIPTION
## Summary

- Replace `FlatTree.NodesByType [][]uint32` with a CSR (compressed sparse row) layout: `NodeTypeOffsets []uint32` + `NodeTypeIndices []uint32`. Allocations per rebuild drop from `2 + distinct_types` (~50 per typical Kotlin file) to exactly 2.
- Dispatcher's hot posting-list path slices the contiguous `NodeTypeIndices` directly; the `NumNodeTypes()` bound is derived from `len(offsets)-1` so the compiler can prove `offsets[typeID+1]` in-bounds. `RunResourceSource` uses the new `NodesOfType` accessor.
- GC scan pointers per cached tree drop from ~50 to 2 — the parse cache rebuilds the posting list on every warm hit (type-IDs are remapped per-process), so this saves both cold and warm.

## Why

`buildNodesByType` runs in `flattenTree` (cold) **and** in `flatTreeFromEntry` (every warm parse-cache hit). With 37k files × ~50 slice allocs per rebuild, that's ~1.85M allocs cold and the same again on cache hits. Wall time is small (0.16% in the CPU profile referenced in design discussion) but the GC scan-set savings compound across the resident cache.

## Test plan

- [x] `go build`, `go vet`, `golangci-lint run` clean across `internal/scanner/...` + `internal/rules/...`
- [x] `go test ./... -count=1` passes
- [x] `make lint-rules` passes
- [x] `make regression` passes (playground finding counts unchanged: 29 webservice, 63 android-app)
- [x] `BenchmarkBuildNodesByType` reports 2 allocs/op, 1056 B/op, ~550 ns/op
- [x] New tests in `internal/scanner/flat_csr_test.go`:
  - empty tree → nil offsets/indices
  - single type / single bucket
  - document-order preserved within buckets (core CSR scatter correctness)
  - out-of-range typeID and nil receiver safe
  - bucket partitioning property (every node appears in exactly one bucket)
  - posting-list matches a brute-force linear scan over `Types` for every typeID
  - fallback path still works when posting list isn't built (ad-hoc test trees)
  - `TestBuildNodesByType_AllocBudget` locks the 2-alloc-per-rebuild budget against future regression