### PR TITLE
fix(profile): surface heap-profile Close errors

### DIFF
--- a/internal/cli/scan/profile.go
+++ b/internal/cli/scan/profile.go
@@ -61,9 +61,21 @@ func writeMemProfile(path string, errOut io.Writer) {
 		fmt.Fprintf(errOut, "error: could not create memory profile: %v\n", err)
 		return
 	}
-	defer f.Close()
+	writeMemProfileTo(f, path, errOut)
+}
+
+// writeMemProfileTo writes a heap profile to w, then closes it,
+// reporting both errors via errOut. Close is reported explicitly
+// because pprof flushes its buffered tail on Close — a silently
+// dropped Close error leaves the profile truncated on disk and the
+// pprof tool later refuses to parse it. Split out so tests can pass
+// a fake io.WriteCloser whose Close fails.
+func writeMemProfileTo(w io.WriteCloser, path string, errOut io.Writer) {
 	runtime.GC()
-	if err := pprof.WriteHeapProfile(f); err != nil {
+	if err := pprof.WriteHeapProfile(w); err != nil {
 		fmt.Fprintf(errOut, "error: could not write memory profile: %v\n", err)
+	}
+	if err := w.Close(); err != nil {
+		fmt.Fprintf(errOut, "error: could not close memory profile %s: %v\n", path, err)
 	}
 }

--- a/internal/cli/scan/profile_close_test.go
+++ b/internal/cli/scan/profile_close_test.go
@@ -1,0 +1,36 @@
+package scan
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+)
+
+type closingBuf struct {
+	bytes.Buffer
+	closeErr error
+}
+
+func (c *closingBuf) Close() error { return c.closeErr }
+
+func TestWriteMemProfileToSurfacesCloseError(t *testing.T) {
+	var errOut bytes.Buffer
+	w := &closingBuf{closeErr: errors.New("nfs writeback")}
+	writeMemProfileTo(w, "/tmp/mem.pprof", &errOut)
+	if !strings.Contains(errOut.String(), "could not close memory profile") {
+		t.Errorf("close error must reach errOut; got %q", errOut.String())
+	}
+	if !strings.Contains(errOut.String(), "nfs writeback") {
+		t.Errorf("close error must include underlying cause; got %q", errOut.String())
+	}
+}
+
+func TestWriteMemProfileToCleanCloseReportsNothing(t *testing.T) {
+	var errOut bytes.Buffer
+	w := &closingBuf{}
+	writeMemProfileTo(w, "/tmp/mem.pprof", &errOut)
+	if errOut.Len() != 0 {
+		t.Errorf("clean run must not write to errOut; got %q", errOut.String())
+	}
+}

--- a/internal/cli/serve/profile.go
+++ b/internal/cli/serve/profile.go
@@ -2,6 +2,7 @@ package serve
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"runtime"
 	"runtime/pprof"
@@ -65,10 +66,23 @@ func writeDaemonMemProfile(path string) []string {
 	if err != nil {
 		return []string{fmt.Sprintf("daemon mem profile create %s: %v", path, err)}
 	}
-	defer f.Close()
+	return writeDaemonMemProfileTo(f, path)
+}
+
+// writeDaemonMemProfileTo writes a heap profile to w, then closes it,
+// returning warnings for both write and close failures. Close is
+// reported explicitly because pprof flushes its buffered tail there
+// — a silently dropped Close error leaves the profile truncated on
+// disk and the pprof tool later refuses to parse it. Split out so
+// tests can pass a fake io.WriteCloser whose Close fails.
+func writeDaemonMemProfileTo(w io.WriteCloser, path string) []string {
 	runtime.GC()
-	if err := pprof.WriteHeapProfile(f); err != nil {
-		return []string{fmt.Sprintf("daemon mem profile write %s: %v", path, err)}
+	var warnings []string
+	if err := pprof.WriteHeapProfile(w); err != nil {
+		warnings = append(warnings, fmt.Sprintf("daemon mem profile write %s: %v", path, err))
 	}
-	return nil
+	if err := w.Close(); err != nil {
+		warnings = append(warnings, fmt.Sprintf("daemon mem profile close %s: %v", path, err))
+	}
+	return warnings
 }

--- a/internal/cli/serve/profile_close_test.go
+++ b/internal/cli/serve/profile_close_test.go
@@ -1,0 +1,35 @@
+package serve
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+)
+
+type closingBuf struct {
+	bytes.Buffer
+	closeErr error
+}
+
+func (c *closingBuf) Close() error { return c.closeErr }
+
+func TestWriteDaemonMemProfileToReportsCloseAsWarning(t *testing.T) {
+	w := &closingBuf{closeErr: errors.New("nfs writeback")}
+	warnings := writeDaemonMemProfileTo(w, "/tmp/mem.pprof")
+	if len(warnings) == 0 {
+		t.Fatal("close error must surface as a warning entry")
+	}
+	joined := strings.Join(warnings, "\n")
+	if !strings.Contains(joined, "daemon mem profile close") || !strings.Contains(joined, "nfs writeback") {
+		t.Errorf("close warning must name the phase and underlying cause; got %v", warnings)
+	}
+}
+
+func TestWriteDaemonMemProfileToCleanRunHasNoWarnings(t *testing.T) {
+	w := &closingBuf{}
+	warnings := writeDaemonMemProfileTo(w, "/tmp/mem.pprof")
+	if len(warnings) != 0 {
+		t.Errorf("clean run must produce no warnings; got %v", warnings)
+	}
+}


### PR DESCRIPTION
## Summary

`writeMemProfile` (scan) and `writeDaemonMemProfile` (serve) used `defer f.Close()` after `pprof.WriteHeapProfile`, dropping any Close error. pprof flushes its buffered tail on Close — a silent failure leaves the heap profile truncated on disk and the pprof tool later refuses to parse it while the verb reports no warnings.

- Extract `writeMemProfileTo` / `writeDaemonMemProfileTo` helpers that take `io.WriteCloser` and run `WriteHeapProfile` + explicit Close, reporting close errors via `errOut` (scan) or as a daemon warning (serve).
- Two unit tests per file inject failing-close behavior to lock in the contract.
- The CPU-profile path is unchanged: `stopCPUProfile` / `stopDaemonCPUProfile` intentionally swallow Close per their existing comment, because the profile bytes are already on disk by the time `pprof.StopCPUProfile` returns.

## Test plan

- [x] `go test ./internal/cli/scan/ -run TestWriteMemProfileTo -v` — green
- [x] `go test ./internal/cli/serve/ -run TestWriteDaemonMemProfileTo -v` — green
- [x] `go build`, `go vet ./...`, `golangci-lint run ./internal/cli/scan/ ./internal/cli/serve/` clean