### PR TITLE
fix(logger): Capture.With shares parent's record buffer

### DIFF
--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -103,17 +103,29 @@ type Record struct {
 }
 
 // Capture is a Logger that buffers records in memory for assertion. Safe for
-// concurrent use.
+// concurrent use. Children produced by With share the parent's record
+// buffer (and mutex) — all records, including those emitted through any
+// derived child, land in the same place where tests read them.
 type Capture struct {
 	level slog.Level
 	with  []any
+	*captureState
+}
 
+// captureState holds the shared mutable state for a Capture and every
+// child created via With. Holding the buffer behind a pointer is what
+// gives a child the documented "all entries land in one place"
+// semantics; an inline mu+slice in Capture would silently fork on
+// every With call.
+type captureState struct {
 	mu      sync.Mutex
 	records []Record
 }
 
 // NewCapture returns a Capture that records every entry at level or above.
-func NewCapture(level slog.Level) *Capture { return &Capture{level: level} }
+func NewCapture(level slog.Level) *Capture {
+	return &Capture{level: level, captureState: &captureState{}}
+}
 
 // Records returns a snapshot of every captured record.
 func (c *Capture) Records() []Record {
@@ -161,16 +173,15 @@ func (c *Capture) Info(msg string, args ...any)  { c.record(slog.LevelInfo, msg,
 func (c *Capture) Warn(msg string, args ...any)  { c.record(slog.LevelWarn, msg, args) }
 func (c *Capture) Error(msg string, args ...any) { c.record(slog.LevelError, msg, args) }
 
-// With returns a child Capture that prepends args to every record. The child
-// shares the parent's record buffer so all entries land in one place.
+// With returns a child Capture that prepends args to every record.
+// The child shares the parent's record buffer so all entries — across
+// parent and every descendant — land in one place where Records,
+// HasMessage, FilterLevel, and Reset see them together.
 func (c *Capture) With(args ...any) Logger {
 	return &Capture{
-		level:   c.level,
-		with:    slices.Concat(c.with, args),
-		mu:      sync.Mutex{},
-		records: nil,
-		// Note: child writes its own records; merge across parents via
-		// the same Capture by passing it directly instead of branching.
+		level:        c.level,
+		with:         slices.Concat(c.with, args),
+		captureState: c.captureState,
 	}
 }
 

--- a/internal/logger/logger_test.go
+++ b/internal/logger/logger_test.go
@@ -156,6 +156,57 @@ func TestFromSlogPassesThrough(t *testing.T) {
 	}
 }
 
+// TestCaptureWithSharesRecordBufferWithParent locks in the documented
+// contract: a child Capture created via With must record into the
+// same buffer the parent exposes via Records / HasMessage, and into
+// the same mutex so concurrent writes interleave safely. The prior
+// implementation forked a fresh records slice on every With call,
+// silently dropping child entries from any assertion that read the
+// parent.
+func TestCaptureWithSharesRecordBufferWithParent(t *testing.T) {
+	parent := NewCapture(slog.LevelDebug)
+	child := parent.With("svc", "auth")
+	parent.Info("parent-msg", "k", 1)
+	child.Warn("child-msg", "n", 2)
+
+	recs := parent.Records()
+	if len(recs) != 2 {
+		t.Fatalf("parent.Records() len = %d, want 2 (parent + child share buffer)", len(recs))
+	}
+	if !parent.HasMessage("parent-msg") || !parent.HasMessage("child-msg") {
+		t.Errorf("parent must observe both messages: %+v", recs)
+	}
+
+	// The child's prepended args are merged into its records only.
+	var childRec Record
+	for _, r := range recs {
+		if r.Msg == "child-msg" {
+			childRec = r
+			break
+		}
+	}
+	if got := childRec.Attrs["svc"]; got != "auth" {
+		t.Errorf("child must prepend its With-args; got svc=%v", got)
+	}
+	if got := childRec.Attrs["n"]; got != 2 {
+		t.Errorf("child must preserve its call-site args; got n=%v", got)
+	}
+
+	// Reset on the parent (or any sibling) must clear the shared
+	// buffer for every view.
+	parent.Reset()
+	if len(parent.Records()) != 0 {
+		t.Error("parent.Reset must clear the shared buffer")
+	}
+	if asCapture, ok := child.(*Capture); ok {
+		if len(asCapture.Records()) != 0 {
+			t.Error("child must see the reset because the buffer is shared")
+		}
+	} else {
+		t.Fatalf("With(...) must return *Capture for this assertion (got %T)", child)
+	}
+}
+
 func TestLoggerEnabledOnSlogImpl(t *testing.T) {
 	var buf bytes.Buffer
 	l := New(Config{Writer: &buf, Format: FormatJSON, Level: slog.LevelWarn})


### PR DESCRIPTION
## Summary

The docstring promised "the child shares the parent's record buffer so all entries land in one place" but the implementation returned a fresh `Capture` with `records: nil` and its own mutex. Tests that asserted via the parent silently missed every child record, and the inline note even contradicted the docstring ("child writes its own records").

- Hoist the mutable state (`mu`, `records`) behind an embedded `*captureState` pointer.
- `NewCapture` initialises a fresh state; `With` forwards that pointer to the child so `Records` / `HasMessage` / `FilterLevel` / `Reset` on any view operate over the same buffer.

## Test plan

- [x] New `TestCaptureWithSharesRecordBufferWithParent` covers: parent + child both land in `Records`, child merges its With-args correctly, and `Reset` on either view clears the shared buffer.
- [x] `go test ./internal/logger/ -count=1 -v` — all existing tests still pass
- [x] `go build`, `go vet ./...`, `golangci-lint run ./internal/logger/` clean