### PR TITLE
fix(rules): scope-bound walk for SqliteCursorWithoutClose source

### DIFF
--- a/internal/rules/database.go
+++ b/internal/rules/database.go
@@ -135,11 +135,16 @@ func (r *SqliteCursorWithoutCloseRule) Confidence() float64 { return 0.75 }
 
 func sqliteCursorCallFlat(file *scanner.File, idx uint32) bool {
 	found := false
-	file.FlatWalkNodes(idx, "call_expression", func(callIdx uint32) {
-		if found {
+	// Only consider call_expression nodes that sit on the property
+	// initializer's top-level call/navigation chain — i.e. nodes whose value
+	// becomes the property's value. Calls nested inside lambdas, anonymous
+	// functions, or local declarations belong to a different scope and do
+	// not determine the property's static type, so they must not count.
+	flatWalkLocalScope(file, idx, func(node uint32) {
+		if found || file.FlatType(node) != "call_expression" {
 			return
 		}
-		name := flatCallExpressionName(file, callIdx)
+		name := flatCallExpressionName(file, node)
 		if name == "rawQuery" || name == "query" {
 			found = true
 		}

--- a/internal/rules/database_test.go
+++ b/internal/rules/database_test.go
@@ -716,6 +716,87 @@ fun loadUsers(db: SQLiteDatabase) {
 	}
 }
 
+func TestSqliteCursorWithoutClose_NegativeNestedScopes(t *testing.T) {
+	cases := []struct {
+		name string
+		src  string
+	}{
+		{
+			name: "Runnable lambda containing rawQuery",
+			src: `
+package test
+
+interface Cursor { fun close() }
+interface SQLiteDatabase { fun rawQuery(sql: String, args: Array<String>?): Cursor }
+fun interface Runnable { fun run() }
+
+fun loadUsers(db: SQLiteDatabase) {
+    val handler = Runnable { db.rawQuery("SELECT * FROM users", null).close() }
+    handler.run()
+}
+`,
+		},
+		{
+			name: "factory lambda returning Cursor",
+			src: `
+package test
+
+interface Cursor { fun close() }
+interface SQLiteDatabase { fun rawQuery(sql: String, args: Array<String>?): Cursor }
+
+fun loadUsers(db: SQLiteDatabase) {
+    val factory: () -> Cursor = { db.rawQuery("SELECT * FROM users", null) }
+    factory().close()
+}
+`,
+		},
+		{
+			name: "lazy delegate wrapping rawQuery",
+			src: `
+package test
+
+interface Cursor { fun close() }
+interface SQLiteDatabase { fun rawQuery(sql: String, args: Array<String>?): Cursor }
+
+fun <T> lazyOf(init: () -> T): T = init()
+
+fun loadUsers(db: SQLiteDatabase) {
+    val lazyCursor = lazyOf { db.rawQuery("SELECT * FROM users", null) }
+    lazyCursor.close()
+}
+`,
+		},
+		{
+			name: "list map producing strings via rawQuery use",
+			src: `
+package test
+
+interface Cursor {
+    fun getString(idx: Int): String
+    fun close()
+}
+interface SQLiteDatabase { fun rawQuery(sql: String, args: Array<String>?): Cursor }
+
+inline fun <T : Cursor, R> T.use(block: (T) -> R): R = try { block(this) } finally { this.close() }
+
+fun loadUsers(db: SQLiteDatabase): List<String> {
+    val tags = listOf("a", "b").map { db.rawQuery(it, null).use { c -> c.getString(0) } }
+    return tags
+}
+`,
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			findings := runRuleByName(t, "SqliteCursorWithoutClose", tc.src)
+			if len(findings) != 0 {
+				t.Fatalf("expected no findings for %s, got %v", tc.name, findings)
+			}
+		})
+	}
+}
+
 func TestRoomMigrationUsesExecSqlWithInterpolation_Positive(t *testing.T) {
 	findings := runRuleByName(t, "RoomMigrationUsesExecSqlWithInterpolation", `
 package test

--- a/tests/fixtures/negative/database/SqliteCursorWithoutClose.kt
+++ b/tests/fixtures/negative/database/SqliteCursorWithoutClose.kt
@@ -2,6 +2,7 @@ package test
 
 interface Cursor {
     fun moveToNext(): Boolean
+    fun getString(idx: Int): String
     fun close()
 }
 
@@ -42,3 +43,37 @@ fun loadUsersShortName(db: SQLiteDatabase) {
         c.close()
     }
 }
+
+fun interface Runnable { fun run() }
+
+fun <T> lazyOf(init: () -> T): T = init()
+
+// Regression: the property's static type is Runnable, not Cursor. The
+// rawQuery call lives inside a nested lambda scope and does not become
+// the property's value, so the rule must not fire.
+fun loadUsersRunnable(db: SQLiteDatabase) {
+    val handler = Runnable { db.rawQuery("SELECT * FROM users", null).close() }
+    handler.run()
+}
+
+// Regression: the property's static type is `() -> Cursor`, not Cursor.
+// The cursor only materialises when the caller invokes the factory.
+fun loadUsersFactory(db: SQLiteDatabase) {
+    val factory: () -> Cursor = { db.rawQuery("SELECT * FROM users", null) }
+    factory().close()
+}
+
+// Regression: the rawQuery call sits inside a lazyOf {} lambda. The
+// scope-bounded walk must not descend into the lambda body.
+fun loadUsersLazy(db: SQLiteDatabase) {
+    val lazyCursor = lazyOf { db.rawQuery("SELECT * FROM users", null) }
+    lazyCursor.close()
+}
+
+// Regression: rawQuery lives inside a map { ... } lambda whose result is
+// a List<String>, not a Cursor. The rule must not flag the property.
+fun loadUserTags(db: SQLiteDatabase): List<String> {
+    val tags = listOf("a", "b").map { db.rawQuery(it, null).use { c -> c.getString(0) } }
+    return tags
+}
+

--- a/tests/fixtures/positive/database/SqliteCursorWithoutClose.kt
+++ b/tests/fixtures/positive/database/SqliteCursorWithoutClose.kt
@@ -37,3 +37,15 @@ fun loadUsersWithLookalike(db: SQLiteDatabase) {
     vc.close()
     // c is never closed
 }
+
+// Regression for scope-bounded walk: the rawQuery call sits on the
+// property initializer's outer call/navigation chain (top-level value),
+// so it must still FIRE even though the chain crosses a navigation
+// expression. Locks in coverage that the scope-aware walk did not
+// over-prune the legitimate case.
+fun loadUsersChain(db: SQLiteDatabase) {
+    val cursor = db.rawQuery("SELECT * FROM users WHERE active = 1", null)
+    while (cursor.moveToNext()) {
+        // never closed
+    }
+}


### PR DESCRIPTION
## Summary

`sqliteCursorCallFlat` walked **every** `call_expression` descendant of the property declaration. A `rawQuery` or `query` call nested inside a lambda, anonymous function, or local declaration was counted as if it determined the property's value. That false-positively flagged initializers whose static type is not a `Cursor`:

- `val handler = Runnable { db.rawQuery(\"...\").close() }` — type is `Runnable`.
- `val factory: () -> Cursor = { db.rawQuery(\"...\", null) }` — type is `() -> Cursor`.
- `val lazyCursor = lazyOf { db.rawQuery(\"...\", null) }` — type is whatever `lazyOf` returns, materialised only when invoked.
- `val tags = listOf(\"a\", \"b\").map { db.rawQuery(it, null).use { c -> c.getString(0) } }` — type is `List<String>`.

## Fix

The walk now uses the existing `flatWalkLocalScope` helper, which prunes descent into `function_declaration`, `lambda_literal`, `anonymous_function`, `class_declaration`, and `object_declaration`. Only call expressions on the initializer's top-level chain (the ones whose value becomes the property's value) count as cursor sources.

## Test plan

- [x] Negative fixture `SqliteCursorWithoutClose.kt` extended with the four patterns above.
- [x] `TestSqliteCursorWithoutClose_NegativeNestedScopes` adds focused subtests for each pattern.
- [x] Positive fixture extended with `val cursor = db.rawQuery(...)` (no nested scope) so the scope-aware walk doesn't over-prune the legitimate case.
- [x] `go build`, `go vet`, `golangci-lint run`, `go test ./... -count=1` all pass.

## Note

The audit example `val cursor = db.rawQuery(...).use { c -> getData { c.query(...) } }` does **not** actually false-positive today: `sqliteCursorRHSWrappedInUseFlat` already short-circuits on the `.use {` text. The other four patterns above do reproduce on the unfixed code.