### PR TITLE
fix(rules): drop OkHttpCallExecuteSync raw-text newCall fallback

### DIFF
--- a/internal/rules/resource_cost.go
+++ b/internal/rules/resource_cost.go
@@ -76,13 +76,6 @@ type OkHTTPCallExecuteSyncRule struct {
 func (r *OkHTTPCallExecuteSyncRule) Confidence() float64 { return 0.75 }
 
 func okHTTPExecuteCallLooksBlocking(file *scanner.File, idx, fn uint32) bool {
-	navText := file.FlatNodeText(idx)
-	if navExpr, _ := flatCallExpressionParts(file, idx); navExpr != 0 {
-		navText = file.FlatNodeText(navExpr)
-	}
-	if strings.Contains(navText, "newCall") || strings.Contains(navText, "okhttp3.Call") {
-		return true
-	}
 	receiver := databaseCallReceiverName(file, idx)
 	if receiver == "" {
 		return false

--- a/tests/fixtures/negative/resource-cost/OkHttpCallExecuteSync.kt
+++ b/tests/fixtures/negative/resource-cost/OkHttpCallExecuteSync.kt
@@ -5,4 +5,14 @@ class OkHttpCallExecuteSync {
         val response = call.execute()
         return response.body?.string() ?: ""
     }
+
+    class NewCallTracker {
+        fun execute() {}
+    }
+
+    private val newCallTracker = NewCallTracker()
+
+    suspend fun trackerExecute() {
+        newCallTracker.execute()
+    }
 }


### PR DESCRIPTION
## Summary
- `okHTTPExecuteCallLooksBlocking` matched the receiver navigation expression with `strings.Contains(navText, "newCall")`, flagging any suspend `*.execute()` whose receiver text merely contained the substring `newCall` (e.g. `newCallTracker.execute()`).
- The real AST check `receiverContainsCallName(file, idx, "newCall")` already runs in the rule's `semanticOkHTTPCall` short-circuit at [registry_resource_cost.go:152](https://github.com/kaeawc/krit/blob/main/internal/rules/registry_resource_cost.go#L152). By the time we reach `okHTTPExecuteCallLooksBlocking`, the AST check has already returned false — the textual fallback only adds substring false positives.
- The `okhttp3.Call` text fallback never matches real expression text (fully-qualified type names don't appear in runtime receiver chains); also removed.

## Test plan
- [x] Added a regression case to `tests/fixtures/negative/resource-cost/OkHttpCallExecuteSync.kt` (`newCallTracker.execute()` in a suspend function). Confirmed it fails on `main` and passes after the fix.
- [x] `go test ./internal/rules/ -run TestNegativeFixtures/negative/OkHttpCallExecuteSync` + `TestPositiveFixtures/positive/OkHttpCallExecuteSync` pass.
- [x] `go test ./... -count=1` green.
- [x] `go vet ./...`, `make lint-rules` clean.