### PR TITLE
test(parity): broaden oracle parity fixture and assertions

### DIFF
--- a/tests/parity/oracle_backend_parity_test.go
+++ b/tests/parity/oracle_backend_parity_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 	"testing"
@@ -12,18 +13,12 @@ import (
 	"github.com/kaeawc/krit/internal/oracle"
 )
 
-// TestOracleBackendParity drives both JVM daemons through their
-// one-shot `--sources --output` CLI and asserts that the resulting
-// type-oracle JSON is structurally equivalent. The check is the CI
-// gate guarding against silent divergence on the analyze surface:
-// changes that affect one backend but not the other will surface here
-// before they leak into rule behaviour.
-//
-// The comparison intentionally tolerates a few backend-internal
-// renderer differences (supertype FQN vs. short name, member return-
-// type spelling for synthetic ctors) by doing substring matches on
-// the supertype list and skipping return-type comparison on the
-// synthetic `<init>` constructor — those don't reach Go-side rules.
+// TestOracleBackendParity is the CI gate guarding KAA ↔ FIR
+// divergence on the type-oracle wire shape. Both backends are
+// invoked through the one-shot CLI on a multi-file fixture covering
+// the Kotlin shapes most likely to expose renderer drift (generics,
+// sealed/enum/data, objects, type aliases, inline-reified,
+// intersection bounds). Tolerances live in the helpers below.
 func TestOracleBackendParity(t *testing.T) {
 	root := repoRoot(t)
 	kaaJar := oracle.FindJar([]string{root})
@@ -34,37 +29,116 @@ func TestOracleBackendParity(t *testing.T) {
 	if firJar == "" || !isExecutableJar(firJar) {
 		t.Skip("krit-fir executable jar not found; run `cd tools/krit-fir && ./gradlew shadowJar` to enable oracle parity")
 	}
+	stdlib := findKotlinStdlib()
+	if stdlib == "" {
+		t.Skip("kotlin-stdlib jar not found in Gradle cache; required for stdlib-typed parity fixture")
+	}
 
-	// A small, dependency-free fixture so we exercise the class /
-	// supertype / member projection without needing a stdlib on the
-	// classpath. Kotlin's auto-imported `Any` is the only library
-	// supertype we touch.
 	tmp := t.TempDir()
 	srcDir := filepath.Join(tmp, "src")
 	if err := os.MkdirAll(srcDir, 0o755); err != nil {
 		t.Fatalf("mkdir: %v", err)
 	}
-	src := `package parity
+	for name, body := range parityFixtureSources() {
+		if err := os.WriteFile(filepath.Join(srcDir, name), []byte(body), 0o644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+
+	opts := oracle.InvocationOptions{Classpath: []string{stdlib}}
+	kaaData := runOneShot(t, kaaJar, srcDir, filepath.Join(tmp, "kaa.json"), opts)
+	firData := runOneShot(t, firJar, srcDir, filepath.Join(tmp, "fir.json"), opts)
+
+	assertOracleParity(t, kaaData, firData)
+}
+
+// parityFixtureSources returns the source files that exercise the
+// declaration shapes most likely to expose backend-rendering drift.
+// Each file targets one axis so a regression points to a category,
+// not a 200-line blob.
+func parityFixtureSources() map[string]string {
+	return map[string]string{
+		"Basics.kt": `package parity
 
 open class Greeter {
     fun greet(name: String): String = "hi, " + name
 }
 
 class LoudGreeter : Greeter()
-`
-	if err := os.WriteFile(filepath.Join(srcDir, "Greeter.kt"), []byte(src), 0o644); err != nil {
-		t.Fatalf("write fixture: %v", err)
-	}
+`,
+		"Generics.kt": `package parity
 
-	kaaData := runOneShot(t, kaaJar, srcDir, filepath.Join(tmp, "kaa.json"))
-	firData := runOneShot(t, firJar, srcDir, filepath.Join(tmp, "fir.json"))
-
-	assertOracleParity(t, kaaData, firData)
+open class Box<T>(val value: T) {
+    fun unwrap(): T = value
 }
 
-func runOneShot(t *testing.T, jar, srcDir, outputPath string) *oracle.Data {
+class StringBox(s: String) : Box<String>(s)
+`,
+		"Sealed.kt": `package parity
+
+sealed class Shape {
+    abstract fun area(): Double
+}
+
+data class Circle(val radius: Double) : Shape() {
+    override fun area(): Double = 3.14 * radius * radius
+}
+
+data class Rectangle(val w: Double, val h: Double) : Shape() {
+    override fun area(): Double = w * h
+}
+`,
+		"Enums.kt": `package parity
+
+enum class Direction {
+    NORTH, SOUTH, EAST, WEST;
+
+    fun describe(): String = name.lowercase()
+}
+`,
+		// Counter + companion intentionally omitted: KAA hides
+		// nested companions from `declarations` while FIR surfaces
+		// them as separate FQNs. That divergence is tracked outside
+		// this parity gate.
+		"Objects.kt": `package parity
+
+object Registry {
+    fun register(id: String): Boolean = id.isNotEmpty()
+}
+`,
+		// Inline-reified + type alias + intersection-bound use sites
+		// are wrapped in classes because FIR projects a file
+		// containing only top-level declarations with an empty
+		// package, which is a separate (real) divergence and not
+		// what this fixture is meant to exercise.
+		"Inline.kt": `package parity
+
+class TypeChecks {
+    inline fun <reified T> isA(x: Any): Boolean = x is T
+}
+`,
+		"Aliases.kt": `package parity
+
+typealias Names = List<String>
+
+class AliasUse {
+    fun firstName(ns: Names): String = ns.first()
+}
+`,
+		// Where-clause bounds aren't yet on the wire; the assertion
+		// is just that the `T` type parameter survives projection.
+		"Intersection.kt": `package parity
+
+class Identity {
+    fun <T> identity(x: T): T where T : Comparable<T>, T : CharSequence = x
+}
+`,
+	}
+}
+
+func runOneShot(t *testing.T, jar, srcDir, outputPath string, opts oracle.InvocationOptions) *oracle.Data {
 	t.Helper()
-	if _, err := oracle.InvokeWithFiles(jar, []string{srcDir}, outputPath, "", false); err != nil {
+	if _, err := oracle.InvokeWithFilesWithOptions(jar, []string{srcDir}, outputPath, "", false, opts); err != nil {
 		t.Fatalf("oracle invoke (%s): %v", jar, err)
 	}
 	raw, err := os.ReadFile(outputPath)
@@ -182,28 +256,156 @@ func assertFileParity(t *testing.T, name string, kaa, fir *oracle.File) {
 
 	for fqn, kaaCls := range kaaDecls {
 		firCls := firDecls[fqn]
-		if kaaCls.Kind != firCls.Kind {
-			t.Errorf("%s.%s: kind mismatch: kaa=%q fir=%q", name, fqn, kaaCls.Kind, firCls.Kind)
-		}
-		// Supertype rendering legitimately differs between backends
-		// (KAA emits `kotlin.Any`, FIR's renderReadable emits `Any`).
-		// Assert each KAA supertype has a corresponding FIR entry
-		// whose suffix matches — strictest parity check we can do
-		// without losing on benign renderer differences.
-		for _, want := range kaaCls.Supertypes {
-			short := lastSegment(want)
-			found := false
-			for _, got := range firCls.Supertypes {
-				if got == want || lastSegment(got) == short {
-					found = true
-					break
-				}
-			}
-			if !found {
-				t.Errorf("%s.%s: kaa supertype %q has no parity in fir %v", name, fqn, want, firCls.Supertypes)
-			}
+		assertClassParity(t, name, fqn, kaaCls, firCls)
+	}
+}
+
+func assertClassParity(t *testing.T, file, fqn string, kaa, fir *oracle.Class) {
+	t.Helper()
+	// KAA emits `kind="sealed class"`, FIR emits `kind="class"` +
+	// `isSealed=true`. The isSealed check below catches drift in
+	// the boolean; here we just strip the prefix for kind parity.
+	if strings.TrimPrefix(kaa.Kind, "sealed ") != strings.TrimPrefix(fir.Kind, "sealed ") {
+		t.Errorf("%s.%s: kind mismatch: kaa=%q fir=%q", file, fqn, kaa.Kind, fir.Kind)
+	}
+	// Supertype rendering legitimately differs between backends
+	// (KAA emits `kotlin.Any`, FIR's renderReadable emits `Any`).
+	// Assert each KAA supertype has a corresponding FIR entry whose
+	// suffix matches — the strictest parity check we can do without
+	// losing on benign renderer differences. Generic supertypes
+	// (`Box<String>`) are compared on the head segment only, since
+	// the type-arg list also differs by renderer (KAA may render
+	// `kotlin.String` where FIR renders `String`).
+	for _, want := range kaa.Supertypes {
+		if !hasMatchingSupertype(want, fir.Supertypes) {
+			t.Errorf("%s.%s: kaa supertype %q has no parity in fir %v", file, fqn, want, fir.Supertypes)
 		}
 	}
+	// Class flags drive Go-side rule decisions (sealed/data/open
+	// detection). A regression here would change rule behaviour
+	// silently when the backend is switched.
+	if kaa.IsSealed != fir.IsSealed {
+		t.Errorf("%s.%s: isSealed mismatch: kaa=%v fir=%v", file, fqn, kaa.IsSealed, fir.IsSealed)
+	}
+	if kaa.IsData != fir.IsData {
+		t.Errorf("%s.%s: isData mismatch: kaa=%v fir=%v", file, fqn, kaa.IsData, fir.IsData)
+	}
+	if kaa.IsAbstract != fir.IsAbstract {
+		t.Errorf("%s.%s: isAbstract mismatch: kaa=%v fir=%v", file, fqn, kaa.IsAbstract, fir.IsAbstract)
+	}
+	// Type-parameter names must match exactly. The fixture uses
+	// single-letter `T` so there's no naming ambiguity. Bounds
+	// aren't on the wire yet, so the assertion is positional.
+	if !slices.Equal(kaa.TypeParameters, fir.TypeParameters) {
+		t.Errorf("%s.%s: typeParameters mismatch: kaa=%v fir=%v", file, fqn, kaa.TypeParameters, fir.TypeParameters)
+	}
+	// User-defined member names — FIR projects only declarations on
+	// the class itself; KAA's set also includes inherited members
+	// it surfaces by walking supertypes. So the parity contract is
+	// `firUser ⊆ kaaUser`: every member FIR exposes must appear in
+	// KAA. A FIR-side regression that drops a declared member fails
+	// here; a KAA-side regression that drops an inherited member
+	// doesn't, but the supertype-rendering check above guards the
+	// inheritance edge that matters for rules.
+	kaaUser := userMemberNames(kaa.Members)
+	firUser := userMemberNames(fir.Members)
+	for name := range firUser {
+		if !kaaUser[name] {
+			t.Errorf("%s.%s: fir member %q missing from kaa set %v", file, fqn, name, sortedSlice(kaaUser))
+		}
+	}
+}
+
+// hasMatchingSupertype compares on the last name segment after
+// stripping generic type arguments, so `Box<String>` ↔ `parity.Box`
+// and `Enum<Direction>` ↔ `kotlin.Enum` both match. The renderers
+// disagree on FQN prefixes and on whether to include type-arg
+// lists; rules only key off the tail.
+func hasMatchingSupertype(want string, got []string) bool {
+	wantTail := lastSegment(typeHead(want))
+	for _, g := range got {
+		if lastSegment(typeHead(g)) == wantTail {
+			return true
+		}
+	}
+	return false
+}
+
+func typeHead(s string) string {
+	if i := strings.IndexByte(s, '<'); i >= 0 {
+		return s[:i]
+	}
+	return s
+}
+
+// userMemberNames keeps only members whose names a rule would care
+// about: user-defined functions and properties. Filtered out:
+//   - Synthesized data-class members: `componentN`, `copy`, plus the
+//     `equals`/`hashCode`/`toString` overrides and the `<init>`
+//     constructor.
+//   - Members inherited from `java.lang.Enum` that KAA surfaces and
+//     FIR does not (`clone`, `finalize`, `ordinal`, `name`).
+//   - Synthetic enum companion members FIR surfaces and KAA does
+//     not (`values`, `valueOf`, `entries`).
+//   - The enum entries themselves (uppercase names with no lower-
+//     case letter), which FIR projects as members of the enum class
+//     and KAA does not.
+//
+// What's left is the surface a rule reads: user-defined functions
+// and properties on the declaration. That's the load-bearing parity
+// contract; the rest is renderer drift.
+func userMemberNames(members []*oracle.Member) map[string]bool {
+	synth := map[string]bool{
+		"equals": true, "hashCode": true, "toString": true, "copy": true, "<init>": true,
+		"clone": true, "finalize": true, "ordinal": true, "name": true,
+		"values": true, "valueOf": true, "entries": true,
+	}
+	out := make(map[string]bool, len(members))
+	for _, m := range members {
+		if synth[m.Name] {
+			continue
+		}
+		if strings.HasPrefix(m.Name, "component") && len(m.Name) > len("component") {
+			continue
+		}
+		if isEnumEntryName(m.Name) {
+			continue
+		}
+		out[m.Name] = true
+	}
+	return out
+}
+
+// isEnumEntryName matches the Kotlin enum-entry convention: all
+// uppercase letters / digits / underscores, with at least one
+// uppercase letter. False positives on user-defined SHOUTY_CASE
+// constants are acceptable for the parity gate because constants
+// are also off the rule-decision path.
+func isEnumEntryName(s string) bool {
+	if s == "" {
+		return false
+	}
+	hasUpper := false
+	for _, r := range s {
+		switch {
+		case r >= 'A' && r <= 'Z':
+			hasUpper = true
+		case r >= '0' && r <= '9', r == '_':
+			// allowed
+		default:
+			return false
+		}
+	}
+	return hasUpper
+}
+
+func sortedSlice(m map[string]bool) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
 }
 
 func indexByBasename(files map[string]*oracle.File) map[string]*oracle.File {


### PR DESCRIPTION
## Summary
- Expands the KAA ↔ FIR parity fixture from a 6-line `Greeter.kt` to per-shape files: generics with type-arg supertype, sealed + data, enum, object, inline-reified, type alias, intersection-bound generic. Each file targets one axis so a regression points to a category rather than a 200-line blob.
- Adds assertions for `typeParameters`, `isSealed` / `isData` / `isAbstract`, and a `firUser ⊆ kaaUser` member-set contract. The prior gate only checked kind + supertype-suffix.
- Renderer tolerances live in small inline normalizers: kind strips a `sealed ` prefix; supertypes compare on the last name segment after stripping generic type args; data-class synthesized members, Java-Enum-inherited members, and enum entries are filtered from the member set so the comparison only weighs the user-declared surface that rules read.
- The fixture pulls kotlin-stdlib onto the classpath (via `--classpath`, the flag added in #513) so `Comparable<T>`, `List<T>`, and `CharSequence` resolve on both backends. The test skips when no stdlib jar is reachable.

## Follow-ups (intentionally not gated here)
- KAA hides nested companion objects from the `declarations` list; FIR surfaces them as separate FQNs. `Counter`/`Companion` was dropped from the fixture rather than papered over.
- FIR projects an empty package for files containing only top-level declarations; the inline-reified, type alias, and intersection-bound fixtures are wrapped in classes so the parity gate isn't blocked on it.

## Test plan
- [x] `go build -o krit ./cmd/krit/ && go vet ./... && golangci-lint run ./tests/parity/`
- [x] `go test ./tests/parity/ -count=1 -v` — `TestOracleBackendParity`, `TestOracleBackendAcceptsClasspathFlag`, and `TestFirPilotParity` all green.