### PR TITLE
feat(cli): --depth=thorough enables FIR checker by default

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -110,10 +110,10 @@ analysis:
 |-----------|-------------------------------------------------------------------------------------------------------|
 | `fast`    | Skips the JVM type oracle. Source-level inference still runs. Best for low-latency local checks.      |
 | `balanced`| (Default) Source inference + JVM type oracle.                                                         |
-| `thorough`| Balanced plus a targeted-resolution pre-pass: opt-in rules batch expression-position queries to KAA so the oracle has precise type facts before dispatch. Improves precision on lambda-param nullsafety and properties with externally-typed initializers. |
+| `thorough`| Balanced plus a targeted-resolution pre-pass (opt-in rules batch expression-position queries to KAA) and the FIR checker pass (krit-fir JVM subprocess). Improves precision on lambda-param nullsafety, properties with externally-typed initializers, and FIR-only diagnostics. Pass `--no-fir` to keep the JVM dependency off. |
 
 Precedence, highest first: explicit individual flag (e.g.
-`--no-type-oracle`) → `--depth=<preset>` → `analysis.depth` → `balanced`.
+`--no-type-oracle`, `--no-fir`) → `--depth=<preset>` → `analysis.depth` → `balanced`.
 
 Compare `fast` and `balanced` on a representative target before changing CI
 defaults. `fast` is appropriate for projects that do not enable rules requiring

--- a/internal/cli/scan/depth.go
+++ b/internal/cli/scan/depth.go
@@ -25,16 +25,8 @@ const (
 	// type oracle.
 	DepthBalanced DepthPreset = "balanced"
 
-	// DepthThorough runs the same source-level inference and JVM type
-	// oracle as balanced, plus a targeted-resolution pre-pass: rules
-	// that declare ExprPositions selectors get their queried expression
-	// positions batched into a single resolveExpressionTypes RPC, so
-	// KAA seeds the oracle's expression map before dispatch begins.
-	// Today the precision win lights up nullsafety rules on lambda-param
-	// `!!` / `?.` / `?:` / `.toString()` patterns and equality null
-	// checks on properties whose initializers source can't type.
-	// Reserved for further oracle expansion (richer expression facts,
-	// expanded class-table coverage) as additional rules opt in.
+	// DepthThorough enables every compiler-backed precision feature.
+	// Explicit `--fir` / `--no-fir` flags still win.
 	DepthThorough DepthPreset = "thorough"
 )
 
@@ -100,9 +92,13 @@ func applyDepthPreset(depth DepthPreset, f *scanFlags, fs *flag.FlagSet) {
 		// Skip the JVM oracle. Source-level inference stays on so rules
 		// that only need lexical/AST signals continue to fire.
 		setBoolIfNotExplicit(f.NoTypeOracle, true, "no-type-oracle", explicit)
-	case DepthBalanced, DepthThorough:
-		// Both keep the oracle eligible; RunProject receives the
-		// additional thorough-only analysis knob after setup.
+	case DepthBalanced:
+		// Default — keep the oracle eligible, no FIR.
+	case DepthThorough:
+		// Oracle stays eligible; RunProject receives the targeted-
+		// resolution knob after setup. FIR defaults on unless the user
+		// passed either `--fir` or `--no-fir` explicitly.
+		setBoolIfNeitherExplicit(f.Fir, true, "fir", "no-fir", explicit)
 	}
 }
 
@@ -125,6 +121,20 @@ func setBoolIfNotExplicit(ptr *bool, value bool, name string, explicit map[strin
 		return
 	}
 	if explicit != nil && explicit[name] {
+		return
+	}
+	*ptr = value
+}
+
+// setBoolIfNeitherExplicit is the dual-flag variant: skip the assignment
+// if either flag name was passed on the command line. Used when a preset
+// wants to default one half of an opposed flag pair (e.g. --fir /
+// --no-fir) but must yield to user steering in either direction.
+func setBoolIfNeitherExplicit(ptr *bool, value bool, name1, name2 string, explicit map[string]bool) {
+	if ptr == nil {
+		return
+	}
+	if explicit != nil && (explicit[name1] || explicit[name2]) {
 		return
 	}
 	*ptr = value

--- a/internal/cli/scan/depth_test.go
+++ b/internal/cli/scan/depth_test.go
@@ -174,3 +174,81 @@ func TestApplyDepthPresetNilFlagSetAppliesUnconditionally(t *testing.T) {
 		t.Errorf("nil FlagSet should apply unconditionally; got NoTypeOracle=false")
 	}
 }
+
+func TestApplyDepthPresetThoroughEnablesFir(t *testing.T) {
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	f := registerScanFlags(fs)
+	if err := fs.Parse(nil); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	applyDepthPreset(DepthThorough, f, fs)
+	if !*f.Fir {
+		t.Errorf("DepthThorough should default Fir=true; got false")
+	}
+	if *f.NoFir {
+		t.Errorf("DepthThorough should leave NoFir=false; got true")
+	}
+}
+
+func TestApplyDepthPresetBalancedLeavesFirAlone(t *testing.T) {
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	f := registerScanFlags(fs)
+	if err := fs.Parse(nil); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	applyDepthPreset(DepthBalanced, f, fs)
+	if *f.Fir {
+		t.Errorf("DepthBalanced should leave Fir=false; got true")
+	}
+}
+
+func TestApplyDepthPresetFastLeavesFirAlone(t *testing.T) {
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	f := registerScanFlags(fs)
+	if err := fs.Parse(nil); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	applyDepthPreset(DepthFast, f, fs)
+	if *f.Fir {
+		t.Errorf("DepthFast should leave Fir=false; got true")
+	}
+}
+
+func TestApplyDepthPresetThoroughExplicitNoFirWins(t *testing.T) {
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	f := registerScanFlags(fs)
+	if err := fs.Parse([]string{"--no-fir"}); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	applyDepthPreset(DepthThorough, f, fs)
+	if *f.Fir {
+		t.Errorf("explicit --no-fir should suppress thorough's Fir default; got Fir=true")
+	}
+	if !*f.NoFir {
+		t.Errorf("explicit --no-fir should remain set; got false")
+	}
+}
+
+func TestApplyDepthPresetThoroughExplicitFirFalseWins(t *testing.T) {
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	f := registerScanFlags(fs)
+	if err := fs.Parse([]string{"--fir=false"}); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	applyDepthPreset(DepthThorough, f, fs)
+	if *f.Fir {
+		t.Errorf("explicit --fir=false should win over DepthThorough; got Fir=true")
+	}
+}
+
+func TestApplyDepthPresetThoroughExplicitFirTrueRespected(t *testing.T) {
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	f := registerScanFlags(fs)
+	if err := fs.Parse([]string{"--fir"}); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	applyDepthPreset(DepthThorough, f, fs)
+	if !*f.Fir {
+		t.Errorf("explicit --fir should remain true under DepthThorough; got false")
+	}
+}

--- a/internal/cli/scan/fir_checker.go
+++ b/internal/cli/scan/fir_checker.go
@@ -82,9 +82,15 @@ func runFIRCheckerPass(opts firCheckerOpts, base []scanner.Finding) []scanner.Fi
 	if !opts.Enabled || opts.Checker == nil {
 		return base
 	}
+	active := firchecks.ActiveFirRules(activeRuleIDs(opts.ActiveRules))
+	if len(active.Names) == 0 {
+		// No FIR-eligible rules in the active set; skip the JVM
+		// subprocess entirely. Matters once `--depth=thorough` defaults
+		// FIR on for rule sets that may not include any FIR checks.
+		return base
+	}
 	start := time.Now()
 	subTracker := opts.Tracker.Serial("firCheck")
-	active := firchecks.ActiveFirRules(activeRuleIDs(opts.ActiveRules))
 	summary := firchecks.CollectFirCheckFiles(active.Filters, opts.ParsedFiles)
 	ktFiles := resolveFIRTargetFiles(summary, opts.ParsedFiles)
 	result, err := opts.Checker.Check(ktFiles, nil, nil, active.Names)

--- a/internal/cli/scan/fir_checker_test.go
+++ b/internal/cli/scan/fir_checker_test.go
@@ -74,6 +74,25 @@ func TestRunFIRCheckerPassDisabledIsNoOp(t *testing.T) {
 	}
 }
 
+// Guard against paying for JVM startup when the active rule set contains
+// no FIR-eligible rules. Important now that --depth=thorough defaults
+// FIR on regardless of which rules the project actually has enabled.
+func TestRunFIRCheckerPassNoActiveRulesSkipsChecker(t *testing.T) {
+	checker := firchecks.NewFakeFirChecker()
+	base := []scanner.Finding{{Rule: "X"}}
+	got := runFIRCheckerPass(firCheckerOpts{
+		Enabled:     true,
+		Checker:     checker,
+		ActiveRules: []*api.Rule{{ID: "NotAFirRule"}},
+	}, base)
+	if !reflect.DeepEqual(got, base) {
+		t.Fatalf("got %v; want %v (base unchanged when no FIR rules active)", got, base)
+	}
+	if len(checker.Called) != 0 {
+		t.Fatalf("checker.Check should not be invoked with zero FIR rules; got %d invocations", len(checker.Called))
+	}
+}
+
 // filepathIsAbs lets the test assert absolute-path-ness without importing
 // path/filepath at the top (and without colliding if other tests in the
 // package shadow it).


### PR DESCRIPTION
## Summary

- `--depth=thorough` now defaults `--fir=on` so the precision tier exercises every compiler-backed signal krit knows about (source inference, JVM type oracle, targeted-resolution pre-pass, FIR checker).
- Explicit `--fir` / `--no-fir` flags still win — users can opt out of the krit-fir JVM dependency at any depth.
- Adds a `setBoolIfNeitherExplicit` helper for the dual-flag opt-out pattern (mirrors the existing `setBoolIfNotExplicit` for single-flag presets like `--no-type-oracle` at fast depth).
- Skips the FIR JVM subprocess when the active rule set contains zero FIR-eligible rules. Without this guard the new default would start the JVM on every thorough scan even for projects with no FIR rules enabled — a pre-existing wasted-startup that the new default makes much more visible.

`fast` and `balanced` depths are unchanged.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...` — 0 issues
- [x] `make lint-rules`
- [x] `go test ./internal/cli/... ./internal/pipeline/... ./internal/firchecks/... -count=1`
- [ ] `make integration` (CI)

New tests cover thorough-defaults-FIR-on, balanced/fast-leave-it-alone, three explicit-flag-precedence cases (`--no-fir`, `--fir=false`, `--fir`), and the zero-active-rules early return on the FIR pass.