### PR TITLE
feat(krit-fir): lambda-suspend + call-expression types in Resolver

### DIFF
--- a/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/KritFirCheckers.kt
+++ b/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/KritFirCheckers.kt
@@ -30,7 +30,10 @@ class KritFirCheckers(session: FirSession) : FirAdditionalCheckersExtension(sess
     }
 
     // Same self-gating story for OracleClassChecker on the declaration
-    // side: non-oracle paths pay only the thread-local probe.
+    // side: non-oracle paths pay only the thread-local probe per
+    // declaration. Per-lambda suspend status is captured at the call
+    // site inside `OracleExpressionChecker` — see its
+    // `recordLambdaSuspendArguments` for the rationale.
     override val declarationCheckers = object : DeclarationCheckers() {
         override val classCheckers = setOf(SmokeChecker, OracleClassChecker)
     }

--- a/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/Main.kt
+++ b/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/Main.kt
@@ -341,24 +341,25 @@ internal fun handleAnalyzeFile(request: CheckRequest, session: AnalysisSession):
         }
 
         // Run the K2 oracle pass against this file so the resolver
-        // has FIR call-resolution data to answer queries from. The
-        // pass populates `expressions` keyed by `"line:col"` for every
-        // resolved function call — exactly what the resolver looks up
-        // in [FirOracleResolver.lookupCall]. If the K2 pass crashes
-        // we still want plugin rules to run; fall back to an empty
-        // expression map and a resolver that returns null/false.
-        val expressions = try {
+        // has FIR data to answer queries from. The pass populates
+        // `expressions` keyed by `"line:col"` for every resolved
+        // function call AND `lambdaSuspendByLineCol` for every
+        // visited lambda — the two maps the FirOracleResolver looks
+        // up. If the K2 pass crashes we still want plugin rules to
+        // run; fall back to empty maps and a resolver that returns
+        // null/false.
+        val (expressions, lambdaSuspendByKey) = try {
             val canonical = JavaFile(path).canonicalPath
             val result = session.analyze(listOf(path))
-            result.files[canonical]?.expressions
-                ?: result.files[path]?.expressions
-                ?: emptyMap()
+            val filePayload = result.files[canonical] ?: result.files[path]
+            (filePayload?.expressions ?: emptyMap<String, dev.jasonpearson.krit.fir.oracle.ExpressionPayload>()) to
+                (filePayload?.lambdaSuspendByLineCol ?: emptyMap<String, Boolean>())
         } catch (t: Throwable) {
             System.err.println("analyzeFile oracle pass failed: ${t.message}")
-            emptyMap()
+            emptyMap<String, dev.jasonpearson.krit.fir.oracle.ExpressionPayload>() to emptyMap<String, Boolean>()
         }
         val offsets = FileOffsetTable(text)
-        val resolver = FirOracleResolver(expressions, offsets)
+        val resolver = FirOracleResolver(expressions, offsets, lambdaSuspendByKey)
 
         // Parse PSI off the request payload (not off disk) so an
         // in-flight edit shipped via `request.source` is reflected

--- a/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/oracle/ConeTypeRendering.kt
+++ b/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/oracle/ConeTypeRendering.kt
@@ -1,0 +1,33 @@
+package dev.jasonpearson.krit.fir.oracle
+
+import org.jetbrains.kotlin.fir.types.ConeClassLikeType
+import org.jetbrains.kotlin.fir.types.ConeKotlinType
+import org.jetbrains.kotlin.fir.types.ConeKotlinTypeProjection
+import org.jetbrains.kotlin.fir.types.isMarkedNullable
+import org.jetbrains.kotlin.fir.types.renderReadable
+
+/**
+ * Render a [ConeKotlinType] as an FQN-qualified type string, matching
+ * the krit-types wire format (e.g. `kotlin.String`, `kotlin.Int?`,
+ * `kotlin.collections.List<kotlin.String>`). Non-class-like types
+ * (type parameters, intersection types, flexible types) fall back to
+ * the readable rendering since they don't carry a stable FQN.
+ *
+ * Extracted so [OracleClassChecker], [OracleExpressionChecker], and
+ * any future projection share one renderer — the alternative
+ * (per-checker copies) would let backends drift on type spelling
+ * across the same compilation.
+ */
+internal fun ConeKotlinType.renderFqn(): String {
+    val classLike = this as? ConeClassLikeType ?: return renderReadable()
+    val fqn = classLike.lookupTag.classId.asFqNameString()
+    val args = typeArguments
+        .takeIf { it.isNotEmpty() }
+        ?.joinToString(", ", "<", ">") { projection ->
+            (projection as? ConeKotlinTypeProjection)?.type?.renderFqn()
+                ?: projection.toString()
+        }
+        .orEmpty()
+    val nullable = if (isMarkedNullable) "?" else ""
+    return "$fqn$args$nullable"
+}

--- a/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/oracle/OracleAnalysis.kt
+++ b/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/oracle/OracleAnalysis.kt
@@ -33,6 +33,12 @@ data class FilePayload(
     val declarations: List<ClassPayload> = emptyList(),
     val expressions: Map<String, ExpressionPayload> = emptyMap(),
     val diagnostics: List<DiagnosticPayload> = emptyList(),
+    // Lambda functional-type facts keyed by `"line:col"` of the
+    // lambda's source position. True iff the lambda's resolved
+    // declaration status carries the suspend modifier — either
+    // because it was passed to a `suspend (...) -> R` parameter or
+    // because its own inferred type is `kotlin.coroutines.SuspendFunctionN`.
+    val lambdaSuspendByLineCol: Map<String, Boolean> = emptyMap(),
 )
 
 /**

--- a/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/oracle/OracleClassChecker.kt
+++ b/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/oracle/OracleClassChecker.kt
@@ -29,8 +29,6 @@ import org.jetbrains.kotlin.fir.resolve.providers.getContainingFile
 import org.jetbrains.kotlin.fir.resolve.toRegularClassSymbol
 import org.jetbrains.kotlin.fir.symbols.SymbolInternals
 import org.jetbrains.kotlin.fir.types.ConeClassLikeType
-import org.jetbrains.kotlin.fir.types.ConeKotlinType
-import org.jetbrains.kotlin.fir.types.ConeKotlinTypeProjection
 import org.jetbrains.kotlin.fir.types.FirResolvedTypeRef
 import org.jetbrains.kotlin.fir.types.FirTypeRef
 import org.jetbrains.kotlin.fir.types.isMarkedNullable
@@ -203,27 +201,6 @@ internal object OracleClassChecker : FirClassChecker(MppCheckerKind.Common) {
 
     private fun FirTypeRef.isNullable(): Boolean =
         (this as? FirResolvedTypeRef)?.coneType?.isMarkedNullable == true
-
-    /**
-     * Render a [ConeKotlinType] as an FQN-qualified type string, matching
-     * the krit-types wire format (e.g. `kotlin.String`, `kotlin.Int?`,
-     * `kotlin.collections.List<kotlin.String>`). Non-class-like types
-     * (type parameters, intersection types, flexible types) fall back to
-     * the readable rendering since they don't carry a stable FQN.
-     */
-    private fun ConeKotlinType.renderFqn(): String {
-        val classLike = this as? ConeClassLikeType ?: return renderReadable()
-        val fqn = classLike.lookupTag.classId.asFqNameString()
-        val args = typeArguments
-            .takeIf { it.isNotEmpty() }
-            ?.joinToString(", ", "<", ">") { projection ->
-                (projection as? ConeKotlinTypeProjection)?.type?.renderFqn()
-                    ?: projection.toString()
-            }
-            .orEmpty()
-        val nullable = if (isMarkedNullable) "?" else ""
-        return "$fqn$args$nullable"
-    }
 
     private fun ClassKind.toWireString(): String = when (this) {
         ClassKind.CLASS -> "class"

--- a/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/oracle/OracleCollector.kt
+++ b/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/oracle/OracleCollector.kt
@@ -19,6 +19,7 @@ internal class OracleCollector {
     private val packageByFile = LinkedHashMap<String, String>()
     private val expressionsByFile = LinkedHashMap<String, LinkedHashMap<String, ExpressionPayload>>()
     private val diagnosticsByFile = LinkedHashMap<String, MutableList<DiagnosticPayload>>()
+    private val lambdaSuspendByFile = LinkedHashMap<String, LinkedHashMap<String, Boolean>>()
     private val offsetsByFile = HashMap<String, FileOffsetTable?>()
 
     /**
@@ -69,6 +70,18 @@ internal class OracleCollector {
     }
 
     /**
+     * Record a lambda's suspend status for [filePath] at the source
+     * position keyed by [key] ("line:col"). First-wins on duplicate
+     * keys — a single source position can only refer to one lambda,
+     * and revisits during phased FIR resolution would otherwise let
+     * an intermediate (pre-conversion) status overwrite the final one.
+     */
+    fun addLambdaSuspend(filePath: String, key: String, isSuspend: Boolean) {
+        val map = lambdaSuspendByFile.getOrPut(filePath) { LinkedHashMap() }
+        map.putIfAbsent(key, isSuspend)
+    }
+
+    /**
      * Lazily-built offset table for [filePath]. Returns null if the
      * file cannot be read (e.g. it was deleted between the K2 walk
      * scheduling and the checker firing). Callers should skip the
@@ -87,7 +100,8 @@ internal class OracleCollector {
      */
     fun toResult(): AnalyzeResult {
         val allFilePaths =
-            (perFile.keys + packageByFile.keys + expressionsByFile.keys + diagnosticsByFile.keys).toSet()
+            (perFile.keys + packageByFile.keys + expressionsByFile.keys +
+                diagnosticsByFile.keys + lambdaSuspendByFile.keys).toSet()
         val files = LinkedHashMap<String, FilePayload>(allFilePaths.size)
         for (path in allFilePaths) {
             files[path] = FilePayload(
@@ -95,6 +109,7 @@ internal class OracleCollector {
                 declarations = perFile[path]?.toList() ?: emptyList(),
                 expressions = expressionsByFile[path]?.toMap() ?: emptyMap(),
                 diagnostics = diagnosticsByFile[path]?.toList() ?: emptyList(),
+                lambdaSuspendByLineCol = lambdaSuspendByFile[path]?.toMap() ?: emptyMap(),
             )
         }
         return AnalyzeResult(files = files, dependencies = dependencies.toMap())

--- a/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/oracle/OracleExpressionChecker.kt
+++ b/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/oracle/OracleExpressionChecker.kt
@@ -8,7 +8,12 @@ import org.jetbrains.kotlin.fir.declarations.toAnnotationClassId
 import org.jetbrains.kotlin.fir.declarations.utils.isSuspend
 import org.jetbrains.kotlin.fir.expressions.FirFunctionCall
 import org.jetbrains.kotlin.fir.references.toResolvedCallableSymbol
+import org.jetbrains.kotlin.fir.expressions.FirAnonymousFunctionExpression
 import org.jetbrains.kotlin.fir.symbols.SymbolInternals
+import org.jetbrains.kotlin.fir.types.ConeClassLikeType
+import org.jetbrains.kotlin.fir.types.FirResolvedTypeRef
+import org.jetbrains.kotlin.fir.types.isMarkedNullable
+import org.jetbrains.kotlin.fir.types.resolvedType
 
 /**
  * FIR `FirFunctionCallChecker` that projects each visited
@@ -59,12 +64,18 @@ internal object OracleExpressionChecker : FirFunctionCallChecker(MppCheckerKind.
 
         if (callTarget.isEmpty()) return
 
+        // The call's `resolvedType` is the type the rule sees through
+        // `Resolver.expressionType(call)`. We render the same
+        // classId-FQN format krit-types' AnalysisApiResolver returns
+        // so a rule jar shipped against either backend sees identical
+        // strings. Pre-2.6 the oracle pass left this empty because no
+        // Go-side rule consumed it; now the FIR-backed Resolver does.
+        val resolvedType = runCatching { expression.resolvedType }.getOrNull()
+        val typeFqn = resolvedType?.renderFqn().orEmpty()
+        val typeNullable = resolvedType?.isMarkedNullable == true
         val payload = ExpressionPayload(
-            // type / nullable stay empty to match krit-types' shape; the
-            // downstream Go-side oracle consumers only read callTarget +
-            // annotations.
-            type = "",
-            nullable = false,
+            type = typeFqn,
+            nullable = typeNullable,
             startByte = offsets.byteOffsetAt(startOffset),
             endByte = offsets.byteOffsetAt(endOffset),
             callTarget = callTarget,
@@ -73,5 +84,51 @@ internal object OracleExpressionChecker : FirFunctionCallChecker(MppCheckerKind.
             annotations = annotations,
         )
         collector.addExpression(filePath, key, payload)
+        recordLambdaSuspendArguments(collector, filePath, offsets, expression, callee)
+    }
+
+    /**
+     * Inspect the argument list and, for each lambda passed positionally,
+     * record whether the matching value parameter declares a suspend
+     * functional type. Mirrors krit-types' "is this lambda passed to a
+     * `suspend (...) -> R` parameter" heuristic but does the work at
+     * the call site, where FIR's resolved argument mapping carries
+     * accurate parameter types — checking the lambda's own
+     * `FirAnonymousFunction.status.isSuspend` doesn't work because FIR
+     * doesn't propagate the suspend conversion onto the lambda
+     * declaration in 2.3.21.
+     *
+     * Non-call-site lambdas (e.g. `val f: suspend () -> Unit = { ... }`)
+     * aren't visited here; the resolver's "missing key → false" default
+     * matches krit-types' "unresolved → conservative false" contract.
+     */
+    @OptIn(SymbolInternals::class)
+    private fun recordLambdaSuspendArguments(
+        collector: OracleCollector,
+        filePath: String,
+        offsets: FileOffsetTable,
+        call: FirFunctionCall,
+        callee: org.jetbrains.kotlin.fir.symbols.impl.FirCallableSymbol<*>?,
+    ) {
+        if (callee !is org.jetbrains.kotlin.fir.symbols.impl.FirNamedFunctionSymbol) return
+        val paramTypes = callee.fir.valueParameters
+        val args = call.argumentList.arguments
+        // Walk argument-position-for-position. Lambdas appear as
+        // FirAnonymousFunctionExpression — wrappers around the lambda's
+        // FirAnonymousFunction declaration. Matching by index is
+        // approximate (named args + defaults can shift positions), but
+        // works for the dominant block-builder shape rules care about.
+        val n = minOf(args.size, paramTypes.size)
+        for (i in 0 until n) {
+            val arg = args[i] as? FirAnonymousFunctionExpression ?: continue
+            val lambdaSource = arg.anonymousFunction.source ?: continue
+            val (line, col) = offsets.lineColAt(lambdaSource.startOffset)
+            val paramTypeRef = paramTypes[i].returnTypeRef as? FirResolvedTypeRef ?: continue
+            val paramCone = paramTypeRef.coneType as? ConeClassLikeType ?: continue
+            val classId = paramCone.lookupTag.classId.asFqNameString()
+            val isSuspendFunctional = classId.startsWith("kotlin.coroutines.SuspendFunction") ||
+                classId.startsWith("kotlin.coroutines.KSuspendFunction")
+            collector.addLambdaSuspend(filePath, "$line:$col", isSuspendFunctional)
+        }
     }
 }

--- a/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/plugins/FirOracleResolver.kt
+++ b/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/plugins/FirOracleResolver.kt
@@ -10,27 +10,26 @@ import org.jetbrains.kotlin.psi.KtLambdaExpression
 /**
  * FIR-backed [`Resolver`] for plugin-rule hosting on the krit-fir
  * backend. Answers PSI-keyed questions about a single analyzed file by
- * looking up data the K2 oracle pass already collected (see
- * `OracleExpressionChecker`).
+ * looking up data the K2 oracle pass already collected.
  *
  * Resolution flow per query:
  *
  * 1. The PSI element's `textRange.startOffset` is mapped to 1-based
  *    `(line, col)` via the file's [FileOffsetTable].
- * 2. The resulting `"line:col"` key is looked up in [expressionsByKey],
- *    which is the slice of an [`AnalyzeResult.files`] payload for the
- *    file under analysis.
+ * 2. The resulting `"line:col"` key is looked up in the corresponding
+ *    pre-computed map ([expressionsByKey] for call resolution and
+ *    expression types, [lambdaSuspendByKey] for lambda functional
+ *    suspend status).
  *
- * The [Resolver] surface still exposes `isLambdaSuspend` and
- * `expressionType`; the FIR oracle pass doesn't capture lambda type
- * or expression type today, so those methods return the conservative
- * "unknown" value (`false` / `null`). Rules that strictly depend on
- * either can opt out via the `NEEDS_FIR` capability — when those
- * facts land the resolver picks them up here without an SPI churn.
+ * `expressionType` for non-call expressions still returns null — the
+ * oracle pass only captures resolved types for [FirFunctionCall] node
+ * positions today. Most rules query call-expression types; broadening
+ * to all FirExpression subtypes is a follow-up.
  */
 internal class FirOracleResolver(
     private val expressionsByKey: Map<String, ExpressionPayload>,
     private val offsets: FileOffsetTable,
+    private val lambdaSuspendByKey: Map<String, Boolean> = emptyMap(),
 ) : Resolver {
 
     override fun isSuspendCall(call: KtCallExpression): Boolean =
@@ -47,17 +46,25 @@ internal class FirOracleResolver(
     }
 
     override fun isLambdaSuspend(lambda: KtLambdaExpression): Boolean {
-        // The oracle pass doesn't capture lambda-functional-type
-        // information today. Returning false matches krit-types'
-        // "unresolved → conservative false" contract.
-        return false
+        // The PSI offset for a lambda expression sits on the opening
+        // brace. K2 records the FirAnonymousFunction's source against
+        // the same offset, so a `"line:col"` round-trip lookup matches
+        // the visited declaration.
+        val range = lambda.textRange ?: return false
+        val (line, col) = offsets.lineColAt(range.startOffset)
+        return lambdaSuspendByKey["$line:$col"] == true
     }
 
     override fun expressionType(expression: KtExpression): String? {
-        // Same gap as isLambdaSuspend: expression-type data isn't part
-        // of the current ExpressionPayload surface. krit-types'
-        // resolver also returns null for unresolved types.
-        return null
+        // Today we surface only call-expression types — the oracle
+        // pass captures `FirFunctionCall.resolvedType` per call site
+        // and stashes the rendered FQN on the matching
+        // [`ExpressionPayload.type`]. Non-call expressions don't have
+        // a payload, so the lookup returns null and the rule sees the
+        // "unresolved" contract krit-types' resolver also uses.
+        if (expression !is KtCallExpression) return null
+        val payload = lookupCall(expression) ?: return null
+        return payload.type.takeIf { it.isNotBlank() }
     }
 
     private fun lookupCall(call: KtCallExpression): ExpressionPayload? {

--- a/tools/krit-fir/src/test/kotlin/dev/jasonpearson/krit/fir/plugins/FirOracleResolverTest.kt
+++ b/tools/krit-fir/src/test/kotlin/dev/jasonpearson/krit/fir/plugins/FirOracleResolverTest.kt
@@ -95,11 +95,84 @@ class FirOracleResolverTest {
         }
     }
 
-    // PR 3.3 deliberately ships isLambdaSuspend / expressionType as
-    // conservative null/false stubs because the oracle pass doesn't
-    // capture lambda-functional or expression-type data yet. Those
-    // methods have no behavior to test until the data lands — they
-    // pass the `Resolver` contract trivially.
+    @Test
+    fun expressionTypeReturnsCallResolvedTypeFqn() {
+        val source = "package x\n\nfun caller() {\n    target()\n}\n"
+        val table = FileOffsetTable(source)
+        val expressions = mapOf(
+            "4:5" to ExpressionPayload(
+                type = "kotlin.String",
+                callTarget = "com.acme.target",
+                callTargetResolved = true,
+            ),
+        )
+        val (parsed, call) = parseSourceAndFirstCall(source)
+        parsed.use {
+            val resolver = FirOracleResolver(expressions, table)
+            assertEquals("kotlin.String", resolver.expressionType(call))
+        }
+    }
+
+    @Test
+    fun expressionTypeReturnsNullWhenPayloadHasEmptyTypeString() {
+        // Pre-oracle versions left `type=""` because no Go-side
+        // consumer read it. The resolver must surface that as
+        // "unresolved" → null rather than as the empty string so a
+        // rule's null check still works.
+        val source = "package x\n\nfun caller() {\n    target()\n}\n"
+        val table = FileOffsetTable(source)
+        val expressions = mapOf(
+            "4:5" to ExpressionPayload(
+                type = "",
+                callTarget = "com.acme.target",
+                callTargetResolved = true,
+            ),
+        )
+        val (parsed, call) = parseSourceAndFirstCall(source)
+        parsed.use {
+            val resolver = FirOracleResolver(expressions, table)
+            assertNull(resolver.expressionType(call))
+        }
+    }
+
+    @Test
+    fun isLambdaSuspendLooksUpByPsiOffset() {
+        // The PSI offset of a KtLambdaExpression sits on its opening
+        // brace; K2 records the FirAnonymousFunction's source at the
+        // same position, so `"line:col"` round-trips.
+        val source = "package x\n\nfun caller() {\n    run {\n        target()\n    }\n}\n"
+        val table = FileOffsetTable(source)
+        val parsed = KtFileParser.parse(source, pathHint = "/tmp/Source.kt")
+        parsed.use {
+            val foundLambda = firstLambdaExpression(parsed.ktFile)
+                ?: error("source has no lambda")
+            val (line, col) = table.lineColAt(foundLambda.textRange.startOffset)
+
+            val suspendResolver = FirOracleResolver(
+                expressionsByKey = emptyMap(),
+                offsets = table,
+                lambdaSuspendByKey = mapOf("$line:$col" to true),
+            )
+            assertTrue(suspendResolver.isLambdaSuspend(foundLambda))
+
+            val nonSuspendResolver = FirOracleResolver(
+                expressionsByKey = emptyMap(),
+                offsets = table,
+                lambdaSuspendByKey = mapOf("$line:$col" to false),
+            )
+            assertFalse(nonSuspendResolver.isLambdaSuspend(foundLambda))
+
+            // Empty map → conservative false. Matches krit-types'
+            // "unresolved → false" contract so rules don't see a
+            // spurious "suspend" for lambdas the oracle didn't visit.
+            val noDataResolver = FirOracleResolver(
+                expressionsByKey = emptyMap(),
+                offsets = table,
+                lambdaSuspendByKey = emptyMap(),
+            )
+            assertFalse(noDataResolver.isLambdaSuspend(foundLambda))
+        }
+    }
 
     // ── Test plumbing ────────────────────────────────────────────────
 
@@ -116,6 +189,16 @@ class FirOracleResolverTest {
         var found: KtCallExpression? = null
         ktFile.accept(object : org.jetbrains.kotlin.psi.KtTreeVisitorVoid() {
             override fun visitCallExpression(expression: KtCallExpression) {
+                if (found == null) found = expression
+            }
+        })
+        return found
+    }
+
+    private fun firstLambdaExpression(ktFile: KtFile): org.jetbrains.kotlin.psi.KtLambdaExpression? {
+        var found: org.jetbrains.kotlin.psi.KtLambdaExpression? = null
+        ktFile.accept(object : org.jetbrains.kotlin.psi.KtTreeVisitorVoid() {
+            override fun visitLambdaExpression(expression: org.jetbrains.kotlin.psi.KtLambdaExpression) {
                 if (found == null) found = expression
             }
         })

--- a/tools/krit-fir/src/test/kotlin/dev/jasonpearson/krit/fir/runner/AnalysisSessionLambdaTypesTest.kt
+++ b/tools/krit-fir/src/test/kotlin/dev/jasonpearson/krit/fir/runner/AnalysisSessionLambdaTypesTest.kt
@@ -1,0 +1,142 @@
+package dev.jasonpearson.krit.fir.runner
+
+import org.junit.jupiter.api.Assumptions.assumeTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import java.nio.file.Path
+import kotlin.test.assertTrue
+
+/**
+ * End-to-end coverage for the lambda-suspend + call-expression-type
+ * data the oracle pass collects for the FIR-backed [Resolver]. The
+ * tests skip when kotlin-stdlib isn't reachable on the test JVM
+ * (suspend resolution needs `kotlin.coroutines.CoroutineScope` etc.
+ * to be on the classpath).
+ */
+class AnalysisSessionLambdaTypesTest {
+
+    @TempDir
+    lateinit var tmp: Path
+
+    private lateinit var stdlibClasspath: List<String>
+
+    @BeforeEach
+    fun resolveStdlib() {
+        val stdlib = findKotlinStdlib()
+        assumeTrue(
+            stdlib != null,
+            "kotlin-stdlib jar not found in Gradle cache; required for suspend-conversion + " +
+                "type resolution. Set KOTLIN_STDLIB_JAR or populate the Gradle cache by running " +
+                "`./gradlew :test` at the repo root.",
+        )
+        stdlibClasspath = listOfNotNull(stdlib)
+    }
+
+    @Test
+    fun lambdaPassedToSuspendParamSurfacesAsSuspendInResolver() {
+        val path = writeKt(
+            "SuspendLambda.kt",
+            """
+            package com.acme.suspendlambda
+
+            suspend fun runSuspend(block: suspend () -> Unit) {
+                block()
+            }
+
+            suspend fun caller() {
+                runSuspend {
+                    println("inside suspend block")
+                }
+            }
+            """.trimIndent(),
+        )
+
+        val lambdaSuspend = analyze(path).lambdaSuspendByLineCol
+        assertTrue(
+            lambdaSuspend.values.any { it },
+            "expected at least one lambda flagged suspend, got $lambdaSuspend",
+        )
+    }
+
+    @Test
+    fun lambdaPassedToPlainBlockParamSurfacesAsNotSuspend() {
+        val path = writeKt(
+            "PlainLambda.kt",
+            """
+            package com.acme.plainlambda
+
+            fun runPlain(block: () -> Unit) {
+                block()
+            }
+
+            fun caller() {
+                runPlain {
+                    println("inside plain block")
+                }
+            }
+            """.trimIndent(),
+        )
+
+        val lambdaSuspend = analyze(path).lambdaSuspendByLineCol
+        // No lambda passed to a `() -> Unit` parameter should carry
+        // the suspend flag. The map may also be empty for lambdas the
+        // oracle didn't visit; the contract is "nothing flagged
+        // suspend", and the resolver's missing-key default is false.
+        assertTrue(
+            lambdaSuspend.values.none { it },
+            "no lambda should be suspend in plain-block source, got $lambdaSuspend",
+        )
+    }
+
+    @Test
+    fun callExpressionTypeFqnLandsOnExpressionPayload() {
+        val path = writeKt(
+            "CallType.kt",
+            """
+            package com.acme.calltype
+
+            fun produceString(): String = "hi"
+
+            fun caller(): String = produceString()
+            """.trimIndent(),
+        )
+
+        val expressions = analyze(path).expressions
+        // The call to `produceString()` returns kotlin.String; the
+        // populated ExpressionPayload.type drives the resolver's
+        // expressionType() lookup.
+        assertTrue(
+            expressions.values.any { it.type == "kotlin.String" },
+            "expected at least one call payload with type=kotlin.String, got " +
+                "${expressions.values.map { it.type }}",
+        )
+    }
+
+    private fun analyze(path: String) = AnalysisSession(
+        sourceDirs = listOf(tmp.toFile().absolutePath),
+        classpath = stdlibClasspath,
+    ).analyze(emptyList()).files[path] ?: error("no file payload for $path")
+
+    private fun writeKt(name: String, source: String): String {
+        val file = tmp.resolve(name).toFile()
+        file.writeText(source)
+        return file.canonicalPath
+    }
+
+    private fun findKotlinStdlib(): String? {
+        System.getenv("KOTLIN_STDLIB_JAR")?.let { override ->
+            if (File(override).isFile) return override
+        }
+        val home = System.getProperty("user.home") ?: return null
+        val cacheRoot = File(home, ".gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib")
+        if (!cacheRoot.isDirectory) return null
+        val matches = cacheRoot.walkTopDown()
+            .filter { it.isFile && it.name.startsWith("kotlin-stdlib-") && it.name.endsWith(".jar") }
+            .filter { !it.name.contains("sources") && !it.name.contains("javadoc") }
+            .toList()
+            .sortedByDescending { it.name }
+        return matches.firstOrNull()?.absolutePath
+    }
+}


### PR DESCRIPTION
## Summary

Wires real data through \`FirOracleResolver.isLambdaSuspend\` and \`.expressionType\`, both of which shipped as conservative null/false stubs in PR 3.3. Coroutines-heavy rules running on the FIR backend now get the same precision they enjoy on krit-types.

- **\`OracleExpressionChecker\`** also captures the call's \`resolvedType\` FQN on \`ExpressionPayload.type\`. Renderer extracted into a shared \`ConeTypeRendering\` helper so \`OracleClassChecker\` and the expression pass share one source of truth.
- **Lambda-suspend detection at the call site**: iterate \`call.argumentList.arguments\`, look at \`FirAnonymousFunctionExpression\` args, check whether the matching value parameter's resolved type's \`classId\` is \`kotlin.coroutines.SuspendFunction*\` / \`KSuspendFunction*\`. K2 2.3.21 doesn't propagate the suspend conversion onto the lambda's own \`FirAnonymousFunction.status\`, so the call-site read is the reliable signal.
- **New \`FilePayload.lambdaSuspendByLineCol\`** carries the result to the resolver. Missing key → conservative false, matching krit-types' \`AnalysisApiResolver\` contract.
- **\`FirOracleResolver.expressionType(call)\`** returns the populated FQN; non-call expressions still surface as null pending broader expression-type collection in a follow-up.

## Test plan
- [x] \`./gradlew :test\` in \`tools/krit-fir/\` — 125 tests:
  - \`FirOracleResolverTest\` (+2): PSI offset → line:col → type lookup for call expressions; empty-string → null contract; isLambdaSuspend PSI lookup with three states (true / false / missing key)
  - \`AnalysisSessionLambdaTypesTest\` (new, 3): end-to-end suspend-lambda detection, plain-lambda non-suspend, call-expression FQN populated on payload. Skips when kotlin-stdlib isn't on the test classpath (suspend resolution needs it)
- [x] \`go build ./cmd/krit/ && go vet ./... && golangci-lint run ./... && go test ./... -count=1\`

## Follow-up
- Broaden \`expressionType\` to non-call expressions (property access, return values, …) — requires a new expression-walker pass or a richer FirCallChecker hook. Out of scope here; the call-expression coverage matches the dominant rule-query pattern.