### PR TITLE
feat(rules): per-rule thorough-only oracle/FIR filter widening

### DIFF
--- a/internal/cli/scan/fir_checker.go
+++ b/internal/cli/scan/fir_checker.go
@@ -27,6 +27,10 @@ type firCheckerOpts struct {
 	ParsedFiles []*scanner.File
 	Tracker     perf.Tracker
 	VerboseOut  io.Writer
+	// Thorough mirrors --depth=thorough and tells ActiveFirRules to
+	// project per-rule ThoroughIdentifiers / ThoroughAllFiles. False
+	// keeps the existing balanced/fast filter shape.
+	Thorough bool
 }
 
 // resolveFIRTargetFiles picks the Kotlin file list the FIR checker should
@@ -82,7 +86,7 @@ func runFIRCheckerPass(opts firCheckerOpts, base []scanner.Finding) []scanner.Fi
 	if !opts.Enabled || opts.Checker == nil {
 		return base
 	}
-	active := firchecks.ActiveFirRules(activeRuleIDs(opts.ActiveRules))
+	active := firchecks.ActiveFirRules(activeRuleIDs(opts.ActiveRules), opts.Thorough)
 	if len(active.Names) == 0 {
 		// No FIR-eligible rules in the active set; skip the JVM
 		// subprocess entirely. Matters once `--depth=thorough` defaults

--- a/internal/cli/scan/oracle_filter_fingerprint.go
+++ b/internal/cli/scan/oracle_filter_fingerprint.go
@@ -53,7 +53,10 @@ func WriteOracleFilterFingerprint(stdoutW, stderrW io.Writer, paths []string, fi
 		return 2
 	}
 
-	filterRules := rules.BuildOracleFilterRulesV2(activeRules)
+	// Fingerprint command runs outside the scan pipeline; the depth flag
+	// is not in scope here. Project filters at the default (non-thorough)
+	// view so baselines stay stable across depths.
+	filterRules := rules.BuildOracleFilterRulesV2(activeRules, false)
 	oracleRuleNames := make([]string, 0, len(filterRules))
 	for _, r := range filterRules {
 		oracleRuleNames = append(oracleRuleNames, r.Name)

--- a/internal/cli/scan/runner_state.go
+++ b/internal/cli/scan/runner_state.go
@@ -485,6 +485,7 @@ func (r *runner) runOracleIndex() (int, error) {
 			InputTypesPath:    *r.f.InputTypes,
 			NoCacheOracle:     *r.f.NoCacheOracle,
 			NoOracleFilter:    *r.f.NoOracleFilter,
+			Thorough:          r.depthPreset == DepthThorough,
 			OracleDiagnostics: *r.f.OracleDiagnostics,
 			UseDaemon:         *r.f.Daemon,
 			Store:             r.oracleStore,
@@ -620,6 +621,7 @@ func (r *runner) firCheckAndCollect() {
 			ParsedFiles: r.parsedFiles,
 			Tracker:     r.tracker,
 			VerboseOut:  os.Stderr,
+			Thorough:    r.depthPreset == DepthThorough,
 		}, r.allFindings)
 
 		r.applySLOs()

--- a/internal/firchecks/filter.go
+++ b/internal/firchecks/filter.go
@@ -10,6 +10,7 @@ package firchecks
 import (
 	"bytes"
 	"path/filepath"
+	"slices"
 	"sort"
 
 	"github.com/kaeawc/krit/internal/scanner"
@@ -24,6 +25,13 @@ type FirFilterSpec struct {
 	Identifiers []string
 	// AllFiles: true means the checker needs every file (no reduction).
 	AllFiles bool
+	// ThoroughOnlyIdentifiers extend Identifiers only at --depth=thorough.
+	// ActiveFirRules projects them when its thorough argument is true;
+	// ignored at fast/balanced. Naming mirrors api.OracleFilter.
+	ThoroughOnlyIdentifiers []string
+	// ThoroughOnlyAllFiles, when true, promotes the rule to AllFiles only
+	// at --depth=thorough.
+	ThoroughOnlyAllFiles bool
 }
 
 // FirFilterRule is the minimal rule view used by CollectFirCheckFiles.
@@ -61,8 +69,12 @@ var firRuleFilters = map[string]FirFilterRule{
 }
 
 // ActiveFirRules returns the FIR check names and coarse file filters that
-// correspond to enabled Krit catalog rule IDs.
-func ActiveFirRules(enabledRuleIDs []string) FirActiveRules {
+// correspond to enabled Krit catalog rule IDs. When thorough is true,
+// each rule's ThoroughOnlyIdentifiers / ThoroughOnlyAllFiles are
+// projected into the returned filter via a shallow clone — the global
+// firRuleFilters map is never mutated, so balanced and thorough
+// requests can share the same daemon process safely.
+func ActiveFirRules(enabledRuleIDs []string, thorough bool) FirActiveRules {
 	out := FirActiveRules{}
 	seen := make(map[string]struct{}, len(enabledRuleIDs))
 	for _, id := range enabledRuleIDs {
@@ -73,6 +85,17 @@ func ActiveFirRules(enabledRuleIDs []string) FirActiveRules {
 		rule, ok := firRuleFilters[id]
 		if !ok {
 			continue
+		}
+		if thorough && rule.Filter != nil &&
+			(rule.Filter.ThoroughOnlyAllFiles || len(rule.Filter.ThoroughOnlyIdentifiers) > 0) {
+			projected := *rule.Filter
+			if rule.Filter.ThoroughOnlyAllFiles {
+				projected.AllFiles = true
+			}
+			if len(rule.Filter.ThoroughOnlyIdentifiers) > 0 {
+				projected.Identifiers = slices.Concat(rule.Filter.Identifiers, rule.Filter.ThoroughOnlyIdentifiers)
+			}
+			rule = FirFilterRule{Name: rule.Name, Filter: &projected}
 		}
 		out.Filters = append(out.Filters, rule)
 		out.Names = append(out.Names, rule.Name)

--- a/internal/firchecks/filter_test.go
+++ b/internal/firchecks/filter_test.go
@@ -84,11 +84,55 @@ func TestCollectFirCheckFiles_NilFilter(t *testing.T) {
 }
 
 func TestActiveFirRules_MapsEnabledCatalogRules(t *testing.T) {
-	active := ActiveFirRules([]string{"InjectDispatcher", "UnrelatedRule", "InjectDispatcher"})
+	active := ActiveFirRules([]string{"InjectDispatcher", "UnrelatedRule", "InjectDispatcher"}, false)
 	if len(active.Names) != 1 || active.Names[0] != "INJECT_DISPATCHER" {
 		t.Fatalf("expected one FIR checker name, got %#v", active.Names)
 	}
 	if len(active.Filters) != 1 || active.Filters[0].Name != "INJECT_DISPATCHER" {
 		t.Fatalf("expected one FIR filter, got %#v", active.Filters)
+	}
+}
+
+// Verifies the thorough projection is non-mutating. Daemon mode issues
+// alternating balanced and thorough requests against the same shared
+// firRuleFilters map; this test confirms the projection returns clones
+// without leaking changes back to the global registry.
+func TestActiveFirRules_ThoroughProjectsExtraIdentifiers(t *testing.T) {
+	const id = "ThoroughProbeRule"
+	t.Cleanup(func() { delete(firRuleFilters, id) })
+	firRuleFilters[id] = FirFilterRule{
+		Name: "THOROUGH_PROBE",
+		Filter: &FirFilterSpec{
+			Identifiers:             []string{"base"},
+			ThoroughOnlyIdentifiers: []string{"extra"},
+			ThoroughOnlyAllFiles:    true,
+		},
+	}
+
+	balanced := ActiveFirRules([]string{id}, false)
+	if balanced.Filters[0].Filter.AllFiles {
+		t.Errorf("balanced must not promote AllFiles; got AllFiles=true")
+	}
+	if len(balanced.Filters[0].Filter.Identifiers) != 1 {
+		t.Errorf("balanced identifiers must be unprojected; got %v", balanced.Filters[0].Filter.Identifiers)
+	}
+
+	thorough := ActiveFirRules([]string{id}, true)
+	if !thorough.Filters[0].Filter.AllFiles {
+		t.Errorf("thorough must project ThoroughOnlyAllFiles; got AllFiles=false")
+	}
+	want := []string{"base", "extra"}
+	if len(thorough.Filters[0].Filter.Identifiers) != len(want) {
+		t.Fatalf("thorough identifiers = %v; want %v", thorough.Filters[0].Filter.Identifiers, want)
+	}
+	for i := range want {
+		if thorough.Filters[0].Filter.Identifiers[i] != want[i] {
+			t.Errorf("identifiers[%d] = %q; want %q", i, thorough.Filters[0].Filter.Identifiers[i], want[i])
+		}
+	}
+
+	registry := firRuleFilters[id]
+	if len(registry.Filter.Identifiers) != 1 || registry.Filter.AllFiles {
+		t.Fatalf("global firRuleFilters mutated by projection: %+v", registry.Filter)
 	}
 }

--- a/internal/pipeline/index.go
+++ b/internal/pipeline/index.go
@@ -170,6 +170,11 @@ type IndexInput struct {
 	// NoOracleFilter mirrors --no-oracle-filter: disables the
 	// rule-classification oracle filter pre-scan.
 	NoOracleFilter bool
+	// Thorough mirrors ProjectArgs.TargetedResolution and tells the
+	// oracle-filter bridge to project per-rule ThoroughIdentifiers /
+	// ThoroughAllFiles into the active filter spec. At fast/balanced the
+	// thorough-only fields are dropped so JVM cost stays unchanged.
+	Thorough bool
 	// OracleDiagnostics enables expensive Kotlin compiler diagnostic
 	// collection in krit-types. The default oracle path leaves this off;
 	// FlatNode/rule fallbacks cover the common cases without forcing every
@@ -912,7 +917,7 @@ func (p IndexPhase) buildOracleFilterListPath(in IndexInput, oracleRules []*api.
 	}
 	var filterRules []oracle.FilterRule
 	jvmTracker.TrackVoid("oracleFilterBuildRules", func() {
-		filterRules = rules.BuildOracleFilterRulesV2(oracleRules)
+		filterRules = rules.BuildOracleFilterRulesV2(oracleRules, in.Thorough)
 	})
 	var lightFiles []*scanner.File
 	jvmTracker.TrackVoid("oracleFilterLoadFiles", func() {

--- a/internal/pipeline/project.go
+++ b/internal/pipeline/project.go
@@ -837,6 +837,7 @@ func runProjectIndexPhase(ctx context.Context, args ProjectArgs, host ProjectHos
 		ModuleJobsFlag:           args.Workers,
 		ModuleHasAwareRule:       hasModuleAwareRule,
 		InputTypesPath:           args.InputTypesPath,
+		Thorough:                 args.TargetedResolution,
 	}
 	wireOracleHandles(&indexInput, args, host, parseResult.KotlinFiles)
 	if warm.result == nil {

--- a/internal/rules/api/rule.go
+++ b/internal/rules/api/rule.go
@@ -672,6 +672,19 @@ func (r OptInReason) String() string {
 type OracleFilter struct {
 	Identifiers []string
 	AllFiles    bool
+
+	// ThoroughOnlyIdentifiers are extra substring matches the rule
+	// wants added to its identifier set only at --depth=thorough.
+	// Bridge projects them into Identifiers when constructing the
+	// oracle filter at thorough; ignored at fast/balanced. Naming
+	// mirrors Rule.ThoroughOnlyNeeds.
+	ThoroughOnlyIdentifiers []string
+
+	// ThoroughOnlyAllFiles, when true, makes the bridge treat this
+	// rule as AllFiles only at --depth=thorough. Use sparingly — one
+	// AllFiles rule short-circuits filter inversion for the whole
+	// oracle pass.
+	ThoroughOnlyAllFiles bool
 }
 
 // OracleDeclarationProfile narrows which KAA symbol fields the JVM extracts
@@ -731,12 +744,16 @@ type OracleCallTargetFilter struct {
 }
 
 // NeverNeedsOracle returns true when the filter declares the rule is
-// purely tree-sitter and will never consult the oracle.
+// purely tree-sitter and will never consult the oracle. Conservatively
+// considers the ThoroughOnly* fields — at thorough the rule may still
+// consult the oracle, so a depth-agnostic caller must not classify the
+// rule as "never needs oracle".
 func (f *OracleFilter) NeverNeedsOracle() bool {
 	if f == nil {
 		return false
 	}
-	return !f.AllFiles && len(f.Identifiers) == 0
+	return !f.AllFiles && len(f.Identifiers) == 0 &&
+		!f.ThoroughOnlyAllFiles && len(f.ThoroughOnlyIdentifiers) == 0
 }
 
 // Rule is the unified rule descriptor. Every analysis rule in krit is

--- a/internal/rules/oracle_filter_bridge.go
+++ b/internal/rules/oracle_filter_bridge.go
@@ -1,6 +1,8 @@
 package rules
 
 import (
+	"slices"
+
 	"github.com/kaeawc/krit/internal/oracle"
 	api "github.com/kaeawc/krit/internal/rules/api"
 	"github.com/kaeawc/krit/internal/scanner"
@@ -79,9 +81,14 @@ func KotlinOracleRulesV2(enabled []*api.Rule) []*api.Rule {
 // rules that do NOT need the oracle are excluded from oracle selection
 // entirely — the oracle is only invoked on files an oracle-needing rule
 // asked for. A rule that needs the oracle with no Oracle filter set (or
-// an AllFiles: true filter) is treated as
-// wanting every file.
-func BuildOracleFilterRulesV2(enabled []*api.Rule) []oracle.FilterRule {
+// an AllFiles: true filter) is treated as wanting every file.
+//
+// thorough projects api.OracleFilter.ThoroughOnlyIdentifiers /
+// ThoroughOnlyAllFiles into the produced FilterSpec when true; at false
+// the thorough-only fields are dropped so balanced/fast pay no extra
+// JVM cost. The bridge is the single projection point so oracle.FilterSpec
+// stays depth-agnostic.
+func BuildOracleFilterRulesV2(enabled []*api.Rule, thorough bool) []oracle.FilterRule {
 	out := make([]oracle.FilterRule, 0, len(enabled))
 	for _, r := range enabled {
 		if !RuleNeedsKotlinOracle(r) {
@@ -89,10 +96,17 @@ func BuildOracleFilterRulesV2(enabled []*api.Rule) []oracle.FilterRule {
 		}
 		var spec *oracle.FilterSpec
 		if r.Oracle != nil {
-			spec = &oracle.FilterSpec{
-				Identifiers: r.Oracle.Identifiers,
-				AllFiles:    r.Oracle.AllFiles,
+			ids := r.Oracle.Identifiers
+			all := r.Oracle.AllFiles
+			if thorough {
+				if r.Oracle.ThoroughOnlyAllFiles {
+					all = true
+				}
+				if len(r.Oracle.ThoroughOnlyIdentifiers) > 0 {
+					ids = slices.Concat(ids, r.Oracle.ThoroughOnlyIdentifiers)
+				}
 			}
+			spec = &oracle.FilterSpec{Identifiers: ids, AllFiles: all}
 		} else {
 			// The rule needs the oracle but did not narrow by
 			// content — it wants every file.

--- a/internal/rules/oracle_filter_bridge_test.go
+++ b/internal/rules/oracle_filter_bridge_test.go
@@ -21,7 +21,7 @@ func TestBuildOracleFilterRulesV2_SkipsRulesWithoutOracleNeed(t *testing.T) {
 		{ID: "NarrowOracleFiltered", Needs: api.NeedsTypeInfo | api.NeedsOracleCallTargets,
 			Oracle: &api.OracleFilter{Identifiers: []string{"!!"}}},
 	}
-	got := BuildOracleFilterRulesV2(rules)
+	got := BuildOracleFilterRulesV2(rules, false)
 	if len(got) != 3 {
 		t.Fatalf("got %d rules, want 3 (only explicit oracle consumers pass through)", len(got))
 	}
@@ -57,13 +57,90 @@ func TestBuildOracleFilterRulesV2_SkipsRulesWithoutOracleNeed(t *testing.T) {
 	}
 }
 
+func TestBuildOracleFilterRulesV2_NotThoroughDropsThoroughFields(t *testing.T) {
+	rules := []*api.Rule{
+		{ID: "OracleThorough", Needs: api.NeedsTypeInfo | api.NeedsOracleCallTargets,
+			Oracle: &api.OracleFilter{
+				Identifiers:             []string{"base"},
+				ThoroughOnlyIdentifiers: []string{"extra"},
+				ThoroughOnlyAllFiles:    true,
+			}},
+	}
+	got := BuildOracleFilterRulesV2(rules, false)
+	if len(got) != 1 {
+		t.Fatalf("got %d rules, want 1", len(got))
+	}
+	spec := got[0].Filter
+	if spec.AllFiles {
+		t.Errorf("ThoroughOnlyAllFiles should not promote AllFiles at balanced; got AllFiles=true")
+	}
+	if len(spec.Identifiers) != 1 || spec.Identifiers[0] != "base" {
+		t.Errorf("ThoroughOnlyIdentifiers should not appear at balanced; got %v", spec.Identifiers)
+	}
+}
+
+func TestBuildOracleFilterRulesV2_ThoroughMergesIdentifiers(t *testing.T) {
+	rules := []*api.Rule{
+		{ID: "OracleThorough", Needs: api.NeedsTypeInfo | api.NeedsOracleCallTargets,
+			Oracle: &api.OracleFilter{
+				Identifiers:             []string{"base"},
+				ThoroughOnlyIdentifiers: []string{"extra1", "extra2"},
+			}},
+	}
+	got := BuildOracleFilterRulesV2(rules, true)
+	if len(got) != 1 {
+		t.Fatalf("got %d rules, want 1", len(got))
+	}
+	spec := got[0].Filter
+	want := []string{"base", "extra1", "extra2"}
+	if len(spec.Identifiers) != len(want) {
+		t.Fatalf("identifiers = %v; want %v", spec.Identifiers, want)
+	}
+	for i := range want {
+		if spec.Identifiers[i] != want[i] {
+			t.Errorf("identifiers[%d] = %q; want %q", i, spec.Identifiers[i], want[i])
+		}
+	}
+}
+
+func TestBuildOracleFilterRulesV2_ThoroughAllFilesPromotes(t *testing.T) {
+	rules := []*api.Rule{
+		{ID: "OracleThorough", Needs: api.NeedsTypeInfo | api.NeedsOracleCallTargets,
+			Oracle: &api.OracleFilter{
+				Identifiers:          []string{"base"},
+				ThoroughOnlyAllFiles: true,
+			}},
+	}
+	got := BuildOracleFilterRulesV2(rules, true)
+	if len(got) != 1 || !got[0].Filter.AllFiles {
+		t.Fatalf("ThoroughOnlyAllFiles must promote AllFiles=true at thorough; got %+v", got[0].Filter)
+	}
+}
+
+// Source rule pointer must not gain identifiers across calls — Registry
+// pointers are shared with the global rule set.
+func TestBuildOracleFilterRulesV2_ThoroughDoesNotMutateInput(t *testing.T) {
+	in := &api.OracleFilter{
+		Identifiers:             []string{"base"},
+		ThoroughOnlyIdentifiers: []string{"extra"},
+	}
+	rules := []*api.Rule{
+		{ID: "OracleThorough", Needs: api.NeedsTypeInfo | api.NeedsOracleCallTargets, Oracle: in},
+	}
+	_ = BuildOracleFilterRulesV2(rules, true)
+	_ = BuildOracleFilterRulesV2(rules, true)
+	if len(in.Identifiers) != 1 || in.Identifiers[0] != "base" {
+		t.Fatalf("input rule's Identifiers grew across calls: %v", in.Identifiers)
+	}
+}
+
 func TestBuildOracleFilterRulesV2_NoOracleRulesReturnsEmpty(t *testing.T) {
 	rules := []*api.Rule{
 		{ID: "A"},
 		{ID: "B", Needs: api.NeedsResolver},
 		{ID: "C", Needs: api.NeedsLinePass},
 	}
-	got := BuildOracleFilterRulesV2(rules)
+	got := BuildOracleFilterRulesV2(rules, false)
 	if len(got) != 0 {
 		t.Errorf("got %d rules, want 0 — no rule declared NeedsOracle", len(got))
 	}


### PR DESCRIPTION
## Summary

- Adds `ThoroughOnlyIdentifiers []string` and `ThoroughOnlyAllFiles bool` to `api.OracleFilter` and `firchecks.FirFilterSpec`. A rule can opt into broader file-set selection only when scanning at `--depth=thorough`; the new fields are inert at fast/balanced so the JVM cost is unchanged.
- Projection happens at the existing bridge points (`rules.BuildOracleFilterRulesV2` and `firchecks.ActiveFirRules`) via a shallow clone. The global `firRuleFilters` map and the Registry `OracleFilter` pointers are never mutated — important for daemon mode where the same Rule pointers serve alternating balanced and thorough requests.
- Pipeline (`IndexInput`) and runner (`firCheckerOpts`) gain a `Thorough` bool plumbed from `ProjectArgs.TargetedResolution` and `runner.depthPreset == DepthThorough`. The standalone `--oracle-filter-fingerprint` command continues to compute with `thorough=false` so CI baselines stay stable.
- Naming mirrors Track 3's `ThoroughOnlyNeeds` for grep-ability.

No rule opts in yet; this PR lands the mechanism so future PRs can adopt it.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...` — 0 issues
- [x] `make lint-rules`
- [x] `go test ./internal/rules/... ./internal/firchecks/... ./internal/pipeline/... ./internal/cli/scan/... -count=1`
- [ ] `make integration` (CI)

New tests cover four behaviors on the oracle bridge (drops Thorough at balanced; merges Identifiers at thorough; promotes AllFiles at thorough; non-mutating across calls) and one combined behavior on `ActiveFirRules` (balanced vs thorough projection + Registry-not-mutated).