### PR TITLE
feat(config): walk up from analyzed root to find krit.yml

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -4,10 +4,16 @@ Krit reads `krit.yml` or `.krit.yml` from the project root. It accepts the same 
 
 ## Resolution order
 
-1. `--config FILE` flag
-2. `krit.yml` in the working directory
-3. `.krit.yml` in the working directory
-4. Built-in defaults
+1. `--config FILE` flag (explicit override).
+2. `krit.yml` or `.krit.yml`, found by walking *upward* from the analyzed
+   directory. The closest-to-source file wins; the walk stops at the
+   worktree root (`.git` / `.hg` / `.jj` marker, file or directory), at
+   `$HOME`, or at the filesystem root.
+3. Built-in defaults.
+
+The walk-up step means a single config at the repo root covers every
+subproject without per-module wiring, while a subproject can still
+override by dropping its own `krit.yml` closer to the source.
 
 ## Example
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -193,19 +193,57 @@ var Filenames = []string{"krit.yml", ".krit.yml"}
 // is probed — preserving legacy callers that invoke LoadConfig with no
 // path and no analyzed-project context.
 //
-// First match wins, in caller order. Returns (nil, nil) when no config
-// is found; non-existence is a normal outcome, not an error.
+// For each root, autoDetect walks upward through ancestor directories
+// looking for a config file at each level. The walk stops at a VCS
+// boundary (`.git`, `.hg`, or `.jj` entry; file *or* directory — a
+// submodule's `.git` is a file that points into the parent superproject
+// gitdir), at the user's home directory, or at the filesystem root.
+// Closest-to-source match wins.
+//
+// First non-empty result across all roots wins, in caller order.
+// Returns (nil, nil) when no config is found; non-existence is a normal
+// outcome, not an error.
 func autoDetect(roots ...string) (*Config, error) {
-	candidates := autoDetectDirs(roots)
-	seen := make(map[string]struct{}, len(candidates))
-	for _, dir := range candidates {
-		if dir == "" {
+	dirs := autoDetectDirs(roots)
+	seen := make(map[string]struct{}, len(dirs)*4)
+	for _, start := range dirs {
+		if start == "" {
 			continue
 		}
-		if _, ok := seen[dir]; ok {
-			continue
+		if cfg, err := walkUpForConfig(start, seen); cfg != nil || err != nil {
+			return cfg, err
+		}
+	}
+	return nil, nil
+}
+
+// walkUpForConfig walks from `start` upward toward the filesystem root,
+// returning the first krit.yml / .krit.yml found at any level. Stops at
+// VCS boundaries (`.git`/`.hg`/`.jj`), the user home directory, the
+// filesystem root, or the first ancestor already in `seen` (so multiple
+// search roots that share a common parent walk it only once).
+//
+// $HOME is a *before-probe* boundary — `~/krit.yml` is never picked up
+// by walk-up — while VCS markers are *after-probe* boundaries, so a
+// worktree root that owns both `.git/` and a `krit.yml` is still a
+// valid match.
+func walkUpForConfig(start string, seen map[string]struct{}) (*Config, error) {
+	abs, err := filepath.Abs(start)
+	if err != nil {
+		abs = start
+	}
+	home, _ := os.UserHomeDir()
+	dir := abs
+	for {
+		if _, visited := seen[dir]; visited {
+			return nil, nil
 		}
 		seen[dir] = struct{}{}
+
+		if home != "" && dir == home {
+			return nil, nil
+		}
+
 		for _, name := range Filenames {
 			candidate := filepath.Join(dir, name)
 			fi, err := os.Stat(candidate)
@@ -217,8 +255,35 @@ func autoDetect(roots ...string) (*Config, error) {
 			}
 			return loadFile(candidate)
 		}
+
+		if IsVCSRoot(dir) {
+			return nil, nil
+		}
+
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return nil, nil
+		}
+		dir = parent
 	}
-	return nil, nil
+}
+
+// vcsMarkers is the set of filenames that mark the root of a
+// version-controlled project. Treated liberally — a marker matches
+// whether it's a directory (normal worktree) or a file (a submodule's
+// `.git` is a pointer file into the superproject's gitdir).
+var vcsMarkers = []string{".git", ".hg", ".jj"}
+
+// IsVCSRoot reports whether `dir` is the root of a version-controlled
+// project. Shared with `internal/projectroot` so config walk-up and
+// project-root detection agree on what counts as a worktree boundary.
+func IsVCSRoot(dir string) bool {
+	for _, name := range vcsMarkers {
+		if _, err := os.Stat(filepath.Join(dir, name)); err == nil {
+			return true
+		}
+	}
+	return false
 }
 
 // autoDetectDirs normalises raw search-root entries to a list of

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1530,3 +1530,265 @@ func TestAutoDetectKritYmlPrecedence(t *testing.T) {
 		}
 	})
 }
+
+// writeGitDir installs a normal worktree `.git/` directory marker. The
+// content doesn't matter — `IsVCSRoot` only checks for existence.
+func writeGitDir(t *testing.T, dir string) {
+	t.Helper()
+	if err := os.Mkdir(filepath.Join(dir, ".git"), 0755); err != nil {
+		t.Fatalf("mkdir .git: %v", err)
+	}
+}
+
+// writeGitFile installs a submodule-style `.git` file marker, which
+// points into the superproject's gitdir. Walk-up must treat this as a
+// boundary even though it's a file, not a directory.
+func writeGitFile(t *testing.T, dir string) {
+	t.Helper()
+	path := filepath.Join(dir, ".git")
+	if err := os.WriteFile(path, []byte("gitdir: ../../.git/modules/sub\n"), 0644); err != nil {
+		t.Fatalf("write .git file: %v", err)
+	}
+}
+
+// withHome stubs $HOME via t.Setenv (auto-restored on cleanup). Tests
+// using this helper must NOT call t.Parallel() — $HOME is process-wide.
+func withHome(t *testing.T, dir string, fn func()) {
+	t.Helper()
+	t.Setenv("HOME", dir)
+	fn()
+}
+
+// TestAutoDetectWalkUpFindsAncestorConfig is the headline behavior: a
+// krit.yml at the repo root is found when krit is invoked against a
+// nested source directory.
+func TestAutoDetectWalkUpFindsAncestorConfig(t *testing.T) {
+	root := t.TempDir()
+	withHome(t, t.TempDir(), func() {
+		writeGitDir(t, root)
+		_ = os.WriteFile(filepath.Join(root, "krit.yml"),
+			[]byte("style:\n  MagicNumber:\n    threshold: 42\n"), 0644)
+		nested := filepath.Join(root, "apps", "web", "src", "main", "kotlin")
+		if err := os.MkdirAll(nested, 0755); err != nil {
+			t.Fatalf("mkdir nested: %v", err)
+		}
+
+		other := t.TempDir()
+		withCwd(t, other, func() {
+			cfg, err := LoadConfig("", nested)
+			if err != nil {
+				t.Fatalf("LoadConfig walking up: %v", err)
+			}
+			if cfg == nil {
+				t.Fatal("expected to find root krit.yml via walk-up; got nil")
+			}
+			if got := cfg.GetInt("style", "MagicNumber", "threshold", 0); got != 42 {
+				t.Errorf("expected threshold=42 from root krit.yml, got %d", got)
+			}
+		})
+	})
+}
+
+// TestAutoDetectWalkUpClosestWins verifies first-match-wins semantics —
+// a closer-to-source config takes precedence over an ancestor.
+func TestAutoDetectWalkUpClosestWins(t *testing.T) {
+	root := t.TempDir()
+	withHome(t, t.TempDir(), func() {
+		writeGitDir(t, root)
+		_ = os.WriteFile(filepath.Join(root, "krit.yml"),
+			[]byte("style:\n  MagicNumber:\n    threshold: 1\n"), 0644)
+		middle := filepath.Join(root, "apps", "web")
+		if err := os.MkdirAll(middle, 0755); err != nil {
+			t.Fatalf("mkdir middle: %v", err)
+		}
+		_ = os.WriteFile(filepath.Join(middle, "krit.yml"),
+			[]byte("style:\n  MagicNumber:\n    threshold: 2\n"), 0644)
+		leaf := filepath.Join(middle, "src", "main", "kotlin")
+		if err := os.MkdirAll(leaf, 0755); err != nil {
+			t.Fatalf("mkdir leaf: %v", err)
+		}
+
+		other := t.TempDir()
+		withCwd(t, other, func() {
+			cfg, err := LoadConfig("", leaf)
+			if err != nil {
+				t.Fatalf("LoadConfig: %v", err)
+			}
+			if got := cfg.GetInt("style", "MagicNumber", "threshold", 0); got != 2 {
+				t.Errorf("expected closest-to-source threshold=2 to win, got %d", got)
+			}
+		})
+	})
+}
+
+// TestAutoDetectStopsAtVCSDirectoryBoundary makes sure walk-up does NOT
+// reach outside a worktree even if an outer ancestor has a krit.yml.
+func TestAutoDetectStopsAtVCSDirectoryBoundary(t *testing.T) {
+	outer := t.TempDir()
+	withHome(t, t.TempDir(), func() {
+		_ = os.WriteFile(filepath.Join(outer, "krit.yml"),
+			[]byte("style:\n  MagicNumber:\n    threshold: 999\n"), 0644)
+		inner := filepath.Join(outer, "project")
+		if err := os.MkdirAll(inner, 0755); err != nil {
+			t.Fatalf("mkdir inner: %v", err)
+		}
+		writeGitDir(t, inner) // inner is its own worktree
+		nested := filepath.Join(inner, "src", "main", "kotlin")
+		if err := os.MkdirAll(nested, 0755); err != nil {
+			t.Fatalf("mkdir nested: %v", err)
+		}
+
+		other := t.TempDir()
+		withCwd(t, other, func() {
+			cfg, err := LoadConfig("", nested)
+			if err != nil {
+				t.Fatalf("LoadConfig: %v", err)
+			}
+			if cfg != nil {
+				got := cfg.GetInt("style", "MagicNumber", "threshold", -1)
+				t.Errorf("walk-up reached outside worktree; got config with threshold=%d", got)
+			}
+		})
+	})
+}
+
+// TestAutoDetectStopsAtSubmoduleGitFile pins the submodule case: a
+// submodule's `.git` is a file, not a directory, but it still marks a
+// worktree boundary.
+func TestAutoDetectStopsAtSubmoduleGitFile(t *testing.T) {
+	outer := t.TempDir()
+	withHome(t, t.TempDir(), func() {
+		writeGitDir(t, outer) // superproject .git/
+		_ = os.WriteFile(filepath.Join(outer, "krit.yml"),
+			[]byte("style:\n  MagicNumber:\n    threshold: 1\n"), 0644)
+
+		submodule := filepath.Join(outer, "vendor", "lib")
+		if err := os.MkdirAll(submodule, 0755); err != nil {
+			t.Fatalf("mkdir submodule: %v", err)
+		}
+		writeGitFile(t, submodule) // submodule .git FILE
+		nested := filepath.Join(submodule, "src")
+		if err := os.MkdirAll(nested, 0755); err != nil {
+			t.Fatalf("mkdir nested: %v", err)
+		}
+
+		other := t.TempDir()
+		withCwd(t, other, func() {
+			cfg, err := LoadConfig("", nested)
+			if err != nil {
+				t.Fatalf("LoadConfig: %v", err)
+			}
+			if cfg != nil {
+				got := cfg.GetInt("style", "MagicNumber", "threshold", -1)
+				t.Errorf("walk-up crossed submodule boundary; got threshold=%d", got)
+			}
+		})
+	})
+}
+
+// TestAutoDetectStopsAtHome ensures we never walk into $HOME's
+// krit.yml, even when no VCS marker is present along the way.
+func TestAutoDetectStopsAtHome(t *testing.T) {
+	home := t.TempDir()
+	withHome(t, home, func() {
+		// Stash a config directly in $HOME that we must NOT pick up.
+		_ = os.WriteFile(filepath.Join(home, "krit.yml"),
+			[]byte("style:\n  MagicNumber:\n    threshold: 9001\n"), 0644)
+		nested := filepath.Join(home, "scratch", "project")
+		if err := os.MkdirAll(nested, 0755); err != nil {
+			t.Fatalf("mkdir nested: %v", err)
+		}
+
+		other := t.TempDir()
+		withCwd(t, other, func() {
+			cfg, err := LoadConfig("", nested)
+			if err != nil {
+				t.Fatalf("LoadConfig: %v", err)
+			}
+			if cfg != nil {
+				got := cfg.GetInt("style", "MagicNumber", "threshold", -1)
+				t.Errorf("walk-up reached $HOME; got threshold=%d", got)
+			}
+		})
+	})
+}
+
+// TestAutoDetectExplicitPathSkipsWalkUp verifies `-c FILE` is still the
+// authoritative override — walk-up only fires when path is empty.
+func TestAutoDetectExplicitPathSkipsWalkUp(t *testing.T) {
+	root := t.TempDir()
+	withHome(t, t.TempDir(), func() {
+		writeGitDir(t, root)
+		_ = os.WriteFile(filepath.Join(root, "krit.yml"),
+			[]byte("style:\n  MagicNumber:\n    threshold: 11\n"), 0644)
+		nested := filepath.Join(root, "src")
+		if err := os.MkdirAll(nested, 0755); err != nil {
+			t.Fatalf("mkdir nested: %v", err)
+		}
+		explicit := filepath.Join(nested, "explicit.yml")
+		_ = os.WriteFile(explicit, []byte("style:\n  MagicNumber:\n    threshold: 22\n"), 0644)
+
+		cfg, err := LoadConfig(explicit, nested)
+		if err != nil {
+			t.Fatalf("LoadConfig: %v", err)
+		}
+		if got := cfg.GetInt("style", "MagicNumber", "threshold", 0); got != 22 {
+			t.Errorf("explicit path must win; got %d", got)
+		}
+	})
+}
+
+// TestAutoDetectNoConfigAnywhere keeps the legacy "not an error" return
+// contract for projects without any krit.yml on the walk.
+func TestAutoDetectNoConfigAnywhere(t *testing.T) {
+	root := t.TempDir()
+	withHome(t, t.TempDir(), func() {
+		writeGitDir(t, root)
+		nested := filepath.Join(root, "src")
+		if err := os.MkdirAll(nested, 0755); err != nil {
+			t.Fatalf("mkdir nested: %v", err)
+		}
+
+		other := t.TempDir()
+		withCwd(t, other, func() {
+			cfg, err := LoadConfig("", nested)
+			if err != nil {
+				t.Fatalf("LoadConfig unexpectedly errored: %v", err)
+			}
+			if cfg != nil {
+				t.Errorf("expected nil config when no krit.yml on the walk-up, got %+v", cfg)
+			}
+		})
+	})
+}
+
+// TestAutoDetectVisitsEachAncestorOnce makes the walker memoise across
+// roots so two analyzed directories that share an ancestor only probe
+// shared parents once. Reuses the same root layout to exercise the
+// `seen` map.
+func TestAutoDetectVisitsEachAncestorOnce(t *testing.T) {
+	root := t.TempDir()
+	withHome(t, t.TempDir(), func() {
+		writeGitDir(t, root)
+		_ = os.WriteFile(filepath.Join(root, "krit.yml"),
+			[]byte("style:\n  MagicNumber:\n    threshold: 7\n"), 0644)
+		a := filepath.Join(root, "apps", "a")
+		b := filepath.Join(root, "apps", "b")
+		for _, dir := range []string{a, b} {
+			if err := os.MkdirAll(dir, 0755); err != nil {
+				t.Fatalf("mkdir %s: %v", dir, err)
+			}
+		}
+
+		other := t.TempDir()
+		withCwd(t, other, func() {
+			cfg, err := LoadConfig("", a, b)
+			if err != nil {
+				t.Fatalf("LoadConfig: %v", err)
+			}
+			if got := cfg.GetInt("style", "MagicNumber", "threshold", 0); got != 7 {
+				t.Errorf("expected shared-ancestor config (threshold=7), got %d", got)
+			}
+		})
+	})
+}

--- a/internal/projectroot/root.go
+++ b/internal/projectroot/root.go
@@ -35,10 +35,15 @@ func Find(scanPaths []string) string {
 	}
 }
 
-var rootMarkers = append([]string{".git"}, append(config.Filenames, "settings.gradle", "settings.gradle.kts")...)
+// kritRootMarkers are krit-specific signals that a directory is a
+// project root, on top of the VCS markers shared via `config.IsVCSRoot`.
+var kritRootMarkers = append(append([]string{}, config.Filenames...), "settings.gradle", "settings.gradle.kts")
 
 func isRootMarkerDir(dir string) bool {
-	for _, name := range rootMarkers {
+	if config.IsVCSRoot(dir) {
+		return true
+	}
+	for _, name := range kritRootMarkers {
 		if _, err := os.Stat(filepath.Join(dir, name)); err == nil {
 			return true
 		}

--- a/krit-gradle-plugin/README.md
+++ b/krit-gradle-plugin/README.md
@@ -16,14 +16,17 @@ plugins {
 }
 ```
 
-That's it for most projects — drop a `krit.yml` next to the build file and
-`./gradlew kritCheck` works.
+That's it for most projects — drop a `krit.yml` at the repo root (or next
+to the build file) and `./gradlew kritCheck` works. The CLI walks upward
+from each analyzed directory looking for `krit.yml` / `.krit.yml`,
+stopping at the worktree boundary (`.git` / `.hg` / `.jj`), so one config
+at the root covers every subproject without per-module wiring.
 
 ### Common configuration
 
 ```kotlin
 krit {
-    config = file("krit.yml")               // optional; auto-discovered when omitted
+    config = file("krit.yml")               // optional; explicit override of walk-up discovery
     baseline = file("krit-baseline.xml")    // optional
     ignoreFailures = false                  // fail the build on findings
 


### PR DESCRIPTION
## Summary

The CLI's \`autoDetect\` now walks upward from each analyzed directory looking for \`krit.yml\` / \`.krit.yml\` at every level, stopping at:

- the worktree boundary (\`.git\` / \`.hg\` / \`.jj\` — file *or* directory, so submodule pointers count),
- \`\$HOME\`,
- or the filesystem root.

Closest-to-source match wins; \`--config FILE\` remains the authoritative override.

This means one \`krit.yml\` at the repo root now covers every subproject. Combined with the recently-landed settings plugin, the minimum consumer setup collapses to:

\`\`\`kotlin
// settings.gradle.kts
plugins { id(\"dev.jasonpearson.krit.settings\") version \"0.2.0\" }
\`\`\`

…plus a \`krit.yml\` at the repo root. No per-module wiring needed.

The new \`config.IsVCSRoot\` helper is shared with \`projectroot.Find\`, so both walkers agree on what counts as a worktree boundary — and \`projectroot.Find\` gains \`.hg\` / \`.jj\` support that it was missing before.

## Test plan

- [x] 8 new tests in \`internal/config/config_test.go\`: ancestor-config discovery, closest-wins precedence, VCS-directory and submodule-\`.git\`-file boundary stops, \`\$HOME\` stop, explicit \`-c FILE\` override, no-config-anywhere returning nil cleanly, shared-ancestor visits-once.
- [x] \`go build\`, \`go vet\`, \`golangci-lint run ./...\` — clean.
- [x] \`go test ./... -count=1\` — full suite green.
- [x] Existing \`projectroot\` test suite still green after the marker unification.

## Behavior change

Pre-1.0 break: any user relying on \"no \`krit.yml\` in cwd means use built-in defaults\" will now pick up an ancestor config if one exists within the worktree. This is the desired behavior for ~all real-world layouts; documented in \`docs/configuration.md\`.