### PR TITLE
ci(actions): add actionlint guard for .github/workflows/*.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -279,3 +279,19 @@ jobs:
         with:
           sarif_file: results.sarif
           category: krit-self-lint
+
+  # actionlint validates the workflow files themselves — catches semantic
+  # mistakes (e.g. `hashFiles()` at workflow-`env` scope) that plain YAML
+  # parsers accept but GitHub Actions silently rejects, causing the
+  # workflow to fail to load with zero checks scheduled.
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+      - name: Install actionlint
+        run: go install github.com/rhysd/actionlint/cmd/actionlint@latest
+      - name: Run actionlint
+        run: bash scripts/lint-actions.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,9 +22,12 @@ go build -o krit ./cmd/krit/   # Build CLI
 go vet ./...                    # Lint Go code
 golangci-lint run ./...         # Lint (gofmt, unused, etc.) — REQUIRED, easy to forget
 go test ./... -count=1          # Full Go test suite
+scripts/lint-actions.sh         # actionlint — REQUIRED after `.github/workflows/*.yml` edits
 ```
 
-After implementation changes, run all four: `go build -o krit ./cmd/krit/`, `go vet ./...`, `golangci-lint run ./...`, and `go test ./... -count=1`. CI runs `golangci-lint`, so missing a gofmt/unused/lint issue locally just causes a CI round-trip — always run it before pushing. Use focused package tests while iterating.
+After implementation changes, run all four Go steps: `go build -o krit ./cmd/krit/`, `go vet ./...`, `golangci-lint run ./...`, and `go test ./... -count=1`. CI runs `golangci-lint`, so missing a gofmt/unused/lint issue locally just causes a CI round-trip — always run it before pushing. Use focused package tests while iterating.
+
+After editing any GitHub Actions workflow (`.github/workflows/*.yml`), also run `scripts/lint-actions.sh`. `actionlint` catches semantic errors that plain YAML parsers accept — e.g. `${{ hashFiles(...) }}` at workflow-`env` scope, which is syntactically valid YAML but illegal in GitHub Actions and causes the workflow to fail to load with **zero checks scheduled** on the PR. The dedicated `actionlint` CI job runs the same check.
 
 Rule metadata and registry entries are checked-in Go source. Update the
 relevant `internal/rules/registry_*.go` file and `Meta()` descriptor directly.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,14 @@ can opt into JVM-backed Kotlin Analysis API/FIR helper facts (`tools/krit-types/
   CI enforces. Skipping it just causes a CI round-trip. It's especially
   easy to forget after a refactor or deletion that leaves orphan helpers;
   make it part of every validation pass.
+- **After editing `.github/workflows/*.yml`, run `scripts/lint-actions.sh`.**
+  `actionlint` catches GitHub Actions semantic errors that plain YAML
+  parsers (including `yamllint`) accept — most importantly, function-call
+  context violations like `${{ hashFiles(...) }}` at workflow-`env`
+  scope, where it is valid YAML but illegal in GitHub Actions and causes
+  the workflow to fail to load with **zero checks scheduled** on the PR.
+  The `actionlint` CI job runs the same check, so a missed local run
+  just costs a round-trip.
 - Run `go test ./... -count=1` for full test validation; use focused
   package tests while iterating.
 - Use tree-sitter AST/flat nodes for structural analysis and regex only for

--- a/scripts/lint-actions.sh
+++ b/scripts/lint-actions.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Lint the GitHub Actions workflow files with actionlint.
+#
+# actionlint catches semantic errors that plain YAML parsers (including
+# yamllint) accept — most importantly, function-call context violations
+# like `${{ hashFiles(...) }}` at workflow-`env` scope, where it is
+# syntactically valid YAML but illegal in GitHub Actions and causes the
+# workflow to fail to load with zero checks scheduled.
+#
+# Run this after touching any file under `.github/workflows/`. CI runs
+# the same command in the `actionlint` job so missing a local check
+# just costs a round-trip.
+
+set -euo pipefail
+
+if ! command -v actionlint >/dev/null 2>&1; then
+    cat >&2 <<'EOF'
+error: actionlint is not on PATH.
+
+Install with one of:
+  brew install actionlint
+  go install github.com/rhysd/actionlint/cmd/actionlint@latest
+
+Then re-run this script.
+EOF
+    exit 127
+fi
+
+cd "$(dirname "$0")/.."
+
+# `actionlint` exits 0 on success, non-zero on findings. Auto-discovery
+# walks `.github/workflows/` (and composite actions under
+# `.github/actions/`) without needing explicit args.
+#
+# Shellcheck severity is raised to `warning` so existing info-level
+# findings in `release.yml` (a separate cleanup) don't gate every
+# unrelated workflow edit. Genuine bugs land at warning+; SC2086 / SC2035
+# infos can be addressed in a focused PR.
+actionlint -shellcheck "shellcheck --severity=warning"


### PR DESCRIPTION
## Summary

- \`scripts/lint-actions.sh\` runs \`actionlint\` against every workflow under \`.github/workflows/\`.
- A new \`actionlint\` CI job runs the same script so drift fails CI instead of silently producing a workflow that fails to load.
- \`CLAUDE.md\` and \`AGENTS.md\` get a one-line rule pointing future contributors at the script.

## Motivation

A recent break (caught at the eleventh hour after PR #468) hoisted \`\${{ hashFiles(...) }}\` to workflow-\`env\` scope. The result was syntactically valid YAML and passed \`yamllint\`, but \`hashFiles()\` is only available in *step* contexts — GitHub Actions silently rejected the workflow and **zero checks were scheduled** on the PR. \`actionlint\` catches the function-call context violation by name with a pointer at the offending line; \`yamllint\` does not.

## Shellcheck severity

The script raises shellcheck severity to \`warning\` (\`actionlint -shellcheck "shellcheck --severity=warning"\`) so two pre-existing info-level findings in \`release.yml\` (SC2086 in \`cp dist/\$pat\` at the staged-artifacts loop, SC2035 in the \`ls *.tar.gz …\` glob inside \`gh release create\`) don't gate every unrelated workflow edit. Both are mechanical fixes that belong in a focused follow-up PR.

## Test plan

- [x] \`./scripts/lint-actions.sh\` is clean on \`main\`.
- [x] Self-check: \`actionlint -shellcheck "shellcheck --severity=warning" .github/workflows/ci.yml\` clean against the new job too.
- [x] Script exits with 127 and a clear install hint when \`actionlint\` is missing.