### PR TITLE
feat(krit-fir): JSON-RPC dispatch scaffold for analyze / analyzeAll

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -302,6 +302,28 @@ jobs:
         with:
           report_paths: gosec-report.xml
 
+  krit-fir:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
+        with:
+          distribution: zulu
+          java-version: "21"
+      - uses: gradle/actions/setup-gradle@0b6dd653ba04f4f93bf581ec31e66cbd7dcb644d # v4
+        with:
+          cache-cleanup: on-success
+          validate-wrappers: true
+      - name: Validate krit-fir
+        working-directory: tools/krit-fir
+        run: ./gradlew --no-daemon test --stacktrace
+      - name: Upload krit-fir test reports
+        if: failure()
+        uses: actions/upload-artifact@de65e23aa2b7e23d713bb51fbfcb6d502f8667d8 # v4.6.2
+        with:
+          name: krit-fir-test-reports
+          path: tools/krit-fir/build/reports/tests/test/
+
   krit-lint-sarif:
     runs-on: ubuntu-latest
     steps:

--- a/tools/krit-fir/build.gradle.kts
+++ b/tools/krit-fir/build.gradle.kts
@@ -16,6 +16,10 @@ kotlin {
 dependencies {
     // Kotlin compiler bundled into the fat JAR — provides FIR checker API, K2JVMCompiler, and plugin infra
     implementation("org.jetbrains.kotlin:kotlin-compiler:$kotlinVersion")
+
+    testImplementation("org.junit.jupiter:junit-jupiter:6.0.3")
+    testImplementation(kotlin("test"))
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }
 
 tasks.shadowJar {

--- a/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/Main.kt
+++ b/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/Main.kt
@@ -1,5 +1,6 @@
 package dev.jasonpearson.krit.fir
 
+import dev.jasonpearson.krit.fir.oracle.OracleResponse
 import dev.jasonpearson.krit.fir.runner.AnalysisSession
 import dev.jasonpearson.krit.fir.runner.BatchResult
 import dev.jasonpearson.krit.fir.runner.FileRef
@@ -171,6 +172,10 @@ fun handleRequestLine(trimmed: String, session: AnalysisSession, startTime: Long
                 RequestResult.Response("""{"id":${request.id},"result":{"ok":true,"uptime":$uptime}}""")
             }
             "shutdown" -> RequestResult.Shutdown("""{"id":${request.id},"result":{"ok":true}}""")
+            // Per-file FIR projection lives in [OracleResponse]; see its KDoc.
+            "analyze", "analyzeAll" -> RequestResult.Response(
+                OracleResponse.buildEmptyAnalyze(request.id),
+            )
             else -> RequestResult.Response("""{"id":${request.id},"error":"Unknown command: ${escJson(request.command)}"}""")
         }
     } catch (e: Exception) {

--- a/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/oracle/OracleResponse.kt
+++ b/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/oracle/OracleResponse.kt
@@ -1,0 +1,66 @@
+package dev.jasonpearson.krit.fir.oracle
+
+/**
+ * Daemon-response builders for the oracle-style RPC methods (`analyze`,
+ * `analyzeAll`, `analyzeFiles`, `analyzeWithDeps`). The wire shape
+ * mirrors `buildDaemonResponse` in krit-types' `Main.kt` so a single
+ * Go-side client can talk to either backend.
+ *
+ * The current builder emits the envelope shell with empty `files` and
+ * `dependencies` maps — well-formed JSON that parses cleanly on the Go
+ * side, but conveys no per-file facts. Per-file projection (class
+ * declarations, members, expressions, annotations, diagnostics) is not
+ * yet implemented; consumers see an empty result until each projection
+ * lands.
+ */
+object OracleResponse {
+
+    /**
+     * Build the krit-types-compatible envelope for an analyze response.
+     * `errors`, when non-empty, is nested inside `result` to match the
+     * legacy builder shape (krit-types' `buildDaemonResponse`); the
+     * flat `cacheDeps`-sibling shape used by `analyzeWithDeps` is
+     * separate and lands with the `cacheDeps` projection in a later PR.
+     */
+    fun buildEmptyAnalyze(id: Long, errors: Map<String, String> = emptyMap()): String {
+        val sb = StringBuilder()
+        sb.append("""{"id":""")
+        sb.append(id)
+        sb.append(""","result":{""")
+        sb.append(""""version":1,""")
+        sb.append(""""kotlinVersion":""")
+        sb.append(jsonString(KotlinVersion.CURRENT.toString()))
+        sb.append(""","files":{},""")
+        sb.append(""""dependencies":{}""")
+        if (errors.isNotEmpty()) {
+            sb.append(""","errors":{""")
+            errors.entries.forEachIndexed { i, (path, msg) ->
+                if (i > 0) sb.append(",")
+                sb.append(jsonString(path))
+                sb.append(":")
+                sb.append(jsonString(msg))
+            }
+            sb.append("}")
+        }
+        sb.append("}}")
+        return sb.toString()
+    }
+
+    private fun jsonString(value: String): String {
+        val sb = StringBuilder(value.length + 2)
+        sb.append('"')
+        for (c in value) {
+            when {
+                c == '"' -> sb.append("\\\"")
+                c == '\\' -> sb.append("\\\\")
+                c == '\n' -> sb.append("\\n")
+                c == '\r' -> sb.append("\\r")
+                c == '\t' -> sb.append("\\t")
+                c.code < 0x20 -> sb.append("\\u%04x".format(c.code))
+                else -> sb.append(c)
+            }
+        }
+        sb.append('"')
+        return sb.toString()
+    }
+}

--- a/tools/krit-fir/src/test/kotlin/dev/jasonpearson/krit/fir/OracleDispatchTest.kt
+++ b/tools/krit-fir/src/test/kotlin/dev/jasonpearson/krit/fir/OracleDispatchTest.kt
@@ -1,0 +1,68 @@
+package dev.jasonpearson.krit.fir
+
+import dev.jasonpearson.krit.fir.runner.AnalysisSession
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Pins the JSON-RPC dispatch path for the oracle commands (`analyze`,
+ * `analyzeAll`) end-to-end through `handleRequestLine` — the same entry
+ * point both the stdio and TCP daemon loops use. Field-level FIR
+ * projection lives in `OracleResponseTest`; this file's job is the
+ * routing contract.
+ */
+class OracleDispatchTest {
+
+    private val session = AnalysisSession(emptyList(), emptyList())
+
+    @Test
+    fun analyzeCommandRoutesToOracleResponseBuilder() {
+        val request = """{"id":11,"command":"analyze"}"""
+        val result = handleRequestLine(request, session, startTime = 0L)
+        val response = (result as RequestResult.Response).json
+        assertTrue(response.startsWith("""{"id":11,"result":{"""), response)
+        assertTrue(""""files":{}""" in response, response)
+        assertTrue(""""dependencies":{}""" in response, response)
+        assertFalse("Unknown command" in response, response)
+    }
+
+    @Test
+    fun analyzeAllCommandRoutesToOracleResponseBuilder() {
+        val request = """{"id":12,"command":"analyzeAll"}"""
+        val result = handleRequestLine(request, session, startTime = 0L)
+        val response = (result as RequestResult.Response).json
+        assertTrue(response.startsWith("""{"id":12,"result":{"""), response)
+        assertTrue(""""files":{}""" in response, response)
+        assertTrue(""""dependencies":{}""" in response, response)
+    }
+
+    @Test
+    fun analyzeResponseIsNotAnErrorEnvelope() {
+        // Belt-and-suspenders: an `else` clause that returns
+        // `{"id":...,"error":"Unknown command:..."}` is one accidental
+        // dispatch ordering bug away from regressing this. Confirm the
+        // response has no `error` field at the top level for either
+        // command.
+        for (cmd in listOf("analyze", "analyzeAll")) {
+            val response =
+                (handleRequestLine("""{"id":1,"command":"$cmd"}""", session, 0L)
+                    as RequestResult.Response).json
+            assertFalse(""""error":""" in response, "$cmd should not produce an error envelope: $response")
+        }
+    }
+
+    @Test
+    fun unknownOracleCommandStillProducesUnknownCommandError() {
+        // Negative: a typo'd command name (e.g. `analyzz`) must NOT
+        // fall through to the oracle handler. Pins the dispatch's
+        // exact-match behavior so additions like `analyzeWithDeps` /
+        // `analyzeFiles` in later PRs don't silently absorb typos.
+        val request = """{"id":99,"command":"analyzz"}"""
+        val result = handleRequestLine(request, session, startTime = 0L)
+        val response = (result as RequestResult.Response).json
+        assertTrue(""""error":"Unknown command:""" in response, response)
+        assertEquals(true, response.contains("analyzz"), response)
+    }
+}

--- a/tools/krit-fir/src/test/kotlin/dev/jasonpearson/krit/fir/oracle/OracleResponseTest.kt
+++ b/tools/krit-fir/src/test/kotlin/dev/jasonpearson/krit/fir/oracle/OracleResponseTest.kt
@@ -1,0 +1,106 @@
+package dev.jasonpearson.krit.fir.oracle
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class OracleResponseTest {
+
+    @Test
+    fun emptyAnalyzeEnvelopeMatchesKritTypesShape() {
+        // The JSON shape mirrors krit-types' `buildDaemonResponse`:
+        // `{"id":N,"result":{"version":1,"kotlinVersion":"...","files":{},"dependencies":{}}}`.
+        // A single Go-side oracle client must parse responses from
+        // either backend without branching on the source — verified by
+        // pinning the exact field set and ordering.
+        val response = OracleResponse.buildEmptyAnalyze(id = 42)
+
+        assertTrue(response.startsWith("""{"id":42,"result":{"""), response)
+        assertTrue(response.endsWith("}}"), response)
+        assertTrue(response.contains(""""version":1"""), response)
+        assertTrue(response.contains(""""files":{}"""), response)
+        assertTrue(response.contains(""""dependencies":{}"""), response)
+        assertTrue(response.contains(""""kotlinVersion":"""), response)
+    }
+
+    @Test
+    fun emptyAnalyzeHasNoErrorsFieldWhenErrorsAreEmpty() {
+        // The `errors` map is suppressed entirely when empty — matches
+        // krit-types' behavior of nesting `errors` inside `result` only
+        // when at least one entry exists.
+        val response = OracleResponse.buildEmptyAnalyze(id = 1)
+        assertTrue("errors" !in response, response)
+    }
+
+    @Test
+    fun errorsAreNestedInsideResult() {
+        // The legacy `buildDaemonResponse` shape (used by `analyze` /
+        // `analyzeAll` / `analyzeFiles`) carries `errors` *inside*
+        // `result`, not as a sibling. The flat sibling shape used by
+        // `analyzeWithDeps` is separate and lands with the cacheDeps
+        // projection.
+        val response = OracleResponse.buildEmptyAnalyze(
+            id = 7,
+            errors = mapOf("/path/to/Foo.kt" to "parse error"),
+        )
+        val resultStart = response.indexOf(""""result":{""")
+        val resultEnd = response.lastIndexOf("}}")
+        val errorsAt = response.indexOf(""""errors":""")
+        assertTrue(
+            resultStart in 0 until errorsAt && errorsAt in 0 until resultEnd,
+            "errors should appear inside result, not as a sibling: $response",
+        )
+    }
+
+    @Test
+    fun errorEntriesAreEscapedAsJsonStrings() {
+        // Paths and messages can contain characters that need JSON
+        // escaping (quotes, backslashes, newlines). The builder must
+        // emit valid JSON without introducing a control char in the
+        // output (only escaped sequences).
+        val response = OracleResponse.buildEmptyAnalyze(
+            id = 1,
+            errors = mapOf(
+                "/path with \"quote\"" to "newline\nbackslash\\",
+            ),
+        )
+        assertTrue(response.contains("\\\"quote\\\""), response)
+        assertTrue(response.contains("newline\\nbackslash\\\\"), response)
+        assertTrue('\n' !in response, "raw newline leaked into envelope: $response")
+    }
+
+    @Test
+    fun kotlinVersionMatchesRuntimeKotlinVersion() {
+        // krit-types stamps `kotlinVersion` from `KotlinVersion.CURRENT`
+        // (the compiler's own runtime version). krit-fir should do the
+        // same so a parity-diff test can pin the field as a known
+        // constant per-run rather than a moving target. This pins the
+        // contract: whatever `KotlinVersion.CURRENT` returns at compile
+        // time, the envelope must report it verbatim.
+        val response = OracleResponse.buildEmptyAnalyze(id = 1)
+        val expectedFragment = """"kotlinVersion":"${KotlinVersion.CURRENT}""""
+        assertTrue(expectedFragment in response, "$expectedFragment not in $response")
+    }
+
+    @Test
+    fun idIsRenderedAsBareIntegerNotQuotedString() {
+        // JSON-RPC ids on the wire are unquoted integers; the Go client
+        // unmarshals into int64. Emit the id raw (not as a quoted
+        // string) so the response parses on the consumer side.
+        val response = OracleResponse.buildEmptyAnalyze(id = 9001)
+        assertTrue(response.startsWith("""{"id":9001,"""), response)
+    }
+
+    @Test
+    fun envelopeIsSingleLineForNewlineDelimitedTransport() {
+        // The transport is newline-delimited JSON over stdio/TCP; a
+        // response that contains a raw newline (not escaped) would
+        // break the protocol mid-message. Belt-and-suspenders given
+        // the per-character escape in jsonString.
+        val response = OracleResponse.buildEmptyAnalyze(
+            id = 1,
+            errors = mapOf("a" to "line1\nline2"),
+        )
+        assertEquals(-1, response.indexOf('\n'), "envelope contains a raw newline: $response")
+    }
+}


### PR DESCRIPTION
## Summary

PR 2.1 in the FIR-oracle-parity sub-sequence. Scaffolds the JSON-RPC dispatch on krit-fir to recognize \`analyze\` and \`analyzeAll\` commands and return an empty-but-correctly-shaped envelope matching krit-types' \`buildDaemonResponse\` wire format.

- \`OracleResponse.buildEmptyAnalyze(id, errors)\` emits \`{id, result:{version, kotlinVersion, files:{}, dependencies:{}}}\` — well-formed JSON that parses cleanly on the Go side.
- krit-fir's dispatch in \`Main.kt\` routes both new commands to the builder.
- Unit tests (\`OracleResponseTest\`) pin envelope shape, JSON escaping, errors-nested-in-result behavior, bare-integer id rendering, kotlinVersion stamping, single-line transport requirement.
- Dispatch tests (\`OracleDispatchTest\`) pin the wire path end-to-end through \`handleRequestLine\` and the negative case (typo'd command name still produces \`Unknown command\` error).
- New \`krit-fir\` CI job validates the test suite on every PR.

## Why empty?

This PR establishes the contract — the single Go-side oracle client (planned for PR #4) can hit either backend by command name. Per-file FIR projection (class declarations, members, expressions, annotations, diagnostics) lives in PRs 2.2 through 2.5; each is its own reviewable diff against a now-real CI baseline.

## Follow-ups

- The \`setup-java + setup-gradle + setup-gradle-actions\` preamble is now duplicated across 4 CI jobs (\`krit-custom-rule-plugin\`, \`krit-settings-plugin\`, \`intellij-plugin\`, \`krit-fir\`). Past rule-of-three; worth extracting into \`.github/actions/setup-jvm-gradle\`. Not blocking.

## Test plan

- [x] \`./gradlew test\` in \`tools/krit-fir\` — new \`:test\` task runs the JUnit suite alongside the existing \`compiler-tests:test\`.
- [x] \`./gradlew shadowJar\` in \`tools/krit-fir\` still produces a working executable jar.
- [x] \`go test ./tests/parity/ -run TestFirPilotParity\` — existing FIR parity end-to-end test still passes (with shadowJar built in this worktree). My dispatch additions don't break the \`check\` command path.
- [x] \`go build\`, \`go vet\`, \`golangci-lint run ./...\`, \`go test ./... -count=1\` — full Go suite green.
- [x] \`scripts/lint-actions.sh\` — workflow change passes actionlint.