### PR TITLE
fix(fsutil): route JVM helper logs through a private user dir

### DIFF
--- a/internal/firchecks/client.go
+++ b/internal/firchecks/client.go
@@ -24,6 +24,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/kaeawc/krit/internal/fsutil"
 	"github.com/kaeawc/krit/internal/hashutil"
 )
 
@@ -103,8 +104,7 @@ func StartFirDaemonWithPort(jarPath string, verbose bool) (*FirDaemon, error) {
 	}
 
 	cmd := exec.CommandContext(context.Background(), javaPath, args...)
-	logPath := filepath.Join(os.TempDir(), "krit-fir-daemon.log")
-	logFile, err := os.Create(logPath)
+	logFile, logPath, err := fsutil.CreateUserKritFile("krit-fir-daemon.log")
 	if err != nil {
 		cmd.Stderr = os.Stderr
 	} else {

--- a/internal/fsutil/userdir.go
+++ b/internal/fsutil/userdir.go
@@ -1,0 +1,48 @@
+package fsutil
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// UserKritDir returns the path to the per-user Krit cache directory,
+// creating it with mode 0700 if it does not exist. The directory lives
+// under os.UserCacheDir when available so it is private to the calling
+// user; on platforms where UserCacheDir fails (e.g. unset HOME and
+// XDG_CACHE_HOME on Unix) it falls back to a uid-tagged subdir of
+// os.TempDir.
+//
+// Krit's JVM helper logs and one-shot cache files live here so a
+// malicious user on a multi-user host cannot pre-place a symlink at a
+// shared /tmp path and redirect Krit's writes — the 0700 directory
+// keeps the path off-limits.
+func UserKritDir() (string, error) {
+	base, err := os.UserCacheDir()
+	if err != nil || base == "" {
+		base = filepath.Join(os.TempDir(), fmt.Sprintf("krit-%d", os.Getuid()))
+	} else {
+		base = filepath.Join(base, "krit")
+	}
+	if err := os.MkdirAll(base, 0o700); err != nil {
+		return "", fmt.Errorf("create krit user dir %s: %w", base, err)
+	}
+	return base, nil
+}
+
+// CreateUserKritFile creates (or truncates) name under UserKritDir
+// with mode 0600. Returns the open file plus its absolute path so
+// callers can surface the location to the user. Convenience wrapper
+// around UserKritDir + os.OpenFile.
+func CreateUserKritFile(name string) (*os.File, string, error) {
+	dir, err := UserKritDir()
+	if err != nil {
+		return nil, "", err
+	}
+	path := filepath.Join(dir, name)
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
+	if err != nil {
+		return nil, path, err
+	}
+	return f, path, nil
+}

--- a/internal/fsutil/userdir_test.go
+++ b/internal/fsutil/userdir_test.go
@@ -1,0 +1,93 @@
+package fsutil
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestUserKritDirCreatesPrivateDirectory(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CACHE_HOME", tmp)
+	if runtime.GOOS == "darwin" {
+		// On darwin os.UserCacheDir uses HOME/Library/Caches; redirect via HOME.
+		t.Setenv("HOME", tmp)
+	}
+
+	dir, err := UserKritDir()
+	if err != nil {
+		t.Fatalf("UserKritDir: %v", err)
+	}
+	info, err := os.Stat(dir)
+	if err != nil {
+		t.Fatalf("stat %s: %v", dir, err)
+	}
+	if !info.IsDir() {
+		t.Fatalf("UserKritDir returned non-directory %s", dir)
+	}
+	// 0700 isolates the dir from other users on multi-user hosts. Windows
+	// reports a different bit mask; only enforce on Unix.
+	if runtime.GOOS != "windows" {
+		if mode := info.Mode().Perm(); mode&0o077 != 0 {
+			t.Errorf("UserKritDir %s mode %o leaks bits to group/other; want owner-only", dir, mode)
+		}
+	}
+}
+
+func TestCreateUserKritFileWritesUnderUserDir(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CACHE_HOME", tmp)
+	if runtime.GOOS == "darwin" {
+		t.Setenv("HOME", tmp)
+	}
+
+	f, path, err := CreateUserKritFile("regression.log")
+	if err != nil {
+		t.Fatalf("CreateUserKritFile: %v", err)
+	}
+	defer func() { _ = f.Close() }()
+	if _, err := f.Write([]byte("entry\n")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	dir, err := UserKritDir()
+	if err != nil {
+		t.Fatalf("UserKritDir: %v", err)
+	}
+	if filepath.Dir(path) != dir {
+		t.Errorf("CreateUserKritFile path %s not under UserKritDir %s", path, dir)
+	}
+
+	if runtime.GOOS != "windows" {
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatalf("stat: %v", err)
+		}
+		if mode := info.Mode().Perm(); mode&0o077 != 0 {
+			t.Errorf("CreateUserKritFile %s mode %o leaks bits to group/other", path, mode)
+		}
+	}
+
+	// Second call truncates so prior content is replaced — important for
+	// log files that should not grow unbounded across daemon restarts.
+	f2, _, err := CreateUserKritFile("regression.log")
+	if err != nil {
+		t.Fatalf("second CreateUserKritFile: %v", err)
+	}
+	if err := f2.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("read after truncate: %v", err)
+	}
+	if len(data) != 0 {
+		t.Errorf("expected truncated file, got %d bytes", len(data))
+	}
+}

--- a/internal/oracle/daemon_jvm.go
+++ b/internal/oracle/daemon_jvm.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/kaeawc/krit/internal/fsutil"
 	"github.com/kaeawc/krit/internal/hashutil"
 )
 
@@ -293,8 +294,7 @@ func purgeJVMCachesForJar(jarPath string, verbose bool) {
 
 // openDaemonLogFile opens (or creates) the daemon log file and wires it to cmd.Stderr.
 func openDaemonLogFile(cmd *exec.Cmd, verbose bool) *os.File {
-	logPath := filepath.Join(os.TempDir(), "krit-types-daemon.log")
-	logFile, err := os.Create(logPath)
+	logFile, logPath, err := fsutil.CreateUserKritFile("krit-types-daemon.log")
 	if err != nil {
 		cmd.Stderr = os.Stderr
 		return nil

--- a/internal/pipeline/index.go
+++ b/internal/pipeline/index.go
@@ -14,6 +14,7 @@ import (
 	"github.com/kaeawc/krit/internal/cache"
 	"github.com/kaeawc/krit/internal/config"
 	"github.com/kaeawc/krit/internal/diag"
+	"github.com/kaeawc/krit/internal/fsutil"
 	"github.com/kaeawc/krit/internal/hashutil"
 	"github.com/kaeawc/krit/internal/javafacts"
 	"github.com/kaeawc/krit/internal/librarymodel"
@@ -989,7 +990,11 @@ func (p IndexPhase) runJvmAnalyze(in IndexInput, oracleRules []*api.Rule, scanPa
 		cacheDest = oracle.CachePath(scanPaths)
 	})
 	if cacheDest == "" {
-		cacheDest = filepath.Join(os.TempDir(), "krit-types.json")
+		if dir, err := fsutil.UserKritDir(); err == nil {
+			cacheDest = filepath.Join(dir, "krit-types.json")
+		} else {
+			cacheDest = filepath.Join(os.TempDir(), "krit-types.json")
+		}
 	}
 	if in.Verbose {
 		in.logf("verbose: Running krit-types (%d source dirs)...\n", len(sourceDirs))


### PR DESCRIPTION
## Summary

Three sites opened predictable shared-`/tmp` paths with `os.Create`: `oracle/daemon_jvm.go` (`krit-types-daemon.log`), `firchecks/client.go` (`krit-fir-daemon.log`), and `pipeline/index.go` (`krit-types.json` fallback). On a multi-user host another user could pre-create the path as a symlink to e.g. `~/.ssh/authorized_keys`; `os.Create` follows the symlink and Krit then truncates the target file as the running user.

- New `fsutil.UserKritDir` creates a private 0700 directory under `os.UserCacheDir` (or a uid-tagged subdir of `TempDir` when UserCacheDir is unavailable), so a non-owner cannot pre-place anything at the file path.
- New `fsutil.CreateUserKritFile(name)` opens (or truncates) `name` inside that dir with mode 0600.
- All three call sites switch from `filepath.Join(os.TempDir(), …) + os.Create` to the helper.
- Two new tests confirm directory mode is owner-only on Unix and that the truncate-on-each-call log-file contract holds.

## Test plan

- [x] `go test ./internal/fsutil/ -v` — all green including new tests
- [x] `go build`, `go vet ./...`, `golangci-lint run ./internal/fsutil/ ./internal/oracle/ ./internal/firchecks/ ./internal/pipeline/` clean