### PR TITLE
fix(rules): resolve receiver FQN for SqliteCursorWithoutClose

### DIFF
--- a/docs/java-support-readiness.yml
+++ b/docs/java-support-readiness.yml
@@ -411,6 +411,9 @@ rules:
     status: supported
     fixtures:
       - internal/rules/security_test.go
+  SqliteCursorWithoutClose:
+    status: not-applicable
+    reason: Rule dispatches on Kotlin property_declaration and matches the val/var initializer chain; Java local variables are syntactically and structurally different.
   ThrowingExceptionInMain:
     status: supported
     fixtures:

--- a/internal/cli/rules/testdata/coverage_java.golden
+++ b/internal/cli/rules/testdata/coverage_java.golden
@@ -6,8 +6,8 @@ AbstractClassCanBeInterface                     style                partial    
 
 Total: 784 rule(s)
   supported: 119
-  partial: 453
+  partial: 452
   pending: 142
   needs-design: 0
-  not-applicable: 49
+  not-applicable: 50
   (unclassified): 21

--- a/internal/rules/database.go
+++ b/internal/rules/database.go
@@ -133,23 +133,27 @@ type SqliteCursorWithoutCloseRule struct {
 // method name without confirming the receiver is SQLiteDatabase.
 func (r *SqliteCursorWithoutCloseRule) Confidence() float64 { return 0.75 }
 
-func sqliteCursorCallFlat(file *scanner.File, idx uint32) bool {
+// sqliteCursorCallFlat reports whether the property initializer at idx has a
+// top-level call_expression named rawQuery or query, and if so returns the
+// matching call node's flat index. Only call_expression nodes that sit on the
+// property initializer's top-level call/navigation chain qualify — calls
+// nested inside lambdas, anonymous functions, or local declarations belong to
+// a different scope and do not determine the property's static type, so they
+// must not count.
+func sqliteCursorCallFlat(file *scanner.File, idx uint32) (uint32, bool) {
+	var match uint32
 	found := false
-	// Only consider call_expression nodes that sit on the property
-	// initializer's top-level call/navigation chain — i.e. nodes whose value
-	// becomes the property's value. Calls nested inside lambdas, anonymous
-	// functions, or local declarations belong to a different scope and do
-	// not determine the property's static type, so they must not count.
 	flatWalkLocalScope(file, idx, func(node uint32) {
 		if found || file.FlatType(node) != "call_expression" {
 			return
 		}
 		name := flatCallExpressionName(file, node)
 		if name == "rawQuery" || name == "query" {
+			match = node
 			found = true
 		}
 	})
-	return found
+	return match, found
 }
 
 func sqliteCursorRHSWrappedInUseFlat(file *scanner.File, idx uint32) bool {

--- a/internal/rules/database_test.go
+++ b/internal/rules/database_test.go
@@ -641,17 +641,10 @@ data class DraftUser(
 }
 
 func TestSqliteCursorWithoutClose_Positive(t *testing.T) {
-	findings := runRuleByName(t, "SqliteCursorWithoutClose", `
+	findings := runRuleByNameWithResolver(t, "SqliteCursorWithoutClose", `
 package test
 
-interface Cursor {
-    fun moveToNext(): Boolean
-    fun close()
-}
-
-interface SQLiteDatabase {
-    fun rawQuery(sql: String, args: Array<String>?): Cursor
-}
+import android.database.sqlite.SQLiteDatabase
 
 fun loadUsers(db: SQLiteDatabase) {
     val cursor = db.rawQuery("SELECT * FROM users", null)
@@ -665,16 +658,14 @@ fun loadUsers(db: SQLiteDatabase) {
 }
 
 func TestSqliteCursorWithoutClose_NegativeUse(t *testing.T) {
-	findings := runRuleByName(t, "SqliteCursorWithoutClose", `
+	findings := runRuleByNameWithResolver(t, "SqliteCursorWithoutClose", `
 package test
+
+import android.database.sqlite.SQLiteDatabase
 
 interface Cursor {
     fun moveToNext(): Boolean
     fun close()
-}
-
-interface SQLiteDatabase {
-    fun rawQuery(sql: String, args: Array<String>?): Cursor
 }
 
 inline fun <T : Cursor, R> T.use(block: (T) -> R): R = block(this)
@@ -692,17 +683,10 @@ fun loadUsers(db: SQLiteDatabase) {
 }
 
 func TestSqliteCursorWithoutClose_NegativeExplicitClose(t *testing.T) {
-	findings := runRuleByName(t, "SqliteCursorWithoutClose", `
+	findings := runRuleByNameWithResolver(t, "SqliteCursorWithoutClose", `
 package test
 
-interface Cursor {
-    fun moveToNext(): Boolean
-    fun close()
-}
-
-interface SQLiteDatabase {
-    fun rawQuery(sql: String, args: Array<String>?): Cursor
-}
+import android.database.sqlite.SQLiteDatabase
 
 fun loadUsers(db: SQLiteDatabase) {
     val cursor = db.rawQuery("SELECT * FROM users", null)
@@ -726,8 +710,9 @@ func TestSqliteCursorWithoutClose_NegativeNestedScopes(t *testing.T) {
 			src: `
 package test
 
+import android.database.sqlite.SQLiteDatabase
+
 interface Cursor { fun close() }
-interface SQLiteDatabase { fun rawQuery(sql: String, args: Array<String>?): Cursor }
 fun interface Runnable { fun run() }
 
 fun loadUsers(db: SQLiteDatabase) {
@@ -741,8 +726,9 @@ fun loadUsers(db: SQLiteDatabase) {
 			src: `
 package test
 
+import android.database.sqlite.SQLiteDatabase
+
 interface Cursor { fun close() }
-interface SQLiteDatabase { fun rawQuery(sql: String, args: Array<String>?): Cursor }
 
 fun loadUsers(db: SQLiteDatabase) {
     val factory: () -> Cursor = { db.rawQuery("SELECT * FROM users", null) }
@@ -755,8 +741,9 @@ fun loadUsers(db: SQLiteDatabase) {
 			src: `
 package test
 
+import android.database.sqlite.SQLiteDatabase
+
 interface Cursor { fun close() }
-interface SQLiteDatabase { fun rawQuery(sql: String, args: Array<String>?): Cursor }
 
 fun <T> lazyOf(init: () -> T): T = init()
 
@@ -771,11 +758,12 @@ fun loadUsers(db: SQLiteDatabase) {
 			src: `
 package test
 
+import android.database.sqlite.SQLiteDatabase
+
 interface Cursor {
     fun getString(idx: Int): String
     fun close()
 }
-interface SQLiteDatabase { fun rawQuery(sql: String, args: Array<String>?): Cursor }
 
 inline fun <T : Cursor, R> T.use(block: (T) -> R): R = try { block(this) } finally { this.close() }
 
@@ -789,7 +777,7 @@ fun loadUsers(db: SQLiteDatabase): List<String> {
 	for _, tc := range cases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			findings := runRuleByName(t, "SqliteCursorWithoutClose", tc.src)
+			findings := runRuleByNameWithResolver(t, "SqliteCursorWithoutClose", tc.src)
 			if len(findings) != 0 {
 				t.Fatalf("expected no findings for %s, got %v", tc.name, findings)
 			}
@@ -1396,5 +1384,79 @@ fun query(connection: Connection) {
 		if strings.Contains(f.Message, "'s'") {
 			t.Fatalf("expected no finding for statement 's' that is explicitly closed; got %v", f)
 		}
+	}
+}
+
+// Regression: SqliteCursorWithoutClose used to fire on any property
+// initializer that contained a call named query/rawQuery, without
+// confirming the receiver was SQLiteDatabase. Local types whose methods
+// happen to share those names must not trigger the rule.
+func TestSqliteCursorWithoutClose_LocalLookalikeDoesNotFire(t *testing.T) {
+	findings := runRuleByNameWithResolver(t, "SqliteCursorWithoutClose", `
+package test
+
+class MyCache {
+    fun query(sql: String): String = ""
+}
+
+class MyDb {
+    fun rawQuery(sql: String): String = ""
+}
+
+fun lookup(cache: MyCache, db: MyDb) {
+    val r1 = cache.query("SELECT...")
+    val r2 = db.rawQuery("SELECT...")
+}
+`)
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings for local lookalike query/rawQuery; got %v", findings)
+	}
+}
+
+// Regression: the receiver-type proof must continue to recognise a
+// real android.database.sqlite.SQLiteDatabase as a cursor source.
+func TestSqliteCursorWithoutClose_RealSQLiteDatabaseStillFires(t *testing.T) {
+	findings := runRuleByNameWithResolver(t, "SqliteCursorWithoutClose", `
+package test
+
+import android.database.sqlite.SQLiteDatabase
+
+fun load(db: SQLiteDatabase) {
+    val cursor = db.rawQuery("SELECT * FROM users", null)
+    cursor.moveToNext()
+}
+`)
+	leaked := false
+	for _, f := range findings {
+		if strings.Contains(f.Message, "'cursor'") {
+			leaked = true
+		}
+	}
+	if !leaked {
+		t.Fatalf("expected leaked cursor on real SQLiteDatabase to be reported; got %v", findings)
+	}
+}
+
+// Regression: androidx.sqlite.db.SupportSQLiteDatabase variant must
+// also be recognised by the receiver-type gate.
+func TestSqliteCursorWithoutClose_SupportSQLiteDatabaseStillFires(t *testing.T) {
+	findings := runRuleByNameWithResolver(t, "SqliteCursorWithoutClose", `
+package test
+
+import androidx.sqlite.db.SupportSQLiteDatabase
+
+fun load(db: SupportSQLiteDatabase) {
+    val cursor = db.query("SELECT * FROM users")
+    cursor.moveToNext()
+}
+`)
+	leaked := false
+	for _, f := range findings {
+		if strings.Contains(f.Message, "'cursor'") {
+			leaked = true
+		}
+	}
+	if !leaked {
+		t.Fatalf("expected leaked cursor on SupportSQLiteDatabase to be reported; got %v", findings)
 	}
 }

--- a/internal/rules/java_support.go
+++ b/internal/rules/java_support.go
@@ -132,6 +132,7 @@ var javaSupportReadiness = JavaSupportMatrix{
 		"StaticIv":                             {Status: api.LanguageSupportSupported, Fixtures: []string{"internal/rules/android_security_test.go"}},
 		"StartActivityWithUntrustedIntent":     {Status: api.LanguageSupportSupported, Fixtures: []string{"internal/rules/android_security_test.go"}},
 		"SqlInjectionRawQuery":                 {Status: api.LanguageSupportSupported, Fixtures: []string{"internal/rules/security_test.go"}},
+		"SqliteCursorWithoutClose":             {Status: api.LanguageSupportNotApplicable, Reason: "Rule dispatches on Kotlin property_declaration and matches the val/var initializer chain; Java local variables are syntactically and structurally different."},
 		"ThrowingExceptionFromFinally":         {Status: api.LanguageSupportSupported, Fixtures: []string{"internal/rules/exceptions_test.go"}},
 		"ThrowingExceptionInMain":              {Status: api.LanguageSupportSupported, Fixtures: []string{"internal/rules/exceptions_test.go"}},
 		"ThrowingNewInstanceOfSameException":   {Status: api.LanguageSupportSupported, Fixtures: []string{"internal/rules/exceptions_test.go"}},

--- a/internal/rules/registry_database.go
+++ b/internal/rules/registry_database.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	api "github.com/kaeawc/krit/internal/rules/api"
+	"github.com/kaeawc/krit/internal/rules/api/evidence"
 	"github.com/kaeawc/krit/internal/scanner"
 )
 
@@ -282,14 +283,25 @@ func registerDatabaseRules() {
 		r := &SqliteCursorWithoutCloseRule{BaseRule: BaseRule{RuleName: "SqliteCursorWithoutClose", RuleSetName: "database", Sev: "warning", Desc: "Detects SQLiteDatabase rawQuery/query cursors assigned to local properties without .use {} or .close() in the same scope."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"property_declaration"}, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"property_declaration"}, Needs: api.NeedsResolver,
+			Confidence: 0.75, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				cursorName := extractIdentifierFlat(file, idx)
 				if cursorName == "" {
 					return
 				}
-				if !sqliteCursorCallFlat(file, idx) {
+				callIdx, ok := sqliteCursorCallFlat(file, idx)
+				if !ok {
+					return
+				}
+				ev := evidence.From(ctx)
+				call := ev.Call(callIdx)
+				if call == nil {
+					return
+				}
+				fqn, source := ev.ResolveOwner(call)
+				if source == evidence.OwnerUnknown || !isSQLiteDatabaseFQN(fqn) {
 					return
 				}
 				if sqliteCursorRHSWrappedInUseFlat(file, idx) {

--- a/tests/fixtures/negative/database/SqliteCursorWithoutClose.kt
+++ b/tests/fixtures/negative/database/SqliteCursorWithoutClose.kt
@@ -1,14 +1,11 @@
 package test
 
+import android.database.sqlite.SQLiteDatabase
+
 interface Cursor {
     fun moveToNext(): Boolean
     fun getString(idx: Int): String
     fun close()
-}
-
-interface SQLiteDatabase {
-    fun rawQuery(sql: String, args: Array<String>?): Cursor
-    fun query(table: String, columns: Array<String>?): Cursor
 }
 
 inline fun <T : Cursor, R> T.use(block: (T) -> R): R = block(this)
@@ -77,3 +74,21 @@ fun loadUserTags(db: SQLiteDatabase): List<String> {
     return tags
 }
 
+// Regression for receiver-type proof: an unrelated local class with a
+// method named `query` or `rawQuery` must NOT trigger the rule. Receiver
+// proof requires the FQN to resolve to android.database.sqlite.SQLiteDatabase
+// or androidx.sqlite.db.SupportSQLiteDatabase.
+class MyCache {
+    fun query(sql: String): String = ""
+}
+
+class MyDb {
+    fun rawQuery(sql: String): String = ""
+}
+
+fun lookup(cache: MyCache, db: MyDb) {
+    val r1 = cache.query("SELECT...")
+    val r2 = db.rawQuery("SELECT...")
+    println(r1)
+    println(r2)
+}

--- a/tests/fixtures/positive/database/SqliteCursorWithoutClose.kt
+++ b/tests/fixtures/positive/database/SqliteCursorWithoutClose.kt
@@ -1,14 +1,6 @@
 package test
 
-interface Cursor {
-    fun moveToNext(): Boolean
-    fun close()
-}
-
-interface SQLiteDatabase {
-    fun rawQuery(sql: String, args: Array<String>?): Cursor
-    fun query(table: String, columns: Array<String>?): Cursor
-}
+import android.database.sqlite.SQLiteDatabase
 
 fun loadUsers(db: SQLiteDatabase) {
     val cursor = db.rawQuery("SELECT * FROM users", null)
@@ -18,7 +10,7 @@ fun loadUsers(db: SQLiteDatabase) {
 }
 
 fun loadAccounts(db: SQLiteDatabase) {
-    val cursor = db.query("accounts", null)
+    val cursor = db.query("accounts", null, null, null, null, null, null)
     while (cursor.moveToNext()) {
         // ...
     }


### PR DESCRIPTION
## Summary

`SqliteCursorWithoutClose` matched property initializers whose top-level chain contained a call named `rawQuery` or `query`, without confirming the receiver type. Any unrelated class with a same-named method on it false-positively reported a leaked cursor:

\`\`\`kotlin
class MyCache { fun query(sql: String): String = \"\" }
class MyDb    { fun rawQuery(sql: String): String = \"\" }

fun lookup(cache: MyCache, db: MyDb) {
    val r1 = cache.query(\"SELECT...\")    // false positive
    val r2 = db.rawQuery(\"SELECT...\")    // false positive
}
\`\`\`

## Fix

Adopts the receiver-proof pattern already used by `SqlInjectionRawQuery`:

- `sqliteCursorCallFlat` now returns the matching `call_expression` node index alongside the bool, so the dispatcher can pass it to evidence.
- The rule declares `Needs: api.NeedsResolver` and calls `evidence.ResolveOwner` on the candidate call. Only FQNs that pass `isSQLiteDatabaseFQN` (`android.database.sqlite.SQLiteDatabase` and `androidx.sqlite.db.SupportSQLiteDatabase`) count as cursor sources.

This is Option A from the analysis — full resolver-backed type proof rather than a source-only import gate. It matches the existing `SqlInjectionRawQuery` rule and gives precise, transitive type proof.

## Knock-on changes

- Fixtures now `import android.database.sqlite.SQLiteDatabase` rather than declaring a local stub interface; the resolver needs the real owner FQN to evaluate.
- The `query(table, columns)` positive case became `query(table, columns, null, null, null, null, null)` to match the real `SQLiteDatabase.query` overload.
- `java_support.go` and `docs/java-support-readiness.yml` mark `SqliteCursorWithoutClose` as `not-applicable` for Java — dispatch is on Kotlin `property_declaration`, which has no Java equivalent the rule consumes. `coverage_java.golden` reflects the resulting bucket shift.

## Test plan

- [x] Negative fixture extended with the unrelated-receiver case.
- [x] `TestSqliteCursorWithoutClose_NegativeNestedScopes` already covers the scope-bound walk regression; receiver-proof regression added alongside.
- [x] Positive fixtures still fire with real SQLiteDatabase receivers.
- [x] `go build`, `go vet`, `golangci-lint run`, `make lint-rules`, `go test ./... -count=1` all pass.