### PR TITLE
feat(rules): ThoroughOnlyNeeds capability gating for thorough depth

### DIFF
--- a/internal/pipeline/project.go
+++ b/internal/pipeline/project.go
@@ -585,6 +585,7 @@ func RunProjectStreaming(ctx context.Context, in ProjectInput, out io.Writer) (P
 	if err != nil {
 		return ProjectResult{}, err
 	}
+	in.Args.ActiveRules = api.ResolveActiveRulesAtDepth(in.Args.ActiveRules, in.Args.TargetedResolution)
 	args := in.Args
 	host := in.Host
 
@@ -666,6 +667,7 @@ func RunProjectAnalysis(ctx context.Context, in ProjectInput) (ProjectAnalysisRe
 	if _, _, err := validateAndDefaultStreaming(ctx, in, io.Discard); err != nil {
 		return ProjectAnalysisResult{}, err
 	}
+	in.Args.ActiveRules = api.ResolveActiveRulesAtDepth(in.Args.ActiveRules, in.Args.TargetedResolution)
 	args := in.Args
 	host := awaitAnalysisCacheFuture(in.Host)
 	hits0, misses0 := parseCacheCounters(host.ParseCache)

--- a/internal/rules/api/depth.go
+++ b/internal/rules/api/depth.go
@@ -1,0 +1,35 @@
+package api
+
+// ResolveActiveRulesAtDepth returns the input slice unchanged when
+// thorough is false or no rule opts in via ThoroughOnlyNeeds. Otherwise
+// it returns a new slice where opted-in rules are shallow copies with
+// `Needs |= ThoroughOnlyNeeds` and `ThoroughOnlyNeeds = 0` (so the
+// projection is idempotent); other entries share the original pointer.
+//
+// The clone-vs-mutate split exists because the global Registry is
+// shared across scans — daemon mode runs balanced and thorough requests
+// against the same Rule pointers and must not leak extra Needs bits
+// across calls.
+func ResolveActiveRulesAtDepth(rules []*Rule, thorough bool) []*Rule {
+	if !thorough || len(rules) == 0 {
+		return rules
+	}
+	var out []*Rule
+	for i, r := range rules {
+		if r == nil || r.ThoroughOnlyNeeds == 0 {
+			continue
+		}
+		if out == nil {
+			out = make([]*Rule, len(rules))
+			copy(out, rules)
+		}
+		cp := *r
+		cp.Needs |= r.ThoroughOnlyNeeds
+		cp.ThoroughOnlyNeeds = 0
+		out[i] = &cp
+	}
+	if out == nil {
+		return rules
+	}
+	return out
+}

--- a/internal/rules/api/depth_test.go
+++ b/internal/rules/api/depth_test.go
@@ -1,0 +1,105 @@
+package api
+
+import (
+	"testing"
+)
+
+func TestResolveActiveRulesAtDepth_NotThoroughIsIdentity(t *testing.T) {
+	rules := []*Rule{
+		{ID: "A", Needs: NeedsResolver},
+		{ID: "B", Needs: NeedsResolver, ThoroughOnlyNeeds: NeedsOracleExprType},
+	}
+	got := ResolveActiveRulesAtDepth(rules, false)
+	if &got[0] != &rules[0] || len(got) != len(rules) {
+		t.Fatalf("expected the original slice header back; got %v", got)
+	}
+	if got[1].Needs != NeedsResolver {
+		t.Fatalf("expected Needs untouched at non-thorough depth; got %v", got[1].Needs)
+	}
+}
+
+func TestResolveActiveRulesAtDepth_ThoroughButNoOptIn(t *testing.T) {
+	rules := []*Rule{
+		{ID: "A", Needs: NeedsResolver},
+		{ID: "B", Needs: NeedsResolver},
+	}
+	got := ResolveActiveRulesAtDepth(rules, true)
+	if &got[0] != &rules[0] {
+		t.Fatalf("expected original slice when no rule opts in")
+	}
+}
+
+func TestResolveActiveRulesAtDepth_ThoroughClonesOptedInRules(t *testing.T) {
+	a := &Rule{ID: "A", Needs: NeedsResolver}
+	b := &Rule{ID: "B", Needs: NeedsResolver, ThoroughOnlyNeeds: NeedsOracleExprType}
+	c := &Rule{ID: "C", Needs: NeedsCrossFile, ThoroughOnlyNeeds: NeedsOracleSupertypes | NeedsOracleClassAnnotations}
+
+	got := ResolveActiveRulesAtDepth([]*Rule{a, b, c}, true)
+
+	if got[0] != a {
+		t.Errorf("rule without ThoroughOnlyNeeds should keep its pointer; got %p, want %p", got[0], a)
+	}
+	if got[1] == b {
+		t.Errorf("rule with ThoroughOnlyNeeds must be cloned, not mutated in place")
+	}
+	if got[1].Needs != NeedsResolver|NeedsOracleExprType {
+		t.Errorf("expected Needs=%v; got %v", NeedsResolver|NeedsOracleExprType, got[1].Needs)
+	}
+	wantC := NeedsCrossFile | NeedsOracleSupertypes | NeedsOracleClassAnnotations
+	if got[2].Needs != wantC {
+		t.Errorf("expected Needs=%v; got %v", wantC, got[2].Needs)
+	}
+}
+
+// Daemon-mode invariant: the helper must not mutate Registry pointers.
+func TestResolveActiveRulesAtDepth_RegistryRulesNotMutated(t *testing.T) {
+	b := &Rule{ID: "B", Needs: NeedsResolver, ThoroughOnlyNeeds: NeedsOracleExprType}
+	originalNeeds := b.Needs
+	originalThorough := b.ThoroughOnlyNeeds
+
+	_ = ResolveActiveRulesAtDepth([]*Rule{b}, true)
+
+	if b.Needs != originalNeeds || b.ThoroughOnlyNeeds != originalThorough {
+		t.Fatalf("input rule mutated: Needs %v→%v, ThoroughOnlyNeeds %v→%v",
+			originalNeeds, b.Needs, originalThorough, b.ThoroughOnlyNeeds)
+	}
+}
+
+// Idempotency: calling the helper on its own output must be free —
+// both pipeline entry points (RunProjectStreaming and RunProjectAnalysis)
+// project rules, and the streaming path runs the helper before passing
+// args downstream to the analysis path. The second call must observe
+// already-projected rules (ThoroughOnlyNeeds==0 on the clones) and
+// return the input slice unchanged.
+func TestResolveActiveRulesAtDepth_IsIdempotent(t *testing.T) {
+	rules := []*Rule{{ID: "B", Needs: NeedsResolver, ThoroughOnlyNeeds: NeedsOracleExprType}}
+
+	first := ResolveActiveRulesAtDepth(rules, true)
+	if first[0].ThoroughOnlyNeeds != 0 {
+		t.Fatalf("clone should have ThoroughOnlyNeeds zeroed; got %v", first[0].ThoroughOnlyNeeds)
+	}
+	second := ResolveActiveRulesAtDepth(first, true)
+	if &second[0] != &first[0] {
+		t.Fatalf("second call should return the same slice; allocations are wasted work")
+	}
+}
+
+func TestResolveActiveRulesAtDepth_NilEntriesPassThrough(t *testing.T) {
+	b := &Rule{ID: "B", Needs: NeedsResolver, ThoroughOnlyNeeds: NeedsOracleExprType}
+	got := ResolveActiveRulesAtDepth([]*Rule{nil, b, nil}, true)
+	if got[0] != nil || got[2] != nil {
+		t.Fatalf("nil entries should pass through unchanged; got %v", got)
+	}
+	if got[1].Needs != NeedsResolver|NeedsOracleExprType {
+		t.Fatalf("expected ORed Needs on opted-in rule; got %v", got[1].Needs)
+	}
+}
+
+func TestResolveActiveRulesAtDepth_EmptyInput(t *testing.T) {
+	if got := ResolveActiveRulesAtDepth(nil, true); got != nil {
+		t.Fatalf("nil input should return nil; got %v", got)
+	}
+	if got := ResolveActiveRulesAtDepth([]*Rule{}, true); len(got) != 0 {
+		t.Fatalf("empty input should return empty slice; got %v", got)
+	}
+}

--- a/internal/rules/api/rule.go
+++ b/internal/rules/api/rule.go
@@ -824,6 +824,12 @@ type Rule struct {
 	NodeTypes []string     // nil + no NeedsLinePass means every AST node; nil + NeedsLinePass means line rule
 	Needs     Capabilities // zero → no extra deps
 
+	// ThoroughOnlyNeeds layers extra capability bits onto Needs only
+	// when running at --depth=thorough. Projection happens once at
+	// pipeline entry via ResolveActiveRulesAtDepth; the global Registry
+	// is not mutated.
+	ThoroughOnlyNeeds Capabilities
+
 	// LexicalCalleeNames narrows call_expression dispatch to calls whose
 	// syntactic callee name matches one of these names. It is intentionally
 	// lexical and AST-only; semantic call-target filtering for the Kotlin


### PR DESCRIPTION
## Summary

- Adds `ThoroughOnlyNeeds Capabilities` field on `api.Rule`. A rule can list extra oracle capability bits (e.g. `NeedsOracleExprType`, `NeedsOracleSupertypes`) that should only apply when scanning at `--depth=thorough`. At balanced/fast the field is inert and the rule pays no extra cost.
- New helper `api.ResolveActiveRulesAtDepth(rules, thorough)` projects effective Needs once at pipeline entry:
  - Returns the input slice unchanged when `thorough==false` or no rule opts in (no allocation, identity preserved).
  - Otherwise shallow-clones only the opted-in rules and zeros `ThoroughOnlyNeeds` on the clone so projection is **idempotent** — both `RunProjectStreaming` and `RunProjectAnalysis` need the projected view (the streaming path's bundle-fingerprint reads `args.ActiveRules` before reaching `RunProjectAnalysis`, so each entry must project independently), and the second call is a no-op.
  - Never mutates the global Registry — critical for daemon mode where the same `Rule` pointers serve balanced and thorough requests in alternating order.

No rules currently opt in via `ThoroughOnlyNeeds`; this PR just lands the mechanism. Future PRs (and the rest of the depth-precision Tracks) can adopt it to expand oracle coverage at thorough without raising balanced cost.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...` — 0 issues
- [x] `make lint-rules`
- [x] `go test ./internal/rules/... ./internal/pipeline/... -count=1`
- [ ] `make integration` (CI)

The new helper has 7 focused tests covering identity-when-not-thorough, identity-when-no-opt-in, clones-only-opted-in-rules, Registry-not-mutated, idempotency, nil-entry passthrough, and empty-input.