### PR TITLE
refactor(gradle): remove customRules(vararg Any), finish DSL modernization

### DIFF
--- a/docs/external-rules.md
+++ b/docs/external-rules.md
@@ -42,10 +42,10 @@ plugins {
 
 kritCustomRules {
     // All properties optional — defaults shown for visibility.
-    // ruleApiVersion.set("<krit-version>")
-    // sdkVersion.set("<krit-version>")
-    vendorId.set("acme")
-    defaultSeverity.set("warning")
+    // ruleApiVersion = "<krit-version>"
+    // sdkVersion = "<krit-version>"
+    vendorId = "acme"
+    defaultSeverity = "warning"
 }
 ```
 
@@ -208,8 +208,9 @@ is on the classpath.
 
 ### 5. Wire the jar into the consumer
 
-The consumer applies `dev.jasonpearson.krit` and adds the rules module
-via the `customRules(...)` DSL:
+The consumer applies `dev.jasonpearson.krit` and pulls the rules module
+through the `kritCustomRules` resolvable configuration in the
+`dependencies` block:
 
 ```kotlin
 // app/build.gradle.kts
@@ -217,15 +218,24 @@ plugins {
     id("dev.jasonpearson.krit") version "<krit-version>"
 }
 
-krit {
-    customRules(project(":my-rules"))
-    // Or pass an already-built jar:
-    // customRules(file("libs/my-rules-0.1.0-krit-rules.jar"))
+dependencies {
+    kritCustomRules(project(":my-rules"))
 }
 ```
 
-Passing a `Project` makes the consumer depend on the producer's `jar`
-task; passing a `File`/`FileCollection` just adds it to the classpath.
+`dev.jasonpearson.krit.custom` publishes the stamped `kritRuleJar`
+archive as an outgoing variant with a `krit-rule-bundle` category
+attribute; `kritCustomRules` resolves it through Gradle's dependency
+graph, so task ordering and artifact production are wired automatically
+(no `evaluationDependsOn`, no cross-project task lookup, Project-
+Isolation safe).
+
+For one-off jars or task outputs that don't fit the dependency-block
+model, append directly to `krit.customRuleJars`:
+
+```kotlin
+krit { customRuleJars.from(file("libs/my-rules-0.1.0-krit-rules.jar")) }
+```
 
 ### 6. Run Krit
 
@@ -239,7 +249,7 @@ Console output (text formatter, default):
 app/src/main/kotlin/com/acme/Foo.kt:12:3: warning [acme.NoTodo] TODO left in source
 ```
 
-JSON output (`krit { reports { json.enabled.set(true) } }` or
+JSON output (`krit { reports { json.required = true } }` or
 `--format json` from the CLI):
 
 ```json

--- a/examples/external-rule/README.md
+++ b/examples/external-rule/README.md
@@ -1,8 +1,12 @@
 # External Rule Example
 
 Copy-paste starter for authoring a custom Krit rule. Builds a rule jar
-that the host Krit binary loads via `--custom-rule-jars` (or the
-`krit { customRules(...) }` DSL in the host Gradle plugin).
+that the host Krit binary loads via `--custom-rule-jars` (or, in a
+Gradle build, the `kritCustomRules` resolvable configuration on the host
+plugin — see [docs/external-rules.md](../../docs/external-rules.md#5-wire-the-jar-into-the-consumer)
+for the variant-resolution rationale and
+[krit-custom-rule-plugin](../../krit-custom-rule-plugin/README.md) for
+the rule-authoring DSL).
 
 ## Layout
 

--- a/krit-custom-rule-plugin/README.md
+++ b/krit-custom-rule-plugin/README.md
@@ -1,6 +1,6 @@
 # Krit Custom Rule Plugin
 
-Gradle plugin that scaffolds a module for authoring custom [Krit](https://github.com/kaeawc/krit) rules. It wires up the Kotlin compile classpath, generates the `META-INF/services` registration, and produces a properly-stamped jar that Krit's `--custom-rule-jars` flag (or the host plugin's `customRules(...)` DSL) consumes.
+Gradle plugin that scaffolds a module for authoring custom [Krit](https://github.com/kaeawc/krit) rules. It wires up the Kotlin compile classpath, generates the `META-INF/services` registration, and produces a properly-stamped jar consumed by Krit's `--custom-rule-jars` flag (or the host plugin's `kritCustomRules` configuration in the `dependencies` block).
 
 ## Usage
 
@@ -12,16 +12,16 @@ plugins {
 
 kritCustomRules {
     // Optional — defaults to the plugin's own version.
-    ruleApiVersion.set("0.2.0")
+    ruleApiVersion = "0.2.0"
 
     // Optional — written to the Krit-SDK-Version manifest attribute.
-    sdkVersion.set("0.2.0")
+    sdkVersion = "0.2.0"
 
     // Optional — recorded as Krit-Vendor-Id.
-    vendorId.set("acme")
+    vendorId = "acme"
 
     // Optional — fallback severity recorded as Krit-Default-Severity.
-    defaultSeverity.set("warning")
+    defaultSeverity = "warning"
 }
 ```
 
@@ -61,12 +61,23 @@ plugins {
 }
 
 dependencies {
-    // OR: krit { customRules(file("path/to/my-rules.jar")) }
+    kritCustomRules(project(":my-rules"))
 }
+```
 
-krit {
-    customRules(project(":my-rules"))
-}
+`dev.jasonpearson.krit.custom` publishes the stamped `kritRuleJar` as an
+outgoing variant with a `krit-rule-bundle` category attribute, and the
+host plugin's `kritCustomRules` configuration resolves that variant
+through Gradle's dependency graph — no `evaluationDependsOn`, no
+cross-project task lookup, Project-Isolation safe. See
+[docs/external-rules.md](../docs/external-rules.md#5-wire-the-jar-into-the-consumer)
+for the longer write-up.
+
+For raw jars or task outputs that don't fit the dependency-block model,
+append directly to `krit.customRuleJars`:
+
+```kotlin
+krit { customRuleJars.from(file("libs/my-rules-0.1.0-krit-rules.jar")) }
 ```
 
 ## What the plugin does

--- a/krit-gradle-plugin/src/main/kotlin/dev/jasonpearson/krit/gradle/KritExtension.kt
+++ b/krit-gradle-plugin/src/main/kotlin/dev/jasonpearson/krit/gradle/KritExtension.kt
@@ -1,13 +1,10 @@
 package dev.jasonpearson.krit.gradle
 
 import org.gradle.api.Action
-import org.gradle.api.Project
-import org.gradle.api.UnknownTaskException
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
-import org.gradle.jvm.tasks.Jar
 import javax.inject.Inject
 
 /**
@@ -31,12 +28,20 @@ import javax.inject.Inject
  *
  * Escape hatches (binary path, parallelism, cache toggles, fix level, etc.)
  * live under [advanced]. Project-level custom-rule wiring goes through the
- * `kritCustomRules` configuration in the `dependencies` block.
+ * `kritCustomRules` configuration in the `dependencies` block:
+ *
+ * ```
+ * dependencies { kritCustomRules(project(":custom-rules")) }
+ * ```
+ *
+ * For one-off jars or task outputs that don't fit the dependency-block model,
+ * append directly to [customRuleJars] (a `ConfigurableFileCollection`):
+ *
+ * ```
+ * krit { customRuleJars.from(file("libs/my-rules.jar")) }
+ * ```
  */
-abstract class KritExtension @Inject constructor(
-    private val project: Project,
-    objects: ObjectFactory,
-) {
+abstract class KritExtension @Inject constructor(objects: ObjectFactory) {
 
     /** Path to krit.yml. Optional — when unset, the CLI auto-discovers from the project root. */
     abstract val config: RegularFileProperty
@@ -64,38 +69,5 @@ abstract class KritExtension @Inject constructor(
     /** Configure advanced settings via DSL block. */
     fun advanced(action: Action<KritAdvanced>) {
         action.execute(advanced)
-    }
-
-    /**
-     * Add Kotlin custom-rule jars or projects that produce a jar task.
-     *
-     * For `Project` notations, prefers `kritRuleJar` (the stamped archive
-     * registered by `dev.jasonpearson.krit.custom`) over the default `jar`
-     * task — only the former carries the `Krit-SDK-Version` / `Krit-Vendor-Id`
-     * manifest attributes the daemon reads. The sibling project is configured
-     * before lookup so its lazily registered tasks are visible.
-     *
-     * Prefer the variant-aware form for project deps:
-     * ```
-     * dependencies { kritCustomRules(project(":custom-rules")) }
-     * ```
-     * which routes through Gradle's dependency graph instead of cross-project
-     * task lookup.
-     */
-    fun customRules(vararg notations: Any) {
-        notations.forEach { notation ->
-            if (notation is Project) {
-                project.evaluationDependsOn(notation.path)
-                val jarTask = try {
-                    notation.tasks.named("kritRuleJar", Jar::class.java)
-                } catch (_: UnknownTaskException) {
-                    notation.tasks.named("jar", Jar::class.java)
-                }
-                customRuleJars.from(jarTask.flatMap { it.archiveFile })
-                customRuleJars.builtBy(jarTask)
-            } else {
-                customRuleJars.from(notation)
-            }
-        }
     }
 }

--- a/krit-gradle-plugin/src/main/kotlin/dev/jasonpearson/krit/gradle/KritPlugin.kt
+++ b/krit-gradle-plugin/src/main/kotlin/dev/jasonpearson/krit/gradle/KritPlugin.kt
@@ -37,7 +37,7 @@ class KritPlugin : Plugin<Project> {
     override fun apply(project: Project) {
         project.pluginManager
 
-        val extension = project.extensions.create("krit", KritExtension::class.java, project)
+        val extension = project.extensions.create("krit", KritExtension::class.java)
 
         // Resolvable configuration for declaring custom-rule producers as
         // project dependencies, e.g. `dependencies { kritCustomRules(project(":rules")) }`.
@@ -57,7 +57,7 @@ class KritPlugin : Plugin<Project> {
 
         // Fold resolved bundles from `kritCustomRules` into the extension's
         // jar collection so they flow into kritCheck/kritBaseline like any
-        // explicit `customRules(file(...))` entry.
+        // explicit `customRuleJars.from(file(...))` entry.
         extension.customRuleJars.from(customRulesConfiguration)
 
         // Set conventions (defaults)

--- a/krit-gradle-plugin/src/test/kotlin/dev/jasonpearson/krit/gradle/KritPluginTest.kt
+++ b/krit-gradle-plugin/src/test/kotlin/dev/jasonpearson/krit/gradle/KritPluginTest.kt
@@ -2,7 +2,6 @@ package dev.jasonpearson.krit.gradle
 
 import org.gradle.api.Project
 import org.gradle.api.attributes.Category
-import org.gradle.api.tasks.bundling.Jar
 import org.gradle.testfixtures.ProjectBuilder
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
@@ -149,28 +148,41 @@ class KritPluginTest {
     }
 
     @Test
-    fun `top-level extension does not expose escape-hatch properties`() {
-        // Compile-time guard: KritExtension must NOT carry these knobs anymore.
-        // Reflection check keeps the regression test honest without re-introducing
-        // imports of the moved Property<*> APIs.
+    fun `KritExtension exposes only the supported top-level surface`() {
+        // KritExtension is the public DSL surface. Escape hatches live under
+        // `advanced { }`; custom-rule wiring goes through the `kritCustomRules`
+        // dependency configuration or the `customRuleJars` file collection.
+        // Each entry here pins one accessor (or DSL method name) that must NOT
+        // appear on KritExtension. The check runs via reflection so the test
+        // does not need to import the moved Property<*> APIs.
+        val forbidden = mapOf(
+            "getToolVersion" to "lives under `advanced`",
+            "getAllRules" to "lives under `advanced`",
+            "getFixLevel" to "lives under `advanced`",
+            "getParallel" to "lives under `advanced`",
+            "getNoCache" to "lives under `advanced`",
+            "getTypeInference" to "lives under `advanced`",
+            "getBinary" to "lives under `advanced`",
+            "getReportsDir" to "lives under `advanced`",
+            "getSource" to "lives under `advanced`",
+            "customRules" to "use the `kritCustomRules` dependency " +
+                "configuration or `customRuleJars.from(...)`",
+        )
         val publicMembers = KritExtension::class.java.methods.map { it.name }.toSet()
-        listOf("getToolVersion", "getAllRules", "getFixLevel", "getParallel",
-               "getNoCache", "getTypeInference", "getBinary", "getReportsDir",
-               "getSource")
-            .forEach { accessor ->
-                assertFalse(accessor in publicMembers,
-                    "KritExtension still exposes $accessor — it should live under `advanced`")
-            }
+        forbidden.forEach { (name, guidance) ->
+            assertFalse(name in publicMembers,
+                "KritExtension exposes $name; $guidance")
+        }
     }
 
     @Test
-    fun `custom rules file notation is configurable`() {
+    fun `customRuleJars accepts raw file notations`() {
         val project = newProject()
 
         val extension = project.extensions.getByType(KritExtension::class.java)
         val rulesJar = project.file("build-logic/krit-rules/build/libs/krit-rules.jar")
 
-        extension.customRules(rulesJar)
+        extension.customRuleJars.from(rulesJar)
 
         assertTrue(extension.customRuleJars.files.contains(rulesJar))
     }
@@ -183,7 +195,7 @@ class KritPluginTest {
         val task = project.tasks.getByName("kritCheck") as KritCheckTask
         val rulesJar = project.file("build-logic/krit-rules/build/libs/krit-rules.jar")
 
-        extension.customRules(rulesJar)
+        extension.customRuleJars.from(rulesJar)
 
         assertTrue(task.customRuleJars.files.contains(rulesJar))
     }
@@ -196,7 +208,7 @@ class KritPluginTest {
         val task = project.tasks.getByName("kritBaseline") as KritBaselineTask
         val rulesJar = project.file("build-logic/krit-rules/build/libs/krit-rules.jar")
 
-        extension.customRules(rulesJar)
+        extension.customRuleJars.from(rulesJar)
 
         assertTrue(task.customRuleJars.files.contains(rulesJar),
             "kritBaseline must inherit customRuleJars so the baseline captures plugin findings")
@@ -438,48 +450,4 @@ class KritPluginTest {
             "kritCheck task must inherit the resolved jars too")
     }
 
-    // --- customRules(Project) prefers kritRuleJar over default jar ---
-
-    @Test
-    fun `customRules(Project) prefers kritRuleJar when present`() {
-        val project = newProject()
-        val producer = ProjectBuilder.builder()
-            .withParent(project)
-            .withName("producer")
-            .build()
-        producer.pluginManager.apply("java")
-        val stampedJar = producer.tasks.register("kritRuleJar", Jar::class.java) {
-            archiveClassifier.set("krit-rules")
-        }
-
-        val extension = project.extensions.getByType(KritExtension::class.java)
-        extension.customRules(producer)
-
-        val expected = stampedJar.flatMap { it.archiveFile }.get().asFile
-        assertTrue(extension.customRuleJars.files.contains(expected),
-            "customRules(project) must pick up kritRuleJar's archive, was: ${extension.customRuleJars.files}")
-        val plainJar = producer.tasks.named("jar", Jar::class.java)
-            .flatMap { it.archiveFile }.get().asFile
-        assertFalse(extension.customRuleJars.files.contains(plainJar),
-            "must not also include the default unstamped jar")
-    }
-
-    @Test
-    fun `customRules(Project) falls back to jar when kritRuleJar absent`() {
-        val project = newProject()
-        val producer = ProjectBuilder.builder()
-            .withParent(project)
-            .withName("producer")
-            .build()
-        producer.pluginManager.apply("java")
-        // No kritRuleJar registered — the default jar should win.
-
-        val extension = project.extensions.getByType(KritExtension::class.java)
-        extension.customRules(producer)
-
-        val plainJar = producer.tasks.named("jar", Jar::class.java)
-            .flatMap { it.archiveFile }.get().asFile
-        assertTrue(extension.customRuleJars.files.contains(plainJar),
-            "without kritRuleJar, customRules(project) must fall back to the default jar")
-    }
 }

--- a/playground/custom-rules/README.md
+++ b/playground/custom-rules/README.md
@@ -6,8 +6,8 @@ sibling [`kotlin-webservice`](../kotlin-webservice) project through the
 [`dev.jasonpearson.krit`](../../krit-gradle-plugin/README.md) plugin.
 
 The module deliberately has **no `settings.gradle.kts`** of its own — it is
-included as a subproject of `kotlin-webservice` so the host project can reference
-it via `customRules(project(":custom-rules"))`.
+included as a subproject of `kotlin-webservice` so the host project can pull
+the produced jar through `dependencies { kritCustomRules(project(":custom-rules")) }`.
 
 ## Rules
 
@@ -59,11 +59,9 @@ means the consumer cannot accidentally pick up a project's normal
 `runtimeElements` jar — the daemon-stamped variant is the only thing the
 host configuration will resolve.
 
-> **Alternatives** for one-off setups: `krit { customRules(file(...)) }`
-> accepts raw jars or task outputs, and `krit { customRules(project(":foo")) }`
-> resolves the project's `kritRuleJar` when present (falling back to its `jar`
-> task). Both bypass the dependency graph, so prefer `kritCustomRules` for
-> project deps.
+> **Raw jars / task outputs** that don't fit the dependency-block model:
+> append directly to `krit.customRuleJars`, e.g.
+> `krit { customRuleJars.from(file("libs/foo.jar")) }`.
 
 ## Running it
 


### PR DESCRIPTION
## Summary

- Deletes `KritExtension.customRules(vararg notations: Any)`. The overload was Project-Isolation-hostile — it called `project.evaluationDependsOn(notation.path)` on a sibling project and reached into its task container via `notation.tasks.named(...)`. Both are forbidden under IP.
- Drops the `Project` constructor parameter from `KritExtension` (it only existed to support the removed overload). The extension is now a pure DSL with no cross-project state.
- Every legitimate use case is already covered by the variant-aware path:
  \`\`\`kotlin
  dependencies { kritCustomRules(project(\":rules\")) }   // project deps
  krit { customRuleJars.from(file(\"libs/rules.jar\")) } // raw jars / task outputs
  \`\`\`
  Both route through Gradle's dependency graph (proper task wiring, no cross-project task lookup, IP-safe).
- Folds the new \"customRules forbidden\" reflection check into the existing top-level surface guard test (single pass, one source of truth).
- Updates README + docs to use Kotlin property-assignment form (\`foo = value\`) instead of \`foo.set(value)\`, and rewrites the custom-rule wiring sections to show \`kritCustomRules\` / \`customRuleJars.from\` everywhere.

## Test plan

- [x] \`./gradlew test\` in \`krit-gradle-plugin\` — surface guard catches the removed method by name; existing tests pass
- [x] \`./gradlew test\` in \`krit-settings-plugin\` — still green against the slimmed extension
- [x] \`go build\`, \`go vet\`, \`golangci-lint\`, \`go test ./... -count=1\` — all clean
- [x] Playground (\`playground/kotlin-webservice\`) configures + \`./gradlew dependencies --configuration kritCustomRules\` still shows \`\\\\--- project :custom-rules\`