### PR TITLE
fix(rules): AST-match JavaObjectInputStream callee, not call text

### DIFF
--- a/internal/rules/security.go
+++ b/internal/rules/security.go
@@ -1037,14 +1037,39 @@ func javaObjectInputStreamConstructor(file *scanner.File, idx uint32) bool {
 }
 
 func javaObjectInputStreamCallShape(file *scanner.File, idx uint32) bool {
-	compact := strings.Join(strings.Fields(file.FlatNodeText(idx)), "")
 	switch file.FlatType(idx) {
 	case "call_expression":
-		return flatCallExpressionName(file, idx) == "ObjectInputStream" ||
-			strings.Contains(compact, "java.io.ObjectInputStream(")
+		// Kotlin: the callee is the first named child of the call_expression —
+		// either a bare simple_identifier or a navigation_expression. Inspect
+		// it directly so string-literal arguments that mention the class
+		// cannot satisfy the shape check.
+		navExpr, _ := flatCallExpressionParts(file, idx)
+		if navExpr != 0 {
+			chain := flatNavigationChainIdentifiers(file, navExpr)
+			if len(chain) == 3 && chain[0] == "java" && chain[1] == "io" && chain[2] == "ObjectInputStream" {
+				return true
+			}
+			return false
+		}
+		return flatCallExpressionName(file, idx) == "ObjectInputStream"
 	case "object_creation_expression":
-		return strings.Contains(compact, "newObjectInputStream(") ||
-			strings.Contains(compact, "newjava.io.ObjectInputStream(")
+		// Java: `new X(args)` parses with the type as a named child —
+		// type_identifier for `ObjectInputStream`, scoped_type_identifier
+		// whose tail identifier is `ObjectInputStream` for the FQN form.
+		for c := file.FlatFirstChild(idx); c != 0; c = file.FlatNextSib(c) {
+			if !file.FlatIsNamed(c) {
+				continue
+			}
+			switch file.FlatType(c) {
+			case "type_identifier":
+				return file.FlatNodeTextEquals(c, "ObjectInputStream")
+			case "scoped_type_identifier":
+				return file.FlatNodeTextEquals(c, "java.io.ObjectInputStream")
+			default:
+				return false
+			}
+		}
+		return false
 	default:
 		return false
 	}

--- a/internal/rules/security_test.go
+++ b/internal/rules/security_test.go
@@ -1103,6 +1103,34 @@ class Decoder {
 	}
 }
 
+func TestJavaObjectInputStream_KotlinStringLiteralMention(t *testing.T) {
+	findings := runRuleByName(t, "JavaObjectInputStream", `
+package test
+
+fun warn() {
+    println("warning: never use java.io.ObjectInputStream(input) directly")
+}
+`)
+	if len(findings) != 0 {
+		t.Fatalf("expected 0 findings, got %d: %v", len(findings), findings)
+	}
+}
+
+func TestJavaObjectInputStream_JavaStringLiteralMention(t *testing.T) {
+	findings := runRuleByNameOnJava(t, "JavaObjectInputStream", `
+package test;
+
+class Warn {
+    void warn() {
+        System.out.println("never use java.io.ObjectInputStream(input) directly");
+    }
+}
+`)
+	if len(findings) != 0 {
+		t.Fatalf("expected 0 Java findings, got %d: %v", len(findings), findings)
+	}
+}
+
 func TestJacksonDefaultTyping_KotlinPositive(t *testing.T) {
 	findings := runRuleByName(t, "JacksonDefaultTyping", `
 package test

--- a/tests/fixtures/negative/security/JavaObjectInputStream.kt
+++ b/tests/fixtures/negative/security/JavaObjectInputStream.kt
@@ -9,3 +9,8 @@ class FilteringInputStream(input: InputStream) : ObjectInputStream(input) {
         return super.resolveClass(desc)
     }
 }
+
+fun warn() {
+    // String literal that merely mentions the FQN must not trip the rule.
+    println("warning: never use java.io.ObjectInputStream(input) directly")
+}


### PR DESCRIPTION
## Summary
- `javaObjectInputStreamCallShape` joined the entire call's text (callee plus arguments) and ran `strings.Contains` against `"java.io.ObjectInputStream("` and `"newjava.io.ObjectInputStream("`. Any string-literal argument that mentioned the FQN passed the shape check, and combined with the Kotlin byte-level fallback in `sourceImportsOrMentions`, code like `println("... java.io.ObjectInputStream(input) ...")` falsely fired `JavaObjectInputStream`.
- Inspect the callee directly via AST: Kotlin reads the `simple_identifier` or `navigation_expression` chain of the `call_expression`; Java reads the `type_identifier` / `scoped_type_identifier` child of `object_creation_expression`. Both cases reject any other shape, regardless of what string literals appear in arguments.
- Added Kotlin and Java unit subtests covering the string-literal-mention regression and extended the negative fixture so the integration suite locks in the behavior.

## Test plan
- [x] `go build -o krit ./cmd/krit/`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...`
- [x] `go test ./... -count=1`
- [x] `make integration` (only the pre-existing `TestKritInitPlaygroundEndToEnd` flake fails)
- [x] `make regression`
- [x] `make lint-rules`