### PR TITLE
fix(oracle): include jar identity in daemon registry key

### DIFF
--- a/internal/oracle/daemon.go
+++ b/internal/oracle/daemon.go
@@ -51,21 +51,22 @@ type Daemon struct {
 var daemonNow = time.Now
 
 // MatchesRepo returns true if this Daemon was started for (or is
-// currently connected to) a daemon whose sourceDirs fingerprint
-// matches the given set. Used by runMissAnalysis to reject daemon
-// reuse across krit invocations that target different repos — when
-// the fingerprints disagree the caller falls back to one-shot for
-// the current invocation rather than trusting a daemon whose
-// sourceModule walks a different file set.
+// currently connected to) a daemon whose (jar, sourceDirs)
+// fingerprint matches the given pair. Used by runMissAnalysis to
+// reject daemon reuse across krit invocations that target different
+// repos OR different backend jars — when the fingerprints disagree
+// the caller falls back to one-shot rather than trusting a daemon
+// whose source-module walks a different file set or whose jar
+// produces different analyze semantics.
 //
 // An empty sourcesHash (older daemon that predates Phase 3 sources
 // tagging) always returns false so callers conservatively fall back.
 // The old daemon keeps running for its original consumer.
-func (d *Daemon) MatchesRepo(sourceDirs []string) bool {
+func (d *Daemon) MatchesRepo(jarPath string, sourceDirs []string) bool {
 	if d.sourcesHash == "" {
 		return false
 	}
-	return d.sourcesHash == hashSources(sourceDirs)
+	return d.sourcesHash == daemonRegistryKey(jarPath, sourceDirs)
 }
 
 // daemonRequest is the JSON request sent to the daemon process.

--- a/internal/oracle/daemon_layers_test.go
+++ b/internal/oracle/daemon_layers_test.go
@@ -19,6 +19,10 @@ import (
 var testSourceDirs = []string{"/test/fixture/repo"}
 var testSourcesHash = hashSources(testSourceDirs)
 
+const testJarPath = "/test/fixture/krit-types.jar"
+
+var testDaemonKey = daemonRegistryKey(testJarPath, testSourceDirs)
+
 func TestWritePIDFile_CreatesFile(t *testing.T) {
 	tmpHome := t.TempDir()
 	origHome := os.Getenv("HOME")
@@ -914,7 +918,7 @@ func TestConnectOrStartDaemon_NoPIDFile_StartsNew(t *testing.T) {
 	defer os.Setenv("HOME", origHome)
 
 	// No PID files — connectExistingDaemon should fail
-	_, err := connectExistingDaemon(testSourceDirs, false)
+	_, err := connectExistingDaemon(testJarPath, testSourceDirs, false)
 	if err == nil {
 		t.Fatal("expected error when no PID file exists")
 	}
@@ -932,12 +936,11 @@ func TestConnectOrStartDaemon_StalePIDFile_StartsNew(t *testing.T) {
 	daemonsDir := filepath.Join(tmpHome, ".krit", "cache", "daemons")
 	os.MkdirAll(daemonsDir, 0755)
 
-	// Write a PID file with a dead process under the test repo's hash
-	os.WriteFile(filepath.Join(daemonsDir, testSourcesHash+".pid"), []byte("99999999\n"), 0644)
-	os.WriteFile(filepath.Join(daemonsDir, testSourcesHash+".port"), []byte("12345\n"), 0644)
+	os.WriteFile(filepath.Join(daemonsDir, testDaemonKey+".pid"), []byte("99999999\n"), 0644)
+	os.WriteFile(filepath.Join(daemonsDir, testDaemonKey+".port"), []byte("12345\n"), 0644)
 
 	// connectExistingDaemon should fail because the PID is dead
-	_, err := connectExistingDaemon(testSourceDirs, false)
+	_, err := connectExistingDaemon(testJarPath, testSourceDirs, false)
 	if err == nil {
 		t.Fatal("expected error for dead PID")
 	}
@@ -946,9 +949,9 @@ func TestConnectOrStartDaemon_StalePIDFile_StartsNew(t *testing.T) {
 	}
 
 	// cleanStaleDaemon should remove the stale PID files
-	cleanStaleDaemon(testSourceDirs, false)
+	cleanStaleDaemon(testJarPath, testSourceDirs, false)
 
-	pidFile := filepath.Join(daemonsDir, testSourcesHash+".pid")
+	pidFile := filepath.Join(daemonsDir, testDaemonKey+".pid")
 	if _, err := os.Stat(pidFile); !os.IsNotExist(err) {
 		t.Error("expected stale PID file to be cleaned up")
 	}
@@ -964,22 +967,21 @@ func TestConnectOrStartDaemon_LiveDaemon_Reuses(t *testing.T) {
 	fake := NewFakeDaemon(t)
 	defer fake.Close()
 
-	// Write PID file pointing to our fake daemon under the test repo's hash
 	daemonsDir := filepath.Join(tmpHome, ".krit", "cache", "daemons")
 	os.MkdirAll(daemonsDir, 0755)
 	os.WriteFile(
-		filepath.Join(daemonsDir, testSourcesHash+".pid"),
+		filepath.Join(daemonsDir, testDaemonKey+".pid"),
 		[]byte(fmt.Sprintf("%d\n", os.Getpid())), // alive PID
 		0644,
 	)
 	os.WriteFile(
-		filepath.Join(daemonsDir, testSourcesHash+".port"),
+		filepath.Join(daemonsDir, testDaemonKey+".port"),
 		[]byte(fmt.Sprintf("%d\n", fake.Port)),
 		0644,
 	)
 
 	// connectExistingDaemon should successfully connect
-	d, err := connectExistingDaemon(testSourceDirs, false)
+	d, err := connectExistingDaemon(testJarPath, testSourceDirs, false)
 	if err != nil {
 		t.Fatalf("connectExistingDaemon: %v", err)
 	}
@@ -1008,24 +1010,24 @@ func TestConnectOrStartDaemon_LiveDaemon_MultipleClients(t *testing.T) {
 	daemonsDir := filepath.Join(tmpHome, ".krit", "cache", "daemons")
 	os.MkdirAll(daemonsDir, 0755)
 	os.WriteFile(
-		filepath.Join(daemonsDir, testSourcesHash+".pid"),
+		filepath.Join(daemonsDir, testDaemonKey+".pid"),
 		[]byte(fmt.Sprintf("%d\n", os.Getpid())),
 		0644,
 	)
 	os.WriteFile(
-		filepath.Join(daemonsDir, testSourcesHash+".port"),
+		filepath.Join(daemonsDir, testDaemonKey+".port"),
 		[]byte(fmt.Sprintf("%d\n", fake.Port)),
 		0644,
 	)
 
 	// Connect two clients to the same fake daemon
-	d1, err := connectExistingDaemon(testSourceDirs, false)
+	d1, err := connectExistingDaemon(testJarPath, testSourceDirs, false)
 	if err != nil {
 		t.Fatalf("first connect: %v", err)
 	}
 	defer d1.Close()
 
-	d2, err := connectExistingDaemon(testSourceDirs, false)
+	d2, err := connectExistingDaemon(testJarPath, testSourceDirs, false)
 	if err != nil {
 		t.Fatalf("second connect: %v", err)
 	}
@@ -1073,18 +1075,18 @@ func TestCleanStaleDaemon_WithLivePIDButBrokenPort(t *testing.T) {
 
 	// Write our own PID but a port where nothing is listening
 	os.WriteFile(
-		filepath.Join(daemonsDir, testSourcesHash+".pid"),
+		filepath.Join(daemonsDir, testDaemonKey+".pid"),
 		[]byte(fmt.Sprintf("%d\n", os.Getpid())),
 		0644,
 	)
 	os.WriteFile(
-		filepath.Join(daemonsDir, testSourcesHash+".port"),
+		filepath.Join(daemonsDir, testDaemonKey+".port"),
 		[]byte("1\n"), // port 1 — nothing listening
 		0644,
 	)
 
 	// connectExistingDaemon should fail because the port connection fails
-	_, err := connectExistingDaemon(testSourceDirs, false)
+	_, err := connectExistingDaemon(testJarPath, testSourceDirs, false)
 	if err == nil {
 		t.Fatal("expected error for unreachable port")
 	}

--- a/internal/oracle/daemon_pool.go
+++ b/internal/oracle/daemon_pool.go
@@ -54,14 +54,14 @@ func ConnectOrStartDaemonPool(jarPath string, sourceDirs []string, classpath []s
 	}
 	pool := &DaemonPool{Requested: size, Members: make([]*Daemon, 0, size)}
 	for slot := 0; slot < size; slot++ {
-		d, err := connectExistingDaemonSlot(sourceDirs, verbose, slot)
+		d, err := connectExistingDaemonSlot(jarPath, sourceDirs, verbose, slot)
 		if err == nil {
 			pool.Members = append(pool.Members, d)
 			pool.Connected++
 			continue
 		}
 
-		cleanStaleDaemonSlot(sourceDirs, verbose, slot)
+		cleanStaleDaemonSlot(jarPath, sourceDirs, verbose, slot)
 		d, err = StartDaemonWithPortSlot(jarPath, sourceDirs, classpath, verbose, slot)
 		if err != nil {
 			_ = pool.Release()
@@ -89,12 +89,12 @@ func (p *DaemonPool) Release() error {
 	return firstErr
 }
 
-func (p *DaemonPool) MatchesRepo(sourceDirs []string) bool {
+func (p *DaemonPool) MatchesRepo(jarPath string, sourceDirs []string) bool {
 	if p == nil || len(p.Members) == 0 {
 		return false
 	}
 	for _, d := range p.Members {
-		if d == nil || !d.MatchesRepo(sourceDirs) {
+		if d == nil || !d.MatchesRepo(jarPath, sourceDirs) {
 			return false
 		}
 	}

--- a/internal/oracle/daemon_pool_test.go
+++ b/internal/oracle/daemon_pool_test.go
@@ -80,19 +80,19 @@ func TestCleanStaleDaemonSlotRemovesOnlyDeadSlot(t *testing.T) {
 	tmpHome := t.TempDir()
 	t.Setenv("HOME", tmpHome)
 
-	srcHash := hashSources(testSourceDirs)
-	if err := writePIDFileSlot(os.Getpid(), 1, srcHash, 0); err != nil {
+	key := daemonRegistryKey(testJarPath, testSourceDirs)
+	if err := writePIDFileSlot(os.Getpid(), 1, key, 0); err != nil {
 		t.Fatalf("write slot 0: %v", err)
 	}
-	if err := writePIDFileSlot(99999999, 2, srcHash, 1); err != nil {
+	if err := writePIDFileSlot(99999999, 2, key, 1); err != nil {
 		t.Fatalf("write slot 1: %v", err)
 	}
 
-	cleanStaleDaemonSlot(testSourceDirs, false, 1)
-	if _, err := readPIDFileSlot(srcHash, 1); err == nil {
+	cleanStaleDaemonSlot(testJarPath, testSourceDirs, false, 1)
+	if _, err := readPIDFileSlot(key, 1); err == nil {
 		t.Fatal("dead slot 1 should be removed")
 	}
-	if info, err := readPIDFileSlot(srcHash, 0); err != nil || info.PID != os.Getpid() {
+	if info, err := readPIDFileSlot(key, 0); err != nil || info.PID != os.Getpid() {
 		t.Fatalf("live slot 0 should remain, info=%+v err=%v", info, err)
 	}
 }
@@ -106,15 +106,16 @@ func TestConnectOrStartDaemonPoolReusesLiveMembers(t *testing.T) {
 	fake1 := NewFakeDaemon(t)
 	defer fake1.Close()
 
-	srcHash := hashSources(testSourceDirs)
-	if err := writePIDFileSlot(os.Getpid(), fake0.Port, srcHash, 0); err != nil {
+	const poolJar = "unused.jar"
+	key := daemonRegistryKey(poolJar, testSourceDirs)
+	if err := writePIDFileSlot(os.Getpid(), fake0.Port, key, 0); err != nil {
 		t.Fatalf("write slot 0: %v", err)
 	}
-	if err := writePIDFileSlot(os.Getpid(), fake1.Port, srcHash, 1); err != nil {
+	if err := writePIDFileSlot(os.Getpid(), fake1.Port, key, 1); err != nil {
 		t.Fatalf("write slot 1: %v", err)
 	}
 
-	pool, err := ConnectOrStartDaemonPool("unused.jar", testSourceDirs, nil, 2, false)
+	pool, err := ConnectOrStartDaemonPool(poolJar, testSourceDirs, nil, 2, false)
 	if err != nil {
 		t.Fatalf("ConnectOrStartDaemonPool: %v", err)
 	}
@@ -129,8 +130,8 @@ func TestConnectOrStartDaemonPoolReusesLiveMembers(t *testing.T) {
 	if pool.Members[0].slot != 0 || pool.Members[1].slot != 1 {
 		t.Fatalf("unexpected member slots: %d, %d", pool.Members[0].slot, pool.Members[1].slot)
 	}
-	if !pool.MatchesRepo(testSourceDirs) {
-		t.Fatal("pool should match repo")
+	if !pool.MatchesRepo(poolJar, testSourceDirs) {
+		t.Fatal("pool should match (jar, repo)")
 	}
 }
 

--- a/internal/oracle/daemon_registry.go
+++ b/internal/oracle/daemon_registry.go
@@ -96,6 +96,20 @@ func hashSources(sourceDirs []string) string {
 	return hashutil.HashHex([]byte(strings.Join(sorted, "\n")))[:16]
 }
 
+// daemonRegistryKey identifies a daemon slot by jar identity AND
+// source-dir set, so a running krit-types daemon isn't reused
+// when a caller asks for krit-fir.
+func daemonRegistryKey(jarPath string, sourceDirs []string) string {
+	return jarTag(jarPath) + "-" + hashSources(sourceDirs)
+}
+
+func jarTag(jarPath string) string {
+	if jarPath == "" {
+		return "unknown"
+	}
+	return strings.TrimSuffix(strings.ToLower(filepath.Base(jarPath)), ".jar")
+}
+
 // pidFileInfo holds the contents of the PID file pair for one daemon.
 type pidFileInfo struct {
 	PID  int
@@ -323,12 +337,12 @@ func startDaemonOnce(jarPath string, sourceDirs []string, classpath []string, ve
 // for the given sourceDirs. Each repo has its own PID file under
 // ~/.krit/cache/daemons/{hash}.{pid,port}, so multiple daemons (one
 // per repo) can coexist under the same user cache hierarchy.
-func connectExistingDaemon(sourceDirs []string, verbose bool) (*Daemon, error) {
-	return connectExistingDaemonSlot(sourceDirs, verbose, 0)
+func connectExistingDaemon(jarPath string, sourceDirs []string, verbose bool) (*Daemon, error) {
+	return connectExistingDaemonSlot(jarPath, sourceDirs, verbose, 0)
 }
 
-func connectExistingDaemonSlot(sourceDirs []string, verbose bool, slot int) (*Daemon, error) {
-	hash := hashSources(sourceDirs)
+func connectExistingDaemonSlot(jarPath string, sourceDirs []string, verbose bool, slot int) (*Daemon, error) {
+	hash := daemonRegistryKey(jarPath, sourceDirs)
 	info, err := readPIDFileSlot(hash, slot)
 	if err != nil {
 		return nil, fmt.Errorf("no existing daemon: %w", err)
@@ -375,14 +389,15 @@ func connectExistingDaemonSlot(sourceDirs []string, verbose bool, slot int) (*Da
 }
 
 // cleanStaleDaemon detects and cleans up a stale daemon process for
-// the given sourceDirs. Only touches the PID file entries belonging
-// to this repo's hash — other repos' daemons are left alone.
-func cleanStaleDaemon(sourceDirs []string, verbose bool) {
-	cleanStaleDaemonSlot(sourceDirs, verbose, 0)
+// the given (jarPath, sourceDirs). Only touches the PID file entries
+// belonging to this (jar, repo) pair — other registry entries are
+// left alone.
+func cleanStaleDaemon(jarPath string, sourceDirs []string, verbose bool) {
+	cleanStaleDaemonSlot(jarPath, sourceDirs, verbose, 0)
 }
 
-func cleanStaleDaemonSlot(sourceDirs []string, verbose bool, slot int) {
-	hash := hashSources(sourceDirs)
+func cleanStaleDaemonSlot(jarPath string, sourceDirs []string, verbose bool, slot int) {
+	hash := daemonRegistryKey(jarPath, sourceDirs)
 	info, err := readPIDFileSlot(hash, slot)
 	if err != nil {
 		// No PID file or unreadable — nothing to clean
@@ -508,7 +523,7 @@ func startDaemonWithPortSlotOnce(jarPath string, sourceDirs []string, classpath 
 		reporter().Verbosef("verbose: Daemon started on port %d (PID %d)\n", ready.Port, cmd.Process.Pid)
 	}
 
-	srcHash := hashSources(sourceDirs)
+	srcHash := daemonRegistryKey(jarPath, sourceDirs)
 
 	if err := writePIDFileSlot(cmd.Process.Pid, ready.Port, srcHash, slot); err != nil {
 		cmd.Process.Kill()
@@ -551,16 +566,19 @@ func startDaemonWithPortSlotOnce(jarPath string, sourceDirs []string, classpath 
 // existing one is unresponsive), cleanStaleDaemon wipes just this
 // repo's entry and StartDaemonWithPort starts a fresh one.
 func ConnectOrStartDaemon(jarPath string, sourceDirs []string, classpath []string, verbose bool) (*Daemon, error) {
-	// Try connecting to an existing daemon for this source tree.
-	if d, err := connectExistingDaemon(sourceDirs, verbose); err == nil {
+	// Try connecting to an existing daemon for this (jar, source tree)
+	// pair. The jar is part of the registry key so a running
+	// krit-types daemon isn't reused when the caller asks for
+	// krit-fir (or vice versa).
+	if d, err := connectExistingDaemon(jarPath, sourceDirs, verbose); err == nil {
 		return d, nil
 	}
 
-	// Clean up this repo's stale daemon entry (if any). Leaves other
-	// repos' entries under daemons/ untouched.
-	cleanStaleDaemon(sourceDirs, verbose)
+	// Clean up this (jar, repo)'s stale daemon entry (if any). Other
+	// registry entries are left alone.
+	cleanStaleDaemon(jarPath, sourceDirs, verbose)
 
-	// Start a new persistent daemon for this source tree.
+	// Start a new persistent daemon.
 	d, err := StartDaemonWithPort(jarPath, sourceDirs, classpath, verbose)
 	if err != nil {
 		return nil, fmt.Errorf("start persistent daemon: %w", err)

--- a/internal/oracle/daemon_test.go
+++ b/internal/oracle/daemon_test.go
@@ -494,19 +494,29 @@ func TestHashSources_LengthIs16(t *testing.T) {
 }
 
 func TestDaemon_MatchesRepo_SameHash(t *testing.T) {
-	d := &Daemon{sourcesHash: hashSources([]string{"/repo/a", "/repo/b"})}
-	if !d.MatchesRepo([]string{"/repo/a", "/repo/b"}) {
-		t.Error("MatchesRepo should return true for identical sources")
+	d := &Daemon{sourcesHash: daemonRegistryKey(testJarPath, []string{"/repo/a", "/repo/b"})}
+	if !d.MatchesRepo(testJarPath, []string{"/repo/a", "/repo/b"}) {
+		t.Error("MatchesRepo should return true for identical (jar, sources)")
 	}
-	if !d.MatchesRepo([]string{"/repo/b", "/repo/a"}) {
+	if !d.MatchesRepo(testJarPath, []string{"/repo/b", "/repo/a"}) {
 		t.Error("MatchesRepo should return true for reordered sources")
 	}
 }
 
 func TestDaemon_MatchesRepo_DifferentHash(t *testing.T) {
-	d := &Daemon{sourcesHash: hashSources([]string{"/repo/a"})}
-	if d.MatchesRepo([]string{"/repo/b"}) {
+	d := &Daemon{sourcesHash: daemonRegistryKey(testJarPath, []string{"/repo/a"})}
+	if d.MatchesRepo(testJarPath, []string{"/repo/b"}) {
 		t.Error("MatchesRepo should return false for different sources")
+	}
+}
+
+func TestDaemon_MatchesRepo_DifferentJar(t *testing.T) {
+	// A daemon registered for krit-types.jar should not match a
+	// caller asking for krit-fir.jar even if the sourceDirs are
+	// identical — this is the bug the daemon-jar-key change fixes.
+	d := &Daemon{sourcesHash: daemonRegistryKey("/path/krit-types.jar", testSourceDirs)}
+	if d.MatchesRepo("/path/krit-fir.jar", testSourceDirs) {
+		t.Error("MatchesRepo should return false when jar identity differs")
 	}
 }
 
@@ -514,7 +524,7 @@ func TestDaemon_MatchesRepo_EmptyHash(t *testing.T) {
 	// An older daemon that didn't write daemon.sources has an empty
 	// sourcesHash. MatchesRepo returns false so callers fall back.
 	d := &Daemon{sourcesHash: ""}
-	if d.MatchesRepo([]string{"/repo/a"}) {
+	if d.MatchesRepo(testJarPath, []string{"/repo/a"}) {
 		t.Error("MatchesRepo should return false when sourcesHash is empty")
 	}
 }
@@ -1352,7 +1362,7 @@ func TestConnectExistingDaemon_NoFiles(t *testing.T) {
 	os.Setenv("HOME", tmpHome)
 	defer os.Setenv("HOME", origHome)
 
-	_, err := connectExistingDaemon(testSourceDirs, false)
+	_, err := connectExistingDaemon(testJarPath, testSourceDirs, false)
 	if err == nil {
 		t.Fatal("expected error when no PID file exists")
 	}
@@ -1368,10 +1378,10 @@ func TestConnectExistingDaemon_DeadPID(t *testing.T) {
 	// test repo's sources hash
 	daemonsDir := filepath.Join(tmpHome, ".krit", "cache", "daemons")
 	os.MkdirAll(daemonsDir, 0755)
-	os.WriteFile(filepath.Join(daemonsDir, testSourcesHash+".pid"), []byte("99999999\n"), 0644)
-	os.WriteFile(filepath.Join(daemonsDir, testSourcesHash+".port"), []byte("12345\n"), 0644)
+	os.WriteFile(filepath.Join(daemonsDir, testDaemonKey+".pid"), []byte("99999999\n"), 0644)
+	os.WriteFile(filepath.Join(daemonsDir, testDaemonKey+".port"), []byte("12345\n"), 0644)
 
-	_, err := connectExistingDaemon(testSourceDirs, false)
+	_, err := connectExistingDaemon(testJarPath, testSourceDirs, false)
 	if err == nil {
 		t.Fatal("expected error for dead PID")
 	}
@@ -1387,7 +1397,7 @@ func TestCleanStaleDaemon_NoFiles(t *testing.T) {
 	defer os.Setenv("HOME", origHome)
 
 	// Should not panic with no PID file
-	cleanStaleDaemon(testSourceDirs, false)
+	cleanStaleDaemon(testJarPath, testSourceDirs, false)
 }
 
 func TestCleanStaleDaemon_DeadPID(t *testing.T) {
@@ -1398,12 +1408,12 @@ func TestCleanStaleDaemon_DeadPID(t *testing.T) {
 
 	daemonsDir := filepath.Join(tmpHome, ".krit", "cache", "daemons")
 	os.MkdirAll(daemonsDir, 0755)
-	pidFile := filepath.Join(daemonsDir, testSourcesHash+".pid")
-	portFile := filepath.Join(daemonsDir, testSourcesHash+".port")
+	pidFile := filepath.Join(daemonsDir, testDaemonKey+".pid")
+	portFile := filepath.Join(daemonsDir, testDaemonKey+".port")
 	os.WriteFile(pidFile, []byte("99999999\n"), 0644)
 	os.WriteFile(portFile, []byte("12345\n"), 0644)
 
-	cleanStaleDaemon(testSourceDirs, false)
+	cleanStaleDaemon(testJarPath, testSourceDirs, false)
 
 	// PID files should be removed
 	if _, err := os.Stat(pidFile); !os.IsNotExist(err) {

--- a/internal/oracle/invoke_cached.go
+++ b/internal/oracle/invoke_cached.go
@@ -1061,9 +1061,9 @@ func runMissAnalysis(
 			"connected": int64(pool.Connected),
 			"started":   int64(pool.Started),
 		}, nil)
-		if !pool.MatchesRepo(sourceDirs) {
+		if !pool.MatchesRepo(jarPath, sourceDirs) {
 			addOracleInstant(tracker, "daemonPoolRepoMismatch", map[string]int64{"misses": int64(len(misses))}, nil)
-			return fallback("daemon pool sourceDirs mismatch")
+			return fallback("daemon pool (jar, sourceDirs) mismatch")
 		}
 		if verbose {
 			reporter().Verbosef("verbose: sharding daemon miss analysis across %d persistent workers (%d files)\n", len(pool.Members), len(misses))
@@ -1099,9 +1099,9 @@ func runMissAnalysis(
 	// invocation, defeating the whole purpose of the persistent daemon.
 	defer func() { _ = d.Release() }()
 
-	if !d.MatchesRepo(sourceDirs) {
+	if !d.MatchesRepo(jarPath, sourceDirs) {
 		addOracleInstant(tracker, "daemonRepoMismatch", map[string]int64{"misses": int64(len(misses))}, nil)
-		return fallback("daemon sourceDirs mismatch")
+		return fallback("daemon (jar, sourceDirs) mismatch")
 	}
 
 	var fresh *Data


### PR DESCRIPTION
## Summary
The persistent oracle-daemon registry was keyed only on `hashSources(sourceDirs)`, so a running krit-types daemon got silently reused when a caller asked for krit-fir (or vice versa) — `ConnectOrStartDaemon` looked up the PID file by source-dir hash alone, found the existing daemon, pinged it (OK), and returned it. The wrong daemon then answered analyze RPCs with KAA semantics regardless of which jar the caller passed.

## Fix
- New `daemonRegistryKey(jarPath, sourceDirs)` = `jarTag(jarPath) + "-" + hashSources(sourceDirs)`. `jarTag` is the jar's basename without the `.jar` suffix (e.g. `krit-types`, `krit-fir`) — stable across rebuilds of the same jar so recompiling doesn't orphan PID files.
- Threads `jarPath` through `connectExistingDaemon`, `cleanStaleDaemon`, `StartDaemonWithPortSlot`, and `Daemon.MatchesRepo` (plus their `Slot` variants and `DaemonPool.MatchesRepo`).
- `TestDaemon_MatchesRepo_DifferentJar` pins the new behavior. Existing layered tests updated where their PID-file write needed to match the new key (the bare `testSourcesHash` is still used for tests that exercise the raw `write/read/removePIDFile` primitives).

## Followup not in this PR
The CLI's `krit daemon serve` delegation strips `--oracle-backend` from the wire args (`buildDaemonAnalyzeArgs`), so when the serve daemon is auto-spawned, the flag is silently dropped before the registry key is ever computed. That's a separate change — once the flag reaches `runJvmAnalyze`, this PR's fix is what makes the daemon pick the right jar.

## Test plan
- [x] `go build -o krit ./cmd/krit/ && go vet ./... && golangci-lint run ./...` (0 issues).
- [x] `go test ./... -count=1` — full suite green.
- [x] Unit tests in `internal/oracle/` exercise the new key on connect/clean/StartDaemonWithPort and the new `MatchesRepo(jarPath, ...)` signature.