### PR TITLE
docs: replace hard-coded ~/github paths with corpus env vars

### DIFF
--- a/.claude/commands/krit-dogfood.md
+++ b/.claude/commands/krit-dogfood.md
@@ -2,7 +2,7 @@
 
 Run Krit against an external Kotlin/Android repo and triage findings.
 
-ARGUMENTS: `$ARGUMENTS` — target repo path (e.g. `~/github/metro`, `playground`, `kotlin-corpus`). Required.
+ARGUMENTS: `$ARGUMENTS` — target repo path to dogfood against. Required.
 
 ## Instructions
 

--- a/.claude/skills/krit-dogfood/SKILL.md
+++ b/.claude/skills/krit-dogfood/SKILL.md
@@ -13,7 +13,7 @@ Useful targets, in rough order of cost/coverage trade-off:
 
 - **playground** (`playground/` in this repo) — fastest, regression-locked via `make regression`. Use first for any pipeline/rule change.
 - **kotlin-corpus** — broader Kotlin coverage, used by `scripts/benchmark-oracle.sh` and `test(serve): report per-phase timings in kotlin-corpus benches`.
-- **`~/github/metro`** or similar large Android app — real Android/Gradle/Compose surface, real catalog, real DI.
+- **large Android app** (metro or similar) — real Android/Gradle/Compose surface, real catalog, real DI.
 - **user-supplied path** — when investigating a reported FP on the reporter's codebase.
 
 Record both the Krit revision and the target revision in any output you share.

--- a/internal/cli/serve/analyze_project_abi_regression_test.go
+++ b/internal/cli/serve/analyze_project_abi_regression_test.go
@@ -15,7 +15,7 @@ import (
 
 // TestAnalyzeProject_RepeatedABIEditFindingsStable_KotlinCorpus is the
 // regression repro for issue #254. With AndroidCacheWriter wired on
-// the daemon path, post-edit analyze runs on ~/github/kotlin collapse
+// the daemon path, post-edit analyze runs on $KRIT_KOTLIN_CORPUS collapse
 // from ~87k findings to ~62 starting on the second run.
 //
 // Flow:

--- a/internal/pipeline/build_manifest_data_test.go
+++ b/internal/pipeline/build_manifest_data_test.go
@@ -15,7 +15,7 @@ import (
 // analyze re-read that manifest through prepopulatedSourcePaths and
 // collapsed the source set to one path — driving the entire daemon
 // pipeline into single-file dispatch and dropping ~87 k findings to
-// ~62 on ~/github/kotlin.
+// ~62 on $KOTLIN_CORPUS.
 //
 // The fix: any path present in host.PriorContentHashes that wasn't
 // parsed this run (and isn't dirty) gets carried into the new


### PR DESCRIPTION
## Summary
- Swap two test-file comments referencing `~/github/kotlin` to the env vars each test actually reads (`$KOTLIN_CORPUS`, `$KRIT_KOTLIN_CORPUS`).
- Drop the specific `~/github/metro` example from the krit-dogfood skill and command so they read generically against any user-supplied target path; the command still requires a path argument.

## Test plan
- [x] `git grep '~/github/'` returns no hits.