### PR TITLE
feat(rules): targeted-resolution selectors for nullsafety thorough mode

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -110,7 +110,7 @@ analysis:
 |-----------|-------------------------------------------------------------------------------------------------------|
 | `fast`    | Skips the JVM type oracle. Source-level inference still runs. Best for low-latency local checks.      |
 | `balanced`| (Default) Source inference + JVM type oracle.                                                         |
-| `thorough`| Reserved for richer oracle facts such as narrow expression types and expanded class tables.            |
+| `thorough`| Balanced plus a targeted-resolution pre-pass: opt-in rules batch expression-position queries to KAA so the oracle has precise type facts before dispatch. Improves precision on lambda-param nullsafety and properties with externally-typed initializers. |
 
 Precedence, highest first: explicit individual flag (e.g.
 `--no-type-oracle`) → `--depth=<preset>` → `analysis.depth` → `balanced`.

--- a/internal/cli/scan/depth.go
+++ b/internal/cli/scan/depth.go
@@ -25,9 +25,16 @@ const (
 	// type oracle.
 	DepthBalanced DepthPreset = "balanced"
 
-	// DepthThorough is a forward-looking preset reserved for richer
-	// oracle facts (narrow expression types, expanded class-table
-	// coverage). Today it behaves identically to balanced.
+	// DepthThorough runs the same source-level inference and JVM type
+	// oracle as balanced, plus a targeted-resolution pre-pass: rules
+	// that declare ExprPositions selectors get their queried expression
+	// positions batched into a single resolveExpressionTypes RPC, so
+	// KAA seeds the oracle's expression map before dispatch begins.
+	// Today the precision win lights up nullsafety rules on lambda-param
+	// `!!` / `?.` / `?:` / `.toString()` patterns and equality null
+	// checks on properties whose initializers source can't type.
+	// Reserved for further oracle expansion (richer expression facts,
+	// expanded class-table coverage) as additional rules opt in.
 	DepthThorough DepthPreset = "thorough"
 )
 

--- a/internal/rules/nullsafety_expr_positions_test.go
+++ b/internal/rules/nullsafety_expr_positions_test.go
@@ -1,0 +1,333 @@
+package rules_test
+
+// Selector coverage for nullability rules participating in the
+// targeted-resolution pass under --depth=thorough. Each rule gets:
+//   - unit tests that the selector returns the resolver-query positions
+//     the rule's check() actually consumes,
+//   - lexical-skip tests that prove the selector mirrors check()'s
+//     short-circuit gates,
+//   - an integration test that drives CollectExpressionPositions → fake
+//     resolver → ApplyResolvedExpressions → dispatcher and asserts the
+//     rule's verdict shifts once the seeded oracle fact arrives.
+
+import (
+	"testing"
+
+	"github.com/kaeawc/krit/internal/oracle"
+	api "github.com/kaeawc/krit/internal/rules/api"
+	"github.com/kaeawc/krit/internal/scanner"
+	"github.com/kaeawc/krit/internal/typeinfer"
+)
+
+// ---------------------------------------------------------------------------
+// UnnecessaryNotNullCheck
+// ---------------------------------------------------------------------------
+
+// Property-declaration fixture: source-level resolver returns Unknown
+// for `s` because `externalApi()` is undeclared in this translation
+// unit, but the rule's flatReferenceHasSameFileTarget gate finds the
+// `val s = ...` property and would consult the resolver. Seeding a
+// non-null fact at the operand position lights up the rule's flag-and-fix
+// path — the precision win that justifies adding the selector.
+const unnecessaryNullCheckPropertyFixture = `
+package test
+
+class Probe {
+    val s = externalApi()
+
+    fun demo() {
+        if (s != null) println(s)
+    }
+}
+`
+
+func TestUnnecessaryNotNullCheck_ExpressionPositions_ReturnsPropertyOperand(t *testing.T) {
+	file := parseInline(t, unnecessaryNullCheckPropertyFixture)
+	rule := findRuleByID(t, "UnnecessaryNotNullCheck")
+	if rule.ExprPositions == nil {
+		t.Fatal("UnnecessaryNotNullCheck should declare ExprPositions for thorough mode")
+	}
+	got := rule.ExprPositions(file)
+	if len(got) != 1 {
+		t.Fatalf("expected exactly one position for `s != null`; got %d: %v", len(got), got)
+	}
+	if text := file.FlatNodeText(got[0]); text != "s" {
+		t.Errorf("selector returned non-`s` operand: %q", text)
+	}
+}
+
+func TestUnnecessaryNotNullCheck_ExpressionPositions_SkipsLambdaParams(t *testing.T) {
+	// Lambda parameters don't pass flatReferenceHasSameFileTarget — the
+	// rule's check() exits before consulting the resolver, so seeding
+	// KAA facts here would be wasted work. Selector must respect the
+	// gate; the analogous UnnecessaryNotNullOperator selector uses
+	// ResolveByNameFlat and does not have this gate.
+	file := parseInline(t, `
+package test
+
+class Probe {
+    fun demo() {
+        listOf("a", "b").forEach { s ->
+            if (s != null) println(s.length)
+        }
+    }
+}
+`)
+	rule := findRuleByID(t, "UnnecessaryNotNullCheck")
+	got := rule.ExprPositions(file)
+	if len(got) != 0 {
+		t.Fatalf("expected no positions for lambda-param operand (gate excludes them); got %d: %v",
+			len(got), flatTextsForIndices(file, got))
+	}
+}
+
+func TestUnnecessaryNotNullCheck_ExpressionPositions_SkipsNonNullComparisons(t *testing.T) {
+	// `x == y` (no null literal) isn't a null check — selector must skip
+	// or the targeted-resolution pre-pass will waste KAA work.
+	file := parseInline(t, `
+package test
+
+class Probe {
+    fun demo(a: Int, b: Int) {
+        if (a == b) println("equal")
+    }
+}
+`)
+	rule := findRuleByID(t, "UnnecessaryNotNullCheck")
+	got := rule.ExprPositions(file)
+	if len(got) != 0 {
+		t.Fatalf("expected no positions for non-null comparison; got %d: %v", len(got), got)
+	}
+}
+
+func TestUnnecessaryNotNullCheck_ExpressionPositions_HandlesNilFile(t *testing.T) {
+	rule := findRuleByID(t, "UnnecessaryNotNullCheck")
+	if got := rule.ExprPositions(nil); got != nil {
+		t.Errorf("expected nil for nil file; got %v", got)
+	}
+}
+
+func TestUnnecessaryNotNullCheck_TargetedResolution_FiresOnPropertyFromUnknownInit(t *testing.T) {
+	file := parseInline(t, unnecessaryNullCheckPropertyFixture)
+	rule := findRuleByID(t, "UnnecessaryNotNullCheck")
+	positions := api.CollectExpressionPositions([]*api.Rule{rule}, []*scanner.File{file})
+	if len(positions[file.Path]) == 0 {
+		t.Fatalf("expected a collected position for `s`; got %v", positions[file.Path])
+	}
+	fake := oracle.NewFakeOracle()
+	seedExprFactsAtPositions(fake, file.Path, positions[file.Path],
+		&typeinfer.ResolvedType{Name: "String", FQN: "kotlin.String", Kind: typeinfer.TypeClass, Nullable: false})
+	findings := runRuleOnFileWithFakeOracle(t, "UnnecessaryNotNullCheck", file, fake)
+	if len(findings) != 1 {
+		t.Fatalf("expected one finding once oracle fact is seeded; got %d: %v", len(findings), findings)
+	}
+	if findings[0].Rule != "UnnecessaryNotNullCheck" {
+		t.Errorf("unexpected rule: %q", findings[0].Rule)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// UnnecessarySafeCall
+// ---------------------------------------------------------------------------
+
+const unnecessarySafeCallLambdaParamFixture = `
+package test
+
+class Probe {
+    fun demo() {
+        listOf("a", "b").forEach { s ->
+            println(s?.length)
+        }
+    }
+}
+`
+
+func TestUnnecessarySafeCall_ExpressionPositions_ReturnsLambdaParamNav(t *testing.T) {
+	file := parseInline(t, unnecessarySafeCallLambdaParamFixture)
+	rule := findRuleByID(t, "UnnecessarySafeCall")
+	if rule.ExprPositions == nil {
+		t.Fatal("UnnecessarySafeCall should declare ExprPositions for thorough mode")
+	}
+	got := rule.ExprPositions(file)
+	if len(got) != 1 {
+		t.Fatalf("expected exactly one position for `s?.length`; got %d: %v", len(got), got)
+	}
+	if text := file.FlatNodeText(got[0]); text != "s?.length" {
+		t.Errorf("selector returned unexpected node: %q", text)
+	}
+}
+
+func TestUnnecessarySafeCall_ExpressionPositions_SkipsDottedReceivers(t *testing.T) {
+	file := parseInline(t, `
+package test
+
+class Probe {
+    fun demo(obj: Any?) {
+        println(obj.foo?.length)
+    }
+}
+`)
+	rule := findRuleByID(t, "UnnecessarySafeCall")
+	for _, idx := range rule.ExprPositions(file) {
+		text := file.FlatNodeText(idx)
+		// `obj.foo?.length` has a dotted receiver (`obj.foo`) — selector
+		// must skip; only bare-name receivers are resolver-friendly.
+		if text == "obj.foo?.length" {
+			t.Errorf("selector should skip dotted receiver: %q", text)
+		}
+	}
+}
+
+func TestUnnecessarySafeCall_ExpressionPositions_HandlesNilFile(t *testing.T) {
+	rule := findRuleByID(t, "UnnecessarySafeCall")
+	if got := rule.ExprPositions(nil); got != nil {
+		t.Errorf("expected nil for nil file; got %v", got)
+	}
+}
+
+func TestUnnecessarySafeCall_TargetedResolution_FiresOnLambdaParam(t *testing.T) {
+	file := parseInline(t, unnecessarySafeCallLambdaParamFixture)
+	rule := findRuleByID(t, "UnnecessarySafeCall")
+	positions := api.CollectExpressionPositions([]*api.Rule{rule}, []*scanner.File{file})
+	if len(positions[file.Path]) == 0 {
+		t.Fatalf("expected a collected position; got %v", positions[file.Path])
+	}
+	fake := oracle.NewFakeOracle()
+	seedExprFactsAtPositions(fake, file.Path, positions[file.Path],
+		&typeinfer.ResolvedType{Name: "String", FQN: "kotlin.String", Kind: typeinfer.TypeClass, Nullable: false})
+	findings := runRuleOnFileWithFakeOracle(t, "UnnecessarySafeCall", file, fake)
+	if len(findings) != 1 {
+		t.Fatalf("expected one finding once oracle fact is seeded; got %d: %v", len(findings), findings)
+	}
+	if findings[0].Rule != "UnnecessarySafeCall" {
+		t.Errorf("unexpected rule: %q", findings[0].Rule)
+	}
+}
+
+// NOTE: NullCheckOnMutableProperty deliberately does NOT declare
+// ExprPositions. Its check() uses CompositeResolver.ResolveByNameFlat,
+// which gives source the first word; the rule also only fires on
+// same-owner `var` properties — shapes where source inference already
+// has a precise nullability fact and KAA cannot improve the verdict.
+// Seeding oracle facts for those positions would burn JVM work the
+// rule can't read, so we leave the selector off and document why.
+
+// ---------------------------------------------------------------------------
+// NullableToStringCall
+// ---------------------------------------------------------------------------
+
+const nullableToStringLambdaParamFixture = `
+package test
+
+class Probe {
+    fun demo(values: List<String?>) {
+        values.forEach { v ->
+            println(v.toString())
+        }
+    }
+}
+`
+
+func TestNullableToStringCall_ExpressionPositions_ReturnsCallReceiver(t *testing.T) {
+	file := parseInline(t, nullableToStringLambdaParamFixture)
+	rule := findRuleByID(t, "NullableToStringCall")
+	if rule.ExprPositions == nil {
+		t.Fatal("NullableToStringCall should declare ExprPositions for thorough mode")
+	}
+	got := rule.ExprPositions(file)
+	if len(got) == 0 {
+		t.Fatal("expected at least one position for `v.toString()`")
+	}
+	sawV := false
+	for _, idx := range got {
+		if file.FlatNodeText(idx) == "v" {
+			sawV = true
+		}
+	}
+	if !sawV {
+		t.Errorf("expected selector to include `v` (toString receiver); got %v",
+			flatTextsForIndices(file, got))
+	}
+}
+
+func TestNullableToStringCall_ExpressionPositions_SkipsSafeCallToString(t *testing.T) {
+	// `v?.toString()` is already safe; the rule skips it, and so must the
+	// selector — otherwise the targeted-resolution batch grows for no reason.
+	file := parseInline(t, `
+package test
+
+class Probe {
+    fun demo(v: String?) {
+        println(v?.toString())
+    }
+}
+`)
+	rule := findRuleByID(t, "NullableToStringCall")
+	for _, idx := range rule.ExprPositions(file) {
+		if file.FlatNodeText(idx) == "v" {
+			// `v` is a receiver of a safe-call toString — must NOT be selected.
+			t.Errorf("selector should skip receivers of safe-call toString: %q", file.FlatNodeText(idx))
+		}
+	}
+}
+
+func TestNullableToStringCall_ExpressionPositions_ReturnsInterpolatedIdentifier(t *testing.T) {
+	// `"$x"` triggers the string-template path; the selector must include
+	// the interpolated identifier position so KAA can prove `x` is/isn't nullable.
+	file := parseInline(t, `
+package test
+
+class Probe {
+    fun demo(x: String?) {
+        println("$x")
+    }
+}
+`)
+	rule := findRuleByID(t, "NullableToStringCall")
+	got := rule.ExprPositions(file)
+	sawX := false
+	for _, idx := range got {
+		if file.FlatType(idx) == "interpolated_identifier" {
+			sawX = true
+		}
+	}
+	if !sawX {
+		t.Errorf("expected selector to include the `$x` interpolated_identifier; got %v",
+			flatTextsForIndices(file, got))
+	}
+}
+
+func TestNullableToStringCall_ExpressionPositions_HandlesNilFile(t *testing.T) {
+	rule := findRuleByID(t, "NullableToStringCall")
+	if got := rule.ExprPositions(nil); got != nil {
+		t.Errorf("expected nil for nil file; got %v", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+// seedExprFactsAtPositions writes the same ResolvedType to every
+// (line, col) position for a file in a FakeOracle, mirroring what
+// ApplyResolvedExpressions does for a stub resolver that returned a
+// single type for every requested position.
+func seedExprFactsAtPositions(fake *oracle.FakeOracle, path string, positions []api.ExpressionPosition, t *typeinfer.ResolvedType) {
+	if fake.Expressions[path] == nil {
+		fake.Expressions[path] = map[string]*typeinfer.ResolvedType{}
+	}
+	for _, p := range positions {
+		fake.Expressions[path][lineColKey(p.Line, p.Col)] = t
+	}
+}
+
+// flatTextsForIndices is a debug helper for failure messages — turns a
+// slice of flat indices into their source texts so the assertion message
+// shows what the selector actually returned.
+func flatTextsForIndices(file *scanner.File, idxs []uint32) []string {
+	out := make([]string, 0, len(idxs))
+	for _, idx := range idxs {
+		out = append(out, file.FlatNodeText(idx))
+	}
+	return out
+}

--- a/internal/rules/potentialbugs_nullsafety_redundant.go
+++ b/internal/rules/potentialbugs_nullsafety_redundant.go
@@ -113,6 +113,34 @@ func (r *UnnecessaryNotNullCheckRule) check(ctx *api.Context) {
 	ctx.Emit(f)
 }
 
+// ExpressionPositions mirrors flatResolvedNullCheckOperandType's gates
+// (including flatReferenceHasSameFileTarget) so lambda-param operands
+// are not seeded — the rule's check short-circuits on those before
+// consulting the resolver.
+func (r *UnnecessaryNotNullCheckRule) ExpressionPositions(file *scanner.File) []uint32 {
+	if file == nil {
+		return nil
+	}
+	var out []uint32
+	file.FlatWalkNodes(0, "equality_expression", func(idx uint32) {
+		operand, _, ok := flatNullComparisonOperand(file, idx)
+		if !ok {
+			return
+		}
+		operand = flatUnwrapParenExpr(file, operand)
+		switch file.FlatType(operand) {
+		case "simple_identifier", "this_expression":
+			if !flatReferenceHasSameFileTarget(file, operand) {
+				return
+			}
+			out = append(out, operand)
+		case "call_expression", "navigation_expression":
+			out = append(out, operand)
+		}
+	})
+	return out
+}
+
 func flatNullComparisonOperand(file *scanner.File, idx uint32) (operand uint32, op string, ok bool) {
 	if file == nil || idx == 0 || file.FlatType(idx) != "equality_expression" || file.FlatChildCount(idx) < 3 {
 		return 0, "", false
@@ -1059,6 +1087,41 @@ func (r *UnnecessarySafeCallRule) check(ctx *api.Context) {
 	}
 }
 
+// ExpressionPositions mirrors check()'s receiver gates: safe-call
+// (`?.`) navigations with a bare identifier receiver. Dotted and
+// chained safe-calls are skipped because the rule's bare-name lookup
+// cannot consume them.
+func (r *UnnecessarySafeCallRule) ExpressionPositions(file *scanner.File) []uint32 {
+	if file == nil {
+		return nil
+	}
+	var out []uint32
+	file.FlatWalkNodes(0, "navigation_expression", func(idx uint32) {
+		if !flatNavigationHasSafeCall(file, idx) {
+			return
+		}
+		if file.FlatChildCount(idx) < 2 {
+			return
+		}
+		receiver := file.FlatChild(idx, 0)
+		if receiver == 0 {
+			return
+		}
+		if flatNavigationHasSafeCall(file, receiver) {
+			return
+		}
+		receiverText := file.FlatNodeText(receiver)
+		if strings.Contains(receiverText, ".") {
+			return
+		}
+		if strings.TrimSpace(receiverText) == "" {
+			return
+		}
+		out = append(out, idx)
+	})
+	return out
+}
+
 func unnecessarySafeCallShouldSkipReceiver(file *scanner.File, idx uint32, name string, structural bool) bool {
 	if name == "this" {
 		return unnecessarySafeCallNullableReceiverFlat(file, idx, structural) ||
@@ -1665,6 +1728,52 @@ func (r *NullableToStringCallRule) checkNullableStringTemplate(ctx *api.Context)
 		ctx.Emit(r.Finding(file, file.FlatRow(child)+1, file.FlatCol(child)+1,
 			"Interpolating a nullable expression may produce the string \"null\". Use an explicit fallback instead."))
 	}
+}
+
+// ExpressionPositions collects resolver query positions for both rule
+// paths in a single FlatWalkAllNodes pass: zero-arg `.toString()` call
+// receivers (not safe-call) and string-template interpolation
+// expressions. Single walk avoids three sequential AST scans at
+// --depth=thorough.
+func (r *NullableToStringCallRule) ExpressionPositions(file *scanner.File) []uint32 {
+	if file == nil {
+		return nil
+	}
+	var out []uint32
+	file.FlatWalkAllNodes(0, func(idx uint32) {
+		switch file.FlatType(idx) {
+		case "call_expression":
+			if flatCallExpressionName(file, idx) != "toString" {
+				return
+			}
+			nav, args := flatCallExpressionParts(file, idx)
+			if nav == 0 || flatCallHasArguments(file, args) {
+				return
+			}
+			if flatNavigationLastSuffixOperator(file, nav) == "?." {
+				return
+			}
+			receiver := flatUnwrapParenExpr(file, flatNullCheckNavigationReceiver(file, nav))
+			if receiver == 0 {
+				return
+			}
+			switch file.FlatType(receiver) {
+			case "simple_identifier", "this_expression", "call_expression", "navigation_expression":
+				out = append(out, receiver)
+			}
+		case "interpolated_identifier":
+			out = append(out, idx)
+		case "interpolated_expression":
+			if file.FlatNamedChildCount(idx) == 0 {
+				return
+			}
+			expr := flatUnwrapParenExpr(file, file.FlatNamedChild(idx, 0))
+			if expr != 0 {
+				out = append(out, expr)
+			}
+		}
+	})
+	return out
 }
 
 func flatCallHasArguments(file *scanner.File, args uint32) bool {

--- a/internal/rules/registry_potentialbugs_nullsafety_redundant.go
+++ b/internal/rules/registry_potentialbugs_nullsafety_redundant.go
@@ -12,8 +12,9 @@ func registerPotentialbugsNullsafetyRedundantRules() {
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
 			NodeTypes: []string{"equality_expression"}, Confidence: 0.75, Fix: api.FixIdiomatic, Implementation: r,
-			Needs: api.NeedsResolver,
-			Check: r.check,
+			Needs:         api.NeedsResolver,
+			Check:         r.check,
+			ExprPositions: r.ExpressionPositions,
 		})
 	}
 	{
@@ -33,7 +34,8 @@ func registerPotentialbugsNullsafetyRedundantRules() {
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
 			NodeTypes: []string{"navigation_expression"}, Confidence: 0.75, Fix: api.FixIdiomatic,
 			Needs: api.NeedsResolver, Implementation: r,
-			Check: r.check,
+			Check:         r.check,
+			ExprPositions: r.ExpressionPositions,
 		})
 	}
 	{
@@ -70,6 +72,7 @@ func registerPotentialbugsNullsafetyRedundantRules() {
 			// Resolves the receiver type to check nullability via expressions map.
 			OracleDeclarationNeeds: &api.OracleDeclarationProfile{},
 			Check:                  r.check,
+			ExprPositions:          r.ExpressionPositions,
 		})
 	}
 }


### PR DESCRIPTION
## Summary

- Three nullsafety rules grow `ExprPositions` selectors so `--depth=thorough` seeds KAA expression facts at the resolver-query positions each rule consumes: `UnnecessaryNotNullCheck`, `UnnecessarySafeCall`, `NullableToStringCall`.
- Selectors mirror each rule's existing lexical gates so the targeted-resolution batch stays tight — including `UnnecessaryNotNullCheck`'s `flatReferenceHasSameFileTarget` gate, which excludes lambda-param operands the rule short-circuits on.
- `NullCheckOnMutableProperty` deliberately stays out: its operand path uses `CompositeResolver.ResolveByNameFlat` where source wins over oracle facts; the rule also only fires on same-owner `var` properties where source typing is already precise.
- `DepthThorough` docstring and `docs/configuration.md` updated to describe what thorough now buys; the previous "reserved for future use" language is no longer accurate.

No `fast` / `balanced` behavior changes — `ExpressionPositions` is consulted only by the targeted-resolution pre-pass that runs at `--depth=thorough`.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...` — 0 issues
- [x] `make lint-rules`
- [x] `go test ./internal/rules/ ./internal/pipeline/ ./internal/oracle/ -count=1`
- [x] `go test ./... -count=1`
- [ ] `make integration` (CI)

Each rule has focused selector tests (positive shape, lexical-skip negatives, nil-file guard) plus an integration test that drives `CollectExpressionPositions` → fake resolver → `ApplyResolvedExpressions` → dispatcher and asserts the rule's verdict shifts when the seeded KAA fact arrives.