### PR TITLE
feat(krit-fir): project-scope payload contexts on analyzeFile

### DIFF
--- a/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/Main.kt
+++ b/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/Main.kt
@@ -8,6 +8,7 @@ import dev.jasonpearson.krit.fir.plugins.KtFileParser
 import dev.jasonpearson.krit.fir.plugins.PluginResponse
 import dev.jasonpearson.krit.fir.plugins.PluginRuleRegistry
 import dev.jasonpearson.krit.fir.plugins.PluginRuleRunner
+import dev.jasonpearson.krit.fir.plugins.ProjectPayloads
 import dev.jasonpearson.krit.fir.runner.AnalysisSession
 import dev.jasonpearson.krit.fir.runner.BatchResult
 import java.io.File as JavaFile
@@ -299,6 +300,13 @@ data class CheckRequest(
     val path: String? = null,
     val source: String? = null,
     val ruleIds: List<String>? = null,
+    // Project-scope facts shipped on analyzeFile. Each field is null
+    // when the corresponding top-level JSON key is absent; the Go
+    // side only sends a key when it has facts to ship, so rules that
+    // declared the matching `NEEDS_*` capability see the data when
+    // it's available and null when the project doesn't have any
+    // (e.g. NEEDS_MANIFEST on a pure-Kotlin library).
+    val projectPayloads: ProjectPayloads = ProjectPayloads.EMPTY,
 )
 
 fun parseRequest(json: String): CheckRequest {
@@ -312,7 +320,8 @@ fun parseRequest(json: String): CheckRequest {
     val path = extractString(json, "path")
     val source = extractString(json, "source")
     val files = extractFileRefs(json)
-    return CheckRequest(id, command, files, sourceDirs, classpath, rules, pluginJars, path, source, ruleIds)
+    val payloads = if (command == "analyzeFile") ProjectPayloads.parse(json) else ProjectPayloads.EMPTY
+    return CheckRequest(id, command, files, sourceDirs, classpath, rules, pluginJars, path, source, ruleIds, payloads)
 }
 
 internal fun handleAnalyzeFile(request: CheckRequest, session: AnalysisSession): String {
@@ -358,7 +367,13 @@ internal fun handleAnalyzeFile(request: CheckRequest, session: AnalysisSession):
         val parsed = KtFileParser.parse(text, pathHint = path)
         try {
             val file = KritFile(path = path, text = text, ktFile = parsed.ktFile)
-            val outcome = PluginRuleRunner.run(file, request.ruleIds, ruleConfigs = null, resolver = resolver)
+            val outcome = PluginRuleRunner.run(
+                file = file,
+                ruleIds = request.ruleIds,
+                ruleConfigs = null,
+                resolver = resolver,
+                projectPayloads = request.projectPayloads,
+            )
             PluginResponse.buildAnalyzeFile(request.id, outcome.findings, outcome.errors)
         } finally {
             parsed.close()

--- a/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/plugins/PayloadContexts.kt
+++ b/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/plugins/PayloadContexts.kt
@@ -1,0 +1,217 @@
+package dev.jasonpearson.krit.fir.plugins
+
+import dev.jasonpearson.krit.api.CrossFileContext
+import dev.jasonpearson.krit.api.CrossFileDeclaration
+import dev.jasonpearson.krit.api.GradleContext
+import dev.jasonpearson.krit.api.ManifestContext
+import dev.jasonpearson.krit.api.ModuleIndexContext
+import dev.jasonpearson.krit.api.ResourcesContext
+
+/**
+ * Wire-format project facts handed to plugin rules via [`RuleContext`].
+ * Mirrors the payload shape krit-types serializes in its `analyzeFile`
+ * request so a rule jar that worked against the KAA backend ships
+ * identical fact access on the FIR backend after rebuild.
+ *
+ * Each payload class carries the flat, easy-to-parse wire shape
+ * (`List<String>` plus a handful of scalars); the matching
+ * `Payload*Context` wrappers build the per-component lookup maps
+ * lazily so rules that only query one direction don't pay for the
+ * other.
+ */
+
+data class GradleProfilePayload(
+    val minSdk: Int?,
+    val targetSdk: Int?,
+    val compileSdk: Int?,
+    val kotlinVersion: String?,
+    val javaTargetVersion: String?,
+    val agpVersion: String?,
+    // `group:name:version` triples, krit-types-compatible.
+    val deps: List<String>,
+)
+
+data class ManifestProfilePayload(
+    val packageName: String?,
+    val minSdk: Int?,
+    val targetSdk: Int?,
+    val permissions: List<String>,
+    val activities: List<String>,
+    val exportedActivities: List<String>,
+    val services: List<String>,
+    val exportedServices: List<String>,
+    val receivers: List<String>,
+    val exportedReceivers: List<String>,
+)
+
+data class ResourcesProfilePayload(
+    // Strings / colors / dimensions are flat `name=value` lists so the
+    // wire format reuses the same `String[]` extractor — the wrapper
+    // parses them back into maps on first query.
+    val strings: List<String>,
+    val drawables: List<String>,
+    val layouts: List<String>,
+    val colors: List<String>,
+    val dimensions: List<String>,
+    val ids: List<String>,
+)
+
+data class ModulesProfilePayload(
+    // Each module is `path|directory|dependsOn,...|sourceRoots,...`.
+    val modules: List<String>,
+)
+
+data class CrossFileProfilePayload(
+    // Declarations are `fqn|kind|file|line|visibility`.
+    val declarations: List<String>,
+    // Pre-grouped non-comment references as `name|file1,file2,...`.
+    val nonCommentRefsByName: List<String>,
+)
+
+internal class PayloadGradleContext(payload: GradleProfilePayload) : GradleContext {
+    override val minSdk: Int? = payload.minSdk
+    override val targetSdk: Int? = payload.targetSdk
+    override val compileSdk: Int? = payload.compileSdk
+    override val kotlinVersion: String? = payload.kotlinVersion
+    override val javaTargetVersion: String? = payload.javaTargetVersion
+    override val agpVersion: String? = payload.agpVersion
+
+    // group:name -> version (last-write-wins on duplicate coords; the
+    // Go-side caller already de-dupes, but Kotlin's map semantics
+    // protect against a malformed payload).
+    private val versionByCoord: Map<String, String> by lazy {
+        val out = HashMap<String, String>(payload.deps.size)
+        for (entry in payload.deps) {
+            val firstColon = entry.indexOf(':')
+            if (firstColon <= 0) continue
+            val secondColon = entry.indexOf(':', firstColon + 1)
+            if (secondColon <= firstColon + 1) continue
+            val coord = entry.substring(0, secondColon)
+            val version = entry.substring(secondColon + 1)
+            if (version.isNotEmpty()) {
+                out[coord] = version
+            }
+        }
+        out
+    }
+
+    override fun hasDependency(group: String, name: String): Boolean =
+        versionByCoord.containsKey("$group:$name")
+
+    override fun dependencyVersion(group: String, name: String): String? =
+        versionByCoord["$group:$name"]
+}
+
+internal class PayloadManifestContext(payload: ManifestProfilePayload) : ManifestContext {
+    override val packageName: String? = payload.packageName
+    override val minSdk: Int? = payload.minSdk
+    override val targetSdk: Int? = payload.targetSdk
+
+    private val permissionSet: Set<String> by lazy { payload.permissions.toHashSet() }
+    private val activitySet: Set<String> by lazy { payload.activities.toHashSet() }
+    private val exportedActivitySet: Set<String> by lazy { payload.exportedActivities.toHashSet() }
+    private val serviceSet: Set<String> by lazy { payload.services.toHashSet() }
+    private val exportedServiceSet: Set<String> by lazy { payload.exportedServices.toHashSet() }
+    private val receiverSet: Set<String> by lazy { payload.receivers.toHashSet() }
+    private val exportedReceiverSet: Set<String> by lazy { payload.exportedReceivers.toHashSet() }
+
+    override fun hasPermission(name: String): Boolean = name in permissionSet
+    override fun hasActivity(name: String): Boolean = name in activitySet
+    override fun isActivityExported(name: String): Boolean = name in exportedActivitySet
+    override fun hasService(name: String): Boolean = name in serviceSet
+    override fun isServiceExported(name: String): Boolean = name in exportedServiceSet
+    override fun hasReceiver(name: String): Boolean = name in receiverSet
+    override fun isReceiverExported(name: String): Boolean = name in exportedReceiverSet
+}
+
+internal class PayloadResourcesContext(payload: ResourcesProfilePayload) : ResourcesContext {
+    private val stringMap: Map<String, String> by lazy { parseNameValueList(payload.strings) }
+    private val colorMap: Map<String, String> by lazy { parseNameValueList(payload.colors) }
+    private val dimensionMap: Map<String, String> by lazy { parseNameValueList(payload.dimensions) }
+    private val drawableSet: Set<String> by lazy { payload.drawables.toHashSet() }
+    private val layoutSet: Set<String> by lazy { payload.layouts.toHashSet() }
+    private val idSet: Set<String> by lazy { payload.ids.toHashSet() }
+
+    override fun stringValue(name: String): String? = stringMap[name]
+    override fun hasString(name: String): Boolean = stringMap.containsKey(name)
+    override fun hasDrawable(name: String): Boolean = name in drawableSet
+    override fun hasLayout(name: String): Boolean = name in layoutSet
+    override fun colorValue(name: String): String? = colorMap[name]
+    override fun hasColor(name: String): Boolean = colorMap.containsKey(name)
+    override fun dimensionValue(name: String): String? = dimensionMap[name]
+    override fun hasDimension(name: String): Boolean = dimensionMap.containsKey(name)
+    override fun hasId(name: String): Boolean = name in idSet
+
+    private fun parseNameValueList(entries: List<String>): Map<String, String> {
+        val out = HashMap<String, String>(entries.size)
+        for (entry in entries) {
+            val eq = entry.indexOf('=')
+            // eq <= 0 catches both "no = found" (-1) and "leading =" (0,
+            // which would make the name empty). Either is malformed.
+            if (eq <= 0) continue
+            out[entry.substring(0, eq)] = entry.substring(eq + 1)
+        }
+        return out
+    }
+}
+
+internal class PayloadModuleIndexContext(payload: ModulesProfilePayload) : ModuleIndexContext {
+    private data class Entry(
+        val directory: String,
+        val dependsOn: List<String>,
+        val sourceRoots: List<String>,
+    )
+
+    private val byPath: Map<String, Entry> by lazy {
+        val out = LinkedHashMap<String, Entry>(payload.modules.size)
+        for (line in payload.modules) {
+            val parts = line.split('|')
+            if (parts.size < 4 || parts[0].isEmpty()) continue
+            val deps = parts[2].takeIf { it.isNotEmpty() }?.split(',') ?: emptyList()
+            val roots = parts[3].takeIf { it.isNotEmpty() }?.split(',') ?: emptyList()
+            out[parts[0]] = Entry(parts[1], deps, roots)
+        }
+        out
+    }
+
+    override val modulePaths: List<String> get() = byPath.keys.toList()
+    override fun directoryOf(modulePath: String): String? = byPath[modulePath]?.directory
+    override fun dependenciesOf(modulePath: String): List<String> =
+        byPath[modulePath]?.dependsOn.orEmpty()
+    override fun sourceRootsOf(modulePath: String): List<String> =
+        byPath[modulePath]?.sourceRoots.orEmpty()
+}
+
+internal class PayloadCrossFileContext(payload: CrossFileProfilePayload) : CrossFileContext {
+    private val byFqn: Map<String, CrossFileDeclaration> by lazy {
+        val out = HashMap<String, CrossFileDeclaration>(payload.declarations.size)
+        for (entry in payload.declarations) {
+            val parts = entry.split('|')
+            if (parts.size < 4 || parts[0].isEmpty()) continue
+            val line = parts[3].toIntOrNull() ?: continue
+            val visibility = parts.getOrNull(4)?.takeIf { it.isNotEmpty() }
+            out[parts[0]] = CrossFileDeclaration(parts[0], parts[1], parts[2], line, visibility)
+        }
+        out
+    }
+
+    private val refFilesByName: Map<String, List<String>> by lazy {
+        val out = HashMap<String, List<String>>(payload.nonCommentRefsByName.size)
+        for (entry in payload.nonCommentRefsByName) {
+            val sep = entry.indexOf('|')
+            if (sep <= 0) continue
+            val name = entry.substring(0, sep)
+            val files = entry.substring(sep + 1)
+                .split(',')
+                .filter { it.isNotEmpty() }
+            if (files.isNotEmpty()) {
+                out[name] = files
+            }
+        }
+        out
+    }
+
+    override fun declarationByFqn(fqn: String): CrossFileDeclaration? = byFqn[fqn]
+    override fun referenceFiles(name: String): List<String> = refFilesByName[name].orEmpty()
+    override fun isReferenced(name: String): Boolean = refFilesByName.containsKey(name)
+}

--- a/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/plugins/PayloadParsers.kt
+++ b/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/plugins/PayloadParsers.kt
@@ -1,0 +1,263 @@
+package dev.jasonpearson.krit.fir.plugins
+
+/**
+ * Minimal JSON helpers for slicing nested objects + scalars out of an
+ * `analyzeFile` request body. Mirrors the krit-types' parser surface
+ * exactly so wire-format drift between the two backends is impossible
+ * — same expression types come out the same Go-side struct on either
+ * side.
+ *
+ * Implemented by hand because adding a JSON dependency to krit-fir's
+ * shadow jar would bloat the wire-format JAR by megabytes for a use
+ * case (analyzeFile request decoding) that hits the parser on the
+ * order of once per IDE keystroke.
+ */
+internal object PayloadParsers {
+
+    /**
+     * Return the JSON object body for `"<key>": {...}` — the inner
+     * `{...}` slice including braces. Brace-balanced so nested
+     * objects don't terminate the slice early. Returns null when the
+     * key is absent or its value is not an object.
+     */
+    fun extractObjectBlock(json: String, key: String): String? {
+        val keyIdx = findKeyStart(json, key) ?: return null
+        var i = json.indexOf(':', keyIdx)
+        if (i < 0) return null
+        i = skipWhitespace(json, i + 1)
+        if (i >= json.length || json[i] != '{') return null
+        val start = i
+        var depth = 0
+        var inString = false
+        var escape = false
+        while (i < json.length) {
+            val c = json[i]
+            when {
+                escape -> escape = false
+                inString && c == '\\' -> escape = true
+                inString && c == '"' -> inString = false
+                !inString && c == '"' -> inString = true
+                !inString && c == '{' -> depth++
+                !inString && c == '}' -> {
+                    depth--
+                    if (depth == 0) return json.substring(start, i + 1)
+                }
+            }
+            i++
+        }
+        return null
+    }
+
+    /**
+     * Reads a string-valued field out of a JSON object. Handles
+     * `\\"`, `\\\\`, `\\n`, `\\r`, `\\t`, and `\\uXXXX` — the same
+     * escape set the wire encoder produces.
+     */
+    fun extractString(json: String, key: String): String? {
+        val keyIdx = findKeyStart(json, key) ?: return null
+        var i = json.indexOf(':', keyIdx)
+        if (i < 0) return null
+        i = skipWhitespace(json, i + 1)
+        if (i >= json.length || json[i] != '"') return null
+        i++
+        val sb = StringBuilder()
+        while (i < json.length) {
+            val c = json[i]
+            when {
+                c == '"' -> return sb.toString()
+                c == '\\' && i + 1 < json.length -> {
+                    when (val esc = json[i + 1]) {
+                        '"', '\\', '/' -> sb.append(esc)
+                        'n' -> sb.append('\n')
+                        'r' -> sb.append('\r')
+                        't' -> sb.append('\t')
+                        'b' -> sb.append('\b')
+                        'f' -> sb.append('\u000C')
+                        'u' -> {
+                            if (i + 5 >= json.length) return null
+                            val code = json.substring(i + 2, i + 6).toIntOrNull(16) ?: return null
+                            sb.append(code.toChar())
+                            i += 4
+                        }
+                        else -> sb.append(esc)
+                    }
+                    i += 2
+                    continue
+                }
+                else -> sb.append(c)
+            }
+            i++
+        }
+        return null
+    }
+
+    /** Reads an integer field. Returns null on absent or non-integer. */
+    fun extractLong(json: String, key: String): Long? {
+        val keyIdx = findKeyStart(json, key) ?: return null
+        var i = json.indexOf(':', keyIdx)
+        if (i < 0) return null
+        i = skipWhitespace(json, i + 1)
+        val start = i
+        if (i < json.length && (json[i] == '-' || json[i] == '+')) i++
+        while (i < json.length && json[i].isDigit()) i++
+        if (i == start) return null
+        return json.substring(start, i).toLongOrNull()
+    }
+
+    /**
+     * Read a `["a","b","c"]` array of strings. Returns null when the
+     * key is absent; returns empty list when the array is present but
+     * empty. Inner strings honour the same escape set as
+     * [`extractString`].
+     */
+    fun extractStringArray(json: String, key: String): List<String>? {
+        val keyIdx = findKeyStart(json, key) ?: return null
+        var i = json.indexOf(':', keyIdx)
+        if (i < 0) return null
+        i = skipWhitespace(json, i + 1)
+        if (i >= json.length || json[i] != '[') return null
+        i++
+        val out = mutableListOf<String>()
+        while (i < json.length) {
+            i = skipWhitespace(json, i)
+            if (i >= json.length) return null
+            if (json[i] == ']') return out
+            if (json[i] != '"') return null
+            // Slice from the open quote forward and let extractString
+            // consume the literal. Wrapping it in a 1-element object
+            // (`{"v":"..."}`) lets us reuse the same helper without a
+            // dedicated array-element parser.
+            val rest = "{\"v\":" + json.substring(i)
+            val value = extractString(rest, "v") ?: return null
+            out.add(value)
+            // Advance past the literal we just consumed. Walk through
+            // the original string honouring escapes so we land on the
+            // closing quote precisely.
+            i++ // step over opening quote
+            var escape = false
+            while (i < json.length) {
+                val c = json[i]
+                if (escape) {
+                    escape = false
+                } else if (c == '\\') {
+                    escape = true
+                } else if (c == '"') {
+                    i++
+                    break
+                }
+                i++
+            }
+            i = skipWhitespace(json, i)
+            if (i < json.length && json[i] == ',') i++
+        }
+        return null
+    }
+
+    /** Find the index of the opening `"` of `"<key>"` in [json]. */
+    private fun findKeyStart(json: String, key: String): Int? {
+        val needle = "\"" + key + "\""
+        var from = 0
+        while (true) {
+            val idx = json.indexOf(needle, from)
+            if (idx < 0) return null
+            // Reject substring matches inside other key names (e.g.
+            // `"sourceDirs"` matching `key="source"`).
+            val before = idx - 1
+            if (before >= 0) {
+                val b = json[before]
+                if (b != '{' && b != ',' && !b.isWhitespace()) {
+                    from = idx + needle.length
+                    continue
+                }
+            }
+            return idx
+        }
+    }
+
+    private fun skipWhitespace(json: String, start: Int): Int {
+        var i = start
+        while (i < json.length && json[i].isWhitespace()) i++
+        return i
+    }
+}
+
+/**
+ * Convenience that pulls all five project-scope payload objects out
+ * of an `analyzeFile` request body in one pass. Each field is null
+ * when the corresponding top-level key is absent.
+ */
+data class ProjectPayloads(
+    val gradle: GradleProfilePayload?,
+    val manifest: ManifestProfilePayload?,
+    val resources: ResourcesProfilePayload?,
+    val moduleIndex: ModulesProfilePayload?,
+    val crossFile: CrossFileProfilePayload?,
+) {
+    companion object {
+        val EMPTY: ProjectPayloads = ProjectPayloads(null, null, null, null, null)
+
+        fun parse(json: String): ProjectPayloads = ProjectPayloads(
+            gradle = parseGradle(json),
+            manifest = parseManifest(json),
+            resources = parseResources(json),
+            moduleIndex = parseModuleIndex(json),
+            crossFile = parseCrossFile(json),
+        )
+
+        private fun parseGradle(json: String): GradleProfilePayload? {
+            val outer = PayloadParsers.extractObjectBlock(json, "gradle") ?: return null
+            return GradleProfilePayload(
+                minSdk = PayloadParsers.extractLong(outer, "minSdk")?.toInt()?.takeIf { it >= 0 },
+                targetSdk = PayloadParsers.extractLong(outer, "targetSdk")?.toInt()?.takeIf { it >= 0 },
+                compileSdk = PayloadParsers.extractLong(outer, "compileSdk")?.toInt()?.takeIf { it >= 0 },
+                kotlinVersion = PayloadParsers.extractString(outer, "kotlinVersion"),
+                javaTargetVersion = PayloadParsers.extractString(outer, "javaTargetVersion"),
+                agpVersion = PayloadParsers.extractString(outer, "agpVersion"),
+                deps = PayloadParsers.extractStringArray(outer, "deps").orEmpty(),
+            )
+        }
+
+        private fun parseManifest(json: String): ManifestProfilePayload? {
+            val outer = PayloadParsers.extractObjectBlock(json, "manifest") ?: return null
+            return ManifestProfilePayload(
+                packageName = PayloadParsers.extractString(outer, "package"),
+                minSdk = PayloadParsers.extractLong(outer, "minSdk")?.toInt()?.takeIf { it >= 0 },
+                targetSdk = PayloadParsers.extractLong(outer, "targetSdk")?.toInt()?.takeIf { it >= 0 },
+                permissions = PayloadParsers.extractStringArray(outer, "permissions").orEmpty(),
+                activities = PayloadParsers.extractStringArray(outer, "activities").orEmpty(),
+                exportedActivities = PayloadParsers.extractStringArray(outer, "exportedActivities").orEmpty(),
+                services = PayloadParsers.extractStringArray(outer, "services").orEmpty(),
+                exportedServices = PayloadParsers.extractStringArray(outer, "exportedServices").orEmpty(),
+                receivers = PayloadParsers.extractStringArray(outer, "receivers").orEmpty(),
+                exportedReceivers = PayloadParsers.extractStringArray(outer, "exportedReceivers").orEmpty(),
+            )
+        }
+
+        private fun parseResources(json: String): ResourcesProfilePayload? {
+            val outer = PayloadParsers.extractObjectBlock(json, "resources") ?: return null
+            return ResourcesProfilePayload(
+                strings = PayloadParsers.extractStringArray(outer, "strings").orEmpty(),
+                drawables = PayloadParsers.extractStringArray(outer, "drawables").orEmpty(),
+                layouts = PayloadParsers.extractStringArray(outer, "layouts").orEmpty(),
+                colors = PayloadParsers.extractStringArray(outer, "colors").orEmpty(),
+                dimensions = PayloadParsers.extractStringArray(outer, "dimensions").orEmpty(),
+                ids = PayloadParsers.extractStringArray(outer, "ids").orEmpty(),
+            )
+        }
+
+        private fun parseModuleIndex(json: String): ModulesProfilePayload? {
+            val outer = PayloadParsers.extractObjectBlock(json, "moduleIndex") ?: return null
+            return ModulesProfilePayload(
+                modules = PayloadParsers.extractStringArray(outer, "modules").orEmpty(),
+            )
+        }
+
+        private fun parseCrossFile(json: String): CrossFileProfilePayload? {
+            val outer = PayloadParsers.extractObjectBlock(json, "crossFile") ?: return null
+            return CrossFileProfilePayload(
+                declarations = PayloadParsers.extractStringArray(outer, "declarations").orEmpty(),
+                nonCommentRefsByName = PayloadParsers.extractStringArray(outer, "nonCommentRefsByName").orEmpty(),
+            )
+        }
+    }
+}

--- a/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/plugins/PluginRuleRunner.kt
+++ b/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/plugins/PluginRuleRunner.kt
@@ -37,16 +37,31 @@ internal object PluginRuleRunner {
         ruleIds: List<String>?,
         ruleConfigs: Map<String, Map<String, Any?>>?,
         resolver: Resolver? = null,
+        projectPayloads: ProjectPayloads = ProjectPayloads.EMPTY,
     ): RunResult {
         val findings = mutableListOf<PluginFinding>()
         val errors = linkedMapOf<String, String>()
+        // Build each project-scope context once per request and reuse
+        // across every rule's RuleContext. Lazy maps in the wrappers
+        // mean an unconsulted context costs nothing beyond construction.
+        val gradle = projectPayloads.gradle?.let(::PayloadGradleContext)
+        val manifest = projectPayloads.manifest?.let(::PayloadManifestContext)
+        val resources = projectPayloads.resources?.let(::PayloadResourcesContext)
+        val moduleIndex = projectPayloads.moduleIndex?.let(::PayloadModuleIndexContext)
+        val crossFile = projectPayloads.crossFile?.let(::PayloadCrossFileContext)
+
         for (loaded in PluginRuleRegistry.selected(ruleIds)) {
             val options = ruleConfigs?.get(loaded.descriptor.ruleId).orEmpty()
-            val needsResolver = loaded.descriptor.needs.contains(Capability.NEEDS_RESOLVER.name)
+            val needs = loaded.descriptor.needs
             val ctx = RuleContext(
                 ruleId = loaded.descriptor.ruleId,
                 config = options,
-                resolver = resolver.takeIf { needsResolver },
+                resolver = resolver.takeIf { needs.contains(Capability.NEEDS_RESOLVER.name) },
+                gradle = gradle.takeIf { needs.contains(Capability.NEEDS_GRADLE.name) },
+                manifest = manifest.takeIf { needs.contains(Capability.NEEDS_MANIFEST.name) },
+                resources = resources.takeIf { needs.contains(Capability.NEEDS_RESOURCES.name) },
+                moduleIndex = moduleIndex.takeIf { needs.contains(Capability.NEEDS_MODULE_INDEX.name) },
+                crossFile = crossFile.takeIf { needs.contains(Capability.NEEDS_CROSS_FILE.name) },
             )
             try {
                 for (finding in loaded.rule.check(file, ctx)) {

--- a/tools/krit-fir/src/test/kotlin/dev/jasonpearson/krit/fir/plugins/PayloadContextsTest.kt
+++ b/tools/krit-fir/src/test/kotlin/dev/jasonpearson/krit/fir/plugins/PayloadContextsTest.kt
@@ -1,0 +1,120 @@
+package dev.jasonpearson.krit.fir.plugins
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class PayloadContextsTest {
+
+    @Test
+    fun gradleContextResolvesDepVersionsAndScalars() {
+        val ctx = PayloadGradleContext(
+            GradleProfilePayload(
+                minSdk = 21,
+                targetSdk = 34,
+                compileSdk = 34,
+                kotlinVersion = "2.3.21",
+                javaTargetVersion = "21",
+                agpVersion = "8.5.0",
+                deps = listOf("org.x:y:1.2.3", "junit:junit:4.13.2"),
+            ),
+        )
+        assertEquals(21, ctx.minSdk)
+        assertEquals("2.3.21", ctx.kotlinVersion)
+        assertTrue(ctx.hasDependency("org.x", "y"))
+        assertEquals("1.2.3", ctx.dependencyVersion("org.x", "y"))
+        assertFalse(ctx.hasDependency("org.x", "missing"))
+        // Malformed entries (no version) are dropped silently to keep
+        // a junky payload from poisoning every other lookup.
+        assertNull(ctx.dependencyVersion("missing", "thing"))
+    }
+
+    @Test
+    fun manifestContextResolvesPermissionsActivitiesAndExports() {
+        val ctx = PayloadManifestContext(
+            ManifestProfilePayload(
+                packageName = "com.acme",
+                minSdk = 24, targetSdk = 34,
+                permissions = listOf("android.permission.INTERNET"),
+                activities = listOf("com.acme.MainActivity"),
+                exportedActivities = listOf("com.acme.MainActivity"),
+                services = listOf("com.acme.Sync"),
+                exportedServices = emptyList(),
+                receivers = listOf("com.acme.Boot"),
+                exportedReceivers = emptyList(),
+            ),
+        )
+        assertEquals("com.acme", ctx.packageName)
+        assertTrue(ctx.hasPermission("android.permission.INTERNET"))
+        assertTrue(ctx.hasActivity("com.acme.MainActivity"))
+        assertTrue(ctx.isActivityExported("com.acme.MainActivity"))
+        assertFalse(ctx.isServiceExported("com.acme.Sync"))
+        assertFalse(ctx.isReceiverExported("com.acme.Boot"))
+    }
+
+    @Test
+    fun resourcesContextParsesNameValuePairsAndIdentifierSets() {
+        val ctx = PayloadResourcesContext(
+            ResourcesProfilePayload(
+                strings = listOf("app_name=Acme", "url=https://x?a=b"),
+                drawables = listOf("ic_launcher"),
+                layouts = listOf("activity_main"),
+                colors = listOf("primary=#FF0000"),
+                dimensions = listOf("gutter=16dp"),
+                ids = listOf("button"),
+            ),
+        )
+        assertEquals("Acme", ctx.stringValue("app_name"))
+        // Values containing `=` round-trip cleanly — the parser
+        // splits on the first `=` only.
+        assertEquals("https://x?a=b", ctx.stringValue("url"))
+        assertEquals("#FF0000", ctx.colorValue("primary"))
+        assertEquals("16dp", ctx.dimensionValue("gutter"))
+        assertTrue(ctx.hasDrawable("ic_launcher"))
+        assertTrue(ctx.hasId("button"))
+    }
+
+    @Test
+    fun moduleIndexParsesPathDirectoryDepsAndRoots() {
+        val ctx = PayloadModuleIndexContext(
+            ModulesProfilePayload(
+                modules = listOf(
+                    ":app|/repo/app|:lib,:util|/repo/app/src/main/kotlin",
+                    ":lib|/repo/lib||/repo/lib/src/main/kotlin,/repo/lib/src/main/java",
+                ),
+            ),
+        )
+        assertEquals(listOf(":app", ":lib"), ctx.modulePaths)
+        assertEquals("/repo/app", ctx.directoryOf(":app"))
+        assertEquals(listOf(":lib", ":util"), ctx.dependenciesOf(":app"))
+        assertEquals(emptyList(), ctx.dependenciesOf(":lib"))
+        assertEquals(2, ctx.sourceRootsOf(":lib").size)
+    }
+
+    @Test
+    fun crossFileContextParsesDeclarationsAndReferences() {
+        val ctx = PayloadCrossFileContext(
+            CrossFileProfilePayload(
+                declarations = listOf(
+                    "com.acme.Foo|class|/Foo.kt|10|public",
+                    "com.acme.Bar|interface|/Bar.kt|3|",
+                ),
+                nonCommentRefsByName = listOf(
+                    "Foo|/A.kt,/B.kt",
+                    "Bar|/A.kt",
+                ),
+            ),
+        )
+        val foo = ctx.declarationByFqn("com.acme.Foo")!!
+        assertEquals("class", foo.kind)
+        assertEquals("/Foo.kt", foo.file)
+        assertEquals(10, foo.line)
+        assertEquals("public", foo.visibility)
+        assertNull(ctx.declarationByFqn("com.acme.Bar")?.visibility)
+        assertEquals(listOf("/A.kt", "/B.kt"), ctx.referenceFiles("Foo"))
+        assertTrue(ctx.isReferenced("Bar"))
+        assertFalse(ctx.isReferenced("Baz"))
+    }
+}

--- a/tools/krit-fir/src/test/kotlin/dev/jasonpearson/krit/fir/plugins/PayloadParsersTest.kt
+++ b/tools/krit-fir/src/test/kotlin/dev/jasonpearson/krit/fir/plugins/PayloadParsersTest.kt
@@ -1,0 +1,125 @@
+package dev.jasonpearson.krit.fir.plugins
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class PayloadParsersTest {
+
+    @Test
+    fun extractObjectBlockReturnsBraceBalancedSlice() {
+        val json = """{"outer":"x","gradle":{"minSdk":21,"nested":{"k":"v"}},"after":"y"}"""
+        val slice = PayloadParsers.extractObjectBlock(json, "gradle")
+        // The whole gradle body should round-trip, including the
+        // nested object — the brace counter must not bail on the
+        // inner `}`.
+        assertEquals("""{"minSdk":21,"nested":{"k":"v"}}""", slice)
+    }
+
+    @Test
+    fun extractObjectBlockReturnsNullWhenMissingOrWrongType() {
+        // Missing key.
+        assertNull(PayloadParsers.extractObjectBlock("""{"x":1}""", "gradle"))
+        // Wrong type — value is an array, not an object. The slicer
+        // must refuse rather than returning a malformed substring.
+        assertNull(PayloadParsers.extractObjectBlock("""{"gradle":[1,2]}""", "gradle"))
+    }
+
+    @Test
+    fun extractStringHonoursJsonEscapeSet() {
+        val json = """{"msg":"hello\nworld with a \"quote\" and a \\back\\"}"""
+        assertEquals(
+            "hello\nworld with a \"quote\" and a \\back\\",
+            PayloadParsers.extractString(json, "msg"),
+        )
+    }
+
+    @Test
+    fun extractStringArraySupportsEmptyArrayAndEscapes() {
+        assertEquals(emptyList(), PayloadParsers.extractStringArray("""{"deps":[]}""", "deps"))
+        assertEquals(
+            listOf("a", "b", "c with \"quote\""),
+            PayloadParsers.extractStringArray("""{"deps":["a","b","c with \"quote\""]}""", "deps"),
+        )
+    }
+
+    @Test
+    fun extractStringArrayReturnsNullWhenMissing() {
+        // Distinction between "absent" (null) and "present but empty"
+        // (empty list) is load-bearing for the parser: empty payloads
+        // ship a key with an empty body, so a missing key surfaces as
+        // "the Go side didn't even include this fact".
+        assertNull(PayloadParsers.extractStringArray("""{"other":[]}""", "deps"))
+    }
+
+    @Test
+    fun extractLongHandlesNegativesAndAbsent() {
+        assertEquals(42L, PayloadParsers.extractLong("""{"n":42}""", "n"))
+        assertEquals(-7L, PayloadParsers.extractLong("""{"n":-7}""", "n"))
+        assertNull(PayloadParsers.extractLong("""{"x":1}""", "n"))
+    }
+
+    @Test
+    fun keyMatcherRejectsSubstringMatchesInOtherKeys() {
+        // The lookup mustn't match `"k":"v"` when asked for `"key"`,
+        // and vice versa. Substring-style key matching is a classic
+        // hand-rolled-parser footgun.
+        val json = """{"keyword":"steel","key":"target"}"""
+        assertEquals("target", PayloadParsers.extractString(json, "key"))
+        assertEquals("steel", PayloadParsers.extractString(json, "keyword"))
+    }
+
+    @Test
+    fun projectPayloadsParseRoundTripsGradleBlock() {
+        val json = """
+            {"command":"analyzeFile","path":"/x.kt",
+             "gradle":{"minSdk":21,"targetSdk":34,"agpVersion":"8.5.0",
+                       "deps":["org.x:y:1.2.3","org.x:z:4.5.6"]}}
+        """.trimIndent()
+        val payloads = ProjectPayloads.parse(json)
+        val gradle = payloads.gradle
+        assertNotNull(gradle)
+        assertEquals(21, gradle.minSdk)
+        assertEquals(34, gradle.targetSdk)
+        assertEquals("8.5.0", gradle.agpVersion)
+        assertEquals(listOf("org.x:y:1.2.3", "org.x:z:4.5.6"), gradle.deps)
+        // The other payload kinds aren't in the request → null.
+        assertNull(payloads.manifest)
+        assertNull(payloads.resources)
+        assertNull(payloads.moduleIndex)
+        assertNull(payloads.crossFile)
+    }
+
+    @Test
+    fun projectPayloadsParsesAllFiveBlocks() {
+        val json = """
+            {"gradle":{"deps":["a:b:1"]},
+             "manifest":{"package":"com.acme","permissions":["INTERNET"]},
+             "resources":{"strings":["app_name=Acme"]},
+             "moduleIndex":{"modules":[":app|/path/app||"]},
+             "crossFile":{"declarations":["com.acme.Foo|class|/Foo.kt|10|public"]}}
+        """.trimIndent()
+        val payloads = ProjectPayloads.parse(json)
+        assertNotNull(payloads.gradle)
+        assertNotNull(payloads.manifest)
+        assertNotNull(payloads.resources)
+        assertNotNull(payloads.moduleIndex)
+        assertNotNull(payloads.crossFile)
+        assertEquals("com.acme", payloads.manifest.packageName)
+        assertEquals(listOf("INTERNET"), payloads.manifest.permissions)
+    }
+
+    @Test
+    fun emptyJsonProducesEmptyProjectPayloads() {
+        val payloads = ProjectPayloads.parse("""{"command":"analyzeFile","path":"/x.kt"}""")
+        assertTrue(payloads === ProjectPayloads.EMPTY || (
+            payloads.gradle == null &&
+                payloads.manifest == null &&
+                payloads.resources == null &&
+                payloads.moduleIndex == null &&
+                payloads.crossFile == null
+        ))
+    }
+}

--- a/tools/krit-fir/src/test/kotlin/dev/jasonpearson/krit/fir/plugins/PluginRuleRunnerTest.kt
+++ b/tools/krit-fir/src/test/kotlin/dev/jasonpearson/krit/fir/plugins/PluginRuleRunnerTest.kt
@@ -109,6 +109,40 @@ class PluginRuleRunnerTest {
     }
 
     @Test
+    fun gradleContextOnlyVisibleToRulesThatDeclareNeedsGradle() {
+        // A rule that declared NEEDS_GRADLE sees a non-null context.
+        val needsJar = buildGradleAwareRuleJar("GradleAwareRule", declareNeed = true)
+        PluginRuleRegistry.load(listOf(needsJar.absolutePath))
+        val payloads = ProjectPayloads(
+            gradle = GradleProfilePayload(
+                minSdk = 24, targetSdk = 34, compileSdk = 34,
+                kotlinVersion = "2.3.21", javaTargetVersion = "21", agpVersion = "8.5.0",
+                deps = listOf("org.x:y:1.0"),
+            ),
+            manifest = null, resources = null, moduleIndex = null, crossFile = null,
+        )
+        val file = KritFile(path = "/tmp/G.kt", text = "fun x() {}", ktFile = null)
+        val withGate = PluginRuleRunner.run(
+            file = file, ruleIds = null, ruleConfigs = null,
+            projectPayloads = payloads,
+        )
+        assertEquals(1, withGate.findings.size, "expected gradle-aware rule to fire: ${withGate.findings}")
+        assertEquals("gradle:24", withGate.findings.single().message)
+
+        // Same rule but without the capability declaration — even
+        // though we pass the payload, the rule shouldn't see it
+        // (otherwise the capability gate is meaningless).
+        PluginRuleRegistry.resetForTesting()
+        val noNeedsJar = buildGradleAwareRuleJar("UndeclaredGradleRule", declareNeed = false)
+        PluginRuleRegistry.load(listOf(noNeedsJar.absolutePath))
+        val withoutGate = PluginRuleRunner.run(
+            file = file, ruleIds = null, ruleConfigs = null,
+            projectPayloads = payloads,
+        )
+        assertEquals(emptyList(), withoutGate.findings, "rule without NEEDS_GRADLE must see gradle=null")
+    }
+
+    @Test
     fun analyzeFileResponseShapeMatchesKritTypes() {
         val findings = listOf(
             PluginRuleRunner.PluginFinding(
@@ -219,6 +253,39 @@ class PluginRuleRunnerTest {
             class $ruleId : KritRule {
                 override fun check(file: KritFile, ctx: RuleContext): List<Finding> {
                     throw IllegalStateException("boom")
+                }
+            }
+        """.trimIndent()
+        return buildJar(ruleId, source)
+    }
+
+    private fun buildGradleAwareRuleJar(ruleId: String, declareNeed: Boolean): File {
+        val needsExpr = if (declareNeed) "dev.jasonpearson.krit.api.Capability.NEEDS_GRADLE" else ""
+        val source = """
+            package dev.jasonpearson.krit.fir.plugins.testrules
+
+            import dev.jasonpearson.krit.api.Capability
+            import dev.jasonpearson.krit.api.Finding
+            import dev.jasonpearson.krit.api.KritFile
+            import dev.jasonpearson.krit.api.KritRule
+            import dev.jasonpearson.krit.api.KritRuleInfo
+            import dev.jasonpearson.krit.api.Language
+            import dev.jasonpearson.krit.api.Maturity
+            import dev.jasonpearson.krit.api.RuleContext
+            import dev.jasonpearson.krit.api.Severity
+
+            @KritRuleInfo(
+                id = "$ruleId",
+                category = "custom",
+                severity = Severity.WARNING,
+                maturity = Maturity.EXPERIMENTAL,
+                languages = [Language.KOTLIN],
+                needs = [$needsExpr],
+            )
+            class $ruleId : KritRule {
+                override fun check(file: KritFile, ctx: RuleContext): List<Finding> {
+                    val sdk = ctx.gradle?.minSdk ?: return emptyList()
+                    return listOf(Finding(message = "gradle:" + sdk, line = 1))
                 }
             }
         """.trimIndent()


### PR DESCRIPTION
## Summary

Closes the largest remaining behavioral gap between the krit-types and krit-fir backends. Plumbs the five project-scope payload contexts (\`gradle\` / \`manifest\` / \`resources\` / \`moduleIndex\` / \`crossFile\`) onto FIR's \`analyzeFile\` RPC so a plugin rule that declared \`NEEDS_GRADLE\` etc. sees real data instead of \`null\`. Mirrors krit-types' \`PayloadGradleContext\` / \`PayloadManifestContext\` / … verbatim — a rule jar that worked against KAA ships identical fact access on FIR after rebuild.

- **\`PayloadContexts.kt\`** — five data classes + five \`Payload*Context\` wrappers implementing the corresponding krit-rule-api interfaces. Lookup maps lazy so an unconsulted context costs nothing beyond construction.
- **\`PayloadParsers.kt\`** — hand-rolled JSON object-block slicer (brace-balanced, escape-aware) + scalar / string-array extractors. Wrapped in \`ProjectPayloads.parse(json)\` which returns all five payload objects in one pass (each null when its top-level key is absent). No new dependencies on the shadow jar.
- **\`Main.kt\`** — \`CheckRequest\` gains \`projectPayloads\`; \`parseRequest\` populates it for \`analyzeFile\` requests only; \`handleAnalyzeFile\` threads it into \`PluginRuleRunner.run\`.
- **\`PluginRuleRunner.run\`** — builds each context once per request, attaches to \`RuleContext\` only when the rule declared the matching \`NEEDS_*\` capability. Without the declaration the field stays null even when the payload is available — opt-in semantics match krit-types.

## Test plan
- [x] \`./gradlew :test\` in \`tools/krit-fir/\` — 15 new tests:
  - \`PayloadParsersTest\` (10): object-block brace balancing across nested objects, JSON escape set, key-substring rejection (no false-matching \`"key"\` against \`"keyword"\`), missing-vs-empty distinction, all five payloads round-trip
  - \`PayloadContextsTest\` (5): dependency-version lookup + malformed-entry dropping; manifest permission / component / exported flags; resource \`name=value\` parsing with \`=\` in values; module deps + source-roots split; cross-file declaration + reference resolution
  - \`PluginRuleRunnerTest\` (+1): gradle context only visible to rules that declared \`NEEDS_GRADLE\` — same rule without the declaration sees \`gradle=null\` even with the payload shipped (capability-gate enforcement)
- [x] \`go build ./cmd/krit/ && go vet ./... && golangci-lint run ./... && go test ./... -count=1\`