### PR TITLE
test(playground): integration test exercising both custom rules end-to-end

### DIFF
--- a/cmd/krit/testdata/regression/playground-kotlin-webservice.json
+++ b/cmd/krit/testdata/regression/playground-kotlin-webservice.json
@@ -6,9 +6,9 @@
       "rule": "DependenciesInRootProject",
       "ruleSet": "supply-chain",
       "file": "build.gradle.kts",
-      "line": 20,
+      "line": 18,
       "col": 0,
-      "message": "Root project dependencies block declares implementation. Move project dependencies into an owning module or add legitimate root tooling configurations to allowedConfigurations."
+      "message": "Root project dependencies block declares implementation, kritCustomRules. Move project dependencies into an owning module or add legitimate root tooling configurations to allowedConfigurations."
     },
     {
       "rule": "WildcardImport",

--- a/krit-custom-rule-plugin/src/main/kotlin/dev/jasonpearson/krit/custom/KritCustomRulePlugin.kt
+++ b/krit-custom-rule-plugin/src/main/kotlin/dev/jasonpearson/krit/custom/KritCustomRulePlugin.kt
@@ -2,6 +2,7 @@ package dev.jasonpearson.krit.custom
 
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.attributes.Category
 import org.gradle.api.file.DuplicatesStrategy
 import org.gradle.api.plugins.JavaPluginExtension
 import org.gradle.api.tasks.SourceSet
@@ -63,7 +64,7 @@ class KritCustomRulePlugin : Plugin<Project> {
         }
 
         val pluginVersion = BuildConfig.PLUGIN_VERSION
-        project.tasks.register(
+        val kritRuleJarTask = project.tasks.register(
             "kritRuleJar",
             Jar::class.java,
         ) {
@@ -88,6 +89,27 @@ class KritCustomRulePlugin : Plugin<Project> {
                 )
             }
         }
+
+        // Outgoing variant consumed by the host plugin's `kritCustomRules`
+        // resolvable configuration. The Category attribute uses a Krit-specific
+        // value so this bundle is fully decoupled from `runtimeElements` /
+        // `apiElements` — projects expressing
+        //   `dependencies { kritCustomRules(project(":this")) }`
+        // pull the stamped jar directly, without intercepting normal compile
+        // or runtime classpaths.
+        val kritRuleBundleCategory = project.objects.named(
+            Category::class.java,
+            KRIT_RULE_BUNDLE_CATEGORY,
+        )
+        project.configurations.create("kritRuleBundleElements") {
+            isCanBeConsumed = true
+            isCanBeResolved = false
+            description = "Krit custom-rule bundle artifact produced by this module."
+            attributes.attribute(Category.CATEGORY_ATTRIBUTE, kritRuleBundleCategory)
+            outgoing.artifact(kritRuleJarTask.flatMap { it.archiveFile }) {
+                builtBy(kritRuleJarTask)
+            }
+        }
     }
 
     internal companion object {
@@ -95,6 +117,13 @@ class KritCustomRulePlugin : Plugin<Project> {
         internal const val MANIFEST_PLUGIN_VERSION = "Krit-Plugin-Version"
         internal const val MANIFEST_VENDOR_ID = "Krit-Vendor-Id"
         internal const val MANIFEST_DEFAULT_SEVERITY = "Krit-Default-Severity"
+
+        /**
+         * Category attribute value identifying a Krit custom-rule bundle
+         * variant. Must stay in sync with the matching string in
+         * `dev.jasonpearson.krit`'s `KritPlugin`.
+         */
+        internal const val KRIT_RULE_BUNDLE_CATEGORY = "krit-rule-bundle"
 
         // Must track the krit-types daemon's bundled compiler so PSI
         // classes resolve at runtime.

--- a/krit-custom-rule-plugin/src/test/kotlin/dev/jasonpearson/krit/custom/KritCustomRulePluginTest.kt
+++ b/krit-custom-rule-plugin/src/test/kotlin/dev/jasonpearson/krit/custom/KritCustomRulePluginTest.kt
@@ -1,10 +1,12 @@
 package dev.jasonpearson.krit.custom
 
 import org.gradle.api.Project
+import org.gradle.api.attributes.Category
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.bundling.Jar
 import org.gradle.testfixtures.ProjectBuilder
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
@@ -89,6 +91,33 @@ class KritCustomRulePluginTest {
         assertEquals("9.9.9", manifestValue(jar, "Krit-SDK-Version"))
         assertEquals("acme", manifestValue(jar, "Krit-Vendor-Id"))
         assertEquals("error", manifestValue(jar, "Krit-Default-Severity"))
+    }
+
+    @Test
+    fun `kritRuleBundleElements configuration is registered as consumable variant`() {
+        val project = newProject()
+        val config = project.configurations.findByName("kritRuleBundleElements")
+        assertNotNull(config, "kritRuleBundleElements outgoing configuration should be registered")
+        assertTrue(config!!.isCanBeConsumed,
+            "kritRuleBundleElements must be consumable so the host's kritCustomRules can pull it")
+        assertFalse(config.isCanBeResolved,
+            "kritRuleBundleElements is a producer variant; it should not be resolvable")
+        val category = config.attributes.getAttribute(Category.CATEGORY_ATTRIBUTE)
+        assertNotNull(category, "kritRuleBundleElements must declare a Category attribute")
+        assertEquals("krit-rule-bundle", category!!.name)
+    }
+
+    @Test
+    fun `kritRuleBundleElements publishes the stamped kritRuleJar archive`() {
+        val project = newProject()
+        val config = project.configurations.getByName("kritRuleBundleElements")
+        val artifacts = config.outgoing.artifacts
+        assertEquals(1, artifacts.size, "expected exactly one outgoing artifact, was: $artifacts")
+        val artifactFile = artifacts.single().file
+        val expected = (project.tasks.getByName("kritRuleJar") as Jar)
+            .archiveFile.get().asFile
+        assertEquals(expected.absolutePath, artifactFile.absolutePath,
+            "outgoing artifact must be kritRuleJar's stamped archive")
     }
 
     private fun manifestValue(jar: Jar, key: String): String? {

--- a/krit-gradle-plugin/src/main/kotlin/dev/jasonpearson/krit/gradle/KritExtension.kt
+++ b/krit-gradle-plugin/src/main/kotlin/dev/jasonpearson/krit/gradle/KritExtension.kt
@@ -2,6 +2,7 @@ package dev.jasonpearson.krit.gradle
 
 import org.gradle.api.Action
 import org.gradle.api.Project
+import org.gradle.api.UnknownTaskException
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
@@ -26,7 +27,10 @@ import javax.inject.Inject
  * }
  * ```
  */
-abstract class KritExtension @Inject constructor(objects: ObjectFactory) {
+abstract class KritExtension @Inject constructor(
+    private val project: Project,
+    objects: ObjectFactory,
+) {
 
     /** Krit binary version to download. Default: plugin's bundled version constant. */
     abstract val toolVersion: Property<String>
@@ -75,11 +79,31 @@ abstract class KritExtension @Inject constructor(objects: ObjectFactory) {
         action.execute(reports)
     }
 
-    /** Add Kotlin custom-rule jars or projects that produce a jar task. */
+    /**
+     * Add Kotlin custom-rule jars or projects that produce a jar task.
+     *
+     * For `Project` notations, prefers `kritRuleJar` (the stamped archive
+     * registered by `dev.jasonpearson.krit.custom`) over the default `jar`
+     * task — only the former carries the `Krit-SDK-Version` / `Krit-Vendor-Id`
+     * manifest attributes the daemon reads. The sibling project is configured
+     * before lookup so its lazily registered tasks are visible.
+     *
+     * Prefer the variant-aware form for project deps:
+     * ```
+     * dependencies { kritCustomRules(project(":custom-rules")) }
+     * ```
+     * which routes through Gradle's dependency graph instead of cross-project
+     * task lookup.
+     */
     fun customRules(vararg notations: Any) {
         notations.forEach { notation ->
             if (notation is Project) {
-                val jarTask = notation.tasks.named("jar", Jar::class.java)
+                project.evaluationDependsOn(notation.path)
+                val jarTask = try {
+                    notation.tasks.named("kritRuleJar", Jar::class.java)
+                } catch (_: UnknownTaskException) {
+                    notation.tasks.named("jar", Jar::class.java)
+                }
                 customRuleJars.from(jarTask.flatMap { it.archiveFile })
                 customRuleJars.builtBy(jarTask)
             } else {

--- a/krit-gradle-plugin/src/main/kotlin/dev/jasonpearson/krit/gradle/KritPlugin.kt
+++ b/krit-gradle-plugin/src/main/kotlin/dev/jasonpearson/krit/gradle/KritPlugin.kt
@@ -2,6 +2,7 @@ package dev.jasonpearson.krit.gradle
 
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.attributes.Category
 import org.gradle.api.plugins.ReportingBasePlugin
 import java.io.File
 
@@ -36,7 +37,28 @@ class KritPlugin : Plugin<Project> {
     override fun apply(project: Project) {
         project.pluginManager
 
-        val extension = project.extensions.create("krit", KritExtension::class.java)
+        val extension = project.extensions.create("krit", KritExtension::class.java, project)
+
+        // Resolvable configuration for declaring custom-rule producers as
+        // project dependencies, e.g. `dependencies { kritCustomRules(project(":rules")) }`.
+        // Matches the outgoing variant published by `dev.jasonpearson.krit.custom`,
+        // so the stamped `kritRuleJar` archive flows through Gradle's dependency
+        // graph (proper task wiring, no cross-project `evaluationDependsOn`).
+        val kritRuleBundleCategory = project.objects.named(
+            Category::class.java,
+            KRIT_RULE_BUNDLE_CATEGORY,
+        )
+        val customRulesConfiguration = project.configurations.create("kritCustomRules") {
+            isCanBeConsumed = false
+            isCanBeResolved = true
+            description = "Krit custom-rule bundles to load into the kritCheck analysis."
+            attributes.attribute(Category.CATEGORY_ATTRIBUTE, kritRuleBundleCategory)
+        }
+
+        // Fold resolved bundles from `kritCustomRules` into the extension's
+        // jar collection so they flow into kritCheck/kritBaseline like any
+        // explicit `customRules(file(...))` entry.
+        extension.customRuleJars.from(customRulesConfiguration)
 
         // Set conventions (defaults)
         extension.toolVersion.convention(KRIT_DEFAULT_VERSION)
@@ -304,5 +326,12 @@ class KritPlugin : Plugin<Project> {
 
     companion object {
         const val KRIT_DEFAULT_VERSION = "0.2.0"
+
+        /**
+         * Category attribute value identifying a Krit custom-rule bundle
+         * variant. Must stay in sync with the matching string in
+         * `dev.jasonpearson.krit.custom`'s `KritCustomRulePlugin`.
+         */
+        const val KRIT_RULE_BUNDLE_CATEGORY = "krit-rule-bundle"
     }
 }

--- a/krit-gradle-plugin/src/test/kotlin/dev/jasonpearson/krit/gradle/KritPluginTest.kt
+++ b/krit-gradle-plugin/src/test/kotlin/dev/jasonpearson/krit/gradle/KritPluginTest.kt
@@ -1,6 +1,8 @@
 package dev.jasonpearson.krit.gradle
 
 import org.gradle.api.Project
+import org.gradle.api.attributes.Category
+import org.gradle.api.tasks.bundling.Jar
 import org.gradle.testfixtures.ProjectBuilder
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
@@ -342,5 +344,82 @@ class KritPluginTest {
         args.appendCustomRuleJarArgs(listOf("/jars/a.jar"))
         assertEquals(1, args.count { it == "--daemon" },
             "--daemon should not be duplicated, was: $args")
+    }
+
+    // --- kritCustomRules resolvable configuration (variant-aware wiring) ---
+
+    @Test
+    fun `kritCustomRules configuration is registered with krit-rule-bundle category`() {
+        val project = newProject()
+        val config = project.configurations.findByName("kritCustomRules")
+        assertNotNull(config, "kritCustomRules configuration should be registered")
+        assertFalse(config!!.isCanBeConsumed,
+            "kritCustomRules should not be consumable — it's a resolver, not a publisher")
+        assertTrue(config.isCanBeResolved,
+            "kritCustomRules should be resolvable so it can read variant artifacts")
+        val category = config.attributes.getAttribute(Category.CATEGORY_ATTRIBUTE)
+        assertNotNull(category, "kritCustomRules must declare a Category attribute")
+        assertEquals(KritPlugin.KRIT_RULE_BUNDLE_CATEGORY, category!!.name)
+    }
+
+    @Test
+    fun `files added to kritCustomRules flow into extension customRuleJars`() {
+        val project = newProject()
+        val fakeJar = File(projectDir, "fake.jar").apply { writeText("not a real jar") }
+
+        project.dependencies.add("kritCustomRules", project.files(fakeJar))
+
+        val extension = project.extensions.getByType(KritExtension::class.java)
+        assertTrue(extension.customRuleJars.files.contains(fakeJar),
+            "files declared on the kritCustomRules dep config must appear in customRuleJars")
+
+        val task = project.tasks.getByName("kritCheck") as KritCheckTask
+        assertTrue(task.customRuleJars.files.contains(fakeJar),
+            "kritCheck task must inherit the resolved jars too")
+    }
+
+    // --- customRules(Project) prefers kritRuleJar over default jar ---
+
+    @Test
+    fun `customRules(Project) prefers kritRuleJar when present`() {
+        val project = newProject()
+        val producer = ProjectBuilder.builder()
+            .withParent(project)
+            .withName("producer")
+            .build()
+        producer.pluginManager.apply("java")
+        val stampedJar = producer.tasks.register("kritRuleJar", Jar::class.java) {
+            archiveClassifier.set("krit-rules")
+        }
+
+        val extension = project.extensions.getByType(KritExtension::class.java)
+        extension.customRules(producer)
+
+        val expected = stampedJar.flatMap { it.archiveFile }.get().asFile
+        assertTrue(extension.customRuleJars.files.contains(expected),
+            "customRules(project) must pick up kritRuleJar's archive, was: ${extension.customRuleJars.files}")
+        val plainJar = producer.tasks.named("jar", Jar::class.java)
+            .flatMap { it.archiveFile }.get().asFile
+        assertFalse(extension.customRuleJars.files.contains(plainJar),
+            "must not also include the default unstamped jar")
+    }
+
+    @Test
+    fun `customRules(Project) falls back to jar when kritRuleJar absent`() {
+        val project = newProject()
+        val producer = ProjectBuilder.builder()
+            .withParent(project)
+            .withName("producer")
+            .build()
+        producer.pluginManager.apply("java")
+        // No kritRuleJar registered — the default jar should win.
+
+        val extension = project.extensions.getByType(KritExtension::class.java)
+        extension.customRules(producer)
+
+        val plainJar = producer.tasks.named("jar", Jar::class.java)
+            .flatMap { it.archiveFile }.get().asFile
+        assertTrue(extension.customRuleJars.files.contains(plainJar),
+            "without kritRuleJar, customRules(project) must fall back to the default jar")
     }
 }

--- a/playground/custom-rules/README.md
+++ b/playground/custom-rules/README.md
@@ -37,28 +37,33 @@ avoid common lexical false positives.
    `Krit-SDK-Version`, `Krit-Plugin-Version`, `Krit-Vendor-Id`
    (`playground`), and `Krit-Default-Severity` (`warning`).
 
+5. Publishes the stamped jar as an outgoing variant
+   (`kritRuleBundleElements`, with a Krit-specific `Category` attribute) so
+   host projects can consume it through Gradle's dependency graph.
+
 The host (`kotlin-webservice`) then wires the produced jar into
-`kritCheck` via:
+`kritCheck` via the `kritCustomRules` resolvable configuration that
+`dev.jasonpearson.krit` registers:
 
 ```kotlin
-val customRulesJar = project(":custom-rules").tasks.named("kritRuleJar", Jar::class.java)
-
-krit {
-    customRules(customRulesJar.flatMap { it.archiveFile })
+dependencies {
+    kritCustomRules(project(":custom-rules"))
 }
 ```
 
 This automatically builds `:custom-rules:kritRuleJar` before each
 `kritCheck` and passes the jar to the krit CLI through
 `--custom-rule-jars` (forcing `--daemon` on, as the JVM-loaded rule path
-requires the daemon).
+requires the daemon). The matching `Category` attribute on both sides
+means the consumer cannot accidentally pick up a project's normal
+`runtimeElements` jar — the daemon-stamped variant is the only thing the
+host configuration will resolve.
 
-> **Note**: the default `jar` task that ships with `kotlin("jvm")` is **not**
-> the one we want — only `kritRuleJar` bakes in the generated
-> `META-INF/services/dev.jasonpearson.krit.api.KritRule` file and the
-> `Krit-SDK-Version` / `Krit-Vendor-Id` / `Krit-Default-Severity` manifest
-> attributes that the krit daemon expects. Reference the stamped task
-> directly rather than calling `customRules(project(":custom-rules"))`.
+> **Alternatives** for one-off setups: `krit { customRules(file(...)) }`
+> accepts raw jars or task outputs, and `krit { customRules(project(":foo")) }`
+> resolves the project's `kritRuleJar` when present (falling back to its `jar`
+> task). Both bypass the dependency graph, so prefer `kritCustomRules` for
+> project deps.
 
 ## Running it
 

--- a/playground/kotlin-webservice/build.gradle.kts
+++ b/playground/kotlin-webservice/build.gradle.kts
@@ -1,5 +1,3 @@
-import org.gradle.api.tasks.bundling.Jar
-
 plugins {
     kotlin("jvm") version "2.3.21"
     application
@@ -22,22 +20,15 @@ dependencies {
     implementation("io.ktor:ktor-server-netty:3.4.3")
     implementation("io.ktor:ktor-server-content-negotiation:3.4.3")
     implementation("io.ktor:ktor-serialization-kotlinx-json:3.4.3")
-}
 
-// `kritRuleJar` (provided by dev.jasonpearson.krit.custom) is the stamped jar
-// that contains both the generated `META-INF/services/...KritRule` file and the
-// `Krit-SDK-Version` / `Krit-Vendor-Id` manifest attributes that the krit
-// daemon reads at load time. The default `jar` task from kotlin("jvm") does
-// not include those, so consume the stamped jar explicitly. The
-// `evaluationDependsOn` call ensures :custom-rules has registered its tasks
-// before we look up `kritRuleJar`.
-evaluationDependsOn(":custom-rules")
-val customRulesJar = project(":custom-rules").tasks.named("kritRuleJar", Jar::class.java)
+    // `dev.jasonpearson.krit.custom` publishes a `krit-rule-bundle` variant
+    // here; the host plugin's `kritCustomRules` configuration resolves it.
+    kritCustomRules(project(":custom-rules"))
+}
 
 krit {
     config.set(file("krit.yml"))
     ignoreFailures.set(true)
-    customRules(customRulesJar.flatMap { it.archiveFile })
 
     // Use the krit binary built from this checkout (`make build` or
     // `go build -o krit ./cmd/krit/` at the repo root) so the demo does not


### PR DESCRIPTION
## Summary

\`tests/playgroundrules/playground_rules_test.go\` builds the \`:custom-rules:kritRuleJar\` artifact via the playground's gradlew (composite-builds krit-gradle-plugin / krit-custom-rule-plugin / krit-rule-api / krit-settings-plugin from local source — no mavenLocal staging needed) and runs the krit CLI's \`--custom-rule-jars\` flag directly against the kotlin-webservice sources.

Two subtests:

1. **\`--list-rules\` surfaces both rules with the plugin marker** — confirms \`playground.NoHardcodedSecret\` and \`playground.NoTodoComment\` are visible to the CLI with the \` P \` plugin-loaded marker column.
2. **\`kritCheck\` JSON output contains exactly the expected findings:**
   - \`NoHardcodedSecret\` on \`Constants.kt:26\` (\`DATABASE_PASSWORD\`) and \`Constants.kt:28\` (\`JWT_SECRET\`).
   - And *not* on the numeric \`MIN_PASSWORD_LENGTH\` / \`MAX_PASSWORD_LENGTH\` at lines 11-12 (validates the regex's string-literal value gate).
   - \`NoTodoComment\` on \`Application.kt:10\` (the TODO comment).

Mirrors \`tests/externalrule/external_rule_test.go\`'s gate-and-skip pattern: skips when \`java\` is missing from PATH or \`krit-types.jar\` cannot be located. A dedicated \`playground-rules\` CI job stages krit-types.jar (shared cache with \`external-rule-example\`) and runs the test for real.

## Drive-by cleanup

Hoists the krit-types cache-key glob into a workflow-level \`KRIT_TYPES_CACHE_KEY\` env so the two consumer jobs cannot drift on the hashFiles input. Surfaced by /simplify review.

## Follow-up (out of scope)

Once a third integration test appears, extract \`tests/internal/kritbin\` for the byte-identical \`repoRoot\` / \`buildKritBinary\` / \`runKrit\` / \`mustAbs\` helpers in \`tests/externalrule\` and \`tests/playgroundrules\`. Two callers is borderline by rule-of-three; three will tip the scale.

## Test plan

- [x] \`go vet ./...\` — clean.
- [x] \`golangci-lint run ./...\` — 0 issues (gofmt drift fixed once during iteration).
- [x] \`go test ./tests/playgroundrules/ -short\` skips cleanly without \`krit-types.jar\`.
- [x] \`KRIT_TYPES_JAR=… go test ./tests/playgroundrules/ -count=1\` passes (both subtests, ~65s).
- [x] \`go test ./... -count=1 -short\` — full suite green.
- [x] Both subtests assert *exact* finding sets (no over-/under-reporting).