### PR TITLE
fix(daemonclient): close parent log fd after spawn

### DIFF
--- a/internal/cli/daemonclient/attach_log_test.go
+++ b/internal/cli/daemonclient/attach_log_test.go
@@ -1,0 +1,60 @@
+package daemonclient
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func TestAttachSpawnLogWiresStdoutAndStderr(t *testing.T) {
+	tmp := t.TempDir()
+	logPath := filepath.Join(tmp, "daemon.log")
+	cmd := exec.Command("nonexistent")
+	f, err := attachSpawnLog(cmd, logPath)
+	if err != nil {
+		t.Fatalf("attachSpawnLog: %v", err)
+	}
+	if f == nil {
+		t.Fatal("non-empty path: expected non-nil log file")
+	}
+	if cmd.Stdout != f || cmd.Stderr != f {
+		t.Errorf("attachSpawnLog must wire stdout/stderr to the opened file")
+	}
+	if err := f.Close(); err != nil {
+		t.Errorf("Close: %v", err)
+	}
+	// After the documented post-Start Close, the parent's handle must
+	// be unusable — proves we are not silently leaking the fd.
+	if _, err := f.Write([]byte("x")); !errors.Is(err, os.ErrClosed) {
+		t.Errorf("expected os.ErrClosed after Close, got %v", err)
+	}
+}
+
+func TestAttachSpawnLogEmptyPathClearsStdio(t *testing.T) {
+	cmd := exec.Command("nonexistent")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	f, err := attachSpawnLog(cmd, "")
+	if err != nil || f != nil {
+		t.Fatalf("got (f=%v, err=%v); want (nil, nil)", f, err)
+	}
+	if cmd.Stdout != nil || cmd.Stderr != nil {
+		t.Error("empty path must null out stdio so the child inherits no parent file descriptors")
+	}
+}
+
+func TestAttachSpawnLogReportsOpenError(t *testing.T) {
+	cmd := exec.Command("nonexistent")
+	// A path under an existing file is guaranteed to fail to open.
+	tmp := t.TempDir()
+	parent := filepath.Join(tmp, "file")
+	if err := os.WriteFile(parent, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	bad := filepath.Join(parent, "child.log")
+	if _, err := attachSpawnLog(cmd, bad); err == nil {
+		t.Errorf("expected open error for path under a regular file %q", bad)
+	}
+}

--- a/internal/cli/daemonclient/client.go
+++ b/internal/cli/daemonclient/client.go
@@ -167,6 +167,29 @@ func computeCurrentBinaryHash() string {
 
 var binaryHashCache atomic.Pointer[string]
 
+// attachSpawnLog opens path append-only and assigns it to cmd.Stdout
+// and cmd.Stderr. The caller is responsible for closing the returned
+// *os.File after cmd.Start (or on Start failure) — exec.Cmd dup's the
+// fd into the child at Start, so the parent's handle would otherwise
+// leak one fd per spawn.
+//
+// Returns (nil, nil) when path is empty: the daemon's stdout/stderr
+// are nil'd out and there is no parent fd to manage.
+func attachSpawnLog(cmd *exec.Cmd, path string) (*os.File, error) {
+	if path == "" {
+		cmd.Stdout = nil
+		cmd.Stderr = nil
+		return nil, nil
+	}
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		return nil, err
+	}
+	cmd.Stdout = f
+	cmd.Stderr = f
+	return f, nil
+}
+
 // SpawnOptions controls EnsureRunning's behaviour.
 type SpawnOptions struct {
 	// Binary is the krit binary to exec. Empty defaults to os.Executable
@@ -227,19 +250,21 @@ func EnsureRunning(repoRoot string, opts SpawnOptions) (*Client, error) {
 		cmd.Env = opts.Env
 	}
 	cmd.Stdin = nil
-	if opts.LogPath != "" {
-		log, err := os.OpenFile(opts.LogPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
-		if err != nil {
-			return nil, fmt.Errorf("daemonclient: open log %s: %w", opts.LogPath, err)
-		}
-		cmd.Stdout = log
-		cmd.Stderr = log
-	} else {
-		cmd.Stdout = nil
-		cmd.Stderr = nil
+	logFile, err := attachSpawnLog(cmd, opts.LogPath)
+	if err != nil {
+		return nil, fmt.Errorf("daemonclient: open log %s: %w", opts.LogPath, err)
 	}
 	if err := cmd.Start(); err != nil {
+		if logFile != nil {
+			_ = logFile.Close()
+		}
 		return nil, fmt.Errorf("daemonclient: spawn %s serve: %w", binary, err)
+	}
+	// exec.Cmd dup'd the fd into the child at Start; the parent's
+	// handle is no longer needed and would otherwise leak one fd per
+	// daemon respawn in a long-lived LSP/MCP session.
+	if logFile != nil {
+		_ = logFile.Close()
 	}
 	// Detach so the daemon outlives the parent. Wait must be reaped
 	// somewhere — do it in a goroutine to avoid a zombie.


### PR DESCRIPTION
## Summary

`EnsureRunning` opened the daemon log via `os.OpenFile` and assigned it to `cmd.Stdout`/`Stderr`, but never closed the parent's `*os.File`. After `cmd.Start` the child holds its own dup of the fd — the parent's handle is pure overhead. One leaked fd per daemon respawn accumulates silently inside long-lived LSP/MCP sessions until the process hits its fd ulimit.

- Extracted the open + wire-up into `attachSpawnLog(cmd, path)`.
- `EnsureRunning` now closes the returned file after `cmd.Start` succeeds, and on the Start-error path.
- Three unit tests cover the contract: stdout/stderr wired, post-Close write returns `os.ErrClosed` (proves we're not silently leaking), empty path nulls the child's stdio, and a deliberately-bad path surfaces the open error.

## Test plan

- [x] `go test ./internal/cli/daemonclient/ -run TestAttachSpawnLog -v` — all green
- [x] `go test ./internal/cli/daemonclient/ -count=1` — full package green
- [x] `go build`, `go vet ./...`, `golangci-lint run ./internal/cli/daemonclient/` clean