### PR TITLE
fix(rules): pre-compile Gradle name regexes once at init

### DIFF
--- a/internal/rules/supply_dependencies.go
+++ b/internal/rules/supply_dependencies.go
@@ -769,10 +769,57 @@ func findGradleRepositoryCallLines(content, callName string) []int {
 	return lines
 }
 
+// gradleBlockOpenerRegexes / gradleDirectCallRegexes precompile the
+// per-name regexes used by per-line Gradle scans. Each known name
+// (repositories, maven, ivy, dependencyLocking, jcenter) is compiled
+// once at init; helpers below look it up on every line. The previous
+// inline regexp.MustCompile was a measurable hot path on multi-module
+// projects.
+//
+// New names must be registered here; the helpers panic on lookup
+// miss to fail loudly during tests rather than silently re-introducing
+// the per-line compile.
+var (
+	gradleBlockOpenerRegexes = compileGradleNameRegexes(
+		[]string{"repositories", "maven", "ivy", "dependencyLocking"},
+		func(name string) string {
+			return `\b` + regexp.QuoteMeta(name) + `\s*(?:\([^)]*\)\s*)?\{`
+		},
+	)
+	gradleDirectCallFunDefRegexes = compileGradleNameRegexes(
+		[]string{"jcenter"},
+		func(name string) string {
+			return `\bfun\s+` + regexp.QuoteMeta(name) + `\s*\(`
+		},
+	)
+	gradleDirectCallInvocationRegexes = compileGradleNameRegexes(
+		[]string{"jcenter"},
+		func(name string) string {
+			return `(^|[;{\s])` + regexp.QuoteMeta(name) + `\s*(?:\(\s*\)|\{)`
+		},
+	)
+	gradleURLSetterRe = regexp.MustCompile(`\b(?:url|setUrl)\b`)
+)
+
+func compileGradleNameRegexes(names []string, pattern func(string) string) map[string]*regexp.Regexp {
+	out := make(map[string]*regexp.Regexp, len(names))
+	for _, name := range names {
+		out[name] = regexp.MustCompile(pattern(name))
+	}
+	return out
+}
+
+func gradleNameRegex(registry map[string]*regexp.Regexp, name, kind string) *regexp.Regexp {
+	re, ok := registry[name]
+	if !ok {
+		panic(fmt.Sprintf("krit internal: gradle %s regex not registered for %q — register it in supply_dependencies.go", kind, name))
+	}
+	return re
+}
+
 func gradleLineOpensNamedBlock(codeOnly string, names ...string) bool {
 	for _, name := range names {
-		re := regexp.MustCompile(`\b` + regexp.QuoteMeta(name) + `\s*(?:\([^)]*\)\s*)?\{`)
-		if re.MatchString(codeOnly) {
+		if gradleNameRegex(gradleBlockOpenerRegexes, name, "block-opener").MatchString(codeOnly) {
 			return true
 		}
 	}
@@ -780,15 +827,14 @@ func gradleLineOpensNamedBlock(codeOnly string, names ...string) bool {
 }
 
 func gradleLineHasDirectRepositoryCall(codeOnly, callName string) bool {
-	escapedName := regexp.QuoteMeta(callName)
-	if regexp.MustCompile(`\bfun\s+` + escapedName + `\s*\(`).MatchString(codeOnly) {
+	if gradleNameRegex(gradleDirectCallFunDefRegexes, callName, "direct-call fun-def").MatchString(codeOnly) {
 		return false
 	}
-	return regexp.MustCompile(`(^|[;{\s])` + escapedName + `\s*(?:\(\s*\)|\{)`).MatchString(codeOnly)
+	return gradleNameRegex(gradleDirectCallInvocationRegexes, callName, "direct-call invocation").MatchString(codeOnly)
 }
 
 func gradleLineMentionsURLSetter(codeOnly string) bool {
-	return regexp.MustCompile(`\b(?:url|setUrl)\b`).MatchString(codeOnly)
+	return gradleURLSetterRe.MatchString(codeOnly)
 }
 
 func isHTTPGradleRepositoryURL(raw string) bool {

--- a/internal/rules/supply_dependencies_regex_test.go
+++ b/internal/rules/supply_dependencies_regex_test.go
@@ -1,0 +1,76 @@
+package rules
+
+import (
+	"testing"
+)
+
+// TestGradleNameRegexReturnsRegisteredInstance proves the per-name
+// regex registry is honoured: looking up the same name twice yields
+// the same *regexp.Regexp pointer, so per-line scans of a Gradle file
+// do not recompile the same pattern on every line.
+func TestGradleNameRegexReturnsRegisteredInstance(t *testing.T) {
+	first := gradleNameRegex(gradleBlockOpenerRegexes, "repositories", "block-opener")
+	second := gradleNameRegex(gradleBlockOpenerRegexes, "repositories", "block-opener")
+	if first != second {
+		t.Fatalf("gradleNameRegex returned distinct instances for the same name; registry miss")
+	}
+}
+
+func TestGradleNameRegexPanicsOnUnregisteredName(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatalf("expected panic for unregistered name; got none")
+		}
+	}()
+	gradleNameRegex(gradleBlockOpenerRegexes, "definitelyNotRegistered", "block-opener")
+}
+
+func TestGradleLineMentionsURLSetterDetectsBothForms(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{"url-prop", `url "https://repo.example.com"`, true},
+		{"setUrl-method", `setUrl("https://repo.example.com")`, true},
+		{"unrelated", `name = "central"`, false},
+		{"bare-prefix-only", `urls = [a, b]`, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := gradleLineMentionsURLSetter(tc.input); got != tc.want {
+				t.Errorf("gradleLineMentionsURLSetter(%q) = %v, want %v", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestGradleLineOpensNamedBlockMatchesKnownGradleNames(t *testing.T) {
+	cases := []struct {
+		name  string
+		line  string
+		names []string
+		want  bool
+	}{
+		{"repositories-open", `repositories {`, []string{"repositories"}, true},
+		{"maven-with-args", `maven(url: "http://x") {`, []string{"maven", "ivy"}, true},
+		{"unrelated-block", `tasks.register("foo") {`, []string{"repositories"}, false},
+		{"name-substring-false-positive", `mavenCentralReleases {`, []string{"maven"}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := gradleLineOpensNamedBlock(tc.line, tc.names...); got != tc.want {
+				t.Errorf("gradleLineOpensNamedBlock(%q, %v) = %v, want %v", tc.line, tc.names, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestGradleLineHasDirectRepositoryCallIgnoresFunDef(t *testing.T) {
+	if gradleLineHasDirectRepositoryCall(`fun jcenter() = mavenCentral()`, "jcenter") {
+		t.Errorf("fun-definition must not match a direct call")
+	}
+	if !gradleLineHasDirectRepositoryCall(`jcenter()`, "jcenter") {
+		t.Errorf("direct call must match")
+	}
+}


### PR DESCRIPTION
## Summary

`findGradleRepositoryURLs` / `findGradleRepositoryCallLines` invoke `gradleLineMentionsURLSetter`, `gradleLineOpensNamedBlock`, and `gradleLineHasDirectRepositoryCall` on every line of every Gradle file. The previous bodies called `regexp.MustCompile` (with `regexp.QuoteMeta` for the parameterised helpers) on every call — a measurable hot path on multi-module Android projects.

- Pre-compile one regex per known Gradle name (`repositories`, `maven`, `ivy`, `dependencyLocking`, `jcenter`) in package-level `map[string]*regexp.Regexp` built at init via `compileGradleNameRegexes`.
- A `gradleNameRegex` lookup helper panics on unregistered names so a new caller cannot silently re-introduce the per-line compile.
- The standalone `url`/`setUrl` regex becomes a single `gradleURLSetterRe` var, matching the existing convention used by `gradleRepoDirectCallRe` and `gradleDepConfigLineRe` in the same file.
- Per the ruleslinter ad-hoc-cache gate, no `sync.Map` is used.

## Test plan

- [x] `go test ./internal/rules/ -run TestGradle -count=1 -v` — all green, including new tests for registry hit, panic on unregistered, and behaviour parity for each helper
- [x] `go test ./internal/rules/ -count=1` (full package, all positive/negative fixtures still pass)
- [x] `make lint-rules` (the ad-hoc-cache gate that previously failed on the sync.Map iteration of this fix now passes)
- [x] `go build`, `go vet ./...`, `golangci-lint run ./internal/rules/` clean