### PR TITLE
perf(fileignore): narrow DefaultPrunedDir to caches gitignore can't cover

### DIFF
--- a/internal/cli/scan/filewalk_cache_test.go
+++ b/internal/cli/scan/filewalk_cache_test.go
@@ -289,15 +289,19 @@ func TestFilewalkCache_NoCacheDir(t *testing.T) {
 	}
 }
 
-// TestFilewalkCache_PrunedDirs verifies that build/, .git/, and other
-// DefaultPrunedDir entries are never collected.
+// TestFilewalkCache_PrunedDirs verifies that DefaultPrunedDir entries
+// are never collected. `build/` and similar project-output dirs are
+// expected to be pruned via the project's .gitignore matcher rather
+// than the hard-coded list — separate coverage lives in the
+// fileignore matcher tests.
 func TestFilewalkCache_PrunedDirs(t *testing.T) {
 	root := t.TempDir()
 	cache := t.TempDir()
 
 	writeFile(t, filepath.Join(root, "src", "Main.kt"), "")
-	writeFile(t, filepath.Join(root, "build", "Main.kt"), "")   // pruned
 	writeFile(t, filepath.Join(root, ".gradle", "Main.kt"), "") // pruned
+	writeFile(t, filepath.Join(root, ".claude", "Main.kt"), "") // pruned
+	writeFile(t, filepath.Join(root, ".grit", "Main.kt"), "")   // pruned
 
 	files, err := CollectFilesCached([]string{root}, ktFilters, cache)
 	if err != nil {

--- a/internal/cli/serve/watcher.go
+++ b/internal/cli/serve/watcher.go
@@ -441,11 +441,16 @@ func isLibraryConfigPath(p string) bool {
 	return strings.HasSuffix(base, ".versions.toml")
 }
 
-// isPrunedDir lists directory basenames the watcher refuses to
-// recurse into. Keep aligned with internal/fileignore.DefaultPrunedDir.
+// isPrunedDir is a superset of fileignore.DefaultPrunedDir plus
+// `build`/`node_modules` — those project-output dirs would
+// otherwise flood the watcher with fsnotify events even when
+// gitignore covers them.
 func isPrunedDir(name string) bool {
 	switch name {
-	case ".git", "build", ".gradle", "node_modules", ".idea", ".krit":
+	case ".git", "build", "node_modules",
+		".krit", ".krit-cache", ".krit-types",
+		".gradle", ".idea", ".kotlin",
+		".claude", ".codex", ".grit":
 		return true
 	}
 	return false

--- a/internal/fileignore/fileignore.go
+++ b/internal/fileignore/fileignore.go
@@ -8,11 +8,18 @@ import (
 	ignore "github.com/sabhiram/go-gitignore"
 )
 
-// DefaultPrunedDir reports Krit's built-in source-discovery skips.
+// DefaultPrunedDir reports Krit's built-in source-discovery skips:
+// caches and metadata that `.gitignore` can't be relied on to
+// cover (and `.git` itself, which can't be in its own gitignore).
+// Project-output dirs like `build`, `node_modules`, `target`, and
+// `vendor` are pruned by the gitignore matcher instead, since
+// conventional projects already exclude them there.
 func DefaultPrunedDir(base string) bool {
 	switch base {
-	case ".git", ".krit", ".krit-cache", ".krit-types", "build", "node_modules", ".idea", ".gradle", "out", ".kotlin",
-		"target", "third-party", "third_party", "vendor", "external":
+	case ".git",
+		".krit", ".krit-cache", ".krit-types",
+		".gradle", ".idea", ".kotlin",
+		".claude", ".codex", ".grit":
 		return true
 	}
 	return false

--- a/internal/fileignore/fileignore_test.go
+++ b/internal/fileignore/fileignore_test.go
@@ -7,13 +7,28 @@ import (
 )
 
 func TestDefaultPrunedDir(t *testing.T) {
-	for _, name := range []string{".git", "build", "node_modules", ".gradle", "target", "vendor"} {
+	// Hard-coded prune list: caches/metadata that .gitignore can't
+	// be relied on to cover.
+	pruned := []string{
+		".git",
+		".krit", ".krit-cache", ".krit-types",
+		".gradle", ".idea", ".kotlin",
+		".claude", ".codex", ".grit",
+	}
+	for _, name := range pruned {
 		if !DefaultPrunedDir(name) {
 			t.Fatalf("DefaultPrunedDir(%q) = false, want true", name)
 		}
 	}
-	if DefaultPrunedDir("src") {
-		t.Fatal("DefaultPrunedDir(\"src\") = true, want false")
+	// Project-output / dep dirs are deliberately NOT in the hard-
+	// coded list — projects that ignore them in `.gitignore` (the
+	// overwhelming convention) get them pruned via the matcher.
+	// Hard-coding them here would over-prune projects that
+	// intentionally check those names in.
+	for _, name := range []string{"src", "build", "node_modules", "target", "vendor", "out", "external"} {
+		if DefaultPrunedDir(name) {
+			t.Fatalf("DefaultPrunedDir(%q) = true, want false", name)
+		}
 	}
 }
 

--- a/internal/lsp/classpath.go
+++ b/internal/lsp/classpath.go
@@ -54,13 +54,17 @@ func discoverGradleClasspath(root string) []string {
 	return out
 }
 
+// VCS/IDE/build caches plus agent caches whose nested checkouts
+// carry their own build.gradle files that would double-count
+// dependencies.
 func shouldSkipClasspathDir(name string) bool {
 	switch name {
-	case ".git", ".gradle", "build", ".idea", "node_modules":
+	case ".git", ".gradle", "build", ".idea", "node_modules",
+		".krit", ".krit-cache", ".krit-types", ".kotlin",
+		".claude", ".codex", ".grit":
 		return true
-	default:
-		return false
 	}
+	return false
 }
 
 func gradleCacheJARs(dep android.Dependency) []string {

--- a/internal/oracle/invoke_cached.go
+++ b/internal/oracle/invoke_cached.go
@@ -77,12 +77,10 @@ func excludedByDefault(path string) bool {
 	return false
 }
 
-// CollectKtFiles walks the given source directories and returns absolute
-// paths of all .kt files. Mirrors the directory pruning FindSourceDirs
-// does (build/.gradle/.git/node_modules) so the Go-side enumeration
-// matches what the JVM side will actually see. Also applies the krit-types
-// default exclude patterns so excluded files don't leak into the cache
-// miss list.
+// CollectKtFiles walks the given source directories and returns
+// absolute paths of all .kt files, matching what the JVM-side
+// enumeration sees (DefaultPrunedDir + gitignore + krit-types
+// default exclude patterns, plus testData/test-resources).
 func CollectKtFiles(sourceDirs []string) ([]string, error) {
 	seen := map[string]bool{}
 	var out []string
@@ -99,7 +97,7 @@ func CollectKtFiles(sourceDirs []string) ([]string, error) {
 			}
 			if info.IsDir() {
 				base := filepath.Base(p)
-				if base == ".gradle" || base == ".git" || base == "node_modules" || matcher.Ignored(p, true) {
+				if fileignore.DefaultPrunedDir(base) || matcher.Ignored(p, true) {
 					return filepath.SkipDir
 				}
 				if base == "testData" || base == "test-resources" {

--- a/internal/oracle/invoke_test.go
+++ b/internal/oracle/invoke_test.go
@@ -135,9 +135,17 @@ func TestFindSourceDirs_EmptyDir(t *testing.T) {
 	}
 }
 
-func TestFindSourceDirs_SkipsBuildDir(t *testing.T) {
+func TestFindSourceDirs_SkipsBuildDirViaGitignore(t *testing.T) {
 	tmp := t.TempDir()
-	// Put kotlin dir under build/ -- should be skipped
+	// `build/` is no longer in DefaultPrunedDir — it's pruned via
+	// the project's .gitignore, which conventional Kotlin/Gradle
+	// projects always include. Mirror that here.
+	if err := os.Mkdir(filepath.Join(tmp, ".git"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmp, ".gitignore"), []byte("build/\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
 	kotlinDir := filepath.Join(tmp, "build", "src", "main", "kotlin")
 	if err := os.MkdirAll(kotlinDir, 0755); err != nil {
 		t.Fatal(err)
@@ -145,7 +153,7 @@ func TestFindSourceDirs_SkipsBuildDir(t *testing.T) {
 
 	dirs := FindSourceDirs([]string{tmp})
 	if len(dirs) != 0 {
-		t.Errorf("expected 0 source dirs (build should be skipped), got %d: %v", len(dirs), dirs)
+		t.Errorf("expected 0 source dirs (gitignored build should be skipped), got %d: %v", len(dirs), dirs)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Trims `fileignore.DefaultPrunedDir` to the minimum it needs to cover: agent / IDE / build-tool caches that a project's `.gitignore` can't be relied on to mention. Project-output dirs (`build`, `node_modules`, `target`, `vendor`, `out`, `external`, `third-party`/`third_party`) are now pruned via the gitignore matcher instead, since conventional Kotlin / Gradle / JS projects already exclude them there.
- Adds `.claude`, `.codex`, `.grit` to cover agent-tooling caches that check repo-relative state into the project directory (claude-code worktrees with duplicate source, grit.io's `materialized-m2` jar mirror, codex state). These aren't always in `.gitignore` yet but never hold analyzable source.
- Unifies the open-coded prune list in `internal/oracle/invoke_cached.go` (`CollectKtFiles`) to call `DefaultPrunedDir`.
- Augments the LSP-classpath walker and the serve watcher with the agent-cache names; both keep their existing `build` / `node_modules` skips since they don't use the gitignore matcher.

## Bench (real Android project)
A cold scan on a project containing a `.grit/worktree/materialized-m2` maven mirror (~1.2 GB / 10K files) and two nested `.claude/worktrees/<id>` checkouts:

| | Before | After |
|---|---|---|
| Wall clock (cold) | ~27 s | **~1.8 s** |
| Files analyzed | 150 | **50** (100 were `.claude/worktrees/` duplicates) |
| `crossFileAnalysis` phase | 6,204 ms | **777 ms** |
| `parse` phase | 1,062 ms | 414 ms |

`durationMs` reported by `-perf`: 13,365 ms → 1,436 ms.

## Test plan
- [x] `go build -o krit ./cmd/krit/ && go vet ./... && golangci-lint run ./...`
- [x] `go test ./... -count=1` — full suite green. Two tests updated for the new policy: `TestFindSourceDirs_SkipsBuildDir` now exercises gitignore-driven pruning, and `TestFilewalkCache_PrunedDirs` now uses cache dirs (`.gradle`, `.claude`, `.grit`) instead of `build/`.
- [x] Reproduced the cold-time win on a real Android project (numbers above).