### PR TITLE
feat(scanner): FQN-strict cross-file helper + AtThoroughDepth plumbing

### DIFF
--- a/internal/pipeline/crossfile.go
+++ b/internal/pipeline/crossfile.go
@@ -126,7 +126,7 @@ func (p CrossFilePhase) runCrossRuleSet(ctx context.Context, in DispatchResult, 
 		}
 		ruleID := r.ID
 		call := func() {
-			rctx := buildCrossRuleContext(r, codeIndex, parsedFiles, in.Resolver, in.LibraryFacts, javaSourceIndex, crossCollector)
+			rctx := buildCrossRuleContext(r, codeIndex, parsedFiles, in.Resolver, in.LibraryFacts, javaSourceIndex, crossCollector, in.Thorough)
 			r.Check(rctx)
 		}
 		if ruleTracker != nil {
@@ -136,7 +136,7 @@ func (p CrossFilePhase) runCrossRuleSet(ctx context.Context, in DispatchResult, 
 		}
 	}
 	if len(concurrentRules) > 0 && ctx.Err() == nil {
-		runConcurrentCrossRules(ctx, concurrentRules, codeIndex, parsedFiles, in.Resolver, in.LibraryFacts, javaSourceIndex, crossCollector, p.Workers, ruleTracker, &result.Stats.Errors)
+		runConcurrentCrossRules(ctx, concurrentRules, codeIndex, parsedFiles, in.Resolver, in.LibraryFacts, javaSourceIndex, crossCollector, p.Workers, ruleTracker, &result.Stats.Errors, in.Thorough)
 	}
 	if ruleTracker != nil {
 		ruleTracker.End()
@@ -508,8 +508,8 @@ func javaSourceIndexForParsedFiles(parsedFiles []*scanner.File) *javafacts.Sourc
 	return nil
 }
 
-func buildCrossRuleContext(r *api.Rule, codeIndex *scanner.CodeIndex, parsedFiles []*scanner.File, resolver typeinfer.TypeResolver, libraryFacts *librarymodel.Facts, javaSourceIndex *javafacts.SourceIndex, collector *scanner.FindingCollector) *api.Context {
-	rctx := &api.Context{Collector: collector, Rule: r, DefaultConfidence: 0.95, LibraryFacts: libraryFacts, JavaSourceIndex: javaSourceIndex}
+func buildCrossRuleContext(r *api.Rule, codeIndex *scanner.CodeIndex, parsedFiles []*scanner.File, resolver typeinfer.TypeResolver, libraryFacts *librarymodel.Facts, javaSourceIndex *javafacts.SourceIndex, collector *scanner.FindingCollector, thorough bool) *api.Context {
+	rctx := &api.Context{Collector: collector, Rule: r, DefaultConfidence: 0.95, LibraryFacts: libraryFacts, JavaSourceIndex: javaSourceIndex, AtThoroughDepth: thorough}
 	if r.Needs.Has(api.NeedsResolver) {
 		rctx.Resolver = resolver
 	}
@@ -534,7 +534,7 @@ const concurrentCrossRuleThreshold = 2
 // owner re-sorts the full columnar result by file/line before output
 // (see applySuppressionColumns + result.Findings path). Rule panics are
 // recovered per-rule so one broken rule does not take down the phase.
-func runConcurrentCrossRules(ctx context.Context, ruleSet []*api.Rule, codeIndex *scanner.CodeIndex, parsedFiles []*scanner.File, resolver typeinfer.TypeResolver, libraryFacts *librarymodel.Facts, javaSourceIndex *javafacts.SourceIndex, dst *scanner.FindingCollector, workers int, tracker perf.Tracker, errs *[]rules.DispatchError) {
+func runConcurrentCrossRules(ctx context.Context, ruleSet []*api.Rule, codeIndex *scanner.CodeIndex, parsedFiles []*scanner.File, resolver typeinfer.TypeResolver, libraryFacts *librarymodel.Facts, javaSourceIndex *javafacts.SourceIndex, dst *scanner.FindingCollector, workers int, tracker perf.Tracker, errs *[]rules.DispatchError, thorough bool) {
 	if len(ruleSet) == 0 {
 		return
 	}
@@ -556,7 +556,7 @@ func runConcurrentCrossRules(ctx context.Context, ruleSet []*api.Rule, codeIndex
 			}
 			ruleID := r.ID
 			call := func() {
-				runConcurrentCrossRule(r, codeIndex, parsedFiles, resolver, libraryFacts, javaSourceIndex, dst, errs)
+				runConcurrentCrossRule(r, codeIndex, parsedFiles, resolver, libraryFacts, javaSourceIndex, dst, errs, thorough)
 			}
 			if tracker != nil {
 				tracker.TrackVoid(ruleID, call)
@@ -598,7 +598,7 @@ func runConcurrentCrossRules(ctx context.Context, ruleSet []*api.Rule, codeIndex
 					return
 				}
 				r := ruleSet[idx]
-				runConcurrentCrossRule(r, codeIndex, parsedFiles, resolver, libraryFacts, javaSourceIndex, local, &localErrs[workerID])
+				runConcurrentCrossRule(r, codeIndex, parsedFiles, resolver, libraryFacts, javaSourceIndex, local, &localErrs[workerID], thorough)
 			}
 		}(w)
 	}
@@ -641,7 +641,7 @@ func mergeSortedLocalErrs(localErrs [][]rules.DispatchError) []rules.DispatchErr
 // runConcurrentCrossRule invokes a single rule's Check against a given
 // collector, recovering from panics the same way the serial path does.
 // Each caller hands its own collector so the goroutines never contend.
-func runConcurrentCrossRule(r *api.Rule, codeIndex *scanner.CodeIndex, parsedFiles []*scanner.File, resolver typeinfer.TypeResolver, libraryFacts *librarymodel.Facts, javaSourceIndex *javafacts.SourceIndex, local *scanner.FindingCollector, errs *[]rules.DispatchError) {
+func runConcurrentCrossRule(r *api.Rule, codeIndex *scanner.CodeIndex, parsedFiles []*scanner.File, resolver typeinfer.TypeResolver, libraryFacts *librarymodel.Facts, javaSourceIndex *javafacts.SourceIndex, local *scanner.FindingCollector, errs *[]rules.DispatchError, thorough bool) {
 	defer func() {
 		if rec := recover(); rec != nil {
 			if errs != nil {
@@ -653,7 +653,7 @@ func runConcurrentCrossRule(r *api.Rule, codeIndex *scanner.CodeIndex, parsedFil
 			}
 		}
 	}()
-	rctx := buildCrossRuleContext(r, codeIndex, parsedFiles, resolver, libraryFacts, javaSourceIndex, local)
+	rctx := buildCrossRuleContext(r, codeIndex, parsedFiles, resolver, libraryFacts, javaSourceIndex, local, thorough)
 	r.Check(rctx)
 }
 

--- a/internal/pipeline/crossfile_concurrent_test.go
+++ b/internal/pipeline/crossfile_concurrent_test.go
@@ -60,7 +60,7 @@ class Foo {}
 	rule := api.FakeRule("SemanticCross", api.WithNeeds(api.NeedsCrossFile|api.NeedsParsedFiles|api.NeedsResolver))
 	javaSourceIndex := javaSourceIndexForParsedFiles(parsedFiles)
 
-	ctx := buildCrossRuleContext(rule, index, parsedFiles, resolver, nil, javaSourceIndex, dst)
+	ctx := buildCrossRuleContext(rule, index, parsedFiles, resolver, nil, javaSourceIndex, dst, false)
 
 	if ctx.CodeIndex != index {
 		t.Fatal("CodeIndex was not wired for NeedsCrossFile")
@@ -79,6 +79,24 @@ class Foo {}
 	}
 	if _, ok := ctx.JavaSourceIndex.ClassesByFQN["app.Foo"]; !ok {
 		t.Fatalf("JavaSourceIndex missing app.Foo: %#v", ctx.JavaSourceIndex.ClassesByFQN)
+	}
+	if ctx.AtThoroughDepth {
+		t.Fatal("AtThoroughDepth must default to false when builder is called with thorough=false")
+	}
+}
+
+func TestBuildCrossRuleContext_PlumbsThoroughFlag(t *testing.T) {
+	rule := api.FakeRule("Cross", api.WithNeeds(api.NeedsCrossFile))
+	dst := scanner.NewFindingCollector(0)
+
+	balanced := buildCrossRuleContext(rule, nil, nil, nil, nil, nil, dst, false)
+	if balanced.AtThoroughDepth {
+		t.Errorf("balanced context must have AtThoroughDepth=false")
+	}
+
+	thorough := buildCrossRuleContext(rule, nil, nil, nil, nil, nil, dst, true)
+	if !thorough.AtThoroughDepth {
+		t.Errorf("thorough context must have AtThoroughDepth=true")
 	}
 }
 
@@ -109,7 +127,7 @@ func TestRunConcurrentCrossRules_FindingEquivalence(t *testing.T) {
 		workers := workers
 		t.Run(fmt.Sprintf("workers=%d", workers), func(t *testing.T) {
 			dst := scanner.NewFindingCollector(0)
-			runConcurrentCrossRules(context.Background(), rules, nil, nil, nil, nil, nil, dst, workers, nil, nil)
+			runConcurrentCrossRules(context.Background(), rules, nil, nil, nil, nil, nil, dst, workers, nil, nil, false)
 			got := *dst.Columns()
 
 			if got.Len() != serialCols.Len() {
@@ -136,7 +154,7 @@ func TestRunConcurrentCrossRules_RecoversFromPanics(t *testing.T) {
 	}))
 	rules := []*api.Rule{good, bad, good, bad}
 	dst := scanner.NewFindingCollector(0)
-	runConcurrentCrossRules(context.Background(), rules, nil, nil, nil, nil, nil, dst, 4, nil, nil)
+	runConcurrentCrossRules(context.Background(), rules, nil, nil, nil, nil, nil, dst, 4, nil, nil, false)
 	if got := dst.Columns().Len(); got != 2 {
 		t.Fatalf("Len=%d want 2 (two Good invocations survive two Bad panics)", got)
 	}
@@ -156,7 +174,7 @@ func TestRunConcurrentCrossRules_HonoursContextCancel(t *testing.T) {
 		}))
 	}
 	dst := scanner.NewFindingCollector(0)
-	runConcurrentCrossRules(ctx, rules, nil, nil, nil, nil, nil, dst, 4, nil, nil)
+	runConcurrentCrossRules(ctx, rules, nil, nil, nil, nil, nil, dst, 4, nil, nil, false)
 	// We allow up to one rule per worker to observe the cancelled ctx
 	// after dispatch; the critical property is that not all rules run.
 	if int(ran.Load()) >= len(rules) {
@@ -172,7 +190,7 @@ func TestRunConcurrentCrossRules_SingleRuleFallsBackToSerial(t *testing.T) {
 		ctx.EmitAt(1, 1, "solo")
 	}))
 	dst := scanner.NewFindingCollector(0)
-	runConcurrentCrossRules(context.Background(), []*api.Rule{r}, nil, nil, nil, nil, nil, dst, 4, nil, nil)
+	runConcurrentCrossRules(context.Background(), []*api.Rule{r}, nil, nil, nil, nil, nil, dst, 4, nil, nil, false)
 	if got := dst.Columns().Len(); got != 1 {
 		t.Fatalf("Len=%d want 1", got)
 	}
@@ -200,7 +218,7 @@ func TestRunConcurrentCrossRules_PanicRecordedInErrors(t *testing.T) {
 			}
 			dst := scanner.NewFindingCollector(0)
 			var errs []rules.DispatchError
-			runConcurrentCrossRules(context.Background(), ruleSet, nil, nil, nil, nil, nil, dst, 4, nil, &errs)
+			runConcurrentCrossRules(context.Background(), ruleSet, nil, nil, nil, nil, nil, dst, 4, nil, &errs, false)
 			if len(errs) != tc.n {
 				t.Fatalf("errs=%d want %d (%v)", len(errs), tc.n, errs)
 			}
@@ -239,7 +257,7 @@ func makeConcurrentRules(n int) []*api.Rule {
 func runCrossRulesSerial(rules []*api.Rule) scanner.FindingColumns {
 	dst := scanner.NewFindingCollector(0)
 	for _, r := range rules {
-		rctx := buildCrossRuleContext(r, nil, nil, nil, nil, nil, dst)
+		rctx := buildCrossRuleContext(r, nil, nil, nil, nil, nil, dst, false)
 		r.Check(rctx)
 	}
 	return *dst.Columns()

--- a/internal/pipeline/index.go
+++ b/internal/pipeline/index.go
@@ -639,6 +639,7 @@ func (p IndexPhase) Run(ctx context.Context, in IndexInput) (IndexResult, error)
 		CrossFileCacheDir:     in.CrossFileCacheDir,
 		CodeIndexCache:        in.CodeIndexCache,
 		JavaSourceIndexCache:  in.JavaSourceIndexCache,
+		Thorough:              in.Thorough,
 	}
 
 	caps := unionNeeds(in.ActiveRules)

--- a/internal/pipeline/types.go
+++ b/internal/pipeline/types.go
@@ -226,6 +226,10 @@ type IndexResult struct {
 	// CodeIndex is the cross-file symbol/reference index. Nil when
 	// no active rule declares NeedsCrossFile.
 	CodeIndex *scanner.CodeIndex
+	// Thorough mirrors ProjectArgs.TargetedResolution and is forwarded
+	// onto api.Context.AtThoroughDepth so rules can opt into stricter
+	// helpers at --depth=thorough without consulting the runner.
+	Thorough bool
 	// Graph lists discovered Gradle modules. Always populated
 	// (possibly empty).
 	Graph *module.Graph

--- a/internal/rules/api/rule.go
+++ b/internal/rules/api/rule.go
@@ -1177,6 +1177,12 @@ type Context struct {
 	// mini-contexts may leave it nil — filefacts accessors are nil-safe
 	// and recompute without caching in that case.
 	Facts *filefacts.Cache
+
+	// AtThoroughDepth is true when the scan ran with --depth=thorough.
+	// Rules read it to branch on stricter cross-file or oracle-confirmed
+	// query paths that trade extra cost for precision. False at
+	// fast/balanced — rules must keep working without this signal.
+	AtThoroughDepth bool
 }
 
 // Emit reports a finding. The finding is stamped with rule metadata and

--- a/internal/scanner/index_query.go
+++ b/internal/scanner/index_query.go
@@ -417,15 +417,22 @@ func (idx *CodeIndex) IsReferencedOutsideFile(name, file string) bool {
 // IsSymbolReferencedOutsideFile checks whether sym is referenced from another
 // file by either simple name or fully-qualified name.
 func (idx *CodeIndex) IsSymbolReferencedOutsideFile(sym Symbol, ignoreCommentRefs bool) bool {
+	return idx.anyReferenceOutsideFile(symbolReferenceNames(sym), sym.File, ignoreCommentRefs)
+}
+
+// anyReferenceOutsideFile is shared between the loose and strict
+// IsSymbolReferenced* variants: returns true on the first name that has
+// an outside-file reference (honouring the comment-exclusion flag).
+func (idx *CodeIndex) anyReferenceOutsideFile(names []string, file string, ignoreCommentRefs bool) bool {
 	if idx == nil {
 		return false
 	}
-	for _, name := range symbolReferenceNames(sym) {
+	for _, name := range names {
 		if ignoreCommentRefs {
-			if idx.IsReferencedOutsideFileExcludingComments(name, sym.File) {
+			if idx.IsReferencedOutsideFileExcludingComments(name, file) {
 				return true
 			}
-		} else if idx.IsReferencedOutsideFile(name, sym.File) {
+		} else if idx.IsReferencedOutsideFile(name, file) {
 			return true
 		}
 	}
@@ -525,6 +532,31 @@ func symbolReferenceNames(sym Symbol) []string {
 		return []string{sym.Name}
 	}
 	return []string{sym.Name, sym.FQN}
+}
+
+// symbolReferenceNamesStrict drops the simple-name path when an FQN is
+// available, so references that only matched by collision with a
+// like-named symbol in another package are not counted. When the
+// symbol has no FQN the strict view falls back to the simple name —
+// the rule has no other handle to disambiguate.
+func symbolReferenceNamesStrict(sym Symbol) []string {
+	if sym.Name == "" {
+		return nil
+	}
+	if sym.FQN != "" && sym.FQN != sym.Name {
+		return []string{sym.FQN}
+	}
+	return []string{sym.Name}
+}
+
+// IsSymbolReferencedOutsideFileFQN is the strict variant of
+// IsSymbolReferencedOutsideFile: it requires an FQN match (when the
+// symbol has one), so a reference to a like-named declaration in a
+// different package does not count as usage. Use at --depth=thorough
+// when reducing false-negative dead-code is worth the loss of the
+// simple-name fallback for symbols without an FQN.
+func (idx *CodeIndex) IsSymbolReferencedOutsideFileFQN(sym Symbol, ignoreCommentRefs bool) bool {
+	return idx.anyReferenceOutsideFile(symbolReferenceNamesStrict(sym), sym.File, ignoreCommentRefs)
 }
 
 // BloomStats returns the bloom filter memory usage in bytes.

--- a/internal/scanner/index_test.go
+++ b/internal/scanner/index_test.go
@@ -1221,3 +1221,58 @@ func TestIsXMLReferenceCandidate(t *testing.T) {
 		}
 	}
 }
+
+// When two packages declare a same-named symbol, the loose
+// IsSymbolReferencedOutsideFile reports either declaration as
+// referenced (simple-name collision); the strict FQN-only variant
+// disambiguates and lets dead-code detection at --depth=thorough drop
+// the false positive.
+func TestIsSymbolReferencedOutsideFileFQN_DropsSimpleNameCollisions(t *testing.T) {
+	dir := t.TempDir()
+	declA := writeTempKt(t, dir, "a_Foo.kt", `package a
+class Foo {}
+`)
+	declB := writeTempKt(t, dir, "b_Foo.kt", `package b
+class Foo {}
+`)
+	consumer := writeTempKt(t, dir, "b_Use.kt", `package b
+fun use(f: Foo) {}
+`)
+
+	fA, err := ParseFile(context.Background(), declA)
+	if err != nil {
+		t.Fatalf("parse declA: %v", err)
+	}
+	fB, err := ParseFile(context.Background(), declB)
+	if err != nil {
+		t.Fatalf("parse declB: %v", err)
+	}
+	fC, err := ParseFile(context.Background(), consumer)
+	if err != nil {
+		t.Fatalf("parse consumer: %v", err)
+	}
+	idx := BuildIndex([]*File{fA, fB, fC}, 1)
+
+	var symA Symbol
+	for _, s := range idx.Symbols {
+		if s.Name == "Foo" && s.File == declA {
+			symA = s
+		}
+	}
+	if symA.Name == "" {
+		t.Fatal("expected to find a.Foo symbol in index")
+	}
+	if symA.FQN == "" {
+		t.Skipf("test fixture did not produce an FQN for a.Foo (got %+v); skipping precision assertion", symA)
+	}
+
+	// Loose helper sees the reference to b.Foo in use.kt and reports
+	// a.Foo as referenced — false positive from the simple-name match.
+	if !idx.IsSymbolReferencedOutsideFile(symA, false) {
+		t.Fatal("loose helper should report a.Foo referenced (simple-name collision with b.Foo)")
+	}
+	// Strict helper requires FQN match; a.Foo is not referenced.
+	if idx.IsSymbolReferencedOutsideFileFQN(symA, false) {
+		t.Errorf("strict helper should NOT report a.Foo referenced; only b.Foo is")
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `CodeIndex.IsSymbolReferencedOutsideFileFQN` — the strict variant of `IsSymbolReferencedOutsideFile`. When a symbol has an FQN the strict check requires an FQN-qualified reference, dropping the simple-name fallback that conflates references to like-named declarations in other packages. Lets dead-code rules at `--depth=thorough` reduce false-alive verdicts caused by simple-name collisions.
- Plumbs a `Thorough bool` through `IndexInput → IndexResult → DispatchResult → buildCrossRuleContext` onto a new `api.Context.AtThoroughDepth` field. Rules read `AtThoroughDepth` to opt into the strict helper (or other thorough-only paths) without consulting CLI flags or runner state.
- No rule reads `AtThoroughDepth` yet; this PR lands the mechanism for future adopters. Per-file dispatcher contexts intentionally leave `AtThoroughDepth=false` — only cross-file rules have helpers that benefit from the signal at this point.
- Refactors the loose and strict reference checks to share a private `anyReferenceOutsideFile` helper so the bloom/file-set traversal lives in one place.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...` — 0 issues
- [x] `make lint-rules`
- [x] `go test ./internal/scanner/... ./internal/pipeline/... ./internal/rules/... ./internal/cli/scan/... -count=1`
- [ ] `make integration` (CI)

New tests:
- `TestIsSymbolReferencedOutsideFileFQN_DropsSimpleNameCollisions` proves the strict helper disambiguates same-named declarations across packages.
- `TestBuildCrossRuleContext_PlumbsThoroughFlag` proves the thorough bool reaches `api.Context.AtThoroughDepth` and defaults to false otherwise.