### PR TITLE
fix(rules): require AST jump_expression for consent early-return evidence

### DIFF
--- a/internal/rules/privacy_analytics.go
+++ b/internal/rules/privacy_analytics.go
@@ -221,8 +221,29 @@ func privacyHasConsentEarlyReturn(file *scanner.File, fn, target uint32) bool {
 		if !consentTokenPattern.MatchString(condText) {
 			return
 		}
-		ifText := file.FlatNodeText(ifNode)
-		if strings.Contains(ifText, "return") {
+		if privacyContainsReturnStatement(file, ifNode) {
+			found = true
+		}
+	})
+	return found
+}
+
+// privacyContainsReturnStatement reports whether the AST subtree rooted
+// at node holds a real `return` jump_expression. Substring matches
+// against identifiers like `returnedValue` or text inside string
+// literals must not count.
+func privacyContainsReturnStatement(file *scanner.File, node uint32) bool {
+	found := false
+	file.FlatWalkNodes(node, "jump_expression", func(jump uint32) {
+		if found {
+			return
+		}
+		first := file.FlatChild(jump, 0)
+		if first == 0 {
+			return
+		}
+		switch file.FlatType(first) {
+		case "return", "return@":
 			found = true
 		}
 	})

--- a/internal/rules/privacy_analytics_test.go
+++ b/internal/rules/privacy_analytics_test.go
@@ -302,6 +302,81 @@ class ScreenTracker(
 		}
 	})
 
+	t.Run("flags analytics call when consent-if has no real return statement", func(t *testing.T) {
+		// The if-condition mentions consent but the body never actually
+		// returns — `return` appears only inside a string literal. The
+		// rule must still flag the unconditional analytics call below.
+		findings := runRuleByName(t, "AnalyticsCallWithoutConsentGate", `
+package test
+
+object Bundle {
+    val EMPTY = Any()
+}
+
+class FirebaseAnalytics {
+    fun logEvent(name: String, payload: Any) {}
+}
+
+class Logger {
+    fun info(message: String) {}
+}
+
+class ConsentState(val analyticsAllowed: Boolean)
+
+class Tracker(
+    private val analytics: FirebaseAnalytics,
+    private val logger: Logger,
+    private val consent: ConsentState,
+) {
+    fun track() {
+        if (consent.analyticsAllowed) {
+            logger.info("return value will be ignored")
+        }
+        analytics.logEvent("screen_view", Bundle.EMPTY)
+    }
+}
+`)
+		if len(findings) != 1 {
+			t.Fatalf("expected 1 finding when consent-if body has no real return, got %d: %v", len(findings), findings)
+		}
+	})
+
+	t.Run("flags analytics call when consent-if body uses return as identifier", func(t *testing.T) {
+		// Same case but the false-positive substring is an identifier
+		// `returnedValue` rather than a string literal.
+		findings := runRuleByName(t, "AnalyticsCallWithoutConsentGate", `
+package test
+
+object Bundle {
+    val EMPTY = Any()
+}
+
+class FirebaseAnalytics {
+    fun logEvent(name: String, payload: Any) {}
+}
+
+class ConsentState(val analyticsAllowed: Boolean)
+
+class Tracker(
+    private val analytics: FirebaseAnalytics,
+    private val consent: ConsentState,
+) {
+    private fun computeReturnedValue(): Int = 1
+
+    fun track() {
+        if (consent.analyticsAllowed) {
+            val returnedValue = computeReturnedValue()
+            println(returnedValue)
+        }
+        analytics.logEvent("screen_view", Bundle.EMPTY)
+    }
+}
+`)
+		if len(findings) != 1 {
+			t.Fatalf("expected 1 finding when consent-if body has identifier containing 'return', got %d: %v", len(findings), findings)
+		}
+	})
+
 	t.Run("allows analytics call when function has consent check elsewhere", func(t *testing.T) {
 		findings := runRuleByName(t, "AnalyticsCallWithoutConsentGate", `
 package test


### PR DESCRIPTION
## Summary
- \`privacyHasConsentEarlyReturn\` checked the if-block text with \`strings.Contains(ifText, "return")\`. An if-body that only mentioned \`return\` inside an identifier (\`returnedValue\`, \`urlReturn\`) or a string literal was treated as an early return, so \`AnalyticsCallWithoutConsentGate\` suppressed real unguarded analytics calls.
- Replace the text scan with \`privacyContainsReturnStatement\`, an AST walk that requires a \`jump_expression\` whose first child is the \`return\` or \`return@\` token.
- Add two regression tests: misleading \`return\` in a string literal, and misleading \`return\` in an identifier name.

## Test plan
- [x] \`go test ./internal/rules/ -run TestAnalyticsCallWithoutConsentGate -count=1\`
- [x] \`go test ./... -count=1\` (unrelated TestDaemonAnalyzeProject_RoundTrip flake re-passes)
- [x] \`go vet ./...\`
- [x] \`golangci-lint run ./...\`