### PR TITLE
fix(bisect): drop backwards HasSuffix in inferModuleFromTestPath

### DIFF
--- a/internal/bisect/bisect.go
+++ b/internal/bisect/bisect.go
@@ -305,12 +305,20 @@ func testOwnsModuleSignals(in Input, blob *snapshot.Blob) []Signal {
 
 func inferModuleFromTestPath(blob *snapshot.Blob, path string) string {
 	for _, marker := range []string{"/src/test/", "/src/androidTest/", "/src/integrationTest/"} {
-		if i := strings.Index(path, marker); i > 0 {
-			prefix := path[:i]
-			for _, m := range blob.Modules {
-				if m.Dir == prefix || strings.HasSuffix(m.Dir, prefix) || strings.HasSuffix(prefix, strings.TrimPrefix(m.Dir, "./")) {
-					return m.Path
-				}
+		i := strings.Index(path, marker)
+		if i <= 0 {
+			continue
+		}
+		prefix := path[:i]
+		for _, m := range blob.Modules {
+			// The test file's prefix (the absolute path up to the
+			// /src/test/ marker) must equal the module dir or have it
+			// as a path suffix. The previous middle clause
+			// `HasSuffix(m.Dir, prefix)` was backwards and would
+			// attribute the test to any sibling module whose dir
+			// happened to end with the test-prefix string.
+			if m.Dir == prefix || strings.HasSuffix(prefix, strings.TrimPrefix(m.Dir, "./")) {
+				return m.Path
 			}
 		}
 	}

--- a/internal/bisect/infer_module_test.go
+++ b/internal/bisect/infer_module_test.go
@@ -1,0 +1,95 @@
+package bisect
+
+import (
+	"testing"
+
+	"github.com/kaeawc/krit/internal/snapshot"
+)
+
+// TestInferModuleFromTestPathMatchesAbsolutePrefix exercises the happy
+// path: a test file under a module's src/test directory should
+// resolve to that module via the prefix-suffix match.
+func TestInferModuleFromTestPathMatchesAbsolutePrefix(t *testing.T) {
+	blob := &snapshot.Blob{
+		Modules: []snapshot.Module{
+			{Path: ":app", Dir: "/repo/app"},
+		},
+	}
+	got := inferModuleFromTestPath(blob, "/repo/app/src/test/kotlin/foo/Bar.kt")
+	if got != ":app" {
+		t.Errorf("expected :app, got %q", got)
+	}
+}
+
+func TestInferModuleFromTestPathMatchesRelativeDir(t *testing.T) {
+	blob := &snapshot.Blob{
+		Modules: []snapshot.Module{
+			{Path: ":app", Dir: "./app"},
+		},
+	}
+	got := inferModuleFromTestPath(blob, "/repo/app/src/test/kotlin/Bar.kt")
+	if got != ":app" {
+		t.Errorf("expected :app, got %q", got)
+	}
+}
+
+// TestInferModuleFromTestPathRejectsBackwardsSuffixMatch is the
+// regression for the bug: the previous middle clause
+// `HasSuffix(m.Dir, prefix)` would attribute a test file under one
+// module to any unrelated module whose Dir happened to end with the
+// test-file's parent prefix string. With that clause removed, only
+// the actually-owning module wins.
+func TestInferModuleFromTestPathRejectsBackwardsSuffixMatch(t *testing.T) {
+	// Two modules: :owner whose dir matches the test-file prefix,
+	// and :unrelated whose Dir is exactly equal to the test-file
+	// prefix string (so the buggy clause `HasSuffix(m.Dir, prefix)`
+	// also matched). The buggy code would return whichever module
+	// came first in the slice; the fixed code returns only :owner.
+	blob := &snapshot.Blob{
+		Modules: []snapshot.Module{
+			// Put the lookalike first so the buggy iteration would
+			// have returned it. The prefix equals m.Dir, which
+			// trivially matches both `m.Dir == prefix` and the
+			// backwards `HasSuffix(m.Dir, prefix)` clause. We must
+			// also keep the third clause from matching: trimming
+			// "./" gives "lookalike/repo/owner", which is not a
+			// suffix of the prefix.
+			{Path: ":lookalike", Dir: "./lookalike/repo/owner"},
+			{Path: ":owner", Dir: "/repo/owner"},
+		},
+	}
+	got := inferModuleFromTestPath(blob, "/repo/owner/src/test/kotlin/Bar.kt")
+	if got != ":owner" {
+		t.Errorf("expected :owner (path-suffix match), got %q (backwards-suffix bug)", got)
+	}
+}
+
+func TestInferModuleFromTestPathReturnsEmptyWhenNoModuleMatches(t *testing.T) {
+	blob := &snapshot.Blob{
+		Modules: []snapshot.Module{
+			{Path: ":other", Dir: "/repo/other"},
+		},
+	}
+	got := inferModuleFromTestPath(blob, "/repo/app/src/test/kotlin/Bar.kt")
+	if got != "" {
+		t.Errorf("expected empty (no match), got %q", got)
+	}
+}
+
+func TestInferModuleFromTestPathRespectsAndroidAndIntegrationMarkers(t *testing.T) {
+	blob := &snapshot.Blob{
+		Modules: []snapshot.Module{
+			{Path: ":app", Dir: "/repo/app"},
+		},
+	}
+	cases := []string{
+		"/repo/app/src/test/kotlin/Bar.kt",
+		"/repo/app/src/androidTest/kotlin/Bar.kt",
+		"/repo/app/src/integrationTest/kotlin/Bar.kt",
+	}
+	for _, p := range cases {
+		if got := inferModuleFromTestPath(blob, p); got != ":app" {
+			t.Errorf("expected :app for %q, got %q", p, got)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

The middle clause of the module-attribution match, `HasSuffix(m.Dir, prefix)`, asks "does this module dir end with the test file's parent prefix path", which is backwards: the test file's prefix is the longer string and should suffix-contain the module dir, not the other way around. The clause attributed a test file to the wrong module whenever a sibling module's `Dir` happened to end with the test-file prefix string (a real shape on multi-checkout snapshots where `Dir` captures the full sub-path).

Drop the backwards clause. The exact-equality and `HasSuffix(prefix, TrimPrefix(m.Dir, "./"))` branches cover the intended cases.

## Test plan

- Regression test (`TestInferModuleFromTestPathRejectsBackwardsSuffixMatch`) sets up a lookalike module whose Dir trivially satisfies the buggy clause and confirms the real owner wins. Verified the test fails on the unfixed code with the literal value `":lookalike"`.
- [x] `go test ./internal/bisect/ -run TestInferModuleFromTestPath -v` — all 5 cases green
- [x] `go test ./internal/bisect/ -count=1` — full package green
- [x] `go build`, `go vet ./...`, `golangci-lint run ./internal/bisect/` clean