### PR TITLE
fix(cache): surface config marshal failure in cache hash

### DIFF
--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"hash"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -307,18 +308,31 @@ func ComputeConfigHash(ruleNames []string, cfg *config.Config, editorConfigEnabl
 		h.Write([]byte("|editorconfig=true"))
 	}
 
-	// Include the full resolved config data so threshold changes invalidate the cache
+	// Include the full resolved config data so threshold changes invalidate the cache.
 	if cfg != nil {
-		if data := cfg.Data(); data != nil {
-			serialized, err := json.Marshal(data)
-			if err == nil {
-				h.Write([]byte("|config="))
-				h.Write(serialized)
-			}
-		}
+		mixConfigData(h, cfg.Data())
 	}
 
 	return hex.EncodeToString(h.Sum(nil))[:16]
+}
+
+// mixConfigData mixes the resolved config map into h. On marshal
+// failure a sentinel that includes the error string is mixed in
+// instead — silently dropping the config bytes would make a marshal
+// failure indistinguishable from "no config" and a stale hash would
+// let the cache report fresh findings against a changed config.
+func mixConfigData(h hash.Hash, data map[string]interface{}) {
+	if data == nil {
+		return
+	}
+	serialized, err := json.Marshal(data)
+	if err == nil {
+		_, _ = h.Write([]byte("|config="))
+		_, _ = h.Write(serialized)
+		return
+	}
+	_, _ = h.Write([]byte("|config-marshal-error="))
+	_, _ = h.Write([]byte(err.Error()))
 }
 
 // NeedsReanalysis checks whether a file needs to be re-analyzed.

--- a/internal/cache/config_hash_test.go
+++ b/internal/cache/config_hash_test.go
@@ -1,0 +1,61 @@
+package cache
+
+import (
+	"testing"
+
+	"github.com/kaeawc/krit/internal/hashutil"
+)
+
+func TestMixConfigDataIncludesMarshallableData(t *testing.T) {
+	h1 := hashutil.Hasher().New()
+	mixConfigData(h1, map[string]interface{}{"k": "v"})
+
+	h2 := hashutil.Hasher().New()
+	mixConfigData(h2, map[string]interface{}{"k": "different"})
+
+	if string(h1.Sum(nil)) == string(h2.Sum(nil)) {
+		t.Errorf("config data must influence hash; same hash for distinct configs")
+	}
+}
+
+func TestMixConfigDataMarshalFailureProducesDistinctHash(t *testing.T) {
+	// chan is unmarshalable; json.Marshal errors with
+	// "json: unsupported type: chan int".
+	bad := map[string]interface{}{"k": make(chan int)}
+
+	hBad := hashutil.Hasher().New()
+	mixConfigData(hBad, bad)
+	badSum := hBad.Sum(nil)
+
+	// Empty / missing-config hash MUST differ from the marshal-error
+	// hash. The previous implementation silently dropped the config
+	// bytes, making these two states indistinguishable.
+	hEmpty := hashutil.Hasher().New()
+	mixConfigData(hEmpty, nil)
+	if string(badSum) == string(hEmpty.Sum(nil)) {
+		t.Errorf("marshal-error hash must differ from no-config hash (silent drop is the bug)")
+	}
+
+	// And the marshal-error hash differs from any successfully
+	// serialised config — so the cache invalidates if a config
+	// changes from marshalable to unmarshalable.
+	hOK := hashutil.Hasher().New()
+	mixConfigData(hOK, map[string]interface{}{"k": "v"})
+	if string(badSum) == string(hOK.Sum(nil)) {
+		t.Errorf("marshal-error hash must differ from successfully-marshaled config hash")
+	}
+}
+
+func TestMixConfigDataMarshalErrorMessageMixedIn(t *testing.T) {
+	// The sentinel includes the error message, so two different
+	// marshal failures (different bad types) produce different
+	// hashes. Otherwise a single sentinel could mask multiple
+	// unrelated marshal regressions.
+	hChan := hashutil.Hasher().New()
+	mixConfigData(hChan, map[string]interface{}{"k": make(chan int)})
+	hFunc := hashutil.Hasher().New()
+	mixConfigData(hFunc, map[string]interface{}{"k": func() {}})
+	if string(hChan.Sum(nil)) == string(hFunc.Sum(nil)) {
+		t.Errorf("distinct marshal errors must produce distinct hashes")
+	}
+}


### PR DESCRIPTION
## Summary

`ComputeConfigHash` skipped the config bytes when `json.Marshal(cfg.Data())` returned an error. That made a marshal failure indistinguishable from "no config provided" — the hash stayed stable across a config change that newly introduced an unmarshalable field, and the cache reported stale findings as fresh.

Extracted `mixConfigData(h, data)`. On marshal success it writes the existing `|config=<bytes>` prefix; on failure it writes a sentinel `|config-marshal-error=<error string>` instead.

Three focused unit tests lock the contract in:
- marshal-error hash differs from no-config hash (the silent-drop bug),
- marshal-error hash differs from any successfully-marshaled config,
- distinct marshal errors produce distinct hashes (the error string is part of the sentinel), so one failure mode cannot mask later unrelated marshal regressions.

## Test plan

- [x] `go test ./internal/cache/ -run TestMixConfigData -v` — green
- [x] `go test ./internal/cache/ -count=1` — full package green
- [x] `go build`, `go vet ./...`, `golangci-lint run ./internal/cache/` clean