### PR TITLE
docs(serve): retire stale TODO on daemon-vs-CLI binary hash handshake

### DIFF
--- a/internal/cli/serve/serve.go
+++ b/internal/cli/serve/serve.go
@@ -39,14 +39,13 @@ var Version = "dev"
 
 // BinaryHashOverride, when non-empty, is returned by daemonBinaryHash()
 // in place of the hash of the running executable. cmd/krit-daemon sets
-// this to the hash of the sibling krit binary so the CLI-vs-daemon
-// handshake compares apples to apples (the CLI hashes its own
+// this to the CLI's hash advertised via --client-binary-hash (which
+// internal/cli/daemoncmd/start.go passes from computeCurrentBinaryHash),
+// falling back to a sibling krit-binary scan when the flag is empty
+// (e.g. third-party respawn). Both branches keep the CLI-vs-daemon
+// handshake comparing apples to apples — the CLI hashes its own
 // executable; daemonbinary != CLI binary in the krit-daemon-as-shim
-// topology). Empty disables the override.
-//
-// TODO(#247-followup): wire this from a --client-binary-hash flag on
-// krit-daemon so the daemon advertises the exact CLI hash it was
-// started against, not just a sibling lookup that races CLI rebuilds.
+// topology. Empty disables the override.
 var BinaryHashOverride string
 
 // daemonBinaryHash returns the SHA-256 hex digest of the krit binary


### PR DESCRIPTION
## Summary

While working through a bug-list item that flagged the TODO in `internal/cli/serve/serve.go:47` as outstanding ("wire this from a `--client-binary-hash` flag on `krit-daemon` so the daemon advertises the exact CLI hash it was started against, not just a sibling lookup that races CLI rebuilds"), I traced the code and found the flag was already wired end to end:

- [cmd/krit-daemon/main.go:51](cmd/krit-daemon/main.go:51) parses `--client-binary-hash` and assigns it to `serve.BinaryHashOverride`. The sibling-binary scan only runs as a fallback when the flag is empty.
- [internal/cli/daemoncmd/start.go:73](internal/cli/daemoncmd/start.go:73) computes `computeCurrentBinaryHash()` (the CLI's own hash) and passes it as `--client-binary-hash` on every spawn.

Updated the comment to describe the actual two-branch resolution order so future readers don't believe the handshake still races CLI rebuilds. No behaviour change; the existing `tryconnect_test` suite already exercises the handshake against fake daemon-side hashes.

## Test plan

- [x] `go build`, `go vet ./...`, `golangci-lint run ./internal/cli/serve/` clean
- [x] No code path changed; existing daemonclient/serve tests cover the handshake.