### PR TITLE
fix(scanner): clear shardsObserved via sync.Map.Clear, not reassignment

### DIFF
--- a/internal/scanner/index_shard.go
+++ b/internal/scanner/index_shard.go
@@ -46,8 +46,10 @@ func (crossFileShardsRegistered) Clear(_ cacheutil.ClearContext) error {
 	// Shards live under the cross-file cache dir, which the cross-file
 	// cache's Clear already removes wholesale. Reset counters so a
 	// subsequent Stats() call in the same process reflects the empty
-	// state.
-	shardsObserved = sync.Map{}
+	// state. Clear() is safe for concurrent observeShard callers;
+	// reassigning the sync.Map value would race with their in-flight
+	// LoadOrStore.
+	shardsObserved.Clear()
 	shardsEntries.Store(0)
 	shardsBytes.Store(0)
 	return nil

--- a/internal/scanner/index_shard_test.go
+++ b/internal/scanner/index_shard_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 
 	"github.com/bits-and-blooms/bloom/v3"
+
+	"github.com/kaeawc/krit/internal/cacheutil"
 )
 
 func TestFileShardRoundTrip(t *testing.T) {
@@ -570,6 +572,45 @@ func TestShardBloomUnionFPRSmallScale(t *testing.T) {
 	if fpr > 0.05 {
 		t.Errorf("union FPR = %.4f exceeds 5%% budget", fpr)
 	}
+}
+
+// TestCrossFileShardsRegisteredClearRace hammers the Clear handler
+// while observeShard runs in parallel. Reassigning shardsObserved to
+// a fresh sync.Map value (the prior implementation) races against
+// in-flight LoadOrStore calls. Run with -race to catch a regression.
+func TestCrossFileShardsRegisteredClearRace(t *testing.T) {
+	const (
+		observers  = 8
+		iterations = 500
+	)
+	reg := crossFileShardsRegistered{}
+
+	var wg sync.WaitGroup
+	for w := 0; w < observers; w++ {
+		wg.Add(1)
+		go func(seed int) {
+			defer wg.Done()
+			for i := 0; i < iterations; i++ {
+				observeShard(fmt.Sprintf("k-%d-%d", seed, i), int64(i))
+			}
+		}(w)
+	}
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations/4; i++ {
+			if err := reg.Clear(cacheutil.ClearContext{}); err != nil {
+				t.Errorf("Clear: %v", err)
+			}
+		}
+	}()
+
+	wg.Wait()
+
+	// Final Clear so this test does not leak observed shard counters
+	// into other tests that read Stats() in the same process.
+	_ = reg.Clear(cacheutil.ClearContext{})
 }
 
 // TestSaveFileShardConcurrent exercises the parallel write path; the


### PR DESCRIPTION
## Summary

`crossFileShardsRegistered.Clear` was reassigning `shardsObserved` to a fresh `sync.Map` value while `observeShard` goroutines might be running `LoadOrStore` on it. `sync.Map` is concurrency-safe for method calls on a stable value, not for whole-struct reassignment — under `-race` on the new regression test the underlying `HashTrieMap` corrupts and the observer goroutine panics with `unlock of unlocked mutex` inside `sync.Map.LoadOrStore`.

Switched the clear to `sync.Map.Clear()` (Go 1.23+), which serialises with concurrent `LoadOrStore` the same way `sync.Map`'s other methods do.

## Test plan

- [x] New `TestCrossFileShardsRegisteredClearRace` races `observeShard` against the `Clear` handler; with the prior reassignment in place, `go test -race` reports a data race **and** the goroutine panics inside `sync.Map.LoadOrStore` — both gone after the fix.
- [x] `go test -race ./internal/scanner/ -run TestCrossFileShardsRegisteredClearRace`
- [x] `go test ./internal/scanner/ -count=1`
- [x] `go vet ./...`
- [x] `golangci-lint run ./internal/scanner/`