### PR TITLE
feat(krit-fir): wire UNREACHABLE_CODE through diagnostic projection

### DIFF
--- a/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/KritFirCheckers.kt
+++ b/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/KritFirCheckers.kt
@@ -10,6 +10,7 @@ import dev.jasonpearson.krit.fir.rules.SmokeChecker
 import org.jetbrains.kotlin.fir.FirSession
 import org.jetbrains.kotlin.fir.analysis.checkers.declaration.DeclarationCheckers
 import org.jetbrains.kotlin.fir.analysis.checkers.expression.ExpressionCheckers
+import org.jetbrains.kotlin.fir.analysis.checkers.extra.UnreachableCodeChecker
 import org.jetbrains.kotlin.fir.analysis.extensions.FirAdditionalCheckersExtension
 
 class KritFirCheckers(session: FirSession) : FirAdditionalCheckersExtension(session) {
@@ -34,7 +35,15 @@ class KritFirCheckers(session: FirSession) : FirAdditionalCheckersExtension(sess
     // declaration. Per-lambda suspend status is captured at the call
     // site inside `OracleExpressionChecker` — see its
     // `recordLambdaSuspendArguments` for the rationale.
+    //
+    // `UnreachableCodeChecker` lives in K2's `extra` package and isn't
+    // wired into the default checker pipeline; registering it here
+    // lets the oracle's `OracleDiagnosticMessageCollector` surface the
+    // UNREACHABLE_CODE factory alongside USELESS_ELVIS and
+    // CAST_NEVER_SUCCEEDS. The class is a static object on K2's side,
+    // so adding it costs nothing extra at JVM init.
     override val declarationCheckers = object : DeclarationCheckers() {
         override val classCheckers = setOf(SmokeChecker, OracleClassChecker)
+        override val controlFlowAnalyserCheckers = setOf(UnreachableCodeChecker)
     }
 }

--- a/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/runner/AnalysisSession.kt
+++ b/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/runner/AnalysisSession.kt
@@ -127,10 +127,12 @@ class AnalysisSession(val sourceDirs: List<String>, val classpath: List<String>)
                 noReflect = true
                 // `suppressWarnings = false` + `reportAllWarnings = true`
                 // so K2 emits warning-level diagnostics through the
-                // message collector — including the
-                // optional/extra-checker subset
-                // (`UNREACHABLE_CODE`, `USELESS_ELVIS`,
-                // `CAST_NEVER_SUCCEEDS`) the oracle projects.
+                // message collector. The plugin's `KritFirCheckers`
+                // adds K2's `UnreachableCodeChecker` to its own
+                // control-flow checker set so the third retained
+                // factory (UNREACHABLE_CODE) lands here too — the
+                // checker lives in the experimental package by
+                // default and is not on the standard pipeline.
                 suppressWarnings = false
                 reportAllWarnings = true
                 if (selfJar != null) {

--- a/tools/krit-fir/src/test/kotlin/dev/jasonpearson/krit/fir/runner/AnalysisSessionDiagnosticsTest.kt
+++ b/tools/krit-fir/src/test/kotlin/dev/jasonpearson/krit/fir/runner/AnalysisSessionDiagnosticsTest.kt
@@ -80,12 +80,12 @@ class AnalysisSessionDiagnosticsTest {
 
     @Test
     fun unreachableCodeIsRecorded() {
-        // K2 only flags unreachable code when extra checkers are
-        // enabled (`-Werror -Wextra` or the `extraCheckers` compiler
-        // flag). The bare default analysis pipeline that ships with
-        // krit-fir doesn't run the unreachable-code checker, so this
-        // test pins the projection layer's behavior end-to-end while
-        // remaining skipped when K2 doesn't emit the diagnostic.
+        // K2's UNREACHABLE_CODE checker lives in the experimental
+        // checker set. AnalysisSession.analyzeFull turns it on via
+        // `useFirExperimentalCheckers = true` so the projection
+        // collects all three retained factories on the default
+        // analyze path — no `-Wextra` opt-in needed at the request
+        // boundary.
         val path = writeKt(
             "Unreachable.kt",
             """
@@ -99,18 +99,13 @@ class AnalysisSessionDiagnosticsTest {
         )
 
         val diagnostics = diagnosticsFor(path)
-        // The projection layer must NEVER conflate factories: even if
-        // K2 doesn't emit UNREACHABLE_CODE, anything emitted must NOT
-        // be mislabeled here. Run the test only if K2 produced the
-        // expected factory; otherwise skip.
-        assumeTrue(
+        assertTrue(
             diagnostics.any { it.factoryName == "UNREACHABLE_CODE" },
-            "UNREACHABLE_CODE not emitted by this K2 build — projection wiring covered by " +
-                "the message-prefix matcher in OracleDiagnosticMessageCollector; full E2E " +
-                "coverage requires the -Wextra checker set.",
+            "expected UNREACHABLE_CODE, got ${diagnostics.map { it.factoryName }}",
         )
-        // If we did get the diagnostic, sanity-check that we didn't
-        // mislabel something else as UNREACHABLE_CODE.
+        // Belt-and-suspenders: ensure factoryName ↔ message pairing
+        // isn't crossed (a prefix-match miss would otherwise label
+        // an unrelated warning with the wrong factory).
         diagnostics.filter { it.factoryName == "UNREACHABLE_CODE" }.forEach {
             assertTrue("Unreachable" in it.message, "factoryName/message mismatch: $it")
         }


### PR DESCRIPTION
## Summary

K2 ships \`UnreachableCodeChecker\` in the experimental \`fir.analysis.checkers.extra\` package — it's not on the default pipeline, so \`reportAllWarnings = true\` alone never let the diagnostic flow through the oracle's message collector. Register the checker directly in \`KritFirCheckers\` and let the existing message-prefix collector pick it up alongside USELESS_ELVIS and CAST_NEVER_SUCCEEDS.

- **\`KritFirCheckers.declarationCheckers\`** gains a \`controlFlowAnalyserCheckers = setOf(UnreachableCodeChecker)\` slot. \`UnreachableCodeChecker\` is a K2-internal singleton object — adding it is free at JVM init.
- **\`AnalysisSessionDiagnosticsTest.unreachableCodeIsRecorded\`** drops its \`assumeTrue\` skip; the full E2E path now fires reliably.

This closes the last deferred follow-up from the FIR migration series. All three retained diagnostic factories (\`USELESS_ELVIS\`, \`CAST_NEVER_SUCCEEDS\`, \`UNREACHABLE_CODE\`) now surface through \`FilePayload.diagnostics\` on the krit-fir backend.

## Test plan
- [x] \`./gradlew :test\` in \`tools/krit-fir/\` — \`AnalysisSessionDiagnosticsTest\` goes from 4-pass-1-skip to 5-pass-0-skip
- [x] \`go build ./cmd/krit/ && go vet ./... && golangci-lint run ./... && go test ./... -count=1\`