### PR TITLE
fix(rules): require KDoc tag boundary for DeprecatedBlockTag match

### DIFF
--- a/internal/rules/comments_test.go
+++ b/internal/rules/comments_test.go
@@ -833,3 +833,39 @@ fun oldMethod() {}
 		t.Fatalf("expected no findings when using @Deprecated annotation, got %d", len(findings))
 	}
 }
+
+func TestDeprecatedBlockTag_NegativeLongerTagName(t *testing.T) {
+	// `@deprecatedSince` is not the `@deprecated` block tag — it is a
+	// different (hypothetical) tag whose name begins with the same
+	// letters. The substring scan previously matched it anyway.
+	findings := runRuleByName(t, "DeprecatedBlockTag", `
+package test
+
+/**
+ * Description.
+ * @deprecatedSince 1.4 used by custom tooling.
+ */
+fun helper() {}
+`)
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings for @deprecatedSince custom tag, got %d", len(findings))
+	}
+}
+
+func TestDeprecatedBlockTag_NegativeInlineCodeSpan(t *testing.T) {
+	// `@deprecated` mentioned inside a Markdown code span in a KDoc
+	// description is documentation about the tag, not the tag itself.
+	findings := runRuleByName(t, "DeprecatedBlockTag", `
+package test
+
+/**
+ * Returns the legacy result. To mark a function as removed in a future
+ * release, prefer the [`+"`@Deprecated`"+`] annotation over a free-form
+ * `+"`@deprecated`"+` block tag in KDoc.
+ */
+fun legacy() {}
+`)
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings when @deprecated appears only inside a code span, got %d", len(findings))
+	}
+}

--- a/internal/rules/registry_comments.go
+++ b/internal/rules/registry_comments.go
@@ -8,6 +8,15 @@ import (
 	"github.com/kaeawc/krit/internal/scanner"
 )
 
+// deprecatedKDocTagRe matches the literal `@deprecated` KDoc block tag.
+// The tag must begin at a non-identifier boundary (start of text,
+// whitespace, or the `*` line marker) and end at a non-identifier
+// boundary (whitespace, end of text, or punctuation like `.` or `:`).
+// This rejects substring matches inside other tag names like
+// `@deprecatedSince` and inside Markdown code spans where the `@` is
+// preceded by a backtick.
+var deprecatedKDocTagRe = regexp.MustCompile(`(?:^|[\s*])@deprecated(?:$|[\s.:])`)
+
 func registerCommentsRules() {
 
 	// --- from comments.go ---
@@ -33,7 +42,7 @@ func registerCommentsRules() {
 					return
 				}
 				text := file.FlatNodeText(idx)
-				if !strings.Contains(text, "@deprecated") {
+				if !deprecatedKDocTagRe.MatchString(text) {
 					return
 				}
 				f := r.Finding(file, file.FlatRow(idx)+1, 1,


### PR DESCRIPTION
## Summary
- DeprecatedBlockTag fired on KDoc comments whose text only contained `@deprecated` as a substring — inside other tag names like `@deprecatedSince`, or inside Markdown code spans where the tag is being quoted as documentation.
- Replace the substring scan with `deprecatedKDocTagRe`, a compiled regex that anchors the tag at a non-identifier boundary on both sides (start/whitespace/`*` before, end/whitespace/`.`/`:` after).
- Add regression tests for the longer-tag and inline-code-span cases.

## Test plan
- [x] `go test ./internal/rules/ -run TestDeprecatedBlockTag -count=1`
- [x] `go test ./... -count=1`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...`