### PR TITLE
test(snapshot): disable git auto-maintenance in Simulate fixture

### DIFF
--- a/internal/snapshot/simulate_test.go
+++ b/internal/snapshot/simulate_test.go
@@ -132,6 +132,18 @@ func initSimulateRepo(t *testing.T) string {
 	}
 	run("init", "-q", "-b", "main")
 	run("config", "commit.gpgsign", "false")
+	// Disable git's background maintenance. Modern git auto-spawns
+	// commit-graph / pack-refs writers from `git commit` (via
+	// `gc.autoDetach` and `maintenance.auto`); those background writes
+	// can land in `.git/objects/info/` *after* the parent command
+	// returns, racing `t.TempDir()`'s `os.RemoveAll` cleanup and
+	// producing flaky "unlinkat .git/objects: directory not empty"
+	// failures on CI. Pinning these knobs off keeps cleanup
+	// deterministic.
+	run("config", "gc.auto", "0")
+	run("config", "gc.autoDetach", "false")
+	run("config", "maintenance.auto", "false")
+	run("config", "core.fsmonitor", "false")
 
 	srcDir := filepath.Join(repo, "src", "main", "kotlin")
 	if err := os.MkdirAll(srcDir, 0o755); err != nil {


### PR DESCRIPTION
## Summary

Fixes a CI flake observed on an unrelated PR's \`integration\` job:

\`\`\`
TempDir RemoveAll cleanup:
  unlinkat /tmp/TestSimulateUsesSidecarFastPath.../001/.git/objects: directory not empty
\`\`\`

Modern git auto-spawns background commit-graph / pack-refs writers from \`git commit\` (via \`gc.autoDetach\` and \`maintenance.auto\`). Those background writes can land in \`.git/objects/info/\` *after* the parent \`git commit\` returns, racing \`t.TempDir()\`'s \`os.RemoveAll\` cleanup.

Pinning the autoknobs off in \`initSimulateRepo\` immediately after \`git init\` keeps cleanup deterministic.

## Test plan
- [x] \`go test ./internal/snapshot/ -count=3 -run 'TestSimulateUsesSidecarFastPath|TestSimulateNoSidecarHonored'\` — green on 3 back-to-back iterations