### PR TITLE
fix(rules): decode boundary rune in gradleHasDependenciesKeyword

### DIFF
--- a/internal/rules/android_gradle.go
+++ b/internal/rules/android_gradle.go
@@ -523,8 +523,8 @@ func gradleHasDependenciesKeyword(s string) bool {
 	idx := strings.Index(s, "dependencies")
 	for idx >= 0 {
 		end := idx + len("dependencies")
-		startOK := idx == 0 || !isGradleIdentPart(rune(s[idx-1]))
-		endOK := end == len(s) || !isGradleIdentPart(rune(s[end]))
+		startOK := idx == 0 || !isGradleIdentPartAt(s, idx, decodeBefore)
+		endOK := end == len(s) || !isGradleIdentPartAt(s, end, decodeAfter)
 		if startOK && endOK {
 			return true
 		}
@@ -533,6 +533,33 @@ func gradleHasDependenciesKeyword(s string) bool {
 			return false
 		}
 		idx = end + next
+	}
+	return false
+}
+
+type decodeDir int
+
+const (
+	decodeBefore decodeDir = iota
+	decodeAfter
+)
+
+// isGradleIdentPartAt decodes the rune that bounds the candidate
+// "dependencies" match and applies the identifier-part predicate to
+// it. The previous implementation used rune(s[idx-1]) / rune(s[idx]),
+// which is a byte-to-rune cast: when the surrounding byte was a UTF-8
+// continuation byte (0x80-0xBF) the cast produced a value that
+// IsLetter/IsDigit reject, so isGradleIdentPart returned false and
+// the boundary check passed even when the real surrounding rune was a
+// non-ASCII identifier character.
+func isGradleIdentPartAt(s string, pos int, dir decodeDir) bool {
+	switch dir {
+	case decodeBefore:
+		r, _ := utf8.DecodeLastRuneInString(s[:pos])
+		return isGradleIdentPart(r)
+	case decodeAfter:
+		r, _ := utf8.DecodeRuneInString(s[pos:])
+		return isGradleIdentPart(r)
 	}
 	return false
 }

--- a/internal/rules/gradle_dependencies_keyword_test.go
+++ b/internal/rules/gradle_dependencies_keyword_test.go
@@ -1,0 +1,38 @@
+package rules
+
+import "testing"
+
+func TestGradleHasDependenciesKeyword(t *testing.T) {
+	cases := []struct {
+		name string
+		s    string
+		want bool
+	}{
+		{"bare-token", "dependencies", true},
+		{"trailing-space", "dependencies ", true},
+		{"leading-space", " dependencies", true},
+		{"surrounded-by-spaces", "  dependencies  ", true},
+		{"after-punct", "buildscript { dependencies", true},
+
+		{"substring-camel-prefix", "subDependencies", false},
+		{"substring-camel-suffix", "dependenciesScope", false},
+		{"substring-underscore-prefix", "_dependencies", false},
+		{"substring-underscore-suffix", "dependencies_extra", false},
+		{"substring-digit-suffix", "dependencies2", false},
+
+		// Bug 21 regression: a multi-byte UTF-8 identifier character
+		// (Cyrillic ya, two bytes 0xD1 0x8F) directly before / after
+		// the candidate match. The previous rune(s[i-1]) byte cast
+		// produced a continuation-byte value that IsLetter rejects,
+		// so the boundary check passed and the rule false-positived.
+		{"cyrillic-prefix-blocks", "я" + "dependencies", false},
+		{"cyrillic-suffix-blocks", "dependencies" + "я", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := gradleHasDependenciesKeyword(tc.s); got != tc.want {
+				t.Errorf("gradleHasDependenciesKeyword(%q) = %v, want %v", tc.s, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

The boundary check around a candidate `"dependencies"` match used `rune(s[idx-1])` / `rune(s[end])` — a byte-to-rune cast, not a UTF-8 decode. When the surrounding byte was a multi-byte continuation (0x80–0xBF) the cast produced a value that `unicode.IsLetter` / `IsDigit` reject, so `isGradleIdentPart` returned false and the boundary check passed even when the real surrounding rune was a non-ASCII identifier character (Cyrillic, Greek, etc.). Rare in practice but a true correctness gap for Gradle scripts that declare a DSL extension adjacent to the literal `"dependencies"`.

- New `isGradleIdentPartAt(s, pos, dir)` helper decodes the surrounding rune via `utf8.DecodeLastRuneInString` / `utf8.DecodeRuneInString` and forwards it to `isGradleIdentPart`.
- Two Cyrillic regression cases in `TestGradleHasDependenciesKeyword` pin the contract.

### Companion bug skipped

The bug-list entry on `observability_helpers.isCamelKey` was investigated and dropped: the for-range loop at the top of `structuredLogKeyConvention` already rejects every non-ASCII rune via its `default` arm, so the later `rune(key[0])` cast can only run when `key` is pure ASCII. Not a real bug.

## Test plan

- [x] `go test ./internal/rules/ -run TestGradleHasDependenciesKeyword -v` — 12 cases pass (5 positive, 5 substring rejections, 2 Cyrillic boundary regressions)
- [x] `go test ./internal/rules/ -count=1` — full package green
- [x] `make lint-rules`, `go build`, `go vet ./...`, `golangci-lint run ./internal/rules/` clean