### PR TITLE
fix(rules): match fully-qualified Log / Timber calls in MaxLineLength

### DIFF
--- a/internal/rules/style_format.go
+++ b/internal/rules/style_format.go
@@ -358,15 +358,17 @@ func isDottedCallChainLine(trimmed string) bool {
 	return dots >= 3
 }
 
-// isLogCallLine returns true if the trimmed line is a Log.<level>(...) call.
+// logCallLineRe matches a trimmed line that begins with a Log / Timber
+// `<level>(` call. An optional dotted package or receiver prefix is
+// allowed so fully-qualified forms like `android.util.Log.d(...)` and
+// `timber.log.Timber.d(...)` are treated the same as the unqualified
+// `Log.d(...)` / `Timber.d(...)`.
+var logCallLineRe = regexp.MustCompile(`^(?:[A-Za-z0-9_.]+\.)?(?:Log\.(?:d|i|w|e|v|wtf)|Timber\.(?:d|i|w|e|v))\(`)
+
+// isLogCallLine returns true if the trimmed line is a Log.<level>(...)
+// or Timber.<level>(...) call, including fully-qualified variants.
 func isLogCallLine(trimmed string) bool {
-	prefixes := []string{"Log.d(", "Log.i(", "Log.w(", "Log.e(", "Log.v(", "Log.wtf(", "Timber.d(", "Timber.i(", "Timber.w(", "Timber.e(", "Timber.v("}
-	for _, p := range prefixes {
-		if strings.HasPrefix(trimmed, p) {
-			return true
-		}
-	}
-	return false
+	return logCallLineRe.MatchString(trimmed)
 }
 
 // containsURLLiteral returns true if the line contains an http(s) URL

--- a/internal/rules/style_format_test.go
+++ b/internal/rules/style_format_test.go
@@ -69,6 +69,30 @@ func TestMaxLineLength_Negative(t *testing.T) {
 	}
 }
 
+func TestMaxLineLength_SkipsFullyQualifiedLogCall(t *testing.T) {
+	// A fully-qualified `android.util.Log.d(...)` call whose overflow
+	// position lands on a concatenated-identifier argument (not inside a
+	// string literal) used to be flagged because the prefix check only
+	// matched lines starting with `Log.`. The same call without the
+	// qualifier was already skipped — this locks the qualified form to
+	// the same treatment.
+	long := `android.util.Log.d(TAGTAGTAGTAGTAGTAGTAGTAG, msgMsgMsgMsgMsgMsgMsgMsgMsg + extraExtraExtraExtraExtraExtraExtraExtraExtraExtraExtra)`
+	code := "package test\nfun main() {\n    " + long + "\n}\n"
+	findings := runRuleByName(t, "MaxLineLength", code)
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings for fully-qualified Log call, got %d: %v", len(findings), findings)
+	}
+}
+
+func TestMaxLineLength_SkipsFullyQualifiedTimberCall(t *testing.T) {
+	long := `timber.log.Timber.d(TAGTAGTAGTAGTAGTAGTAGTAG, msgMsgMsgMsgMsgMsgMsgMsgMsg + extraExtraExtraExtraExtraExtraExtraExtraExtraExtraExtra)`
+	code := "package test\nfun main() {\n    " + long + "\n}\n"
+	findings := runRuleByName(t, "MaxLineLength", code)
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings for fully-qualified Timber call, got %d: %v", len(findings), findings)
+	}
+}
+
 func TestMaxLineLength_Java(t *testing.T) {
 	longLine := "String result = aaaaaaaa + bbbbbbbb + cccccccc + dddddddd + eeeeeeee + ffffffff + gggggggg + hhhhhhhh + iiiiiiii + jjjjjjjj;"
 	code := "package test;\nclass Example {\n  void run() {\n    " + longLine + "\n  }\n}\n"


### PR DESCRIPTION
## Summary
- \`isLogCallLine\` used \`strings.HasPrefix\` against unqualified \`Log.d(\` / \`Timber.d(\` prefixes, so a line beginning with a qualified receiver like \`android.util.Log.d(...)\` or \`timber.log.Timber.d(...)\` was not recognized as a log call and got flagged by MaxLineLength even though log messages typically cannot be wrapped.
- Replace the prefix list with \`logCallLineRe\` — a compiled regex that accepts an optional dotted-identifier prefix in front of \`Log.<level>(\` or \`Timber.<level>(\`.
- Add two regression tests built around long identifier arguments so \`overflowInsideStringLiteral\` does not short-circuit the check before \`isLogCallLine\` is reached.

## Test plan
- [x] \`go test ./internal/rules/ -run TestMaxLineLength -count=1\`
- [x] \`go test ./... -count=1\`
- [x] \`go vet ./...\`
- [x] \`golangci-lint run ./...\`