### PR TITLE
feat(krit-fir): PSI parsing + FIR-backed Resolver for analyzeFile

### DIFF
--- a/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/Main.kt
+++ b/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/Main.kt
@@ -1,13 +1,16 @@
 package dev.jasonpearson.krit.fir
 
 import dev.jasonpearson.krit.api.KritFile
+import dev.jasonpearson.krit.fir.oracle.FileOffsetTable
 import dev.jasonpearson.krit.fir.oracle.OracleResponse
+import dev.jasonpearson.krit.fir.plugins.FirOracleResolver
+import dev.jasonpearson.krit.fir.plugins.KtFileParser
 import dev.jasonpearson.krit.fir.plugins.PluginResponse
 import dev.jasonpearson.krit.fir.plugins.PluginRuleRegistry
 import dev.jasonpearson.krit.fir.plugins.PluginRuleRunner
-import java.io.File as JavaFile
 import dev.jasonpearson.krit.fir.runner.AnalysisSession
 import dev.jasonpearson.krit.fir.runner.BatchResult
+import java.io.File as JavaFile
 import dev.jasonpearson.krit.fir.runner.FileRef
 import dev.jasonpearson.krit.fir.runner.Finding
 import java.io.BufferedReader
@@ -218,8 +221,20 @@ fun handleRequestLine(trimmed: String, session: AnalysisSession, startTime: Long
                 RequestResult.Response(response)
             }
             "analyzeFile" -> {
-                val response = handleAnalyzeFile(request)
-                RequestResult.Response(response)
+                val needsRebuild =
+                    request.sourceDirs != session.sourceDirs || request.classpath != session.classpath
+                val activeSession = if (needsRebuild) {
+                    session.dispose()
+                    AnalysisSession(request.sourceDirs, request.classpath)
+                } else {
+                    session
+                }
+                val response = handleAnalyzeFile(request, activeSession)
+                if (needsRebuild) {
+                    RequestResult.SessionRebuilt(response, activeSession)
+                } else {
+                    RequestResult.Response(response)
+                }
             }
             else -> RequestResult.Response("""{"id":${request.id},"error":"Unknown command: ${escJson(request.command)}"}""")
         }
@@ -261,7 +276,7 @@ fun parseRequest(json: String): CheckRequest {
     return CheckRequest(id, command, files, sourceDirs, classpath, rules, pluginJars, path, source, ruleIds)
 }
 
-internal fun handleAnalyzeFile(request: CheckRequest): String {
+internal fun handleAnalyzeFile(request: CheckRequest, session: AnalysisSession): String {
     val path = request.path
     if (path.isNullOrBlank()) {
         return """{"id":${request.id},"error":"analyzeFile requires path"}"""
@@ -276,13 +291,39 @@ internal fun handleAnalyzeFile(request: CheckRequest): String {
         if (text.isBlank()) {
             return """{"id":${request.id},"error":"analyzeFile could not resolve source for ${escJson(path)}"}"""
         }
-        // PSI parsing and the FIR-backed Resolver land in PR 3.3. For
-        // now line-scanner-style rules work end-to-end; rules that
-        // expect a non-null `KritFile.ktFile` or `RuleContext.resolver`
-        // see them as null and either degrade gracefully or no-op.
-        val file = KritFile(path = path, text = text, ktFile = null)
-        val outcome = PluginRuleRunner.run(file, request.ruleIds, ruleConfigs = null)
-        PluginResponse.buildAnalyzeFile(request.id, outcome.findings, outcome.errors)
+
+        // Run the K2 oracle pass against this file so the resolver
+        // has FIR call-resolution data to answer queries from. The
+        // pass populates `expressions` keyed by `"line:col"` for every
+        // resolved function call — exactly what the resolver looks up
+        // in [FirOracleResolver.lookupCall]. If the K2 pass crashes
+        // we still want plugin rules to run; fall back to an empty
+        // expression map and a resolver that returns null/false.
+        val expressions = try {
+            val canonical = JavaFile(path).canonicalPath
+            val result = session.analyze(listOf(path))
+            result.files[canonical]?.expressions
+                ?: result.files[path]?.expressions
+                ?: emptyMap()
+        } catch (t: Throwable) {
+            System.err.println("analyzeFile oracle pass failed: ${t.message}")
+            emptyMap()
+        }
+        val offsets = FileOffsetTable(text)
+        val resolver = FirOracleResolver(expressions, offsets)
+
+        // Parse PSI off the request payload (not off disk) so an
+        // in-flight edit shipped via `request.source` is reflected
+        // in the KtFile the rule sees. The parser's Disposable holds
+        // the IntelliJ infrastructure for the request lifetime.
+        val parsed = KtFileParser.parse(text, pathHint = path)
+        try {
+            val file = KritFile(path = path, text = text, ktFile = parsed.ktFile)
+            val outcome = PluginRuleRunner.run(file, request.ruleIds, ruleConfigs = null, resolver = resolver)
+            PluginResponse.buildAnalyzeFile(request.id, outcome.findings, outcome.errors)
+        } finally {
+            parsed.close()
+        }
     } catch (t: Throwable) {
         """{"id":${request.id},"error":"${escJson(t.message ?: "analyzeFile failed")}"}"""
     }

--- a/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/plugins/FirOracleResolver.kt
+++ b/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/plugins/FirOracleResolver.kt
@@ -1,0 +1,68 @@
+package dev.jasonpearson.krit.fir.plugins
+
+import dev.jasonpearson.krit.api.Resolver
+import dev.jasonpearson.krit.fir.oracle.ExpressionPayload
+import dev.jasonpearson.krit.fir.oracle.FileOffsetTable
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtExpression
+import org.jetbrains.kotlin.psi.KtLambdaExpression
+
+/**
+ * FIR-backed [`Resolver`] for plugin-rule hosting on the krit-fir
+ * backend. Answers PSI-keyed questions about a single analyzed file by
+ * looking up data the K2 oracle pass already collected (see
+ * `OracleExpressionChecker`).
+ *
+ * Resolution flow per query:
+ *
+ * 1. The PSI element's `textRange.startOffset` is mapped to 1-based
+ *    `(line, col)` via the file's [FileOffsetTable].
+ * 2. The resulting `"line:col"` key is looked up in [expressionsByKey],
+ *    which is the slice of an [`AnalyzeResult.files`] payload for the
+ *    file under analysis.
+ *
+ * The [Resolver] surface still exposes `isLambdaSuspend` and
+ * `expressionType`; the FIR oracle pass doesn't capture lambda type
+ * or expression type today, so those methods return the conservative
+ * "unknown" value (`false` / `null`). Rules that strictly depend on
+ * either can opt out via the `NEEDS_FIR` capability — when those
+ * facts land the resolver picks them up here without an SPI churn.
+ */
+internal class FirOracleResolver(
+    private val expressionsByKey: Map<String, ExpressionPayload>,
+    private val offsets: FileOffsetTable,
+) : Resolver {
+
+    override fun isSuspendCall(call: KtCallExpression): Boolean =
+        lookupCall(call)?.callTargetSuspend == true
+
+    override fun resolvedCallFqName(call: KtCallExpression): String? {
+        val payload = lookupCall(call) ?: return null
+        // krit-types' AnalysisApiResolver returns null when the symbol
+        // graph couldn't recover an FQN. Mirror that here by also
+        // gating on `callTargetResolved` — an entry that fell back to
+        // the lexical callee text isn't a real FQN.
+        if (!payload.callTargetResolved) return null
+        return payload.callTarget?.takeIf { it.isNotBlank() }
+    }
+
+    override fun isLambdaSuspend(lambda: KtLambdaExpression): Boolean {
+        // The oracle pass doesn't capture lambda-functional-type
+        // information today. Returning false matches krit-types'
+        // "unresolved → conservative false" contract.
+        return false
+    }
+
+    override fun expressionType(expression: KtExpression): String? {
+        // Same gap as isLambdaSuspend: expression-type data isn't part
+        // of the current ExpressionPayload surface. krit-types'
+        // resolver also returns null for unresolved types.
+        return null
+    }
+
+    private fun lookupCall(call: KtCallExpression): ExpressionPayload? {
+        val range = call.textRange ?: return null
+        val (line, col) = offsets.lineColAt(range.startOffset)
+        return expressionsByKey["$line:$col"]
+    }
+}

--- a/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/plugins/KtFileParser.kt
+++ b/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/plugins/KtFileParser.kt
@@ -1,0 +1,82 @@
+package dev.jasonpearson.krit.fir.plugins
+
+import com.intellij.openapi.util.Disposer
+import org.jetbrains.kotlin.K1Deprecation
+import org.jetbrains.kotlin.cli.common.messages.MessageCollector
+import org.jetbrains.kotlin.cli.jvm.compiler.EnvironmentConfigFiles
+import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
+import org.jetbrains.kotlin.config.CommonConfigurationKeys
+import org.jetbrains.kotlin.config.CompilerConfiguration
+import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.psi.KtPsiFactory
+import java.io.File
+
+/**
+ * Parses Kotlin source text into a [KtFile] suitable for handing to a
+ * plugin rule's [`KritRule.check`] invocation. The `analyzeFile` RPC
+ * accepts a `(path, source)` pair, so the daemon needs to materialize
+ * PSI on demand rather than relying on a pre-parsed source cache
+ * (which is what krit-types' Analysis API session provides).
+ *
+ * The IntelliJ [KotlinCoreEnvironment] is a process-wide singleton:
+ * the first `createForProduction` call wires up an
+ * [com.intellij.openapi.application.Application]; subsequent calls
+ * fail because Application can only be set once per JVM. To stay
+ * compatible we keep one environment alive for the daemon's lifetime
+ * and reuse its `Project` for every parse — see
+ * [sharedEnvironment]. Parses themselves are stateless because
+ * [KtPsiFactory.createFile] does not mutate the `Project`.
+ */
+internal object KtFileParser {
+
+    private val rootDisposable by lazy {
+        Disposer.newDisposable("KtFileParser-root")
+    }
+
+    @OptIn(K1Deprecation::class)
+    private val sharedEnvironment: KotlinCoreEnvironment by lazy {
+        val config = CompilerConfiguration().apply {
+            put(CommonConfigurationKeys.MESSAGE_COLLECTOR_KEY, MessageCollector.NONE)
+            put(CommonConfigurationKeys.MODULE_NAME, "krit-fir-analyzeFile")
+        }
+        // `createForProduction` carries the @DeprecatedCompilerApi
+        // marker in 2.3.x — that signals K2 migration is in flight,
+        // not removal. We opt in deliberately and continue using the
+        // K1 environment because the daemon only needs PSI parsing,
+        // which the K2 successor doesn't yet expose as a stable
+        // public surface.
+        KotlinCoreEnvironment.createForProduction(
+            rootDisposable,
+            config,
+            EnvironmentConfigFiles.JVM_CONFIG_FILES,
+        )
+    }
+
+    /**
+     * Parse [source] as Kotlin code. Uses the leaf of [pathHint] as
+     * the synthesized file name when present so a rule that reads
+     * `file.name` sees the request path.
+     */
+    fun parse(source: String, pathHint: String? = null): ParsedKtFile {
+        val name = pathHint?.let { File(it).name }.takeUnless { it.isNullOrBlank() } ?: "Source.kt"
+        val ktFile = KtPsiFactory(sharedEnvironment.project, markGenerated = false)
+            .createFile(name, source)
+        return ParsedKtFile(ktFile)
+    }
+
+    /**
+     * Returned wrapper for parsed [KtFile]s. The environment itself
+     * lives across requests, so `close` is a no-op today; callers
+     * still use try-with-resources for forward-compat in case we move
+     * to a per-request disposable later (e.g. when PSI references
+     * accumulate enough to need pruning).
+     */
+    class ParsedKtFile(val ktFile: KtFile) : AutoCloseable {
+        override fun close() {
+            // Intentional no-op; see class doc.
+        }
+
+        /** Alias for [close] for callers that already think in disposables. */
+        fun dispose() = close()
+    }
+}

--- a/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/plugins/PluginRuleRunner.kt
+++ b/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/plugins/PluginRuleRunner.kt
@@ -1,51 +1,52 @@
 package dev.jasonpearson.krit.fir.plugins
 
+import dev.jasonpearson.krit.api.Capability
 import dev.jasonpearson.krit.api.Finding
 import dev.jasonpearson.krit.api.FixSafety
 import dev.jasonpearson.krit.api.KritFile
+import dev.jasonpearson.krit.api.Resolver
 import dev.jasonpearson.krit.api.RuleContext
 
 /**
- * Driver for the `analyzeFileWithPlugins` RPC. Wires loaded plugin
- * rules ([PluginRuleRegistry]) through the [RuleContext] / [Finding]
+ * Driver for the `analyzeFile` RPC. Wires loaded plugin rules
+ * ([PluginRuleRegistry]) through the [RuleContext] / [Finding]
  * surface that lives in `krit-rule-api`, then produces a wire-shape
  * response matching krit-types' `buildAnalyzeFileResponse`.
  *
- * Current scope (PR 3.2):
+ * A FIR-backed [Resolver] is supplied to rules that declared
+ * [Capability.NEEDS_RESOLVER]; rules that didn't opt in see
+ * `RuleContext.resolver` as null even when a resolver is available,
+ * matching krit-types' opt-in semantics.
  *
- * - Rules run with `ktFile = null` and `resolver = null`. Tree-sitter-
- *   style line-scanner rules work today; rules that opt into
- *   `NEEDS_RESOLVER` or expect PSI get the corresponding fields as
- *   null and either degrade gracefully or no-op.
- * - PSI parsing and a real FIR-backed [Resolver] land in PR 3.3.
- * - Project-scope payload contexts (`gradle`, `manifest`, `resources`,
- *   `moduleIndex`, `crossFile`) also land in PR 3.3 alongside the
- *   request parsers for them.
+ * The project-scope payload contexts (`gradle`, `manifest`,
+ * `resources`, `moduleIndex`, `crossFile`) still ride as null —
+ * request parsers for them land in a follow-up.
  */
 internal object PluginRuleRunner {
 
     /**
      * Execute the selected plugin rules against [file] and return both
      * the emitted findings and any per-rule execution failures
-     * (caught Throwables) keyed by rule ID.
+     * (caught Throwables) keyed by rule ID. Pass [resolver] = null
+     * (the default) for callers that don't want to provide one —
+     * rules declaring [Capability.NEEDS_RESOLVER] then see
+     * `RuleContext.resolver` as null.
      */
     fun run(
         file: KritFile,
         ruleIds: List<String>?,
         ruleConfigs: Map<String, Map<String, Any?>>?,
+        resolver: Resolver? = null,
     ): RunResult {
         val findings = mutableListOf<PluginFinding>()
         val errors = linkedMapOf<String, String>()
         for (loaded in PluginRuleRegistry.selected(ruleIds)) {
             val options = ruleConfigs?.get(loaded.descriptor.ruleId).orEmpty()
-            // resolver and the project-scope context fields stay null
-            // on the krit-fir backend today. A rule that declared the
-            // matching `NEEDS_*` capability passed the load-time gate;
-            // we just don't provide the fact yet. PSI parsing and the
-            // FIR-backed Resolver land in PR 3.3.
+            val needsResolver = loaded.descriptor.needs.contains(Capability.NEEDS_RESOLVER.name)
             val ctx = RuleContext(
                 ruleId = loaded.descriptor.ruleId,
                 config = options,
+                resolver = resolver.takeIf { needsResolver },
             )
             try {
                 for (finding in loaded.rule.check(file, ctx)) {

--- a/tools/krit-fir/src/test/kotlin/dev/jasonpearson/krit/fir/plugins/FirOracleResolverTest.kt
+++ b/tools/krit-fir/src/test/kotlin/dev/jasonpearson/krit/fir/plugins/FirOracleResolverTest.kt
@@ -1,0 +1,124 @@
+package dev.jasonpearson.krit.fir.plugins
+
+import dev.jasonpearson.krit.fir.oracle.ExpressionPayload
+import dev.jasonpearson.krit.fir.oracle.FileOffsetTable
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtFile
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class FirOracleResolverTest {
+
+    @Test
+    fun resolvedCallFqNameRoundTripsThroughLineColLookup() {
+        // Source has the call at (line 4, col 5):
+        // "package x\n\nfun caller() {\n    target()\n}\n"
+        // line 4 starts at offset 27 ('    target...'); col 5 = 't'.
+        val source = "package x\n\nfun caller() {\n    target()\n}\n"
+        val table = FileOffsetTable(source)
+        val expressions = mapOf(
+            "4:5" to ExpressionPayload(
+                type = "",
+                callTarget = "com.acme.target",
+                callTargetResolved = true,
+                callTargetSuspend = false,
+            ),
+        )
+
+        val (parsed, call) = parseSourceAndFirstCall(source)
+        parsed.use {
+            val resolver = FirOracleResolver(expressions, table)
+            assertEquals("com.acme.target", resolver.resolvedCallFqName(call))
+            assertFalse(resolver.isSuspendCall(call))
+        }
+    }
+
+    @Test
+    fun unresolvedCallReturnsNullEvenWithLexicalFallbackEntry() {
+        // krit-types' AnalysisApiResolver returns null when the symbol
+        // graph couldn't recover an FQN. We do the same: only resolved
+        // FQNs surface; lexical-fallback entries don't.
+        val source = "package x\n\nfun caller() {\n    mystery()\n}\n"
+        val table = FileOffsetTable(source)
+        val expressions = mapOf(
+            "4:5" to ExpressionPayload(
+                type = "",
+                callTarget = "mystery",
+                callTargetResolved = false,
+                callTargetSuspend = false,
+            ),
+        )
+
+        val (parsed, call) = parseSourceAndFirstCall(source)
+        parsed.use {
+            val resolver = FirOracleResolver(expressions, table)
+            assertNull(resolver.resolvedCallFqName(call))
+        }
+    }
+
+    @Test
+    fun suspendFlagSurfacesViaIsSuspendCall() {
+        val source = "package x\n\nsuspend fun caller() {\n    delay()\n}\n"
+        val table = FileOffsetTable(source)
+        val expressions = mapOf(
+            "4:5" to ExpressionPayload(
+                type = "",
+                callTarget = "kotlinx.coroutines.delay",
+                callTargetResolved = true,
+                callTargetSuspend = true,
+            ),
+        )
+
+        val (parsed, call) = parseSourceAndFirstCall(source)
+        parsed.use {
+            val resolver = FirOracleResolver(expressions, table)
+            assertTrue(resolver.isSuspendCall(call))
+            assertEquals("kotlinx.coroutines.delay", resolver.resolvedCallFqName(call))
+        }
+    }
+
+    @Test
+    fun unknownCallSiteReturnsNull() {
+        // Empty expression map → resolver has nothing to surface and
+        // returns null/false. Mirrors krit-types' behavior when the
+        // call wasn't resolvable in this file's analysis.
+        val source = "package x\n\nfun caller() {\n    target()\n}\n"
+        val table = FileOffsetTable(source)
+        val (parsed, call) = parseSourceAndFirstCall(source)
+        parsed.use {
+            val resolver = FirOracleResolver(expressionsByKey = emptyMap(), offsets = table)
+            assertNull(resolver.resolvedCallFqName(call))
+            assertFalse(resolver.isSuspendCall(call))
+        }
+    }
+
+    // PR 3.3 deliberately ships isLambdaSuspend / expressionType as
+    // conservative null/false stubs because the oracle pass doesn't
+    // capture lambda-functional or expression-type data yet. Those
+    // methods have no behavior to test until the data lands — they
+    // pass the `Resolver` contract trivially.
+
+    // ── Test plumbing ────────────────────────────────────────────────
+
+    private fun parseSourceAndFirstCall(
+        source: String,
+    ): Pair<KtFileParser.ParsedKtFile, KtCallExpression> {
+        val parsed = KtFileParser.parse(source, pathHint = "/tmp/Source.kt")
+        val call = firstCallExpression(parsed.ktFile)
+            ?: error("source has no KtCallExpression: $source")
+        return parsed to call
+    }
+
+    private fun firstCallExpression(ktFile: KtFile): KtCallExpression? {
+        var found: KtCallExpression? = null
+        ktFile.accept(object : org.jetbrains.kotlin.psi.KtTreeVisitorVoid() {
+            override fun visitCallExpression(expression: KtCallExpression) {
+                if (found == null) found = expression
+            }
+        })
+        return found
+    }
+}


### PR DESCRIPTION
## Summary

PR 3.3 closes the rule-execution gap from PR 3.2 — plugin rules running on the krit-fir backend now receive both a parsed \`KtFile\` and a FIR-backed \`Resolver\`, matching the surface krit-types delivers via its \`AnalysisApiResolver\`.

- \`FirOracleResolver\` wraps the \`AnalyzeResult\`'s per-file expression map (keyed by \`"line:col"\`) plus a \`FileOffsetTable\` to answer the \`Resolver\` interface:
  - \`resolvedCallFqName\`: returns the resolved \`callableId\` FQN, gating on \`callTargetResolved\` so lexical-fallback entries surface as null (mirrors krit-types' \`AnalysisApiResolver\` behavior).
  - \`isSuspendCall\`: returns \`callTargetSuspend\`.
  - \`isLambdaSuspend\` / \`expressionType\`: conservative null/false until the oracle pass captures lambda functional types + expression types (follow-up).
- \`KtFileParser\` materializes PSI on demand via a process-wide \`KotlinCoreEnvironment\` + \`KtPsiFactory\`. The IntelliJ \`Application\` is a JVM singleton, so the environment is lazily initialized once and shared across requests — per-request disposables would fail on the second parse.
- \`handleAnalyzeFile\` now drives the K2 oracle pass against the requested file (giving the resolver real call-resolution data), parses the source into a \`KtFile\`, builds a \`FirOracleResolver\`, and hands both to \`PluginRuleRunner\`.
- \`PluginRuleRunner.run\` accepts an optional \`Resolver\`. \`RuleContext.resolver\` is non-null only when the rule declared \`NEEDS_RESOLVER\`, matching krit-types' opt-in semantics.

## Test plan
- [x] \`./gradlew :test\` in \`tools/krit-fir/\` — 101 tests, +4 in \`FirOracleResolverTest\`: resolved FQN round-trip, lexical-fallback null, suspend flag, unknown-call-site null/false. Each test parses a real \`KtFile\` via \`KtFileParser\` and asks the resolver about the first \`KtCallExpression\` in the tree.
- [x] \`go build ./cmd/krit/ && go vet ./... && golangci-lint run ./... && go test ./... -count=1\`

## Follow-up
- Capture lambda functional types + expression types in the oracle pass so \`isLambdaSuspend\` / \`expressionType\` answer real data instead of stubs.
- Plumb project-scope payload contexts (\`gradle\`, \`manifest\`, \`resources\`, \`moduleIndex\`, \`crossFile\`) through the request parser.