### PR TITLE
fix(metrics): surface AppendRecord close error to caller

### DIFF
--- a/internal/metrics/history.go
+++ b/internal/metrics/history.go
@@ -46,9 +46,22 @@ func AppendRecord(path string, record Record) error {
 	if err != nil {
 		return err
 	}
-	defer f.Close()
-	enc := json.NewEncoder(f)
-	return enc.Encode(record)
+	return appendRecordTo(f, record)
+}
+
+// appendRecordTo encodes one JSONL record to w and closes it,
+// returning whichever of encode/close fired first. Close is where
+// buffered writes flush on many filesystems, so dropping the Close
+// error (the original implementation used `defer f.Close()`) silently
+// loses the just-appended record on disk-full or NFS write-back
+// failures.
+func appendRecordTo(w io.WriteCloser, record Record) error {
+	encErr := json.NewEncoder(w).Encode(record)
+	closeErr := w.Close()
+	if encErr != nil {
+		return encErr
+	}
+	return closeErr
 }
 
 func Query(opts QueryOptions) ([]QueryRow, error) {

--- a/internal/metrics/history_test.go
+++ b/internal/metrics/history_test.go
@@ -1,6 +1,8 @@
 package metrics
 
 import (
+	"bytes"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -9,6 +11,60 @@ import (
 
 	"github.com/kaeawc/krit/internal/output"
 )
+
+type failingCloseBuffer struct {
+	bytes.Buffer
+	closeErr error
+}
+
+func (f *failingCloseBuffer) Close() error { return f.closeErr }
+
+type failingWriter struct {
+	writeErr error
+	closeErr error
+	closed   bool
+}
+
+func (f *failingWriter) Write(p []byte) (int, error) {
+	if f.writeErr != nil {
+		return 0, f.writeErr
+	}
+	return len(p), nil
+}
+
+func (f *failingWriter) Close() error {
+	f.closed = true
+	return f.closeErr
+}
+
+func TestAppendRecordToSurfacesCloseError(t *testing.T) {
+	buf := &failingCloseBuffer{closeErr: errors.New("disk full")}
+	err := appendRecordTo(buf, Record{Version: "v"})
+	if err == nil || !strings.Contains(err.Error(), "disk full") {
+		t.Fatalf("want close error, got %v", err)
+	}
+	if buf.Len() == 0 {
+		t.Fatalf("expected encoder to write before close fails")
+	}
+}
+
+func TestAppendRecordToReturnsEncodeErrorEvenIfCloseAlsoFails(t *testing.T) {
+	w := &failingWriter{writeErr: errors.New("encode boom"), closeErr: errors.New("close boom")}
+	err := appendRecordTo(w, Record{Version: "v"})
+	if err == nil || !strings.Contains(err.Error(), "encode boom") {
+		t.Fatalf("want encode error to win, got %v", err)
+	}
+	if !w.closed {
+		t.Fatalf("Close must still run even when Encode fails")
+	}
+}
+
+func TestAppendRecordToReturnsNilOnCleanCloseAndEncode(t *testing.T) {
+	buf := &failingCloseBuffer{}
+	if err := appendRecordTo(buf, Record{Version: "v"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
 
 func TestAppendRecordAndQuery(t *testing.T) {
 	path := filepath.Join(t.TempDir(), ".krit", "metrics.jsonl")


### PR DESCRIPTION
## Summary

`AppendRecord` wrote a JSONL record with `defer f.Close()` and `return enc.Encode(record)`, dropping any Close error. On disk-full or NFS write-back failures the just-appended record can be lost while the function reports success — silent metrics history loss.

Split the encode-and-close into `appendRecordTo(io.WriteCloser, ...)`, which returns whichever of encode/close fired first (encode wins when both fail so the more specific cause is preserved). Three new tests inject failing Close / Write behavior to lock in the contract.

## Test plan

- [x] `go test ./internal/metrics/ -count=1 -v` — all green including 3 new tests
- [x] `go build`, `go vet ./...`, `golangci-lint run ./internal/metrics/` clean