### PR TITLE
fix(rules): AST-match XXE hardening in XmlExternalEntity

### DIFF
--- a/internal/rules/security.go
+++ b/internal/rules/security.go
@@ -841,26 +841,183 @@ func xmlExternalEntityFactoryCall(file *scanner.File, call uint32) bool {
 	return sourceImportsOrMentions(file, receiver)
 }
 
+// xxeFeatureHardening maps each XXE-related feature URL to the boolean
+// value that disables the unsafe behavior when passed to
+// `factory.setFeature(URL, BOOL)`.
+var xxeFeatureHardening = map[string]bool{
+	"http://apache.org/xml/features/disallow-doctype-decl":    true,
+	"http://xml.org/sax/features/external-general-entities":   false,
+	"http://xml.org/sax/features/external-parameter-entities": false,
+}
+
 func xmlExternalEntityHasHardeningAfter(file *scanner.File, call uint32) bool {
 	scope, ok := flatEnclosingCallable(file, call)
 	if !ok {
 		return false
 	}
-	text := file.FlatNodeText(scope)
-	callText := file.FlatNodeText(call)
-	pos := strings.Index(text, callText)
-	if pos >= 0 {
-		text = text[pos+len(callText):]
+	callStart := file.FlatStartByte(call)
+	found := false
+	sawXInclude := false
+	sawExpandEntities := false
+
+	file.FlatWalkAllNodes(scope, func(n uint32) {
+		if found || file.FlatStartByte(n) <= callStart {
+			return
+		}
+		switch file.FlatType(n) {
+		case "call_expression", "method_invocation":
+			if xxeCallIsHardening(file, n) {
+				found = true
+			}
+		case "assignment":
+			switch xxePropertyAssignmentName(file, n) {
+			case "isXIncludeAware":
+				sawXInclude = true
+			case "isExpandEntityReferences":
+				sawExpandEntities = true
+			}
+			if sawXInclude && sawExpandEntities {
+				found = true
+			}
+		}
+	})
+	return found
+}
+
+// xxeCallIsHardening reports whether the call_expression / method_invocation
+// is one of the XXE-disabling setFeature / setProperty invocations with the
+// expected literal arguments. Match is AST-based so formatting, whitespace,
+// or interleaved comments do not break detection.
+func xxeCallIsHardening(file *scanner.File, call uint32) bool {
+	name := javaAwareCallName(file, call)
+	switch name {
+	case "setFeature":
+		urlExpr, valExpr := xxeCallTwoArgExprs(file, call)
+		if urlExpr == 0 || valExpr == 0 {
+			return false
+		}
+		url, ok := xxeLiteralStringContent(file, urlExpr)
+		if !ok {
+			return false
+		}
+		expected, known := xxeFeatureHardening[url]
+		if !known {
+			return false
+		}
+		got, ok := xxeLiteralBool(file, valExpr)
+		return ok && got == expected
+	case "setProperty":
+		urlExpr, valExpr := xxeCallTwoArgExprs(file, call)
+		if urlExpr == 0 || valExpr == 0 {
+			return false
+		}
+		if !xxeExprIsSupportDTD(file, urlExpr) {
+			return false
+		}
+		got, ok := xxeLiteralBool(file, valExpr)
+		return ok && !got
 	}
-	if strings.Contains(text, `setFeature("http://apache.org/xml/features/disallow-doctype-decl", true)`) ||
-		strings.Contains(text, `setFeature("http://xml.org/sax/features/external-general-entities", false)`) ||
-		strings.Contains(text, `setFeature("http://xml.org/sax/features/external-parameter-entities", false)`) ||
-		strings.Contains(text, `setProperty(XMLInputFactory.SUPPORT_DTD, false)`) ||
-		strings.Contains(text, `setProperty(javax.xml.stream.XMLInputFactory.SUPPORT_DTD, false)`) {
-		return true
+	return false
+}
+
+// xxeCallTwoArgExprs returns the first two positional argument expressions
+// of a two-arg call, regardless of whether it parsed as a Kotlin
+// call_expression (value_arguments) or Java method_invocation
+// (argument_list).
+func xxeCallTwoArgExprs(file *scanner.File, call uint32) (uint32, uint32) {
+	switch file.FlatType(call) {
+	case "call_expression":
+		_, args := flatCallExpressionParts(file, call)
+		if args == 0 {
+			return 0, 0
+		}
+		a0 := flatValueArgumentExpression(file, flatPositionalValueArgument(file, args, 0))
+		a1 := flatValueArgumentExpression(file, flatPositionalValueArgument(file, args, 1))
+		return a0, a1
+	case "method_invocation":
+		args, ok := file.FlatFindChild(call, "argument_list")
+		if !ok || file.FlatNamedChildCount(args) < 2 {
+			return 0, 0
+		}
+		return file.FlatNamedChild(args, 0), file.FlatNamedChild(args, 1)
 	}
-	return strings.Contains(text, "isXIncludeAware = false") &&
-		strings.Contains(text, "isExpandEntityReferences = false")
+	return 0, 0
+}
+
+// xxeLiteralStringContent returns the unquoted content of a string literal
+// expression with no interpolation, or "", false.
+func xxeLiteralStringContent(file *scanner.File, expr uint32) (string, bool) {
+	expr = flatUnwrapParenExpr(file, expr)
+	switch file.FlatType(expr) {
+	case "string_literal", "line_string_literal", "multi_line_string_literal":
+		if flatContainsStringInterpolation(file, expr) {
+			return "", false
+		}
+		if value := stringLiteralContent(file, expr); value != "" {
+			return value, true
+		}
+		text := strings.TrimSpace(file.FlatNodeText(expr))
+		if unq, err := strconv.Unquote(text); err == nil {
+			return unq, true
+		}
+	}
+	return "", false
+}
+
+// xxeLiteralBool returns the boolean value of a `true` / `false` literal,
+// or false, false for anything else.
+func xxeLiteralBool(file *scanner.File, expr uint32) (bool, bool) {
+	expr = flatUnwrapParenExpr(file, expr)
+	switch strings.TrimSpace(file.FlatNodeText(expr)) {
+	case "true":
+		return true, true
+	case "false":
+		return false, true
+	}
+	return false, false
+}
+
+// xxeExprIsSupportDTD reports whether the expression resolves to a
+// reference whose trailing identifier is `SUPPORT_DTD` (matching both
+// `XMLInputFactory.SUPPORT_DTD` and the fully-qualified variant), or the
+// bare `SUPPORT_DTD` constant.
+func xxeExprIsSupportDTD(file *scanner.File, expr uint32) bool {
+	expr = flatUnwrapParenExpr(file, expr)
+	switch file.FlatType(expr) {
+	case "simple_identifier", "identifier":
+		return file.FlatNodeTextEquals(expr, "SUPPORT_DTD")
+	case "navigation_expression":
+		return flatNavigationExpressionLastIdentifierEquals(file, expr, "SUPPORT_DTD")
+	case "field_access":
+		// Java: XMLInputFactory.SUPPORT_DTD parses as field_access whose last
+		// named child is the identifier.
+		count := file.FlatNamedChildCount(expr)
+		if count == 0 {
+			return false
+		}
+		last := file.FlatNamedChild(expr, count-1)
+		return file.FlatNodeTextEquals(last, "SUPPORT_DTD")
+	}
+	return false
+}
+
+// xxePropertyAssignmentName returns the trailing property name of a Kotlin
+// property assignment whose right-hand side is the literal `false`, or "".
+// Used to detect the `factory.isXIncludeAware = false` /
+// `factory.isExpandEntityReferences = false` hardening pair.
+func xxePropertyAssignmentName(file *scanner.File, assignment uint32) string {
+	_, tail := chainSplitTrailing(kotlinAssignmentTargetChain(file, assignment))
+	if tail == "" {
+		return ""
+	}
+	value := findKotlinAssignmentValue(file, assignment)
+	if value == 0 {
+		return ""
+	}
+	if got, ok := xxeLiteralBool(file, value); !ok || got {
+		return ""
+	}
+	return tail
 }
 
 func javaObjectInputStreamConstructor(file *scanner.File, idx uint32) bool {

--- a/internal/rules/security_test.go
+++ b/internal/rules/security_test.go
@@ -825,6 +825,167 @@ class XmlLoader {
 	}
 }
 
+func TestXmlExternalEntity_HardeningFormattingVariants(t *testing.T) {
+	t.Run("multi-line setFeature kotlin", func(t *testing.T) {
+		findings := runRuleByName(t, "XmlExternalEntity", `
+package test
+
+import javax.xml.parsers.DocumentBuilderFactory
+
+class XmlLoader {
+    fun load(input: java.io.InputStream) {
+        val factory = DocumentBuilderFactory.newInstance()
+        factory.setFeature(
+            "http://apache.org/xml/features/disallow-doctype-decl",
+            true,
+        )
+        factory.newDocumentBuilder().parse(input)
+    }
+}`)
+		if len(findings) != 0 {
+			t.Fatalf("expected 0 findings for multi-line setFeature, got %d: %v", len(findings), findings)
+		}
+	})
+
+	t.Run("extra whitespace around args kotlin", func(t *testing.T) {
+		findings := runRuleByName(t, "XmlExternalEntity", `
+package test
+
+import javax.xml.parsers.DocumentBuilderFactory
+
+class XmlLoader {
+    fun load(input: java.io.InputStream) {
+        val factory = DocumentBuilderFactory.newInstance()
+        factory.setFeature( "http://apache.org/xml/features/disallow-doctype-decl" , true )
+        factory.newDocumentBuilder().parse(input)
+    }
+}`)
+		if len(findings) != 0 {
+			t.Fatalf("expected 0 findings for whitespaced setFeature, got %d: %v", len(findings), findings)
+		}
+	})
+
+	t.Run("comment inside setFeature kotlin", func(t *testing.T) {
+		findings := runRuleByName(t, "XmlExternalEntity", `
+package test
+
+import javax.xml.parsers.DocumentBuilderFactory
+
+class XmlLoader {
+    fun load(input: java.io.InputStream) {
+        val factory = DocumentBuilderFactory.newInstance()
+        factory.setFeature(
+            // disable DOCTYPE
+            "http://apache.org/xml/features/disallow-doctype-decl",
+            true,
+        )
+        factory.newDocumentBuilder().parse(input)
+    }
+}`)
+		if len(findings) != 0 {
+			t.Fatalf("expected 0 findings for commented setFeature, got %d: %v", len(findings), findings)
+		}
+	})
+
+	t.Run("wrong boolean value still fires", func(t *testing.T) {
+		findings := runRuleByName(t, "XmlExternalEntity", `
+package test
+
+import javax.xml.parsers.DocumentBuilderFactory
+
+class XmlLoader {
+    fun load(input: java.io.InputStream) {
+        val factory = DocumentBuilderFactory.newInstance()
+        factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", false)
+        factory.newDocumentBuilder().parse(input)
+    }
+}`)
+		if len(findings) != 1 {
+			t.Fatalf("expected 1 finding when hardening boolean is wrong, got %d: %v", len(findings), findings)
+		}
+	})
+
+	t.Run("multi-line setProperty kotlin", func(t *testing.T) {
+		findings := runRuleByName(t, "XmlExternalEntity", `
+package test
+
+import javax.xml.stream.XMLInputFactory
+
+class XmlLoader {
+    fun load(input: java.io.InputStream) {
+        val factory = XMLInputFactory.newInstance()
+        factory.setProperty(
+            XMLInputFactory.SUPPORT_DTD,
+            false,
+        )
+    }
+}`)
+		if len(findings) != 0 {
+			t.Fatalf("expected 0 findings for multi-line setProperty, got %d: %v", len(findings), findings)
+		}
+	})
+
+	t.Run("multi-line property assignment kotlin", func(t *testing.T) {
+		findings := runRuleByName(t, "XmlExternalEntity", `
+package test
+
+import javax.xml.parsers.DocumentBuilderFactory
+
+class XmlLoader {
+    fun load(input: java.io.InputStream) {
+        val factory = DocumentBuilderFactory.newInstance()
+        factory.isXIncludeAware =
+            false
+        factory.isExpandEntityReferences =
+            false
+        factory.newDocumentBuilder().parse(input)
+    }
+}`)
+		if len(findings) != 0 {
+			t.Fatalf("expected 0 findings for split property assignments, got %d: %v", len(findings), findings)
+		}
+	})
+
+	t.Run("missing one property assignment still fires", func(t *testing.T) {
+		findings := runRuleByName(t, "XmlExternalEntity", `
+package test
+
+import javax.xml.parsers.DocumentBuilderFactory
+
+class XmlLoader {
+    fun load(input: java.io.InputStream) {
+        val factory = DocumentBuilderFactory.newInstance()
+        factory.isXIncludeAware = false
+        factory.newDocumentBuilder().parse(input)
+    }
+}`)
+		if len(findings) != 1 {
+			t.Fatalf("expected 1 finding when only isXIncludeAware is set, got %d: %v", len(findings), findings)
+		}
+	})
+
+	t.Run("multi-line setFeature java", func(t *testing.T) {
+		findings := runRuleByNameOnJava(t, "XmlExternalEntity", `
+package test;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+
+class XmlLoader {
+    void load(java.io.InputStream input) throws Exception {
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setFeature(
+            "http://apache.org/xml/features/disallow-doctype-decl",
+            true
+        );
+        factory.newDocumentBuilder().parse(input);
+    }
+}`)
+		if len(findings) != 0 {
+			t.Fatalf("expected 0 Java findings for multi-line setFeature, got %d: %v", len(findings), findings)
+		}
+	})
+}
+
 func TestJavaObjectInputStream_KotlinPositive(t *testing.T) {
 	findings := runRuleByName(t, "JavaObjectInputStream", `
 package test

--- a/tests/fixtures/negative/security/XmlExternalEntity.java
+++ b/tests/fixtures/negative/security/XmlExternalEntity.java
@@ -8,4 +8,13 @@ class XmlExternalEntityJavaSafeFixture {
         factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
         factory.newDocumentBuilder().parse(input);
     }
+
+    void loadMultiLine(java.io.InputStream input) throws Exception {
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setFeature(
+            "http://apache.org/xml/features/disallow-doctype-decl",
+            true
+        );
+        factory.newDocumentBuilder().parse(input);
+    }
 }

--- a/tests/fixtures/negative/security/XmlExternalEntity.kt
+++ b/tests/fixtures/negative/security/XmlExternalEntity.kt
@@ -12,4 +12,20 @@ class XmlExternalEntitySafeFixture {
         val streamFactory = XMLInputFactory.newInstance()
         streamFactory.setProperty(XMLInputFactory.SUPPORT_DTD, false)
     }
+
+    fun loadMultiLine(input: java.io.InputStream) {
+        val factory = DocumentBuilderFactory.newInstance()
+        factory.setFeature(
+            "http://apache.org/xml/features/disallow-doctype-decl",
+            true,
+        )
+        factory.newDocumentBuilder().parse(input)
+    }
+
+    fun loadWithProperties(input: java.io.InputStream) {
+        val factory = DocumentBuilderFactory.newInstance()
+        factory.isXIncludeAware = false
+        factory.isExpandEntityReferences = false
+        factory.newDocumentBuilder().parse(input)
+    }
 }


### PR DESCRIPTION
## Summary

`xmlExternalEntityHasHardeningAfter` compared raw scope text against single-line literal forms of the disallowed-feature `setFeature` / `setProperty` calls and the `isXIncludeAware = false` / `isExpandEntityReferences = false` property pair. Any reformatting defeated the match and caused **false positives** on factories that were actually hardened:

- Multi-line argument lists (`setFeature(\n  "...",\n  true\n)`).
- Extra whitespace around args (`setFeature( "...", true )`).
- An interleaved line comment inside the call.

These shapes are common in real code — anything that runs through an IDE formatter or a long URL gets wrapped.

## Fix

The hardening check now walks the enclosing callable's flat AST and matches calls / assignments structurally:

- **`setFeature(URL_LITERAL, BOOL_LITERAL)`** — URL must be a non-interpolated string literal whose unquoted content is one of the three known disallowed-feature URLs, and the boolean literal must match the expected value (`true` for disallow-doctype, `false` for the external-entity features).
- **`setProperty(... SUPPORT_DTD, false)`** — receiver expression ends in the `SUPPORT_DTD` identifier (qualified `XMLInputFactory.SUPPORT_DTD`, fully qualified, or bare).
- **Property pair** — both `factory.isXIncludeAware = false` and `factory.isExpandEntityReferences = false` matched via Kotlin assignment AST, not raw text.

The walk is bounded to the enclosing callable and short-circuits as soon as any sufficient hardening is found, so per-call cost is unchanged.

## Test plan

- [x] Unit subtests `TestXmlExternalEntity_HardeningFormattingVariants` cover: multi-line `setFeature` (Kotlin + Java), extra whitespace, comment inside call, multi-line `setProperty`, multi-line property pair, wrong-boolean still fires, single missing property still fires.
- [x] Negative fixtures `XmlExternalEntity.kt` / `.java` extended with multi-line `setFeature` and property-pair cases.
- [x] Existing positive fixtures still fire (`TestXmlExternalEntity_KotlinPositive` / `TestXmlExternalEntity_JavaPositive` pass unchanged).
- [x] `go build`, `go vet`, `golangci-lint run`, `go test ./... -count=1` all pass.