### PR TITLE
feat(krit-fir): annotations, analyzeFiles, analyzeWithDeps

### DIFF
--- a/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/Main.kt
+++ b/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/Main.kt
@@ -172,7 +172,7 @@ fun handleRequestLine(trimmed: String, session: AnalysisSession, startTime: Long
                 RequestResult.Response("""{"id":${request.id},"result":{"ok":true,"uptime":$uptime}}""")
             }
             "shutdown" -> RequestResult.Shutdown("""{"id":${request.id},"result":{"ok":true}}""")
-            "analyze", "analyzeAll" -> {
+            "analyze", "analyzeAll", "analyzeFiles", "analyzeWithDeps" -> {
                 val needsRebuild =
                     request.sourceDirs != session.sourceDirs || request.classpath != session.classpath
                 val activeSession = if (needsRebuild) {
@@ -187,7 +187,11 @@ fun handleRequestLine(trimmed: String, session: AnalysisSession, startTime: Long
                     request.files.map { it.path }
                 }
                 val result = activeSession.analyze(analyzeFiles)
-                val response = OracleResponse.buildAnalyze(request.id, result)
+                val response = if (request.command == "analyzeWithDeps") {
+                    OracleResponse.buildAnalyzeWithDeps(request.id, result)
+                } else {
+                    OracleResponse.buildAnalyze(request.id, result)
+                }
                 if (needsRebuild) {
                     RequestResult.SessionRebuilt(response, activeSession)
                 } else {

--- a/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/oracle/OracleAnalysis.kt
+++ b/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/oracle/OracleAnalysis.kt
@@ -91,12 +91,23 @@ data class ExpressionPayload(
     val annotations: List<String> = emptyList(),
 )
 
-/** Compiler diagnostic surfaced through the analyze envelope. */
+/**
+ * Compiler diagnostic surfaced through the analyze envelope. Mirrors
+ * krit-types' `DiagnosticResult` — same field names so the Go-side
+ * client parses either backend's response with one struct.
+ *
+ * `startByte` / `endByte` are 0-based UTF-8 byte offsets and are
+ * emitted only when they describe a real range (`endByte > startByte`);
+ * matches the omit-when-empty rule the krit-types serializer uses.
+ */
 data class DiagnosticPayload(
+    val factoryName: String,
     val severity: String,
     val message: String,
     val line: Int,
-    val column: Int = 1,
+    val col: Int = 1,
+    val startByte: Int = 0,
+    val endByte: Int = 0,
 )
 
 /**

--- a/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/oracle/OracleClassChecker.kt
+++ b/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/oracle/OracleClassChecker.kt
@@ -8,6 +8,8 @@ import org.jetbrains.kotlin.diagnostics.DiagnosticReporter
 import org.jetbrains.kotlin.fir.analysis.checkers.MppCheckerKind
 import org.jetbrains.kotlin.fir.analysis.checkers.context.CheckerContext
 import org.jetbrains.kotlin.fir.analysis.checkers.declaration.FirClassChecker
+import org.jetbrains.kotlin.fir.FirAnnotationContainer
+import org.jetbrains.kotlin.fir.FirSession
 import org.jetbrains.kotlin.fir.declarations.DirectDeclarationsAccess
 import org.jetbrains.kotlin.fir.declarations.FirClass
 import org.jetbrains.kotlin.fir.declarations.FirConstructor
@@ -17,6 +19,7 @@ import org.jetbrains.kotlin.fir.declarations.FirNamedFunction
 import org.jetbrains.kotlin.fir.declarations.FirProperty
 import org.jetbrains.kotlin.fir.declarations.FirRegularClass
 import org.jetbrains.kotlin.fir.declarations.FirValueParameter
+import org.jetbrains.kotlin.fir.declarations.toAnnotationClassId
 import org.jetbrains.kotlin.fir.declarations.utils.isData
 import org.jetbrains.kotlin.fir.declarations.utils.modality
 import org.jetbrains.kotlin.fir.declarations.utils.visibility
@@ -38,11 +41,11 @@ import org.jetbrains.kotlin.fir.types.renderReadable
  * lookup per visited class.
  *
  * Covered surface: `fqn`, `kind`, `supertypes`, `visibility`, four
- * modality flags, `typeParameters`, and class members
+ * modality flags, `typeParameters`, `annotations`, and class members
  * (functions / properties / constructors / enum entries with name,
  * kind, returnType, nullable, visibility, override / abstract flags,
- * and parameters). Annotations and `jarPath` stay empty until their
- * respective projection passes land.
+ * parameters, and annotations). `jarPath` stays empty until library
+ * projection lands.
  */
 internal object OracleClassChecker : FirClassChecker(MppCheckerKind.Common) {
 
@@ -61,11 +64,11 @@ internal object OracleClassChecker : FirClassChecker(MppCheckerKind.Common) {
         val filePath = context.containingFileSymbol?.fir?.sourceFile?.path ?: return
 
         collector.setPackage(filePath, regular.symbol.classId.packageFqName.asString())
-        collector.addClass(filePath, regular.toClassPayload())
+        collector.addClass(filePath, regular.toClassPayload(context.session))
     }
 
     @OptIn(DirectDeclarationsAccess::class)
-    private fun FirRegularClass.toClassPayload(): ClassPayload = ClassPayload(
+    private fun FirRegularClass.toClassPayload(session: FirSession): ClassPayload = ClassPayload(
         fqn = symbol.classId.asFqNameString(),
         kind = classKind.toWireString(),
         supertypes = superTypeRefs.mapNotNull { ref ->
@@ -79,7 +82,8 @@ internal object OracleClassChecker : FirClassChecker(MppCheckerKind.Common) {
         isAbstract = modality == Modality.ABSTRACT,
         visibility = visibility.toWireString(),
         typeParameters = typeParameters.map { it.symbol.name.asString() },
-        members = declarations.mapNotNull { it.toMemberPayload() },
+        members = declarations.mapNotNull { it.toMemberPayload(session) },
+        annotations = annotationFqns(session),
     )
 
     /**
@@ -90,7 +94,7 @@ internal object OracleClassChecker : FirClassChecker(MppCheckerKind.Common) {
      * declarations without a stable wire shape (e.g. compiler-synthesized
      * companion object fields) are skipped.
      */
-    private fun FirDeclaration.toMemberPayload(): MemberPayload? = when (this) {
+    private fun FirDeclaration.toMemberPayload(session: FirSession): MemberPayload? = when (this) {
         is FirNamedFunction -> MemberPayload(
             name = name.asString(),
             kind = "function",
@@ -100,6 +104,7 @@ internal object OracleClassChecker : FirClassChecker(MppCheckerKind.Common) {
             isOverride = status.isOverride,
             isAbstract = status.modality == Modality.ABSTRACT,
             params = valueParameters.map { it.toParamPayload() },
+            annotations = annotationFqns(session),
         )
         is FirProperty -> MemberPayload(
             name = name.asString(),
@@ -109,6 +114,7 @@ internal object OracleClassChecker : FirClassChecker(MppCheckerKind.Common) {
             visibility = status.visibility.toWireString(),
             isOverride = status.isOverride,
             isAbstract = status.modality == Modality.ABSTRACT,
+            annotations = annotationFqns(session),
         )
         is FirConstructor -> MemberPayload(
             // `<init>` matches krit-types' canonical constructor name
@@ -122,6 +128,7 @@ internal object OracleClassChecker : FirClassChecker(MppCheckerKind.Common) {
             isOverride = false,
             isAbstract = false,
             params = valueParameters.map { it.toParamPayload() },
+            annotations = annotationFqns(session),
         )
         is FirEnumEntry -> MemberPayload(
             name = name.asString(),
@@ -129,9 +136,13 @@ internal object OracleClassChecker : FirClassChecker(MppCheckerKind.Common) {
             returnType = "",
             nullable = false,
             visibility = "public",
+            annotations = annotationFqns(session),
         )
         else -> null
     }
+
+    private fun FirAnnotationContainer.annotationFqns(session: FirSession): List<String> =
+        annotations.mapNotNull { it.toAnnotationClassId(session)?.asSingleFqName()?.asString() }
 
     private fun FirValueParameter.toParamPayload(): ParamPayload = ParamPayload(
         name = name.asString(),

--- a/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/oracle/OracleResponse.kt
+++ b/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/oracle/OracleResponse.kt
@@ -16,17 +16,52 @@ package dev.jasonpearson.krit.fir.oracle
 object OracleResponse {
 
     /**
-     * Build the krit-types-compatible envelope for an analyze response.
-     * Errors carried on [result] are nested inside the `result` object
-     * to match krit-types' legacy `buildDaemonResponse` shape; the flat
-     * `cacheDeps`-sibling envelope used by `analyzeWithDeps` is
-     * separate and lands with the cacheDeps projection in a later PR.
+     * Build the krit-types-compatible envelope for the legacy
+     * `analyze` / `analyzeAll` / `analyzeFiles` RPC. Errors carried on
+     * [result] are nested inside the `result` object to match
+     * krit-types' `buildDaemonResponse` shape.
      */
     fun buildAnalyze(id: Long, result: AnalyzeResult = AnalyzeResult.EMPTY): String {
         val sb = StringBuilder()
         sb.append("""{"id":""")
         sb.append(id)
         sb.append(""","result":{""")
+        appendResultBody(sb, result)
+        if (result.errors.isNotEmpty()) {
+            sb.append(""","errors":""")
+            appendErrors(sb, result.errors)
+        }
+        sb.append("}}")
+        return sb.toString()
+    }
+
+    /**
+     * Build the flat-envelope response shape used by `analyzeWithDeps`.
+     * Mirrors krit-types' `buildDaemonResponseWithDeps`: `result`,
+     * `errors`, and `cacheDeps` are siblings rather than nested inside
+     * `result`. `cacheDeps` is always emitted (currently with empty
+     * `files` and `crashed` maps) so the Go-side client can detect that
+     * the daemon speaks the new protocol revision; population of the
+     * per-file dependency closure lands with the cacheDeps projection
+     * in a follow-up PR.
+     */
+    fun buildAnalyzeWithDeps(id: Long, result: AnalyzeResult = AnalyzeResult.EMPTY): String {
+        val sb = StringBuilder()
+        sb.append("""{"id":""")
+        sb.append(id)
+        sb.append(""","result":{""")
+        appendResultBody(sb, result)
+        sb.append("}")
+        if (result.errors.isNotEmpty()) {
+            sb.append(""","errors":""")
+            appendErrors(sb, result.errors)
+        }
+        sb.append(""","cacheDeps":{"files":{},"crashed":{}}""")
+        sb.append("}")
+        return sb.toString()
+    }
+
+    private fun appendResultBody(sb: StringBuilder, result: AnalyzeResult) {
         sb.append(""""version":1,""")
         sb.append(""""kotlinVersion":""")
         sb.append(jsonString(KotlinVersion.CURRENT.toString()))
@@ -34,12 +69,6 @@ object OracleResponse {
         appendFiles(sb, result.files)
         sb.append(""","dependencies":""")
         appendDependencies(sb, result.dependencies)
-        if (result.errors.isNotEmpty()) {
-            sb.append(""","errors":""")
-            appendErrors(sb, result.errors)
-        }
-        sb.append("}}")
-        return sb.toString()
     }
 
     private fun appendFiles(sb: StringBuilder, files: Map<String, FilePayload>) {
@@ -210,14 +239,22 @@ object OracleResponse {
         sb.append("[")
         diags.forEachIndexed { i, d ->
             if (i > 0) sb.append(",")
-            sb.append("""{"severity":""")
+            sb.append("""{"factoryName":""")
+            sb.append(jsonString(d.factoryName))
+            sb.append(""","severity":""")
             sb.append(jsonString(d.severity))
             sb.append(""","message":""")
             sb.append(jsonString(d.message))
             sb.append(""","line":""")
             sb.append(d.line)
-            sb.append(""","column":""")
-            sb.append(d.column)
+            sb.append(""","col":""")
+            sb.append(d.col)
+            if (d.endByte > d.startByte) {
+                sb.append(""","startByte":""")
+                sb.append(d.startByte)
+                sb.append(""","endByte":""")
+                sb.append(d.endByte)
+            }
             sb.append("}")
         }
         sb.append("]")

--- a/tools/krit-fir/src/test/kotlin/dev/jasonpearson/krit/fir/OracleDispatchTest.kt
+++ b/tools/krit-fir/src/test/kotlin/dev/jasonpearson/krit/fir/OracleDispatchTest.kt
@@ -39,13 +39,36 @@ class OracleDispatchTest {
     }
 
     @Test
+    fun analyzeFilesCommandRoutesToOracleResponseBuilder() {
+        val request = """{"id":13,"command":"analyzeFiles"}"""
+        val result = handleRequestLine(request, session, startTime = 0L)
+        val response = (result as RequestResult.Response).json
+        assertTrue(response.startsWith("""{"id":13,"result":{"""), response)
+        assertTrue(""""files":{}""" in response, response)
+        assertTrue(""""dependencies":{}""" in response, response)
+    }
+
+    @Test
+    fun analyzeWithDepsCommandUsesFlatEnvelopeWithCacheDeps() {
+        // analyzeWithDeps uses krit-types' flat envelope shape:
+        // `result` / `errors` / `cacheDeps` as siblings, and cacheDeps
+        // is always present (currently empty) so the Go-side client
+        // can detect that the daemon speaks the new protocol revision.
+        val request = """{"id":14,"command":"analyzeWithDeps"}"""
+        val result = handleRequestLine(request, session, startTime = 0L)
+        val response = (result as RequestResult.Response).json
+        assertTrue(response.startsWith("""{"id":14,"result":{"""), response)
+        assertTrue(""""cacheDeps":{"files":{},"crashed":{}}""" in response, response)
+    }
+
+    @Test
     fun analyzeResponseIsNotAnErrorEnvelope() {
         // Belt-and-suspenders: an `else` clause that returns
         // `{"id":...,"error":"Unknown command:..."}` is one accidental
         // dispatch ordering bug away from regressing this. Confirm the
-        // response has no `error` field at the top level for either
-        // command.
-        for (cmd in listOf("analyze", "analyzeAll")) {
+        // response has no `error` field at the top level for any
+        // oracle command.
+        for (cmd in listOf("analyze", "analyzeAll", "analyzeFiles", "analyzeWithDeps")) {
             val response =
                 (handleRequestLine("""{"id":1,"command":"$cmd"}""", session, 0L)
                     as RequestResult.Response).json

--- a/tools/krit-fir/src/test/kotlin/dev/jasonpearson/krit/fir/oracle/OracleResponseTest.kt
+++ b/tools/krit-fir/src/test/kotlin/dev/jasonpearson/krit/fir/oracle/OracleResponseTest.kt
@@ -160,6 +160,111 @@ class OracleResponseTest {
     }
 
     @Test
+    fun analyzeWithDepsEmitsFlatEnvelopeWithCacheDeps() {
+        // The `analyzeWithDeps` shape moves errors out of `result` into a
+        // sibling key and always emits `cacheDeps` (even empty) so the
+        // Go-side client can detect new-protocol daemons.
+        val response = OracleResponse.buildAnalyzeWithDeps(
+            id = 4,
+            result = AnalyzeResult(
+                errors = mapOf("/src/Bad.kt" to "parse error"),
+            ),
+        )
+        assertTrue(response.startsWith("""{"id":4,"result":{"""), response)
+        assertTrue(""""cacheDeps":{"files":{},"crashed":{}}""" in response, response)
+        // errors is a sibling of result, not nested inside it.
+        val resultEnd = response.indexOf("}", response.indexOf(""""result":{"""))
+        val errorsAt = response.indexOf(""""errors":""")
+        assertTrue(
+            errorsAt > resultEnd,
+            "errors should be a sibling of result, not nested: $response",
+        )
+    }
+
+    @Test
+    fun analyzeWithDepsOmitsErrorsKeyWhenEmpty() {
+        val response = OracleResponse.buildAnalyzeWithDeps(id = 5)
+        assertTrue("errors" !in response, response)
+        assertTrue(""""cacheDeps":{"files":{},"crashed":{}}""" in response, response)
+    }
+
+    @Test
+    fun classAndMemberAnnotationsRideOnTheWire() {
+        val response = OracleResponse.buildAnalyze(
+            id = 1,
+            result = AnalyzeResult(
+                files = mapOf(
+                    "/src/Foo.kt" to FilePayload(
+                        declarations = listOf(
+                            ClassPayload(
+                                fqn = "com.acme.Foo",
+                                kind = "class",
+                                annotations = listOf("kotlin.Deprecated"),
+                                members = listOf(
+                                    MemberPayload(
+                                        name = "doStuff",
+                                        kind = "function",
+                                        returnType = "kotlin.Unit",
+                                        annotations = listOf("kotlin.jvm.JvmStatic"),
+                                    ),
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+        )
+        assertTrue(""""annotations":["kotlin.Deprecated"]""" in response, response)
+        assertTrue(""""annotations":["kotlin.jvm.JvmStatic"]""" in response, response)
+    }
+
+    @Test
+    fun diagnosticWireShapeMatchesKritTypes() {
+        // krit-types emits `{factoryName, severity, message, line, col,
+        // startByte?, endByte?}` for each diagnostic. Pinning the field
+        // names + omit-when-empty byte range guards against accidentally
+        // diverging from the consumer's parser shape.
+        val response = OracleResponse.buildAnalyze(
+            id = 1,
+            result = AnalyzeResult(
+                files = mapOf(
+                    "/src/Foo.kt" to FilePayload(
+                        diagnostics = listOf(
+                            DiagnosticPayload(
+                                factoryName = "USELESS_ELVIS",
+                                severity = "WARNING",
+                                message = "Elvis operator (?:) always returns the left operand of non-nullable type",
+                                line = 3,
+                                col = 7,
+                                startByte = 10,
+                                endByte = 22,
+                            ),
+                            DiagnosticPayload(
+                                factoryName = "CAST_NEVER_SUCCEEDS",
+                                severity = "WARNING",
+                                message = "cast can never succeed",
+                                line = 5,
+                                col = 1,
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+        )
+        assertTrue(""""factoryName":"USELESS_ELVIS"""" in response, response)
+        assertTrue(""""col":7""" in response, response)
+        assertTrue(""""startByte":10,"endByte":22""" in response, response)
+        // The zero-range diagnostic must omit startByte/endByte to keep
+        // the wire payload minimal (krit-types' rule).
+        assertTrue(""""factoryName":"CAST_NEVER_SUCCEEDS","severity":"WARNING"""" in response, response)
+        val secondDiagFragment = response.substringAfter("CAST_NEVER_SUCCEEDS")
+        assertTrue(
+            "startByte" !in secondDiagFragment,
+            "zero-range diagnostic must omit startByte: $response",
+        )
+    }
+
+    @Test
     fun expressionPayloadOmitsZeroByteRangeAndFalseFlags() {
         // Expressions ride on every analyze response and can be dense
         // on real codebases. Emit only fields that carry information:

--- a/tools/krit-fir/src/test/kotlin/dev/jasonpearson/krit/fir/runner/AnalysisSessionAnnotationsTest.kt
+++ b/tools/krit-fir/src/test/kotlin/dev/jasonpearson/krit/fir/runner/AnalysisSessionAnnotationsTest.kt
@@ -1,0 +1,89 @@
+package dev.jasonpearson.krit.fir.runner
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * End-to-end coverage for annotation projection on classes and
+ * members. Mirrors krit-types' shape: each annotation contributes its
+ * containing class FQN to the `annotations` list (no value rendering).
+ */
+class AnalysisSessionAnnotationsTest {
+
+    @TempDir
+    lateinit var tmp: Path
+
+    @Test
+    fun classAndMemberAnnotationsRoundTripAsFqnLists() {
+        writeKt(
+            "Annotated.kt",
+            """
+            package com.acme.ann
+
+            @Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION, AnnotationTarget.PROPERTY)
+            @Retention(AnnotationRetention.SOURCE)
+            annotation class Tag
+
+            @Tag
+            class Box(val label: String) {
+                @Tag
+                fun describe(): String = label
+
+                @Tag
+                val secondary: String = ""
+            }
+            """.trimIndent(),
+        )
+
+        val result = AnalysisSession(
+            sourceDirs = listOf(tmp.toFile().absolutePath),
+            classpath = emptyList(),
+        ).analyze(emptyList())
+
+        val box = result.dependencies["com.acme.ann.Box"]
+        assertNotNull(box)
+        assertTrue("com.acme.ann.Tag" in box.annotations, "class annotations: ${box.annotations}")
+
+        val describe = box.members.singleOrNull { it.kind == "function" && it.name == "describe" }
+        assertNotNull(describe)
+        assertEquals(listOf("com.acme.ann.Tag"), describe.annotations)
+
+        val secondary = box.members.singleOrNull { it.kind == "property" && it.name == "secondary" }
+        assertNotNull(secondary)
+        assertEquals(listOf("com.acme.ann.Tag"), secondary.annotations)
+    }
+
+    @Test
+    fun unannotatedDeclarationsCarryEmptyAnnotationLists() {
+        writeKt(
+            "Plain.kt",
+            """
+            package com.acme.plain
+
+            class Plain {
+                fun greet(): String = "hi"
+            }
+            """.trimIndent(),
+        )
+
+        val result = AnalysisSession(
+            sourceDirs = listOf(tmp.toFile().absolutePath),
+            classpath = emptyList(),
+        ).analyze(emptyList())
+
+        val plain = result.dependencies["com.acme.plain.Plain"]
+        assertNotNull(plain)
+        assertEquals(emptyList(), plain.annotations)
+        plain.members.forEach { m ->
+            assertEquals(emptyList(), m.annotations, "expected empty annotations on $m")
+        }
+    }
+
+    private fun writeKt(name: String, source: String) {
+        tmp.resolve(name).toFile().writeText(source)
+    }
+}


### PR DESCRIPTION
## Summary

PR 2.6 in the krit-fir oracle parity series. Closes out the synchronous coverage gap between the FIR and KAA backends.

- **Annotations**: \`OracleClassChecker\` projects \`@Annotation\` FQNs onto \`ClassPayload\` and every \`MemberPayload\` kind (function / property / constructor / enum entry) via \`FirAnnotation.toAnnotationClassId(session)\`. Mirrors krit-types' \`symbol.annotations.mapNotNull { it.classId?.asFqNameString() }\` shape.
- **\`analyzeFiles\`**: routed through the same \`AnalysisSession.analyze\` pipeline as \`analyze\` / \`analyzeAll\` (the krit-types mtime-skip gate has no analog in our K2-per-request model, so behavior collapses to plain analyze).
- **\`analyzeWithDeps\`**: new \`OracleResponse.buildAnalyzeWithDeps\` emits krit-types' flat envelope (\`result\` / \`errors\` / \`cacheDeps\` as siblings). \`cacheDeps\` is always present (\`{\"files\":{},\"crashed\":{}}\`) so the Go-side client can detect new-protocol daemons; real per-file dependency-closure population lands with the dep-tracker pass in a follow-up.
- **\`DiagnosticPayload\` wire shape**: now matches krit-types — \`factoryName\` + \`col\` (not \`column\`) + optional \`startByte\`/\`endByte\`. Diagnostic *population* (the UNREACHABLE_CODE / USELESS_ELVIS / CAST_NEVER_SUCCEEDS subset krit-types retains) needs a K2 diagnostic-subscriber pass and is deferred to a follow-up — the wire contract is pinned here so consumers don't churn when data flips on.

Type parameters with bounds were on the original 2.6 scope list, but krit-types itself only exposes \`typeParameters: List<String>\` (names only) — already covered in PR 2.3.

## Test plan
- [x] \`./gradlew :test\` in \`tools/krit-fir/\` — new \`AnalysisSessionAnnotationsTest\`, \`analyzeFiles\` + \`analyzeWithDeps\` dispatch cases, flat-envelope + diagnostic-shape + annotation cases in \`OracleResponseTest\`
- [x] \`go build ./cmd/krit/ && go vet ./... && golangci-lint run ./... && go test ./... -count=1\`