### PR TITLE
fix(rules): walk chain spine for UselessElvisOnNonNull safe-call detection

### DIFF
--- a/internal/rules/potentialbugs_nullsafety_redundant.go
+++ b/internal/rules/potentialbugs_nullsafety_redundant.go
@@ -1888,9 +1888,9 @@ func uselessElvisOperandResolvable(file *scanner.File, operand uint32) bool {
 	case "this_expression":
 		return true
 	case "navigation_expression":
-		return !flatNavigationHasSafeCall(file, operand)
+		return !flatExpressionChainShortCircuits(file, operand)
 	case "call_expression":
-		return true
+		return !flatExpressionChainShortCircuits(file, operand)
 	case "postfix_expression":
 		return flatPostfixHasNotNullAssertion(file, operand)
 	case "as_expression":
@@ -1898,6 +1898,56 @@ func uselessElvisOperandResolvable(file *scanner.File, operand uint32) bool {
 	default:
 		return false
 	}
+}
+
+// flatExpressionChainShortCircuits reports whether the static result of the
+// expression at idx may be null because some `?.` in its receiver/callee
+// spine can short-circuit the chain. Walking only the leftmost spine —
+// rather than every descendant — avoids treating `?.` inside call argument
+// lists (which do not propagate null to the call's return type) as a
+// short-circuit. Used by UselessElvisOnNonNull to refuse operands like
+// `obj?.foo()` and `obj?.foo().bar()` whose final return-type lookup hides
+// an upstream null-propagating step.
+//
+// Each iteration strictly descends to a child node, so the loop terminates
+// naturally at any leaf (default case). Self-loop guards on the descent
+// step keep a malformed AST from spinning indefinitely.
+func flatExpressionChainShortCircuits(file *scanner.File, idx uint32) bool {
+	if file == nil || idx == 0 {
+		return false
+	}
+	for idx != 0 {
+		switch file.FlatType(idx) {
+		case "parenthesized_expression":
+			inner := file.FlatNamedChild(idx, 0)
+			if inner == 0 || inner == idx {
+				return false
+			}
+			idx = inner
+		case "navigation_expression":
+			if flatNavigationSafeCallOperator(file, idx) != 0 {
+				return true
+			}
+			recv := file.FlatNamedChild(idx, 0)
+			if recv == 0 || recv == idx {
+				return false
+			}
+			idx = recv
+		case "call_expression":
+			callee := file.FlatNamedChild(idx, 0)
+			if callee == 0 || callee == idx {
+				return false
+			}
+			idx = callee
+		case "postfix_expression":
+			// `!!` asserts non-null at this level and seals the chain.
+			// Other postfix forms (++/--) do not appear in elvis operands.
+			return false
+		default:
+			return false
+		}
+	}
+	return false
 }
 
 // uselessElvisOperandShouldSkip guards against false positives the

--- a/internal/rules/potentialbugs_nullsafety_redundant_internal_test.go
+++ b/internal/rules/potentialbugs_nullsafety_redundant_internal_test.go
@@ -203,3 +203,114 @@ func TestGetterNullableReceiverFlat_BacktickColonInPropertyName_Internal(t *test
 		t.Fatal("getterNullableReceiverFlat (structural) must not return true when `?.` appears only inside a backtick-quoted property name")
 	}
 }
+
+// TestFlatExpressionChainShortCircuits_SafeCallInCallee pins the
+// UselessElvisOnNonNull regression: a call_expression whose callee contains
+// `?.` (e.g. `obj?.foo()`) must be reported as short-circuiting, because
+// the call evaluates to null whenever the safe-call receiver is null —
+// even when the resolver hands back a non-null return type for the
+// underlying function. Before the fix, the rule accepted every
+// call_expression as resolvable and trusted the return type, producing a
+// false positive on `obj?.foo() ?: fallback`.
+func TestFlatExpressionChainShortCircuits_SafeCallInCallee(t *testing.T) {
+	file := parseInlineForInternalTest(t, "fun f(s: String?): Int { return s?.length?.toInt() ?: 0 }\n")
+	var call uint32
+	file.FlatWalkNodes(0, "call_expression", func(idx uint32) {
+		if call == 0 {
+			call = idx
+		}
+	})
+	if call == 0 {
+		t.Fatal("expected to find a call_expression")
+	}
+	if !flatExpressionChainShortCircuits(file, call) {
+		t.Fatal("call_expression whose callee chain contains a `?.` must be reported as short-circuiting")
+	}
+}
+
+// TestFlatExpressionChainShortCircuits_NavigationAfterSafeCall covers
+// `obj?.foo().bar` — the outer navigation_expression's own operator is `.`
+// but its receiver call_expression carries the `?.` propagation. Walking
+// the leftmost spine must descend through the call and find the safe call.
+func TestFlatExpressionChainShortCircuits_NavigationAfterSafeCall(t *testing.T) {
+	file := parseInlineForInternalTest(t, "class Box { val len: Int = 0 }; fun box(): Box? = null; fun f(): Int { return box()?.len.toString().length ?: 0 }\n")
+	var nav uint32
+	file.FlatWalkNodes(0, "navigation_expression", func(idx uint32) {
+		if nav == 0 {
+			nav = idx
+		}
+	})
+	if nav == 0 {
+		t.Fatal("expected to find a navigation_expression")
+	}
+	if !flatExpressionChainShortCircuits(file, nav) {
+		t.Fatal("navigation chain whose receiver contains a `?.` must be reported as short-circuiting")
+	}
+}
+
+// TestFlatExpressionChainShortCircuits_SafeCallOnlyInArgsNotTriggered keeps
+// the helper precise: a `?.` that only appears inside a call's value
+// argument list does not propagate null to the call's return type, so the
+// helper must NOT report short-circuiting. A descendant-only walk would
+// over-trigger here and silently suppress real UselessElvisOnNonNull hits.
+func TestFlatExpressionChainShortCircuits_SafeCallOnlyInArgsNotTriggered(t *testing.T) {
+	file := parseInlineForInternalTest(t, "fun pick(s: String?): Int = (s?.length ?: 0); fun f(s: String?): Int { return pick(s) ?: 0 }\n")
+	var call uint32
+	file.FlatWalkNodes(0, "call_expression", func(idx uint32) {
+		if call != 0 {
+			return
+		}
+		// Take the outermost `pick(...)` call, not the inner `s?.length`
+		// navigation's call container.
+		text := file.FlatNodeText(idx)
+		if len(text) > 0 && text[0] == 'p' {
+			call = idx
+		}
+	})
+	if call == 0 {
+		t.Fatal("expected to find the outer `pick(...)` call_expression")
+	}
+	if flatExpressionChainShortCircuits(file, call) {
+		t.Fatal("a `?.` confined to a value argument must not be treated as a chain short-circuit")
+	}
+}
+
+// TestFlatExpressionChainShortCircuits_NotNullAssertionSealsChain ensures
+// `obj?.foo()!!` is reported as non-short-circuiting at the postfix level:
+// the `!!` raises on null, so the expression's static type is non-null and
+// the elvis fallback is genuinely dead.
+func TestFlatExpressionChainShortCircuits_NotNullAssertionSealsChain(t *testing.T) {
+	file := parseInlineForInternalTest(t, "fun f(s: String?): Int { return (s?.length!!) ?: 0 }\n")
+	var postfix uint32
+	file.FlatWalkNodes(0, "postfix_expression", func(idx uint32) {
+		if postfix == 0 {
+			postfix = idx
+		}
+	})
+	if postfix == 0 {
+		t.Fatal("expected to find a postfix_expression")
+	}
+	if flatExpressionChainShortCircuits(file, postfix) {
+		t.Fatal("`!!` seals the chain — postfix_expression with !! must not be treated as short-circuiting")
+	}
+}
+
+// TestFlatExpressionChainShortCircuits_PlainCallNoSafeCall is the baseline
+// negative: a call_expression with no `?.` anywhere in its spine must not
+// be flagged. This guards against an over-broad walker that would suppress
+// every call-expression-based UselessElvisOnNonNull hit.
+func TestFlatExpressionChainShortCircuits_PlainCallNoSafeCall(t *testing.T) {
+	file := parseInlineForInternalTest(t, "fun answer(): Int = 42; fun f(): Int { return answer() ?: 0 }\n")
+	var call uint32
+	file.FlatWalkNodes(0, "call_expression", func(idx uint32) {
+		if call == 0 {
+			call = idx
+		}
+	})
+	if call == 0 {
+		t.Fatal("expected to find a call_expression")
+	}
+	if flatExpressionChainShortCircuits(file, call) {
+		t.Fatal("plain call_expression without `?.` must not be reported as short-circuiting")
+	}
+}

--- a/tests/fixtures/negative/potential-bugs/UselessElvisOnNonNull.kt
+++ b/tests/fixtures/negative/potential-bugs/UselessElvisOnNonNull.kt
@@ -28,6 +28,20 @@ class UselessElvisOnNonNull {
     fun findOrFallback(items: List<String>) {
         val y = items.find { it.isEmpty() } ?: "fallback"
     }
+
+    // Call-expression whose callee is a safe-call chain. The call's
+    // declared return type is non-nullable Int, but the chain short-
+    // circuits to null when `s` is null, so the elvis fallback is real.
+    fun safeCallTerminatingInCall(s: String?) {
+        val y = s?.length?.toInt() ?: 0
+    }
+
+    // Navigation chain that ends in `.bar` whose receiver is a safe-call
+    // call_expression. The outer step is `.`, but the receiver propagates
+    // null upstream — the elvis must be preserved.
+    fun navigationAfterSafeCall(harness: TestHarness?) {
+        val y = harness?.group?.length.toString() ?: "fallback"
+    }
 }
 
 class TestHarness {


### PR DESCRIPTION
## Summary

- `UselessElvisOnNonNull` accepted every `call_expression` operand as resolvable and trusted the resolver's return type, so `obj?.foo() ?: fallback` fired even though the chain short-circuits to null whenever the safe-call receiver is null.
- New helper `flatExpressionChainShortCircuits` walks the leftmost receiver/callee spine, finds `?.` on the actual chain (via `flatNavigationSafeCallOperator`), and ignores `?.` confined to value arguments. `!!` seals the chain at any postfix step.
- Wired into both `navigation_expression` and `call_expression` branches of `uselessElvisOperandResolvable`.

## Test plan
- [x] Five new helper unit tests pin the spine semantics: safe-call-in-callee, navigation-after-safe-call, args-only `?.`, `!!`-sealed chain, plain call.
- [x] Two new negative fixtures (`safeCallTerminatingInCall`, `navigationAfterSafeCall`) document the shapes at fixture level.
- [x] `go build ./...`, `go vet ./...`, `golangci-lint run ./...`, `go test ./... -count=1` all clean.