### PR TITLE
feat(oracle): --oracle-backend flag selects krit-types or krit-fir

### DIFF
--- a/internal/cli/scan/flags.go
+++ b/internal/cli/scan/flags.go
@@ -57,6 +57,7 @@ type scanFlags struct {
 	InputTypes               *string
 	OutputTypes              *string
 	NoTypeOracle             *bool
+	OracleBackend            *string
 	NoCacheOracle            *bool
 	NoCrossFileCache         *bool
 	CustomRuleJars           *string
@@ -164,6 +165,7 @@ func registerScanFlags(fs *flag.FlagSet) *scanFlags {
 	f.InputTypes = fs.String("input-types", "", "Load pre-built type oracle JSON (skip JVM invocation)")
 	f.OutputTypes = fs.String("output-types", "", "Run krit-types and write oracle JSON to this path, then exit")
 	f.NoTypeOracle = fs.Bool("no-type-oracle", false, "Skip the JVM type oracle entirely (faster, less precise)")
+	f.OracleBackend = fs.String("oracle-backend", "", "Pick the JVM daemon for the type oracle: 'kaa' (krit-types, default) or 'fir' (krit-fir). Overrides the oracle.backend value in krit.yml.")
 	f.NoCacheOracle = fs.Bool("no-cache-oracle", false, "Disable the on-disk incremental oracle cache (forces a full JVM run)")
 	f.NoCrossFileCache = fs.Bool("no-cross-file-cache", false, "Disable the on-disk cross-file index cache (forces a full crossFileAnalysis rebuild)")
 	f.CustomRuleJars = fs.String("custom-rule-jars", "", "Comma-separated Kotlin custom-rule jars to load through the krit-types daemon (experimental)")

--- a/internal/cli/scan/oracle_backend.go
+++ b/internal/cli/scan/oracle_backend.go
@@ -1,0 +1,24 @@
+package scan
+
+import (
+	"github.com/kaeawc/krit/internal/config"
+	"github.com/kaeawc/krit/internal/oracle"
+)
+
+// resolveOracleBackend implements the priority chain runner_state.go
+// uses when picking the JVM daemon: the `--oracle-backend` flag wins
+// over the `oracle.backend` value in krit.yml, which in turn wins over
+// [oracle.DefaultBackend]. Returning a typed error keeps malformed
+// values from silently falling back to the default — see
+// [oracle.ParseBackend].
+//
+// Kept on its own so the resolution rule has one tested home; both
+// the CLI plumbing and oracle-backend-resolution unit tests call this
+// directly.
+func resolveOracleBackend(flagValue string, cfg *config.Config) (oracle.Backend, error) {
+	raw := flagValue
+	if raw == "" && cfg != nil {
+		raw = cfg.Oracle().Backend
+	}
+	return oracle.ParseBackend(raw)
+}

--- a/internal/cli/scan/oracle_backend_test.go
+++ b/internal/cli/scan/oracle_backend_test.go
@@ -1,0 +1,91 @@
+package scan
+
+import (
+	"testing"
+
+	"github.com/kaeawc/krit/internal/config"
+	"github.com/kaeawc/krit/internal/oracle"
+)
+
+func TestOracleBackendResolution(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name      string
+		flagValue string
+		yamlValue string
+		want      oracle.Backend
+		wantErr   bool
+	}{
+		{
+			name: "neither set falls through to default",
+			want: oracle.DefaultBackend,
+		},
+		{
+			name:      "config-only is honoured",
+			yamlValue: "fir",
+			want:      oracle.BackendFIR,
+		},
+		{
+			name:      "flag wins over config",
+			flagValue: "kaa",
+			yamlValue: "fir",
+			want:      oracle.BackendKAA,
+		},
+		{
+			name:      "flag wins even with reversed roles",
+			flagValue: "fir",
+			yamlValue: "kaa",
+			want:      oracle.BackendFIR,
+		},
+		{
+			name:      "alias canonicalization passes through",
+			flagValue: "krit-fir",
+			want:      oracle.BackendFIR,
+		},
+		{
+			name:      "invalid flag surfaces error",
+			flagValue: "garbage",
+			wantErr:   true,
+		},
+		{
+			name:      "invalid config surfaces error when no flag override",
+			yamlValue: "nonsense",
+			wantErr:   true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			cfg := config.NewConfigFromData(map[string]interface{}{
+				"oracle": map[string]interface{}{"backend": tc.yamlValue},
+			})
+			got, err := resolveOracleBackend(tc.flagValue, cfg)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for flag=%q yaml=%q, got backend=%q", tc.flagValue, tc.yamlValue, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error for flag=%q yaml=%q: %v", tc.flagValue, tc.yamlValue, err)
+			}
+			if got != tc.want {
+				t.Errorf("flag=%q yaml=%q: got %q, want %q", tc.flagValue, tc.yamlValue, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestOracleBackendResolutionWithNilConfig(t *testing.T) {
+	// A nil-config caller is shaped like the CLI defaulting path
+	// before krit.yml is loaded; the helper must not panic.
+	got, err := resolveOracleBackend("", nil)
+	if err != nil {
+		t.Fatalf("nil-config resolution errored: %v", err)
+	}
+	if got != oracle.DefaultBackend {
+		t.Errorf("nil-config resolution = %q, want %q", got, oracle.DefaultBackend)
+	}
+}

--- a/internal/cli/scan/runner_state.go
+++ b/internal/cli/scan/runner_state.go
@@ -474,6 +474,12 @@ func (r *runner) runOracleIndex() (int, error) {
 	var preloadedCache *cache.Cache
 	r.tracker.TrackVoid("oracleIndex", func() {
 		staleOraclePaths := computeStaleOraclePaths(r.paths, r.files, r.tracker, *r.f.Verbose)
+		oracleBackend, oracleBackendErr := resolveOracleBackend(*r.f.OracleBackend, r.cfg)
+		if oracleBackendErr != nil {
+			fmt.Fprintf(os.Stderr, "error: %v\n", oracleBackendErr)
+			err = oracleBackendErr
+			return
+		}
 		in := pipeline.IndexInput{
 			ParseResult:       pipeline.ParseResult{ActiveRules: r.activeRules},
 			Reporter:          r.reporter,
@@ -488,6 +494,7 @@ func (r *runner) runOracleIndex() (int, error) {
 			Thorough:          r.depthPreset == DepthThorough,
 			OracleDiagnostics: *r.f.OracleDiagnostics,
 			UseDaemon:         *r.f.Daemon,
+			OracleBackend:     oracleBackend,
 			Store:             r.oracleStore,
 			OracleCacheWriter: r.oracleCacheWriter,
 			StaleOraclePaths:  staleOraclePaths,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -49,9 +49,15 @@ type LSPConfig struct {
 }
 
 // OracleConfig is the typed shape of the top-level `oracle:` block.
-// Used by the JVM-backed Kotlin Analysis API daemon. Nil/empty
-// Classpath means "no user override".
+// Used by the JVM-backed daemon. Nil/empty Classpath means "no user
+// override".
 type OracleConfig struct {
+	// Backend selects which JVM daemon krit spawns for the type
+	// oracle role: "kaa" (krit-types, the default) or "fir"
+	// (krit-fir). Empty means default. Validation happens in
+	// internal/oracle.ParseBackend; values not handled there are
+	// surfaced as a CLI error rather than silently falling back.
+	Backend   string
 	Classpath []string
 }
 
@@ -542,6 +548,7 @@ func (c *Config) LSP() LSPConfig {
 // Oracle returns the typed `oracle:` block.
 func (c *Config) Oracle() OracleConfig {
 	return OracleConfig{
+		Backend:   c.GetTopLevelString("oracle", "backend", ""),
 		Classpath: c.GetTopLevelStringList("oracle", "classpath"),
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1211,10 +1211,14 @@ func TestTypedSections(t *testing.T) {
 			"classpath": []interface{}{"/a.jar", "/b.jar"},
 		},
 		"oracle": map[string]interface{}{
+			"backend":   "fir",
 			"classpath": []interface{}{"/c.jar"},
 		},
 	})
 
+	if got := cfg.Oracle().Backend; got != "fir" {
+		t.Errorf("Oracle().Backend = %q, want %q", got, "fir")
+	}
 	if got := cfg.Analysis().Depth; got != "deep" {
 		t.Errorf("Analysis().Depth = %q, want %q", got, "deep")
 	}
@@ -1245,6 +1249,9 @@ func TestTypedSectionsEmpty(t *testing.T) {
 	if got := cfg.Oracle().Classpath; got != nil {
 		t.Errorf("expected nil Oracle classpath on empty config, got %v", got)
 	}
+	if got := cfg.Oracle().Backend; got != "" {
+		t.Errorf("expected empty Oracle backend on empty config, got %q", got)
+	}
 }
 
 func TestTypedSectionsNilConfig(t *testing.T) {
@@ -1263,6 +1270,9 @@ func TestTypedSectionsNilConfig(t *testing.T) {
 	}
 	if got := cfg.Oracle().Classpath; got != nil {
 		t.Errorf("nil cfg Oracle().Classpath = %v, want nil", got)
+	}
+	if got := cfg.Oracle().Backend; got != "" {
+		t.Errorf("nil cfg Oracle().Backend = %q, want empty", got)
 	}
 }
 

--- a/internal/oracle/backend.go
+++ b/internal/oracle/backend.go
@@ -1,0 +1,78 @@
+package oracle
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Backend identifies which JVM-side daemon krit invokes for the
+// type-oracle role: krit-types (the long-standing KAA-backed daemon)
+// or krit-fir (the K2/FIR-backed daemon shipped alongside it).
+//
+// Both backends speak the same analyze / analyzeAll / analyzeFiles /
+// analyzeWithDeps RPCs (see tools/krit-fir/.../OracleResponse.kt for
+// parity), so the Go-side oracle client deserializes either backend's
+// response with the same struct. Switching between them is a JAR
+// resolution decision: which daemon do we spawn?
+type Backend string
+
+const (
+	// BackendKAA is the krit-types daemon — Kotlin Analysis API
+	// backed. The historical default and the only backend before
+	// krit-fir landed.
+	BackendKAA Backend = "kaa"
+
+	// BackendFIR is the krit-fir daemon — K2/FIR backed. Required
+	// for rules that opt into Capability.NEEDS_FIR; usable as a
+	// drop-in replacement for KAA today thanks to oracle-protocol
+	// parity (see PR 2.x series).
+	BackendFIR Backend = "fir"
+
+	// DefaultBackend stays KAA until the FIR backend has shipped a
+	// CI parity gate. Flipping the default is a separate change.
+	DefaultBackend Backend = BackendKAA
+)
+
+// ParseBackend accepts the canonical lower-case spellings plus
+// common aliases. Unknown values surface as a typed error so callers
+// can render a useful message — `--oracle-backend=foo` shouldn't
+// silently fall back to a default.
+func ParseBackend(raw string) (Backend, error) {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "":
+		return DefaultBackend, nil
+	case "kaa", "krit-types", "types":
+		return BackendKAA, nil
+	case "fir", "krit-fir", "k2":
+		return BackendFIR, nil
+	default:
+		return "", fmt.Errorf("unknown oracle backend %q: want one of kaa, fir", raw)
+	}
+}
+
+// String renders the canonical wire form for the backend (matching
+// the value users set on the CLI / in krit.yml). Useful for error
+// messages and verbose logging.
+func (b Backend) String() string {
+	switch b {
+	case BackendKAA, BackendFIR:
+		return string(b)
+	case "":
+		return string(DefaultBackend)
+	default:
+		return string(b)
+	}
+}
+
+// JarName returns the canonical jar filename the backend expects on
+// disk — `krit-types.jar` for KAA, `krit-fir.jar` for FIR. Centralized
+// here so the discovery helper, the auto-download installer, and the
+// CI parity job share one source of truth.
+func (b Backend) JarName() string {
+	switch b {
+	case BackendFIR:
+		return "krit-fir.jar"
+	default:
+		return "krit-types.jar"
+	}
+}

--- a/internal/oracle/backend_test.go
+++ b/internal/oracle/backend_test.go
@@ -1,0 +1,83 @@
+package oracle
+
+import (
+	"testing"
+)
+
+func TestParseBackend(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		input   string
+		want    Backend
+		wantErr bool
+	}{
+		{name: "empty defaults to KAA", input: "", want: DefaultBackend},
+		{name: "canonical kaa", input: "kaa", want: BackendKAA},
+		{name: "canonical fir", input: "fir", want: BackendFIR},
+		{name: "case-insensitive KAA", input: "KAA", want: BackendKAA},
+		{name: "case-insensitive Fir", input: "Fir", want: BackendFIR},
+		{name: "trims whitespace", input: "  fir\t", want: BackendFIR},
+		{name: "alias krit-types", input: "krit-types", want: BackendKAA},
+		{name: "alias krit-fir", input: "krit-fir", want: BackendFIR},
+		{name: "alias types", input: "types", want: BackendKAA},
+		{name: "alias k2", input: "k2", want: BackendFIR},
+		{name: "unknown rejected", input: "foo", wantErr: true},
+		// Aliases mustn't bleed across backends — the test above
+		// fails closed if someone accidentally maps "k2" to KAA.
+		{name: "no silent fallback for typo", input: "fir2", wantErr: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := ParseBackend(tc.input)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for %q, got %q", tc.input, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error parsing %q: %v", tc.input, err)
+			}
+			if got != tc.want {
+				t.Fatalf("ParseBackend(%q) = %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestBackendString(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		in   Backend
+		want string
+	}{
+		{in: BackendKAA, want: "kaa"},
+		{in: BackendFIR, want: "fir"},
+		// Empty backend renders as the default so verbose log lines
+		// don't print a blank value when callers forget to set one.
+		{in: "", want: "kaa"},
+	}
+	for _, tc := range cases {
+		if got := tc.in.String(); got != tc.want {
+			t.Errorf("(%q).String() = %q, want %q", string(tc.in), got, tc.want)
+		}
+	}
+}
+
+func TestBackendJarName(t *testing.T) {
+	t.Parallel()
+	if got, want := BackendKAA.JarName(), "krit-types.jar"; got != want {
+		t.Errorf("BackendKAA.JarName() = %q, want %q", got, want)
+	}
+	if got, want := BackendFIR.JarName(), "krit-fir.jar"; got != want {
+		t.Errorf("BackendFIR.JarName() = %q, want %q", got, want)
+	}
+	// Unknown backend falls back to the KAA jar — surfacing it as an
+	// error in JarName would force every call site to handle the
+	// failure mode, but the canonical surface is ParseBackend.
+	if got := Backend("garbage").JarName(); got != "krit-types.jar" {
+		t.Errorf("unknown backend jar name should fall back to krit-types.jar, got %q", got)
+	}
+}

--- a/internal/pipeline/index.go
+++ b/internal/pipeline/index.go
@@ -14,6 +14,7 @@ import (
 	"github.com/kaeawc/krit/internal/cache"
 	"github.com/kaeawc/krit/internal/config"
 	"github.com/kaeawc/krit/internal/diag"
+	"github.com/kaeawc/krit/internal/firchecks"
 	"github.com/kaeawc/krit/internal/fsutil"
 	"github.com/kaeawc/krit/internal/hashutil"
 	"github.com/kaeawc/krit/internal/javafacts"
@@ -184,6 +185,13 @@ type IndexInput struct {
 	// UseDaemon mirrors --daemon: use the long-lived krit-types daemon
 	// instead of one-shot invocation.
 	UseDaemon bool
+	// OracleBackend selects which JVM daemon to spawn for the type
+	// oracle role. Empty means defer to oracle.DefaultBackend
+	// (currently krit-types / "kaa"). The value is the resolved
+	// `--oracle-backend` flag, or `oracle.backend` from krit.yml
+	// when the flag isn't set. Parsing happens in the caller; the
+	// pipeline just routes on the value.
+	OracleBackend oracle.Backend
 	// PrebuiltOracleDaemon, when non-nil, is reused by runDaemonOracle
 	// instead of calling oracle.InvokeDaemon. The serve daemon's
 	// ensureOracleDaemon supplies a *oracle.Daemon kept alive across
@@ -970,9 +978,22 @@ func (p IndexPhase) buildOracleFilterListPath(in IndexInput, oracleRules []*api.
 // runJvmAnalyze attempts to invoke krit-types to produce an oracle JSON path.
 // Returns the path to the produced oracle JSON (empty on failure).
 func (p IndexPhase) runJvmAnalyze(in IndexInput, oracleRules []*api.Rule, scanPaths []string, loadOracleFilterFiles func() []*scanner.File, jvmTracker perf.Tracker) string {
+	backend := in.OracleBackend
+	if backend == "" {
+		backend = oracle.DefaultBackend
+	}
 	var jarPath string
 	jvmTracker.TrackVoid("findJar", func() {
-		jarPath = oracle.FindJar(scanPaths)
+		switch backend {
+		case oracle.BackendFIR:
+			// krit-fir ships the same analyze / analyzeAll /
+			// analyzeWithDeps RPCs as krit-types (see PR 2.x
+			// parity work), so we can swap the jar without
+			// touching the InvokeCached pipeline below.
+			jarPath = firchecks.FindFirJar(scanPaths)
+		default:
+			jarPath = oracle.FindJar(scanPaths)
+		}
 	})
 	if jarPath == "" {
 		return ""
@@ -997,7 +1018,11 @@ func (p IndexPhase) runJvmAnalyze(in IndexInput, oracleRules []*api.Rule, scanPa
 		}
 	}
 	if in.Verbose {
-		in.logf("verbose: Running krit-types (%d source dirs)...\n", len(sourceDirs))
+		daemonName := "krit-types"
+		if backend == oracle.BackendFIR {
+			daemonName = "krit-fir"
+		}
+		in.logf("verbose: Running %s (%d source dirs)...\n", daemonName, len(sourceDirs))
 	}
 
 	filterListPath, cleanup := p.buildOracleFilterListPath(in, oracleRules, loadOracleFilterFiles, jvmTracker)
@@ -1146,7 +1171,20 @@ func (p IndexPhase) runOracle(in IndexInput, base typeinfer.TypeResolver, result
 
 	var resolver typeinfer.TypeResolver
 	if in.UseDaemon {
-		resolver = p.runDaemonOracle(in, oracleRules, scanPaths, loadOracleFilterFiles, oracleTracker, base, result)
+		if in.OracleBackend == oracle.BackendFIR {
+			// runDaemonOracle's long-lived oracle.InvokeDaemon path
+			// is wired specifically to krit-types' daemon-protocol
+			// surface. The krit-fir daemon ships the same RPCs but
+			// the Go-side persistent-daemon wrapper hasn't been
+			// ported yet — surface that as a verbose-warn fallback
+			// to the one-shot path so users get a working analysis
+			// even when they combine `--daemon` with
+			// `--oracle-backend=fir` by mistake.
+			in.warnf("warning: --daemon is not yet supported with --oracle-backend=fir; falling back to one-shot mode\n")
+			resolver = p.runAutoDetectOracle(in, oracleRules, scanPaths, loadOracleFilterFiles, oracleTracker, base)
+		} else {
+			resolver = p.runDaemonOracle(in, oracleRules, scanPaths, loadOracleFilterFiles, oracleTracker, base, result)
+		}
 	} else {
 		resolver = p.runAutoDetectOracle(in, oracleRules, scanPaths, loadOracleFilterFiles, oracleTracker, base)
 	}


### PR DESCRIPTION
## Summary

PR 4 of the FIR migration series. Adds a Go-side selector that routes the type-oracle role between the two JVM daemons. Both backends ship the same \`analyze\` / \`analyzeAll\` / \`analyzeFiles\` / \`analyzeWithDeps\` RPCs (see PR 2.x parity work), so the switch is a JAR resolution decision; the rest of the oracle pipeline (cache, lazy lookup, \`CompositeResolver\`) is shared.

- \`internal/oracle\`: new \`Backend\` type with \`ParseBackend\` (canonical \`kaa\` / \`fir\`, common aliases like \`krit-types\` / \`k2\`), \`String()\`, \`JarName()\`. Unknown values fail closed so a typo doesn't silently fall through.
- \`internal/config\`: \`OracleConfig.Backend\` reads \`oracle.backend\` from \`krit.yml\`.
- \`internal/cli/scan\`: new \`--oracle-backend\` flag + \`resolveOracleBackend\` helper implementing the priority chain (flag > yaml > \`oracle.DefaultBackend\`).
- \`internal/pipeline\`: \`IndexInput.OracleBackend\` threads through; \`runJvmAnalyze\` switches between \`oracle.FindJar\` and \`firchecks.FindFirJar\` based on the backend. Verbose log prints the resolved daemon name.

\`--daemon\` mode hasn't been ported to FIR yet (its long-lived \`oracle.InvokeDaemon\` wraps krit-types' specific protocol). Combining \`--daemon\` with \`--oracle-backend=fir\` prints a warning and falls back to the one-shot path so a working analysis still ships; a follow-up will land a FIR-aware persistent daemon wrapper.

## Test plan
- [x] \`go build ./cmd/krit/ && go vet ./... && golangci-lint run ./... && go test ./... -count=1\`
- [x] \`internal/oracle/backend_test.go\` — \`ParseBackend\` canonical/alias/case-insensitive/whitespace/unknown handling; \`JarName\` / \`String\` contract
- [x] \`internal/cli/scan/oracle_backend_test.go\` — resolution priority chain (flag > yaml > default), aliases, nil-config tolerance, malformed-flag and malformed-yaml error paths
- [x] \`internal/config\` — TypedSections coverage for the new \`Backend\` field

## Next
PR 5 — CI oracle-parity validation job that runs the same analyze through both backends and diffs the responses to catch behavioral drift.