### PR TITLE
feat(krit-fir): K2 plugin extension + class declaration projection

### DIFF
--- a/tools/krit-fir/build.gradle.kts
+++ b/tools/krit-fir/build.gradle.kts
@@ -38,4 +38,16 @@ tasks.shadowJar {
 
 tasks.test {
     useJUnitPlatform()
+    // AnalysisSessionAnalyzeTest drives the embedded K2 compiler and
+    // needs the krit-fir plugin classes on the plugin classpath. Point
+    // it at the plain `:jar` output (the compiler runtime is already
+    // on the test classpath via the `kotlin-compiler` dep), so tests
+    // don't need to wait for the slower shadow-jar build.
+    dependsOn("jar")
+    val pluginJar = tasks.named("jar", Jar::class.java).flatMap { it.archiveFile }
+    inputs.file(pluginJar)
+    systemProperty(
+        "krit.fir.plugin.jar",
+        pluginJar.get().asFile.absolutePath,
+    )
 }

--- a/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/KritFirCheckers.kt
+++ b/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/KritFirCheckers.kt
@@ -4,6 +4,7 @@ import dev.jasonpearson.krit.fir.checkers.ComposeRememberWithoutKey
 import dev.jasonpearson.krit.fir.checkers.FlowCollectInOnCreate
 import dev.jasonpearson.krit.fir.checkers.InjectDispatcher
 import dev.jasonpearson.krit.fir.checkers.UnsafeCastWhenNullable
+import dev.jasonpearson.krit.fir.oracle.OracleClassChecker
 import dev.jasonpearson.krit.fir.rules.SmokeChecker
 import org.jetbrains.kotlin.fir.FirSession
 import org.jetbrains.kotlin.fir.analysis.checkers.declaration.DeclarationCheckers
@@ -22,7 +23,11 @@ class KritFirCheckers(session: FirSession) : FirAdditionalCheckersExtension(sess
         )
     }
 
+    // OracleClassChecker is included unconditionally — it gates itself on
+    // `OracleCollectorRegistry.current() != null`, so non-oracle paths
+    // (diagnostic `check` command) pay only a thread-local lookup per
+    // visited class.
     override val declarationCheckers = object : DeclarationCheckers() {
-        override val classCheckers = setOf(SmokeChecker)
+        override val classCheckers = setOf(SmokeChecker, OracleClassChecker)
     }
 }

--- a/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/Main.kt
+++ b/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/Main.kt
@@ -172,10 +172,28 @@ fun handleRequestLine(trimmed: String, session: AnalysisSession, startTime: Long
                 RequestResult.Response("""{"id":${request.id},"result":{"ok":true,"uptime":$uptime}}""")
             }
             "shutdown" -> RequestResult.Shutdown("""{"id":${request.id},"result":{"ok":true}}""")
-            // Per-file FIR projection lives in [OracleResponse]; see its KDoc.
-            "analyze", "analyzeAll" -> RequestResult.Response(
-                OracleResponse.buildAnalyze(request.id),
-            )
+            "analyze", "analyzeAll" -> {
+                val needsRebuild =
+                    request.sourceDirs != session.sourceDirs || request.classpath != session.classpath
+                val activeSession = if (needsRebuild) {
+                    session.dispose()
+                    AnalysisSession(request.sourceDirs, request.classpath)
+                } else {
+                    session
+                }
+                val analyzeFiles = if (request.command == "analyzeAll") {
+                    emptyList()
+                } else {
+                    request.files.map { it.path }
+                }
+                val result = activeSession.analyze(analyzeFiles)
+                val response = OracleResponse.buildAnalyze(request.id, result)
+                if (needsRebuild) {
+                    RequestResult.SessionRebuilt(response, activeSession)
+                } else {
+                    RequestResult.Response(response)
+                }
+            }
             else -> RequestResult.Response("""{"id":${request.id},"error":"Unknown command: ${escJson(request.command)}"}""")
         }
     } catch (e: Exception) {

--- a/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/oracle/OracleClassChecker.kt
+++ b/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/oracle/OracleClassChecker.kt
@@ -1,0 +1,92 @@
+package dev.jasonpearson.krit.fir.oracle
+
+import org.jetbrains.kotlin.descriptors.ClassKind
+import org.jetbrains.kotlin.descriptors.Modality
+import org.jetbrains.kotlin.descriptors.Visibilities
+import org.jetbrains.kotlin.descriptors.Visibility
+import org.jetbrains.kotlin.diagnostics.DiagnosticReporter
+import org.jetbrains.kotlin.fir.analysis.checkers.MppCheckerKind
+import org.jetbrains.kotlin.fir.analysis.checkers.context.CheckerContext
+import org.jetbrains.kotlin.fir.analysis.checkers.declaration.FirClassChecker
+import org.jetbrains.kotlin.fir.declarations.FirClass
+import org.jetbrains.kotlin.fir.declarations.FirRegularClass
+import org.jetbrains.kotlin.fir.declarations.utils.isData
+import org.jetbrains.kotlin.fir.declarations.utils.modality
+import org.jetbrains.kotlin.fir.declarations.utils.visibility
+import org.jetbrains.kotlin.fir.symbols.SymbolInternals
+import org.jetbrains.kotlin.fir.types.FirResolvedTypeRef
+import org.jetbrains.kotlin.fir.types.renderReadable
+
+/**
+ * FIR `FirClassChecker` that projects each visited [FirRegularClass]
+ * into a [ClassPayload] and pushes it onto the active [OracleCollector],
+ * if any. Runs unconditionally during compilation but gates itself on
+ * `OracleCollectorRegistry.current() != null`, so non-oracle paths
+ * (e.g. the diagnostic-only `check()` command) pay only a thread-local
+ * lookup per visited class.
+ *
+ * The covered surface is intentionally narrow: `fqn`, `kind`,
+ * `supertypes`, `visibility`, four modality flags (`isSealed`,
+ * `isOpen`, `isAbstract`, `isData`), and `typeParameters`. Members,
+ * annotations, and `jarPath` ride on later projection passes; the
+ * `ClassPayload` defaults for those fields stay empty for now.
+ */
+internal object OracleClassChecker : FirClassChecker(MppCheckerKind.Common) {
+
+    @OptIn(SymbolInternals::class)
+    context(context: CheckerContext, reporter: DiagnosticReporter)
+    override fun check(declaration: FirClass) {
+        // `reporter` is unused — this checker collects structured data
+        // for the oracle response instead of emitting diagnostics.
+        val collector = OracleCollectorRegistry.current() ?: return
+        val regular = declaration as? FirRegularClass ?: return
+
+        // `containingFileSymbol.fir.sourceFile.path` is the standard way
+        // to recover the absolute path of the currently-checked file.
+        // The `.fir` accessor is `SymbolInternals`-gated — annotated
+        // above. No public alternative exists in K2 today.
+        val filePath = context.containingFileSymbol?.fir?.sourceFile?.path ?: return
+
+        collector.setPackage(filePath, regular.symbol.classId.packageFqName.asString())
+        collector.addClass(filePath, regular.toClassPayload())
+    }
+
+    private fun FirRegularClass.toClassPayload(): ClassPayload = ClassPayload(
+        fqn = symbol.classId.asFqNameString(),
+        kind = classKind.toWireString(),
+        supertypes = superTypeRefs.mapNotNull { ref ->
+            // Unresolved type refs (e.g. for sources with parse errors)
+            // don't carry a `coneType`; skip them rather than crashing.
+            (ref as? FirResolvedTypeRef)?.coneType?.renderReadable()
+        },
+        isSealed = modality == Modality.SEALED,
+        isData = isData,
+        isOpen = modality == Modality.OPEN,
+        isAbstract = modality == Modality.ABSTRACT,
+        visibility = visibility.toWireString(),
+        typeParameters = typeParameters.map { it.symbol.name.asString() },
+    )
+
+    private fun ClassKind.toWireString(): String = when (this) {
+        ClassKind.CLASS -> "class"
+        ClassKind.INTERFACE -> "interface"
+        ClassKind.OBJECT -> "object"
+        ClassKind.ENUM_CLASS -> "enum"
+        ClassKind.ENUM_ENTRY -> "enum_entry"
+        ClassKind.ANNOTATION_CLASS -> "annotation"
+    }
+
+    /**
+     * Maps Kotlin's visibility values to the lowercased strings the
+     * krit-types JSON shape uses. Unknown / module-local visibilities
+     * fall back to `"public"` to match krit-types' default rendering.
+     */
+    private fun Visibility.toWireString(): String = when (this) {
+        Visibilities.Public -> "public"
+        Visibilities.Internal -> "internal"
+        Visibilities.Private -> "private"
+        Visibilities.PrivateToThis -> "private"
+        Visibilities.Protected -> "protected"
+        else -> "public"
+    }
+}

--- a/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/oracle/OracleCollector.kt
+++ b/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/oracle/OracleCollector.kt
@@ -1,0 +1,70 @@
+package dev.jasonpearson.krit.fir.oracle
+
+/**
+ * Mutable buffer that collects per-class projections during a single
+ * K2 compilation. The orchestrator ([`AnalysisSession.analyze`]) creates
+ * one [OracleCollector], publishes it on [OracleCollectorRegistry] for
+ * the duration of compilation, then drains it once the compiler returns.
+ *
+ * The compiler walks declarations on a single thread per compilation,
+ * so the collector itself is not synchronized. [OracleCollectorRegistry]
+ * uses a thread-local to scope visibility — multiple concurrent
+ * compilations on different threads each see their own collector.
+ */
+internal class OracleCollector {
+    private val perFile = LinkedHashMap<String, MutableList<ClassPayload>>()
+    private val dependencies = LinkedHashMap<String, ClassPayload>()
+    private val packageByFile = LinkedHashMap<String, String>()
+
+    fun addClass(filePath: String, payload: ClassPayload) {
+        perFile.getOrPut(filePath) { mutableListOf() }.add(payload)
+        // The `dependencies` map mirrors krit-types' cross-file class
+        // index — keyed by FQN so the Go-side oracle can resolve a
+        // symbol without walking every file. First-wins on duplicate
+        // FQNs across files; matches krit-types' behavior.
+        dependencies.putIfAbsent(payload.fqn, payload)
+    }
+
+    fun setPackage(filePath: String, packageName: String) {
+        packageByFile[filePath] = packageName
+    }
+
+    /**
+     * Build the final [AnalyzeResult] from buffered data. Files that
+     * had no class declarations but did have a package directive still
+     * appear with an empty `declarations` list — matches krit-types'
+     * behavior of emitting one `FileResult` per visited Kotlin file.
+     */
+    fun toResult(): AnalyzeResult {
+        val allFilePaths = (perFile.keys + packageByFile.keys).toSet()
+        val files = LinkedHashMap<String, FilePayload>(allFilePaths.size)
+        for (path in allFilePaths) {
+            files[path] = FilePayload(
+                packageName = packageByFile[path] ?: "",
+                declarations = perFile[path]?.toList() ?: emptyList(),
+            )
+        }
+        return AnalyzeResult(files = files, dependencies = dependencies.toMap())
+    }
+}
+
+/**
+ * Thread-local registry that publishes the active [OracleCollector] for
+ * the duration of a single K2 compilation. K2's frontend pipeline is
+ * single-threaded per compilation, so a thread-local is sufficient to
+ * scope collector visibility across the dispatched class checker and
+ * the orchestrator.
+ */
+internal object OracleCollectorRegistry {
+    private val active = ThreadLocal<OracleCollector?>()
+
+    fun begin(collector: OracleCollector) {
+        active.set(collector)
+    }
+
+    fun current(): OracleCollector? = active.get()
+
+    fun end() {
+        active.remove()
+    }
+}

--- a/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/runner/AnalysisSession.kt
+++ b/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/runner/AnalysisSession.kt
@@ -1,6 +1,10 @@
 package dev.jasonpearson.krit.fir.runner
 
+import dev.jasonpearson.krit.fir.oracle.AnalyzeResult
+import dev.jasonpearson.krit.fir.oracle.OracleCollector
+import dev.jasonpearson.krit.fir.oracle.OracleCollectorRegistry
 import org.jetbrains.kotlin.cli.common.arguments.K2JVMCompilerArguments
+import org.jetbrains.kotlin.cli.common.messages.MessageCollector
 import org.jetbrains.kotlin.cli.jvm.K2JVMCompiler
 import org.jetbrains.kotlin.config.Services
 import java.io.File
@@ -75,6 +79,43 @@ class AnalysisSession(val sourceDirs: List<String>, val classpath: List<String>)
         )
     }
 
+    /**
+     * Run a K2 frontend compilation to collect oracle-style per-class
+     * projections for `files` (or every source in `sourceDirs` when
+     * `files` is empty). The result mirrors krit-types' analyze /
+     * analyzeAll JSON shape — classes captured during compilation feed
+     * through the dispatched [OracleClassChecker] into an
+     * [OracleCollector], which the orchestrator drains here.
+     *
+     * Diagnostic checkers run on the same K2 invocation but produce no
+     * findings on this path; compiler messages are discarded via
+     * `MessageCollector.NONE` because the oracle path cares about
+     * structured class data, not lint diagnostics.
+     */
+    fun analyze(files: List<String>): AnalyzeResult {
+        val collector = OracleCollector()
+        OracleCollectorRegistry.begin(collector)
+        val outDir = Files.createTempDirectory("krit-fir-oracle-out-").toFile()
+        try {
+            val args = K2JVMCompilerArguments().apply {
+                freeArgs = (allSourceFiles + files).distinct().ifEmpty { files }
+                this.classpath = this@AnalysisSession.classpath.joinToString(File.pathSeparator)
+                destination = outDir.absolutePath
+                noStdlib = true
+                noReflect = true
+                suppressWarnings = true
+                if (selfJar != null) {
+                    pluginClasspaths = arrayOf(selfJar)
+                }
+            }
+            K2JVMCompiler().exec(MessageCollector.NONE, Services.EMPTY, args)
+        } finally {
+            outDir.deleteRecursively()
+            OracleCollectorRegistry.end()
+        }
+        return collector.toResult()
+    }
+
     fun dispose() {} // No long-lived JVM resources beyond the lazy source file list.
 
     companion object {
@@ -87,11 +128,22 @@ class AnalysisSession(val sourceDirs: List<String>, val classpath: List<String>)
             "SmokeChecker" to "SMOKE_CLASS",
         )
 
-        private fun resolveSelfJar(): String? = try {
-            val location = AnalysisSession::class.java.protectionDomain?.codeSource?.location
-            location?.toURI()?.let { File(it) }?.absolutePath?.takeIf { it.endsWith(".jar") }
-        } catch (_: Exception) {
-            null
+        private fun resolveSelfJar(): String? {
+            // Test harnesses override the plugin classpath via this
+            // system property — the plain `:jar` task output is enough
+            // (the test JVM already has the Kotlin compiler), and
+            // pointing here means tests don't need the slower
+            // shadow-jar build to register the plugin.
+            System.getProperty("krit.fir.plugin.jar")?.let { override ->
+                val file = File(override)
+                if (file.isFile) return file.absolutePath
+            }
+            return try {
+                val location = AnalysisSession::class.java.protectionDomain?.codeSource?.location
+                location?.toURI()?.let { File(it) }?.absolutePath?.takeIf { it.endsWith(".jar") }
+            } catch (_: Exception) {
+                null
+            }
         }
     }
 }

--- a/tools/krit-fir/src/test/kotlin/dev/jasonpearson/krit/fir/oracle/OracleCollectorTest.kt
+++ b/tools/krit-fir/src/test/kotlin/dev/jasonpearson/krit/fir/oracle/OracleCollectorTest.kt
@@ -1,0 +1,100 @@
+package dev.jasonpearson.krit.fir.oracle
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class OracleCollectorTest {
+
+    @Test
+    fun emptyCollectorProducesEmptyResult() {
+        val result = OracleCollector().toResult()
+        assertEquals(emptyMap(), result.files)
+        assertEquals(emptyMap(), result.dependencies)
+        assertEquals(emptyMap(), result.errors)
+    }
+
+    @Test
+    fun addClassEmitsBothFileEntryAndDependencyEntry() {
+        // The collector mirrors krit-types' two-output shape: the
+        // per-file `declarations` list AND the by-FQN `dependencies`
+        // map are populated from the same class declaration. The Go
+        // side uses one for per-file analysis and the other for
+        // cross-file symbol resolution; both must agree on the payload.
+        val c = OracleCollector()
+        val payload = ClassPayload(fqn = "com.acme.Foo", kind = "class")
+        c.addClass("/src/Foo.kt", payload)
+
+        val result = c.toResult()
+        assertEquals(listOf(payload), result.files["/src/Foo.kt"]?.declarations)
+        assertEquals(payload, result.dependencies["com.acme.Foo"])
+    }
+
+    @Test
+    fun multipleClassesInOneFileAccumulateInOrder() {
+        val c = OracleCollector()
+        val first = ClassPayload(fqn = "com.acme.First", kind = "class")
+        val second = ClassPayload(fqn = "com.acme.Second", kind = "interface")
+        c.addClass("/src/Foo.kt", first)
+        c.addClass("/src/Foo.kt", second)
+
+        val declarations = c.toResult().files["/src/Foo.kt"]?.declarations
+        assertEquals(listOf(first, second), declarations)
+    }
+
+    @Test
+    fun duplicateFqnAcrossFilesKeepsFirstSeenInDependencies() {
+        // Two files declaring the same FQN is unusual but possible
+        // during incremental analysis with stale sources. Match
+        // krit-types' first-wins behavior so the Go-side resolver
+        // doesn't see an unpredictable "last writer wins" race.
+        val c = OracleCollector()
+        val firstSeen = ClassPayload(fqn = "com.acme.Foo", kind = "class", visibility = "public")
+        val secondSeen = ClassPayload(fqn = "com.acme.Foo", kind = "object", visibility = "internal")
+        c.addClass("/src/A.kt", firstSeen)
+        c.addClass("/src/B.kt", secondSeen)
+
+        assertEquals(firstSeen, c.toResult().dependencies["com.acme.Foo"])
+    }
+
+    @Test
+    fun packageDirectiveWithoutClassDeclarationsStillEmitsFileEntry() {
+        // A Kotlin file with just `package` and top-level functions
+        // (no classes) should still appear in the `files` map with
+        // its package name — matches krit-types' behavior of always
+        // emitting one FileResult per visited file.
+        val c = OracleCollector()
+        c.setPackage("/src/Helpers.kt", "com.acme.util")
+
+        val payload = c.toResult().files["/src/Helpers.kt"]
+        assertEquals("com.acme.util", payload?.packageName)
+        assertEquals(emptyList(), payload?.declarations)
+    }
+
+    @Test
+    fun packageNameTrackedSeparatelyFromClassEntries() {
+        val c = OracleCollector()
+        c.setPackage("/src/Foo.kt", "com.acme")
+        c.addClass("/src/Foo.kt", ClassPayload(fqn = "com.acme.Foo", kind = "class"))
+
+        val payload = c.toResult().files["/src/Foo.kt"]
+        assertEquals("com.acme", payload?.packageName)
+        assertEquals(1, payload?.declarations?.size)
+    }
+
+    @Test
+    fun registryScopesActiveCollectorPerThread() {
+        // Sanity check on the thread-local guard. The orchestrator
+        // assumes K2 runs single-threaded per compilation; the test
+        // confirms a second `begin` overwrites the first, and `end`
+        // clears.
+        val first = OracleCollector()
+        val second = OracleCollector()
+        OracleCollectorRegistry.begin(first)
+        assertTrue(OracleCollectorRegistry.current() === first)
+        OracleCollectorRegistry.begin(second)
+        assertTrue(OracleCollectorRegistry.current() === second)
+        OracleCollectorRegistry.end()
+        assertTrue(OracleCollectorRegistry.current() == null)
+    }
+}

--- a/tools/krit-fir/src/test/kotlin/dev/jasonpearson/krit/fir/runner/AnalysisSessionAnalyzeTest.kt
+++ b/tools/krit-fir/src/test/kotlin/dev/jasonpearson/krit/fir/runner/AnalysisSessionAnalyzeTest.kt
@@ -1,0 +1,165 @@
+package dev.jasonpearson.krit.fir.runner
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import java.nio.file.Path
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * End-to-end coverage for [AnalysisSession.analyze] — drives a real K2
+ * compilation against a small Kotlin source tree and confirms the FIR
+ * class projection feeds the resulting `AnalyzeResult` with the
+ * expected per-class data.
+ *
+ * Each test creates a fresh `AnalysisSession` so the source-file walk
+ * picks up the tempdir state. K2 cold-start is ~1-3s per test — fine
+ * at this scale.
+ */
+class AnalysisSessionAnalyzeTest {
+
+    @TempDir
+    lateinit var tmp: Path
+
+    @Test
+    fun analyzeProjectsTopLevelClassDeclarations() {
+        val file = writeKt(
+            "Foo.kt",
+            """
+            package com.acme
+
+            class Bar {
+                fun greet() = "hi"
+            }
+            """.trimIndent(),
+        )
+
+        val result = AnalysisSession(
+            sourceDirs = listOf(tmp.toFile().absolutePath),
+            classpath = emptyList(),
+        ).analyze(emptyList())
+
+        val payload = result.files[file]
+        assertNotNull(payload, "file payload missing: files=${result.files.keys}")
+        assertEquals("com.acme", payload.packageName)
+        val bar = payload.declarations.singleOrNull { it.fqn == "com.acme.Bar" }
+        assertNotNull(bar, "declaration missing: ${payload.declarations.map { it.fqn }}")
+        assertEquals("class", bar.kind)
+        assertEquals("public", bar.visibility)
+        assertEquals(emptyList<String>(), bar.typeParameters)
+        // Cross-file index agrees with the per-file declaration.
+        assertEquals(bar, result.dependencies["com.acme.Bar"])
+    }
+
+    @Test
+    fun analyzeCapturesClassKindAndModalityFlags() {
+        writeKt(
+            "Mixed.kt",
+            """
+            package com.acme.mixed
+
+            sealed class Tree
+            class Leaf : Tree()
+            interface Shape
+            object Singleton
+            enum class Color { RED, GREEN }
+            data class Point(val x: Int, val y: Int)
+            abstract class Base
+            open class Extensible
+            """.trimIndent(),
+        )
+
+        val result = AnalysisSession(
+            sourceDirs = listOf(tmp.toFile().absolutePath),
+            classpath = emptyList(),
+        ).analyze(emptyList())
+
+        val byFqn = result.dependencies.mapValues { it.value }
+        // Every class kind maps to the wire string krit-types uses.
+        assertEquals("class", byFqn["com.acme.mixed.Tree"]?.kind)
+        assertEquals("interface", byFqn["com.acme.mixed.Shape"]?.kind)
+        assertEquals("object", byFqn["com.acme.mixed.Singleton"]?.kind)
+        assertEquals("enum", byFqn["com.acme.mixed.Color"]?.kind)
+
+        // Modality flags map to the right boolean fields.
+        assertTrue(byFqn["com.acme.mixed.Tree"]?.isSealed == true, "Tree.isSealed")
+        assertTrue(byFqn["com.acme.mixed.Point"]?.isData == true, "Point.isData")
+        assertTrue(byFqn["com.acme.mixed.Base"]?.isAbstract == true, "Base.isAbstract")
+        assertTrue(byFqn["com.acme.mixed.Extensible"]?.isOpen == true, "Extensible.isOpen")
+        // Non-data, final classes carry NO modifier flags so the wire
+        // payload stays minimal — krit-types' `appendClass` follows the
+        // same omit-when-false rule.
+        val leaf = byFqn["com.acme.mixed.Leaf"]
+        assertNotNull(leaf)
+        assertEquals(false, leaf.isSealed)
+        assertEquals(false, leaf.isOpen)
+        assertEquals(false, leaf.isData)
+        assertEquals(false, leaf.isAbstract)
+    }
+
+    @Test
+    fun analyzeCapturesSupertypesAndTypeParameters() {
+        writeKt(
+            "Generic.kt",
+            """
+            package com.acme.generic
+
+            interface Container<T>
+            abstract class StringContainer<T : CharSequence> : Container<T>
+            """.trimIndent(),
+        )
+
+        val result = AnalysisSession(
+            sourceDirs = listOf(tmp.toFile().absolutePath),
+            classpath = emptyList(),
+        ).analyze(emptyList())
+
+        val container = result.dependencies["com.acme.generic.Container"]
+        assertNotNull(container)
+        assertEquals(listOf("T"), container.typeParameters)
+
+        val stringContainer = result.dependencies["com.acme.generic.StringContainer"]
+        assertNotNull(stringContainer)
+        assertEquals(listOf("T"), stringContainer.typeParameters)
+        // Supertype list captures the FIR-rendered cone type. Exact
+        // rendering can vary across compiler versions; just confirm the
+        // declared supertype name appears somewhere.
+        assertTrue(
+            stringContainer.supertypes.any { "Container" in it },
+            "expected Container supertype, got ${stringContainer.supertypes}",
+        )
+    }
+
+    @Test
+    fun packageNameRecoveredFromClassDeclaration() {
+        writeKt(
+            "WithPackage.kt",
+            """
+            package com.acme.nested.deep
+
+            class Marker
+            """.trimIndent(),
+        )
+
+        val result = AnalysisSession(
+            sourceDirs = listOf(tmp.toFile().absolutePath),
+            classpath = emptyList(),
+        ).analyze(emptyList())
+
+        val payload = result.files.values.firstOrNull()
+        assertNotNull(payload)
+        assertEquals("com.acme.nested.deep", payload.packageName)
+    }
+
+    private fun writeKt(name: String, source: String): String {
+        val file = tmp.resolve(name).toFile()
+        file.writeText(source)
+        // K2's source-file path goes through canonicalization (macOS
+        // symlinks `/var` → `/private/var`); return the canonical path
+        // so test assertions against the `files` map line up with what
+        // the projection layer captured.
+        return file.canonicalPath
+    }
+}


### PR DESCRIPTION
## Summary

PR 2.3 in the FIR-oracle-parity sub-sequence. Wires the \`analyze\` / \`analyzeAll\` RPC dispatch on krit-fir to actually return FIR-extracted per-class data instead of the empty envelopes PR 2.2 stood up.

- New \`OracleClassChecker\` (\`FirClassChecker\`) projects each \`FirRegularClass\` into a \`ClassPayload\`: \`fqn\`, \`kind\`, \`supertypes\`, \`visibility\`, \`typeParameters\`, and the four modality flags (\`isSealed\`, \`isOpen\`, \`isAbstract\`, \`isData\`). Members, annotations, and \`jarPath\` stay empty for later projection passes.
- New \`OracleCollector\` mutable buffer + \`OracleCollectorRegistry\` thread-local hook scope the active collector for one K2 compilation. Thread-local is the standard K2 idiom for passing per-compilation state into checkers registered via \`FirAdditionalCheckersExtension\` — there's no public API on \`FirSession\` to receive custom state through the extension constructor.
- \`AnalysisSession.analyze(files)\` orchestrates the K2 invocation: begins a collector, runs the compiler (messages discarded via \`MessageCollector.NONE\` because oracle output is structured, not diagnostic), drains the collector, returns the populated \`AnalyzeResult\`.
- \`OracleClassChecker\` is registered unconditionally in \`KritFirCheckers.declarationCheckers\` — gates itself on \`OracleCollectorRegistry.current() != null\` so the diagnostic \`check\` command pays only a thread-local lookup per visited class.

## Test plan

- [x] \`OracleCollectorTest\` (unit): collector mechanics — file/dependency dual emission, in-order accumulation, first-wins on FQN conflicts, packages tracked separately, registry lifecycle.
- [x] \`AnalysisSessionAnalyzeTest\` (integration): drives K2 against tempdir Kotlin sources covering class / interface / object / enum / sealed / data / abstract / open / generic, asserts each kind maps to the right wire string and modality flags propagate.
- [x] \`./gradlew test\` in \`tools/krit-fir\` — 4 new integration tests + 7 new unit tests pass alongside existing compiler-tests.
- [x] \`./gradlew shadowJar\` still produces a working fat jar.
- [x] \`go test ./tests/parity/ -run TestFirPilotParity\` — existing FIR end-to-end parity test still passes; the new checker runs alongside the diagnostic checkers without interfering.
- [x] \`go build\`, \`go vet\`, \`golangci-lint run ./...\`, \`go test ./... -count=1\` — full Go suite green.
- [x] \`scripts/lint-actions.sh\` — clean.

## Test-jvm plugin-classpath wiring

\`AnalysisSession.resolveSelfJar\` honors a new \`krit.fir.plugin.jar\` system property so the test JVM can point at the freshly-built \`:jar\` output. Without the override, \`selfJar\` resolves to a class directory (not a jar) and K2 won't register the plugin — the test would see an empty result. The new \`tasks.test\` config in \`build.gradle.kts\` sets the property automatically and depends on \`:jar\`.