### PR TITLE
feat(rule-api): add NEEDS_FIR capability + krit-types load-time gate

### DIFF
--- a/docs/external-rules.md
+++ b/docs/external-rules.md
@@ -333,6 +333,7 @@ copy-pasteable diagnostic.
 | `NEEDS_RESOURCES` | **supported** | Populates `RuleContext.resources` with a `ResourcesContext`. Methods: `stringValue(name)`, `hasString(name)`, `colorValue(name)`, `dimensionValue(name)`, `hasDrawable(name)`, `hasLayout(name)`, `hasId(name)`. Null when the project has no Android `res/` directory. |
 | `NEEDS_MODULE_INDEX` | **supported** | Populates `RuleContext.moduleIndex` with a `ModuleIndexContext`. Properties: `modulePaths`. Methods: `directoryOf(modulePath)`, `dependenciesOf(modulePath)`, `sourceRootsOf(modulePath)`. Null when the project has no Gradle modules. |
 | `NEEDS_CROSS_FILE` | **supported** | Populates `RuleContext.crossFile` with a `CrossFileContext`. Methods: `declarationByFqn(fqn)`, `referenceFiles(name)`, `isReferenced(name)` (non-comment references only). Null when the daemon's cross-file pass did not run. The wire payload can be sizable on large projects — declare this capability only when the rule genuinely needs whole-project visibility. |
+| `NEEDS_FIR` | **FIR-backend only** | Opts the rule into the K2 frontend IR. Methods on `Resolver` that have no KAA implementation throw `NotImplementedError("FIR backend required …")` when called against the krit-types (KAA) backend; declaring this capability moves the failure from runtime mid-analysis to deterministic load-time refusal. Rules declaring `NEEDS_FIR` fail to load on `--oracle-backend=kaa` (default today) with a diagnostic naming the flag they need to flip. Use this when a rule depends on FIR-only surface — most rules should leave it off and stick to the always-implementable `Resolver` methods. |
 
 ### What a load failure looks like
 
@@ -345,6 +346,17 @@ error: krit-rule-api: /tmp/acme-rules.jar: rule jar declares capabilities
 the daemon does not yet provide to plugin rules; the rule would run
 without the facts it asked for. Remove the declaration(s) or wait for
 support. Unsupported: [acme.NoTodo: NEEDS_TIME_TRAVEL]
+```
+
+A jar declaring `NEEDS_FIR` against the KAA backend gets a different,
+backend-specific message:
+
+```
+error: krit-rule-api: /tmp/acme-rules.jar: rule jar declares FIR-only
+capabilities the krit-types (KAA) backend cannot provide. Run with
+`--oracle-backend=fir` so the krit-fir backend hosts the rule, or
+remove the FIR-only declaration if the rule does not actually need it.
+Unsupported: [acme.NeedsFirRule: NEEDS_FIR]
 ```
 
 The diagnostic surfaces on the same channels as the SDK-compat verdict:

--- a/tools/krit-rule-api/src/main/kotlin/dev/jasonpearson/krit/api/KritRule.kt
+++ b/tools/krit-rule-api/src/main/kotlin/dev/jasonpearson/krit/api/KritRule.kt
@@ -494,6 +494,17 @@ enum class Capability {
      * for the project; null when running on a bare Kotlin directory.
      */
     NEEDS_GRADLE,
+
+    /**
+     * Declares the rule requires FIR-backend facilities — methods on
+     * [Resolver] that are only implementable against the K2 compiler's
+     * frontend IR. Without this declaration, calling a FIR-only
+     * `Resolver` method throws `NotImplementedError` at runtime against
+     * a non-FIR backend; declaring it moves the failure to deterministic
+     * load-time refusal with a diagnostic pointing at
+     * `--oracle-backend=fir`.
+     */
+    NEEDS_FIR,
 }
 
 /** Safety tier for a custom rule autofix. */

--- a/tools/krit-types/src/main/kotlin/dev/jasonpearson/krit/types/PluginRules.kt
+++ b/tools/krit-types/src/main/kotlin/dev/jasonpearson/krit/types/PluginRules.kt
@@ -183,6 +183,18 @@ internal object PluginCapabilities {
         Capability.NEEDS_CROSS_FILE.name,
     )
 
+    /**
+     * Capabilities that exist on the rule SPI but are intentionally not
+     * supported on the krit-types (KAA) backend — declaring them is a
+     * load-time opt-in that the rule needs a different backend. The
+     * `everyCapabilityIsClassified` test invariant treats a value here
+     * as deliberately-not-in-[SUPPORTED] rather than an accidental
+     * omission.
+     */
+    val FIR_ONLY: Set<String> = setOf(
+        Capability.NEEDS_FIR.name,
+    )
+
     fun unsupported(needs: List<String>): List<String> =
         needs.filter { it !in SUPPORTED }
 
@@ -196,15 +208,22 @@ internal object PluginCapabilities {
         // ServiceLoader iteration order — otherwise the same offending
         // jar would produce different diagnostic strings on different
         // runs, breaking exact-match assertions in downstream tests.
-        val rendered = violations
-            .sortedBy { it.ruleId }
-            .joinToString(separator = "; ") { (id, caps) ->
-                "$id: ${caps.joinToString(separator = ", ")}"
-            }
-        val message = "rule jar declares capabilities the daemon does not yet provide " +
-            "to plugin rules; the rule would run without the facts it asked for. " +
-            "Remove the declaration(s) or wait for support (tracked on " +
-            "$TRACKING_ISSUE_URL). Unsupported: [$rendered]"
+        val sorted = violations.sortedBy { it.ruleId }
+        val rendered = sorted.joinToString(separator = "; ") { (id, caps) ->
+            "$id: ${caps.joinToString(separator = ", ")}"
+        }
+        val firRestricted = sorted.any { v -> v.unsupported.any { it in FIR_ONLY } }
+        val message = if (firRestricted) {
+            "rule jar declares FIR-only capabilities the krit-types (KAA) backend " +
+                "cannot provide. Run with `--oracle-backend=fir` so the krit-fir " +
+                "backend hosts the rule, or remove the FIR-only declaration if the " +
+                "rule does not actually need it. Unsupported: [$rendered]"
+        } else {
+            "rule jar declares capabilities the daemon does not yet provide " +
+                "to plugin rules; the rule would run without the facts it asked for. " +
+                "Remove the declaration(s) or wait for support (tracked on " +
+                "$TRACKING_ISSUE_URL). Unsupported: [$rendered]"
+        }
         return PluginLoadDiagnostic(
             jar = jar,
             level = PluginLoadDiagnostic.Level.ERROR,

--- a/tools/krit-types/src/test/kotlin/dev/jasonpearson/krit/types/PluginCapabilitiesTest.kt
+++ b/tools/krit-types/src/test/kotlin/dev/jasonpearson/krit/types/PluginCapabilitiesTest.kt
@@ -10,18 +10,47 @@ class PluginCapabilitiesTest {
     private val jar = "/tmp/acme-rules.jar"
 
     @Test
-    fun everyEnumValueIsSupported() {
-        // Issue #357 promotes the final four `@Deprecated` capabilities
-        // (MANIFEST, RESOURCES, MODULE_INDEX, CROSS_FILE) to supported.
-        // A Capability enum value must be either in SUPPORTED or
-        // removed from the enum entirely — there is no third
-        // "advisory" state.
+    fun everyEnumValueIsClassified() {
+        // Every Capability must be either in SUPPORTED (krit-types
+        // delivers the fact into RuleContext) or in FIR_ONLY
+        // (deliberately not on this backend; a different backend hosts
+        // it). A capability missing from both buckets is an accidental
+        // omission — without this guard a typo at enum-add time would
+        // pass silently and leak through `unsupported()` as a generic
+        // "unknown capability" rejection.
         for (capability in Capability.values()) {
+            val name = capability.name
+            val supported = name in PluginCapabilities.SUPPORTED
+            val firOnly = name in PluginCapabilities.FIR_ONLY
             assertTrue(
-                PluginCapabilities.unsupported(listOf(capability.name)).isEmpty(),
-                "$capability should be supported but unsupported() returned a non-empty list",
+                supported xor firOnly,
+                "$capability must be classified into exactly one of SUPPORTED " +
+                    "or FIR_ONLY (supported=$supported, firOnly=$firOnly)",
             )
         }
+    }
+
+    @Test
+    fun supportedCapabilitiesPassUnsupportedFilter() {
+        // The eight non-FIR capabilities should all pass through the
+        // krit-types gate cleanly.
+        for (capability in Capability.values()) {
+            if (capability.name in PluginCapabilities.FIR_ONLY) continue
+            assertTrue(
+                PluginCapabilities.unsupported(listOf(capability.name)).isEmpty(),
+                "$capability is in SUPPORTED but unsupported() flagged it",
+            )
+        }
+    }
+
+    @Test
+    fun firOnlyCapabilitiesAreRefusedByKaaBackend() {
+        // Declaring NEEDS_FIR opts a rule into the FIR-backend-only
+        // surface. The krit-types (KAA) backend must reject the rule at
+        // load time so the rule never silently runs against a backend
+        // that would throw `NotImplementedError` mid-analysis.
+        val unsupported = PluginCapabilities.unsupported(listOf(Capability.NEEDS_FIR.name))
+        assertEquals(listOf(Capability.NEEDS_FIR.name), unsupported)
     }
 
     @Test
@@ -83,5 +112,55 @@ class PluginCapabilitiesTest {
         val idxA = diagnostic.message.indexOf("a.RuleA")
         val idxZ = diagnostic.message.indexOf("z.RuleZ")
         assertTrue(idxA in 0 until idxZ, "rules out of order: ${diagnostic.message}")
+    }
+
+    @Test
+    fun firOnlyViolationProducesBackendSpecificDiagnostic() {
+        // A rule declaring NEEDS_FIR needs to know which backend to
+        // switch to, not the generic "unsupported capability" message.
+        // The diagnostic must surface the FIR backend by name and the
+        // --oracle-backend flag.
+        val diagnostic = PluginCapabilities.buildLoadDiagnostic(
+            jar = jar,
+            ruleSdkVersion = "1.2.3",
+            daemonSdkVersion = "1.2.3",
+            violations = listOf(
+                CapabilityViolation("acme.NeedsFirRule", listOf(Capability.NEEDS_FIR.name)),
+            ),
+        )
+        assertEquals(PluginLoadDiagnostic.Level.ERROR, diagnostic.level)
+        assertTrue(diagnostic.message.contains("--oracle-backend=fir"), diagnostic.message)
+        assertTrue(diagnostic.message.contains("krit-fir"), diagnostic.message)
+        assertTrue(diagnostic.message.contains("acme.NeedsFirRule"), diagnostic.message)
+        assertTrue(diagnostic.message.contains(Capability.NEEDS_FIR.name), diagnostic.message)
+        // The FIR-specific message replaces the generic tracking-issue
+        // pointer because the user-actionable next step is a flag, not
+        // an upstream issue.
+        assertTrue(
+            !diagnostic.message.contains(PluginCapabilities.TRACKING_ISSUE_URL),
+            "FIR-only diagnostic should not point at the tracking issue: ${diagnostic.message}",
+        )
+    }
+
+    @Test
+    fun firOnlyTakesPrecedenceOverUnknownInDiagnostic() {
+        // When the same jar declares both a FIR-only capability and an
+        // unknown one, the FIR backend hint is the more actionable
+        // signal — surface it. Both capability names still appear in
+        // the unsupported list so the user can see the full picture.
+        val diagnostic = PluginCapabilities.buildLoadDiagnostic(
+            jar = jar,
+            ruleSdkVersion = "1.2.3",
+            daemonSdkVersion = "1.2.3",
+            violations = listOf(
+                CapabilityViolation(
+                    "acme.MixedRule",
+                    listOf(Capability.NEEDS_FIR.name, "NEEDS_TIME_TRAVEL"),
+                ),
+            ),
+        )
+        assertTrue(diagnostic.message.contains("--oracle-backend=fir"), diagnostic.message)
+        assertTrue(diagnostic.message.contains(Capability.NEEDS_FIR.name), diagnostic.message)
+        assertTrue(diagnostic.message.contains("NEEDS_TIME_TRAVEL"), diagnostic.message)
     }
 }


### PR DESCRIPTION
## Summary

First of a 5-PR sequence migrating Krit's JVM oracle toward krit-fir / krit-types coexistence behind a backend selector. Establishes the load-time opt-in that lets a plugin rule declare it needs the FIR backend without changing the existing wire shape or Go-side plumbing.

- New \`Capability.NEEDS_FIR\` enum value in \`tools/krit-rule-api/\`. Rule authors who use a FIR-only \`Resolver\` method (none exist yet; this lands forward-compatibly) opt into deterministic load-time refusal on non-FIR backends.
- \`tools/krit-types/.../PluginRules.kt\` gains a \`FIR_ONLY\` set alongside \`SUPPORTED\`. \`PluginCapabilities.buildLoadDiagnostic\` switches to a FIR-specific message naming \`--oracle-backend=fir\` when violations include a FIR-only capability, instead of the generic tracking-issue pointer.
- Unit-test invariant updated: \`everyEnumValueIsClassified\` requires every \`Capability\` to be in exactly one of \`SUPPORTED\` or \`FIR_ONLY\`, so a typo at enum-add time fails fast rather than leaking through as a generic \"unknown capability\" rejection.
- New tests cover (a) the gate refuses \`NEEDS_FIR\` on krit-types, (b) the FIR-specific diagnostic surfaces the right flag and rule names, (c) the FIR message takes precedence when a jar mixes \`NEEDS_FIR\` with truly unknown capabilities.

## Why no runtime test?

The runtime throw policy — \`NotImplementedError\` on FIR-only \`Resolver\` methods in the KAA backend — gets exercised when those methods exist. None do in this PR (the \`Resolver\` interface is unchanged). When the first FIR-only method lands, it brings its own throw-from-KAA test.

## Test plan

- [x] \`./gradlew test\` in \`tools/krit-types\` — all unit tests pass including the new gate coverage.
- [x] \`go build -o krit ./cmd/krit/\`, \`go vet ./...\`, \`golangci-lint run ./...\` — clean.
- [x] \`go test ./... -count=1\` — full suite green.
- [x] \`scripts/lint-actions.sh\` — workflows unchanged but verified clean.

## Follow-ups in this series

2. \`feat(krit-fir): oracle RPC parity with krit-types\`
3. \`feat(krit-fir): host plugin rules\`
4. \`feat(oracle): backend abstraction + --oracle-backend flag\`
5. \`ci(oracle): parity validation job\`