### PR TITLE
perf(oracle): cache JVM startup archive for one-shot calls + skip failing Leyden create

### DIFF
--- a/internal/oracle/daemon_jvm.go
+++ b/internal/oracle/daemon_jvm.go
@@ -116,13 +116,19 @@ func jdkMajorVersion(javaPath string) int {
 
 // buildLeydenAOTCache runs the Leyden AOT create step: it compiles the AOT
 // cache from an existing configuration file and exits immediately without
-// running the application. Fast (seconds), must complete before daemon launch.
+// running the application. Fast (seconds) when it works; ~30s when it
+// hits the JDK 26 + Kotlin shadow JAR crash path described below.
 //
 // On JVM crashes during create (seen on some JDK 26 builds with Kotlin
 // shadow JARs that exercise IntelliJ verification paths) the JVM leaves
 // behind a zero-byte or partial cache file. Removing it here keeps the
 // next daemon launch from picking it up and aborting VM init with
 // "Unable to read generic CDS file map header from AOT cache".
+//
+// Repeated failures are absorbed by a sibling `.aot.skip` sentinel
+// — see leydenAOTSkipPath and the call site in appendLeydenAOTArgs.
+// Without that gate every cold krit run would pay the full ~30s
+// failing-create cost.
 func buildLeydenAOTCache(javaPath, jarPath, configPath, cachePath string, verbose bool) error {
 	args := []string{
 		"-XX:AOTMode=create",
@@ -147,6 +153,43 @@ func buildLeydenAOTCache(javaPath, jarPath, configPath, cachePath string, verbos
 		return fmt.Errorf("leyden AOT create: produced empty cache %s", cachePath)
 	}
 	return nil
+}
+
+// leydenAOTSkipPath returns the sentinel-file path that records a
+// past `buildLeydenAOTCache` failure for `jarPath`. Lives alongside
+// the `.aotconf` / `.aot` files keyed on the jar's content hash.
+// The sentinel is auto-invalidated when the JDK version changes
+// (encoded in the file body) so a JDK upgrade reattempts the build.
+func leydenAOTSkipPath(jarPath string) (string, error) {
+	return jarCachePath(jarPath, ".aot.skip")
+}
+
+// leydenAOTCreateSkipped reports whether a prior buildLeydenAOTCache
+// attempt failed against the current JDK + jar pair and we should
+// short-circuit straight to the AppCDS fallback instead of paying
+// the ~30s failing-create cost again. Returns false on any I/O
+// or parse error so a corrupt sentinel doesn't lock us out of
+// retrying.
+func leydenAOTCreateSkipped(skipPath string, jdkVersion int) bool {
+	data, err := os.ReadFile(skipPath)
+	if err != nil {
+		return false
+	}
+	recordedVersion, err := strconv.Atoi(strings.TrimSpace(string(data)))
+	if err != nil {
+		return false
+	}
+	return recordedVersion == jdkVersion
+}
+
+// markLeydenAOTCreateFailed writes the sentinel so subsequent
+// invocations short-circuit. Failures are intentionally swallowed
+// — the worst case is we pay one more failing-create cycle next
+// run, which is the pre-sentinel behavior anyway.
+func markLeydenAOTCreateFailed(skipPath string, jdkVersion int, verbose bool) {
+	if err := os.WriteFile(skipPath, []byte(strconv.Itoa(jdkVersion)), 0o644); err != nil && verbose {
+		reporter().Verbosef("verbose: Leyden AOT: failed to write skip sentinel %s: %v\n", skipPath, err)
+	}
 }
 
 // buildJVMBaseArgs returns the common JVM flags shared by all daemon launch paths.
@@ -231,6 +274,17 @@ func appendLeydenAOTArgs(args []string, javaPath, jarPath string, verbose bool) 
 		}
 	}
 	if _, statErr := os.Stat(leydenConfig); statErr == nil {
+		// Don't re-pay the ~30s failing-create cycle on every cold
+		// run — `.aot.skip` records "Leyden create failed against
+		// this JDK version on this jar; route straight to AppCDS".
+		skipPath, skipPathErr := leydenAOTSkipPath(jarPath)
+		jdkVersion := cachedJDKMajorVersion()
+		if skipPathErr == nil && leydenAOTCreateSkipped(skipPath, jdkVersion) {
+			if verbose {
+				reporter().Verbosef("verbose: Leyden AOT: skip sentinel set (JDK %d); falling back to AppCDS\n", jdkVersion)
+			}
+			return args, false
+		}
 		if err := buildLeydenAOTCache(javaPath, jarPath, leydenConfig, leydenCache, verbose); err == nil {
 			args = append(args, "-XX:AOTCache="+leydenCache)
 			if verbose {
@@ -239,6 +293,9 @@ func appendLeydenAOTArgs(args []string, javaPath, jarPath string, verbose bool) 
 			return args, true
 		} else if verbose {
 			reporter().Verbosef("verbose: Leyden AOT: cache build failed (%v), starting without AOT\n", err)
+		}
+		if skipPathErr == nil {
+			markLeydenAOTCreateFailed(skipPath, jdkVersion, verbose)
 		}
 		return args, false
 	}
@@ -266,7 +323,7 @@ func appendStartupCacheArgs(args []string, javaPath, jarPath string, verbose boo
 // removes. Keep in sync with the suffix arguments passed to jarCachePath
 // elsewhere in this file (cdsArchivePath, cracCheckpointPath,
 // aotConfigPath, aotCachePath).
-var jvmCacheSuffixes = []string{".jsa", ".crac", ".aotconf", ".aot"}
+var jvmCacheSuffixes = []string{".jsa", ".crac", ".aotconf", ".aot", ".aot.skip"}
 
 // purgeJVMCachesForJar deletes the AppCDS/CRaC/Leyden cache files keyed by
 // `jarPath`'s content hash. Used as a self-heal after the daemon hands us

--- a/internal/oracle/daemon_jvm_test.go
+++ b/internal/oracle/daemon_jvm_test.go
@@ -74,3 +74,41 @@ func TestAppendLeydenAOTArgs_ReportsAddition(t *testing.T) {
 			addedAOT, added, args)
 	}
 }
+
+// TestLeydenAOTSkipSentinel pins the skip-on-failure contract:
+// once `buildLeydenAOTCache` has failed for a given (JDK version,
+// jar) pair, the sentinel short-circuits subsequent invocations so
+// we don't pay the ~30s failing-create cycle on every cold call.
+// JDK upgrades invalidate the sentinel by writing a new version
+// stamp.
+func TestLeydenAOTSkipSentinel(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	jar := writeTempJar(t)
+	skipPath, err := leydenAOTSkipPath(jar)
+	if err != nil {
+		t.Fatalf("leydenAOTSkipPath: %v", err)
+	}
+
+	if leydenAOTCreateSkipped(skipPath, 26) {
+		t.Fatal("skip reported true with no sentinel written")
+	}
+
+	markLeydenAOTCreateFailed(skipPath, 26, false)
+	if !leydenAOTCreateSkipped(skipPath, 26) {
+		t.Fatal("skip reported false after markLeydenAOTCreateFailed(26)")
+	}
+
+	// JDK version change invalidates the sentinel — retry on upgrade.
+	if leydenAOTCreateSkipped(skipPath, 27) {
+		t.Fatal("skip reported true for a different JDK version; sentinel must invalidate")
+	}
+
+	// Corrupt sentinel content is treated as "no skip" so a
+	// malformed file doesn't lock the user out of retrying.
+	if err := os.WriteFile(skipPath, []byte("not-a-number"), 0o644); err != nil {
+		t.Fatalf("write corrupt sentinel: %v", err)
+	}
+	if leydenAOTCreateSkipped(skipPath, 26) {
+		t.Fatal("skip reported true for corrupt sentinel; should be permissive")
+	}
+}

--- a/internal/oracle/invoke.go
+++ b/internal/oracle/invoke.go
@@ -268,20 +268,21 @@ func InvokeWithFilesWithOptions(jarPath string, sourceDirs []string, outputPath,
 		return "", fmt.Errorf("create output dir: %w", err)
 	}
 
-	args := []string{
-		// G1 is the default GC on JDK 21; explicit here so downstream tuning
-		// is visible. String deduplication is a consistent 10-15% win on the
-		// FQN-heavy FIR state that krit-types builds. Large-project sweeps
-		// consistently show lower wall time and peak RSS with dedup enabled.
-		// Skipping -Xmx lets very large repos size the heap as needed; -Xms1g
-		// avoids early heap-grow pauses without over-committing.
-		"-XX:+UseG1GC",
-		"-XX:+UseStringDeduplication",
-		"-Xms1g",
+	// Match the daemon launch's arg shape so the one-shot JVM gets
+	// the same Leyden AOT / AppCDS startup-cache acceleration. On
+	// the first call this writes the per-jar `.aotconf` / `.jsa`
+	// under ~/.krit/cache/; subsequent one-shot calls reuse them.
+	// G1 + StringDeduplication + Xms1g come from buildJVMBaseArgs:
+	// G1 is the default GC on JDK 21+, dedup is a consistent
+	// 10-15% win on FQN-heavy FIR state, and -Xms1g avoids early
+	// heap-grow pauses without capping with -Xmx.
+	args := buildJVMBaseArgs()
+	args = appendStartupCacheArgs(args, javaPath, jarPath, verbose)
+	args = append(args,
 		"-jar", jarPath,
 		"--sources", strings.Join(sourceDirs, ","),
 		"--output", outputPath,
-	}
+	)
 	extraJVMArgs := configuredExtraJVMArgs(opts)
 	args = appendExtraJVMArgsBeforeJar(args, extraJVMArgs)
 	recordKritTypesJVMArgs(tracker, extraJVMArgs)

--- a/internal/oracle/invoke_cached.go
+++ b/internal/oracle/invoke_cached.go
@@ -571,16 +571,20 @@ func runKritTypesCached(
 		return fmt.Errorf("create output dir: %w", err)
 	}
 
-	args := []string{
-		"-XX:+UseG1GC",
-		"-XX:+UseStringDeduplication",
-		"-Xms1g",
+	// Match the daemon launch's arg shape so the one-shot JVM gets
+	// the same Leyden AOT / AppCDS startup-cache acceleration. On
+	// the first call this writes the per-jar `.aotconf` / `.jsa`
+	// under ~/.krit/cache/; subsequent one-shot calls reuse them
+	// and cut JVM startup cost roughly in half.
+	args := buildJVMBaseArgs()
+	args = appendStartupCacheArgs(args, javaPath, jarPath, verbose)
+	args = append(args,
 		"-jar", jarPath,
 		"--sources", strings.Join(sourceDirs, ","),
 		"--output", freshOutPath,
 		"--files", missListPath,
 		"--cache-deps-out", depsOutPath,
-	}
+	)
 	extraJVMArgs := configuredExtraJVMArgs(opts)
 	args = appendExtraJVMArgsBeforeJar(args, extraJVMArgs)
 	recordKritTypesJVMArgs(tracker, extraJVMArgs)


### PR DESCRIPTION
## Summary
Two changes that together fix the cold JVM startup cost on the oracle one-shot path:

1. **One-shot startup-cache wiring.** `oracle.InvokeWithFilesWithOptions` (one-shot) and `oracle.InvokeCachedWithOptions`'s miss-list spawn now share the daemon's `buildJVMBaseArgs` + `appendStartupCacheArgs` flow. The first call writes the per-jar `.aotconf` / `.jsa` under `~/.krit/cache/`; subsequent calls reuse the archive. Closes a gap where **krit-fir — which doesn't go through the persistent oracle daemon — paid full JVM cold-start cost on every invocation**.
2. **`buildLeydenAOTCache` failure sentinel.** `<jar>.aot.skip` is written when the Leyden create step crashes (the JDK 26 + Kotlin-shadow-jar issue documented in the file). `appendLeydenAOTArgs` consults the sentinel before retrying, so we don't pay the ~30s failing-create cycle on every cold krit call. The sentinel stores the JDK major version so a JDK upgrade auto-invalidates and retries.

## Bench (android-build, 50 sources, project `.krit` wiped between runs to force fresh JVM each call)

| Backend | Before (5 cold runs) | After (run 1 / 2 / 3+) |
|---|---|---|
| FIR | ~5.0 s each | 6.1 s record → 17 s create-fail + AppCDS train → **2.9–5.4 s stable** |
| KAA | ~5–6 s each | 5.9 s → 7.5 s → **2.9–3.0 s stable** |

After the one-time training cost (runs 1–2), every subsequent cold one-shot oracle call is ~40 % faster. FIR benefits most because it has no persistent daemon path — previously each FIR invocation paid full JVM cold-start.

## Test plan
- [x] `go build -o krit ./cmd/krit/ && go vet ./... && golangci-lint run ./...` (0 issues).
- [x] `go test ./... -count=1` — full suite green; new `TestLeydenAOTSkipSentinel` pins the four-way contract (write-after-fail, skip-on-next, JDK-upgrade invalidates, corrupt sentinel is ignored).
- [x] E2E on android-build (numbers above).