### PR TITLE
fix(librarymodel): pre-compile catalog version-accessor regexes

### DIFF
--- a/internal/librarymodel/catalog.go
+++ b/internal/librarymodel/catalog.go
@@ -689,51 +689,63 @@ func applyCatalogPlugin(profile *ProjectProfile, plugin CatalogPlugin) {
 	}
 }
 
+// catalogVersionAccessorSuffix / catalogKotlinVersionAccessorSuffix
+// are the two trailing regex shapes used by applyCatalogVersionAccessors.
+// Per-Gradle-file regex compilation was a measurable hot path on
+// multi-module projects — the eight final patterns are now compiled
+// once at package init.
+const (
+	catalogVersionAccessorSuffix       = `[^\n]*libs\.versions\.([A-Za-z0-9_.]+)\.get\s*\(`
+	catalogKotlinVersionAccessorSuffix = `(?s:.{0,300}?)KotlinVersion(?s:.{0,200}?)libs\.versions\.([A-Za-z0-9_.]+)\.get\s*\(`
+)
+
+var (
+	catalogAssignCompileSdkRe   = regexp.MustCompile(`compileSdk(?:Version)?\s*(?:=|\()` + catalogVersionAccessorSuffix)
+	catalogAssignTargetSdkRe    = regexp.MustCompile(`targetSdk(?:Version)?\s*(?:=|\()` + catalogVersionAccessorSuffix)
+	catalogAssignMinSdkRe       = regexp.MustCompile(`minSdk(?:Version)?\s*(?:=|\()` + catalogVersionAccessorSuffix)
+	catalogAssignJvmTargetRe    = regexp.MustCompile(`jvmTarget(?:\.set)?\s*(?:=|\()` + catalogVersionAccessorSuffix)
+	catalogAssignSourceCompatRe = regexp.MustCompile(`sourceCompatibility\s*(?:=|\()` + catalogVersionAccessorSuffix)
+	catalogAssignTargetCompatRe = regexp.MustCompile(`targetCompatibility\s*(?:=|\()` + catalogVersionAccessorSuffix)
+	catalogNearbyLanguageVerRe  = regexp.MustCompile(`languageVersion(?:\.set)?\s*(?:=|\()` + catalogKotlinVersionAccessorSuffix)
+	catalogNearbyAPIVerRe       = regexp.MustCompile(`apiVersion(?:\.set)?\s*(?:=|\()` + catalogKotlinVersionAccessorSuffix)
+)
+
 func applyCatalogVersionAccessors(profile *ProjectProfile, content string, catalog VersionCatalog) {
-	applyAssignmentVersion := func(pattern string, apply func(string)) {
-		re := regexp.MustCompile(pattern + `[^\n]*libs\.versions\.([A-Za-z0-9_.]+)\.get\s*\(`)
+	apply := func(re *regexp.Regexp, fn func(string)) {
 		for _, match := range re.FindAllStringSubmatch(content, -1) {
 			if version := catalog.Versions[catalogAccessorToAlias(match[1])]; version != "" {
-				apply(normalizeVersion(version))
+				fn(normalizeVersion(version))
 			}
 		}
 	}
-	applyNearbyKotlinVersion := func(pattern string, apply func(string)) {
-		re := regexp.MustCompile(pattern + `(?s:.{0,300}?)KotlinVersion(?s:.{0,200}?)libs\.versions\.([A-Za-z0-9_.]+)\.get\s*\(`)
-		for _, match := range re.FindAllStringSubmatch(content, -1) {
-			if version := catalog.Versions[catalogAccessorToAlias(match[1])]; version != "" {
-				apply(normalizeVersion(version))
-			}
-		}
-	}
-	applyAssignmentVersion(`compileSdk(?:Version)?\s*(?:=|\()`, func(version string) {
+	apply(catalogAssignCompileSdkRe, func(version string) {
 		profile.Android.CompileSDK = KnownVersion(version)
 		profile.CompileSdkVersion = parsePositiveInt(version, profile.CompileSdkVersion)
 	})
-	applyAssignmentVersion(`targetSdk(?:Version)?\s*(?:=|\()`, func(version string) {
+	apply(catalogAssignTargetSdkRe, func(version string) {
 		profile.Android.TargetSDK = KnownVersion(version)
 		profile.TargetSdkVersion = parsePositiveInt(version, profile.TargetSdkVersion)
 	})
-	applyAssignmentVersion(`minSdk(?:Version)?\s*(?:=|\()`, func(version string) {
+	apply(catalogAssignMinSdkRe, func(version string) {
 		profile.Android.MinSDK = KnownVersion(version)
 		profile.MinSdkVersion = parsePositiveInt(version, profile.MinSdkVersion)
 	})
-	applyAssignmentVersion(`jvmTarget(?:\.set)?\s*(?:=|\()`, func(version string) {
+	apply(catalogAssignJvmTargetRe, func(version string) {
 		profile.JVM.KotlinJvmTarget = KnownVersion(version)
 	})
-	applyAssignmentVersion(`sourceCompatibility\s*(?:=|\()`, func(version string) {
+	apply(catalogAssignSourceCompatRe, func(version string) {
 		profile.JVM.SourceCompatibility = KnownVersion(version)
 	})
-	applyAssignmentVersion(`targetCompatibility\s*(?:=|\()`, func(version string) {
+	apply(catalogAssignTargetCompatRe, func(version string) {
 		profile.JVM.TargetCompatibility = KnownVersion(version)
 	})
-	applyNearbyKotlinVersion(`languageVersion(?:\.set)?\s*(?:=|\()`, func(version string) {
+	apply(catalogNearbyLanguageVerRe, func(version string) {
 		profile.Kotlin.LanguageVersion = KnownVersion(version)
 		if strings.HasPrefix(version, "2.") {
 			profile.Kotlin.K2 = PresencePresent
 		}
 	})
-	applyNearbyKotlinVersion(`apiVersion(?:\.set)?\s*(?:=|\()`, func(version string) {
+	apply(catalogNearbyAPIVerRe, func(version string) {
 		profile.Kotlin.APIVersion = KnownVersion(version)
 	})
 }

--- a/internal/librarymodel/catalog_version_accessors_test.go
+++ b/internal/librarymodel/catalog_version_accessors_test.go
@@ -1,0 +1,132 @@
+package librarymodel
+
+import "testing"
+
+// TestApplyCatalogVersionAccessorsResolvesEightShapes covers the eight
+// SDK / JVM / Kotlin version-accessor patterns the regex registry
+// pre-compiles. Each input snippet uses a single Gradle DSL shape
+// and the test asserts the corresponding ProjectProfile field is
+// populated from the catalog version.
+func TestApplyCatalogVersionAccessorsResolvesEightShapes(t *testing.T) {
+	catalog := VersionCatalog{
+		Versions: map[string]string{
+			"compileSdk":          "34",
+			"targetSdk":           "33",
+			"minSdk":              "24",
+			"jvmTarget":           "17",
+			"sourceCompatibility": "11",
+			"targetCompatibility": "17",
+			"languageVersion":     "2.0",
+			"apiVersion":          "1.9",
+		},
+	}
+
+	cases := []struct {
+		name    string
+		content string
+		check   func(t *testing.T, p ProjectProfile)
+	}{
+		{
+			name:    "compileSdk-assignment",
+			content: `android { compileSdk = libs.versions.compileSdk.get() }`,
+			check: func(t *testing.T, p ProjectProfile) {
+				if p.CompileSdkVersion != 34 {
+					t.Errorf("CompileSdkVersion = %d, want 34", p.CompileSdkVersion)
+				}
+			},
+		},
+		{
+			name:    "targetSdk-assignment",
+			content: `android { targetSdk = libs.versions.targetSdk.get() }`,
+			check: func(t *testing.T, p ProjectProfile) {
+				if p.TargetSdkVersion != 33 {
+					t.Errorf("TargetSdkVersion = %d, want 33", p.TargetSdkVersion)
+				}
+			},
+		},
+		{
+			name:    "minSdk-assignment",
+			content: `defaultConfig { minSdk = libs.versions.minSdk.get() }`,
+			check: func(t *testing.T, p ProjectProfile) {
+				if p.MinSdkVersion != 24 {
+					t.Errorf("MinSdkVersion = %d, want 24", p.MinSdkVersion)
+				}
+			},
+		},
+		{
+			name:    "jvmTarget-set",
+			content: `kotlinOptions { jvmTarget.set(libs.versions.jvmTarget.get()) }`,
+			check: func(t *testing.T, p ProjectProfile) {
+				if p.JVM.KotlinJvmTarget.Presence != PresencePresent {
+					t.Errorf("KotlinJvmTarget must be populated")
+				}
+			},
+		},
+		{
+			name:    "sourceCompatibility",
+			content: `compileOptions { sourceCompatibility = libs.versions.sourceCompatibility.get() }`,
+			check: func(t *testing.T, p ProjectProfile) {
+				if p.JVM.SourceCompatibility.Presence != PresencePresent {
+					t.Errorf("SourceCompatibility must be populated")
+				}
+			},
+		},
+		{
+			name:    "targetCompatibility",
+			content: `compileOptions { targetCompatibility = libs.versions.targetCompatibility.get() }`,
+			check: func(t *testing.T, p ProjectProfile) {
+				if p.JVM.TargetCompatibility.Presence != PresencePresent {
+					t.Errorf("TargetCompatibility must be populated")
+				}
+			},
+		},
+		{
+			name: "languageVersion-nearby-KotlinVersion",
+			content: `kotlinOptions {
+				languageVersion = KotlinVersion.fromVersion(libs.versions.languageVersion.get())
+			}`,
+			check: func(t *testing.T, p ProjectProfile) {
+				if p.Kotlin.LanguageVersion.Presence != PresencePresent {
+					t.Errorf("Kotlin.LanguageVersion must be populated")
+				}
+				if p.Kotlin.K2 != PresencePresent {
+					t.Errorf("Kotlin.K2 must be PresencePresent for 2.x languageVersion, got %v", p.Kotlin.K2)
+				}
+			},
+		},
+		{
+			name: "apiVersion-nearby-KotlinVersion",
+			content: `kotlinOptions {
+				apiVersion = KotlinVersion.fromVersion(libs.versions.apiVersion.get())
+			}`,
+			check: func(t *testing.T, p ProjectProfile) {
+				if p.Kotlin.APIVersion.Presence != PresencePresent {
+					t.Errorf("Kotlin.APIVersion must be populated")
+				}
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var profile ProjectProfile
+			applyCatalogVersionAccessors(&profile, tc.content, catalog)
+			tc.check(t, profile)
+		})
+	}
+}
+
+func TestCatalogVersionAccessorRegexesArePackageLevelSingletons(t *testing.T) {
+	// Guard against a refactor moving the regex compile back into
+	// the function body (the original hot-path bug).
+	if catalogAssignCompileSdkRe == nil ||
+		catalogAssignTargetSdkRe == nil ||
+		catalogAssignMinSdkRe == nil ||
+		catalogAssignJvmTargetRe == nil ||
+		catalogAssignSourceCompatRe == nil ||
+		catalogAssignTargetCompatRe == nil ||
+		catalogNearbyLanguageVerRe == nil ||
+		catalogNearbyAPIVerRe == nil {
+		t.Fatal("catalog version-accessor regexes must be package-level vars")
+	}
+}


### PR DESCRIPTION
## Summary

`applyCatalogVersionAccessors` invoked `applyAssignmentVersion` and `applyNearbyKotlinVersion` via closures that rebuilt the same regex from the same string pattern on every call — eight regex compilations per Gradle file, all textually invariant. On a multi-module project with N module-level build files, that's 9N redundant compilations.

- Hoist the eight final patterns to package-level vars via shared suffix constants (`catalogVersionAccessorSuffix`, `catalogKotlinVersionAccessorSuffix`).
- Collapse the two closures into a single `apply(re, fn)` helper.

## Test plan

- [x] New table-driven test exercises all eight DSL shapes (compileSdk, targetSdk, minSdk, jvmTarget.set, sourceCompatibility, targetCompatibility, languageVersion-near-KotlinVersion, apiVersion-near-KotlinVersion) and asserts the regex vars stay package-level so a future refactor cannot move them back into the function body.
- [x] `go test ./internal/librarymodel/ -count=1` — green
- [x] `go build`, `go vet ./...`, `golangci-lint run ./internal/librarymodel/` clean