### PR TITLE
fix(rules): require stdout receiver for LogPii println

### DIFF
--- a/internal/rules/security.go
+++ b/internal/rules/security.go
@@ -479,7 +479,7 @@ var androidLogMethods = map[string]bool{"v": true, "d": true, "i": true, "w": tr
 
 func logPiiIsLoggerCall(file *scanner.File, call uint32) bool {
 	name := javaAwareCallName(file, call)
-	if name == "println" {
+	if name == "println" && logPiiIsStdoutPrintln(file, call) {
 		return true
 	}
 	text := file.FlatNodeText(call)
@@ -500,6 +500,76 @@ func logPiiIsLoggerCall(file *scanner.File, call uint32) bool {
 			strings.Contains(strings.ToLower(receiver), "logger")
 	}
 	return false
+}
+
+// logPiiIsStdoutPrintln returns true only when the call resolves to a
+// stdout/stderr-style println: a bare `println(...)` that is not shadowed
+// by a same-file declaration or non-kotlin.io import, or an explicit
+// `System.out.println` / `System.err.println` invocation (Kotlin or Java).
+// Returning true for any method named `println` would false-positive on
+// arbitrary `obj.println(...)` calls and on files that shadow the kotlin.io
+// built-in with a local function.
+func logPiiIsStdoutPrintln(file *scanner.File, call uint32) bool {
+	if file == nil || call == 0 {
+		return false
+	}
+	switch file.FlatType(call) {
+	case "call_expression":
+		callee, _ := flatCallExpressionParts(file, call)
+		if callee != 0 && file.FlatType(callee) == "navigation_expression" {
+			segs := flatNavigationChainIdentifiers(file, callee)
+			return len(segs) == 3 && segs[0] == "System" &&
+				(segs[1] == "out" || segs[1] == "err") &&
+				segs[2] == "println"
+		}
+		// Bare `println(...)` resolves to kotlin.io.println only when nothing
+		// in the file shadows the built-in name.
+		return !kotlinFileShadowsBuiltinPrint(file, "println")
+	case "method_invocation":
+		// Java has no bare top-level println; require System.out / System.err
+		// as the receiver. The Java parser represents `System.out` as a
+		// single field_access child, so wrongViewCastCallReceiverName (which
+		// joins bare identifier siblings) does not capture it. Trim trailing
+		// whitespace from the receiver text and compare directly.
+		receiverText := logPiiMethodInvocationReceiverText(file, call)
+		return receiverText == "System.out" || receiverText == "System.err"
+	}
+	return false
+}
+
+// logPiiMethodInvocationReceiverText returns the textual form of a Java
+// method_invocation's receiver — the named child that appears before the
+// `.identifier(args)` suffix — or "" when the call has no qualifier.
+// Tracks "saw a `.` separator" so a bare `foo(args)` returns "" instead of
+// "foo". Used to distinguish `System.out.println(...)` from `obj.println(...)`.
+func logPiiMethodInvocationReceiverText(file *scanner.File, call uint32) string {
+	if file == nil || call == 0 || file.FlatType(call) != "method_invocation" {
+		return ""
+	}
+	var receiver uint32
+	sawDot := false
+	for child := file.FlatFirstChild(call); child != 0; child = file.FlatNextSib(child) {
+		if file.FlatType(child) == "argument_list" {
+			break
+		}
+		if file.FlatType(child) == "." {
+			sawDot = true
+			continue
+		}
+		if !file.FlatIsNamed(child) {
+			continue
+		}
+		if sawDot {
+			// We've already captured the receiver in `receiver`; remaining
+			// named children are the method name (or type arguments).
+			break
+		}
+		receiver = child
+	}
+	if !sawDot || receiver == 0 {
+		return ""
+	}
+	return strings.TrimSpace(file.FlatNodeText(receiver))
 }
 
 func logPiiHasLocalType(file *scanner.File, name string) bool {

--- a/internal/rules/security_test.go
+++ b/internal/rules/security_test.go
@@ -570,6 +570,90 @@ class Log {
 	}
 }
 
+func TestLogPii_PrintlnRequiresStdoutResolution(t *testing.T) {
+	// Bare println in a file that shadows kotlin.io.println with a local
+	// function must not be treated as a PII sink.
+	shadowed := runRuleByName(t, "LogPii", `
+package test
+
+fun println(message: String) {}
+
+class AuthLogger {
+    fun emit(password: String) {
+        println("password=$password")
+    }
+}`)
+	if len(shadowed) != 0 {
+		t.Fatalf("shadowed println: expected 0 findings, got %d", len(shadowed))
+	}
+
+	// Receiver-qualified println on an unrelated object is not stdout.
+	receiverShadowed := runRuleByName(t, "LogPii", `
+package test
+
+class Sink {
+    fun println(message: String) {}
+}
+
+class AuthLogger {
+    fun emit(password: String) {
+        val sink = Sink()
+        sink.println("password=$password")
+    }
+}`)
+	if len(receiverShadowed) != 0 {
+		t.Fatalf("receiver println: expected 0 findings, got %d", len(receiverShadowed))
+	}
+
+	// System.out.println / System.err.println both count.
+	systemOut := runRuleByName(t, "LogPii", `
+package test
+
+class AuthLogger {
+    fun emit(password: String) {
+        System.out.println("password=$password")
+        System.err.println("password=$password")
+    }
+}`)
+	if len(systemOut) != 2 {
+		t.Fatalf("System.out/err println: expected 2 findings, got %d", len(systemOut))
+	}
+}
+
+func TestLogPii_JavaPrintlnRequiresStdoutReceiver(t *testing.T) {
+	// A Java method named println on an unrelated class must not be treated
+	// as a stdout sink.
+	receiver := runRuleByNameOnJava(t, "LogPii", `
+package test;
+
+class Sink {
+    void println(String message) {}
+}
+
+class AuthLogger {
+    void emit(String password) {
+        Sink sink = new Sink();
+        sink.println("password=" + password);
+    }
+}`)
+	if len(receiver) != 0 {
+		t.Fatalf("receiver println: expected 0 findings, got %d", len(receiver))
+	}
+
+	systemOut := runRuleByNameOnJava(t, "LogPii", `
+package test;
+
+class AuthLogger {
+    void emit(String password) {
+        System.out.println("password=" + password);
+        System.err.println("password=" + password);
+    }
+}`)
+	if len(systemOut) != 2 {
+		t.Fatalf("System.out/err println: expected 2 findings, got %d", len(systemOut))
+	}
+}
+
 func TestJdbcStatementExecute_KotlinInterpolated(t *testing.T) {
 	findings := runRuleByNameWithResolver(t, "JdbcStatementExecute", `
 package test

--- a/tests/fixtures/negative/security/LogPii.java
+++ b/tests/fixtures/negative/security/LogPii.java
@@ -8,3 +8,14 @@ class LogPiiJavaSafeFixture {
         Log.d("Auth", "token=<redacted>");
     }
 }
+
+class LogPiiJavaCustomSink {
+    void println(String message) {
+        // no-op
+    }
+
+    void emit(String password) {
+        LogPiiJavaCustomSink sink = new LogPiiJavaCustomSink();
+        sink.println("password=" + password);
+    }
+}

--- a/tests/fixtures/negative/security/LogPii.kt
+++ b/tests/fixtures/negative/security/LogPii.kt
@@ -8,3 +8,28 @@ class LogPiiSafeFixture {
         Log.d("Auth", "password=<redacted>")
     }
 }
+
+// A file-local function that shadows kotlin.io.println. The PII rule must
+// not treat the bare call below as a stdout println.
+fun println(message: String) {
+    // no-op
+}
+
+class LogPiiShadowedPrintlnFixture {
+    fun emit(password: String) {
+        println("password=$password")
+    }
+}
+
+class LogPiiCustomSink {
+    fun println(message: String) {
+        // no-op
+    }
+}
+
+class LogPiiReceiverPrintln {
+    fun emit(password: String) {
+        val sink = LogPiiCustomSink()
+        sink.println("password=$password")
+    }
+}

--- a/tests/fixtures/positive/security/LogPii.kt
+++ b/tests/fixtures/positive/security/LogPii.kt
@@ -9,3 +9,13 @@ class LogPiiFixture {
         Timber.i("token=$token")
     }
 }
+
+class LogPiiStdoutFixture {
+    fun emit(password: String) {
+        // Bare println in a file that does not shadow kotlin.io.println
+        // resolves to stdout and counts as a PII-relevant sink.
+        println("password=$password")
+        System.out.println("password=$password")
+        System.err.println("password=$password")
+    }
+}


### PR DESCRIPTION
## Summary

`logPiiIsLoggerCall` accepted any call whose method/function name was `println` as a logger sink, regardless of receiver. That false-positively reported PII findings on:

- Files that shadow `kotlin.io.println` with a local `fun println(...)` declaration.
- Calls on unrelated objects that happen to expose a `println` method (Kotlin or Java).

## Fix

A new `logPiiIsStdoutPrintln` helper accepts the call only when it resolves to stdout/stderr:

- **Bare `println(...)` (Kotlin)** — accepted only when `kotlinFileShadowsBuiltinPrint(file, "println")` is false. Reuses the cached filefacts check that `PrintlnInProduction` already relies on, so there is no extra per-call AST walk.
- **Kotlin navigation chain** — accepted only when the chain is exactly `System.out.println` or `System.err.println`.
- **Java `method_invocation`** — accepted only when the receiver text is `System.out` or `System.err`.

All other shapes (arbitrary `obj.println(...)`, locally-shadowed bare calls) are rejected.

## Test plan

- [x] Negative fixture `tests/fixtures/negative/security/LogPii.kt` covers same-file `fun println` shadow and `sink.println(...)` on an unrelated class.
- [x] Negative fixture `tests/fixtures/negative/security/LogPii.java` covers `sink.println(...)` on a Java class with its own `println` method.
- [x] Positive fixture `tests/fixtures/positive/security/LogPii.kt` adds bare `println` (non-shadowing file) plus `System.out.println` and `System.err.println`.
- [x] Unit tests `TestLogPii_PrintlnRequiresStdoutResolution` and `TestLogPii_JavaPrintlnRequiresStdoutReceiver` lock in the behavior end-to-end.
- [x] `go build`, `go vet`, `golangci-lint run`, `go test ./... -count=1` all pass.
- [x] `make integration` and `make regression` pass aside from a pre-existing flake in `TestKritInitPlaygroundEndToEnd` that reproduces identically on the base branch without this change.