### PR TITLE
feat(krit-fir): structured analyze request/response data model

### DIFF
--- a/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/Main.kt
+++ b/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/Main.kt
@@ -174,7 +174,7 @@ fun handleRequestLine(trimmed: String, session: AnalysisSession, startTime: Long
             "shutdown" -> RequestResult.Shutdown("""{"id":${request.id},"result":{"ok":true}}""")
             // Per-file FIR projection lives in [OracleResponse]; see its KDoc.
             "analyze", "analyzeAll" -> RequestResult.Response(
-                OracleResponse.buildEmptyAnalyze(request.id),
+                OracleResponse.buildAnalyze(request.id),
             )
             else -> RequestResult.Response("""{"id":${request.id},"error":"Unknown command: ${escJson(request.command)}"}""")
         }

--- a/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/oracle/OracleAnalysis.kt
+++ b/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/oracle/OracleAnalysis.kt
@@ -1,0 +1,116 @@
+package dev.jasonpearson.krit.fir.oracle
+
+/**
+ * Structured input for the `analyze` / `analyzeAll` RPC methods. The
+ * wire shape mirrors what `internal/oracle/daemon.go`'s `Analyze(files)`
+ * call sends:
+ *
+ * ```
+ * {"id":N,"command":"analyze","files":[...],"sourceDirs":[...],"classpath":[...]}
+ * ```
+ *
+ * `analyzeAll` is the zero-files variant — the daemon walks every
+ * Kotlin file in `sourceDirs`.
+ */
+data class AnalyzeRequest(
+    val id: Long,
+    val command: String,
+    val files: List<String> = emptyList(),
+    val sourceDirs: List<String> = emptyList(),
+    val classpath: List<String> = emptyList(),
+)
+
+/**
+ * Per-file payload returned for an analyze request. Mirrors
+ * `FileResult` in `tools/krit-types/src/main/kotlin/dev/jasonpearson/krit/types/Main.kt`
+ * — same field names, same semantics, so the Go-side oracle client
+ * parses either backend's response with one struct. All fields default
+ * to empty so partially-populated payloads still serialize as
+ * well-formed JSON.
+ */
+data class FilePayload(
+    val packageName: String = "",
+    val declarations: List<ClassPayload> = emptyList(),
+    val expressions: Map<String, ExpressionPayload> = emptyMap(),
+    val diagnostics: List<DiagnosticPayload> = emptyList(),
+)
+
+/**
+ * Class / interface / object declaration. Mirrors krit-types'
+ * `ClassResult`. Optional fields (`members`, `annotations`,
+ * `typeParameters`, `jarPath`) default empty so partially-populated
+ * payloads stay well-formed on the wire.
+ */
+data class ClassPayload(
+    val fqn: String,
+    val kind: String,
+    val supertypes: List<String> = emptyList(),
+    val isSealed: Boolean = false,
+    val isData: Boolean = false,
+    val isOpen: Boolean = false,
+    val isAbstract: Boolean = false,
+    val visibility: String = "public",
+    val typeParameters: List<String> = emptyList(),
+    val members: List<MemberPayload> = emptyList(),
+    val annotations: List<String> = emptyList(),
+    val jarPath: String? = null,
+)
+
+/** Member of a class — function / property / constructor. Mirrors `MemberResult`. */
+data class MemberPayload(
+    val name: String,
+    val kind: String,
+    val returnType: String,
+    val nullable: Boolean = false,
+    val visibility: String = "public",
+    val isOverride: Boolean = false,
+    val isAbstract: Boolean = false,
+    val params: List<ParamPayload> = emptyList(),
+    val annotations: List<String> = emptyList(),
+)
+
+/** Function / constructor parameter. Mirrors `ParamResult`. */
+data class ParamPayload(
+    val name: String,
+    val type: String,
+    val nullable: Boolean = false,
+)
+
+/**
+ * Expression-level type information. Keyed by source-position string
+ * in the `expressions` map. Mirrors krit-types' `ExpressionResult`.
+ */
+data class ExpressionPayload(
+    val type: String,
+    val nullable: Boolean = false,
+    val startByte: Int = 0,
+    val endByte: Int = 0,
+    val callTarget: String? = null,
+    val callTargetResolved: Boolean = false,
+    val callTargetSuspend: Boolean = false,
+    val annotations: List<String> = emptyList(),
+)
+
+/** Compiler diagnostic surfaced through the analyze envelope. */
+data class DiagnosticPayload(
+    val severity: String,
+    val message: String,
+    val line: Int,
+    val column: Int = 1,
+)
+
+/**
+ * Result of an analyze request. `files` is keyed by absolute file
+ * path; `dependencies` is keyed by class FQN for cross-file class
+ * dependencies the Go-side index needs.
+ */
+data class AnalyzeResult(
+    val files: Map<String, FilePayload> = emptyMap(),
+    val dependencies: Map<String, ClassPayload> = emptyMap(),
+    val errors: Map<String, String> = emptyMap(),
+) {
+    companion object {
+        /** An empty result with no per-file data and no errors. */
+        val EMPTY: AnalyzeResult = AnalyzeResult()
+    }
+}

--- a/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/oracle/OracleResponse.kt
+++ b/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/oracle/OracleResponse.kt
@@ -6,23 +6,23 @@ package dev.jasonpearson.krit.fir.oracle
  * mirrors `buildDaemonResponse` in krit-types' `Main.kt` so a single
  * Go-side client can talk to either backend.
  *
- * The current builder emits the envelope shell with empty `files` and
- * `dependencies` maps — well-formed JSON that parses cleanly on the Go
- * side, but conveys no per-file facts. Per-file projection (class
- * declarations, members, expressions, annotations, diagnostics) is not
- * yet implemented; consumers see an empty result until each projection
- * lands.
+ * Per-file payloads come in as a structured [AnalyzeResult]; the
+ * serialization preserves the krit-types JSON shape regardless of how
+ * populated the result is. Callers handing [AnalyzeResult.EMPTY] get an
+ * envelope shell with empty `files` and `dependencies` maps; callers
+ * handing a populated result get the same envelope with the per-file
+ * payloads filled in.
  */
 object OracleResponse {
 
     /**
      * Build the krit-types-compatible envelope for an analyze response.
-     * `errors`, when non-empty, is nested inside `result` to match the
-     * legacy builder shape (krit-types' `buildDaemonResponse`); the
-     * flat `cacheDeps`-sibling shape used by `analyzeWithDeps` is
-     * separate and lands with the `cacheDeps` projection in a later PR.
+     * Errors carried on [result] are nested inside the `result` object
+     * to match krit-types' legacy `buildDaemonResponse` shape; the flat
+     * `cacheDeps`-sibling envelope used by `analyzeWithDeps` is
+     * separate and lands with the cacheDeps projection in a later PR.
      */
-    fun buildEmptyAnalyze(id: Long, errors: Map<String, String> = emptyMap()): String {
+    fun buildAnalyze(id: Long, result: AnalyzeResult = AnalyzeResult.EMPTY): String {
         val sb = StringBuilder()
         sb.append("""{"id":""")
         sb.append(id)
@@ -30,20 +30,217 @@ object OracleResponse {
         sb.append(""""version":1,""")
         sb.append(""""kotlinVersion":""")
         sb.append(jsonString(KotlinVersion.CURRENT.toString()))
-        sb.append(""","files":{},""")
-        sb.append(""""dependencies":{}""")
-        if (errors.isNotEmpty()) {
-            sb.append(""","errors":{""")
-            errors.entries.forEachIndexed { i, (path, msg) ->
-                if (i > 0) sb.append(",")
-                sb.append(jsonString(path))
-                sb.append(":")
-                sb.append(jsonString(msg))
-            }
-            sb.append("}")
+        sb.append(""","files":""")
+        appendFiles(sb, result.files)
+        sb.append(""","dependencies":""")
+        appendDependencies(sb, result.dependencies)
+        if (result.errors.isNotEmpty()) {
+            sb.append(""","errors":""")
+            appendErrors(sb, result.errors)
         }
         sb.append("}}")
         return sb.toString()
+    }
+
+    private fun appendFiles(sb: StringBuilder, files: Map<String, FilePayload>) {
+        if (files.isEmpty()) {
+            sb.append("{}")
+            return
+        }
+        sb.append("{")
+        files.entries.forEachIndexed { i, (path, payload) ->
+            if (i > 0) sb.append(",")
+            sb.append(jsonString(path))
+            sb.append(":")
+            appendFilePayload(sb, payload)
+        }
+        sb.append("}")
+    }
+
+    private fun appendFilePayload(sb: StringBuilder, payload: FilePayload) {
+        sb.append("{")
+        sb.append(""""package":""")
+        sb.append(jsonString(payload.packageName))
+        sb.append(""","declarations":""")
+        appendClassList(sb, payload.declarations)
+        sb.append(""","expressions":""")
+        appendExpressions(sb, payload.expressions)
+        if (payload.diagnostics.isNotEmpty()) {
+            sb.append(""","diagnostics":""")
+            appendDiagnostics(sb, payload.diagnostics)
+        }
+        sb.append("}")
+    }
+
+    private fun appendDependencies(sb: StringBuilder, deps: Map<String, ClassPayload>) {
+        if (deps.isEmpty()) {
+            sb.append("{}")
+            return
+        }
+        sb.append("{")
+        deps.entries.forEachIndexed { i, (fqn, cls) ->
+            if (i > 0) sb.append(",")
+            sb.append(jsonString(fqn))
+            sb.append(":")
+            appendClass(sb, cls)
+        }
+        sb.append("}")
+    }
+
+    private fun appendClassList(sb: StringBuilder, classes: List<ClassPayload>) {
+        sb.append("[")
+        classes.forEachIndexed { i, cls ->
+            if (i > 0) sb.append(",")
+            appendClass(sb, cls)
+        }
+        sb.append("]")
+    }
+
+    private fun appendClass(sb: StringBuilder, cls: ClassPayload) {
+        sb.append("{")
+        sb.append(""""fqn":""")
+        sb.append(jsonString(cls.fqn))
+        sb.append(""","kind":""")
+        sb.append(jsonString(cls.kind))
+        sb.append(""","supertypes":""")
+        appendStringList(sb, cls.supertypes)
+        sb.append(""","visibility":""")
+        sb.append(jsonString(cls.visibility))
+        if (cls.isSealed) sb.append(""","isSealed":true""")
+        if (cls.isData) sb.append(""","isData":true""")
+        if (cls.isOpen) sb.append(""","isOpen":true""")
+        if (cls.isAbstract) sb.append(""","isAbstract":true""")
+        if (cls.typeParameters.isNotEmpty()) {
+            sb.append(""","typeParameters":""")
+            appendStringList(sb, cls.typeParameters)
+        }
+        if (cls.members.isNotEmpty()) {
+            sb.append(""","members":""")
+            appendMembers(sb, cls.members)
+        }
+        if (cls.annotations.isNotEmpty()) {
+            sb.append(""","annotations":""")
+            appendStringList(sb, cls.annotations)
+        }
+        cls.jarPath?.let {
+            sb.append(""","jarPath":""")
+            sb.append(jsonString(it))
+        }
+        sb.append("}")
+    }
+
+    private fun appendMembers(sb: StringBuilder, members: List<MemberPayload>) {
+        sb.append("[")
+        members.forEachIndexed { i, m ->
+            if (i > 0) sb.append(",")
+            sb.append("{")
+            sb.append(""""name":""")
+            sb.append(jsonString(m.name))
+            sb.append(""","kind":""")
+            sb.append(jsonString(m.kind))
+            sb.append(""","returnType":""")
+            sb.append(jsonString(m.returnType))
+            if (m.nullable) sb.append(""","nullable":true""")
+            sb.append(""","visibility":""")
+            sb.append(jsonString(m.visibility))
+            if (m.isOverride) sb.append(""","isOverride":true""")
+            if (m.isAbstract) sb.append(""","isAbstract":true""")
+            if (m.params.isNotEmpty()) {
+                sb.append(""","params":""")
+                appendParams(sb, m.params)
+            }
+            if (m.annotations.isNotEmpty()) {
+                sb.append(""","annotations":""")
+                appendStringList(sb, m.annotations)
+            }
+            sb.append("}")
+        }
+        sb.append("]")
+    }
+
+    private fun appendParams(sb: StringBuilder, params: List<ParamPayload>) {
+        sb.append("[")
+        params.forEachIndexed { i, p ->
+            if (i > 0) sb.append(",")
+            sb.append("""{"name":""")
+            sb.append(jsonString(p.name))
+            sb.append(""","type":""")
+            sb.append(jsonString(p.type))
+            if (p.nullable) sb.append(""","nullable":true""")
+            sb.append("}")
+        }
+        sb.append("]")
+    }
+
+    private fun appendExpressions(sb: StringBuilder, expressions: Map<String, ExpressionPayload>) {
+        if (expressions.isEmpty()) {
+            sb.append("{}")
+            return
+        }
+        sb.append("{")
+        expressions.entries.forEachIndexed { i, (key, expr) ->
+            if (i > 0) sb.append(",")
+            sb.append(jsonString(key))
+            sb.append(""":{"type":""")
+            sb.append(jsonString(expr.type))
+            sb.append(""","nullable":""")
+            sb.append(expr.nullable.toString())
+            if (expr.endByte > expr.startByte) {
+                sb.append(""","startByte":""")
+                sb.append(expr.startByte)
+                sb.append(""","endByte":""")
+                sb.append(expr.endByte)
+            }
+            expr.callTarget?.let {
+                sb.append(""","callTarget":""")
+                sb.append(jsonString(it))
+            }
+            if (expr.callTargetResolved) sb.append(""","callTargetResolved":true""")
+            if (expr.callTargetSuspend) sb.append(""","callTargetSuspend":true""")
+            if (expr.annotations.isNotEmpty()) {
+                sb.append(""","annotations":""")
+                appendStringList(sb, expr.annotations)
+            }
+            sb.append("}")
+        }
+        sb.append("}")
+    }
+
+    private fun appendDiagnostics(sb: StringBuilder, diags: List<DiagnosticPayload>) {
+        sb.append("[")
+        diags.forEachIndexed { i, d ->
+            if (i > 0) sb.append(",")
+            sb.append("""{"severity":""")
+            sb.append(jsonString(d.severity))
+            sb.append(""","message":""")
+            sb.append(jsonString(d.message))
+            sb.append(""","line":""")
+            sb.append(d.line)
+            sb.append(""","column":""")
+            sb.append(d.column)
+            sb.append("}")
+        }
+        sb.append("]")
+    }
+
+    private fun appendErrors(sb: StringBuilder, errors: Map<String, String>) {
+        sb.append("{")
+        errors.entries.forEachIndexed { i, (path, msg) ->
+            if (i > 0) sb.append(",")
+            sb.append(jsonString(path))
+            sb.append(":")
+            sb.append(jsonString(msg))
+        }
+        sb.append("}")
+    }
+
+    private fun appendStringList(sb: StringBuilder, items: List<String>) {
+        sb.append("[")
+        items.forEachIndexed { i, s ->
+            if (i > 0) sb.append(",")
+            sb.append(jsonString(s))
+        }
+        sb.append("]")
     }
 
     private fun jsonString(value: String): String {

--- a/tools/krit-fir/src/test/kotlin/dev/jasonpearson/krit/fir/oracle/OracleResponseTest.kt
+++ b/tools/krit-fir/src/test/kotlin/dev/jasonpearson/krit/fir/oracle/OracleResponseTest.kt
@@ -11,9 +11,10 @@ class OracleResponseTest {
         // The JSON shape mirrors krit-types' `buildDaemonResponse`:
         // `{"id":N,"result":{"version":1,"kotlinVersion":"...","files":{},"dependencies":{}}}`.
         // A single Go-side oracle client must parse responses from
-        // either backend without branching on the source — verified by
-        // pinning the exact field set and ordering.
-        val response = OracleResponse.buildEmptyAnalyze(id = 42)
+        // either backend without branching on the source — pin the
+        // exact field set so future projection work cannot accidentally
+        // change the envelope contract.
+        val response = OracleResponse.buildAnalyze(id = 42)
 
         assertTrue(response.startsWith("""{"id":42,"result":{"""), response)
         assertTrue(response.endsWith("}}"), response)
@@ -28,7 +29,7 @@ class OracleResponseTest {
         // The `errors` map is suppressed entirely when empty — matches
         // krit-types' behavior of nesting `errors` inside `result` only
         // when at least one entry exists.
-        val response = OracleResponse.buildEmptyAnalyze(id = 1)
+        val response = OracleResponse.buildAnalyze(id = 1)
         assertTrue("errors" !in response, response)
     }
 
@@ -39,9 +40,9 @@ class OracleResponseTest {
         // `result`, not as a sibling. The flat sibling shape used by
         // `analyzeWithDeps` is separate and lands with the cacheDeps
         // projection.
-        val response = OracleResponse.buildEmptyAnalyze(
+        val response = OracleResponse.buildAnalyze(
             id = 7,
-            errors = mapOf("/path/to/Foo.kt" to "parse error"),
+            result = AnalyzeResult(errors = mapOf("/path/to/Foo.kt" to "parse error")),
         )
         val resultStart = response.indexOf(""""result":{""")
         val resultEnd = response.lastIndexOf("}}")
@@ -58,10 +59,10 @@ class OracleResponseTest {
         // escaping (quotes, backslashes, newlines). The builder must
         // emit valid JSON without introducing a control char in the
         // output (only escaped sequences).
-        val response = OracleResponse.buildEmptyAnalyze(
+        val response = OracleResponse.buildAnalyze(
             id = 1,
-            errors = mapOf(
-                "/path with \"quote\"" to "newline\nbackslash\\",
+            result = AnalyzeResult(
+                errors = mapOf("/path with \"quote\"" to "newline\nbackslash\\"),
             ),
         )
         assertTrue(response.contains("\\\"quote\\\""), response)
@@ -74,10 +75,8 @@ class OracleResponseTest {
         // krit-types stamps `kotlinVersion` from `KotlinVersion.CURRENT`
         // (the compiler's own runtime version). krit-fir should do the
         // same so a parity-diff test can pin the field as a known
-        // constant per-run rather than a moving target. This pins the
-        // contract: whatever `KotlinVersion.CURRENT` returns at compile
-        // time, the envelope must report it verbatim.
-        val response = OracleResponse.buildEmptyAnalyze(id = 1)
+        // constant per-run rather than a moving target.
+        val response = OracleResponse.buildAnalyze(id = 1)
         val expectedFragment = """"kotlinVersion":"${KotlinVersion.CURRENT}""""
         assertTrue(expectedFragment in response, "$expectedFragment not in $response")
     }
@@ -87,7 +86,7 @@ class OracleResponseTest {
         // JSON-RPC ids on the wire are unquoted integers; the Go client
         // unmarshals into int64. Emit the id raw (not as a quoted
         // string) so the response parses on the consumer side.
-        val response = OracleResponse.buildEmptyAnalyze(id = 9001)
+        val response = OracleResponse.buildAnalyze(id = 9001)
         assertTrue(response.startsWith("""{"id":9001,"""), response)
     }
 
@@ -97,10 +96,94 @@ class OracleResponseTest {
         // response that contains a raw newline (not escaped) would
         // break the protocol mid-message. Belt-and-suspenders given
         // the per-character escape in jsonString.
-        val response = OracleResponse.buildEmptyAnalyze(
+        val response = OracleResponse.buildAnalyze(
             id = 1,
-            errors = mapOf("a" to "line1\nline2"),
+            result = AnalyzeResult(errors = mapOf("a" to "line1\nline2")),
         )
         assertEquals(-1, response.indexOf('\n'), "envelope contains a raw newline: $response")
+    }
+
+    @Test
+    fun populatedFilePayloadSerializesPackageAndDeclarations() {
+        // Seeded data pins the JSON shape produced when a non-empty
+        // `FilePayload` rides on the wire — the projection layer hands
+        // an `AnalyzeResult` to `buildAnalyze` and the envelope must
+        // surface each populated field in the documented place.
+        val response = OracleResponse.buildAnalyze(
+            id = 1,
+            result = AnalyzeResult(
+                files = mapOf(
+                    "/src/Foo.kt" to FilePayload(
+                        packageName = "com.acme.foo",
+                        declarations = listOf(
+                            ClassPayload(
+                                fqn = "com.acme.foo.Bar",
+                                kind = "class",
+                                supertypes = listOf("kotlin.Any"),
+                                visibility = "public",
+                                isOpen = true,
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+        )
+        assertTrue(""""/src/Foo.kt":{""" in response, response)
+        assertTrue(""""package":"com.acme.foo"""" in response, response)
+        assertTrue(""""fqn":"com.acme.foo.Bar"""" in response, response)
+        assertTrue(""""kind":"class"""" in response, response)
+        assertTrue(""""supertypes":["kotlin.Any"]""" in response, response)
+        assertTrue(""""isOpen":true""" in response, response)
+        // Modifier flags are emitted only when true — false flags must
+        // not bloat the wire payload.
+        assertTrue("isSealed" !in response, response)
+        assertTrue("isData" !in response, response)
+    }
+
+    @Test
+    fun dependenciesMapKeyedByFqn() {
+        // `dependencies` is the cross-file class index — keyed by FQN
+        // rather than by source path. krit-types uses this for Go-side
+        // symbol resolution; the shape must round-trip identically.
+        val response = OracleResponse.buildAnalyze(
+            id = 1,
+            result = AnalyzeResult(
+                dependencies = mapOf(
+                    "com.acme.foo.Bar" to ClassPayload(
+                        fqn = "com.acme.foo.Bar",
+                        kind = "class",
+                    ),
+                ),
+            ),
+        )
+        assertTrue(""""dependencies":{"com.acme.foo.Bar":""" in response, response)
+    }
+
+    @Test
+    fun expressionPayloadOmitsZeroByteRangeAndFalseFlags() {
+        // Expressions ride on every analyze response and can be dense
+        // on real codebases. Emit only fields that carry information:
+        // suppress the byte range when start == end, suppress flag
+        // fields when false. Matches krit-types' `buildJson` shape so
+        // a Go-side parity diff stays comparable.
+        val response = OracleResponse.buildAnalyze(
+            id = 1,
+            result = AnalyzeResult(
+                files = mapOf(
+                    "/src/Foo.kt" to FilePayload(
+                        packageName = "com.acme",
+                        expressions = mapOf(
+                            "12:5" to ExpressionPayload(
+                                type = "kotlin.String",
+                                nullable = false,
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+        )
+        assertTrue(""""12:5":{"type":"kotlin.String","nullable":false}""" in response, response)
+        assertTrue("startByte" !in response, response)
+        assertTrue("callTargetSuspend" !in response, response)
     }
 }


### PR DESCRIPTION
## Summary

PR 2.2 in the FIR-oracle-parity sub-sequence. Adds the structured data model for analyze RPC payloads and the serialization plumbing so the projection layer can hand structured results to the envelope builder.

- New \`AnalyzeRequest\` / \`AnalyzeResult\` + per-file / per-class / per-member / per-expression / per-diagnostic payloads in \`tools/krit-fir/.../oracle/OracleAnalysis.kt\`.
- \`OracleResponse.buildAnalyze(id, result)\` replaces \`buildEmptyAnalyze(id, errors)\` — serializes populated results to krit-types-compatible JSON, omitting empty optional fields.
- Dispatch path in \`Main.kt\` unchanged in behavior: hands \`AnalyzeResult.EMPTY\` for now; wire output is byte-identical to PR 2.1's empty envelope.
- Tests pin envelope shape, JSON escaping, errors-nested-inside-result, single-line transport, bare-integer id rendering, populated-payload serialization, and the wire-minimization rules (omit zero byte ranges and false-flag fields).

## Why decouple data model from K2 plumbing?

PR 2.3 wires a K2 \`FirAdditionalCheckersExtension\` (or similar) into \`AnalysisSession.analyze(request)\` to actually populate the result. Keeping that change separate from the data model + serialization means PR 2.3 is a focused K2-API diff against a now-known wire contract, and any regressions are isolated.

## Test plan

- [x] \`./gradlew test\` in \`tools/krit-fir\` — all unit tests pass.
- [x] \`./gradlew shadowJar\` — fat jar still builds.
- [x] \`go test ./tests/parity/ -run TestFirPilotParity\` — existing FIR end-to-end parity test still passes.
- [x] \`go build\`, \`go vet\`, \`golangci-lint run ./...\`, \`go test ./... -count=1\` — full Go suite green.
- [x] \`scripts/lint-actions.sh\` — workflows unchanged but verified clean.