### PR TITLE
fix(rules): UnusedParameter no longer false-flags for-iterable receivers and soft-keyword params

### DIFF
--- a/internal/rules/style_unused.go
+++ b/internal/rules/style_unused.go
@@ -91,7 +91,45 @@ func unusedParameterUsageFlat(file *scanner.File, scope uint32, paramIdx uint32,
 			break
 		}
 	}
+	if !used && !unknown && unusedParameterErrorSubtreeMentionsNameFlat(file, scope, paramName) {
+		unknown = true
+	}
 	return used, unknown
+}
+
+// unusedParameterErrorSubtreeMentionsNameFlat reports whether any ERROR node
+// inside scope contains a descendant whose text equals name. Tree-sitter-kotlin
+// mis-parses identifiers that collide with Kotlin soft keywords
+// (`annotation`, `field`, `value`, `dynamic`, etc.) when they appear in
+// receiver position before `.`, classifying the name under an ERROR subtree
+// instead of a simple_identifier — so the body walk over simple_identifier
+// nodes never sees the use. Treat any such mention as unknown to suppress the
+// false positive.
+func unusedParameterErrorSubtreeMentionsNameFlat(file *scanner.File, scope uint32, name string) bool {
+	if file == nil || scope == 0 || name == "" {
+		return false
+	}
+	// Posting-list-backed fast path: most Kotlin files have no ERROR nodes,
+	// so the per-parameter recursive scope walk below can be skipped entirely.
+	errorTypeID, ok := scanner.LookupFlatNodeType("ERROR")
+	if !ok || file.FlatTree == nil || len(file.FlatTree.NodesOfType(errorTypeID)) == 0 {
+		return false
+	}
+	mentioned := false
+	file.FlatWalkNodes(scope, "ERROR", func(errNode uint32) {
+		if mentioned {
+			return
+		}
+		file.FlatWalkAllNodes(errNode, func(child uint32) {
+			if mentioned || child == errNode {
+				return
+			}
+			if file.FlatNodeTextEquals(child, name) {
+				mentioned = true
+			}
+		})
+	})
+	return mentioned
 }
 
 func unusedParameterResolveReferenceFlat(file *scanner.File, scope uint32, paramIdx uint32, ref uint32, paramName string, paramIsFunctionType bool) unusedParameterReferenceMatch {
@@ -244,8 +282,15 @@ func unusedParameterLambdaDeclaresNameFlat(file *scanner.File, lambda uint32, na
 	return false
 }
 
+// unusedParameterForDeclaresNameFlat reports whether the for-statement's loop
+// variable binds name. Only children positioned before the `in` keyword
+// count — the iterable expression that follows `in` is also a direct child
+// and must not be treated as a declaration.
 func unusedParameterForDeclaresNameFlat(file *scanner.File, forStmt uint32, name string) bool {
 	for child := file.FlatFirstChild(forStmt); child != 0; child = file.FlatNextSib(child) {
+		if !file.FlatIsNamed(child) && file.FlatType(child) == "in" {
+			return false
+		}
 		switch file.FlatType(child) {
 		case "simple_identifier":
 			if file.FlatNodeTextEquals(child, name) {

--- a/internal/rules/style_unused_internal_test.go
+++ b/internal/rules/style_unused_internal_test.go
@@ -1,0 +1,127 @@
+package rules
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/kaeawc/krit/internal/scanner"
+)
+
+func firstFlatNode(file *scanner.File, nodeType string) uint32 {
+	var first uint32
+	file.FlatWalkNodes(0, nodeType, func(idx uint32) {
+		if first == 0 {
+			first = idx
+		}
+	})
+	return first
+}
+
+// TestUnusedParameterForDeclaresNameFlat_IterableNotADeclaration locks the
+// helper that decides whether a for-statement's loop variable binds a given
+// name. The iterable expression after `in` is also a child of the
+// for_statement, so a naive scan over all children would mistake the iterable
+// for the loop variable and silently shadow the outer parameter.
+func TestUnusedParameterForDeclaresNameFlat_IterableNotADeclaration(t *testing.T) {
+	file := parseInlineForInternalTest(t, `package test
+fun process(params: List<String>) {
+    for (param in params) {
+        println(param)
+    }
+}
+`)
+	forStmt := firstFlatNode(file, "for_statement")
+	if forStmt == 0 {
+		t.Fatal("expected to find a for_statement in fixture")
+	}
+
+	if !unusedParameterForDeclaresNameFlat(file, forStmt, "param") {
+		t.Errorf("for-statement should declare its loop variable %q", "param")
+	}
+	if unusedParameterForDeclaresNameFlat(file, forStmt, "params") {
+		t.Errorf("for-statement must not be treated as declaring iterable name %q", "params")
+	}
+	if unusedParameterForDeclaresNameFlat(file, forStmt, "println") {
+		t.Errorf("for-statement should not declare unrelated name %q", "println")
+	}
+}
+
+// TestUnusedParameterForDeclaresNameFlat_DestructuringLoopVar pins the
+// multi_variable_declaration branch — for ((k, v) in entries) — so a future
+// refactor cannot silently regress destructured-name shadowing while keeping
+// the iterable-name fix intact.
+func TestUnusedParameterForDeclaresNameFlat_DestructuringLoopVar(t *testing.T) {
+	file := parseInlineForInternalTest(t, `package test
+fun process(entries: Map<String, String>) {
+    for ((k, v) in entries) {
+        println("$k=$v")
+    }
+}
+`)
+	forStmt := firstFlatNode(file, "for_statement")
+	if forStmt == 0 {
+		t.Fatal("expected to find a for_statement in fixture")
+	}
+	if !unusedParameterForDeclaresNameFlat(file, forStmt, "k") {
+		t.Errorf("destructured loop var %q should be treated as declared", "k")
+	}
+	if !unusedParameterForDeclaresNameFlat(file, forStmt, "v") {
+		t.Errorf("destructured loop var %q should be treated as declared", "v")
+	}
+	if unusedParameterForDeclaresNameFlat(file, forStmt, "entries") {
+		t.Errorf("iterable %q must not be treated as a loop declaration", "entries")
+	}
+}
+
+// TestUnusedParameterErrorSubtreeMentionsNameFlat_SoftKeywordReceiver locks
+// the fallback used when tree-sitter-kotlin mis-parses a soft-keyword
+// identifier (e.g. `annotation`) as a class_modifier under an ERROR subtree.
+// Without the fallback the body walk over simple_identifier nodes never sees
+// the usage and the parameter is reported as unused.
+func TestUnusedParameterErrorSubtreeMentionsNameFlat_SoftKeywordReceiver(t *testing.T) {
+	file := parseInlineForInternalTest(t, `package test
+class KSAnnotation { fun process() {} }
+fun foo(annotation: KSAnnotation) {
+    annotation.process()
+}
+`)
+	// Pick the function_body of foo() — the one that contains the
+	// `annotation.process()` call; the empty stub body of process() must be
+	// skipped or the ERROR subtree won't be in scope.
+	var body uint32
+	file.FlatWalkNodes(0, "function_body", func(idx uint32) {
+		if body == 0 && strings.Contains(file.FlatNodeText(idx), "annotation.process") {
+			body = idx
+		}
+	})
+	if body == 0 {
+		t.Fatal("expected to find foo()'s function_body in fixture")
+	}
+
+	if !unusedParameterErrorSubtreeMentionsNameFlat(file, body, "annotation") {
+		t.Errorf("ERROR fallback should mention soft-keyword param name %q", "annotation")
+	}
+	if unusedParameterErrorSubtreeMentionsNameFlat(file, body, "missing") {
+		t.Errorf("ERROR fallback must not invent a mention of unrelated name %q", "missing")
+	}
+	if unusedParameterErrorSubtreeMentionsNameFlat(file, body, "") {
+		t.Errorf("empty name must never be reported as mentioned")
+	}
+}
+
+// TestUnusedParameterErrorSubtreeMentionsNameFlat_NoErrorReturnsFalse pins
+// the posting-list fast path: well-parsed bodies must skip the ERROR walk.
+func TestUnusedParameterErrorSubtreeMentionsNameFlat_NoErrorReturnsFalse(t *testing.T) {
+	file := parseInlineForInternalTest(t, `package test
+fun foo(name: String) {
+    println(name)
+}
+`)
+	body := firstFlatNode(file, "function_body")
+	if body == 0 {
+		t.Fatal("expected function_body")
+	}
+	if unusedParameterErrorSubtreeMentionsNameFlat(file, body, "name") {
+		t.Errorf("well-parsed body must not produce ERROR-fallback mentions")
+	}
+}

--- a/internal/rules/style_unused_test.go
+++ b/internal/rules/style_unused_test.go
@@ -329,6 +329,88 @@ fun onEvent(event: String) {
 			wantHits: 0,
 		},
 		{
+			name: "for-loop iterable references function parameter",
+			code: `
+package test
+fun process(params: List<String>) {
+    for (param in params) {
+        println(param)
+    }
+}
+`,
+			wantHits: 0,
+		},
+		{
+			name: "for-loop iterable inside parenthesized expression",
+			code: `
+package test
+fun process(params: List<String>) {
+    for (param in (params)) {
+        println(param)
+    }
+}
+`,
+			wantHits: 0,
+		},
+		{
+			name: "for-loop iterable via member call on parameter",
+			code: `
+package test
+fun process(items: List<String>) {
+    for (item in items.asReversed()) {
+        println(item)
+    }
+}
+`,
+			wantHits: 0,
+		},
+		{
+			name: "for-loop with destructuring iterates over parameter",
+			code: `
+package test
+fun process(entries: Map<String, String>) {
+    for ((k, v) in entries) {
+        println("$k=$v")
+    }
+}
+`,
+			wantHits: 0,
+		},
+		{
+			name: "soft-keyword param used as receiver (annotation)",
+			code: `
+package test
+class KSAnnotation { fun process() {} }
+fun foo(annotation: KSAnnotation) {
+    annotation.process()
+}
+`,
+			wantHits: 0,
+		},
+		{
+			name: "soft-keyword param used as receiver (field)",
+			code: `
+package test
+class Field { fun read() {} }
+fun foo(field: Field) {
+    field.read()
+}
+`,
+			wantHits: 0,
+		},
+		{
+			name: "for-loop variable named same as parameter is flagged",
+			code: `
+package test
+fun process(item: String) {
+    for (item in listOf("a")) {
+        println(item)
+    }
+}
+`,
+			wantHits: 1,
+		},
+		{
 			name: "allowed name is excluded",
 			code: `
 package test

--- a/tests/fixtures/negative/style/UnusedParameter.kt
+++ b/tests/fixtures/negative/style/UnusedParameter.kt
@@ -74,3 +74,25 @@ fun subscribed(event: String) {
 fun placeholders(ignored: String, expected: Int, _: Boolean) {
     println("allowed names")
 }
+
+fun forLoopIterableReference(params: List<String>) {
+    for (param in params) {
+        println(param)
+    }
+}
+
+fun forLoopDestructuredOverParameter(entries: Map<String, String>) {
+    for ((k, v) in entries) {
+        println("$k=$v")
+    }
+}
+
+class KSAnnotation {
+    fun process() {}
+}
+
+// Soft-keyword param name (`annotation`) used as receiver — tree-sitter
+// mis-parse handled via ERROR-mention fallback.
+fun receivesSoftKeywordParam(annotation: KSAnnotation) {
+    annotation.process()
+}

--- a/tests/fixtures/positive/style/UnusedParameter.kt
+++ b/tests/fixtures/positive/style/UnusedParameter.kt
@@ -24,3 +24,9 @@ fun shadowedByNestedFunction(id: String) {
     }
     nested("local")
 }
+
+fun shadowedByForLoopVariable(item: String) {
+    for (item in listOf("a")) {
+        println(item)
+    }
+}


### PR DESCRIPTION
## Summary

Fixes two UnusedParameter false positives:

- **`for (x in PARAM)` iterable was treated as a loop-variable shadow.** The
  iterable expression is a direct `simple_identifier` child of `for_statement`
  in tree-sitter-kotlin. The shadow helper walked all children looking for a
  name match, so any iterable named the same as the parameter (`params`,
  `keys`, `shards`, `separators`, `injectFunctions`, `bindsCallables`, ...)
  silently shadowed the outer parameter and the rule reported it unused.
  Helper now stops at the `in` keyword.

- **Soft-keyword parameter names used as receivers** (`fun foo(annotation: KSAnnotation) { annotation.process() }`)
  were missed entirely. Tree-sitter-kotlin mis-parses such receivers under an
  ERROR subtree as a `class_modifier`/`annotation` node, so the body walk over
  `simple_identifier` nodes never saw the use. Added an ERROR-subtree
  fallback that marks usage as unknown when any descendant text equals the
  parameter name. Gated by a posting-list fast path — clean files pay nothing.

## Test plan

- [x] Helper unit tests pin both invariants directly
      (`unusedParameterForDeclaresNameFlat`, `unusedParameterErrorSubtreeMentionsNameFlat`)
- [x] Table-driven end-to-end sub-tests cover loop-iterable, parenthesised
      iterable, member-call iterable, destructured loop, soft-keyword receiver,
      and a positive case where the loop var legitimately shadows the param
- [x] Positive / negative fixtures added under `tests/fixtures/{positive,negative}/style/UnusedParameter.kt`
- [x] `make ci` green (build + vet + lint + tests + integration + regression)