### PR TITLE
fix(oracle): decompile cache writes via fsutil.WriteFileAtomic

### DIFF
--- a/internal/oracle/decompile.go
+++ b/internal/oracle/decompile.go
@@ -10,6 +10,8 @@ import (
 	"sort"
 	"strings"
 	"sync"
+
+	"github.com/kaeawc/krit/internal/fsutil"
 )
 
 // Decompiler turns a {jar, fqn} pair into Kotlin-shaped source text. The
@@ -102,7 +104,7 @@ func (c *DecompileCache) Get(jarPath, fqn string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if err := writeFileAtomic(cachePath, []byte(src)); err != nil {
+	if err := writeDecompiledSourceAtomic(cachePath, []byte(src)); err != nil {
 		// Cache failures are non-fatal — the caller still gets a result.
 		return src, nil //nolint:nilerr // see comment: cache write failure surfaces nothing to caller, source is already decompiled
 	}
@@ -158,25 +160,17 @@ func fqnToFilename(fqn string) string {
 	return strings.ReplaceAll(fqn, ".", "/") + ".kt"
 }
 
-func writeFileAtomic(path string, data []byte) error {
+// writeDecompiledSourceAtomic creates any missing parent directories
+// and then delegates to fsutil.WriteFileAtomic so the cached
+// decompiled source survives a hard crash. The previous local helper
+// renamed without fsync of the tempfile or the parent directory,
+// which on power loss could leave the cache showing a clean write
+// while the file vanished or reverted on remount.
+func writeDecompiledSourceAtomic(path string, data []byte) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return err
 	}
-	tmp, err := os.CreateTemp(filepath.Dir(path), ".decompile-*")
-	if err != nil {
-		return err
-	}
-	tmpName := tmp.Name()
-	if _, err := tmp.Write(data); err != nil {
-		tmp.Close()
-		os.Remove(tmpName)
-		return err
-	}
-	if err := tmp.Close(); err != nil {
-		os.Remove(tmpName)
-		return err
-	}
-	return os.Rename(tmpName, path)
+	return fsutil.WriteFileAtomic(path, data, 0o644)
 }
 
 // SignatureStubDecompiler renders Kotlin-shaped source from the oracle's

--- a/internal/oracle/decompile_test.go
+++ b/internal/oracle/decompile_test.go
@@ -117,6 +117,51 @@ func TestSignatureStubDecompiler(t *testing.T) {
 	}
 }
 
+func TestWriteDecompiledSourceAtomicCreatesParentDirAndWrites(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "nested", "p", "Q.kt")
+	if err := writeDecompiledSourceAtomic(path, []byte("class Q\n")); err != nil {
+		t.Fatalf("writeDecompiledSourceAtomic: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(data) != "class Q\n" {
+		t.Errorf("content = %q, want %q", string(data), "class Q\n")
+	}
+	// fsutil.WriteFileAtomic renames the tempfile into place atomically;
+	// after a successful return no dot-prefixed temp entries should
+	// remain alongside the target.
+	entries, err := os.ReadDir(filepath.Dir(path))
+	if err != nil {
+		t.Fatalf("readdir: %v", err)
+	}
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), ".") && e.Name() != filepath.Base(path) {
+			t.Errorf("leftover temp entry after atomic write: %s", e.Name())
+		}
+	}
+}
+
+func TestWriteDecompiledSourceAtomicOverwritesExistingFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "Q.kt")
+	if err := os.WriteFile(path, []byte("stale\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeDecompiledSourceAtomic(path, []byte("fresh\n")); err != nil {
+		t.Fatalf("writeDecompiledSourceAtomic: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "fresh\n" {
+		t.Errorf("overwrite content = %q, want %q", string(data), "fresh\n")
+	}
+}
+
 func TestFallbackDecompilerFallsBackOnPrimaryError(t *testing.T) {
 	primary := &countingDecompiler{err: os.ErrNotExist}
 	fallback := &countingDecompiler{out: "fallback"}


### PR DESCRIPTION
## Summary

The local `writeFileAtomic` in `internal/oracle/decompile.go` forked from `fsutil.WriteFileAtomic` but lost the tempfile fsync and parent-directory fsync steps. After a power loss the cached decompiled source could vanish or revert even though the API reported a clean write.

- Delete the local helper and route through `fsutil.WriteFileAtomic` (Chmod + Sync + parent fsync).
- New `writeDecompiledSourceAtomic` wrapper keeps the prior `MkdirAll` behaviour the canonical helper omits.

## Test plan

- [x] Two regression tests cover nested-parent creation + no temp-file leftover after an atomic write, and the overwrite-existing case.
- [x] `go test ./internal/oracle/ -run TestWriteDecompiledSourceAtomic -v` — green
- [x] `go test ./internal/oracle/ -count=1` — green
- [x] `go build`, `go vet ./...`, `golangci-lint run ./internal/oracle/` clean