### PR TITLE
feat(krit-fir): plugin-rule loader + listPlugins RPC

### DIFF
--- a/tools/krit-fir/build.gradle.kts
+++ b/tools/krit-fir/build.gradle.kts
@@ -16,6 +16,10 @@ kotlin {
 dependencies {
     // Kotlin compiler bundled into the fat JAR — provides FIR checker API, K2JVMCompiler, and plugin infra
     implementation("org.jetbrains.kotlin:kotlin-compiler:$kotlinVersion")
+    // krit-rule-api: KritRule + KritRuleInfo + Capability + RuleApiVersion.
+    // The plugin loader inspects ServiceLoader-discovered impls of these
+    // types against the daemon's compatible SDK version.
+    implementation(project(":krit-rule-api"))
 
     testImplementation("org.junit.jupiter:junit-jupiter:6.0.3")
     testImplementation(kotlin("test"))

--- a/tools/krit-fir/settings.gradle.kts
+++ b/tools/krit-fir/settings.gradle.kts
@@ -1,6 +1,9 @@
 rootProject.name = "krit-fir"
 include("compiler-tests")
 
+include(":krit-rule-api")
+project(":krit-rule-api").projectDir = file("../krit-rule-api")
+
 dependencyResolutionManagement {
     repositories {
         mavenCentral()

--- a/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/Main.kt
+++ b/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/Main.kt
@@ -1,6 +1,8 @@
 package dev.jasonpearson.krit.fir
 
 import dev.jasonpearson.krit.fir.oracle.OracleResponse
+import dev.jasonpearson.krit.fir.plugins.PluginResponse
+import dev.jasonpearson.krit.fir.plugins.PluginRuleRegistry
 import dev.jasonpearson.krit.fir.runner.AnalysisSession
 import dev.jasonpearson.krit.fir.runner.BatchResult
 import dev.jasonpearson.krit.fir.runner.FileRef
@@ -199,6 +201,19 @@ fun handleRequestLine(trimmed: String, session: AnalysisSession, startTime: Long
                     RequestResult.Response(response)
                 }
             }
+            "listPlugins" -> {
+                val response = try {
+                    PluginRuleRegistry.load(request.pluginJars)
+                    PluginResponse.buildListPlugins(
+                        id = request.id,
+                        descriptors = PluginRuleRegistry.descriptorsForJars(request.pluginJars),
+                        diagnostics = PluginRuleRegistry.diagnosticsForJars(request.pluginJars),
+                    )
+                } catch (t: Throwable) {
+                    """{"id":${request.id},"error":"${escJson(t.message ?: "listPlugins failed")}"}"""
+                }
+                RequestResult.Response(response)
+            }
             else -> RequestResult.Response("""{"id":${request.id},"error":"Unknown command: ${escJson(request.command)}"}""")
         }
     } catch (e: Exception) {
@@ -216,6 +231,9 @@ data class CheckRequest(
     val sourceDirs: List<String> = emptyList(),
     val classpath: List<String> = emptyList(),
     val rules: List<String> = emptyList(),
+    // Plugin-rule jar paths, matching krit-types' `"jars"` array in
+    // `listPlugins` / `analyzeFileWithPlugins` requests.
+    val pluginJars: List<String> = emptyList(),
 )
 
 fun parseRequest(json: String): CheckRequest {
@@ -224,8 +242,9 @@ fun parseRequest(json: String): CheckRequest {
     val sourceDirs = extractStringArray(json, "sourceDirs") ?: emptyList()
     val classpath = extractStringArray(json, "classpath") ?: emptyList()
     val rules = extractStringArray(json, "rules") ?: emptyList()
+    val pluginJars = extractStringArray(json, "jars") ?: emptyList()
     val files = extractFileRefs(json)
-    return CheckRequest(id, command, files, sourceDirs, classpath, rules)
+    return CheckRequest(id, command, files, sourceDirs, classpath, rules, pluginJars)
 }
 
 // ── Response building ─────────────────────────────────────────────────────────

--- a/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/plugins/PluginLoader.kt
+++ b/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/plugins/PluginLoader.kt
@@ -1,0 +1,368 @@
+package dev.jasonpearson.krit.fir.plugins
+
+import dev.jasonpearson.krit.api.Capability
+import dev.jasonpearson.krit.api.KritRule
+import dev.jasonpearson.krit.api.KritRuleInfo
+import dev.jasonpearson.krit.api.RuleApiVersion
+import java.io.File
+import java.net.URLClassLoader
+import java.util.ServiceLoader
+import java.util.jar.JarFile
+
+/**
+ * Plugin-rule loader for the krit-fir backend. Mirrors the loader in
+ * krit-types' `PluginRules.kt` so a JAR built against the same
+ * `krit-rule-api` works against either backend.
+ *
+ * Differences from the krit-types loader are intentional:
+ *
+ * - The FIR backend SUPPORTS `NEEDS_FIR` capability. krit-types treats
+ *   it as a load-time error because the KAA-backed daemon cannot
+ *   deliver FIR-only facts.
+ * - The actual rule-execution surface (`Resolver`, payload contexts)
+ *   lives in later PRs in this series — this PR ships the loader,
+ *   SDK-compat gate, capability gate, and `listPlugins` RPC only.
+ */
+internal data class PluginRuleDescriptor(
+    val ruleId: String,
+    val category: String,
+    val severity: String,
+    val maturity: String,
+    val languages: List<String>,
+    val needs: List<String>,
+    val sdkVersion: String,
+)
+
+internal data class LoadedPluginRule(
+    val rule: KritRule,
+    val descriptor: PluginRuleDescriptor,
+)
+
+/**
+ * Load-time diagnostic for one rule jar. SDK-compat warnings and
+ * capability violations both surface as entries here so the
+ * `listPlugins` RPC can attribute them back to the originating jar.
+ */
+internal data class PluginLoadDiagnostic(
+    val jar: String,
+    val level: Level,
+    val ruleSdkVersion: String,
+    val daemonSdkVersion: String,
+    val message: String,
+) {
+    enum class Level { WARN, ERROR }
+}
+
+/**
+ * Semver-based compatibility gate for the rule SDK. Identical policy
+ * to krit-types' [SdkCompatibility]: a `0.x` minor mismatch is
+ * treated as breaking, otherwise matching major + minor is
+ * compatible. See `docs/external-rules.md#compatibility-matrix` for
+ * the rationale.
+ */
+internal object SdkCompatibility {
+    val DAEMON_SDK_VERSION: String = RuleApiVersion.VERSION
+
+    private const val DEV_SNAPSHOT = "0.0.0-SNAPSHOT"
+
+    fun check(
+        jar: String,
+        ruleSdkVersion: String,
+        daemonSdkVersion: String = DAEMON_SDK_VERSION,
+    ): PluginLoadDiagnostic? {
+        if (ruleSdkVersion.isBlank()) {
+            return PluginLoadDiagnostic(
+                jar = jar,
+                level = PluginLoadDiagnostic.Level.WARN,
+                ruleSdkVersion = "",
+                daemonSdkVersion = daemonSdkVersion,
+                message = "rule jar is missing the Krit-SDK-Version manifest attribute; " +
+                    "rebuild against dev.jasonpearson.krit:krit-rule-api:$daemonSdkVersion",
+            )
+        }
+        if (ruleSdkVersion == DEV_SNAPSHOT || daemonSdkVersion == DEV_SNAPSHOT) {
+            return null
+        }
+        val rule = Semver.parse(ruleSdkVersion)
+        val daemon = Semver.parse(daemonSdkVersion)
+        if (rule == null) {
+            return PluginLoadDiagnostic(
+                jar = jar,
+                level = PluginLoadDiagnostic.Level.WARN,
+                ruleSdkVersion = ruleSdkVersion,
+                daemonSdkVersion = daemonSdkVersion,
+                message = "could not parse rule Krit-SDK-Version '$ruleSdkVersion'; " +
+                    "expected semver matching daemon $daemonSdkVersion",
+            )
+        }
+        if (daemon == null) return null
+        if (rule.major == daemon.major && rule.minor == daemon.minor) {
+            return null
+        }
+        val breaking = rule.major != daemon.major ||
+            (rule.major == 0 && rule.minor != daemon.minor)
+        val level = if (breaking) PluginLoadDiagnostic.Level.ERROR else PluginLoadDiagnostic.Level.WARN
+        val reason = when {
+            rule.major != daemon.major -> "major version mismatch"
+            rule.major == 0 -> "0.x minor version mismatch (treated as breaking under semver)"
+            else -> "minor version differs"
+        }
+        val verb = if (breaking) "is incompatible with" else "may not be fully compatible with"
+        return PluginLoadDiagnostic(
+            jar = jar,
+            level = level,
+            ruleSdkVersion = ruleSdkVersion,
+            daemonSdkVersion = daemonSdkVersion,
+            message = "rule jar built against krit-rule-api $ruleSdkVersion " +
+                "$verb daemon krit-rule-api $daemonSdkVersion ($reason); " +
+                "rebuild against $daemonSdkVersion",
+        )
+    }
+}
+
+internal data class Semver(val major: Int, val minor: Int, val patch: Int) {
+    companion object {
+        // Accept `1.2.3`, `1.2.3-rc1`, `1.2.3+build.7`. Pre-release / build
+        // metadata is ignored for compatibility comparisons — the policy
+        // is expressed in terms of MAJOR.MINOR only.
+        private val SEMVER = Regex("""^(\d+)\.(\d+)\.(\d+)(?:[-+].*)?$""")
+
+        fun parse(s: String): Semver? {
+            val m = SEMVER.matchEntire(s.trim()) ?: return null
+            return Semver(
+                major = m.groupValues[1].toInt(),
+                minor = m.groupValues[2].toInt(),
+                patch = m.groupValues[3].toInt(),
+            )
+        }
+    }
+}
+
+internal data class CapabilityViolation(
+    val ruleId: String,
+    val unsupported: List<String>,
+)
+
+/**
+ * Source of truth for the capabilities the krit-fir daemon can
+ * actually deliver into a rule's [`RuleContext`]. Anything outside
+ * this set is rejected at jar-load time so a rule cannot silently run
+ * without the facts it asked for.
+ *
+ * Differs from krit-types' supported set: the krit-fir backend
+ * accepts `NEEDS_FIR` (rules that opt into FIR-only facts) because
+ * the FIR helpers land alongside the loader. Rule-execution support
+ * for the project-scope payload contexts (`NEEDS_GRADLE`, etc.) lands
+ * in a later PR; the daemon advertises them as supported now so a
+ * jar shipped today doesn't reject when the FIR runtime catches up.
+ */
+internal object PluginCapabilities {
+    val SUPPORTED: Set<String> = setOf(
+        Capability.NEEDS_RESOLVER.name,
+        Capability.NEEDS_FIR.name,
+        Capability.NEEDS_PARSED_FILES.name,
+        Capability.NEEDS_GRADLE.name,
+        Capability.NEEDS_MANIFEST.name,
+        Capability.NEEDS_RESOURCES.name,
+        Capability.NEEDS_MODULE_INDEX.name,
+        Capability.NEEDS_CROSS_FILE.name,
+    )
+
+    fun unsupported(needs: List<String>): List<String> =
+        needs.filter { it !in SUPPORTED }
+
+    fun buildLoadDiagnostic(
+        jar: String,
+        ruleSdkVersion: String,
+        daemonSdkVersion: String,
+        violations: List<CapabilityViolation>,
+    ): PluginLoadDiagnostic {
+        // Sort by rule ID so the message is deterministic across
+        // ServiceLoader iteration order — otherwise the same offending
+        // jar would produce different diagnostic strings on different
+        // runs, breaking exact-match assertions in downstream tests.
+        val sorted = violations.sortedBy { it.ruleId }
+        val rendered = sorted.joinToString(separator = "; ") { (id, caps) ->
+            "$id: ${caps.joinToString(separator = ", ")}"
+        }
+        return PluginLoadDiagnostic(
+            jar = jar,
+            level = PluginLoadDiagnostic.Level.ERROR,
+            ruleSdkVersion = ruleSdkVersion,
+            daemonSdkVersion = daemonSdkVersion,
+            message = "rule jar declares capabilities the krit-fir daemon does not " +
+                "yet provide to plugin rules; the rule would run without the facts " +
+                "it asked for. Remove the declaration(s) or wait for support. " +
+                "Unsupported: [$rendered]",
+        )
+    }
+}
+
+/**
+ * Process-wide, synchronized registry of loaded plugin jars and their
+ * rules. The K2-backed daemon may rebuild the per-request analysis
+ * session, but the loaded JARs are stable across the daemon lifetime
+ * so we keep the registry global. Matches krit-types' lifecycle.
+ */
+internal object PluginRuleRegistry {
+
+    private val classloaders = mutableListOf<URLClassLoader>()
+    private val loadedJars = linkedSetOf<String>()
+    private val ruleIdsByJar = linkedMapOf<String, MutableList<String>>()
+    private val rules = linkedMapOf<String, LoadedPluginRule>()
+    private val diagnostics: MutableList<PluginLoadDiagnostic> = mutableListOf()
+
+    @Synchronized
+    fun load(jars: List<String>) {
+        for (jar in jars) {
+            val file = File(jar).canonicalFile
+            if (!file.isFile) {
+                throw IllegalArgumentException("plugin jar not found: ${file.path}")
+            }
+            if (file.path in loadedJars) {
+                continue
+            }
+            val sdkVersion = readSdkVersion(file)
+            val sdkDiagnostic = SdkCompatibility.check(file.path, sdkVersion)
+            sdkDiagnostic?.let { diagnostics.add(it) }
+            if (sdkDiagnostic?.level == PluginLoadDiagnostic.Level.ERROR) {
+                loadedJars.add(file.path)
+                continue
+            }
+            val loader = URLClassLoader(arrayOf(file.toURI().toURL()), KritRule::class.java.classLoader)
+            val staged: List<LoadedPluginRule>
+            try {
+                staged = stageRules(loader, sdkVersion)
+            } catch (t: Throwable) {
+                loader.closeQuietly()
+                throw t
+            }
+            val violations = staged.mapNotNull { loaded ->
+                val unsupported = PluginCapabilities.unsupported(loaded.descriptor.needs)
+                if (unsupported.isEmpty()) null else CapabilityViolation(loaded.descriptor.ruleId, unsupported)
+            }
+            if (violations.isNotEmpty()) {
+                diagnostics.add(
+                    PluginCapabilities.buildLoadDiagnostic(
+                        jar = file.path,
+                        ruleSdkVersion = sdkVersion,
+                        daemonSdkVersion = SdkCompatibility.DAEMON_SDK_VERSION,
+                        violations = violations,
+                    ),
+                )
+                loadedJars.add(file.path)
+                loader.closeQuietly()
+                continue
+            }
+            val jarRuleIds = ruleIdsByJar.getOrPut(file.path) { mutableListOf() }
+            for (loaded in staged) {
+                jarRuleIds.add(loaded.descriptor.ruleId)
+                rules[loaded.descriptor.ruleId] = loaded
+            }
+            loadedJars.add(file.path)
+            classloaders.add(loader)
+        }
+    }
+
+    // Loader close is best-effort: failing to release JAR file
+    // handles shouldn't mask the diagnostic or error we're about to
+    // surface, since the diagnostic is the user-actionable signal.
+    private fun URLClassLoader.closeQuietly() {
+        try {
+            close()
+        } catch (_: Exception) {
+        }
+    }
+
+    private fun stageRules(loader: URLClassLoader, sdkVersion: String): List<LoadedPluginRule> {
+        val staged = mutableListOf<LoadedPluginRule>()
+        for (rule in ServiceLoader.load(KritRule::class.java, loader)) {
+            val info = rule.javaClass.getAnnotation(KritRuleInfo::class.java)
+            val descriptor = if (info != null) {
+                PluginRuleDescriptor(
+                    ruleId = info.id,
+                    category = info.category,
+                    severity = info.severity.name.lowercase(),
+                    maturity = info.maturity.name.lowercase(),
+                    languages = info.languages.map { it.name.lowercase() },
+                    needs = info.needs.map { it.name },
+                    sdkVersion = sdkVersion,
+                )
+            } else {
+                PluginRuleDescriptor(
+                    ruleId = rule.javaClass.name,
+                    category = "custom",
+                    severity = "warning",
+                    maturity = "experimental",
+                    languages = listOf("kotlin"),
+                    needs = emptyList(),
+                    sdkVersion = sdkVersion,
+                )
+            }
+            staged.add(LoadedPluginRule(rule, descriptor))
+        }
+        return staged
+    }
+
+    @Synchronized
+    fun diagnosticsForJars(jars: List<String>): List<PluginLoadDiagnostic> {
+        if (jars.isEmpty()) return emptyList()
+        val wanted = jars.map { File(it).canonicalFile.path }.toSet()
+        return diagnostics.filter { it.jar in wanted }
+    }
+
+    @Synchronized
+    fun descriptors(ruleIds: List<String>? = null): List<PluginRuleDescriptor> {
+        val wanted = ruleIds?.toSet()
+        return rules.values
+            .asSequence()
+            .filter { wanted == null || it.descriptor.ruleId in wanted }
+            .map { it.descriptor }
+            .sortedBy { it.ruleId }
+            .toList()
+    }
+
+    @Synchronized
+    fun descriptorsForJars(jars: List<String>): List<PluginRuleDescriptor> {
+        if (jars.isEmpty()) {
+            return descriptors()
+        }
+        val wanted = linkedSetOf<String>()
+        for (jar in jars) {
+            val path = File(jar).canonicalFile.path
+            wanted.addAll(ruleIdsByJar[path].orEmpty())
+        }
+        return descriptors(wanted.toList())
+    }
+
+    @Synchronized
+    fun selected(ruleIds: List<String>?): List<LoadedPluginRule> {
+        val wanted = ruleIds?.toSet()
+        return rules.values
+            .asSequence()
+            .filter { wanted == null || it.descriptor.ruleId in wanted }
+            .sortedBy { it.descriptor.ruleId }
+            .toList()
+    }
+
+    /** Drop all loaded state. Test-only — production code never resets. */
+    @Synchronized
+    internal fun resetForTesting() {
+        for (loader in classloaders) loader.closeQuietly()
+        classloaders.clear()
+        loadedJars.clear()
+        ruleIdsByJar.clear()
+        rules.clear()
+        diagnostics.clear()
+    }
+
+    private fun readSdkVersion(file: File): String {
+        return try {
+            JarFile(file).use { jar ->
+                jar.manifest?.mainAttributes?.getValue("Krit-SDK-Version").orEmpty()
+            }
+        } catch (_: Exception) {
+            ""
+        }
+    }
+}

--- a/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/plugins/PluginResponse.kt
+++ b/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/plugins/PluginResponse.kt
@@ -1,0 +1,86 @@
+package dev.jasonpearson.krit.fir.plugins
+
+/**
+ * JSON wire-shape builders for the plugin-rule daemon RPCs. The shape
+ * mirrors krit-types' `buildListPluginsResponse` so a single Go-side
+ * client parses either backend's response with one struct.
+ */
+internal object PluginResponse {
+
+    fun buildListPlugins(
+        id: Long,
+        descriptors: List<PluginRuleDescriptor>,
+        diagnostics: List<PluginLoadDiagnostic>,
+    ): String {
+        val sb = StringBuilder()
+        sb.append("""{"id":""").append(id).append(""","result":{"rules":[""")
+        descriptors.forEachIndexed { i, descriptor ->
+            if (i > 0) sb.append(',')
+            sb.append('{')
+            sb.append("\"ruleId\":").append(jsonString(descriptor.ruleId)).append(',')
+            sb.append("\"category\":").append(jsonString(descriptor.category)).append(',')
+            sb.append("\"severity\":").append(jsonString(descriptor.severity)).append(',')
+            sb.append("\"maturity\":").append(jsonString(descriptor.maturity)).append(',')
+            appendStringArray(sb, "languages", descriptor.languages)
+            sb.append(',')
+            appendStringArray(sb, "needs", descriptor.needs)
+            if (descriptor.sdkVersion.isNotBlank()) {
+                sb.append(",\"sdkVersion\":").append(jsonString(descriptor.sdkVersion))
+            }
+            sb.append('}')
+        }
+        sb.append(']')
+        appendDiagnostics(sb, diagnostics)
+        sb.append('}').append('}')
+        return sb.toString()
+    }
+
+    private fun appendDiagnostics(sb: StringBuilder, diagnostics: List<PluginLoadDiagnostic>) {
+        if (diagnostics.isEmpty()) return
+        sb.append(",\"diagnostics\":[")
+        diagnostics.forEachIndexed { i, d ->
+            if (i > 0) sb.append(',')
+            sb.append('{')
+            sb.append("\"jar\":").append(jsonString(d.jar)).append(',')
+            sb.append("\"level\":").append(jsonString(d.level.name.lowercase())).append(',')
+            sb.append("\"ruleSdkVersion\":").append(jsonString(d.ruleSdkVersion)).append(',')
+            sb.append("\"daemonSdkVersion\":").append(jsonString(d.daemonSdkVersion)).append(',')
+            sb.append("\"message\":").append(jsonString(d.message))
+            sb.append('}')
+        }
+        sb.append(']')
+    }
+
+    private fun appendStringArray(sb: StringBuilder, key: String, values: List<String>) {
+        sb.append('"').append(key).append("\":[")
+        values.forEachIndexed { i, v ->
+            if (i > 0) sb.append(',')
+            sb.append(jsonString(v))
+        }
+        sb.append(']')
+    }
+
+    /**
+     * Minimal JSON string escaper for plugin-response payloads. Mirrors
+     * the escape set used by `OracleResponse.jsonString`; we don't share
+     * the function because the two builders evolve independently and
+     * exposing a shared helper means publishing one of them as public.
+     */
+    private fun jsonString(value: String): String {
+        val sb = StringBuilder(value.length + 2)
+        sb.append('"')
+        for (c in value) {
+            when {
+                c == '"' -> sb.append("\\\"")
+                c == '\\' -> sb.append("\\\\")
+                c == '\n' -> sb.append("\\n")
+                c == '\r' -> sb.append("\\r")
+                c == '\t' -> sb.append("\\t")
+                c.code < 0x20 -> sb.append("\\u%04x".format(c.code))
+                else -> sb.append(c)
+            }
+        }
+        sb.append('"')
+        return sb.toString()
+    }
+}

--- a/tools/krit-fir/src/test/kotlin/dev/jasonpearson/krit/fir/OracleDispatchTest.kt
+++ b/tools/krit-fir/src/test/kotlin/dev/jasonpearson/krit/fir/OracleDispatchTest.kt
@@ -64,6 +64,19 @@ class OracleDispatchTest {
     }
 
     @Test
+    fun listPluginsCommandReturnsEmptyRulesWhenNoJarsProvided() {
+        // Zero pluginJars → the registry has nothing to load, and the
+        // response carries an empty `rules` array. The shape mirrors
+        // krit-types' buildListPluginsResponse so a single Go-side
+        // client parses either backend's payload with one struct.
+        val request = """{"id":20,"command":"listPlugins"}"""
+        val result = handleRequestLine(request, session, startTime = 0L)
+        val response = (result as RequestResult.Response).json
+        assertTrue(response.startsWith("""{"id":20,"result":{"rules":["""), response)
+        assertFalse(""""error":""" in response, response)
+    }
+
+    @Test
     fun analyzeResponseIsNotAnErrorEnvelope() {
         // Belt-and-suspenders: an `else` clause that returns
         // `{"id":...,"error":"Unknown command:..."}` is one accidental

--- a/tools/krit-fir/src/test/kotlin/dev/jasonpearson/krit/fir/plugins/PluginCapabilitiesTest.kt
+++ b/tools/krit-fir/src/test/kotlin/dev/jasonpearson/krit/fir/plugins/PluginCapabilitiesTest.kt
@@ -1,0 +1,61 @@
+package dev.jasonpearson.krit.fir.plugins
+
+import dev.jasonpearson.krit.api.Capability
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class PluginCapabilitiesTest {
+
+    @Test
+    fun needsFirIsSupportedOnTheFirBackend() {
+        // The whole point of the krit-fir backend: rules can opt
+        // into FIR-only facts via NEEDS_FIR. krit-types refuses
+        // them at load time; the FIR daemon accepts them.
+        assertEquals(emptyList(), PluginCapabilities.unsupported(listOf(Capability.NEEDS_FIR.name)))
+    }
+
+    @Test
+    fun coreCapabilitiesAreSupported() {
+        val needs = listOf(
+            Capability.NEEDS_RESOLVER,
+            Capability.NEEDS_PARSED_FILES,
+            Capability.NEEDS_GRADLE,
+            Capability.NEEDS_MANIFEST,
+            Capability.NEEDS_RESOURCES,
+            Capability.NEEDS_MODULE_INDEX,
+            Capability.NEEDS_CROSS_FILE,
+        ).map { it.name }
+        assertEquals(emptyList(), PluginCapabilities.unsupported(needs))
+    }
+
+    @Test
+    fun unknownCapabilityNameIsReportedAsUnsupported() {
+        // Test future-proofing: if a new capability ships in
+        // krit-rule-api before the backend catches up, the loader
+        // must reject the rule jar rather than silently dropping
+        // the declaration.
+        val unsupported = PluginCapabilities.unsupported(
+            listOf("NEEDS_FIR", "NEEDS_TIME_TRAVEL"),
+        )
+        assertEquals(listOf("NEEDS_TIME_TRAVEL"), unsupported)
+    }
+
+    @Test
+    fun buildLoadDiagnosticSortsViolationsByRuleId() {
+        val diagnostic = PluginCapabilities.buildLoadDiagnostic(
+            jar = "/p/rules.jar",
+            ruleSdkVersion = "1.2.3",
+            daemonSdkVersion = "1.2.3",
+            violations = listOf(
+                CapabilityViolation("z.Rule", listOf("NEEDS_X")),
+                CapabilityViolation("a.Rule", listOf("NEEDS_Y", "NEEDS_Z")),
+            ),
+        )
+        assertEquals(PluginLoadDiagnostic.Level.ERROR, diagnostic.level)
+        // Sorted insertion: a.Rule renders before z.Rule.
+        val aIdx = diagnostic.message.indexOf("a.Rule")
+        val zIdx = diagnostic.message.indexOf("z.Rule")
+        assertTrue(aIdx in 0 until zIdx, "expected a.Rule before z.Rule: ${diagnostic.message}")
+    }
+}

--- a/tools/krit-fir/src/test/kotlin/dev/jasonpearson/krit/fir/plugins/PluginResponseTest.kt
+++ b/tools/krit-fir/src/test/kotlin/dev/jasonpearson/krit/fir/plugins/PluginResponseTest.kt
@@ -1,0 +1,85 @@
+package dev.jasonpearson.krit.fir.plugins
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertTrue
+
+class PluginResponseTest {
+
+    @Test
+    fun emptyListPluginsResponseShape() {
+        val response = PluginResponse.buildListPlugins(
+            id = 1,
+            descriptors = emptyList(),
+            diagnostics = emptyList(),
+        )
+        assertTrue(response.startsWith("""{"id":1,"result":{"rules":[]"""), response)
+        // No diagnostics → no `"diagnostics"` field. Matches
+        // krit-types' omit-when-empty rule so a healthy load surface
+        // stays minimal.
+        assertTrue("diagnostics" !in response, response)
+    }
+
+    @Test
+    fun populatedRuleDescriptorSerializes() {
+        val response = PluginResponse.buildListPlugins(
+            id = 2,
+            descriptors = listOf(
+                PluginRuleDescriptor(
+                    ruleId = "com.acme.MyRule",
+                    category = "performance",
+                    severity = "warning",
+                    maturity = "stable",
+                    languages = listOf("kotlin"),
+                    needs = listOf("NEEDS_RESOLVER", "NEEDS_FIR"),
+                    sdkVersion = "1.2.3",
+                ),
+            ),
+            diagnostics = emptyList(),
+        )
+        assertTrue(""""ruleId":"com.acme.MyRule"""" in response, response)
+        assertTrue(""""category":"performance"""" in response, response)
+        assertTrue(""""needs":["NEEDS_RESOLVER","NEEDS_FIR"]""" in response, response)
+        assertTrue(""""sdkVersion":"1.2.3"""" in response, response)
+    }
+
+    @Test
+    fun blankSdkVersionOmitsSdkVersionField() {
+        val response = PluginResponse.buildListPlugins(
+            id = 3,
+            descriptors = listOf(
+                PluginRuleDescriptor(
+                    ruleId = "x",
+                    category = "custom",
+                    severity = "info",
+                    maturity = "experimental",
+                    languages = emptyList(),
+                    needs = emptyList(),
+                    sdkVersion = "",
+                ),
+            ),
+            diagnostics = emptyList(),
+        )
+        assertTrue("sdkVersion" !in response, response)
+    }
+
+    @Test
+    fun diagnosticsSerializeWithJarLevelAndMessage() {
+        val response = PluginResponse.buildListPlugins(
+            id = 4,
+            descriptors = emptyList(),
+            diagnostics = listOf(
+                PluginLoadDiagnostic(
+                    jar = "/p/r.jar",
+                    level = PluginLoadDiagnostic.Level.ERROR,
+                    ruleSdkVersion = "1.0.0",
+                    daemonSdkVersion = "2.0.0",
+                    message = "major version mismatch",
+                ),
+            ),
+        )
+        assertTrue(""""diagnostics":[""" in response, response)
+        assertTrue(""""jar":"/p/r.jar"""" in response, response)
+        assertTrue(""""level":"error"""" in response, response)
+        assertTrue(""""message":"major version mismatch"""" in response, response)
+    }
+}

--- a/tools/krit-fir/src/test/kotlin/dev/jasonpearson/krit/fir/plugins/PluginRuleRegistryTest.kt
+++ b/tools/krit-fir/src/test/kotlin/dev/jasonpearson/krit/fir/plugins/PluginRuleRegistryTest.kt
@@ -1,0 +1,183 @@
+package dev.jasonpearson.krit.fir.plugins
+
+import dev.jasonpearson.krit.api.Capability
+import dev.jasonpearson.krit.api.KritRule
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import java.nio.file.Path
+import java.util.jar.Attributes
+import java.util.jar.JarOutputStream
+import java.util.jar.Manifest
+import java.util.zip.ZipEntry
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class PluginRuleRegistryTest {
+
+    @TempDir
+    lateinit var tmp: Path
+
+    @BeforeEach
+    fun resetRegistryBefore() {
+        PluginRuleRegistry.resetForTesting()
+    }
+
+    @AfterEach
+    fun resetRegistryAfter() {
+        PluginRuleRegistry.resetForTesting()
+    }
+
+    @Test
+    fun loadIsIdempotentAcrossRepeatedCalls() {
+        // The Go-side daemon calls listPlugins repeatedly. Each call
+        // passes the same plugin jar paths; the second load() must
+        // be a no-op rather than re-registering the rules.
+        val jar = buildSampleJar("NoOpRule", needs = emptyList())
+        PluginRuleRegistry.load(listOf(jar.absolutePath))
+        val firstCount = PluginRuleRegistry.descriptors().size
+        PluginRuleRegistry.load(listOf(jar.absolutePath))
+        val secondCount = PluginRuleRegistry.descriptors().size
+        assertEquals(firstCount, secondCount, "load() must be idempotent on the same jar path")
+    }
+
+    @Test
+    fun rulesAreReturnedSortedByRuleId() {
+        val jar = buildSampleJar("ZRule", "ARule")
+        PluginRuleRegistry.load(listOf(jar.absolutePath))
+        val descriptors = PluginRuleRegistry.descriptorsForJars(listOf(jar.absolutePath))
+        assertEquals(listOf("ARule", "ZRule"), descriptors.map { it.ruleId })
+    }
+
+    // Note: end-to-end "unsupported capability triggers load error"
+    // can't be expressed here because every `Capability` enum value
+    // is SUPPORTED on the krit-fir backend. The capability gate's
+    // classification logic and diagnostic-message format are covered
+    // by [`PluginCapabilitiesTest`]; this e2e suite focuses on the
+    // happy paths and the load-failure paths reachable through the
+    // real API.
+
+    @Test
+    fun ruleDeclaringNeedsFirLoadsSuccessfullyOnFirBackend() {
+        // The whole point of the krit-fir backend: NEEDS_FIR is
+        // SUPPORTED here. krit-types would refuse the same jar.
+        val jar = buildSampleJar(
+            "FirRule",
+            needs = listOf(Capability.NEEDS_FIR.name),
+        )
+        PluginRuleRegistry.load(listOf(jar.absolutePath))
+        val descriptors = PluginRuleRegistry.descriptorsForJars(listOf(jar.absolutePath))
+        assertEquals(listOf("FirRule"), descriptors.map { it.ruleId })
+        assertEquals(emptyList(), PluginRuleRegistry.diagnosticsForJars(listOf(jar.absolutePath)))
+    }
+
+    @Test
+    fun missingJarThrowsIllegalArgumentException() {
+        val missing = tmp.resolve("nope.jar").toFile().absolutePath
+        val error = runCatching { PluginRuleRegistry.load(listOf(missing)) }.exceptionOrNull()
+        assertNotNull(error)
+        assertTrue(error is IllegalArgumentException, "got ${error::class}: ${error.message}")
+        assertTrue(error.message!!.contains("plugin jar not found"), error.message)
+    }
+
+    /**
+     * Build a tiny `.jar` containing `NoOpRuleImpl`-style classes that
+     * implement [KritRule] plus a `META-INF/services` entry that lists
+     * them. Compiling actual Kotlin rules at test time would balloon
+     * the suite — instead we hand-assemble the classfile bytes via
+     * Java reflection through a service-loader friendly stub.
+     */
+    private fun buildSampleJar(
+        vararg ruleIds: String,
+        needs: List<String> = emptyList(),
+    ): File {
+        val jarFile = tmp.resolve("plugin-${ruleIds.joinToString("-")}.jar").toFile()
+        val manifest = Manifest().apply {
+            mainAttributes[Attributes.Name.MANIFEST_VERSION] = "1.0"
+            mainAttributes.putValue("Krit-SDK-Version", SdkCompatibility.DAEMON_SDK_VERSION)
+        }
+        JarOutputStream(jarFile.outputStream(), manifest).use { jar ->
+            // Service file pointing at each rule's stub class.
+            val serviceEntry = ZipEntry("META-INF/services/${KritRule::class.java.name}")
+            jar.putNextEntry(serviceEntry)
+            val service = ruleIds.joinToString("\n") { "dev.jasonpearson.krit.fir.plugins.testrules.$it" }
+            jar.write(service.toByteArray())
+            jar.closeEntry()
+
+            for (ruleId in ruleIds) {
+                val classBytes = generateRuleClassWithK2(ruleId, needs)
+                jar.putNextEntry(ZipEntry("dev/jasonpearson/krit/fir/plugins/testrules/$ruleId.class"))
+                jar.write(classBytes)
+                jar.closeEntry()
+            }
+        }
+        return jarFile
+    }
+
+    /**
+     * Compile a synthetic `KritRule` implementation through the K2
+     * compiler that krit-fir already bundles. The class lives at
+     * `dev.jasonpearson.krit.fir.plugins.testrules.<ruleId>`, carries
+     * a `@KritRuleInfo` annotation with the requested needs list, and
+     * its `check` returns no findings. Compiling at test time keeps
+     * the rule jar wired to the same `krit-rule-api` the loader uses
+     * — handwritten classfile bytes would drift the moment the API
+     * changes.
+     */
+    private fun generateRuleClassWithK2(ruleId: String, needs: List<String>): ByteArray {
+        val srcDir = tmp.resolve("gen-${ruleId}-src").toFile().apply { mkdirs() }
+        val outDir = tmp.resolve("gen-${ruleId}-out").toFile().apply { mkdirs() }
+        val needsExpr = needs.joinToString(", ") { "dev.jasonpearson.krit.api.Capability.$it" }
+        val source = """
+            package dev.jasonpearson.krit.fir.plugins.testrules
+
+            import dev.jasonpearson.krit.api.Finding
+            import dev.jasonpearson.krit.api.KritFile
+            import dev.jasonpearson.krit.api.KritRule
+            import dev.jasonpearson.krit.api.KritRuleInfo
+            import dev.jasonpearson.krit.api.Language
+            import dev.jasonpearson.krit.api.Maturity
+            import dev.jasonpearson.krit.api.RuleContext
+            import dev.jasonpearson.krit.api.Severity
+
+            @KritRuleInfo(
+                id = "$ruleId",
+                category = "custom",
+                severity = Severity.WARNING,
+                maturity = Maturity.EXPERIMENTAL,
+                languages = [Language.KOTLIN],
+                needs = [$needsExpr],
+            )
+            class $ruleId : KritRule {
+                override fun check(file: KritFile, ctx: RuleContext): List<Finding> = emptyList()
+            }
+        """.trimIndent()
+        val sourceFile = srcDir.resolve("$ruleId.kt")
+        sourceFile.writeText(source)
+
+        val classpath = listOfNotNull(
+            System.getProperty("java.class.path"),
+        ).joinToString(File.pathSeparator)
+        val compiler = org.jetbrains.kotlin.cli.jvm.K2JVMCompiler()
+        val args = org.jetbrains.kotlin.cli.common.arguments.K2JVMCompilerArguments().apply {
+            freeArgs = listOf(sourceFile.absolutePath)
+            destination = outDir.absolutePath
+            this.classpath = classpath
+            noStdlib = true
+            noReflect = true
+        }
+        val exitCode = compiler.exec(
+            org.jetbrains.kotlin.cli.common.messages.MessageCollector.NONE,
+            org.jetbrains.kotlin.config.Services.EMPTY,
+            args,
+        )
+        check(exitCode.code == 0) { "K2 compilation failed for $ruleId: $exitCode" }
+
+        val produced = outDir
+            .resolve("dev/jasonpearson/krit/fir/plugins/testrules/$ruleId.class")
+        return produced.readBytes()
+    }
+}

--- a/tools/krit-fir/src/test/kotlin/dev/jasonpearson/krit/fir/plugins/SdkCompatibilityTest.kt
+++ b/tools/krit-fir/src/test/kotlin/dev/jasonpearson/krit/fir/plugins/SdkCompatibilityTest.kt
@@ -1,0 +1,102 @@
+package dev.jasonpearson.krit.fir.plugins
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class SdkCompatibilityTest {
+
+    @Test
+    fun blankSdkVersionEmitsManifestAttributeWarn() {
+        // A jar shipped without `Krit-SDK-Version` predates the
+        // compat-gate work. WARN keeps load behavior compatible with
+        // krit-types so the same JAR doesn't get flagged differently
+        // across backends.
+        val d = SdkCompatibility.check(jar = "/p/rules.jar", ruleSdkVersion = "")
+        assertNotNull(d)
+        assertEquals(PluginLoadDiagnostic.Level.WARN, d.level)
+        assertTrue("Krit-SDK-Version manifest attribute" in d.message, d.message)
+    }
+
+    @Test
+    fun matchingMajorAndMinorIsCompatible() {
+        val d = SdkCompatibility.check(
+            jar = "/p/rules.jar",
+            ruleSdkVersion = "1.2.0",
+            daemonSdkVersion = "1.2.7",
+        )
+        assertNull(d)
+    }
+
+    @Test
+    fun majorMismatchIsBreakingError() {
+        val d = SdkCompatibility.check(
+            jar = "/p/rules.jar",
+            ruleSdkVersion = "1.0.0",
+            daemonSdkVersion = "2.0.0",
+        )
+        assertNotNull(d)
+        assertEquals(PluginLoadDiagnostic.Level.ERROR, d.level)
+        assertTrue("major version mismatch" in d.message, d.message)
+    }
+
+    @Test
+    fun zeroXMinorMismatchIsBreaking() {
+        // Under semver, 0.x is "anything goes". The compat gate
+        // mirrors that by treating 0.x minor differences as breaking
+        // ERROR rather than a soft WARN. Matches krit-types verbatim.
+        val d = SdkCompatibility.check(
+            jar = "/p/rules.jar",
+            ruleSdkVersion = "0.3.0",
+            daemonSdkVersion = "0.4.1",
+        )
+        assertNotNull(d)
+        assertEquals(PluginLoadDiagnostic.Level.ERROR, d.level)
+        assertTrue("0.x minor version mismatch" in d.message, d.message)
+    }
+
+    @Test
+    fun postOneMinorMismatchIsSoftWarn() {
+        val d = SdkCompatibility.check(
+            jar = "/p/rules.jar",
+            ruleSdkVersion = "1.4.0",
+            daemonSdkVersion = "1.6.2",
+        )
+        assertNotNull(d)
+        assertEquals(PluginLoadDiagnostic.Level.WARN, d.level)
+        assertTrue("minor version differs" in d.message, d.message)
+    }
+
+    @Test
+    fun devSnapshotSkipsTheCompatGate() {
+        // 0.0.0-SNAPSHOT is the dev-time version published by the
+        // local build. The compat gate must skip it so contributors
+        // running against a SNAPSHOT daemon aren't blocked.
+        assertNull(SdkCompatibility.check("/p/rules.jar", "0.0.0-SNAPSHOT", "1.2.3"))
+        assertNull(SdkCompatibility.check("/p/rules.jar", "1.2.3", "0.0.0-SNAPSHOT"))
+    }
+
+    @Test
+    fun unparseableRuleSdkVersionEmitsWarn() {
+        val d = SdkCompatibility.check(
+            jar = "/p/rules.jar",
+            ruleSdkVersion = "garbage",
+            daemonSdkVersion = "1.2.3",
+        )
+        assertNotNull(d)
+        assertEquals(PluginLoadDiagnostic.Level.WARN, d.level)
+        assertTrue("could not parse rule Krit-SDK-Version" in d.message, d.message)
+    }
+
+    @Test
+    fun semverWithPreReleaseAndBuildIsAccepted() {
+        // Pre-release and build metadata are stripped before
+        // comparison so an RC build of the rule API is treated as
+        // its base version. Mirrors krit-types' parser regex.
+        assertEquals(Semver(1, 2, 3), Semver.parse("1.2.3-rc1"))
+        assertEquals(Semver(1, 2, 3), Semver.parse("1.2.3+build.7"))
+        assertEquals(null, Semver.parse("not.a.version"))
+    }
+}


### PR DESCRIPTION
## Summary

First slice of PR 3 — plugin-rule hosting on the krit-fir backend. This PR ships the loader, SDK-compat gate, capability classification, and \`listPlugins\` RPC. Rule *execution* (the \`analyzeFileWithPlugins\` RPC + a FIR-backed \`Resolver\`) lands in PR 3.2.

- \`PluginRuleRegistry\` loads jars via \`URLClassLoader\` + \`ServiceLoader<KritRule>\`, reads \`Krit-SDK-Version\` from the manifest, runs the SDK-compat gate, classifies declared capabilities, and emits \`PluginLoadDiagnostic\`s for warns/errors.
- \`SdkCompatibility\` mirrors krit-types' policy verbatim: blank → WARN, major mismatch → ERROR, 0.x minor mismatch → ERROR (treated as breaking per semver), post-1.0 minor diff → WARN, dev \`0.0.0-SNAPSHOT\` skips the gate.
- \`PluginCapabilities.SUPPORTED\` includes \`NEEDS_FIR\` plus the seven KAA-supported capabilities, so a jar built once works on either backend (subject to the SDK-compat gate). \`NEEDS_FIR\` was refused by krit-types in PR 1; now it's accepted here.
- \`PluginResponse.buildListPlugins\` emits krit-types' canonical wire shape (\`rules\` array, optional \`diagnostics\`) so the Go-side client parses either backend's payload with one struct.
- \`Main.kt\` routes the new \`listPlugins\` command, parses \`jars\` from the request, and feeds the registry.
- \`krit-fir\` now depends on the existing \`krit-rule-api\` project (added to \`settings.gradle.kts\` + \`build.gradle.kts\`).

## Test plan
- [x] \`./gradlew :test\` in \`tools/krit-fir/\` — 89 tests, +21 in this PR:
  - \`SdkCompatibilityTest\` (8): blank/matching/major/0.x-minor/post-1.0-minor/dev-snapshot/unparseable/semver-prerelease
  - \`PluginCapabilitiesTest\` (4): NEEDS_FIR supported, core capabilities, unknown rejected, sorted-by-ruleId diagnostic message
  - \`PluginResponseTest\` (4): empty / populated / blank-sdk / with-diagnostics shapes
  - \`PluginRuleRegistryTest\` (4): idempotent load, ruleId sorting, NEEDS_FIR happy path, missing-jar error path. Synthetic rule jars compiled at test time via the bundled K2 compiler so the loader exercises a real \`KritRule\` impl
  - \`OracleDispatchTest\` (+1): \`listPlugins\` routing
- [x] \`go build ./cmd/krit/ && go vet ./... && golangci-lint run ./... && go test ./... -count=1\`

## Follow-ups
- **PR 3.2**: FIR-backed \`Resolver\` impl (analog of krit-types' \`AnalysisApiResolver\`)
- **PR 3.3**: \`analyzeFileWithPlugins\` RPC — wires loaded rules through \`KritRule.check\` with \`RuleContext\` populated from the request payload contexts