### PR TITLE
feat(krit-fir): project FIR member declarations

### DIFF
--- a/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/oracle/OracleClassChecker.kt
+++ b/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/oracle/OracleClassChecker.kt
@@ -8,13 +8,25 @@ import org.jetbrains.kotlin.diagnostics.DiagnosticReporter
 import org.jetbrains.kotlin.fir.analysis.checkers.MppCheckerKind
 import org.jetbrains.kotlin.fir.analysis.checkers.context.CheckerContext
 import org.jetbrains.kotlin.fir.analysis.checkers.declaration.FirClassChecker
+import org.jetbrains.kotlin.fir.declarations.DirectDeclarationsAccess
 import org.jetbrains.kotlin.fir.declarations.FirClass
+import org.jetbrains.kotlin.fir.declarations.FirConstructor
+import org.jetbrains.kotlin.fir.declarations.FirDeclaration
+import org.jetbrains.kotlin.fir.declarations.FirEnumEntry
+import org.jetbrains.kotlin.fir.declarations.FirNamedFunction
+import org.jetbrains.kotlin.fir.declarations.FirProperty
 import org.jetbrains.kotlin.fir.declarations.FirRegularClass
+import org.jetbrains.kotlin.fir.declarations.FirValueParameter
 import org.jetbrains.kotlin.fir.declarations.utils.isData
 import org.jetbrains.kotlin.fir.declarations.utils.modality
 import org.jetbrains.kotlin.fir.declarations.utils.visibility
 import org.jetbrains.kotlin.fir.symbols.SymbolInternals
+import org.jetbrains.kotlin.fir.types.ConeClassLikeType
+import org.jetbrains.kotlin.fir.types.ConeKotlinType
+import org.jetbrains.kotlin.fir.types.ConeKotlinTypeProjection
 import org.jetbrains.kotlin.fir.types.FirResolvedTypeRef
+import org.jetbrains.kotlin.fir.types.FirTypeRef
+import org.jetbrains.kotlin.fir.types.isMarkedNullable
 import org.jetbrains.kotlin.fir.types.renderReadable
 
 /**
@@ -25,11 +37,12 @@ import org.jetbrains.kotlin.fir.types.renderReadable
  * (e.g. the diagnostic-only `check()` command) pay only a thread-local
  * lookup per visited class.
  *
- * The covered surface is intentionally narrow: `fqn`, `kind`,
- * `supertypes`, `visibility`, four modality flags (`isSealed`,
- * `isOpen`, `isAbstract`, `isData`), and `typeParameters`. Members,
- * annotations, and `jarPath` ride on later projection passes; the
- * `ClassPayload` defaults for those fields stay empty for now.
+ * Covered surface: `fqn`, `kind`, `supertypes`, `visibility`, four
+ * modality flags, `typeParameters`, and class members
+ * (functions / properties / constructors / enum entries with name,
+ * kind, returnType, nullable, visibility, override / abstract flags,
+ * and parameters). Annotations and `jarPath` stay empty until their
+ * respective projection passes land.
  */
 internal object OracleClassChecker : FirClassChecker(MppCheckerKind.Common) {
 
@@ -51,6 +64,7 @@ internal object OracleClassChecker : FirClassChecker(MppCheckerKind.Common) {
         collector.addClass(filePath, regular.toClassPayload())
     }
 
+    @OptIn(DirectDeclarationsAccess::class)
     private fun FirRegularClass.toClassPayload(): ClassPayload = ClassPayload(
         fqn = symbol.classId.asFqNameString(),
         kind = classKind.toWireString(),
@@ -65,7 +79,92 @@ internal object OracleClassChecker : FirClassChecker(MppCheckerKind.Common) {
         isAbstract = modality == Modality.ABSTRACT,
         visibility = visibility.toWireString(),
         typeParameters = typeParameters.map { it.symbol.name.asString() },
+        members = declarations.mapNotNull { it.toMemberPayload() },
     )
+
+    /**
+     * Project one of a class's [declarations][FirRegularClass.declarations]
+     * into a [MemberPayload]. Returns null for declaration kinds the
+     * oracle does not surface today — nested classes are walked
+     * separately by the per-file class pass, and synthetic / generated
+     * declarations without a stable wire shape (e.g. compiler-synthesized
+     * companion object fields) are skipped.
+     */
+    private fun FirDeclaration.toMemberPayload(): MemberPayload? = when (this) {
+        is FirNamedFunction -> MemberPayload(
+            name = name.asString(),
+            kind = "function",
+            returnType = returnTypeRef.renderType(),
+            nullable = returnTypeRef.isNullable(),
+            visibility = status.visibility.toWireString(),
+            isOverride = status.isOverride,
+            isAbstract = status.modality == Modality.ABSTRACT,
+            params = valueParameters.map { it.toParamPayload() },
+        )
+        is FirProperty -> MemberPayload(
+            name = name.asString(),
+            kind = "property",
+            returnType = returnTypeRef.renderType(),
+            nullable = returnTypeRef.isNullable(),
+            visibility = status.visibility.toWireString(),
+            isOverride = status.isOverride,
+            isAbstract = status.modality == Modality.ABSTRACT,
+        )
+        is FirConstructor -> MemberPayload(
+            // `<init>` matches krit-types' canonical constructor name
+            // and is also the JVM-level signature, so Go-side consumers
+            // can pivot on the literal string.
+            name = "<init>",
+            kind = "constructor",
+            returnType = returnTypeRef.renderType(),
+            nullable = false,
+            visibility = status.visibility.toWireString(),
+            isOverride = false,
+            isAbstract = false,
+            params = valueParameters.map { it.toParamPayload() },
+        )
+        is FirEnumEntry -> MemberPayload(
+            name = name.asString(),
+            kind = "enum_entry",
+            returnType = "",
+            nullable = false,
+            visibility = "public",
+        )
+        else -> null
+    }
+
+    private fun FirValueParameter.toParamPayload(): ParamPayload = ParamPayload(
+        name = name.asString(),
+        type = returnTypeRef.renderType(),
+        nullable = returnTypeRef.isNullable(),
+    )
+
+    private fun FirTypeRef.renderType(): String =
+        (this as? FirResolvedTypeRef)?.coneType?.renderFqn() ?: ""
+
+    private fun FirTypeRef.isNullable(): Boolean =
+        (this as? FirResolvedTypeRef)?.coneType?.isMarkedNullable == true
+
+    /**
+     * Render a [ConeKotlinType] as an FQN-qualified type string, matching
+     * the krit-types wire format (e.g. `kotlin.String`, `kotlin.Int?`,
+     * `kotlin.collections.List<kotlin.String>`). Non-class-like types
+     * (type parameters, intersection types, flexible types) fall back to
+     * the readable rendering since they don't carry a stable FQN.
+     */
+    private fun ConeKotlinType.renderFqn(): String {
+        val classLike = this as? ConeClassLikeType ?: return renderReadable()
+        val fqn = classLike.lookupTag.classId.asFqNameString()
+        val args = typeArguments
+            .takeIf { it.isNotEmpty() }
+            ?.joinToString(", ", "<", ">") { projection ->
+                (projection as? ConeKotlinTypeProjection)?.type?.renderFqn()
+                    ?: projection.toString()
+            }
+            .orEmpty()
+        val nullable = if (isMarkedNullable) "?" else ""
+        return "$fqn$args$nullable"
+    }
 
     private fun ClassKind.toWireString(): String = when (this) {
         ClassKind.CLASS -> "class"

--- a/tools/krit-fir/src/test/kotlin/dev/jasonpearson/krit/fir/runner/AnalysisSessionMembersTest.kt
+++ b/tools/krit-fir/src/test/kotlin/dev/jasonpearson/krit/fir/runner/AnalysisSessionMembersTest.kt
@@ -1,0 +1,209 @@
+package dev.jasonpearson.krit.fir.runner
+
+import dev.jasonpearson.krit.fir.oracle.ClassPayload
+import dev.jasonpearson.krit.fir.oracle.MemberPayload
+import dev.jasonpearson.krit.fir.oracle.ParamPayload
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * End-to-end coverage for the [`OracleClassChecker`]
+ * member-projection pass: every visited class's
+ * function / property / constructor / enum-entry declarations come
+ * back as [MemberPayload]s with the right kind, return type,
+ * nullability, visibility, override / abstract flags, and parameters.
+ */
+class AnalysisSessionMembersTest {
+
+    @TempDir
+    lateinit var tmp: Path
+
+    @Test
+    fun functionsCaptureNameKindReturnTypeAndParams() {
+        writeKt(
+            "Funcs.kt",
+            """
+            package com.acme.funcs
+
+            class Greeter {
+                fun greet(name: String): String = "hi, " + name
+                fun nullableGreet(name: String?): String? = name
+            }
+            """.trimIndent(),
+        )
+
+        val classes = analyzeAndIndex()
+        val greeter = classes["com.acme.funcs.Greeter"]
+        assertNotNull(greeter)
+        val greet = greeter.functionsByName()["greet"]
+        assertNotNull(greet)
+        assertEquals("function", greet.kind)
+        assertEquals("kotlin.String", greet.returnType)
+        assertEquals(false, greet.nullable)
+        assertEquals(
+            listOf(ParamPayload(name = "name", type = "kotlin.String", nullable = false)),
+            greet.params,
+        )
+
+        val nullableGreet = greeter.functionsByName()["nullableGreet"]
+        assertNotNull(nullableGreet)
+        assertEquals("kotlin.String?", nullableGreet.returnType)
+        assertEquals(true, nullableGreet.nullable)
+        assertTrue(nullableGreet.params.single().nullable)
+    }
+
+    @Test
+    fun propertiesAndConstructorsHaveCorrectKindAndParams() {
+        writeKt(
+            "Props.kt",
+            """
+            package com.acme.props
+
+            class Point(val x: Int, val y: Int) {
+                val sum: Int get() = x + y
+                var label: String? = null
+            }
+            """.trimIndent(),
+        )
+
+        val classes = analyzeAndIndex()
+        val point = classes["com.acme.props.Point"]
+        assertNotNull(point)
+
+        // Primary constructor surfaces with the canonical "<init>" name
+        // and carries its value parameters.
+        val ctor = point.members.singleOrNull { it.kind == "constructor" }
+        assertNotNull(ctor, "constructor missing: ${point.members.map { it.name }}")
+        assertEquals("<init>", ctor.name)
+        assertEquals(
+            listOf(
+                ParamPayload(name = "x", type = "kotlin.Int", nullable = false),
+                ParamPayload(name = "y", type = "kotlin.Int", nullable = false),
+            ),
+            ctor.params,
+        )
+
+        // Properties — including the synthetic backing properties for
+        // val/var constructor parameters — appear with kind=property.
+        val byName = point.propertiesByName()
+        val sum = byName["sum"]
+        assertNotNull(sum)
+        assertEquals("property", sum.kind)
+        assertEquals("kotlin.Int", sum.returnType)
+
+        val label = byName["label"]
+        assertNotNull(label)
+        assertEquals("kotlin.String?", label.returnType)
+        assertEquals(true, label.nullable)
+    }
+
+    @Test
+    fun visibilityAndOverrideAndAbstractFlagsPropagate() {
+        writeKt(
+            "Flags.kt",
+            """
+            package com.acme.flags
+
+            interface Greeter {
+                fun greet(): String
+            }
+            abstract class Base : Greeter {
+                abstract fun shout(): String
+                protected open fun guarded() {}
+                private fun secret() {}
+                internal fun pkgwide() {}
+            }
+            class Concrete : Base() {
+                override fun greet() = "hi"
+                override fun shout() = "HI"
+            }
+            """.trimIndent(),
+        )
+
+        val classes = analyzeAndIndex()
+
+        // Concrete.greet overrides Greeter.greet — isOverride must surface.
+        val concrete = classes["com.acme.flags.Concrete"]
+        assertNotNull(concrete)
+        val greet = concrete.functionsByName()["greet"]
+        assertNotNull(greet)
+        assertEquals(true, greet.isOverride)
+        assertEquals(false, greet.isAbstract)
+
+        // Base.shout is abstract; visibility is public, isAbstract = true.
+        val base = classes["com.acme.flags.Base"]
+        assertNotNull(base)
+        val shout = base.functionsByName()["shout"]
+        assertNotNull(shout)
+        assertEquals(true, shout.isAbstract)
+
+        // Each access modifier renders to the krit-types wire string.
+        assertEquals("protected", base.functionsByName()["guarded"]?.visibility)
+        assertEquals("private", base.functionsByName()["secret"]?.visibility)
+        assertEquals("internal", base.functionsByName()["pkgwide"]?.visibility)
+    }
+
+    @Test
+    fun enumEntriesAppearAsMembersOfTheEnumClass() {
+        writeKt(
+            "Color.kt",
+            """
+            package com.acme.color
+
+            enum class Color { RED, GREEN, BLUE }
+            """.trimIndent(),
+        )
+
+        val classes = analyzeAndIndex()
+        val color = classes["com.acme.color.Color"]
+        assertNotNull(color)
+        val entries = color.members.filter { it.kind == "enum_entry" }.map { it.name }
+        assertEquals(listOf("RED", "GREEN", "BLUE"), entries)
+    }
+
+    @Test
+    fun classWithNoMembersStillEmitsEmptyMembersList() {
+        writeKt(
+            "Marker.kt",
+            """
+            package com.acme.marker
+
+            class Marker
+            """.trimIndent(),
+        )
+
+        val classes = analyzeAndIndex()
+        val marker = classes["com.acme.marker.Marker"]
+        assertNotNull(marker)
+        // The default no-arg constructor is synthesized by K2 — it shows
+        // up in `declarations` as a `FirConstructor` and we surface it.
+        // Anything else (synthetic equals / hashCode / toString on
+        // non-data classes) is skipped by our `toMemberPayload` filter.
+        val nonCtor = marker.members.filter { it.kind != "constructor" }
+        assertEquals(emptyList(), nonCtor, "non-ctor members: $nonCtor")
+    }
+
+    private fun analyzeAndIndex(): Map<String, ClassPayload> {
+        val result = AnalysisSession(
+            sourceDirs = listOf(tmp.toFile().absolutePath),
+            classpath = emptyList(),
+        ).analyze(emptyList())
+        return result.dependencies
+    }
+
+    private fun ClassPayload.functionsByName(): Map<String, MemberPayload> =
+        members.filter { it.kind == "function" }.associateBy { it.name }
+
+    private fun ClassPayload.propertiesByName(): Map<String, MemberPayload> =
+        members.filter { it.kind == "property" }.associateBy { it.name }
+
+    private fun writeKt(name: String, source: String): String {
+        val file = tmp.resolve(name).toFile()
+        file.writeText(source)
+        return file.canonicalPath
+    }
+}


### PR DESCRIPTION
## Summary

PR 2.4 in the krit-fir oracle parity series. Extends \`OracleClassChecker\` to project each visited class's declarations into \`MemberPayload\` entries, matching the wire shape that krit-types already produces.

- Walks \`FirRegularClass.declarations\` (under \`@OptIn(DirectDeclarationsAccess::class)\`) and emits a member per \`FirNamedFunction\`, \`FirProperty\`, \`FirConstructor\`, or \`FirEnumEntry\`.
- Captures \`name\`, \`kind\`, \`returnType\`, \`nullable\`, \`visibility\`, \`isOverride\`, \`isAbstract\`, plus \`params\` for callables.
- Constructors surface with the canonical \`<init>\` name so Go-side consumers can pivot on the literal string.
- Type rendering uses \`classId.asFqNameString()\` (with type-arg recursion and \`?\` nullability suffix) so the wire format matches \`kotlin.String\` / \`kotlin.collections.List<kotlin.Int>\` rather than the bare-name \`renderReadable\` output.
- Annotations and \`jarPath\` continue to ride on later projection passes.

## Test plan
- [x] \`./gradlew :test\` in \`tools/krit-fir/\` (incl. new \`AnalysisSessionMembersTest\` — functions, properties + ctors, visibility/override/abstract flags, enum entries, empty-members)
- [x] \`go build ./cmd/krit/ && go vet ./... && golangci-lint run ./... && go test ./... -count=1\` (FIR parity test green once \`shadowJar\` is current)