### PR TITLE
fix(rules): parseGradleCoordinate returns parts[2] as version

### DIFF
--- a/internal/rules/parse_gradle_coordinate_test.go
+++ b/internal/rules/parse_gradle_coordinate_test.go
@@ -1,0 +1,82 @@
+package rules
+
+import "testing"
+
+func TestParseGradleCoordinate(t *testing.T) {
+	cases := []struct {
+		name        string
+		input       string
+		wantGroup   string
+		wantName    string
+		wantVersion string
+		wantOK      bool
+	}{
+		{
+			name:        "three-part-canonical",
+			input:       "com.example:lib:1.2.3",
+			wantGroup:   "com.example",
+			wantName:    "lib",
+			wantVersion: "1.2.3",
+			wantOK:      true,
+		},
+		{
+			name:        "four-part-classifier",
+			input:       "com.example:lib:1.2.3:sources",
+			wantGroup:   "com.example",
+			wantName:    "lib",
+			wantVersion: "1.2.3",
+			wantOK:      true,
+		},
+		{
+			name:        "four-part-aar-extension-after-split",
+			input:       "com.example:lib:1.2.3:aar",
+			wantGroup:   "com.example",
+			wantName:    "lib",
+			wantVersion: "1.2.3",
+			wantOK:      true,
+		},
+		{
+			name:        "trims-whitespace",
+			input:       " com.example : lib : 1.2.3 ",
+			wantGroup:   "com.example",
+			wantName:    "lib",
+			wantVersion: "1.2.3",
+			wantOK:      true,
+		},
+		{
+			name:   "too-few-parts-is-not-ok",
+			input:  "com.example:lib",
+			wantOK: false,
+		},
+		{
+			name:   "empty-group-fails",
+			input:  ":lib:1.2.3",
+			wantOK: false,
+		},
+		{
+			name:   "empty-name-fails",
+			input:  "com.example::1.2.3",
+			wantOK: false,
+		},
+		{
+			name:   "empty-version-fails",
+			input:  "com.example:lib:",
+			wantOK: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			g, n, v, ok := parseGradleCoordinate(tc.input)
+			if ok != tc.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tc.wantOK)
+			}
+			if !tc.wantOK {
+				return
+			}
+			if g != tc.wantGroup || n != tc.wantName || v != tc.wantVersion {
+				t.Errorf("parseGradleCoordinate(%q) = (%q, %q, %q), want (%q, %q, %q)",
+					tc.input, g, n, v, tc.wantGroup, tc.wantName, tc.wantVersion)
+			}
+		})
+	}
+}

--- a/internal/rules/supply_dependencies.go
+++ b/internal/rules/supply_dependencies.go
@@ -617,9 +617,16 @@ func parseGradleCoordinate(raw string) (group, name, version string, ok bool) {
 	if len(parts) < 3 {
 		return "", "", "", false
 	}
+	// Gradle coordinates can be 3- or 4-part:
+	//   group:name:version
+	//   group:name:version:classifier   (or  group:name:version@ext after split)
+	// The previous version picked parts[len-1] and would return the
+	// classifier ("sources") as the version on a 4-part coord, then
+	// supply-chain rules would compare the wrong string against advisory
+	// data.
 	group = strings.TrimSpace(parts[0])
 	name = strings.TrimSpace(parts[1])
-	version = strings.TrimSpace(parts[len(parts)-1])
+	version = strings.TrimSpace(parts[2])
 	return group, name, version, group != "" && name != "" && version != ""
 }
 


### PR DESCRIPTION
## Summary

`parseGradleCoordinate` read `parts[len-1]` as the version. On a 4-part Gradle coordinate like `group:name:version:classifier` (or `group:name:version@ext` after the split) that returned the classifier (`sources`) or extension (`aar`) instead of the actual version. Supply-chain rules then compared the wrong string against advisory data, producing false positives and missing real positives.

Anchor version at `parts[2]` now that the `len(parts) >= 3` guard already holds; classifier / extension live at `parts[3:]` and are ignored, matching Gradle semantics.

## Test plan

- [x] New table test covers 3-part canonical, two 4-part shapes (`sources` classifier and `aar` extension), whitespace trimming, and four `not enough / empty fields` rejection cases.
- [x] `go test ./internal/rules/ -run TestParseGradleCoordinate -v` — all 8 cases green
- [x] `go test ./internal/rules/ -count=1` — full package green
- [x] `make lint-rules` clean
- [x] `go build`, `go vet ./...`, `golangci-lint run ./internal/rules/` clean