### PR TITLE
fix(strutil): hand-rolled word-boundary token scan replaces per-call regex

### DIFF
--- a/internal/cli/mocks/mocks.go
+++ b/internal/cli/mocks/mocks.go
@@ -9,6 +9,8 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+
+	"github.com/kaeawc/krit/internal/strutil"
 )
 
 type Report struct {
@@ -199,8 +201,7 @@ func mockDirectlyInteracted(text, name string) bool {
 }
 
 func tokenInText(text, token string) bool {
-	re := regexp.MustCompile(`(^|[^A-Za-z0-9_])` + regexp.QuoteMeta(token) + `([^A-Za-z0-9_]|$)`)
-	return re.MatchString(text)
+	return strutil.ContainsTokenWordBoundary(text, token)
 }
 
 func dedupeMocks(in []Mock) []Mock {

--- a/internal/cli/testcoverage/testcoverage.go
+++ b/internal/cli/testcoverage/testcoverage.go
@@ -7,12 +7,12 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"regexp"
 	"runtime"
 	"sort"
 	"strings"
 
 	"github.com/kaeawc/krit/internal/scanner"
+	"github.com/kaeawc/krit/internal/strutil"
 )
 
 type Finding struct {
@@ -247,11 +247,7 @@ func symbolText(file *scanner.File, sym scanner.Symbol) string {
 }
 
 func tokenInText(text, token string) bool {
-	if token == "" {
-		return false
-	}
-	re := regexp.MustCompile(`(^|[^A-Za-z0-9_])` + regexp.QuoteMeta(token) + `([^A-Za-z0-9_]|$)`)
-	return re.MatchString(text)
+	return strutil.ContainsTokenWordBoundary(text, token)
 }
 
 func isTestPath(path string) bool {

--- a/internal/rules/android_security.go
+++ b/internal/rules/android_security.go
@@ -16,6 +16,7 @@ import (
 	"github.com/kaeawc/krit/internal/filefacts"
 	api "github.com/kaeawc/krit/internal/rules/api"
 	"github.com/kaeawc/krit/internal/scanner"
+	"github.com/kaeawc/krit/internal/strutil"
 	"github.com/kaeawc/krit/internal/typeinfer"
 )
 
@@ -1885,8 +1886,7 @@ func insecureTrustManagerDecl(file *scanner.File, idx uint32) bool {
 }
 
 func insecureTrustManagerTextHasTypeToken(text, token string) bool {
-	re := regexp.MustCompile(`(^|[^A-Za-z0-9_])` + regexp.QuoteMeta(token) + `([^A-Za-z0-9_]|$)`)
-	return re.MatchString(text)
+	return strutil.ContainsTokenWordBoundary(text, token)
 }
 
 func insecureTrustManagerTrivialChecks(file *scanner.File, owner uint32) []uint32 {

--- a/internal/strutil/token.go
+++ b/internal/strutil/token.go
@@ -1,0 +1,52 @@
+// Package strutil holds allocation-free string scans shared by Krit's
+// rules and CLI commands. Hand-rolled equivalents of small regex
+// patterns belong here when the regex shows up in a per-line or
+// per-token hot path.
+package strutil
+
+import "strings"
+
+// ContainsTokenWordBoundary reports whether token appears in text
+// bounded by non-identifier characters (or string start/end).
+// Identifier characters are [A-Za-z0-9_]. Equivalent to the regex
+// `(^|[^A-Za-z0-9_])\Q<token>\E([^A-Za-z0-9_]|$)` but with no
+// per-call regex compile and no allocation.
+//
+// An empty token returns false; this matches the regex form
+// (`regexp.QuoteMeta("")` is the empty string and `(^|x)([^x]|$)`
+// would degenerate to a position-only match the callers do not want).
+func ContainsTokenWordBoundary(text, token string) bool {
+	if token == "" {
+		return false
+	}
+	from := 0
+	for from <= len(text) {
+		rel := strings.Index(text[from:], token)
+		if rel < 0 {
+			return false
+		}
+		pos := from + rel
+		end := pos + len(token)
+		leftOK := pos == 0 || !isIdentByte(text[pos-1])
+		rightOK := end == len(text) || !isIdentByte(text[end])
+		if leftOK && rightOK {
+			return true
+		}
+		from = pos + 1
+	}
+	return false
+}
+
+func isIdentByte(b byte) bool {
+	switch {
+	case b >= 'a' && b <= 'z':
+		return true
+	case b >= 'A' && b <= 'Z':
+		return true
+	case b >= '0' && b <= '9':
+		return true
+	case b == '_':
+		return true
+	}
+	return false
+}

--- a/internal/strutil/token_test.go
+++ b/internal/strutil/token_test.go
@@ -1,0 +1,61 @@
+package strutil
+
+import (
+	"regexp"
+	"testing"
+)
+
+func TestContainsTokenWordBoundary(t *testing.T) {
+	cases := []struct {
+		name  string
+		text  string
+		token string
+		want  bool
+	}{
+		{"exact-match-only", "foo", "foo", true},
+		{"surrounded-by-spaces", " foo ", "foo", true},
+		{"at-start", "foo bar", "foo", true},
+		{"at-end", "bar foo", "foo", true},
+		{"identifier-prefix-blocks", "myfoo", "foo", false},
+		{"identifier-suffix-blocks", "foobar", "foo", false},
+		{"digit-suffix-blocks", "foo1", "foo", false},
+		{"underscore-suffix-blocks", "foo_bar", "foo", false},
+		{"punctuation-boundary", "foo.bar()", "foo", true},
+		{"multiple-occurrences-second-matches", "myfoo, foo", "foo", true},
+		{"empty-token-is-false", "anything", "", false},
+		{"empty-text", "", "foo", false},
+		{"token-with-regex-meta-chars", "a.b.c", "a.b", true},
+		{"token-with-regex-meta-chars-blocked", "xa.bc", "a.b", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ContainsTokenWordBoundary(tc.text, tc.token)
+			if got != tc.want {
+				t.Errorf("ContainsTokenWordBoundary(%q, %q) = %v, want %v", tc.text, tc.token, got, tc.want)
+			}
+			// Confirm parity with the regex form callers replaced.
+			if tc.token != "" {
+				ref := regexp.MustCompile(`(^|[^A-Za-z0-9_])` + regexp.QuoteMeta(tc.token) + `([^A-Za-z0-9_]|$)`)
+				refGot := ref.MatchString(tc.text)
+				if refGot != got {
+					t.Errorf("regex parity drift on (%q, %q): hand-rolled=%v regex=%v", tc.text, tc.token, got, refGot)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkContainsTokenWordBoundaryHandRolled(b *testing.B) {
+	text := "fun setupBar(): Bar = bar.also { it.something() } // mocks.bar.bar"
+	for i := 0; i < b.N; i++ {
+		_ = ContainsTokenWordBoundary(text, "bar")
+	}
+}
+
+func BenchmarkContainsTokenWordBoundaryRegex(b *testing.B) {
+	text := "fun setupBar(): Bar = bar.also { it.something() } // mocks.bar.bar"
+	for i := 0; i < b.N; i++ {
+		re := regexp.MustCompile(`(^|[^A-Za-z0-9_])` + regexp.QuoteMeta("bar") + `([^A-Za-z0-9_]|$)`)
+		_ = re.MatchString(text)
+	}
+}


### PR DESCRIPTION
## Summary

Three independent helpers (`testcoverage.tokenInText`, `mocks.tokenInText`, `android_security.insecureTrustManagerTextHasTypeToken`) implemented the same identifier-boundary check by compiling `(^|[^A-Za-z0-9_])\Q<token>\E([^A-Za-z0-9_]|$)` on every call. On a moderate Kotlin module those calls fire inside per-(test, member) double loops and per-class scans — tens of thousands of identical regex compilations per scan.

- New `internal/strutil` package exposes `ContainsTokenWordBoundary(text, token) bool` — a hand-rolled byte scan using `strings.Index` plus inline identifier-byte checks on either side. Allocation-free, no `sync.Map`, faster than even a cached regex.
- All three call sites now delegate to the shared helper; unused `regexp` imports removed.
- Package tests cover the contract (start/end, identifier prefix/suffix, digits, underscores, punctuation boundaries, regex-meta tokens) and explicitly verify parity with the regex form they replace.

## Test plan

- [x] `go test ./internal/strutil/ -v` — all green, including the parity-vs-regex assertion on every case
- [x] `go test ./internal/cli/testcoverage/ ./internal/cli/mocks/ ./internal/rules/` — green
- [x] `make lint-rules` (no sync.Map / ad-hoc-cache violations)
- [x] `go build`, `go vet ./...`, `golangci-lint run ./...` clean