### PR TITLE
fix(rules): cover destructuring + parse-error edge cases in UnusedVariable

### DIFF
--- a/internal/rules/filefacts.go
+++ b/internal/rules/filefacts.go
@@ -42,5 +42,6 @@ const (
 	slotTestQualityMockNames        = "testQualityMockNames"
 	slotTestQualityAssertionHelpers = "testQualityAssertionHelpers"
 	slotUnusedImportRefs            = "unusedImportRefs"
+	slotUnusedVariableHasParseError = "unusedVariableHasParseError"
 	slotPrintBuiltinShadows         = "printBuiltinShadows"
 )

--- a/internal/rules/style_unused.go
+++ b/internal/rules/style_unused.go
@@ -441,12 +441,25 @@ func unusedVariableDeclaration(file *scanner.File, idx uint32) (unusedVariableDe
 		if !ok || file.FlatType(parent) != "multi_variable_declaration" {
 			return target, false
 		}
-		prop, ok := flatEnclosingAncestor(file, idx, "property_declaration")
+		grand, ok := file.FlatParent(parent)
 		if !ok {
 			return target, false
 		}
-		stmt = prop
-		nameNode, _ = file.FlatFindChild(idx, "simple_identifier")
+		switch file.FlatType(grand) {
+		case "property_declaration":
+			stmt = grand
+			nameNode, _ = file.FlatFindChild(idx, "simple_identifier")
+		case "for_statement":
+			// `for ((a, b) in xs) { ... }`: bindings live only inside the
+			// loop body. The pattern (multi_variable_declaration) sits in
+			// the for header, so the scope is the for's control body,
+			// and the "statement end" for filtering pre-decl refs is the
+			// end of the pattern itself.
+			stmt = parent
+			nameNode, _ = file.FlatFindChild(idx, "simple_identifier")
+		default:
+			return target, false
+		}
 	default:
 		return target, false
 	}
@@ -469,7 +482,7 @@ func unusedVariableDeclaration(file *scanner.File, idx uint32) (unusedVariableDe
 	if !unusedVariableIsLocalProperty(file, stmt) {
 		return target, false
 	}
-	scope, ok := unusedVariableLexicalScope(file, stmt)
+	scope, ok := unusedVariableDeclScope(file, stmt)
 	if !ok {
 		return target, false
 	}
@@ -480,6 +493,22 @@ func unusedVariableDeclaration(file *scanner.File, idx uint32) (unusedVariableDe
 		emitNode: idx,
 		scope:    scope,
 	}, true
+}
+
+// unusedVariableDeclScope returns the lexical scope a declaration's
+// references must fall inside. For a for-loop destructuring pattern the
+// scope is the loop's control body; for plain locals it is the nearest
+// statements / function_body / lambda block.
+func unusedVariableDeclScope(file *scanner.File, stmt uint32) (uint32, bool) {
+	if file.FlatType(stmt) == "multi_variable_declaration" {
+		if forStmt, ok := file.FlatParent(stmt); ok && file.FlatType(forStmt) == "for_statement" {
+			if body, ok := file.FlatFindChild(forStmt, "control_structure_body"); ok {
+				return body, true
+			}
+			return 0, false
+		}
+	}
+	return unusedVariableLexicalScope(file, stmt)
 }
 
 func unusedVariablePropertyHasVisibilityModifier(file *scanner.File, idx uint32) bool {
@@ -573,9 +602,22 @@ func unusedVariableIsLocalProperty(file *scanner.File, idx uint32) bool {
 			return false
 		}
 		if t == "function_body" || t == "function_declaration" ||
-			t == "anonymous_function" || t == "lambda_literal" ||
+			t == "anonymous_function" ||
 			t == "control_structure_body" || t == "anonymous_initializer" ||
 			t == "secondary_constructor" {
+			return true
+		}
+		if t == "lambda_literal" {
+			// A lambda_literal is only a real local scope when it is a
+			// lambda *expression* — i.e., its parent is a call/argument-like
+			// context. Tree-sitter sometimes emits a lambda_literal node when
+			// recovering from a malformed class header (e.g. `class Foo\n
+			// private constructor(...)` parses the class body as a lambda
+			// inside an expression). In that case the "properties" inside
+			// are real class members, not locals.
+			if !unusedVariableLambdaIsExpression(file, a) {
+				return false
+			}
 			return true
 		}
 		if t == "class_body" || t == "enum_class_body" ||
@@ -584,6 +626,94 @@ func unusedVariableIsLocalProperty(file *scanner.File, idx uint32) bool {
 			t == "class_declaration" || t == "source_file" {
 			return false
 		}
+	}
+	return false
+}
+
+// unusedVariableUnaryContinuationUsesName reports whether the target's
+// initializer ends with `... + name` or `... - name` where the operator
+// starts on a new line *after* the preceding operand ends — the syntactic
+// shape of a user-intended unary-prefix expression statement that the
+// parser bound into the previous declaration's initializer.
+func unusedVariableUnaryContinuationUsesName(file *scanner.File, target unusedVariableDecl) bool {
+	if file == nil || target.stmt == 0 || target.name == "" {
+		return false
+	}
+	if file.FlatType(target.stmt) != "property_declaration" {
+		return false
+	}
+	found := false
+	file.FlatWalkNodes(target.stmt, "additive_expression", func(node uint32) {
+		if found || file.FlatChildCount(node) != 3 {
+			return
+		}
+		lhs, op, rhs := file.FlatChild(node, 0), file.FlatChild(node, 1), file.FlatChild(node, 2)
+		opType := file.FlatType(op)
+		if opType != "+" && opType != "-" {
+			return
+		}
+		lhsEndRow := file.FlatRow(lhs) + strings.Count(file.FlatNodeText(lhs), "\n")
+		if file.FlatRow(op) <= lhsEndRow {
+			return
+		}
+		if file.FlatType(rhs) != "simple_identifier" {
+			return
+		}
+		if unusedVariableIdentifierName(file, rhs) != target.name {
+			return
+		}
+		found = true
+	})
+	return found
+}
+
+// unusedVariableScopeHasParseError reports whether `scope` (or any of its
+// descendants) is a tree-sitter ERROR node. Rules that need full visibility
+// into a scope (so that references can attach to declarations) must abstain
+// when the parse is incomplete, since references can land in orphan subtrees.
+//
+// Backed by a per-file fact: the set of ERROR start bytes. The common case
+// (no parse errors in the file) short-circuits to O(1).
+func unusedVariableScopeHasParseError(file *scanner.File, scope uint32) bool {
+	if file == nil || scope == 0 {
+		return false
+	}
+	errorStarts := filefacts.FileFact(fileFactsCache(), file, slotUnusedVariableHasParseError, func() []uint32 {
+		var starts []uint32
+		file.FlatWalkAllNodes(0, func(candidate uint32) {
+			if file.FlatType(candidate) == "ERROR" {
+				starts = append(starts, file.FlatStartByte(candidate))
+			}
+		})
+		return starts
+	})
+	if len(errorStarts) == 0 {
+		return false
+	}
+	scopeStart := file.FlatStartByte(scope)
+	scopeEnd := file.FlatEndByte(scope)
+	for _, start := range errorStarts {
+		if start >= scopeStart && start < scopeEnd {
+			return true
+		}
+	}
+	return false
+}
+
+// unusedVariableLambdaIsExpression reports whether a lambda_literal node is
+// in a position where Kotlin actually treats it as a lambda expression
+// (function argument, property delegate, function body, etc.) rather than
+// being a parse-error artifact from a malformed declaration.
+func unusedVariableLambdaIsExpression(file *scanner.File, lambda uint32) bool {
+	parent, ok := file.FlatParent(lambda)
+	if !ok {
+		return false
+	}
+	switch file.FlatType(parent) {
+	case "annotated_lambda", "call_suffix", "value_arguments", "value_argument",
+		"function_value_parameters", "function_body", "property_delegate",
+		"control_structure_body", "when_entry", "statements":
+		return true
 	}
 	return false
 }
@@ -607,6 +737,23 @@ func unusedVariableLexicalScope(file *scanner.File, stmt uint32) (uint32, bool) 
 }
 
 func unusedVariableUsage(file *scanner.File, target unusedVariableDecl) (used bool, unknown bool) {
+	// If the target's lookup scope contains parse errors (e.g. unsupported
+	// Kotlin syntax such as `when` entries with `is X if (cond)` guards), the
+	// tree-sitter tree can drop legit references into ERROR/orphan subtrees.
+	// Abstain rather than risk a false positive.
+	if unusedVariableScopeHasParseError(file, target.scope) {
+		return false, true
+	}
+	// Kotlin allows a unary-prefixed expression statement (e.g. a DSL builder
+	// `+factory`) to follow another expression on the next line. tree-sitter
+	// (and Kotlin's own grammar) bind that into a binary additive_expression
+	// inside the previous statement, so a reference like `+factoryCall` after
+	// `val factoryCall = when { ... }` looks textually as if `factoryCall` is
+	// referenced inside its own initializer. Recognize that pattern as a use
+	// to avoid a false positive.
+	if unusedVariableUnaryContinuationUsesName(file, target) {
+		return true, false
+	}
 	stmtEnd := file.FlatEndByte(target.stmt)
 	for _, nodeType := range []string{"simple_identifier", "interpolated_identifier", "line_str_ref", "multi_line_str_ref"} {
 		file.FlatWalkNodes(target.scope, nodeType, func(candidate uint32) {
@@ -710,6 +857,14 @@ func unusedVariableNearestDeclaration(file *scanner.File, target unusedVariableD
 	refStart := file.FlatStartByte(ref)
 	best := uint32(0)
 	bestStart := uint32(0)
+	// Seed with the target binding so it can match references in `target.scope`
+	// even when the declaration itself sits outside the scope (e.g. a for-loop
+	// destructuring pattern in the loop header). A later in-scope shadow with
+	// a larger start byte still wins via the `start < bestStart` check below.
+	if target.nameNode != 0 && file.FlatStartByte(target.nameNode) <= refStart {
+		best = target.nameNode
+		bestStart = file.FlatStartByte(target.nameNode)
+	}
 	file.FlatWalkAllNodes(target.scope, func(candidate uint32) {
 		if file.FlatStartByte(candidate) > refStart {
 			return

--- a/internal/rules/style_unused_test.go
+++ b/internal/rules/style_unused_test.go
@@ -671,6 +671,198 @@ fun main() {
 	}
 }
 
+func TestUnusedVariable_ForLoopDestructuring(t *testing.T) {
+	cases := []struct {
+		name     string
+		body     string
+		wantMsgs []string
+	}{
+		{
+			name: "both used",
+			body: "println(a); println(b)",
+		},
+		{
+			name:     "none used",
+			body:     `println("body")`,
+			wantMsgs: []string{"Local variable 'a' is never used.", "Local variable 'b' is never used."},
+		},
+		{
+			name:     "only first used",
+			body:     "println(a)",
+			wantMsgs: []string{"Local variable 'b' is never used."},
+		},
+		{
+			name: "string interpolation counts as use",
+			body: `println("a=$a b=${b}")`,
+		},
+		{
+			name:     "shadowed by inner val before any use",
+			body:     "val a = 99; println(a); println(b)",
+			wantMsgs: []string{"Local variable 'a' is never used."},
+		},
+		{
+			name: "use before shadow",
+			body: "println(a); val a = 99; println(a); println(b)",
+		},
+		{
+			name:     "nested function parameter shadows",
+			body:     "fun nested(a: Int) { println(a) }; nested(0); println(b)",
+			wantMsgs: []string{"Local variable 'a' is never used."},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			code := "package test\nfun main() {\n    val pairs = listOf(1 to 2)\n    for ((a, b) in pairs) {\n        " + c.body + "\n    }\n}\n"
+			findings := runRuleByName(t, "UnusedVariable", code)
+			if len(findings) != len(c.wantMsgs) {
+				t.Fatalf("expected %d findings, got %d: %v", len(c.wantMsgs), len(findings), findings)
+			}
+			for i, want := range c.wantMsgs {
+				if findings[i].Message != want {
+					t.Fatalf("finding %d: expected %q, got %q", i, want, findings[i].Message)
+				}
+			}
+		})
+	}
+}
+
+func TestUnusedVariable_ForLoopDestructuringReferenceOutsideBodyDoesNotCount(t *testing.T) {
+	// Destructured bindings are out of scope outside the loop body. The two
+	// findings are the destructured 'a' and 'b'; the trailing `val a`/`val b`
+	// are used.
+	findings := runRuleByName(t, "UnusedVariable", `
+package test
+fun main() {
+    val pairs = listOf(1 to 2)
+    for ((a, b) in pairs) {
+        println("body")
+    }
+    val a = 1
+    val b = 2
+    println(a)
+    println(b)
+}
+`)
+	if len(findings) != 2 {
+		t.Fatalf("expected two findings for destructured bindings (refs outside loop don't count), got %d: %v", len(findings), findings)
+	}
+}
+
+func TestUnusedVariable_ForLoopDestructuringUnderscorePlaceholderAllowed(t *testing.T) {
+	findings := runRuleByName(t, "UnusedVariable", `
+package test
+fun main() {
+    val pairs = listOf(1 to 2)
+    for ((_, b) in pairs) {
+        println(b)
+    }
+}
+`)
+	if len(findings) != 0 {
+		t.Fatalf("expected underscore placeholder to be ignored, got %d: %v", len(findings), findings)
+	}
+}
+
+func TestUnusedVariable_LambdaDestructuringNotFlagged(t *testing.T) {
+	// Lambda destructuring `{ (a, b) -> ... }` should not be touched by the
+	// UnusedVariable rule — those bindings are lambda parameters handled by
+	// UnusedParameter. The bug fix for for-loop destructuring must not extend
+	// to lambdas.
+	findings := runRuleByName(t, "UnusedVariable", `
+package test
+fun main() {
+    val pairs = listOf(1 to 2)
+    pairs.forEach { (a, b) ->
+        println("ignore both")
+    }
+}
+`)
+	if len(findings) != 0 {
+		t.Fatalf("expected lambda destructuring bindings to be ignored by UnusedVariable, got %d: %v", len(findings), findings)
+	}
+}
+
+func TestUnusedVariable_ClassWithSeparateLinePrivateConstructorBodyIsNotLocal(t *testing.T) {
+	// tree-sitter mis-parses `class Foo\nprivate constructor(...) ... { ... }`
+	// as a class header followed by an expression containing a lambda; class
+	// members end up under a lambda_literal that is not actually a lambda
+	// expression. They must not be flagged as "local variable".
+	findings := runRuleByName(t, "UnusedVariable", `
+package test
+internal class Parameter
+private constructor(
+  val kind: Int,
+  val name: String,
+) : Comparable<Parameter> {
+  val typeKey: Int = kind
+  val type: Int = kind
+}
+`)
+	if len(findings) != 0 {
+		t.Fatalf("expected zero findings (class body mis-parsed as lambda), got %d: %v", len(findings), findings)
+	}
+}
+
+func TestUnusedVariable_ScopeWithParseErrorsAbstains(t *testing.T) {
+	// tree-sitter Kotlin does not support `when` entries with `is X if (cond)`
+	// guards yet. References that land in ERROR/orphan subtrees would
+	// otherwise be invisible, producing false positives. The rule must
+	// abstain when its lookup scope contains parse errors.
+	findings := runRuleByName(t, "UnusedVariable", `
+package test
+fun fn(x: Any): Boolean {
+    val isGraph = true
+    val isContributedGraph = true
+    when (x) {
+        is String -> println("s")
+        is IntArray if (isGraph && x.size > 0) -> println("a")
+        else -> {}
+    }
+    return isContributedGraph
+}
+`)
+	if len(findings) != 0 {
+		t.Fatalf("expected zero findings when scope has parse errors, got %d: %v", len(findings), findings)
+	}
+}
+
+func TestUnusedVariable_UnaryPlusContinuationAfterWhenBlockCountsAsUse(t *testing.T) {
+	// A user-intended unary-plus statement after a multi-line expression is
+	// bound by tree-sitter (and Kotlin's grammar) into an additive_expression
+	// inside the previous initializer. The rule must recognize that pattern
+	// and treat the trailing identifier as a use.
+	findings := runRuleByName(t, "UnusedVariable", `
+package test
+operator fun String.unaryPlus(): Unit = Unit
+fun foo(x: Int) {
+    val factoryCall = when (x) {
+        1 -> "a"
+        else -> "b"
+    }
+    +factoryCall
+}
+`)
+	if len(findings) != 0 {
+		t.Fatalf("expected unary-plus continuation to be treated as a use, got %d: %v", len(findings), findings)
+	}
+}
+
+func TestUnusedVariable_UnaryPlusContinuationOnSameLineDoesNotAffectOtherCases(t *testing.T) {
+	// A genuine self-reference on the same line (no leading newline before
+	// the `+`) should still be treated as unused — only newline-prefixed
+	// unary continuations should be rescued.
+	findings := runRuleByName(t, "UnusedVariable", `
+package test
+fun foo(outer: Int) {
+    val self = outer + outer
+    println("done")
+}
+`)
+	if len(findings) != 1 {
+		t.Fatalf("expected `self` to remain flagged as unused, got %d: %v", len(findings), findings)
+	}
+}
+
 func TestUnusedVariable_AnnotatedConstructorClassBodyPropertiesAreNotLocalVariables(t *testing.T) {
 	findings := runRuleByName(t, "UnusedVariable", `
 package test

--- a/tests/fixtures/negative/style/UnusedVariable.kt
+++ b/tests/fixtures/negative/style/UnusedVariable.kt
@@ -32,3 +32,15 @@ enum class Direction(val degrees: Int) {
 
     val radians: Double get() = degrees * 3.14159 / 180.0
 }
+
+fun walkPairs(pairs: List<Pair<Int, Int>>) {
+    for ((a, b) in pairs) {
+        println("a=$a b=${b}")
+    }
+}
+
+fun walkPairsIgnoringFirst(pairs: List<Pair<Int, Int>>) {
+    for ((_, b) in pairs) {
+        println(b)
+    }
+}

--- a/tests/fixtures/positive/style/UnusedVariable.kt
+++ b/tests/fixtures/positive/style/UnusedVariable.kt
@@ -11,3 +11,9 @@ class Worker {
         println("ready")
     }
 }
+
+fun walkPairs(pairs: List<Pair<Int, Int>>) {
+    for ((a, b) in pairs) {
+        println("body")
+    }
+}


### PR DESCRIPTION
## Summary

UnusedVariable previously missed for-loop destructuring entirely and emitted false positives on a handful of tree-sitter parse shapes seen in real Kotlin code:

- `for ((a, b) in xs) { ... }` — the destructuring pattern sits in the for header (outside any property_declaration), so neither binding was analyzed.
- `internal class Foo\nprivate constructor(...) { ... }` — tree-sitter recovers by parsing the class body as a lambda, making real class members look like locals.
- `when` entries with `is X if (cond)` guards — tree-sitter drops references into ERROR/orphan subtrees that the rule can't see.
- `val factoryCall = when { ... }\n+factoryCall` (Compose-style DSL) — Kotlin's grammar binds the unary statement into the previous initializer as `expr + factoryCall`, so the reference appears inside the val's text range.

Fixes:
- Recognize the for-loop destructuring shape; use the loop body as the binding scope and seed the nearest-declaration walk with the target's name node so refs in scope match the binding even when the declaration lives in the header.
- Treat `lambda_literal` as a local scope only when its parent context is a real lambda expression.
- Abstain when the lookup scope contains ERROR nodes (cached per file via filefacts).
- Detect the newline-prefixed `+name` continuation pattern as a use.

Eliminates 19 UnusedVariable false positives on the metro compiler corpus, including the user-reported cases (class-level delegated properties, `+factoryCall`, locals shadowed by Kotlin `when` guards).

## Test plan
- [x] `go build ./...`, `go vet ./...`, `golangci-lint run ./...` — clean
- [x] `go test ./internal/rules ./internal/scanner ./internal/ruleslinter -count=1`
- [x] Existing UnusedVariable suite + 13 new tests (for-loop destructuring table-driven + parse-error abstention + unary-plus continuation + class-with-newline-constructor)
- [x] Dogfooded against `github.com/zacsweers/metro` — UnusedVariable findings dropped from 19 to 0
- [x] Positive/negative fixtures updated for for-loop destructuring