### PR TITLE
fix(rules): hoist stripComments regexes to package-level vars

### DIFF
--- a/internal/rules/emptyblocks.go
+++ b/internal/rules/emptyblocks.go
@@ -38,14 +38,19 @@ func detectIndent(content []byte, byteOffset int) string {
 	return string(indent)
 }
 
+// stripCommentsBlockRe and stripCommentsLineRe are compiled once at
+// package init so stripComments — called for every block_body /
+// catch_block / class_body the dispatcher visits across every Kotlin
+// and Java file — does not recompile the same patterns on each call.
+var (
+	stripCommentsBlockRe = regexp.MustCompile(`(?s)/\*.*?\*/`)
+	stripCommentsLineRe  = regexp.MustCompile(`//[^\n]*`)
+)
+
 // stripComments removes line comments and block comments from a string.
 func stripComments(s string) string {
-	// Remove block comments
-	blockRe := regexp.MustCompile(`(?s)/\*.*?\*/`)
-	s = blockRe.ReplaceAllString(s, "")
-	// Remove line comments
-	lineRe := regexp.MustCompile(`//[^\n]*`)
-	s = lineRe.ReplaceAllString(s, "")
+	s = stripCommentsBlockRe.ReplaceAllString(s, "")
+	s = stripCommentsLineRe.ReplaceAllString(s, "")
 	return s
 }
 

--- a/internal/rules/emptyblocks_internal_test.go
+++ b/internal/rules/emptyblocks_internal_test.go
@@ -1,0 +1,36 @@
+package rules
+
+import "testing"
+
+func TestStripCommentsStripsLineAndBlock(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"line-only", "x // trailing\n", "x \n"},
+		{"block-inline", "a /* b */ c", "a  c"},
+		{"block-multiline", "a /* line1\nline2 */ b", "a  b"},
+		{"both", "/* leading */ code // trailing", " code "},
+		{"no-comments", "fun f() {}", "fun f() {}"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := stripComments(tc.in); got != tc.want {
+				t.Errorf("stripComments(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestStripCommentsPackageRegexesAreHoisted asserts the package-level
+// vars used by stripComments are populated. If a future refactor
+// moves them back inside the function body, this fails.
+func TestStripCommentsPackageRegexesAreHoisted(t *testing.T) {
+	if stripCommentsBlockRe == nil {
+		t.Fatal("stripCommentsBlockRe must be initialised at package level")
+	}
+	if stripCommentsLineRe == nil {
+		t.Fatal("stripCommentsLineRe must be initialised at package level")
+	}
+}


### PR DESCRIPTION
## Summary

`emptyblocks.stripComments` is called by every empty-block rule (`EmptyCatchBlock`, `EmptyClassBody`, `EmptyFunctionBody`, ...) for every \`block_body\` / \`catch_block\` / \`class_body\` the dispatcher visits across every Kotlin and Java file. Both regexes were compiled per call.

- Pre-compile the block-comment and line-comment regexes once at package init as `stripCommentsBlockRe` / `stripCommentsLineRe`, matching the naming convention used by the sibling files in this package.
- New internal test exercises strip-comments behaviour (line, block, multiline, both, none) and guards against a refactor moving the regexes back inside the function.

## Test plan

- [x] `go test ./internal/rules/ -run "TestStripComments|TestEmptyBlock|TestEmptyCatch|TestEmptyKotlinFile" -v` — all green including new tests
- [x] `make lint-rules` (ad-hoc-cache gate clean)
- [x] `go build`, `go vet ./...`, `golangci-lint run ./internal/rules/` clean