### PR TITLE
feat(krit-fir): populate analyzeWithDeps cacheDeps closure

### DIFF
--- a/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/Main.kt
+++ b/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/Main.kt
@@ -186,10 +186,11 @@ fun handleRequestLine(trimmed: String, session: AnalysisSession, startTime: Long
                 } else {
                     request.files.map { it.path }
                 }
-                val result = activeSession.analyze(analyzeFiles)
                 val response = if (request.command == "analyzeWithDeps") {
-                    OracleResponse.buildAnalyzeWithDeps(request.id, result)
+                    val outcome = activeSession.analyzeFull(analyzeFiles)
+                    OracleResponse.buildAnalyzeWithDeps(request.id, outcome.result, outcome.cacheDeps)
                 } else {
+                    val result = activeSession.analyze(analyzeFiles)
                     OracleResponse.buildAnalyze(request.id, result)
                 }
                 if (needsRebuild) {

--- a/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/oracle/DepTracker.kt
+++ b/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/oracle/DepTracker.kt
@@ -1,0 +1,72 @@
+package dev.jasonpearson.krit.fir.oracle
+
+/**
+ * Per-analyzed-file dependency-closure tracker. Mirrors krit-types'
+ * `DepTracker` shape so the Go-side cache layer (which reads
+ * `cacheDeps` from the `analyzeWithDeps` envelope) can populate the
+ * same per-file dependency index regardless of backend.
+ *
+ * For each analyzed file we track:
+ *
+ * - `depPathsByFile` — the set of OTHER source files whose declarations
+ *   the analyzed file touched (e.g. supertypes resolved against a
+ *   class defined in another file in the same compilation). The
+ *   Go-side cache uses this to invalidate this file's cache entry
+ *   when one of those source files changes.
+ * - `perFileDeps` — per-file `FQN → ClassPayload` map for the
+ *   dependency classes observed while analyzing this file. Each cache
+ *   entry is self-contained: it carries the dependency-class
+ *   projections it needs so a single-file cache hit doesn't have to
+ *   pull from the global `dependencies` map of a different run.
+ * - `crashedFiles` — files that deterministically failed analysis.
+ *   The K2 plugin compiles in a single batch (unlike krit-types'
+ *   per-file KAA loop) so crashes are rare; the map exists so the
+ *   wire shape matches krit-types and stays ready when per-file
+ *   recovery lands.
+ */
+internal class DepTracker {
+
+    private val depPaths = LinkedHashMap<String, LinkedHashSet<String>>()
+    private val depsByFile = LinkedHashMap<String, LinkedHashMap<String, ClassPayload>>()
+    private val crashes = LinkedHashMap<String, String>()
+
+    /**
+     * Record that [forFile] depends on [depPath]. Self-references are
+     * skipped so a file isn't listed as its own dep, matching
+     * krit-types' `recordDepPath` semantics.
+     */
+    fun recordDepPath(forFile: String, depPath: String) {
+        if (depPath == forFile) return
+        depPaths.getOrPut(forFile) { LinkedHashSet() }.add(depPath)
+    }
+
+    /**
+     * Record a dependency class projection observed while analyzing
+     * [forFile]. First-wins on duplicate FQNs within the same file —
+     * supertype resolution can revisit the same class via multiple
+     * paths but the projection is the same shape either way.
+     */
+    fun recordPerFileDep(forFile: String, fqn: String, payload: ClassPayload) {
+        depsByFile.getOrPut(forFile) { LinkedHashMap() }.putIfAbsent(fqn, payload)
+    }
+
+    /** Record a deterministic analysis crash for [forFile] with the given message. */
+    fun recordCrash(forFile: String, error: String) {
+        crashes[forFile] = error
+    }
+
+    /** Read-only snapshot of `depPathsByFile`. */
+    val depPathsByFile: Map<String, Set<String>>
+        get() = depPaths
+
+    /** Read-only snapshot of `perFileDeps`. */
+    val perFileDeps: Map<String, Map<String, ClassPayload>>
+        get() = depsByFile
+
+    /** Read-only snapshot of `crashedFiles`. */
+    val crashedFiles: Map<String, String>
+        get() = crashes
+
+    /** True iff no per-file deps or crashes have been recorded yet. */
+    fun isEmpty(): Boolean = depPaths.isEmpty() && depsByFile.isEmpty() && crashes.isEmpty()
+}

--- a/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/oracle/OracleClassChecker.kt
+++ b/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/oracle/OracleClassChecker.kt
@@ -19,10 +19,14 @@ import org.jetbrains.kotlin.fir.declarations.FirNamedFunction
 import org.jetbrains.kotlin.fir.declarations.FirProperty
 import org.jetbrains.kotlin.fir.declarations.FirRegularClass
 import org.jetbrains.kotlin.fir.declarations.FirValueParameter
+import org.jetbrains.kotlin.fir.declarations.FirDeclarationOrigin
 import org.jetbrains.kotlin.fir.declarations.toAnnotationClassId
 import org.jetbrains.kotlin.fir.declarations.utils.isData
 import org.jetbrains.kotlin.fir.declarations.utils.modality
 import org.jetbrains.kotlin.fir.declarations.utils.visibility
+import org.jetbrains.kotlin.fir.resolve.providers.firProvider
+import org.jetbrains.kotlin.fir.resolve.providers.getContainingFile
+import org.jetbrains.kotlin.fir.resolve.toRegularClassSymbol
 import org.jetbrains.kotlin.fir.symbols.SymbolInternals
 import org.jetbrains.kotlin.fir.types.ConeClassLikeType
 import org.jetbrains.kotlin.fir.types.ConeKotlinType
@@ -64,7 +68,51 @@ internal object OracleClassChecker : FirClassChecker(MppCheckerKind.Common) {
         val filePath = context.containingFileSymbol?.fir?.sourceFile?.path ?: return
 
         collector.setPackage(filePath, regular.symbol.classId.packageFqName.asString())
-        collector.addClass(filePath, regular.toClassPayload(context.session))
+        val payload = regular.toClassPayload(context.session)
+        collector.addClass(filePath, payload)
+        recordSupertypeDeps(collector, filePath, regular, context.session)
+    }
+
+    /**
+     * Record per-file supertype dependencies for the analyzed class.
+     * For each resolved supertype whose declaring symbol is a
+     * source-origin class in another file of the same compilation,
+     * append both:
+     *
+     * - the supertype's source-file path to `depPathsByFile` so the
+     *   Go-side cache layer invalidates this file when that supertype
+     *   changes;
+     * - the supertype's [ClassPayload] projection to `perFileDeps` so
+     *   the cache entry is self-contained.
+     *
+     * Library supertypes (FirDeclarationOrigin != Source, e.g.
+     * `kotlin.Any`, classes loaded from JARs) are intentionally
+     * skipped — the Go-side cache doesn't track them by source-file
+     * path, and including them would make the wire payload churn on
+     * every library upgrade.
+     */
+    @OptIn(SymbolInternals::class)
+    private fun recordSupertypeDeps(
+        collector: OracleCollector,
+        forFile: String,
+        regular: FirRegularClass,
+        session: FirSession,
+    ) {
+        val provider = session.firProvider
+        for (ref in regular.superTypeRefs) {
+            val cone = (ref as? FirResolvedTypeRef)?.coneType as? ConeClassLikeType ?: continue
+            val symbol = cone.lookupTag.toRegularClassSymbol(session) ?: continue
+            if (symbol.origin != FirDeclarationOrigin.Source) continue
+            val containingFile = provider.getContainingFile(symbol) ?: continue
+            val depFile = containingFile.sourceFile?.path ?: continue
+            if (depFile == forFile) continue
+            collector.depTracker.recordDepPath(forFile, depFile)
+            collector.depTracker.recordPerFileDep(
+                forFile,
+                symbol.classId.asFqNameString(),
+                symbol.fir.toClassPayload(session),
+            )
+        }
     }
 
     @OptIn(DirectDeclarationsAccess::class)

--- a/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/oracle/OracleCollector.kt
+++ b/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/oracle/OracleCollector.kt
@@ -21,6 +21,15 @@ internal class OracleCollector {
     private val diagnosticsByFile = LinkedHashMap<String, MutableList<DiagnosticPayload>>()
     private val offsetsByFile = HashMap<String, FileOffsetTable?>()
 
+    /**
+     * Per-file dependency-closure tracker. Populated by
+     * [OracleClassChecker] when it walks supertypes resolvable to
+     * other source files in the same compilation; drained by
+     * [OracleResponse.buildAnalyzeWithDeps] to populate the
+     * `cacheDeps` field on the wire.
+     */
+    val depTracker: DepTracker = DepTracker()
+
     fun addClass(filePath: String, payload: ClassPayload) {
         perFile.getOrPut(filePath) { mutableListOf() }.add(payload)
         // The `dependencies` map mirrors krit-types' cross-file class

--- a/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/oracle/OracleResponse.kt
+++ b/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/oracle/OracleResponse.kt
@@ -39,13 +39,17 @@ object OracleResponse {
      * Build the flat-envelope response shape used by `analyzeWithDeps`.
      * Mirrors krit-types' `buildDaemonResponseWithDeps`: `result`,
      * `errors`, and `cacheDeps` are siblings rather than nested inside
-     * `result`. `cacheDeps` is always emitted (currently with empty
-     * `files` and `crashed` maps) so the Go-side client can detect that
-     * the daemon speaks the new protocol revision; population of the
-     * per-file dependency closure lands with the cacheDeps projection
-     * in a follow-up PR.
+     * `result`. The `cacheDeps` field carries the per-file dependency
+     * closure ([cacheDeps]) so the Go-side cache layer can invalidate
+     * entries when one of a file's source dependencies changes; if no
+     * tracker data is provided, an empty cacheDeps shell still ships
+     * so the Go-side client can detect the new protocol revision.
      */
-    fun buildAnalyzeWithDeps(id: Long, result: AnalyzeResult = AnalyzeResult.EMPTY): String {
+    fun buildAnalyzeWithDeps(
+        id: Long,
+        result: AnalyzeResult = AnalyzeResult.EMPTY,
+        cacheDeps: CacheDepsView = CacheDepsView.EMPTY,
+    ): String {
         val sb = StringBuilder()
         sb.append("""{"id":""")
         sb.append(id)
@@ -56,9 +60,55 @@ object OracleResponse {
             sb.append(""","errors":""")
             appendErrors(sb, result.errors)
         }
-        sb.append(""","cacheDeps":{"files":{},"crashed":{}}""")
+        sb.append(""","cacheDeps":""")
+        appendCacheDeps(sb, cacheDeps)
         sb.append("}")
         return sb.toString()
+    }
+
+    /**
+     * Read-only view over the dependency-closure state needed by the
+     * `analyzeWithDeps` response. Decouples the serializer from
+     * [`OracleCollector`] / [`DepTracker`] so the response builder
+     * stays a pure JSON producer.
+     */
+    data class CacheDepsView(
+        val depPathsByFile: Map<String, Set<String>>,
+        val perFileDeps: Map<String, Map<String, ClassPayload>>,
+        val crashedFiles: Map<String, String>,
+    ) {
+        companion object {
+            val EMPTY: CacheDepsView = CacheDepsView(emptyMap(), emptyMap(), emptyMap())
+        }
+    }
+
+    private fun appendCacheDeps(sb: StringBuilder, view: CacheDepsView) {
+        sb.append("""{"version":1,"approximation":"symbol-resolved-sources","files":{""")
+        val fileKeys = (view.depPathsByFile.keys + view.perFileDeps.keys).toSet()
+        var firstFile = true
+        for (filePath in fileKeys) {
+            if (!firstFile) sb.append(",") else firstFile = false
+            sb.append(jsonString(filePath)).append(""":{"depPaths":[""")
+            val depPaths = view.depPathsByFile[filePath].orEmpty()
+            depPaths.forEachIndexed { i, p ->
+                if (i > 0) sb.append(",")
+                sb.append(jsonString(p))
+            }
+            sb.append("""],"perFileDeps":{""")
+            val perFile = view.perFileDeps[filePath].orEmpty()
+            perFile.entries.forEachIndexed { i, (fqn, cls) ->
+                if (i > 0) sb.append(",")
+                sb.append(jsonString(fqn)).append(":")
+                appendClass(sb, cls)
+            }
+            sb.append("}}")
+        }
+        sb.append("""},"crashed":{""")
+        view.crashedFiles.entries.forEachIndexed { i, (path, msg) ->
+            if (i > 0) sb.append(",")
+            sb.append(jsonString(path)).append(":").append(jsonString(msg))
+        }
+        sb.append("}}")
     }
 
     private fun appendResultBody(sb: StringBuilder, result: AnalyzeResult) {

--- a/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/runner/AnalysisSession.kt
+++ b/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/runner/AnalysisSession.kt
@@ -4,6 +4,7 @@ import dev.jasonpearson.krit.fir.oracle.AnalyzeResult
 import dev.jasonpearson.krit.fir.oracle.OracleCollector
 import dev.jasonpearson.krit.fir.oracle.OracleCollectorRegistry
 import dev.jasonpearson.krit.fir.oracle.OracleDiagnosticMessageCollector
+import dev.jasonpearson.krit.fir.oracle.OracleResponse
 import org.jetbrains.kotlin.cli.common.arguments.K2JVMCompilerArguments
 import org.jetbrains.kotlin.cli.jvm.K2JVMCompiler
 import org.jetbrains.kotlin.config.Services
@@ -11,6 +12,18 @@ import java.io.File
 import java.nio.file.Files
 
 data class FileRef(val path: String, val contentHash: String = "")
+
+/**
+ * Bundle of an analyze run's structured result and per-file
+ * dependency-closure view. Returned by [AnalysisSession.analyze] so
+ * callers can ride both onto either response shape — the legacy
+ * `buildAnalyze` envelope discards [cacheDeps], the
+ * `buildAnalyzeWithDeps` envelope rides it onto the wire.
+ */
+data class AnalyzeOutcome(
+    val result: AnalyzeResult,
+    val cacheDeps: OracleResponse.CacheDepsView,
+)
 
 data class BatchResult(
     val id: Long,
@@ -93,7 +106,15 @@ class AnalysisSession(val sourceDirs: List<String>, val classpath: List<String>)
      * [`FilePayload.diagnostics`] via [`OracleDiagnosticMessageCollector`].
      * Non-matching compiler messages are dropped.
      */
-    fun analyze(files: List<String>): AnalyzeResult {
+    fun analyze(files: List<String>): AnalyzeResult = analyzeFull(files).result
+
+    /**
+     * Same K2 compilation as [analyze] but also drains the
+     * collector's [DepTracker] into a [CacheDepsView] so the
+     * `analyzeWithDeps` RPC envelope can populate the per-file
+     * dependency closure.
+     */
+    fun analyzeFull(files: List<String>): AnalyzeOutcome {
         val collector = OracleCollector()
         OracleCollectorRegistry.begin(collector)
         val outDir = Files.createTempDirectory("krit-fir-oracle-out-").toFile()
@@ -121,7 +142,15 @@ class AnalysisSession(val sourceDirs: List<String>, val classpath: List<String>)
             outDir.deleteRecursively()
             OracleCollectorRegistry.end()
         }
-        return collector.toResult()
+        val tracker = collector.depTracker
+        return AnalyzeOutcome(
+            result = collector.toResult(),
+            cacheDeps = OracleResponse.CacheDepsView(
+                depPathsByFile = tracker.depPathsByFile,
+                perFileDeps = tracker.perFileDeps,
+                crashedFiles = tracker.crashedFiles,
+            ),
+        )
     }
 
     fun dispose() {} // No long-lived JVM resources beyond the lazy source file list.

--- a/tools/krit-fir/src/test/kotlin/dev/jasonpearson/krit/fir/OracleDispatchTest.kt
+++ b/tools/krit-fir/src/test/kotlin/dev/jasonpearson/krit/fir/OracleDispatchTest.kt
@@ -51,14 +51,16 @@ class OracleDispatchTest {
     @Test
     fun analyzeWithDepsCommandUsesFlatEnvelopeWithCacheDeps() {
         // analyzeWithDeps uses krit-types' flat envelope shape:
-        // `result` / `errors` / `cacheDeps` as siblings, and cacheDeps
-        // is always present (currently empty) so the Go-side client
-        // can detect that the daemon speaks the new protocol revision.
+        // `result` / `errors` / `cacheDeps` as siblings. The
+        // `cacheDeps` field always carries the krit-types preamble
+        // (`version`, `approximation`) so the Go-side client can
+        // detect the new-protocol daemon even when no per-file deps
+        // have been recorded.
         val request = """{"id":14,"command":"analyzeWithDeps"}"""
         val result = handleRequestLine(request, session, startTime = 0L)
         val response = (result as RequestResult.Response).json
         assertTrue(response.startsWith("""{"id":14,"result":{"""), response)
-        assertTrue(""""cacheDeps":{"files":{},"crashed":{}}""" in response, response)
+        assertTrue(""""cacheDeps":{"version":1,"approximation":"symbol-resolved-sources","files":{},"crashed":{}}""" in response, response)
     }
 
     @Test

--- a/tools/krit-fir/src/test/kotlin/dev/jasonpearson/krit/fir/oracle/DepTrackerTest.kt
+++ b/tools/krit-fir/src/test/kotlin/dev/jasonpearson/krit/fir/oracle/DepTrackerTest.kt
@@ -1,0 +1,63 @@
+package dev.jasonpearson.krit.fir.oracle
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class DepTrackerTest {
+
+    @Test
+    fun depPathsAreDedupedPerFileInInsertionOrder() {
+        val t = DepTracker()
+        t.recordDepPath("/src/Leaf.kt", "/src/Base.kt")
+        t.recordDepPath("/src/Leaf.kt", "/src/Helper.kt")
+        t.recordDepPath("/src/Leaf.kt", "/src/Base.kt")
+
+        assertEquals(
+            listOf("/src/Base.kt", "/src/Helper.kt"),
+            t.depPathsByFile["/src/Leaf.kt"]?.toList(),
+        )
+    }
+
+    @Test
+    fun selfReferenceIsSkipped() {
+        // Mirrors krit-types' DepTracker.recordDepPath: a file is
+        // never listed as its own dep. The Go-side cache layer would
+        // otherwise see spurious "self-dependent" entries.
+        val t = DepTracker()
+        t.recordDepPath("/src/Foo.kt", "/src/Foo.kt")
+
+        assertTrue(t.depPathsByFile["/src/Foo.kt"].isNullOrEmpty())
+    }
+
+    @Test
+    fun perFileDepsFirstWinsOnDuplicateFqn() {
+        // Supertype resolution can revisit the same dep class via
+        // multiple paths within one file (e.g. when interface A and
+        // class B both extend the same Base). First-wins matches
+        // krit-types' behavior.
+        val t = DepTracker()
+        val first = ClassPayload(fqn = "com.acme.Base", kind = "class", visibility = "public")
+        val second = ClassPayload(fqn = "com.acme.Base", kind = "interface", visibility = "internal")
+        t.recordPerFileDep("/src/Leaf.kt", "com.acme.Base", first)
+        t.recordPerFileDep("/src/Leaf.kt", "com.acme.Base", second)
+
+        assertEquals(first, t.perFileDeps["/src/Leaf.kt"]?.get("com.acme.Base"))
+    }
+
+    @Test
+    fun crashedFilesRoundTrip() {
+        val t = DepTracker()
+        t.recordCrash("/src/Broken.kt", "boom")
+        assertEquals(mapOf("/src/Broken.kt" to "boom"), t.crashedFiles)
+    }
+
+    @Test
+    fun isEmptyReflectsCombinedState() {
+        val t = DepTracker()
+        assertTrue(t.isEmpty())
+
+        t.recordDepPath("/a", "/b")
+        assertTrue(!t.isEmpty())
+    }
+}

--- a/tools/krit-fir/src/test/kotlin/dev/jasonpearson/krit/fir/oracle/OracleResponseTest.kt
+++ b/tools/krit-fir/src/test/kotlin/dev/jasonpearson/krit/fir/oracle/OracleResponseTest.kt
@@ -171,7 +171,7 @@ class OracleResponseTest {
             ),
         )
         assertTrue(response.startsWith("""{"id":4,"result":{"""), response)
-        assertTrue(""""cacheDeps":{"files":{},"crashed":{}}""" in response, response)
+        assertTrue(""""cacheDeps":{"version":1,"approximation":"symbol-resolved-sources","files":{},"crashed":{}}""" in response, response)
         // errors is a sibling of result, not nested inside it.
         val resultEnd = response.indexOf("}", response.indexOf(""""result":{"""))
         val errorsAt = response.indexOf(""""errors":""")
@@ -185,7 +185,31 @@ class OracleResponseTest {
     fun analyzeWithDepsOmitsErrorsKeyWhenEmpty() {
         val response = OracleResponse.buildAnalyzeWithDeps(id = 5)
         assertTrue("errors" !in response, response)
-        assertTrue(""""cacheDeps":{"files":{},"crashed":{}}""" in response, response)
+        assertTrue(""""cacheDeps":{"version":1,"approximation":"symbol-resolved-sources","files":{},"crashed":{}}""" in response, response)
+    }
+
+    @Test
+    fun analyzeWithDepsSerializesCacheDepsView() {
+        // Populated dep tracker → cacheDeps carries per-file
+        // depPaths + perFileDeps + crashed maps. Pins the wire shape
+        // krit-types' `buildCacheDepsJson` produces so the Go-side
+        // cache layer parses either backend's payload with one struct.
+        val response = OracleResponse.buildAnalyzeWithDeps(
+            id = 6,
+            result = AnalyzeResult.EMPTY,
+            cacheDeps = OracleResponse.CacheDepsView(
+                depPathsByFile = mapOf("/src/Leaf.kt" to setOf("/src/Base.kt")),
+                perFileDeps = mapOf(
+                    "/src/Leaf.kt" to mapOf(
+                        "com.acme.Base" to ClassPayload(fqn = "com.acme.Base", kind = "class"),
+                    ),
+                ),
+                crashedFiles = mapOf("/src/Broken.kt" to "boom"),
+            ),
+        )
+        assertTrue(""""cacheDeps":{"version":1,"approximation":"symbol-resolved-sources"""" in response, response)
+        assertTrue(""""/src/Leaf.kt":{"depPaths":["/src/Base.kt"],"perFileDeps":{"com.acme.Base":""" in response, response)
+        assertTrue(""""crashed":{"/src/Broken.kt":"boom"}""" in response, response)
     }
 
     @Test

--- a/tools/krit-fir/src/test/kotlin/dev/jasonpearson/krit/fir/runner/AnalysisSessionCacheDepsTest.kt
+++ b/tools/krit-fir/src/test/kotlin/dev/jasonpearson/krit/fir/runner/AnalysisSessionCacheDepsTest.kt
@@ -1,0 +1,124 @@
+package dev.jasonpearson.krit.fir.runner
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * End-to-end coverage for the per-file dependency-closure projection
+ * powering the `analyzeWithDeps` envelope's `cacheDeps` field. The
+ * tracker records cross-file supertype links so the Go-side cache can
+ * invalidate dependent files when a source dependency changes.
+ */
+class AnalysisSessionCacheDepsTest {
+
+    @TempDir
+    lateinit var tmp: Path
+
+    @Test
+    fun supertypeFromAnotherSourceFileIsRecordedAsDepPath() {
+        val basePath = writeKt(
+            "Base.kt",
+            """
+            package com.acme.deps
+
+            open class Base
+            """.trimIndent(),
+        )
+        val leafPath = writeKt(
+            "Leaf.kt",
+            """
+            package com.acme.deps
+
+            class Leaf : Base()
+            """.trimIndent(),
+        )
+
+        val outcome = analyze()
+        val depPaths = outcome.cacheDeps.depPathsByFile[leafPath]
+        assertNotNull(depPaths, "leaf should have dep paths: ${outcome.cacheDeps.depPathsByFile.keys}")
+        assertTrue(
+            basePath in depPaths,
+            "expected $basePath in $depPaths",
+        )
+
+        val perFileDeps = outcome.cacheDeps.perFileDeps[leafPath]
+        assertNotNull(perFileDeps)
+        val base = perFileDeps["com.acme.deps.Base"]
+        assertNotNull(base, "Base ClassPayload missing in leaf's perFileDeps: $perFileDeps")
+        assertEquals("class", base.kind)
+    }
+
+    @Test
+    fun supertypeInSameFileIsNotRecordedAsDep() {
+        // A class that extends another class in the SAME file should
+        // not list itself as a dep path; krit-types' DepTracker skips
+        // self-references and we mirror that.
+        val path = writeKt(
+            "Same.kt",
+            """
+            package com.acme.same
+
+            open class Parent
+            class Child : Parent()
+            """.trimIndent(),
+        )
+
+        val outcome = analyze()
+        val depPaths = outcome.cacheDeps.depPathsByFile[path]
+        // Either no entry at all, or an empty set — both mean "no
+        // cross-file deps".
+        assertTrue(
+            depPaths == null || path !in depPaths,
+            "self-reference leaked into cacheDeps: $depPaths",
+        )
+    }
+
+    @Test
+    fun librarySupertypeIsNotRecordedAsDep() {
+        // `kotlin.Any` (the implicit supertype of every class) is a
+        // library class — origin != Source. It must NOT appear in
+        // depPathsByFile because the Go-side cache layer keys on
+        // source-file paths, not jar paths.
+        val path = writeKt(
+            "Standalone.kt",
+            """
+            package com.acme.standalone
+
+            class Standalone
+            """.trimIndent(),
+        )
+
+        val outcome = analyze()
+        val depPaths = outcome.cacheDeps.depPathsByFile[path]
+        assertTrue(
+            depPaths.isNullOrEmpty(),
+            "library supertype leaked into cacheDeps: $depPaths",
+        )
+    }
+
+    @Test
+    fun cleanProjectProducesEmptyCacheDepsView() {
+        // Nothing analyzed → the view is empty across the board so
+        // the wire payload stays minimal.
+        val outcome = analyze()
+        assertEquals(emptyMap(), outcome.cacheDeps.depPathsByFile)
+        assertEquals(emptyMap(), outcome.cacheDeps.perFileDeps)
+        assertEquals(emptyMap(), outcome.cacheDeps.crashedFiles)
+    }
+
+    private fun analyze(): AnalyzeOutcome =
+        AnalysisSession(
+            sourceDirs = listOf(tmp.toFile().absolutePath),
+            classpath = emptyList(),
+        ).analyzeFull(emptyList())
+
+    private fun writeKt(name: String, source: String): String {
+        val file = tmp.resolve(name).toFile()
+        file.writeText(source)
+        return file.canonicalPath
+    }
+}


### PR DESCRIPTION
## Summary

PR 2.8 closes the last oracle-parity gap with krit-types: the \`analyzeWithDeps\` response now ships a populated per-file dependency closure in \`cacheDeps\` instead of an empty stub.

- \`DepTracker\` (new): per-file \`depPathsByFile\` + \`perFileDeps\` + \`crashedFiles\`, mirroring krit-types' tracker shape and first-wins semantics.
- \`OracleClassChecker.check\` now walks each class's resolved supertype refs. For every source-origin supertype defined in another file of the same compilation, it records:
  - the supertype's source-file path → \`depPathsByFile\`
  - the supertype's \`ClassPayload\` projection → \`perFileDeps\`
  Library supertypes (e.g. \`kotlin.Any\`) are skipped — the Go-side cache keys on source-file paths, not jar paths, so including them would churn the wire payload on every library upgrade.
- \`AnalysisSession\` grows \`analyzeFull(files): AnalyzeOutcome\` (the new \`analyzeWithDeps\` RPC path); the legacy \`analyze(files): AnalyzeResult\` API is preserved so existing callers don't churn.
- \`OracleResponse.buildAnalyzeWithDeps\` takes a \`CacheDepsView\` and emits krit-types' canonical shape:
  \`\`\`json
  "cacheDeps":{"version":1,"approximation":"symbol-resolved-sources",
               "files":{"/src/Leaf.kt":{"depPaths":["/src/Base.kt"],
                                        "perFileDeps":{"com.acme.Base":{...}}}},
               "crashed":{...}}
  \`\`\`

## Test plan
- [x] \`./gradlew :test\` in \`tools/krit-fir/\` — new \`AnalysisSessionCacheDepsTest\` (cross-file supertype, same-file skip, library-supertype skip, clean-project baseline), \`DepTrackerTest\` (dedup, self-ref skip, first-wins on FQN, crash map), updated \`OracleResponseTest\` + \`OracleDispatchTest\` cacheDeps shape assertions
- [x] \`go build ./cmd/krit/ && go vet ./... && golangci-lint run ./... && go test ./... -count=1\`

## Oracle parity status

With this PR, the krit-fir oracle backend matches krit-types on the synchronous surface area:
- \`analyze\` / \`analyzeAll\` / \`analyzeFiles\` / \`analyzeWithDeps\` ✅
- class / member / expression / annotation projection ✅
- diagnostic projection (USELESS_ELVIS + CAST_NEVER_SUCCEEDS; UNREACHABLE_CODE requires \`-Wextra\`) ✅
- per-file dependency closure ✅

Next up: PR 3 — port plugin-rule hosting into krit-fir.