### PR TITLE
feat(pipeline): thread oracle classpath into FIR daemon analyze

### DIFF
--- a/internal/cli/scan/oracle_classpath.go
+++ b/internal/cli/scan/oracle_classpath.go
@@ -1,0 +1,61 @@
+package scan
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/kaeawc/krit/internal/config"
+)
+
+// resolveOracleClasspath assembles the user-configured classpath
+// the FIR daemon's `analyze` RPC receives. Order of precedence:
+//
+//  1. `oracle.classpath` from krit.yml
+//  2. The `CLASSPATH` env var, split on the platform path separator
+//
+// Empty result is fine: the daemon falls back to source-tree
+// dependency discovery — same shape the KAA backend uses today, so
+// projects without an explicit classpath still analyze.
+//
+// Path validity is not checked here. The Kotlin side opens what we
+// hand it; missing entries surface as resolution errors inside the
+// daemon's analyze response, which is the right layer for that
+// signal.
+func resolveOracleClasspath(cfg *config.Config) []string {
+	var out []string
+	if cfg != nil {
+		out = append(out, cfg.Oracle().Classpath...)
+	}
+	out = append(out, splitEnvClasspath()...)
+	return dedupePreservingOrder(out)
+}
+
+func splitEnvClasspath() []string {
+	v := os.Getenv("CLASSPATH")
+	if v == "" {
+		return nil
+	}
+	return filepath.SplitList(v)
+}
+
+// dedupePreservingOrder drops empty strings and duplicate entries
+// while keeping the first occurrence's position. Stable order makes
+// the wire payload deterministic for snapshot tests.
+func dedupePreservingOrder(in []string) []string {
+	if len(in) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(in))
+	out := in[:0]
+	for _, s := range in {
+		if s == "" {
+			continue
+		}
+		if _, ok := seen[s]; ok {
+			continue
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
+	}
+	return out
+}

--- a/internal/cli/scan/oracle_classpath_test.go
+++ b/internal/cli/scan/oracle_classpath_test.go
@@ -1,0 +1,98 @@
+package scan
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/kaeawc/krit/internal/config"
+)
+
+func TestResolveOracleClasspath_ConfigOnly(t *testing.T) {
+	t.Setenv("CLASSPATH", "")
+	cfg := config.NewConfigFromData(map[string]interface{}{
+		"oracle": map[string]interface{}{
+			"classpath": []interface{}{"/lib/a.jar", "/lib/b.jar"},
+		},
+	})
+	got := resolveOracleClasspath(cfg)
+	want := []string{"/lib/a.jar", "/lib/b.jar"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestResolveOracleClasspath_EnvOnly(t *testing.T) {
+	// Synthesize a CLASSPATH using the platform's path separator so
+	// the test runs on Linux and macOS without branching.
+	envValue := "/env/x.jar" + string(os.PathListSeparator) + "/env/y.jar"
+	t.Setenv("CLASSPATH", envValue)
+	got := resolveOracleClasspath(nil)
+	want := []string{"/env/x.jar", "/env/y.jar"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestResolveOracleClasspath_ConfigBeforeEnv(t *testing.T) {
+	envValue := "/env/x.jar" + string(os.PathListSeparator) + "/env/y.jar"
+	t.Setenv("CLASSPATH", envValue)
+	cfg := config.NewConfigFromData(map[string]interface{}{
+		"oracle": map[string]interface{}{
+			"classpath": []interface{}{"/cfg/a.jar"},
+		},
+	})
+	got := resolveOracleClasspath(cfg)
+	// Config entries come first so an explicit krit.yml override
+	// wins over an ambient env value if the daemon honors order.
+	want := []string{"/cfg/a.jar", "/env/x.jar", "/env/y.jar"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestResolveOracleClasspath_DedupesAcrossSources(t *testing.T) {
+	envValue := "/shared.jar" + string(os.PathListSeparator) + "/env/y.jar"
+	t.Setenv("CLASSPATH", envValue)
+	cfg := config.NewConfigFromData(map[string]interface{}{
+		"oracle": map[string]interface{}{
+			"classpath": []interface{}{"/cfg/a.jar", "/shared.jar"},
+		},
+	})
+	got := resolveOracleClasspath(cfg)
+	want := []string{"/cfg/a.jar", "/shared.jar", "/env/y.jar"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestResolveOracleClasspath_EmptyByDefault(t *testing.T) {
+	t.Setenv("CLASSPATH", "")
+	if got := resolveOracleClasspath(nil); got != nil {
+		t.Errorf("expected nil, got %v", got)
+	}
+	emptyCfg := config.NewConfigFromData(nil)
+	if got := resolveOracleClasspath(emptyCfg); got != nil {
+		t.Errorf("expected nil for empty cfg, got %v", got)
+	}
+}
+
+func TestResolveOracleClasspath_IgnoresBlankEntries(t *testing.T) {
+	// A trailing separator on CLASSPATH inserts an empty entry on
+	// most platforms — `filepath.SplitList` returns "" for it. We
+	// drop those so the daemon's classpath array stays clean.
+	envValue := "/x.jar" + string(os.PathListSeparator) + "" + string(os.PathListSeparator) + "/y.jar"
+	t.Setenv("CLASSPATH", envValue)
+	got := resolveOracleClasspath(nil)
+	for _, p := range got {
+		if p == "" {
+			t.Fatalf("blank entry leaked: %v", got)
+		}
+	}
+	// Use filepath to avoid platform-specific assertions on path
+	// formatting.
+	if filepath.Clean(got[0]) != filepath.Clean("/x.jar") {
+		t.Errorf("first entry = %q, want %q", got[0], "/x.jar")
+	}
+}

--- a/internal/cli/scan/runner_state.go
+++ b/internal/cli/scan/runner_state.go
@@ -480,6 +480,7 @@ func (r *runner) runOracleIndex() (int, error) {
 			err = oracleBackendErr
 			return
 		}
+		oracleClasspath := resolveOracleClasspath(r.cfg)
 		in := pipeline.IndexInput{
 			ParseResult:       pipeline.ParseResult{ActiveRules: r.activeRules},
 			Reporter:          r.reporter,
@@ -495,6 +496,7 @@ func (r *runner) runOracleIndex() (int, error) {
 			OracleDiagnostics: *r.f.OracleDiagnostics,
 			UseDaemon:         *r.f.Daemon,
 			OracleBackend:     oracleBackend,
+			OracleClasspath:   oracleClasspath,
 			Store:             r.oracleStore,
 			OracleCacheWriter: r.oracleCacheWriter,
 			StaleOraclePaths:  staleOraclePaths,

--- a/internal/firchecks/oracle_methods_test.go
+++ b/internal/firchecks/oracle_methods_test.go
@@ -151,6 +151,29 @@ func TestFirDaemonAnalyzeFilesShipsExplicitCommand(t *testing.T) {
 	}
 }
 
+func TestFirDaemonAnalyzeForwardsClasspathToDaemon(t *testing.T) {
+	// The classpath argument arrives at the krit-fir daemon as the
+	// request body's `classpath` array — without forwarding, K2
+	// resolves against an empty dependency set and rules that opt
+	// into types from project libs see "unresolved" everywhere.
+	server := newFakeFirOracleServer(t)
+	server.responses["analyzeAll"] = `{"id":{{ID}},"result":{"version":1,"kotlinVersion":"","files":{},"dependencies":{}}}`
+	d := server.connect(t)
+	cp := []string{"/lib/a.jar", "/lib/b.jar"}
+	if _, err := d.AnalyzeAll([]string{"/src"}, cp); err != nil {
+		t.Fatalf("AnalyzeAll: %v", err)
+	}
+	server.mu.Lock()
+	defer server.mu.Unlock()
+	if len(server.requests) != 1 {
+		t.Fatalf("expected one request, got %d", len(server.requests))
+	}
+	gotCP := server.requests[0].Classpath
+	if len(gotCP) != len(cp) || gotCP[0] != cp[0] || gotCP[1] != cp[1] {
+		t.Fatalf("classpath not forwarded verbatim: got %v want %v", gotCP, cp)
+	}
+}
+
 func TestFirDaemonAnalyzeWithDepsParsesFlatEnvelope(t *testing.T) {
 	server := newFakeFirOracleServer(t)
 	server.responses["analyzeWithDeps"] = `{"id":{{ID}},"result":{"version":1,"kotlinVersion":"2.3.21","files":{},"dependencies":{}},"cacheDeps":{"version":1,"approximation":"symbol-resolved-sources","files":{"/leaf.kt":{"depPaths":["/base.kt"],"perFileDeps":{}}},"crashed":{}}}`

--- a/internal/pipeline/index.go
+++ b/internal/pipeline/index.go
@@ -192,6 +192,13 @@ type IndexInput struct {
 	// when the flag isn't set. Parsing happens in the caller; the
 	// pipeline just routes on the value.
 	OracleBackend oracle.Backend
+	// OracleClasspath is the resolved user-override classpath the FIR
+	// daemon receives on `analyze` requests. Built from
+	// `oracle.classpath` in krit.yml and the `CLASSPATH` env var. The
+	// daemon falls back to source-tree dependency discovery when this
+	// is empty. The KAA backend ignores this field today; classpath
+	// threading for krit-types is a separate effort.
+	OracleClasspath []string
 	// PrebuiltOracleDaemon, when non-nil, is reused by runDaemonOracle
 	// instead of calling oracle.InvokeDaemon. The serve daemon's
 	// ensureOracleDaemon supplies a *oracle.Daemon kept alive across
@@ -956,13 +963,12 @@ func (p IndexPhase) runDaemonOracleFir(in IndexInput, scanPaths []string, oracle
 
 	var oracleData *oracle.Data
 	oracleTracker.TrackVoid("firDaemonAnalyzeAll", func() {
-		// Classpath stays nil: the krit-fir daemon auto-discovers
-		// dependencies through the source tree, and threading a
-		// Go-side resolved classpath is its own multi-step refactor.
-		// Users that need an explicit classpath today fall back to
-		// the one-shot path (which also doesn't take one) or to the
-		// KAA backend.
-		od, err := d.AnalyzeAll(sourceDirs, nil)
+		// Pass the user-configured classpath (oracle.classpath in
+		// krit.yml + the CLASSPATH env var) to the FIR daemon. Empty
+		// classpath means the daemon falls back to source-tree
+		// discovery — same as krit-types' behavior — so projects
+		// that don't set anything still work.
+		od, err := d.AnalyzeAll(sourceDirs, in.OracleClasspath)
 		if err != nil {
 			in.warnf("warning: fir daemon analyzeAll: %v\n", err)
 			return


### PR DESCRIPTION
## Summary

Closes the second deferred follow-up: \`runDaemonOracleFir\` was passing nil for the classpath argument, so K2 always fell back to source-tree dependency discovery. Now the daemon receives the user-configured classpath (krit.yml \`oracle.classpath\` plus the \`CLASSPATH\` env var), letting rules opt into types from project libraries.

- **\`internal/pipeline\`** — new \`IndexInput.OracleClasspath\` field plumbs through to \`d.AnalyzeAll(sourceDirs, in.OracleClasspath)\`. Empty list keeps the source-tree-discovery fallback the KAA backend also uses, so projects without explicit classpath still work.
- **\`internal/cli/scan\`** — new \`resolveOracleClasspath\` helper combines config + env values, dedups while preserving order, drops blank entries from trailing-separator env vars. \`runner_state.go\` populates the field once before constructing the pipeline input.

## Scope

This PR only wires the **daemon** path. The one-shot \`runJvmAnalyze\` flow runs the FIR jar with no \`--classpath\` CLI arg today; threading there needs a \`Main.kt\` parser addition plus a new \`oracle.InvokeWithFiles\` signature to accept one. KAA backend classpath threading is also out of scope — krit-types' daemon already discovers via the source tree, and changing that surface is its own multi-step refactor.

## Test plan
- [x] \`internal/cli/scan/oracle_classpath_test.go\` (6 cases): config-only, env-only, config-before-env precedence, cross-source dedup, empty-by-default, blank-entry filtering
- [x] \`internal/firchecks/oracle_methods_test.go\` (+1): \`TestFirDaemonAnalyzeForwardsClasspathToDaemon\` asserts the classpath array round-trips into the JSON-RPC request the daemon actually receives
- [x] \`go build ./cmd/krit/ && go vet ./... && golangci-lint run ./... && go test ./... -count=1\`