### PR TITLE
fix(scan): surface output-file Close error as non-zero exit

### DIFF
--- a/internal/cli/scan/finalize_output_test.go
+++ b/internal/cli/scan/finalize_output_test.go
@@ -1,0 +1,56 @@
+package scan
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+)
+
+type errCloser struct{ err error }
+
+func (e errCloser) Close() error { return e.err }
+
+func TestFinalizeOutputCloseSuccessPreservesExitCode(t *testing.T) {
+	var stderr bytes.Buffer
+	got := finalizeOutputClose(errCloser{}, &stderr, 0)
+	if got != 0 {
+		t.Errorf("clean close: want exit 0, got %d", got)
+	}
+	if stderr.Len() != 0 {
+		t.Errorf("clean close: want no stderr, got %q", stderr.String())
+	}
+}
+
+func TestFinalizeOutputCloseFailureEscalatesToExitTwo(t *testing.T) {
+	var stderr bytes.Buffer
+	got := finalizeOutputClose(errCloser{err: errors.New("disk full")}, &stderr, 0)
+	if got != 2 {
+		t.Errorf("close error from clean run: want exit 2, got %d", got)
+	}
+	if !strings.Contains(stderr.String(), "disk full") {
+		t.Errorf("close error must reach stderr, got %q", stderr.String())
+	}
+}
+
+func TestFinalizeOutputCloseFailurePreservesNonzeroExit(t *testing.T) {
+	var stderr bytes.Buffer
+	got := finalizeOutputClose(errCloser{err: errors.New("late")}, &stderr, 1)
+	if got != 1 {
+		t.Errorf("close error after prior failure must preserve exit 1, got %d", got)
+	}
+	if !strings.Contains(stderr.String(), "late") {
+		t.Errorf("close error must still reach stderr even when exit was already nonzero, got %q", stderr.String())
+	}
+}
+
+func TestFinalizeOutputNilCloserIsNoop(t *testing.T) {
+	var stderr bytes.Buffer
+	got := finalizeOutputClose(nil, &stderr, 0)
+	if got != 0 {
+		t.Errorf("nil writer: want exit 0, got %d", got)
+	}
+	if stderr.Len() != 0 {
+		t.Errorf("nil writer: want no stderr, got %q", stderr.String())
+	}
+}

--- a/internal/cli/scan/scan.go
+++ b/internal/cli/scan/scan.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -353,15 +354,34 @@ func (r *runner) run(ctx context.Context) (int, error) {
 	if code, err := r.openOutputWriter(); err != nil {
 		return code, err
 	}
-	if r.w != nil && r.w != os.Stdout {
-		defer r.w.Close()
-	}
 
 	// Flush again after openOutputWriter. flushCaches is idempotent.
 	r.flushCaches()
 
 	r.recordTotalTimingAndStopProfiles()
-	return r.outputPhase(), nil
+	exitCode := r.outputPhase()
+	if r.w != nil && r.w != os.Stdout {
+		exitCode = finalizeOutputClose(r.w, os.Stderr, exitCode)
+	}
+	return exitCode, nil
+}
+
+// finalizeOutputClose closes the scan output writer and surfaces any
+// Close error as a non-zero exit. Close is where buffered writes flush
+// on many filesystems, so a deferred Close that drops its error lets
+// scans report success while writing truncated JSON/SARIF to disk.
+// A non-zero exitCode already in flight is preserved.
+func finalizeOutputClose(w io.Closer, stderr io.Writer, exitCode int) int {
+	if w == nil {
+		return exitCode
+	}
+	if err := w.Close(); err != nil {
+		fmt.Fprintf(stderr, "error: close output: %v\n", err)
+		if exitCode == 0 {
+			exitCode = 2
+		}
+	}
+	return exitCode
 }
 
 // runLegacy remains as a no-op compile-time reference.


### PR DESCRIPTION
## Summary

`runner.run` wired the `-o` output file behind `defer r.w.Close()`, which silently dropped any error. `Close` is where buffered writes flush on many filesystems (NFS, network mounts, near-full disks), so a failing `Close` left scans reporting exit 0 while writing truncated or corrupted JSON/SARIF — CI consumers parsed the bad output as a clean run.

- Replaced the deferred close with an explicit `finalizeOutputClose(r.w, os.Stderr, exitCode)` invoked after `outputPhase`.
- The helper writes the error to stderr and escalates exit to 2 if no failure was already in flight; a prior non-zero exit is preserved so the close error never masks a more specific scan failure.
- The helper takes `io.Closer` and `io.Writer` so unit tests can exercise it with an injected failing Close (4 new tests covering clean close, escalate-from-zero, preserve-non-zero, and nil-writer).
- The daemon path (`writeDaemonFindings`) was already checking the closer error — left alone.

## Test plan

- [x] `go test ./internal/cli/scan/ -run TestFinalizeOutput -count=1 -v` — 4/4 pass
- [x] `go test ./internal/cli/scan/ -count=1` (full package, all -o-related tests still green)
- [x] `go build`, `go vet ./...`, `golangci-lint run ./internal/cli/scan/` clean