### PR TITLE
feat(krit-fir): project FIR call expressions

### DIFF
--- a/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/KritFirCheckers.kt
+++ b/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/KritFirCheckers.kt
@@ -5,6 +5,7 @@ import dev.jasonpearson.krit.fir.checkers.FlowCollectInOnCreate
 import dev.jasonpearson.krit.fir.checkers.InjectDispatcher
 import dev.jasonpearson.krit.fir.checkers.UnsafeCastWhenNullable
 import dev.jasonpearson.krit.fir.oracle.OracleClassChecker
+import dev.jasonpearson.krit.fir.oracle.OracleExpressionChecker
 import dev.jasonpearson.krit.fir.rules.SmokeChecker
 import org.jetbrains.kotlin.fir.FirSession
 import org.jetbrains.kotlin.fir.analysis.checkers.declaration.DeclarationCheckers
@@ -12,21 +13,24 @@ import org.jetbrains.kotlin.fir.analysis.checkers.expression.ExpressionCheckers
 import org.jetbrains.kotlin.fir.analysis.extensions.FirAdditionalCheckersExtension
 
 class KritFirCheckers(session: FirSession) : FirAdditionalCheckersExtension(session) {
+    // The oracle expression checker is included unconditionally and gates
+    // itself on `OracleCollectorRegistry.current() != null`, so non-oracle
+    // paths (diagnostic `check` command) pay only a thread-local lookup
+    // per call expression.
     override val expressionCheckers = object : ExpressionCheckers() {
         override val functionCallCheckers = setOf(
             FlowCollectInOnCreate,
             ComposeRememberWithoutKey,
             InjectDispatcher,
+            OracleExpressionChecker,
         )
         override val typeOperatorCallCheckers = setOf(
             UnsafeCastWhenNullable,
         )
     }
 
-    // OracleClassChecker is included unconditionally — it gates itself on
-    // `OracleCollectorRegistry.current() != null`, so non-oracle paths
-    // (diagnostic `check` command) pay only a thread-local lookup per
-    // visited class.
+    // Same self-gating story for OracleClassChecker on the declaration
+    // side: non-oracle paths pay only the thread-local probe.
     override val declarationCheckers = object : DeclarationCheckers() {
         override val classCheckers = setOf(SmokeChecker, OracleClassChecker)
     }

--- a/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/oracle/FileOffsetTable.kt
+++ b/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/oracle/FileOffsetTable.kt
@@ -1,0 +1,86 @@
+package dev.jasonpearson.krit.fir.oracle
+
+/**
+ * Pre-computed line and UTF-8 byte offset tables for a single source
+ * file. Letting callers translate a FIR `KtSourceElement` offset
+ * (which is a char index into the original text) into:
+ *
+ * - 1-based `(line, col)` for the `"line:col"` expression key that
+ *   matches krit-types' wire format.
+ * - 0-based UTF-8 byte offset for `startByte` / `endByte`, also
+ *   matching krit-types' rendering (which uses `Utf8ByteOffsets`).
+ *
+ * Computed once per file from the file's content; safe to cache for
+ * the lifetime of the enclosing [`OracleCollector`] because that
+ * collector is rebuilt per compilation.
+ */
+internal class FileOffsetTable(private val content: String) {
+
+    /** Char offset where each line begins; lineStarts[0] = 0 by definition. */
+    private val lineStarts: IntArray = buildLineStarts(content)
+
+    /**
+     * UTF-8 byte offset for each char offset in `0..content.length`. The
+     * trailing entry holds the file's total UTF-8 byte length so
+     * `byteOffsetAt(content.length)` is well-defined.
+     */
+    private val charToByte: IntArray = buildCharToByte(content)
+
+    /** Map a 0-based char offset to a 1-based (line, column) pair. */
+    fun lineColAt(charOffset: Int): Pair<Int, Int> {
+        val clamped = charOffset.coerceIn(0, content.length)
+        val line = lineIndexFor(clamped)
+        val col = clamped - lineStarts[line] + 1
+        return (line + 1) to col
+    }
+
+    /** Map a 0-based char offset to a 0-based UTF-8 byte offset. */
+    fun byteOffsetAt(charOffset: Int): Int {
+        val clamped = charOffset.coerceIn(0, content.length)
+        return charToByte[clamped]
+    }
+
+    private fun lineIndexFor(charOffset: Int): Int {
+        var lo = 0
+        var hi = lineStarts.size - 1
+        while (lo < hi) {
+            val mid = (lo + hi + 1) ushr 1
+            if (lineStarts[mid] <= charOffset) lo = mid else hi = mid - 1
+        }
+        return lo
+    }
+
+    companion object {
+        private fun buildLineStarts(content: String): IntArray {
+            val starts = ArrayList<Int>().apply { add(0) }
+            for (i in content.indices) {
+                if (content[i] == '\n') starts.add(i + 1)
+            }
+            return starts.toIntArray()
+        }
+
+        private fun buildCharToByte(content: String): IntArray {
+            val table = IntArray(content.length + 1)
+            var bytes = 0
+            for (i in content.indices) {
+                table[i] = bytes
+                val cp = content[i].code
+                bytes += when {
+                    cp < 0x80 -> 1
+                    cp < 0x800 -> 2
+                    cp in 0xD800..0xDBFF -> {
+                        // High surrogate: counted with its low surrogate as a
+                        // single 4-byte UTF-8 sequence. Only the high
+                        // surrogate contributes the four bytes; the low
+                        // surrogate that follows contributes zero.
+                        4
+                    }
+                    cp in 0xDC00..0xDFFF -> 0
+                    else -> 3
+                }
+            }
+            table[content.length] = bytes
+            return table
+        }
+    }
+}

--- a/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/oracle/OracleCollector.kt
+++ b/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/oracle/OracleCollector.kt
@@ -1,5 +1,7 @@
 package dev.jasonpearson.krit.fir.oracle
 
+import java.io.File
+
 /**
  * Mutable buffer that collects per-class projections during a single
  * K2 compilation. The orchestrator ([`AnalysisSession.analyze`]) creates
@@ -15,6 +17,8 @@ internal class OracleCollector {
     private val perFile = LinkedHashMap<String, MutableList<ClassPayload>>()
     private val dependencies = LinkedHashMap<String, ClassPayload>()
     private val packageByFile = LinkedHashMap<String, String>()
+    private val expressionsByFile = LinkedHashMap<String, LinkedHashMap<String, ExpressionPayload>>()
+    private val offsetsByFile = HashMap<String, FileOffsetTable?>()
 
     fun addClass(filePath: String, payload: ClassPayload) {
         perFile.getOrPut(filePath) { mutableListOf() }.add(payload)
@@ -30,18 +34,45 @@ internal class OracleCollector {
     }
 
     /**
+     * Add an expression payload for [filePath] under [key]
+     * ("line:col"). First-wins on duplicate keys — matches krit-types'
+     * dedup behavior where overlapping call expressions at the same
+     * source position are reported once.
+     */
+    fun addExpression(filePath: String, key: String, payload: ExpressionPayload) {
+        val map = expressionsByFile.getOrPut(filePath) { LinkedHashMap() }
+        map.putIfAbsent(key, payload)
+    }
+
+    /** True iff an expression has already been recorded at this key in this file. */
+    fun hasExpression(filePath: String, key: String): Boolean =
+        expressionsByFile[filePath]?.containsKey(key) == true
+
+    /**
+     * Lazily-built offset table for [filePath]. Returns null if the
+     * file cannot be read (e.g. it was deleted between the K2 walk
+     * scheduling and the checker firing). Callers should skip the
+     * expression in that case rather than crashing.
+     */
+    fun offsetsFor(filePath: String): FileOffsetTable? =
+        offsetsByFile.getOrPut(filePath) {
+            runCatching { FileOffsetTable(File(filePath).readText()) }.getOrNull()
+        }
+
+    /**
      * Build the final [AnalyzeResult] from buffered data. Files that
      * had no class declarations but did have a package directive still
      * appear with an empty `declarations` list — matches krit-types'
      * behavior of emitting one `FileResult` per visited Kotlin file.
      */
     fun toResult(): AnalyzeResult {
-        val allFilePaths = (perFile.keys + packageByFile.keys).toSet()
+        val allFilePaths = (perFile.keys + packageByFile.keys + expressionsByFile.keys).toSet()
         val files = LinkedHashMap<String, FilePayload>(allFilePaths.size)
         for (path in allFilePaths) {
             files[path] = FilePayload(
                 packageName = packageByFile[path] ?: "",
                 declarations = perFile[path]?.toList() ?: emptyList(),
+                expressions = expressionsByFile[path]?.toMap() ?: emptyMap(),
             )
         }
         return AnalyzeResult(files = files, dependencies = dependencies.toMap())

--- a/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/oracle/OracleExpressionChecker.kt
+++ b/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/oracle/OracleExpressionChecker.kt
@@ -1,0 +1,77 @@
+package dev.jasonpearson.krit.fir.oracle
+
+import org.jetbrains.kotlin.diagnostics.DiagnosticReporter
+import org.jetbrains.kotlin.fir.analysis.checkers.MppCheckerKind
+import org.jetbrains.kotlin.fir.analysis.checkers.context.CheckerContext
+import org.jetbrains.kotlin.fir.analysis.checkers.expression.FirFunctionCallChecker
+import org.jetbrains.kotlin.fir.declarations.toAnnotationClassId
+import org.jetbrains.kotlin.fir.declarations.utils.isSuspend
+import org.jetbrains.kotlin.fir.expressions.FirFunctionCall
+import org.jetbrains.kotlin.fir.references.toResolvedCallableSymbol
+import org.jetbrains.kotlin.fir.symbols.SymbolInternals
+
+/**
+ * FIR `FirFunctionCallChecker` that projects each visited
+ * [FirFunctionCall] into an [ExpressionPayload] and pushes it onto the
+ * active [OracleCollector], if any. Mirrors krit-types' per-call
+ * projection: only callable resolution is exposed (no expression type
+ * or nullability), since the Go-side rules consuming this data only
+ * read `callTarget`, `callTargetSuspend`, and annotations.
+ *
+ * The checker gates itself on `OracleCollectorRegistry.current() != null`
+ * so plugin-only compilations (the diagnostic `check()` command) pay
+ * only a thread-local probe per call.
+ */
+internal object OracleExpressionChecker : FirFunctionCallChecker(MppCheckerKind.Common) {
+
+    @OptIn(SymbolInternals::class)
+    context(context: CheckerContext, reporter: DiagnosticReporter)
+    override fun check(expression: FirFunctionCall) {
+        val collector = OracleCollectorRegistry.current() ?: return
+        val source = expression.source ?: return
+        val filePath = context.containingFileSymbol?.fir?.sourceFile?.path ?: return
+        val offsets = collector.offsetsFor(filePath) ?: return
+
+        val startOffset = source.startOffset
+        val endOffset = source.endOffset
+        val (line, col) = offsets.lineColAt(startOffset)
+        val key = "$line:$col"
+        if (collector.hasExpression(filePath, key)) return
+
+        val callee = expression.calleeReference.toResolvedCallableSymbol()
+        val lexicalFallback = expression.calleeReference.name.asString()
+
+        var callTarget: String = lexicalFallback
+        var callTargetResolved = false
+        var callTargetSuspend = false
+        var annotations: List<String> = emptyList()
+        if (callee != null) {
+            val fqn = callee.callableId?.asSingleFqName()?.asString().orEmpty()
+            if (fqn.isNotEmpty()) {
+                callTarget = fqn
+                callTargetResolved = true
+                callTargetSuspend = callee.isSuspend
+                annotations = callee.annotations.mapNotNull {
+                    it.toAnnotationClassId(context.session)?.asSingleFqName()?.asString()
+                }
+            }
+        }
+
+        if (callTarget.isEmpty()) return
+
+        val payload = ExpressionPayload(
+            // type / nullable stay empty to match krit-types' shape; the
+            // downstream Go-side oracle consumers only read callTarget +
+            // annotations.
+            type = "",
+            nullable = false,
+            startByte = offsets.byteOffsetAt(startOffset),
+            endByte = offsets.byteOffsetAt(endOffset),
+            callTarget = callTarget,
+            callTargetResolved = callTargetResolved,
+            callTargetSuspend = callTargetSuspend,
+            annotations = annotations,
+        )
+        collector.addExpression(filePath, key, payload)
+    }
+}

--- a/tools/krit-fir/src/test/kotlin/dev/jasonpearson/krit/fir/oracle/FileOffsetTableTest.kt
+++ b/tools/krit-fir/src/test/kotlin/dev/jasonpearson/krit/fir/oracle/FileOffsetTableTest.kt
@@ -1,0 +1,51 @@
+package dev.jasonpearson.krit.fir.oracle
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+class FileOffsetTableTest {
+
+    @Test
+    fun lineColIsOneBasedAndRecoversFromOffset() {
+        // 0  1  2  3 4 5
+        // a  b  \n c d e
+        val table = FileOffsetTable("ab\ncde")
+
+        assertEquals(1 to 1, table.lineColAt(0))   // 'a'
+        assertEquals(1 to 2, table.lineColAt(1))   // 'b'
+        assertEquals(1 to 3, table.lineColAt(2))   // '\n' is end of line 1
+        assertEquals(2 to 1, table.lineColAt(3))   // 'c'
+        assertEquals(2 to 3, table.lineColAt(5))   // 'e'
+    }
+
+    @Test
+    fun byteOffsetTracksUtf8WidthOfPrecedingChars() {
+        // "é" is U+00E9, two UTF-8 bytes.
+        val table = FileOffsetTable("aé")
+
+        assertEquals(0, table.byteOffsetAt(0))   // before 'a'
+        assertEquals(1, table.byteOffsetAt(1))   // before 'é' — one byte in
+        assertEquals(3, table.byteOffsetAt(2))   // after 'é' — three bytes total
+    }
+
+    @Test
+    fun byteOffsetHandlesSupplementaryCodepointSurrogatePairs() {
+        // U+1F600 (😀) is encoded as a surrogate pair in Kotlin strings
+        // (high + low surrogate) and as four UTF-8 bytes on the wire.
+        val emoji = "😀"
+        val table = FileOffsetTable("a${emoji}b")
+
+        assertEquals(0, table.byteOffsetAt(0))   // before 'a'
+        assertEquals(1, table.byteOffsetAt(1))   // before high surrogate
+        assertEquals(5, table.byteOffsetAt(3))   // after the emoji's 4 bytes
+        assertEquals(6, table.byteOffsetAt(4))   // after 'b'
+    }
+
+    @Test
+    fun lineColClampsToFileBounds() {
+        val table = FileOffsetTable("abc")
+
+        assertEquals(1 to 1, table.lineColAt(-1))
+        assertEquals(1 to 4, table.lineColAt(10))
+    }
+}

--- a/tools/krit-fir/src/test/kotlin/dev/jasonpearson/krit/fir/oracle/OracleCollectorTest.kt
+++ b/tools/krit-fir/src/test/kotlin/dev/jasonpearson/krit/fir/oracle/OracleCollectorTest.kt
@@ -83,6 +83,44 @@ class OracleCollectorTest {
     }
 
     @Test
+    fun addExpressionAccumulatesUnderFilePathAndKey() {
+        val c = OracleCollector()
+        val payload = ExpressionPayload(type = "", callTarget = "com.acme.foo")
+        c.addExpression("/src/Foo.kt", "10:5", payload)
+
+        val expressions = c.toResult().files["/src/Foo.kt"]?.expressions
+        assertEquals(mapOf("10:5" to payload), expressions)
+    }
+
+    @Test
+    fun duplicateExpressionKeysKeepFirstSeen() {
+        // K2 can revisit the same call site during phased checking;
+        // first-wins matches krit-types' "skip if key already present"
+        // dedup pattern so the wire shape is deterministic.
+        val c = OracleCollector()
+        val first = ExpressionPayload(type = "", callTarget = "first")
+        val second = ExpressionPayload(type = "", callTarget = "second")
+        c.addExpression("/src/Foo.kt", "1:1", first)
+        c.addExpression("/src/Foo.kt", "1:1", second)
+
+        assertEquals(first, c.toResult().files["/src/Foo.kt"]?.expressions?.get("1:1"))
+        assertTrue(c.hasExpression("/src/Foo.kt", "1:1"))
+    }
+
+    @Test
+    fun expressionsForFileWithoutClassesStillEmitsFileEntry() {
+        // A file that has only top-level function calls (no class
+        // declarations and no package directive in the test) should
+        // still appear in `files` with its expressions populated.
+        val c = OracleCollector()
+        c.addExpression("/src/Only.kt", "1:1", ExpressionPayload(type = "", callTarget = "x"))
+
+        val payload = c.toResult().files["/src/Only.kt"]
+        assertEquals(1, payload?.expressions?.size)
+        assertEquals(emptyList(), payload?.declarations)
+    }
+
+    @Test
     fun registryScopesActiveCollectorPerThread() {
         // Sanity check on the thread-local guard. The orchestrator
         // assumes K2 runs single-threaded per compilation; the test

--- a/tools/krit-fir/src/test/kotlin/dev/jasonpearson/krit/fir/runner/AnalysisSessionExpressionsTest.kt
+++ b/tools/krit-fir/src/test/kotlin/dev/jasonpearson/krit/fir/runner/AnalysisSessionExpressionsTest.kt
@@ -1,0 +1,153 @@
+package dev.jasonpearson.krit.fir.runner
+
+import dev.jasonpearson.krit.fir.oracle.ExpressionPayload
+import dev.jasonpearson.krit.fir.oracle.FilePayload
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * End-to-end coverage for the [`OracleExpressionChecker`] call
+ * projection: every visited [`FirFunctionCall`] should surface in the
+ * resulting `expressions` map keyed by `"line:col"` with the resolved
+ * callable FQN, suspend flag, and callable annotations.
+ */
+class AnalysisSessionExpressionsTest {
+
+    @TempDir
+    lateinit var tmp: Path
+
+    @Test
+    fun resolvedCallsRecordFqnSuspendFlagAndByteOffsets() {
+        val path = writeKt(
+            "Calls.kt",
+            """
+            package com.acme.calls
+
+            suspend fun runSuspend(): Int = 1
+            fun runPlain(): Int = 2
+
+            suspend fun caller() {
+                runSuspend()
+                runPlain()
+            }
+            """.trimIndent(),
+        )
+
+        val expressions = expressionsFor(path)
+        val resolved = expressions.values.associateBy { it.callTarget }
+
+        val suspendCall = resolved["com.acme.calls.runSuspend"]
+        assertNotNull(suspendCall, "runSuspend missing: ${expressions.values.map { it.callTarget }}")
+        assertEquals(true, suspendCall.callTargetResolved)
+        assertEquals(true, suspendCall.callTargetSuspend)
+        assertTrue(suspendCall.endByte > suspendCall.startByte, "byte range empty: $suspendCall")
+
+        val plainCall = resolved["com.acme.calls.runPlain"]
+        assertNotNull(plainCall)
+        assertEquals(true, plainCall.callTargetResolved)
+        assertEquals(false, plainCall.callTargetSuspend)
+    }
+
+    @Test
+    fun keysUseOneBasedLineAndColumnAtTheCallSite() {
+        val path = writeKt(
+            "Position.kt",
+            """
+            package com.acme.position
+
+            fun target(): Int = 1
+
+            fun caller() {
+                target()
+            }
+            """.trimIndent(),
+        )
+
+        val expressions = expressionsFor(path)
+        // The single `target()` call site sits on line 6, column 5 of
+        // the formatted source above.
+        val entry = expressions.entries.singleOrNull { it.value.callTarget == "com.acme.position.target" }
+        assertNotNull(entry, "target() call missing: ${expressions.entries}")
+        assertEquals("6:5", entry.key)
+    }
+
+    @Test
+    fun annotationsOnCalleeSurfaceAsFqnList() {
+        val path = writeKt(
+            "Annotated.kt",
+            """
+            package com.acme.annotated
+
+            @Target(AnnotationTarget.FUNCTION)
+            @Retention(AnnotationRetention.SOURCE)
+            annotation class Marker
+
+            @Marker
+            fun target(): Int = 1
+
+            fun caller() {
+                target()
+            }
+            """.trimIndent(),
+        )
+
+        val expressions = expressionsFor(path)
+        val targetCall = expressions.values.singleOrNull { it.callTarget == "com.acme.annotated.target" }
+        assertNotNull(targetCall, "target() call missing: ${expressions.values.map { it.callTarget }}")
+        assertTrue(
+            "com.acme.annotated.Marker" in targetCall.annotations,
+            "expected Marker annotation, got ${targetCall.annotations}",
+        )
+    }
+
+    @Test
+    fun distinctCallSitesProduceDistinctKeys() {
+        val path = writeKt(
+            "Many.kt",
+            """
+            package com.acme.many
+
+            fun target(): Int = 1
+
+            fun caller() {
+                target()
+                target()
+                target()
+            }
+            """.trimIndent(),
+        )
+
+        val expressions = expressionsFor(path)
+        val targetCalls = expressions.entries.filter { it.value.callTarget == "com.acme.many.target" }
+        assertEquals(3, targetCalls.size, "expected three distinct target calls, got $targetCalls")
+        assertEquals(
+            targetCalls.size,
+            targetCalls.map { it.key }.toSet().size,
+            "expected unique line:col keys for each call",
+        )
+    }
+
+    private fun expressionsFor(path: String): Map<String, ExpressionPayload> {
+        val result = AnalysisSession(
+            sourceDirs = listOf(tmp.toFile().absolutePath),
+            classpath = emptyList(),
+        ).analyze(emptyList())
+        val file: FilePayload? = result.files[path]
+        assertNotNull(file, "file payload missing: files=${result.files.keys}")
+        return file.expressions
+    }
+
+    private fun writeKt(name: String, source: String): String {
+        val file = tmp.resolve(name).toFile()
+        file.writeText(source)
+        // K2's source-file path goes through canonicalization (macOS
+        // symlinks `/var` → `/private/var`); return the canonical path
+        // so test assertions against the `files` map line up with what
+        // the projection layer captured.
+        return file.canonicalPath
+    }
+}


### PR DESCRIPTION
## Summary

PR 2.5 in the krit-fir oracle parity series. Adds an \`OracleExpressionChecker\` that projects every visited \`FirFunctionCall\` into an \`ExpressionPayload\` and emits the result through the existing collector pipeline, matching krit-types' wire shape.

- \`OracleExpressionChecker\` (\`FirFunctionCallChecker\`) resolves the callee via \`calleeReference.toResolvedCallableSymbol()\` and records \`callTarget\` (callableId FQN), \`callTargetResolved\`, \`callTargetSuspend\`, and callable annotations. Falls back to the lexical callee name when resolution fails so downstream rules still have something to match on.
- \`type\` and \`nullable\` intentionally stay empty — the krit-types projection documents them as having zero consumers, only \`callTarget\` + \`annotations\` are read downstream.
- \`startByte\` / \`endByte\` come from a new \`FileOffsetTable\` (cached per file on the \`OracleCollector\`) that maps char offsets to 1-based line/column and 0-based UTF-8 byte offsets — handles ASCII, multi-byte UTF-8, and surrogate-pair codepoints.
- Registered alongside the existing rule checkers in \`KritFirCheckers.expressionCheckers.functionCallCheckers\`; gated on \`OracleCollectorRegistry.current()\` so non-oracle paths pay only a thread-local probe per call.
- \`OracleCollector\` gains \`addExpression\` / \`hasExpression\` / \`offsetsFor\` and includes \`expressions\` when building \`FilePayload\`s. First-wins dedup by \`"line:col"\` matches krit-types' behavior.

## Test plan
- [x] \`./gradlew :test\` in \`tools/krit-fir/\` — new \`AnalysisSessionExpressionsTest\` (resolved FQN + suspend, line:col keys, annotated callables, distinct call sites) + \`FileOffsetTableTest\` (line/col, multi-byte UTF-8, surrogate pairs, clamping) + new \`OracleCollectorTest\` cases (expression dedup, classless file still emits entry)
- [x] \`go build ./cmd/krit/ && go vet ./... && golangci-lint run ./... && go test ./... -count=1\` (FIR parity test green against the freshly-built shadowJar)