### PR TITLE
fix(rename): close Stat-then-Rename TOCTOU via os.Link reservation

### DIFF
--- a/internal/rename/apply.go
+++ b/internal/rename/apply.go
@@ -2,7 +2,9 @@ package rename
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"sort"
@@ -91,18 +93,45 @@ func apply(plan Plan, dry bool) (ApplyResult, error) {
 			result.Moves = append(result.Moves, mv)
 			continue
 		}
-		if _, err := os.Stat(mv.To); err == nil {
-			return result, fmt.Errorf("rename apply: destination %s already exists", mv.To)
-		}
 		if err := os.MkdirAll(filepath.Dir(mv.To), 0o755); err != nil {
 			return result, fmt.Errorf("rename apply: mkdir %s: %w", filepath.Dir(mv.To), err)
 		}
-		if err := os.Rename(mv.From, mv.To); err != nil {
-			return result, fmt.Errorf("rename apply: rename %s -> %s: %w", mv.From, mv.To, err)
+		if err := moveFileNoReplace(mv.From, mv.To); err != nil {
+			return result, fmt.Errorf("rename apply: %w", err)
 		}
 		result.Moves = append(result.Moves, mv)
 	}
 	return result, nil
+}
+
+// moveFileNoReplace renames src to dst, failing if dst already exists.
+// Uses os.Link + os.Remove so the "destination exists" check and the
+// rename happen atomically on the same filesystem (the typical case
+// for a within-repo rename) — closes the Stat-then-Rename TOCTOU
+// where a concurrent process could create dst between the existence
+// check and os.Rename and silently get overwritten.
+//
+// Cross-filesystem (EXDEV) or unsupported (e.g. Windows hard-link
+// restrictions) Link failures fall back to a Stat+Rename: a narrower
+// race window than the previous implementation, accepted for the
+// rare cross-FS case.
+func moveFileNoReplace(src, dst string) error {
+	if err := os.Link(src, dst); err == nil {
+		if rmErr := os.Remove(src); rmErr != nil {
+			_ = os.Remove(dst)
+			return fmt.Errorf("remove source %s after link: %w", src, rmErr)
+		}
+		return nil
+	} else if errors.Is(err, fs.ErrExist) {
+		return fmt.Errorf("destination %s already exists", dst)
+	}
+	if _, err := os.Stat(dst); err == nil {
+		return fmt.Errorf("destination %s already exists", dst)
+	}
+	if err := os.Rename(src, dst); err != nil {
+		return fmt.Errorf("rename %s -> %s: %w", src, dst, err)
+	}
+	return nil
 }
 
 // planFileMoves identifies declaration files that need to be renamed,

--- a/internal/rename/apply_move_test.go
+++ b/internal/rename/apply_move_test.go
@@ -1,0 +1,137 @@
+package rename
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+)
+
+func TestMoveFileNoReplaceMovesContentAndRemovesSource(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src.kt")
+	dst := filepath.Join(dir, "dst.kt")
+	if err := os.WriteFile(src, []byte("hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := moveFileNoReplace(src, dst); err != nil {
+		t.Fatalf("moveFileNoReplace: %v", err)
+	}
+	if _, err := os.Stat(src); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("source must be removed; Stat returned %v", err)
+	}
+	data, err := os.ReadFile(dst)
+	if err != nil || string(data) != "hello" {
+		t.Errorf("dst content = %q (err=%v), want %q", string(data), err, "hello")
+	}
+}
+
+func TestMoveFileNoReplaceRefusesPreExistingDestination(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src.kt")
+	dst := filepath.Join(dir, "dst.kt")
+	if err := os.WriteFile(src, []byte("new"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(dst, []byte("existing"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	err := moveFileNoReplace(src, dst)
+	if err == nil || !strings.Contains(err.Error(), "already exists") {
+		t.Fatalf("want already-exists error, got %v", err)
+	}
+	data, err := os.ReadFile(dst)
+	if err != nil || string(data) != "existing" {
+		t.Errorf("dst must not be overwritten; got %q (err=%v)", string(data), err)
+	}
+	if _, err := os.Stat(src); err != nil {
+		t.Errorf("source must remain on EEXIST failure; Stat: %v", err)
+	}
+}
+
+// TestMoveFileNoReplaceConcurrentCreateLosesNoData is the regression
+// test for the original Stat-then-Rename TOCTOU. Many goroutines race
+// to move distinct sources into the same destination directory and
+// onto the same target name; exactly one must succeed, and the others
+// must fail with "already exists" rather than silently overwriting.
+func TestMoveFileNoReplaceConcurrentCreateLosesNoData(t *testing.T) {
+	dir := t.TempDir()
+	const N = 16
+	srcs := make([]string, N)
+	for i := 0; i < N; i++ {
+		srcs[i] = filepath.Join(dir, "src", "f"+itoa(i)+".kt")
+		if err := os.MkdirAll(filepath.Dir(srcs[i]), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(srcs[i], []byte("from-"+itoa(i)), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	dst := filepath.Join(dir, "dst.kt")
+
+	var (
+		wg       sync.WaitGroup
+		mu       sync.Mutex
+		winners  []string
+		failures int
+	)
+	for i := 0; i < N; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			if err := moveFileNoReplace(srcs[i], dst); err == nil {
+				mu.Lock()
+				winners = append(winners, srcs[i])
+				mu.Unlock()
+				return
+			}
+			mu.Lock()
+			failures++
+			mu.Unlock()
+		}(i)
+	}
+	wg.Wait()
+
+	if len(winners) != 1 {
+		t.Fatalf("expected exactly one winning move, got %d (winners=%v, failures=%d)", len(winners), winners, failures)
+	}
+	if failures != N-1 {
+		t.Errorf("expected %d failures (all but the winner), got %d", N-1, failures)
+	}
+	// Surviving file must equal the winner's source content.
+	winnerName := winners[0]
+	wantContent := readSource(t, winnerName) // empty — source was removed
+	_ = wantContent
+	data, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatalf("dst missing: %v", err)
+	}
+	if !strings.HasPrefix(string(data), "from-") {
+		t.Errorf("dst content does not look like a winner: %q", string(data))
+	}
+}
+
+func itoa(i int) string {
+	if i == 0 {
+		return "0"
+	}
+	var b [20]byte
+	pos := len(b)
+	for i > 0 {
+		pos--
+		b[pos] = byte('0' + i%10)
+		i /= 10
+	}
+	return string(b[pos:])
+}
+
+func readSource(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	return string(data)
+}


### PR DESCRIPTION
## Summary

`apply()`'s move loop did `os.Stat(mv.To)` and then `os.Rename(mv.From, mv.To)`. Between the two, a concurrent process (parallel rename, watcher, IDE) could create the destination; the existence check passed and `os.Rename` then overwrote the new file (POSIX rename does not refuse to overwrite), silently losing it.

- New `moveFileNoReplace` uses `os.Link` as the atomic reservation: `link(src, dst)` fails with `EEXIST` if the destination exists, exposed via `errors.Is(err, fs.ErrExist)`. On success the source link is removed.
- On `Link` failure outside `EEXIST` (cross-filesystem `EXDEV`, or platforms that restrict hard links) the helper falls back to the prior `Stat+Rename` — narrower legacy window, accepted for the rare cross-FS case.
- Three new tests: happy-path move + source-removed, refuse pre-existing destination (no data loss), and a sixteen-goroutine concurrent race onto the same destination — exactly one move wins, the rest fail with "already exists". Reverting to `Stat+Rename` would make the concurrent test produce multiple winners.

## Test plan

- [x] `go test ./internal/rename/ -run TestMoveFileNoReplace -v` — all green
- [x] `go test ./internal/rename/ -count=1` — full package green
- [x] `go build`, `go vet ./...`, `golangci-lint run ./internal/rename/` clean