### PR TITLE
fix(scan): bypass daemon delegation when --oracle-backend is set

### DIFF
--- a/internal/cli/scan/daemon_delegate.go
+++ b/internal/cli/scan/daemon_delegate.go
@@ -579,6 +579,15 @@ func daemonCompatibleFlags(f *scanFlags) bool {
 			return false
 		}
 	}
+	// `--oracle-backend` selects the JVM jar the oracle pass uses
+	// (krit-types vs krit-fir). The serve daemon's resident oracle
+	// always ties itself to krit-types via oracle.FindJar, and the
+	// daemon wire doesn't carry the backend flag — delegating would
+	// silently ignore the user's choice. Bypass delegation so the
+	// in-process path picks the right jar.
+	if *f.OracleBackend != "" {
+		return false
+	}
 	return true
 }
 

--- a/internal/cli/scan/daemon_delegate_oracle_args_test.go
+++ b/internal/cli/scan/daemon_delegate_oracle_args_test.go
@@ -39,6 +39,29 @@ func TestDaemonCompatibleFlags_OracleArgsAllowed(t *testing.T) {
 	}
 }
 
+// TestDaemonCompatibleFlags_OracleBackendBypassesDaemon pins the
+// short-circuit added when an explicit `--oracle-backend` arrives:
+// the serve daemon's resident oracle is tied to krit-types via
+// oracle.FindJar, and the wire doesn't carry the backend flag.
+// Delegating would silently ignore the user's choice — so the
+// gate refuses delegation and the in-process path handles it.
+func TestDaemonCompatibleFlags_OracleBackendBypassesDaemon(t *testing.T) {
+	for _, backend := range []string{"kaa", "fir"} {
+		t.Run(backend, func(t *testing.T) {
+			f := freshScanFlags(t)
+			*f.OracleBackend = backend
+			if got := daemonCompatibleFlags(f); got {
+				t.Errorf("daemonCompatibleFlags(--oracle-backend=%s) = true, want false", backend)
+			}
+		})
+	}
+	// Empty (default) value keeps delegation enabled.
+	f := freshScanFlags(t)
+	if got := daemonCompatibleFlags(f); !got {
+		t.Errorf("daemonCompatibleFlags(default) = false, want true")
+	}
+}
+
 // TestBuildDaemonAnalyzeArgs_InputTypesAbsolutised confirms the CLI
 // resolves --input-types against the caller's CWD before forwarding so
 // the daemon (which runs from the project root) can open the file. A

--- a/internal/oracle/invoke_cached.go
+++ b/internal/oracle/invoke_cached.go
@@ -612,7 +612,8 @@ func runKritTypesCached(
 		args = append(args, "--timings-out", timingsPath)
 	}
 	if verbose {
-		reporter().Verbosef("verbose: Running krit-types (cached): %s %s\n", javaPath, strings.Join(args, " "))
+		// Whatever jar the caller passed in — krit-types or krit-fir.
+		reporter().Verbosef("verbose: Running oracle JVM (cached) jar=%s: %s %s\n", filepath.Base(jarPath), javaPath, strings.Join(args, " "))
 	}
 
 	timeout := invokeTimeout()


### PR DESCRIPTION
## Summary
The serve daemon's resident oracle is bound to krit-types via `oracle.FindJar`, and `AnalyzeProjectArgs` doesn't carry the backend flag — so when the CLI delegates a scan to a krit serve daemon, `--oracle-backend=fir` is silently dropped on the wire and the analysis runs against krit-types regardless of the user's choice.

This PR makes `daemonCompatibleFlags` refuse delegation whenever `--oracle-backend` is non-empty, so the in-process path handles it. `runJvmAnalyze` already routes to `firchecks.FindFirJar` for FIR (and `oracle.FindJar` for KAA), so no further plumbing is needed for the user's choice to surface.

Threading the flag fully through the wire (`AnalyzeProjectArgs.OracleBackend` + `ensureOracleDaemon` taking a backend hint) is a larger change worth doing once we know users care about backend choice with daemon delegation. Today the explicit flag is mostly for experimentation; bypassing delegation gives the right behavior with three lines of code.

## Verification
Verbose log on `krit --oracle-backend=fir`:
```
verbose: Running krit-fir (3 source dirs)...
verbose: Running oracle JVM (cached) jar=krit-fir.jar: /usr/bin/java ... -jar /…/krit-fir.jar …
```
The spawned JVM args end in `-jar krit-fir.jar` (was `krit-types.jar` before this PR).

Also fixes the misleading verbose log line `Running krit-types (cached)` → `Running oracle JVM (cached) jar=<basename>` since the actual jar can be either backend.

## Test plan
- [x] `go build -o krit ./cmd/krit/ && go vet ./... && golangci-lint run ./...` (0 issues).
- [x] `go test ./... -count=1` — full suite green; new pinning test `TestDaemonCompatibleFlags_OracleBackendBypassesDaemon` covers `kaa` and `fir` values and the empty-default round-trip.
- [x] Manual E2E on a real Android project — verified that `--oracle-backend=fir` spawns `-jar krit-fir.jar`.