### PR TITLE
feat(firchecks): persistent daemon answers analyze RPCs

### DIFF
--- a/internal/firchecks/oracle_methods.go
+++ b/internal/firchecks/oracle_methods.go
@@ -1,0 +1,192 @@
+package firchecks
+
+// oracle_methods.go — analyze/analyzeAll/analyzeWithDeps RPCs on the
+// long-lived krit-fir daemon. The Kotlin side already speaks these
+// commands (see tools/krit-fir/.../Main.kt's analyze branches). This
+// file is the Go-side wrapper so `--daemon --oracle-backend=fir` can
+// reuse a warm JVM instead of paying the cold-start cost per analyze.
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/kaeawc/krit/internal/oracle"
+)
+
+// firAnalyzeResponse is the envelope krit-fir's OracleResponse.buildAnalyze
+// produces. Result mirrors oracle.Data so a Go-side consumer parses
+// the same fields the krit-types daemon ships.
+type firAnalyzeResponse struct {
+	ID     int64        `json:"id"`
+	Result *oracle.Data `json:"result"`
+	Error  string       `json:"error,omitempty"`
+}
+
+// firAnalyzeWithDepsResponse is the flat envelope krit-fir produces for
+// the analyzeWithDeps command — result, errors, and cacheDeps are
+// siblings (not nested), matching krit-types' buildDaemonResponseWithDeps.
+type firAnalyzeWithDepsResponse struct {
+	ID        int64                 `json:"id"`
+	Result    *oracle.Data          `json:"result"`
+	Errors    map[string]string     `json:"errors,omitempty"`
+	CacheDeps *oracle.CacheDepsFile `json:"cacheDeps,omitempty"`
+	Error     string                `json:"error,omitempty"`
+}
+
+// Analyze sends an `analyze` request to the krit-fir daemon and
+// returns the parsed oracle data. The daemon analyzes the listed
+// [files] against the session's sourceDirs/classpath (set at startup
+// via ConnectOrStartFirDaemon).
+//
+// `files` may be nil/empty — pass nil to run a full project sweep
+// (equivalent to [AnalyzeAll]).
+func (d *FirDaemon) Analyze(files, sourceDirs, classpath []string) (*oracle.Data, error) {
+	command := "analyze"
+	if len(files) == 0 {
+		command = "analyzeAll"
+	}
+	return d.runAnalyze(command, toFileRefs(files), sourceDirs, classpath)
+}
+
+// AnalyzeAll is the explicit form of [Analyze] with no per-file slice
+// — sends `analyzeAll` and returns the full-project oracle data.
+func (d *FirDaemon) AnalyzeAll(sourceDirs, classpath []string) (*oracle.Data, error) {
+	return d.runAnalyze("analyzeAll", nil, sourceDirs, classpath)
+}
+
+// AnalyzeWithDeps sends an `analyzeWithDeps` request and parses out
+// both the oracle data and the cache-deps closure the Go-side cache
+// layer needs. Mirrors `oracle.Daemon.AnalyzeWithDeps`.
+func (d *FirDaemon) AnalyzeWithDeps(files, sourceDirs, classpath []string) (*oracle.Data, *oracle.CacheDepsFile, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if !d.started {
+		return nil, nil, fmt.Errorf("fir daemon not started")
+	}
+	id := d.nextID
+	d.nextID++
+	req := firDaemonRequest{
+		ID:         id,
+		Command:    "analyzeWithDeps",
+		Files:      toFileRefs(files),
+		SourceDirs: sourceDirs,
+		Classpath:  classpath,
+	}
+	line, err := d.sendAndReceive(req)
+	if err != nil {
+		return nil, nil, err
+	}
+	var resp firAnalyzeWithDepsResponse
+	if err := json.Unmarshal([]byte(line), &resp); err != nil {
+		return nil, nil, fmt.Errorf("unmarshal fir analyzeWithDeps response: %w (got: %s)", err, line)
+	}
+	if resp.Error != "" {
+		return nil, nil, fmt.Errorf("fir daemon error: %s", resp.Error)
+	}
+	if resp.ID != id {
+		return nil, nil, fmt.Errorf("fir response ID mismatch: expected %d, got %d", id, resp.ID)
+	}
+	if resp.Result != nil && len(resp.Errors) > 0 {
+		// Surface fatal per-file errors by returning a non-nil Data
+		// alongside the err so the caller can decide whether to
+		// proceed with partial results. Matches oracle.Daemon's
+		// behavior where errors live inside `result` for the legacy
+		// shape but are surfaced separately here.
+		return resp.Result, resp.CacheDeps, fmt.Errorf("fir daemon analyzeWithDeps errors: %v", resp.Errors)
+	}
+	return resp.Result, resp.CacheDeps, nil
+}
+
+// runAnalyze is the shared body of Analyze / AnalyzeAll. Held lock,
+// id alloc, TCP send, response parse all live here so the public
+// methods stay declarative.
+func (d *FirDaemon) runAnalyze(command string, files []fileRef, sourceDirs, classpath []string) (*oracle.Data, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if !d.started {
+		return nil, fmt.Errorf("fir daemon not started")
+	}
+	id := d.nextID
+	d.nextID++
+	req := firDaemonRequest{
+		ID:         id,
+		Command:    command,
+		Files:      files,
+		SourceDirs: sourceDirs,
+		Classpath:  classpath,
+	}
+	line, err := d.sendAndReceive(req)
+	if err != nil {
+		return nil, err
+	}
+	var resp firAnalyzeResponse
+	if err := json.Unmarshal([]byte(line), &resp); err != nil {
+		return nil, fmt.Errorf("unmarshal fir %s response: %w (got: %s)", command, err, line)
+	}
+	if resp.Error != "" {
+		return nil, fmt.Errorf("fir daemon %s error: %s", command, resp.Error)
+	}
+	if resp.ID != id {
+		return nil, fmt.Errorf("fir response ID mismatch: expected %d, got %d", id, resp.ID)
+	}
+	return resp.Result, nil
+}
+
+// sendAndReceive writes [req] as newline-delimited JSON and reads one
+// response line. Mirrors the scan-with-timeout pattern in [Check] but
+// factored out so the analyze methods don't duplicate it.
+//
+// Caller must hold d.mu.
+func (d *FirDaemon) sendAndReceive(req firDaemonRequest) (string, error) {
+	data, err := json.Marshal(req)
+	if err != nil {
+		return "", fmt.Errorf("marshal fir request: %w", err)
+	}
+	data = append(data, '\n')
+	if _, err := d.conn.Write(data); err != nil {
+		return "", fmt.Errorf("write to fir daemon: %w", err)
+	}
+
+	type scanResult struct {
+		line string
+		ok   bool
+		err  error
+	}
+	ch := make(chan scanResult, 1)
+	go func() {
+		if d.reader.Scan() {
+			ch <- scanResult{line: d.reader.Text(), ok: true}
+			return
+		}
+		ch <- scanResult{err: d.reader.Err()}
+	}()
+	timeout := daemonRequestTimeout()
+	select {
+	case res := <-ch:
+		if !res.ok {
+			if res.err != nil {
+				return "", fmt.Errorf("read from fir daemon: %w", res.err)
+			}
+			return "", fmt.Errorf("fir daemon closed stdout unexpectedly")
+		}
+		return res.line, nil
+	case <-time.After(timeout):
+		if d.cmd != nil && d.cmd.Process != nil {
+			_ = d.cmd.Process.Kill()
+		}
+		d.started = false
+		return "", fmt.Errorf("fir daemon request timed out after %s; daemon killed", timeout)
+	}
+}
+
+func toFileRefs(paths []string) []fileRef {
+	if len(paths) == 0 {
+		return nil
+	}
+	out := make([]fileRef, len(paths))
+	for i, p := range paths {
+		out[i] = fileRef{Path: p}
+	}
+	return out
+}

--- a/internal/firchecks/oracle_methods_test.go
+++ b/internal/firchecks/oracle_methods_test.go
@@ -1,0 +1,201 @@
+package firchecks
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"net"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// fakeFirOracleServer is a small TCP listener that fields one
+// firDaemonRequest per connection and returns a canned response keyed
+// by command. Used to exercise the analyze / analyzeAll /
+// analyzeWithDeps round-trip without a real JVM in the loop.
+type fakeFirOracleServer struct {
+	listener  net.Listener
+	responses map[string]string
+	requests  []firDaemonRequest
+	mu        sync.Mutex
+}
+
+func newFakeFirOracleServer(t *testing.T) *fakeFirOracleServer {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+	s := &fakeFirOracleServer{
+		listener:  ln,
+		responses: map[string]string{},
+	}
+	go s.serve()
+	return s
+}
+
+func (s *fakeFirOracleServer) serve() {
+	for {
+		conn, err := s.listener.Accept()
+		if err != nil {
+			return
+		}
+		go s.handle(conn)
+	}
+}
+
+func (s *fakeFirOracleServer) handle(conn net.Conn) {
+	defer conn.Close()
+	sc := bufio.NewScanner(conn)
+	for sc.Scan() {
+		var req firDaemonRequest
+		if err := json.Unmarshal([]byte(sc.Text()), &req); err != nil {
+			fmt.Fprintf(conn, "{\"id\":0,\"error\":\"invalid json: %s\"}\n", err)
+			continue
+		}
+		s.mu.Lock()
+		s.requests = append(s.requests, req)
+		body, ok := s.responses[req.Command]
+		s.mu.Unlock()
+		if !ok {
+			fmt.Fprintf(conn, "{\"id\":%d,\"error\":\"no canned response for %s\"}\n", req.ID, req.Command)
+			continue
+		}
+		// Inject the request ID into the canned body via a simple
+		// `%d` placeholder so the fake server tracks the correlation
+		// rules expect.
+		response := strings.ReplaceAll(body, "{{ID}}", fmt.Sprintf("%d", req.ID))
+		fmt.Fprintln(conn, response)
+	}
+}
+
+// connect dials the fake server and constructs a FirDaemon ready for
+// analyze calls. Callers t.Cleanup the returned daemon.
+func (s *fakeFirOracleServer) connect(t *testing.T) *FirDaemon {
+	t.Helper()
+	conn, err := net.Dial("tcp", s.listener.Addr().String())
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	d := &FirDaemon{
+		conn:    conn,
+		reader:  bufio.NewScanner(conn),
+		nextID:  1,
+		started: true,
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+	return d
+}
+
+func TestFirDaemonAnalyzeAllRoundTrip(t *testing.T) {
+	server := newFakeFirOracleServer(t)
+	server.responses["analyzeAll"] = `{"id":{{ID}},"result":{"version":1,"kotlinVersion":"2.3.21","files":{"/x.kt":{"package":"x","declarations":[{"fqn":"x.Y","kind":"class"}]}},"dependencies":{}}}`
+	d := server.connect(t)
+
+	data, err := d.AnalyzeAll([]string{"/src"}, nil)
+	if err != nil {
+		t.Fatalf("AnalyzeAll: %v", err)
+	}
+	if data == nil {
+		t.Fatal("expected non-nil oracle.Data")
+	}
+	if data.Version != 1 || data.KotlinVersion != "2.3.21" {
+		t.Errorf("envelope fields wrong: %+v", data)
+	}
+	if got := len(data.Files); got != 1 {
+		t.Fatalf("expected 1 file, got %d", got)
+	}
+	f := data.Files["/x.kt"]
+	if f == nil || f.Package != "x" {
+		t.Fatalf("file payload wrong: %+v", f)
+	}
+	if len(f.Declarations) != 1 || f.Declarations[0].FQN != "x.Y" {
+		t.Fatalf("declarations wrong: %+v", f.Declarations)
+	}
+}
+
+func TestFirDaemonAnalyzeRouteShiftsCommandWhenFilesEmpty(t *testing.T) {
+	// An empty file list should route to `analyzeAll` (not `analyze`),
+	// matching krit-types' behavior. The fake server records the
+	// command we sent so we can assert routing without relying on
+	// response shape.
+	server := newFakeFirOracleServer(t)
+	server.responses["analyzeAll"] = `{"id":{{ID}},"result":{"version":1,"kotlinVersion":"","files":{},"dependencies":{}}}`
+	d := server.connect(t)
+	if _, err := d.Analyze(nil, []string{"/src"}, nil); err != nil {
+		t.Fatalf("Analyze: %v", err)
+	}
+	server.mu.Lock()
+	defer server.mu.Unlock()
+	if len(server.requests) != 1 || server.requests[0].Command != "analyzeAll" {
+		t.Fatalf("expected analyzeAll routing for empty files, got %+v", server.requests)
+	}
+}
+
+func TestFirDaemonAnalyzeFilesShipsExplicitCommand(t *testing.T) {
+	server := newFakeFirOracleServer(t)
+	server.responses["analyze"] = `{"id":{{ID}},"result":{"version":1,"kotlinVersion":"","files":{},"dependencies":{}}}`
+	d := server.connect(t)
+	if _, err := d.Analyze([]string{"/src/x.kt"}, []string{"/src"}, nil); err != nil {
+		t.Fatalf("Analyze: %v", err)
+	}
+	server.mu.Lock()
+	defer server.mu.Unlock()
+	if len(server.requests) != 1 || server.requests[0].Command != "analyze" {
+		t.Fatalf("expected analyze command, got %+v", server.requests)
+	}
+	if len(server.requests[0].Files) != 1 || server.requests[0].Files[0].Path != "/src/x.kt" {
+		t.Fatalf("files not forwarded: %+v", server.requests[0])
+	}
+}
+
+func TestFirDaemonAnalyzeWithDepsParsesFlatEnvelope(t *testing.T) {
+	server := newFakeFirOracleServer(t)
+	server.responses["analyzeWithDeps"] = `{"id":{{ID}},"result":{"version":1,"kotlinVersion":"2.3.21","files":{},"dependencies":{}},"cacheDeps":{"version":1,"approximation":"symbol-resolved-sources","files":{"/leaf.kt":{"depPaths":["/base.kt"],"perFileDeps":{}}},"crashed":{}}}`
+	d := server.connect(t)
+	data, deps, err := d.AnalyzeWithDeps(nil, []string{"/src"}, nil)
+	if err != nil {
+		t.Fatalf("AnalyzeWithDeps: %v", err)
+	}
+	if data == nil || data.Version != 1 {
+		t.Fatalf("data missing or wrong: %+v", data)
+	}
+	if deps == nil {
+		t.Fatal("expected non-nil cacheDeps")
+	}
+	if deps.Approximation != "symbol-resolved-sources" {
+		t.Errorf("cacheDeps.approximation = %q, want %q", deps.Approximation, "symbol-resolved-sources")
+	}
+	if entry := deps.Files["/leaf.kt"]; entry == nil || len(entry.DepPaths) != 1 || entry.DepPaths[0] != "/base.kt" {
+		t.Errorf("cacheDeps entry wrong: %+v", entry)
+	}
+}
+
+func TestFirDaemonAnalyzeSurfacesErrorEnvelope(t *testing.T) {
+	server := newFakeFirOracleServer(t)
+	server.responses["analyzeAll"] = `{"id":{{ID}},"error":"boom"}`
+	d := server.connect(t)
+	if _, err := d.AnalyzeAll(nil, nil); err == nil {
+		t.Fatal("expected error from envelope")
+	} else if !strings.Contains(err.Error(), "boom") {
+		t.Errorf("error message lost: %v", err)
+	}
+}
+
+func TestFirDaemonAnalyzeChecksIdMatch(t *testing.T) {
+	server := newFakeFirOracleServer(t)
+	// Hard-code an id of 999 — the actual nextID starts at 1, so the
+	// mismatch should surface as a clear error rather than silently
+	// returning the wrong response.
+	server.responses["analyzeAll"] = `{"id":999,"result":{"version":1,"kotlinVersion":"","files":{},"dependencies":{}}}`
+	d := server.connect(t)
+	_, err := d.AnalyzeAll(nil, nil)
+	if err == nil {
+		t.Fatal("expected ID-mismatch error")
+	}
+	if !strings.Contains(err.Error(), "ID mismatch") {
+		t.Errorf("error should mention ID mismatch: %v", err)
+	}
+}

--- a/internal/pipeline/index.go
+++ b/internal/pipeline/index.go
@@ -918,6 +918,80 @@ func (p IndexPhase) runDaemonOracle(in IndexInput, oracleRules []*api.Rule, scan
 	return oracle.NewCompositeResolver(oracleLoaded, base)
 }
 
+// runDaemonOracleFir spawns (or reuses) the krit-fir persistent
+// daemon and asks it for the full project's oracle data. Skinnier
+// than [runDaemonOracle]: the krit-fir backend has no call-filter
+// optimization, no partial-reanalyze merge (its session.analyze is
+// already per-call rather than long-lived), and no in-flight crash
+// markers — the warm-JVM win is the only thing carrying over.
+//
+// Daemon resolution mirrors runJvmAnalyze's backend split: the FIR
+// jar comes from `firchecks.FindFirJar(scanPaths)` and the spawn
+// goes through `firchecks.ConnectOrStartFirDaemon`, which reuses an
+// existing daemon when one already serves the same sourceDirs hash.
+func (p IndexPhase) runDaemonOracleFir(in IndexInput, scanPaths []string, oracleTracker perf.Tracker, base typeinfer.TypeResolver, result *IndexResult) typeinfer.TypeResolver {
+	jarPath := firchecks.FindFirJar(scanPaths)
+	if jarPath == "" {
+		in.warnf("warning: --daemon: krit-fir.jar not found; falling back to base resolver\n")
+		return base
+	}
+	var sourceDirs []string
+	oracleTracker.TrackVoid("findSourceDirs", func() {
+		sourceDirs = oracle.FindSourceDirs(scanPaths)
+	})
+	if len(sourceDirs) == 0 {
+		return base
+	}
+
+	var d *firchecks.FirDaemon
+	var daemonErr error
+	oracleTracker.TrackVoid("firDaemonStart", func() {
+		d, daemonErr = firchecks.ConnectOrStartFirDaemon(jarPath, sourceDirs, in.Verbose)
+	})
+	if daemonErr != nil {
+		in.warnf("warning: --daemon: %v\n", daemonErr)
+		return base
+	}
+	result.FirDaemon = d
+
+	var oracleData *oracle.Data
+	oracleTracker.TrackVoid("firDaemonAnalyzeAll", func() {
+		// Classpath stays nil: the krit-fir daemon auto-discovers
+		// dependencies through the source tree, and threading a
+		// Go-side resolved classpath is its own multi-step refactor.
+		// Users that need an explicit classpath today fall back to
+		// the one-shot path (which also doesn't take one) or to the
+		// KAA backend.
+		od, err := d.AnalyzeAll(sourceDirs, nil)
+		if err != nil {
+			in.warnf("warning: fir daemon analyzeAll: %v\n", err)
+			return
+		}
+		oracleData = od
+	})
+	if oracleData == nil {
+		return base
+	}
+
+	var oracleLoaded *oracle.Oracle
+	oracleTracker.TrackVoid("indexBuild", func() {
+		ol, err := oracle.LoadFromData(oracleData)
+		if err != nil {
+			in.warnf("warning: fir daemon oracle: %v\n", err)
+			return
+		}
+		oracleLoaded = ol
+	})
+	if oracleLoaded == nil {
+		return base
+	}
+	result.Oracle = oracleLoaded
+	if in.Verbose {
+		in.logf("verbose: Type oracle loaded from fir daemon (%d dependency types)\n", len(oracleLoaded.Dependencies()))
+	}
+	return oracle.NewCompositeResolver(oracleLoaded, base)
+}
+
 // buildOracleFilterListPath computes and writes the oracle filter list file
 // when the filter reduces the file set. Returns the temp file path (empty
 // when no filter file is written) and a cleanup function.
@@ -1170,22 +1244,12 @@ func (p IndexPhase) runOracle(in IndexInput, base typeinfer.TypeResolver, result
 	}
 
 	var resolver typeinfer.TypeResolver
-	if in.UseDaemon {
-		if in.OracleBackend == oracle.BackendFIR {
-			// runDaemonOracle's long-lived oracle.InvokeDaemon path
-			// is wired specifically to krit-types' daemon-protocol
-			// surface. The krit-fir daemon ships the same RPCs but
-			// the Go-side persistent-daemon wrapper hasn't been
-			// ported yet — surface that as a verbose-warn fallback
-			// to the one-shot path so users get a working analysis
-			// even when they combine `--daemon` with
-			// `--oracle-backend=fir` by mistake.
-			in.warnf("warning: --daemon is not yet supported with --oracle-backend=fir; falling back to one-shot mode\n")
-			resolver = p.runAutoDetectOracle(in, oracleRules, scanPaths, loadOracleFilterFiles, oracleTracker, base)
-		} else {
-			resolver = p.runDaemonOracle(in, oracleRules, scanPaths, loadOracleFilterFiles, oracleTracker, base, result)
-		}
-	} else {
+	switch {
+	case in.UseDaemon && in.OracleBackend == oracle.BackendFIR:
+		resolver = p.runDaemonOracleFir(in, scanPaths, oracleTracker, base, result)
+	case in.UseDaemon:
+		resolver = p.runDaemonOracle(in, oracleRules, scanPaths, loadOracleFilterFiles, oracleTracker, base, result)
+	default:
 		resolver = p.runAutoDetectOracle(in, oracleRules, scanPaths, loadOracleFilterFiles, oracleTracker, base)
 	}
 

--- a/internal/pipeline/types.go
+++ b/internal/pipeline/types.go
@@ -9,6 +9,7 @@ import (
 	"github.com/kaeawc/krit/internal/cacheutil"
 	"github.com/kaeawc/krit/internal/config"
 	"github.com/kaeawc/krit/internal/diag"
+	"github.com/kaeawc/krit/internal/firchecks"
 	"github.com/kaeawc/krit/internal/javafacts"
 	"github.com/kaeawc/krit/internal/librarymodel"
 	"github.com/kaeawc/krit/internal/module"
@@ -220,9 +221,15 @@ type IndexResult struct {
 	// --no-type-oracle or no rule needs oracle data.
 	Oracle *oracle.Oracle
 	// Daemon is the optional long-lived krit-types daemon handle
-	// (populated when --daemon is set). Callers are responsible for
-	// Close()-ing it at program exit.
+	// (populated when --daemon is set and the KAA backend is
+	// selected). Callers are responsible for Close()-ing it at
+	// program exit.
 	Daemon *oracle.Daemon
+	// FirDaemon is the optional long-lived krit-fir daemon handle
+	// (populated when --daemon is set and --oracle-backend=fir is
+	// selected). Mutually exclusive with [Daemon] within one run.
+	// Callers are responsible for Close()-ing it at program exit.
+	FirDaemon *firchecks.FirDaemon
 	// CodeIndex is the cross-file symbol/reference index. Nil when
 	// no active rule declares NeedsCrossFile.
 	CodeIndex *scanner.CodeIndex


### PR DESCRIPTION
## Summary

Closes the gap PR 4 left open: \`--daemon\` combined with \`--oracle-backend=fir\` no longer warns-and-falls-back to one-shot; the krit-fir daemon now answers the same long-lived analyze RPCs the krit-types daemon does. Warm-JVM amortization works for FIR.

- **\`internal/firchecks/oracle_methods.go\`** — new \`Analyze\` / \`AnalyzeAll\` / \`AnalyzeWithDeps\` on \`*FirDaemon\`. Same TCP framing pattern as \`Check\`; parses krit-fir's envelope into \`*oracle.Data\` and (for \`analyzeWithDeps\`) \`*oracle.CacheDepsFile\` so a single Go-side struct serves both backends.
- **\`internal/pipeline\`** — new \`runDaemonOracleFir\` spawns/reuses the FirDaemon (via \`firchecks.ConnectOrStartFirDaemon\`, same PID-file pattern as before), calls \`AnalyzeAll\`, wraps in \`CompositeResolver\`. Skips the partial-reanalyze + \`types.json\` merge dance — krit-fir's \`session.analyze\` is already per-call, so the warm JVM is the only win carrying over from KAA's persistent session.
- **\`runOracle\`** daemon branch now switches on \`OracleBackend\` with no warn-and-fallback path. \`IndexResult\` grows a \`FirDaemon\` handle next to the existing \`Daemon\` field; callers \`Close()\` each at program exit.

## Test plan
- [x] \`go test ./internal/firchecks/ -count=1\` — 6 new cases (\`AnalyzeAll\` round-trip into \`oracle.Data\`; \`Analyze(nil)\` routes to \`analyzeAll\`; \`Analyze(files)\` routes to \`analyze\` and forwards file paths; \`AnalyzeWithDeps\` parses the flat \`cacheDeps\` sibling; error envelope surfaces; ID-mismatch caught). In-process TCP fake server, no JVM needed.
- [x] \`go build ./cmd/krit/ && go vet ./... && golangci-lint run ./... && go test ./... -count=1\`

## Follow-up
- Threading an explicit classpath through to the FIR daemon (currently the analyze call passes \`nil\`; the daemon auto-discovers via the source tree). Both backends today rely on source-tree discovery; an explicit-classpath story is its own multi-step refactor.