### PR TITLE
fix(rules): use AST throw target for ThrowingNewInstanceOfSameException

### DIFF
--- a/internal/rules/exceptions.go
+++ b/internal/rules/exceptions.go
@@ -1355,6 +1355,91 @@ func walkThrowExpressionsFlat(file *scanner.File, idx uint32, fn func(throwNode 
 	file.FlatWalkNodes(idx, "throw_statement", fn)
 }
 
+// throwExpressionTargetFlat returns the call_expression (Kotlin) or
+// object_creation_expression (Java) used as the thrown instance, or 0
+// if the throw is bare (`throw` with no operand) or rethrows a simple
+// identifier (`throw e`).
+func throwExpressionTargetFlat(file *scanner.File, throwNode uint32) uint32 {
+	for child := file.FlatFirstChild(throwNode); child != 0; child = file.FlatNextSib(child) {
+		if !file.FlatIsNamed(child) {
+			continue
+		}
+		switch file.FlatType(child) {
+		case "call_expression", "object_creation_expression":
+			return child
+		}
+	}
+	return 0
+}
+
+// throwTargetTypeNameFlat returns the last identifier of the type
+// constructed by a throw target — `IOException` for both
+// `IOException(msg)` and `java.io.IOException(msg)`.
+func throwTargetTypeNameFlat(file *scanner.File, target uint32) string {
+	switch file.FlatType(target) {
+	case "call_expression":
+		return flatCallExpressionName(file, target)
+	case "object_creation_expression":
+		for child := file.FlatFirstChild(target); child != 0; child = file.FlatNextSib(child) {
+			switch file.FlatType(child) {
+			case "type_identifier":
+				return file.FlatNodeText(child)
+			case "scoped_type_identifier", "scoped_identifier":
+				if name := flatTypeLastIdentifier(file, child); name != "" {
+					return name
+				}
+			}
+		}
+	}
+	return ""
+}
+
+// throwTargetArgUsageFlat reports the number of positional arguments
+// in the throw target and whether any of them references varName as
+// an identifier. String literals and comments are skipped because
+// they are not identifier AST nodes.
+func throwTargetArgUsageFlat(file *scanner.File, target uint32, varName string) (argCount int, hasVar bool) {
+	args := throwTargetArgsFlat(file, target)
+	if args == 0 {
+		return 0, false
+	}
+	for child := file.FlatFirstChild(args); child != 0; child = file.FlatNextSib(child) {
+		if !file.FlatIsNamed(child) {
+			continue
+		}
+		argCount++
+		if hasVar {
+			continue
+		}
+		file.FlatWalkAllNodes(child, func(id uint32) {
+			if hasVar {
+				return
+			}
+			switch file.FlatType(id) {
+			case "simple_identifier", "identifier":
+				if file.FlatNodeTextEquals(id, varName) {
+					hasVar = true
+				}
+			}
+		})
+	}
+	return argCount, hasVar
+}
+
+func throwTargetArgsFlat(file *scanner.File, target uint32) uint32 {
+	switch file.FlatType(target) {
+	case "call_expression":
+		return flatCallKeyArguments(file, target)
+	case "object_creation_expression":
+		for child := file.FlatFirstChild(target); child != 0; child = file.FlatNextSib(child) {
+			if file.FlatType(child) == "argument_list" {
+				return child
+			}
+		}
+	}
+	return 0
+}
+
 func javaCatchOnlyRethrowsVar(file *scanner.File, catchNode uint32, varName string) bool {
 	block, ok := file.FlatFindChild(catchNode, "block")
 	if !ok || block == 0 {

--- a/internal/rules/exceptions_test.go
+++ b/internal/rules/exceptions_test.go
@@ -1199,6 +1199,40 @@ class Example {
 	}
 }
 
+func TestExc_ThrowingNewInstanceOfSameException_NegativeStringMentionsCaughtType(t *testing.T) {
+	findings := runRuleByName(t, "ThrowingNewInstanceOfSameException", `
+fun test() {
+    try {
+        doWork()
+    } catch (e: Exception) {
+        throw RuntimeException("about to throw Exception(extra)")
+    }
+}
+`)
+	if len(findings) != 0 {
+		t.Fatalf("expected 0 findings — the new exception is RuntimeException, the string literal merely mentions Exception(...); got %d:\n%v", len(findings), findings)
+	}
+}
+
+func TestExc_ThrowingNewInstanceOfSameException_NegativeJavaStringMentionsCaughtType(t *testing.T) {
+	findings := runRuleByNameOnJava(t, "ThrowingNewInstanceOfSameException", `
+package test;
+class Example {
+  void run() {
+    try {
+      work();
+    } catch (Exception e) {
+      throw new RuntimeException("about to throw Exception(extra)");
+    }
+  }
+  void work() throws Exception {}
+}
+`)
+	if len(findings) != 0 {
+		t.Fatalf("expected 0 findings — the new exception is RuntimeException, the string literal merely mentions Exception(...); got %d:\n%v", len(findings), findings)
+	}
+}
+
 // --- ThrowingExceptionInMain ---
 
 func TestExc_ThrowingExceptionInMain_Positive(t *testing.T) {

--- a/internal/rules/registry_exceptions.go
+++ b/internal/rules/registry_exceptions.go
@@ -2,7 +2,6 @@ package rules
 
 import (
 	"fmt"
-	"regexp"
 	"strings"
 
 	"github.com/kaeawc/krit/internal/experiment"
@@ -274,29 +273,17 @@ func registerExceptionsRules() {
 				}
 				caughtVar := extractCaughtVarNameFlat(file, idx)
 				walkThrowExpressionsFlat(file, idx, func(throwNode uint32) {
-					throwText := file.FlatNodeText(throwNode)
-					pattern := fmt.Sprintf(`throw\s+(?:new\s+)?%s\s*\(`, regexp.QuoteMeta(caughtType))
-					matched, err := regexp.MatchString(pattern, throwText)
-					if err != nil {
-						matched = strings.Contains(throwText, "throw "+caughtType+"(")
+					target := throwExpressionTargetFlat(file, throwNode)
+					if target == 0 {
+						return
 					}
-					if !matched {
+					if throwTargetTypeNameFlat(file, target) != caughtType {
 						return
 					}
 					if caughtVar != "" {
-						parenIdx := strings.Index(throwText, "(")
-						if parenIdx >= 0 {
-							argsText := strings.TrimSpace(throwText[parenIdx+1:])
-							closeIdx := strings.LastIndex(argsText, ")")
-							if closeIdx >= 0 {
-								argsText = strings.TrimSpace(argsText[:closeIdx])
-								if strings.Contains(argsText, ",") {
-									argPattern := fmt.Sprintf(`\b%s\b`, regexp.QuoteMeta(caughtVar))
-									if m, _ := regexp.MatchString(argPattern, argsText); m {
-										return
-									}
-								}
-							}
+						argCount, hasVar := throwTargetArgUsageFlat(file, target, caughtVar)
+						if argCount > 1 && hasVar {
+							return
 						}
 					}
 					ctx.EmitAt(file.FlatRow(throwNode)+1, file.FlatCol(throwNode)+1,


### PR DESCRIPTION
## Summary
- `ThrowingNewInstanceOfSameException` ran `regexp.MatchString(\`throw\s+(?:new\s+)?<caughtType>\s*\(\`, throwText)` against the whole `throw_expression` text — including string-literal content. A log message such as `"about to throw Exception(...)"` inside `throw RuntimeException(...)` produced a false positive in any catch block that caught `Exception`.
- The `regexp.MatchString` err fallback (`strings.Contains(throwText, "throw "+caughtType+"(")`) and the regex-based wrap-detection on the extracted args text suffered from the same lexical-state blindness.
- Replaced the regex pipeline with three AST helpers in `internal/rules/exceptions.go`:
  - `throwExpressionTargetFlat` — locates the `call_expression` (Kotlin) or `object_creation_expression` (Java) directly under the throw.
  - `throwTargetTypeNameFlat` — returns the last identifier of the constructed type (handles scoped/qualified Java types).
  - `throwTargetArgUsageFlat` — walks named args and their identifier descendants for the caught variable; string literals and comments aren't identifier nodes so they're correctly ignored.

## Test plan
- [x] Two new unit tests demonstrate the FP and confirm the fix (Kotlin + Java); both fail on `main` and pass with the fix.
- [x] All existing positive/negative/Java tests for `ThrowingNewInstanceOfSameException` still pass.
- [x] `go test ./... -count=1` green.
- [x] `go vet ./...`, `make lint-rules` clean.