### PR TITLE
demo(playground): migrate kotlin-webservice to settings plugin + walk-up

### DIFF
--- a/cmd/krit/testdata/regression/playground-kotlin-webservice.json
+++ b/cmd/krit/testdata/regression/playground-kotlin-webservice.json
@@ -6,7 +6,7 @@
       "rule": "DependenciesInRootProject",
       "ruleSet": "supply-chain",
       "file": "build.gradle.kts",
-      "line": 18,
+      "line": 19,
       "col": 0,
       "message": "Root project dependencies block declares implementation, kritCustomRules. Move project dependencies into an owning module or add legitimate root tooling configurations to allowedConfigurations."
     },

--- a/playground/kotlin-webservice/build.gradle.kts
+++ b/playground/kotlin-webservice/build.gradle.kts
@@ -1,7 +1,8 @@
 plugins {
     kotlin("jvm") version "2.3.21"
     application
-    id("dev.jasonpearson.krit")
+    // No `id("dev.jasonpearson.krit")` — auto-applied by the
+    // dev.jasonpearson.krit.settings plugin from settings.gradle.kts.
 }
 
 group = "com.example"
@@ -26,10 +27,10 @@ dependencies {
     kritCustomRules(project(":custom-rules"))
 }
 
+// `krit.yml` next to this file is auto-discovered by the CLI's walk-up
+// config search, so no `config = file(...)` line is needed. `ignoreFailures`
+// flows in from the root settings.
 krit {
-    config = file("krit.yml")
-    ignoreFailures = true
-
     reports {
         plain.required = true
         json.required = true

--- a/playground/kotlin-webservice/settings.gradle.kts
+++ b/playground/kotlin-webservice/settings.gradle.kts
@@ -5,6 +5,11 @@ pluginManagement {
     }
     includeBuild("../../krit-gradle-plugin")
     includeBuild("../../krit-custom-rule-plugin")
+    includeBuild("../../krit-settings-plugin")
+}
+
+plugins {
+    id("dev.jasonpearson.krit.settings")
 }
 
 dependencyResolutionManagement {
@@ -23,3 +28,9 @@ rootProject.name = "kotlin-webservice"
 
 include(":custom-rules")
 project(":custom-rules").projectDir = file("../custom-rules")
+
+krit {
+    ignoreFailures = true
+    // :custom-rules is a rule producer, not a target for analysis.
+    skip(":custom-rules")
+}


### PR DESCRIPTION
## Summary

Updates \`playground/kotlin-webservice\` to use the modern minimal-setup flow that landed across the recent gradle-plugin series:

- \`settings.gradle.kts\` applies \`dev.jasonpearson.krit.settings\`, which auto-applies the project plugin to every Kotlin/Java subproject. Root-level \`ignoreFailures = true\` and \`skip(\":custom-rules\")\` live on the settings extension.
- \`build.gradle.kts\` no longer applies \`id(\"dev.jasonpearson.krit\")\` manually and no longer sets \`config = file(\"krit.yml\")\` — walk-up discovery picks up the sibling \`krit.yml\` automatically.
- Per-module surface is down to the two bits that are genuinely module-scoped: the \`reports { }\` overrides (plain + json on top of the default sarif, useful for the demo) and the \`advanced.binary\` pointer at the locally-built krit binary.

Replaces #449, which was stuck on a phantom \`mergeable=CONFLICTING\` cache despite a clean local rebase against origin/main and \`gh pr merge --admin\` confirming the merge commit \"cannot be cleanly created\" via the API while \`git merge origin/main\` locally reports \"Already up to date\". Closing + opening fresh to reset the stale state.

## Test plan

- [x] \`./gradlew help\` configures
- [x] \`./gradlew :tasks --all | grep krit\` shows \`kritCheck\` / \`kritCheckMain\` / \`kritCheckTest\` / \`kritFormat\` / \`kritBaseline\` auto-registered on the root project
- [x] \`./gradlew :custom-rules:tasks --all | grep krit\` shows no analysis tasks (skip list honored)
- [x] \`./gradlew :kritCheck\` runs end-to-end (with \`ignoreFailures\` inherited from settings — build succeeds despite custom-rule findings)
- [x] \`go build\`, \`go vet\`, \`golangci-lint run ./...\` — clean
- [x] \`go test ./... -count=1\` — full suite green
- [x] Regression baseline regenerated for the 1-line shift on the existing \`DependenciesInRootProject\` finding