### PR TITLE
fix(rules): use AST jump_expression for SuspendFunSwallowedCancellation rethrow

### DIFF
--- a/internal/rules/coroutines_test.go
+++ b/internal/rules/coroutines_test.go
@@ -1767,3 +1767,58 @@ fun start() {
 		t.Errorf("expected no findings, got %d", len(findings))
 	}
 }
+
+// --- SuspendFunSwallowedCancellation ---
+
+func TestSuspendFunSwallowedCancellation_RealRethrow(t *testing.T) {
+	findings := runRuleByName(t, "SuspendFunSwallowedCancellation", `
+package test
+import kotlinx.coroutines.CancellationException
+suspend fun doWork() {
+    try {
+        delay(1000)
+    } catch (e: CancellationException) {
+        println("cancelled")
+        throw e
+    }
+}
+`)
+	if len(findings) != 0 {
+		t.Fatalf("expected 0 findings when caught exception is actually rethrown, got %d:\n%v", len(findings), findings)
+	}
+}
+
+func TestSuspendFunSwallowedCancellation_CommentedRethrow(t *testing.T) {
+	findings := runRuleByName(t, "SuspendFunSwallowedCancellation", `
+package test
+import kotlinx.coroutines.CancellationException
+suspend fun doWork() {
+    try {
+        delay(1000)
+    } catch (e: CancellationException) {
+        println("cancelled")
+        // throw e — disabled while debugging
+    }
+}
+`)
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding when rethrow only appears in a comment, got %d:\n%v", len(findings), findings)
+	}
+}
+
+func TestSuspendFunSwallowedCancellation_RethrowInStringLiteral(t *testing.T) {
+	findings := runRuleByName(t, "SuspendFunSwallowedCancellation", `
+package test
+import kotlinx.coroutines.CancellationException
+suspend fun doWork() {
+    try {
+        delay(1000)
+    } catch (e: CancellationException) {
+        println("note: caller can throw e to surface this")
+    }
+}
+`)
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding when 'throw e' only appears in a string literal, got %d:\n%v", len(findings), findings)
+	}
+}

--- a/internal/rules/registry_coroutines.go
+++ b/internal/rules/registry_coroutines.go
@@ -2,7 +2,6 @@ package rules
 
 import (
 	"fmt"
-	"regexp"
 	"strings"
 
 	"github.com/kaeawc/krit/internal/oracle"
@@ -460,13 +459,7 @@ func registerCoroutinesSuspendFunSwallowedCancellation() {
 				return
 			}
 			caughtVar := extractCaughtVarNameFlat(file, idx)
-			catchText := file.FlatNodeText(idx)
-			rethrowPattern := fmt.Sprintf(`\bthrow\s+%s\b`, regexp.QuoteMeta(caughtVar))
-			matched, err := regexp.MatchString(rethrowPattern, catchText)
-			if err != nil {
-				matched = strings.Contains(catchText, "throw "+caughtVar)
-			}
-			if !matched {
+			if !catchBodyRethrowsCaughtException(file, idx, caughtVar) {
 				msg := "CancellationException is caught but not rethrown. This can break structured concurrency."
 				if caughtType != "CancellationException" {
 					msg = fmt.Sprintf("Catching '%s' swallows CancellationException without rethrowing. This can break structured concurrency.", caughtType)


### PR DESCRIPTION
## Summary
- `registerCoroutinesSuspendFunSwallowedCancellation` ran `regexp.MatchString(\bthrow\s+<var>\b, catchText)` against the entire `catch_block` text. The text included comments, KDoc, and string literals — so a commented-out `// throw e` or a log message like `"caller can throw e"` masqueraded as a real rethrow and the rule silently stopped firing (false negative).
- Replaced the regex with the existing `catchBodyRethrowsCaughtException` helper, which walks `jump_expression` AST nodes and matches the exact `throw <var>` shape. Comments and string literals aren't `jump_expression` nodes, so they're correctly ignored.
- The `regexp.MatchString` `err != nil` fallback (`strings.Contains(catchText, "throw "+caughtVar)`) was dead code — QuoteMeta-built patterns never fail to compile — and is removed along with the now-unused `regexp` import.

## Test plan
- [x] Added three coroutine unit tests:
  - `TestSuspendFunSwallowedCancellation_RealRethrow` — actual `throw e` → 0 findings (still negative).
  - `TestSuspendFunSwallowedCancellation_CommentedRethrow` — `// throw e` only → 1 finding (regression that would have failed before the fix).
  - `TestSuspendFunSwallowedCancellation_RethrowInStringLiteral` — `"throw e"` only inside a `println` → 1 finding.
- [x] Existing positive/negative coroutine tests for the rule still pass.
- [x] `go test ./... -count=1` green.
- [x] `go vet ./...`, `make lint-rules` clean.