### PR TITLE
feat(krit-fir): analyzeFile RPC runs plugin rules end-to-end

### DIFF
--- a/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/Main.kt
+++ b/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/Main.kt
@@ -1,8 +1,11 @@
 package dev.jasonpearson.krit.fir
 
+import dev.jasonpearson.krit.api.KritFile
 import dev.jasonpearson.krit.fir.oracle.OracleResponse
 import dev.jasonpearson.krit.fir.plugins.PluginResponse
 import dev.jasonpearson.krit.fir.plugins.PluginRuleRegistry
+import dev.jasonpearson.krit.fir.plugins.PluginRuleRunner
+import java.io.File as JavaFile
 import dev.jasonpearson.krit.fir.runner.AnalysisSession
 import dev.jasonpearson.krit.fir.runner.BatchResult
 import dev.jasonpearson.krit.fir.runner.FileRef
@@ -214,6 +217,10 @@ fun handleRequestLine(trimmed: String, session: AnalysisSession, startTime: Long
                 }
                 RequestResult.Response(response)
             }
+            "analyzeFile" -> {
+                val response = handleAnalyzeFile(request)
+                RequestResult.Response(response)
+            }
             else -> RequestResult.Response("""{"id":${request.id},"error":"Unknown command: ${escJson(request.command)}"}""")
         }
     } catch (e: Exception) {
@@ -232,8 +239,12 @@ data class CheckRequest(
     val classpath: List<String> = emptyList(),
     val rules: List<String> = emptyList(),
     // Plugin-rule jar paths, matching krit-types' `"jars"` array in
-    // `listPlugins` / `analyzeFileWithPlugins` requests.
+    // `listPlugins` / `analyzeFile` requests.
     val pluginJars: List<String> = emptyList(),
+    // analyzeFile (plugin-rule execution) payload.
+    val path: String? = null,
+    val source: String? = null,
+    val ruleIds: List<String>? = null,
 )
 
 fun parseRequest(json: String): CheckRequest {
@@ -243,8 +254,38 @@ fun parseRequest(json: String): CheckRequest {
     val classpath = extractStringArray(json, "classpath") ?: emptyList()
     val rules = extractStringArray(json, "rules") ?: emptyList()
     val pluginJars = extractStringArray(json, "jars") ?: emptyList()
+    val ruleIds = extractStringArray(json, "ruleIds")
+    val path = extractString(json, "path")
+    val source = extractString(json, "source")
     val files = extractFileRefs(json)
-    return CheckRequest(id, command, files, sourceDirs, classpath, rules, pluginJars)
+    return CheckRequest(id, command, files, sourceDirs, classpath, rules, pluginJars, path, source, ruleIds)
+}
+
+internal fun handleAnalyzeFile(request: CheckRequest): String {
+    val path = request.path
+    if (path.isNullOrBlank()) {
+        return """{"id":${request.id},"error":"analyzeFile requires path"}"""
+    }
+    return try {
+        PluginRuleRegistry.load(request.pluginJars)
+        val text = request.source ?: try {
+            JavaFile(path).readText()
+        } catch (t: Throwable) {
+            return """{"id":${request.id},"error":"analyzeFile could not read source for ${escJson(path)}: ${escJson(t.message ?: "io error")}"}"""
+        }
+        if (text.isBlank()) {
+            return """{"id":${request.id},"error":"analyzeFile could not resolve source for ${escJson(path)}"}"""
+        }
+        // PSI parsing and the FIR-backed Resolver land in PR 3.3. For
+        // now line-scanner-style rules work end-to-end; rules that
+        // expect a non-null `KritFile.ktFile` or `RuleContext.resolver`
+        // see them as null and either degrade gracefully or no-op.
+        val file = KritFile(path = path, text = text, ktFile = null)
+        val outcome = PluginRuleRunner.run(file, request.ruleIds, ruleConfigs = null)
+        PluginResponse.buildAnalyzeFile(request.id, outcome.findings, outcome.errors)
+    } catch (t: Throwable) {
+        """{"id":${request.id},"error":"${escJson(t.message ?: "analyzeFile failed")}"}"""
+    }
 }
 
 // ── Response building ─────────────────────────────────────────────────────────

--- a/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/plugins/PluginResponse.kt
+++ b/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/plugins/PluginResponse.kt
@@ -7,6 +7,55 @@ package dev.jasonpearson.krit.fir.plugins
  */
 internal object PluginResponse {
 
+    /**
+     * Build the `analyzeFileWithPlugins` response. Mirrors krit-types'
+     * `buildAnalyzeFileResponse`: a `findings` array (with optional
+     * per-finding `fix` metadata) plus an optional `errors` map keyed
+     * by rule ID for rules that threw mid-`check`.
+     */
+    fun buildAnalyzeFile(
+        id: Long,
+        findings: List<PluginRuleRunner.PluginFinding>,
+        errors: Map<String, String>,
+    ): String {
+        val sb = StringBuilder()
+        sb.append("""{"id":""").append(id).append(""","result":{"findings":[""")
+        findings.forEachIndexed { i, f ->
+            if (i > 0) sb.append(',')
+            sb.append('{')
+            sb.append("\"file\":").append(jsonString(f.file)).append(',')
+            sb.append("\"line\":").append(f.line).append(',')
+            sb.append("\"column\":").append(f.column).append(',')
+            sb.append("\"startByte\":").append(f.startByte).append(',')
+            sb.append("\"endByte\":").append(f.endByte).append(',')
+            sb.append("\"ruleSet\":").append(jsonString(f.ruleSet)).append(',')
+            sb.append("\"ruleId\":").append(jsonString(f.ruleId)).append(',')
+            sb.append("\"severity\":").append(jsonString(f.severity)).append(',')
+            sb.append("\"message\":").append(jsonString(f.message)).append(',')
+            sb.append("\"confidence\":").append(f.confidence)
+            f.fix?.let { fix ->
+                sb.append(",\"fix\":{")
+                sb.append("\"startLine\":").append(fix.startLine).append(',')
+                sb.append("\"endLine\":").append(fix.endLine).append(',')
+                sb.append("\"replacement\":").append(jsonString(fix.replacement)).append(',')
+                sb.append("\"safety\":").append(jsonString(fix.safety))
+                sb.append('}')
+            }
+            sb.append('}')
+        }
+        sb.append(']')
+        if (errors.isNotEmpty()) {
+            sb.append(",\"errors\":{")
+            errors.entries.forEachIndexed { i, (ruleId, msg) ->
+                if (i > 0) sb.append(',')
+                sb.append(jsonString(ruleId)).append(':').append(jsonString(msg))
+            }
+            sb.append('}')
+        }
+        sb.append("}}")
+        return sb.toString()
+    }
+
     fun buildListPlugins(
         id: Long,
         descriptors: List<PluginRuleDescriptor>,

--- a/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/plugins/PluginRuleRunner.kt
+++ b/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/plugins/PluginRuleRunner.kt
@@ -1,0 +1,120 @@
+package dev.jasonpearson.krit.fir.plugins
+
+import dev.jasonpearson.krit.api.Finding
+import dev.jasonpearson.krit.api.FixSafety
+import dev.jasonpearson.krit.api.KritFile
+import dev.jasonpearson.krit.api.RuleContext
+
+/**
+ * Driver for the `analyzeFileWithPlugins` RPC. Wires loaded plugin
+ * rules ([PluginRuleRegistry]) through the [RuleContext] / [Finding]
+ * surface that lives in `krit-rule-api`, then produces a wire-shape
+ * response matching krit-types' `buildAnalyzeFileResponse`.
+ *
+ * Current scope (PR 3.2):
+ *
+ * - Rules run with `ktFile = null` and `resolver = null`. Tree-sitter-
+ *   style line-scanner rules work today; rules that opt into
+ *   `NEEDS_RESOLVER` or expect PSI get the corresponding fields as
+ *   null and either degrade gracefully or no-op.
+ * - PSI parsing and a real FIR-backed [Resolver] land in PR 3.3.
+ * - Project-scope payload contexts (`gradle`, `manifest`, `resources`,
+ *   `moduleIndex`, `crossFile`) also land in PR 3.3 alongside the
+ *   request parsers for them.
+ */
+internal object PluginRuleRunner {
+
+    /**
+     * Execute the selected plugin rules against [file] and return both
+     * the emitted findings and any per-rule execution failures
+     * (caught Throwables) keyed by rule ID.
+     */
+    fun run(
+        file: KritFile,
+        ruleIds: List<String>?,
+        ruleConfigs: Map<String, Map<String, Any?>>?,
+    ): RunResult {
+        val findings = mutableListOf<PluginFinding>()
+        val errors = linkedMapOf<String, String>()
+        for (loaded in PluginRuleRegistry.selected(ruleIds)) {
+            val options = ruleConfigs?.get(loaded.descriptor.ruleId).orEmpty()
+            // resolver and the project-scope context fields stay null
+            // on the krit-fir backend today. A rule that declared the
+            // matching `NEEDS_*` capability passed the load-time gate;
+            // we just don't provide the fact yet. PSI parsing and the
+            // FIR-backed Resolver land in PR 3.3.
+            val ctx = RuleContext(
+                ruleId = loaded.descriptor.ruleId,
+                config = options,
+            )
+            try {
+                for (finding in loaded.rule.check(file, ctx)) {
+                    findings.add(toPluginFinding(file.path, loaded.descriptor, finding))
+                }
+            } catch (t: Throwable) {
+                errors[loaded.descriptor.ruleId] = t.message ?: "rule failed"
+            }
+        }
+        return RunResult(findings, errors)
+    }
+
+    data class RunResult(
+        val findings: List<PluginFinding>,
+        val errors: Map<String, String>,
+    )
+
+    /**
+     * Wire representation of a finding emitted by a plugin rule.
+     * Shape matches krit-types' `PluginFinding` so the Go-side client
+     * unmarshals either backend's response with one struct.
+     */
+    data class PluginFinding(
+        val file: String,
+        val line: Int,
+        val column: Int,
+        val startByte: Int,
+        val endByte: Int,
+        val ruleSet: String,
+        val ruleId: String,
+        val severity: String,
+        val message: String,
+        val confidence: Double,
+        val fix: PluginFix?,
+    )
+
+    data class PluginFix(
+        val startLine: Int,
+        val endLine: Int,
+        val replacement: String,
+        val safety: String,
+    )
+
+    private fun toPluginFinding(
+        path: String,
+        descriptor: PluginRuleDescriptor,
+        finding: Finding,
+    ): PluginFinding = PluginFinding(
+        file = path,
+        line = finding.line,
+        column = finding.column,
+        startByte = finding.startByte,
+        endByte = finding.endByte,
+        ruleSet = descriptor.category,
+        ruleId = descriptor.ruleId,
+        severity = descriptor.severity,
+        message = finding.message,
+        confidence = finding.confidence,
+        fix = finding.fix?.let {
+            PluginFix(
+                startLine = it.startLine,
+                endLine = it.endLine,
+                replacement = it.replacement,
+                safety = when (it.safety) {
+                    FixSafety.COSMETIC -> "cosmetic"
+                    FixSafety.IDIOMATIC -> "idiomatic"
+                    FixSafety.SEMANTIC -> "semantic"
+                },
+            )
+        },
+    )
+}

--- a/tools/krit-fir/src/test/kotlin/dev/jasonpearson/krit/fir/OracleDispatchTest.kt
+++ b/tools/krit-fir/src/test/kotlin/dev/jasonpearson/krit/fir/OracleDispatchTest.kt
@@ -64,6 +64,26 @@ class OracleDispatchTest {
     }
 
     @Test
+    fun analyzeFileWithMissingPathReturnsError() {
+        val request = """{"id":21,"command":"analyzeFile"}"""
+        val result = handleRequestLine(request, session, startTime = 0L)
+        val response = (result as RequestResult.Response).json
+        assertTrue(""""error":"analyzeFile requires path"""" in response, response)
+    }
+
+    @Test
+    fun analyzeFileWithNoPluginsReturnsEmptyFindings() {
+        // No plugin jars loaded → no rules to run → response carries
+        // an empty findings array. The handler short-circuits before
+        // touching K2 / PSI.
+        val request = """{"id":22,"command":"analyzeFile","path":"/tmp/x.kt","source":"fun x() {}"}"""
+        val result = handleRequestLine(request, session, startTime = 0L)
+        val response = (result as RequestResult.Response).json
+        assertTrue(response.startsWith("""{"id":22,"result":{"findings":["""), response)
+        assertFalse(""""error":""" in response, response)
+    }
+
+    @Test
     fun listPluginsCommandReturnsEmptyRulesWhenNoJarsProvided() {
         // Zero pluginJars → the registry has nothing to load, and the
         // response carries an empty `rules` array. The shape mirrors

--- a/tools/krit-fir/src/test/kotlin/dev/jasonpearson/krit/fir/plugins/PluginRuleRunnerTest.kt
+++ b/tools/krit-fir/src/test/kotlin/dev/jasonpearson/krit/fir/plugins/PluginRuleRunnerTest.kt
@@ -1,0 +1,304 @@
+package dev.jasonpearson.krit.fir.plugins
+
+import dev.jasonpearson.krit.api.KritFile
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import java.nio.file.Path
+import java.util.jar.Attributes
+import java.util.jar.JarOutputStream
+import java.util.jar.Manifest
+import java.util.zip.ZipEntry
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * End-to-end coverage for the analyzeFile RPC: a real plugin JAR is
+ * compiled at test time, loaded into [PluginRuleRegistry], and
+ * executed against a synthetic Kotlin source. We verify the wire
+ * shape that ships back through [PluginResponse.buildAnalyzeFile]
+ * mirrors krit-types' `buildAnalyzeFileResponse`.
+ */
+class PluginRuleRunnerTest {
+
+    @TempDir
+    lateinit var tmp: Path
+
+    @BeforeEach
+    fun resetRegistryBefore() {
+        PluginRuleRegistry.resetForTesting()
+    }
+
+    @AfterEach
+    fun resetRegistryAfter() {
+        PluginRuleRegistry.resetForTesting()
+    }
+
+    @Test
+    fun lineScannerRuleProducesFindingsWithoutPsiOrResolver() {
+        // The rule below scans the file text for "FORBIDDEN" and
+        // emits one finding per match. It doesn't need PSI or a
+        // Resolver — i.e. the exact rule shape PR 3.2 targets.
+        val jar = buildLineScannerJar("ForbiddenWordRule")
+        PluginRuleRegistry.load(listOf(jar.absolutePath))
+
+        val file = KritFile(
+            path = "/tmp/Sample.kt",
+            text = "val a = 1\nval b = FORBIDDEN\n",
+            ktFile = null,
+        )
+        val result = PluginRuleRunner.run(file, ruleIds = null, ruleConfigs = null)
+        assertEquals(emptyMap(), result.errors)
+        assertEquals(1, result.findings.size, "expected one match, got ${result.findings}")
+        val finding = result.findings.single()
+        assertEquals("ForbiddenWordRule", finding.ruleId)
+        assertEquals("/tmp/Sample.kt", finding.file)
+        assertEquals(2, finding.line)
+        assertEquals("warning", finding.severity)
+    }
+
+    @Test
+    fun ruleThrowsBubblesAsErrorEntryNotCrash() {
+        // Per-rule exception handling must isolate failures so one
+        // broken rule doesn't kill the entire analyzeFile request.
+        // Mirrors krit-types' behavior.
+        val jar = buildThrowingRuleJar("BrokenRule")
+        PluginRuleRegistry.load(listOf(jar.absolutePath))
+
+        val file = KritFile(path = "/tmp/Any.kt", text = "fun x() {}", ktFile = null)
+        val result = PluginRuleRunner.run(file, ruleIds = null, ruleConfigs = null)
+        assertEquals(emptyList(), result.findings)
+        assertEquals(setOf("BrokenRule"), result.errors.keys)
+        assertTrue("boom" in (result.errors["BrokenRule"] ?: ""), result.errors.toString())
+    }
+
+    @Test
+    fun selectedRuleIdsFilterToOnlyTheRequestedSubset() {
+        val one = buildLineScannerJar("OneRule")
+        val two = buildLineScannerJar("TwoRule")
+        PluginRuleRegistry.load(listOf(one.absolutePath, two.absolutePath))
+
+        val file = KritFile(path = "/tmp/Both.kt", text = "FORBIDDEN line\n", ktFile = null)
+        val result = PluginRuleRunner.run(file, ruleIds = listOf("TwoRule"), ruleConfigs = null)
+        assertEquals(setOf("TwoRule"), result.findings.map { it.ruleId }.toSet())
+    }
+
+    @Test
+    fun ruleConfigsArePropagatedAsConfigOptions() {
+        // The rule reads `keyword` from RuleContext.config and emits
+        // a finding per line matching it. This confirms the
+        // ruleConfigs map plumbs through end-to-end.
+        val jar = buildKeywordRuleJar("KeywordRule")
+        PluginRuleRegistry.load(listOf(jar.absolutePath))
+
+        val file = KritFile(
+            path = "/tmp/Configured.kt",
+            text = "println(\"hi\")\nprintln(\"BYE\")\n",
+            ktFile = null,
+        )
+        val result = PluginRuleRunner.run(
+            file = file,
+            ruleIds = null,
+            ruleConfigs = mapOf("KeywordRule" to mapOf("keyword" to "BYE")),
+        )
+        assertEquals(1, result.findings.size, "expected one match for 'BYE': ${result.findings}")
+        assertEquals(2, result.findings.single().line)
+    }
+
+    @Test
+    fun analyzeFileResponseShapeMatchesKritTypes() {
+        val findings = listOf(
+            PluginRuleRunner.PluginFinding(
+                file = "/tmp/F.kt",
+                line = 3,
+                column = 5,
+                startByte = 12,
+                endByte = 20,
+                ruleSet = "custom",
+                ruleId = "R",
+                severity = "warning",
+                message = "msg",
+                confidence = 0.9,
+                fix = null,
+            ),
+        )
+        val response = PluginResponse.buildAnalyzeFile(id = 11, findings = findings, errors = emptyMap())
+        assertTrue(response.startsWith("""{"id":11,"result":{"findings":["""), response)
+        assertTrue(""""file":"/tmp/F.kt"""" in response, response)
+        assertTrue(""""line":3""" in response, response)
+        assertTrue(""""column":5""" in response, response)
+        assertTrue(""""confidence":0.9""" in response, response)
+        assertTrue("fix" !in response, response)
+        // No errors → no errors field. Matches krit-types' omit-when-empty rule.
+        assertTrue(""""errors":""" !in response, response)
+    }
+
+    @Test
+    fun analyzeFileResponseIncludesFixAndErrorsWhenPresent() {
+        val response = PluginResponse.buildAnalyzeFile(
+            id = 7,
+            findings = listOf(
+                PluginRuleRunner.PluginFinding(
+                    file = "/F.kt",
+                    line = 1, column = 1, startByte = 0, endByte = 0,
+                    ruleSet = "custom", ruleId = "R", severity = "warning",
+                    message = "m", confidence = 0.5,
+                    fix = PluginRuleRunner.PluginFix(
+                        startLine = 1, endLine = 1, replacement = "rep", safety = "idiomatic",
+                    ),
+                ),
+            ),
+            errors = mapOf("BadRule" to "broken"),
+        )
+        assertTrue(""""fix":{"startLine":1,"endLine":1,"replacement":"rep","safety":"idiomatic"}""" in response, response)
+        assertTrue(""""errors":{"BadRule":"broken"}""" in response, response)
+    }
+
+    // ── Test plumbing ────────────────────────────────────────────────
+
+    private fun buildLineScannerJar(ruleId: String): File {
+        val source = """
+            package dev.jasonpearson.krit.fir.plugins.testrules
+
+            import dev.jasonpearson.krit.api.Finding
+            import dev.jasonpearson.krit.api.KritFile
+            import dev.jasonpearson.krit.api.KritRule
+            import dev.jasonpearson.krit.api.KritRuleInfo
+            import dev.jasonpearson.krit.api.Language
+            import dev.jasonpearson.krit.api.Maturity
+            import dev.jasonpearson.krit.api.RuleContext
+            import dev.jasonpearson.krit.api.Severity
+
+            @KritRuleInfo(
+                id = "$ruleId",
+                category = "custom",
+                severity = Severity.WARNING,
+                maturity = Maturity.EXPERIMENTAL,
+                languages = [Language.KOTLIN],
+                needs = [],
+            )
+            class $ruleId : KritRule {
+                override fun check(file: KritFile, ctx: RuleContext): List<Finding> {
+                    val out = mutableListOf<Finding>()
+                    file.text.split('\n').forEachIndexed { i, line ->
+                        if ("FORBIDDEN" in line) {
+                            out += Finding(message = "forbidden", line = i + 1)
+                        }
+                    }
+                    return out
+                }
+            }
+        """.trimIndent()
+        return buildJar(ruleId, source)
+    }
+
+    private fun buildThrowingRuleJar(ruleId: String): File {
+        val source = """
+            package dev.jasonpearson.krit.fir.plugins.testrules
+
+            import dev.jasonpearson.krit.api.Finding
+            import dev.jasonpearson.krit.api.KritFile
+            import dev.jasonpearson.krit.api.KritRule
+            import dev.jasonpearson.krit.api.KritRuleInfo
+            import dev.jasonpearson.krit.api.Language
+            import dev.jasonpearson.krit.api.Maturity
+            import dev.jasonpearson.krit.api.RuleContext
+            import dev.jasonpearson.krit.api.Severity
+
+            @KritRuleInfo(
+                id = "$ruleId",
+                category = "custom",
+                severity = Severity.WARNING,
+                maturity = Maturity.EXPERIMENTAL,
+                languages = [Language.KOTLIN],
+                needs = [],
+            )
+            class $ruleId : KritRule {
+                override fun check(file: KritFile, ctx: RuleContext): List<Finding> {
+                    throw IllegalStateException("boom")
+                }
+            }
+        """.trimIndent()
+        return buildJar(ruleId, source)
+    }
+
+    private fun buildKeywordRuleJar(ruleId: String): File {
+        val source = """
+            package dev.jasonpearson.krit.fir.plugins.testrules
+
+            import dev.jasonpearson.krit.api.Finding
+            import dev.jasonpearson.krit.api.KritFile
+            import dev.jasonpearson.krit.api.KritRule
+            import dev.jasonpearson.krit.api.KritRuleInfo
+            import dev.jasonpearson.krit.api.Language
+            import dev.jasonpearson.krit.api.Maturity
+            import dev.jasonpearson.krit.api.RuleContext
+            import dev.jasonpearson.krit.api.Severity
+
+            @KritRuleInfo(
+                id = "$ruleId",
+                category = "custom",
+                severity = Severity.WARNING,
+                maturity = Maturity.EXPERIMENTAL,
+                languages = [Language.KOTLIN],
+                needs = [],
+            )
+            class $ruleId : KritRule {
+                override fun check(file: KritFile, ctx: RuleContext): List<Finding> {
+                    val keyword = ctx.stringOption("keyword")
+                    if (keyword.isEmpty()) return emptyList()
+                    val out = mutableListOf<Finding>()
+                    file.text.split('\n').forEachIndexed { i, line ->
+                        if (keyword in line) out += Finding(message = "match", line = i + 1)
+                    }
+                    return out
+                }
+            }
+        """.trimIndent()
+        return buildJar(ruleId, source)
+    }
+
+    private fun buildJar(ruleId: String, source: String): File {
+        val srcDir = tmp.resolve("gen-${ruleId}-src").toFile().apply { mkdirs() }
+        val outDir = tmp.resolve("gen-${ruleId}-out").toFile().apply { mkdirs() }
+        val sourceFile = srcDir.resolve("$ruleId.kt")
+        sourceFile.writeText(source)
+
+        val classpath = System.getProperty("java.class.path") ?: ""
+        val compiler = org.jetbrains.kotlin.cli.jvm.K2JVMCompiler()
+        val args = org.jetbrains.kotlin.cli.common.arguments.K2JVMCompilerArguments().apply {
+            freeArgs = listOf(sourceFile.absolutePath)
+            destination = outDir.absolutePath
+            this.classpath = classpath
+            noStdlib = true
+            noReflect = true
+        }
+        val exit = compiler.exec(
+            org.jetbrains.kotlin.cli.common.messages.MessageCollector.NONE,
+            org.jetbrains.kotlin.config.Services.EMPTY,
+            args,
+        )
+        check(exit.code == 0) { "K2 compilation failed for $ruleId: $exit" }
+
+        val jarFile = tmp.resolve("$ruleId.jar").toFile()
+        val manifest = Manifest().apply {
+            mainAttributes[Attributes.Name.MANIFEST_VERSION] = "1.0"
+            mainAttributes.putValue("Krit-SDK-Version", SdkCompatibility.DAEMON_SDK_VERSION)
+        }
+        JarOutputStream(jarFile.outputStream(), manifest).use { jar ->
+            jar.putNextEntry(ZipEntry("META-INF/services/dev.jasonpearson.krit.api.KritRule"))
+            jar.write("dev.jasonpearson.krit.fir.plugins.testrules.$ruleId".toByteArray())
+            jar.closeEntry()
+
+            val classFile = outDir.resolve("dev/jasonpearson/krit/fir/plugins/testrules/$ruleId.class")
+            assertNotNull(classFile.takeIf { it.isFile }, "compiled class missing: $classFile")
+            jar.putNextEntry(ZipEntry("dev/jasonpearson/krit/fir/plugins/testrules/$ruleId.class"))
+            jar.write(classFile.readBytes())
+            jar.closeEntry()
+        }
+        return jarFile
+    }
+}


### PR DESCRIPTION
## Summary

PR 3.2 wires the loaded plugin rules from PR 3.1 through the \`analyzeFile\` RPC, so a krit-fir daemon can execute \`KritRule.check\` today.

- \`PluginRuleRunner\` takes a \`KritFile\` + selected rule IDs + per-rule configs, calls \`KritRule.check\` on each loaded rule with a fresh \`RuleContext\`, catches per-rule throwables into an errors map, and projects \`Finding\` + \`Fix\` metadata into the wire shape.
- \`PluginResponse.buildAnalyzeFile\` emits krit-types' shape: \`{"findings":[...],"errors":{...}}\` with errors omitted when empty.
- \`Main.kt\` routes the \`analyzeFile\` command. Parses \`path\` + \`source\` + \`ruleIds\`. If \`source\` is absent the handler reads the file off disk.

## Scope

- \`RuleContext.resolver\` and the project-context fields (\`gradle\`, \`manifest\`, etc.) stay null. Rules declaring those capabilities pass the load-time gate but see null at runtime — they either degrade gracefully or no-op for now.
- \`KritFile.ktFile\` is null. PSI parsing and a FIR-backed \`Resolver\` land in PR 3.3.
- **Line-scanner-style rules (\`file.text\` only) work end-to-end today.**

## Test plan
- [x] \`./gradlew :test\` in \`tools/krit-fir/\` — 97 tests, +8 in this PR:
  - \`PluginRuleRunnerTest\` (6): line-scanner finding emission, per-rule throwables isolated as errors, ruleIds filter, ruleConfigs propagation, fix + errors serialization
  - \`OracleDispatchTest\` (+2): \`analyzeFile\` missing-path error, empty-findings short-circuit
  - Each runner test compiles a real \`KritRule\` jar through the bundled K2 compiler and loads it via the registry, so the loader → runner → response chain is exercised end-to-end
- [x] \`go build ./cmd/krit/ && go vet ./... && golangci-lint run ./... && go test ./... -count=1\`

## Follow-up

**PR 3.3** — PSI parsing of the analyzed file + a FIR-backed \`Resolver\` implementing \`isSuspendCall\` / \`resolvedCallFqName\` / \`isLambdaSuspend\` / \`expressionType\` against FIR data collected during a K2 pass over the source.