### PR TITLE
fix(cache): serialise header writes under filesMu

### DIFF
--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -95,19 +95,23 @@ func (e *FileEntry) UnmarshalJSON(data []byte) error {
 
 // Cache holds the entire incremental analysis cache.
 //
-// Files is guarded by filesMu: the daemon shares a single *Cache across
-// concurrent analyze RPCs (see internal/cli/serve/serve.go), and a
-// background periodic-flush goroutine may iterate the map while a
-// pipeline run mutates it. All access to Files must go through the
-// exported methods, which take filesMu read/write as appropriate.
+// Files, Version, RuleHash, and ScanPaths are guarded by filesMu: the
+// daemon shares a single *Cache across concurrent analyze RPCs (see
+// internal/cli/serve/serve.go), and a background periodic-flush
+// goroutine may iterate the map and serialise the header while a
+// pipeline run mutates them. All access to those fields must go
+// through the exported methods, which take filesMu read/write as
+// appropriate.
 type Cache struct {
 	Version   string               `json:"version"`
 	RuleHash  string               `json:"ruleHash"`
 	ScanPaths []string             `json:"scanPaths,omitempty"`
 	Files     map[string]FileEntry `json:"files"`
 
-	// filesMu guards Files. Heavy I/O (file hashing, os.Stat) is performed
-	// outside the lock; only the map access is serialised.
+	// filesMu guards Files plus the Version, RuleHash, and ScanPaths
+	// header fields. Heavy I/O (file hashing, os.Stat) is performed
+	// outside the lock; only the map and header reads/writes are
+	// serialised.
 	filesMu sync.RWMutex
 
 	// store, when non-nil, backs all reads and writes instead of the
@@ -371,6 +375,38 @@ func (c *Cache) AttachStore(s *store.FileStore, ruleSetHash [16]byte) {
 	c.storeRuleSetHash = ruleSetHash
 }
 
+// SetHeader updates the cache header fields (Version, RuleHash, and
+// optionally ScanPaths) atomically with respect to concurrent Save and
+// CheckFiles readers. If scanPaths is empty, ScanPaths is left
+// unchanged; non-empty slices are defensively copied.
+func (c *Cache) SetHeader(version, ruleHash string, scanPaths []string) {
+	c.filesMu.Lock()
+	defer c.filesMu.Unlock()
+	c.Version = version
+	c.RuleHash = ruleHash
+	if len(scanPaths) > 0 {
+		c.ScanPaths = append([]string(nil), scanPaths...)
+	}
+}
+
+// headerMatches reports whether the cached header is compatible with
+// the requested ruleHash and scanPaths, under filesMu.RLock. Returns
+// false if the rule hash differs, or (when both sides are non-empty)
+// if the scan paths diverge.
+func (c *Cache) headerMatches(ruleHash string, scanPaths []string) bool {
+	c.filesMu.RLock()
+	defer c.filesMu.RUnlock()
+	if c.RuleHash != ruleHash {
+		return false
+	}
+	if len(scanPaths) > 0 && len(c.ScanPaths) > 0 {
+		if !scanPathsMatch(c.ScanPaths, scanPaths) {
+			return false
+		}
+	}
+	return true
+}
+
 // CheckFiles checks which files can use cached results and which need reanalysis.
 // Returns cached findings and a set of paths that are cache hits.
 // When scanPaths is non-empty, the cache is invalidated if the scan paths differ.
@@ -386,16 +422,8 @@ func (c *Cache) CheckFiles(filePaths []string, ruleHash string, scanPaths ...str
 		return c.checkFilesFromStore(filePaths, result, collector)
 	}
 
-	// If rule hash changed, everything needs reanalysis
-	if c.RuleHash != ruleHash {
+	if !c.headerMatches(ruleHash, scanPaths) {
 		return result
-	}
-
-	// If scan paths are provided and cached scan paths differ, invalidate
-	if len(scanPaths) > 0 && len(c.ScanPaths) > 0 {
-		if !scanPathsMatch(c.ScanPaths, scanPaths) {
-			return result
-		}
 	}
 	dirtyPaths, dirtyOK := gitDirtyPathSet(scanPaths)
 	result.GitDirtyPathsKnown = dirtyOK
@@ -456,13 +484,8 @@ func (c *Cache) CheckFilesIncremental(
 		return c.checkFilesFromStore(filePaths, result, collector)
 	}
 
-	if c.RuleHash != ruleHash {
+	if !c.headerMatches(ruleHash, scanPaths) {
 		return result
-	}
-	if len(scanPaths) > 0 && len(c.ScanPaths) > 0 {
-		if !scanPathsMatch(c.ScanPaths, scanPaths) {
-			return result
-		}
 	}
 
 	dirtySet := make(map[string]struct{}, len(dirty))

--- a/internal/cache/cache_race_test.go
+++ b/internal/cache/cache_race_test.go
@@ -102,5 +102,21 @@ func TestCacheRace(t *testing.T) {
 		}
 	}()
 
+	// Concurrent header writes: dispatch.writeCacheBack assigns Version,
+	// RuleHash, and ScanPaths after each run. Without filesMu coverage of
+	// the header fields, this races against Save/CheckFiles in the
+	// daemon.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			c.SetHeader(
+				fmt.Sprintf("v%d", i),
+				"samehash",
+				[]string{fmt.Sprintf("/scan/%d", i)},
+			)
+		}
+	}()
+
 	wg.Wait()
 }

--- a/internal/pipeline/dispatch.go
+++ b/internal/pipeline/dispatch.go
@@ -116,11 +116,7 @@ func (DispatchPhase) writeCacheBack(in IndexResult, findingsByFile map[string]sc
 			in.Cache.UpdateEntryColumns(pf.Path, &fileColumns)
 		}
 	}
-	in.Cache.Version = in.Version
-	in.Cache.RuleHash = in.RuleHash
-	if len(in.CacheScanPaths) > 0 {
-		in.Cache.ScanPaths = in.CacheScanPaths
-	}
+	in.Cache.SetHeader(in.Version, in.RuleHash, in.CacheScanPaths)
 	in.Cache.Prune()
 	if in.Cache.ShouldSkipFullSaveForSmallDelta(in.CacheResult, 4) {
 		if in.Tracker != nil {


### PR DESCRIPTION
## Summary

`Cache.Version`, `Cache.RuleHash`, and `Cache.ScanPaths` were written by `pipeline.writeCacheBack` outside any lock, while the daemon's background flush goroutine reads them inside `Cache.Save` under `filesMu.RLock` and the analyze RPCs read them inside `CheckFiles` / `CheckFilesIncremental`. That's a real data race in long-running daemon mode; corrupted header bytes can break cache invalidation and ship stale findings.

- New `Cache.SetHeader(version, ruleHash, scanPaths)` takes `filesMu.Lock` and writes the three fields; defensively copies `scanPaths`.
- New `Cache.headerMatches(ruleHash, scanPaths)` takes `filesMu.RLock` once and folds the prior two reads (rule-hash compare + scan-paths compare) into a single predicate — no per-call allocation.
- `pipeline.writeCacheBack` calls `SetHeader` instead of bare assignments.
- `CheckFiles` / `CheckFilesIncremental` consult `headerMatches` once at the top, after the backing-store early return.
- `TestCacheRace` gains a goroutine that hammers `SetHeader` concurrently; with the locks removed the race detector flags writes/reads on the header fields (verified locally).

## Test plan

- [x] `go test -race ./internal/cache/ -count=1` passes
- [x] `go test ./internal/pipeline/ -count=1` passes
- [x] `go test ./... -count=1` passes
- [x] `go vet ./...` clean
- [x] `golangci-lint run ./...` clean
- [x] Verified the new test catches the regression: temporarily removing the locks from `SetHeader` makes the race detector trip on `Version`, `RuleHash`, and `ScanPaths`.