### PR TITLE
feat(krit-fir): expressionType covers qualified-access expressions

### DIFF
--- a/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/KritFirCheckers.kt
+++ b/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/KritFirCheckers.kt
@@ -6,6 +6,7 @@ import dev.jasonpearson.krit.fir.checkers.InjectDispatcher
 import dev.jasonpearson.krit.fir.checkers.UnsafeCastWhenNullable
 import dev.jasonpearson.krit.fir.oracle.OracleClassChecker
 import dev.jasonpearson.krit.fir.oracle.OracleExpressionChecker
+import dev.jasonpearson.krit.fir.oracle.OracleQualifiedAccessChecker
 import dev.jasonpearson.krit.fir.rules.SmokeChecker
 import org.jetbrains.kotlin.fir.FirSession
 import org.jetbrains.kotlin.fir.analysis.checkers.declaration.DeclarationCheckers
@@ -27,6 +28,15 @@ class KritFirCheckers(session: FirSession) : FirAdditionalCheckersExtension(sess
         )
         override val typeOperatorCallCheckers = setOf(
             UnsafeCastWhenNullable,
+        )
+        // OracleQualifiedAccessChecker fills in the expression-type
+        // gap that OracleExpressionChecker leaves: property reads,
+        // variable references, receiver expressions in non-call
+        // chains. The checker bypasses FirFunctionCall (which is also
+        // a FirQualifiedAccessExpression) so call-site entries from
+        // OracleExpressionChecker remain authoritative on collisions.
+        override val qualifiedAccessExpressionCheckers = setOf(
+            OracleQualifiedAccessChecker,
         )
     }
 

--- a/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/oracle/OracleQualifiedAccessChecker.kt
+++ b/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/oracle/OracleQualifiedAccessChecker.kt
@@ -1,0 +1,76 @@
+package dev.jasonpearson.krit.fir.oracle
+
+import org.jetbrains.kotlin.diagnostics.DiagnosticReporter
+import org.jetbrains.kotlin.fir.analysis.checkers.MppCheckerKind
+import org.jetbrains.kotlin.fir.analysis.checkers.context.CheckerContext
+import org.jetbrains.kotlin.fir.analysis.checkers.expression.FirExpressionChecker
+import org.jetbrains.kotlin.fir.expressions.FirFunctionCall
+import org.jetbrains.kotlin.fir.expressions.FirQualifiedAccessExpression
+import org.jetbrains.kotlin.fir.symbols.SymbolInternals
+import org.jetbrains.kotlin.fir.types.isMarkedNullable
+import org.jetbrains.kotlin.fir.types.resolvedType
+
+/**
+ * FIR `FirExpressionChecker<FirQualifiedAccessExpression>` that
+ * captures resolved-type info for every property / variable access
+ * the K2 frontend visits. Powers `Resolver.expressionType(expr)`
+ * queries from plugin rules running on the krit-fir backend for
+ * non-call expressions — without this checker, only
+ * [`FirFunctionCall`] sites had a populated [`ExpressionPayload.type`]
+ * and rules asking about `someVar`, `obj.field`, etc. saw null.
+ *
+ * The checker writes the same payload shape `OracleExpressionChecker`
+ * uses (just with `callTarget = null` and `callTargetResolved = false`),
+ * so the [`OracleCollector.addExpression`] first-wins dedup keeps
+ * call-site entries authoritative when a property access shares the
+ * same `"line:col"` (e.g. the receiver of a chained call). The
+ * resolver's call-specific methods still ignore non-call entries
+ * via the `callTargetResolved` gate.
+ *
+ * Self-gates on `OracleCollectorRegistry.current() != null` like the
+ * other oracle checkers — non-oracle compilation paths pay only the
+ * thread-local probe.
+ */
+internal object OracleQualifiedAccessChecker :
+    FirExpressionChecker<FirQualifiedAccessExpression>(MppCheckerKind.Common) {
+
+    @OptIn(SymbolInternals::class)
+    context(context: CheckerContext, reporter: DiagnosticReporter)
+    override fun check(expression: FirQualifiedAccessExpression) {
+        // FirFunctionCall is a subtype of FirQualifiedAccessExpression
+        // in FIR. OracleExpressionChecker already handles the call
+        // case with full callTarget / suspend / annotations metadata,
+        // so let it own that path; we only need to fill in the gap
+        // for non-call qualified accesses.
+        if (expression is FirFunctionCall) return
+
+        val collector = OracleCollectorRegistry.current() ?: return
+        val source = expression.source ?: return
+        val filePath = context.containingFileSymbol?.fir?.sourceFile?.path ?: return
+        val offsets = collector.offsetsFor(filePath) ?: return
+
+        val startOffset = source.startOffset
+        val (line, col) = offsets.lineColAt(startOffset)
+        val key = "$line:$col"
+        if (collector.hasExpression(filePath, key)) return
+
+        val resolvedType = runCatching { expression.resolvedType }.getOrNull() ?: return
+        val typeFqn = resolvedType.renderFqn()
+        if (typeFqn.isBlank()) return
+
+        collector.addExpression(
+            filePath,
+            key,
+            ExpressionPayload(
+                type = typeFqn,
+                nullable = resolvedType.isMarkedNullable,
+                startByte = offsets.byteOffsetAt(startOffset),
+                endByte = offsets.byteOffsetAt(source.endOffset),
+                callTarget = null,
+                callTargetResolved = false,
+                callTargetSuspend = false,
+                annotations = emptyList(),
+            ),
+        )
+    }
+}

--- a/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/plugins/FirOracleResolver.kt
+++ b/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/plugins/FirOracleResolver.kt
@@ -56,15 +56,19 @@ internal class FirOracleResolver(
     }
 
     override fun expressionType(expression: KtExpression): String? {
-        // Today we surface only call-expression types — the oracle
-        // pass captures `FirFunctionCall.resolvedType` per call site
-        // and stashes the rendered FQN on the matching
-        // [`ExpressionPayload.type`]. Non-call expressions don't have
-        // a payload, so the lookup returns null and the rule sees the
-        // "unresolved" contract krit-types' resolver also uses.
-        if (expression !is KtCallExpression) return null
-        val payload = lookupCall(expression) ?: return null
-        return payload.type.takeIf { it.isNotBlank() }
+        // The oracle pass populates [`ExpressionPayload.type`] for
+        // function calls (via OracleExpressionChecker) and qualified
+        // accesses — property reads, variable refs, receivers in
+        // call chains (via OracleQualifiedAccessChecker). Both write
+        // entries into `expressionsByKey` keyed by `"line:col"`, so a
+        // single PSI offset → line:col lookup serves either source.
+        // Expressions outside that set (literals, when expressions,
+        // tries, etc.) still return null — broadening coverage is
+        // purely additive on the writer side and doesn't change the
+        // resolver contract.
+        val range = expression.textRange ?: return null
+        val (line, col) = offsets.lineColAt(range.startOffset)
+        return expressionsByKey["$line:$col"]?.type?.takeIf { it.isNotBlank() }
     }
 
     private fun lookupCall(call: KtCallExpression): ExpressionPayload? {

--- a/tools/krit-fir/src/test/kotlin/dev/jasonpearson/krit/fir/plugins/FirOracleResolverTest.kt
+++ b/tools/krit-fir/src/test/kotlin/dev/jasonpearson/krit/fir/plugins/FirOracleResolverTest.kt
@@ -136,6 +136,45 @@ class FirOracleResolverTest {
     }
 
     @Test
+    fun expressionTypeServesNonCallEntriesFromTheSameMap() {
+        // After the qualified-access broadening, property reads and
+        // variable references also land in `expressionsByKey` —
+        // with `callTargetResolved=false` so they don't interfere
+        // with call-resolution lookups. The resolver looks up by
+        // PSI offset → line:col regardless of expression subtype.
+        val source = "package x\n\nval name: String = \"hi\"\nfun caller() {\n    val s = name\n}\n"
+        val table = FileOffsetTable(source)
+        val parsed = KtFileParser.parse(source, pathHint = "/tmp/Source.kt")
+        parsed.use {
+            var ref: org.jetbrains.kotlin.psi.KtNameReferenceExpression? = null
+            parsed.ktFile.accept(object : org.jetbrains.kotlin.psi.KtTreeVisitorVoid() {
+                override fun visitReferenceExpression(expression: org.jetbrains.kotlin.psi.KtReferenceExpression) {
+                    super.visitReferenceExpression(expression)
+                    if (
+                        ref == null &&
+                        expression is org.jetbrains.kotlin.psi.KtNameReferenceExpression &&
+                        expression.getReferencedName() == "name"
+                    ) {
+                        ref = expression
+                    }
+                }
+            })
+            val nameRef = ref ?: error("source has no `name` reference: $source")
+            val (line, col) = table.lineColAt(nameRef.textRange.startOffset)
+            val expressions = mapOf(
+                "$line:$col" to ExpressionPayload(
+                    type = "kotlin.String",
+                    nullable = false,
+                    callTarget = null,
+                    callTargetResolved = false,
+                ),
+            )
+            val resolver = FirOracleResolver(expressions, table)
+            assertEquals("kotlin.String", resolver.expressionType(nameRef))
+        }
+    }
+
+    @Test
     fun isLambdaSuspendLooksUpByPsiOffset() {
         // The PSI offset of a KtLambdaExpression sits on its opening
         // brace; K2 records the FirAnonymousFunction's source at the

--- a/tools/krit-fir/src/test/kotlin/dev/jasonpearson/krit/fir/runner/AnalysisSessionLambdaTypesTest.kt
+++ b/tools/krit-fir/src/test/kotlin/dev/jasonpearson/krit/fir/runner/AnalysisSessionLambdaTypesTest.kt
@@ -91,6 +91,35 @@ class AnalysisSessionLambdaTypesTest {
     }
 
     @Test
+    fun propertyAccessTypeFqnLandsOnNonCallPayload() {
+        // OracleQualifiedAccessChecker captures property reads. The
+        // payload it writes has a populated `type` and
+        // `callTargetResolved=false` so the resolver's call-specific
+        // lookups still ignore it; `expressionType(propertyRef)`
+        // returns the real FQN.
+        val path = writeKt(
+            "PropAccess.kt",
+            """
+            package com.acme.propaccess
+
+            class Box(val label: String)
+
+            fun caller(box: Box): String = box.label
+            """.trimIndent(),
+        )
+
+        val expressions = analyze(path).expressions
+        val nonCallStringEntries = expressions.values.filter {
+            it.type == "kotlin.String" && !it.callTargetResolved
+        }
+        assertTrue(
+            nonCallStringEntries.isNotEmpty(),
+            "expected at least one non-call property-access payload with type=kotlin.String, got " +
+                "${expressions.values.map { it.type to it.callTargetResolved }}",
+        )
+    }
+
+    @Test
     fun callExpressionTypeFqnLandsOnExpressionPayload() {
         val path = writeKt(
             "CallType.kt",


### PR DESCRIPTION
## Summary

PR 508 wired up \`expressionType\` for \`FirFunctionCall\`. Plugin rules querying property reads, variable references, or receiver chains still saw null. Add a sibling checker that captures resolved-type info for every \`FirQualifiedAccessExpression\` so the resolver can serve those queries from the same \`expressionsByKey\` map.

- **\`OracleQualifiedAccessChecker\`** — \`FirExpressionChecker<FirQualifiedAccessExpression>\` writes an \`ExpressionPayload\` with \`callTargetResolved=false\` / \`callTarget=null\` and the rendered \`resolvedType\` FQN. Bypasses \`FirFunctionCall\` (a subtype of \`FirQualifiedAccessExpression\` in FIR) so call-site entries from \`OracleExpressionChecker\` stay authoritative on shared source positions via first-wins dedup.
- **\`KritFirCheckers\`** registers it in \`expressionCheckers.qualifiedAccessExpressionCheckers\`.
- **\`FirOracleResolver.expressionType\`** drops its \`is KtCallExpression\` gate: a single PSI offset → line:col lookup serves both call and non-call entries. Returns null when the position isn't in the map (literals, \`when\` / \`try\` expressions, …) — broadening writer coverage is purely additive.

## Test plan
- [x] \`./gradlew :test\` in \`tools/krit-fir/\`:
  - \`FirOracleResolverTest\` (+1): non-call PSI reference (\`name\`) round-trips through the resolver with a \`callTargetResolved=false\` payload entry
  - \`AnalysisSessionLambdaTypesTest\` (+1): end-to-end — property-access type lands as a non-call payload entry with \`type=kotlin.String\`
- [x] \`go build ./cmd/krit/ && go vet ./... && golangci-lint run ./... && go test ./... -count=1\`