### PR TITLE
fix(daemon): surface Close error from Diff.WriteLog

### DIFF
--- a/internal/daemon/divergence.go
+++ b/internal/daemon/divergence.go
@@ -3,6 +3,7 @@ package daemon
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"sort"
@@ -143,17 +144,38 @@ func (d Diff) WriteLog(path string) error {
 	if err != nil {
 		return fmt.Errorf("divergence: create log: %w", err)
 	}
-	defer f.Close()
-	enc := json.NewEncoder(f)
+	return writeDivergenceLog(f, d)
+}
+
+// writeDivergenceLog encodes one JSON row per diff entry and then
+// closes w, returning the encode error if any, otherwise the close
+// error. Close is where buffered writes flush, so the original
+// `defer f.Close()` could leave the log truncated while WriteLog
+// reported success — breaking the CI presence-or-absence check the
+// type comment promises.
+func writeDivergenceLog(w io.WriteCloser, d Diff) error {
+	enc := json.NewEncoder(w)
+	var encErr error
 	for _, row := range d.AddedByDaemon {
 		if err := enc.Encode(divergenceRow(sideDaemon, row)); err != nil {
-			return fmt.Errorf("divergence: write row: %w", err)
+			encErr = fmt.Errorf("divergence: write row: %w", err)
+			break
 		}
 	}
-	for _, row := range d.DroppedByDaemon {
-		if err := enc.Encode(divergenceRow(sideBaseline, row)); err != nil {
-			return fmt.Errorf("divergence: write row: %w", err)
+	if encErr == nil {
+		for _, row := range d.DroppedByDaemon {
+			if err := enc.Encode(divergenceRow(sideBaseline, row)); err != nil {
+				encErr = fmt.Errorf("divergence: write row: %w", err)
+				break
+			}
 		}
+	}
+	closeErr := w.Close()
+	if encErr != nil {
+		return encErr
+	}
+	if closeErr != nil {
+		return fmt.Errorf("divergence: close log: %w", closeErr)
 	}
 	return nil
 }

--- a/internal/daemon/divergence_test.go
+++ b/internal/daemon/divergence_test.go
@@ -2,11 +2,14 @@ package daemon
 
 import (
 	"bufio"
+	"bytes"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"reflect"
 	"sort"
+	"strings"
 	"testing"
 
 	"github.com/kaeawc/krit/internal/scanner"
@@ -182,6 +185,56 @@ func TestDiffWriteLogCleanProducesEmptyFile(t *testing.T) {
 	}
 	if info.Size() != 0 {
 		t.Fatalf("expected empty log for clean diff, got %d bytes", info.Size())
+	}
+}
+
+type closeFailingWriter struct {
+	written  bytes.Buffer
+	closeErr error
+	writeErr error
+	closed   bool
+}
+
+func (c *closeFailingWriter) Write(p []byte) (int, error) {
+	if c.writeErr != nil {
+		return 0, c.writeErr
+	}
+	return c.written.Write(p)
+}
+
+func (c *closeFailingWriter) Close() error {
+	c.closed = true
+	return c.closeErr
+}
+
+func TestWriteDivergenceLogSurfacesCloseError(t *testing.T) {
+	w := &closeFailingWriter{closeErr: errors.New("nfs writeback")}
+	d := Diff{AddedByDaemon: []scanner.Finding{{File: "x.kt", Line: 1, Rule: "R"}}}
+	err := writeDivergenceLog(w, d)
+	if err == nil || !strings.Contains(err.Error(), "nfs writeback") {
+		t.Fatalf("want close error wrapped, got %v", err)
+	}
+	if !w.closed {
+		t.Fatalf("Close must run")
+	}
+}
+
+func TestWriteDivergenceLogEncodeErrorMasksCloseError(t *testing.T) {
+	w := &closeFailingWriter{writeErr: errors.New("encode boom"), closeErr: errors.New("close boom")}
+	d := Diff{AddedByDaemon: []scanner.Finding{{File: "x.kt", Line: 1, Rule: "R"}}}
+	err := writeDivergenceLog(w, d)
+	if err == nil || !strings.Contains(err.Error(), "encode boom") {
+		t.Fatalf("want encode error to win, got %v", err)
+	}
+	if !w.closed {
+		t.Fatalf("Close must still run after encode failure")
+	}
+}
+
+func TestWriteDivergenceLogReturnsNilOnCleanRun(t *testing.T) {
+	w := &closeFailingWriter{}
+	if err := writeDivergenceLog(w, Diff{}); err != nil {
+		t.Fatalf("clean run must return nil, got %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

`Diff.WriteLog` used `defer f.Close()` and returned `nil` after the JSONL encode loop. On disk-full or NFS write-back failures, Close drops the buffered tail and the log on disk is truncated — yet WriteLog reports success. That breaks the presence-or-absence CI check the type comment promises and lets divergence tracking miss real drift.

Extracted the encode-and-close into `writeDivergenceLog(io.WriteCloser, Diff)`. The helper collects the first encode error, then always closes the writer, and returns whichever fired first — encode wins (more specific) when both fail. Three new tests inject failing Write / Close behavior to lock in the contract.

## Test plan

- [x] `go test ./internal/daemon/ -run "TestDiffWriteLog|TestWriteDivergenceLog" -v` — all green
- [x] `go test ./internal/daemon/ -count=1` — full package green
- [x] `go build`, `go vet ./...`, `golangci-lint run ./internal/daemon/` clean