### PR TITLE
fix(store): surface os.Remove errors from FileStore.Invalidate

### DIFF
--- a/internal/store/file.go
+++ b/internal/store/file.go
@@ -102,18 +102,27 @@ func (s *FileStore) Invalidate(ruleIDs ...string) error {
 			return nil
 		}
 		if len(ruleIDs) == 0 {
-			os.Remove(path)
-			return nil
+			return removeIfExists(path)
 		}
 		// Conservative: any ruleID match clears the entry.
 		for _, id := range ruleIDs {
 			if strings.Contains(info.Name(), id) {
-				os.Remove(path)
-				return nil
+				return removeIfExists(path)
 			}
 		}
 		return nil
 	})
+}
+
+// removeIfExists deletes path and returns nil if removal succeeded or the
+// file was already gone. Any other error (permission denied, locked file,
+// transient FS failure) is returned so Invalidate surfaces partial failure
+// instead of silently leaving stale cache entries on disk.
+func removeIfExists(path string) error {
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
 }
 
 // Stats returns entry count and total byte size by walking the store root,

--- a/internal/store/file_test.go
+++ b/internal/store/file_test.go
@@ -2,6 +2,9 @@ package store
 
 import (
 	"bytes"
+	"os"
+	"path/filepath"
+	"runtime"
 	"testing"
 )
 
@@ -95,6 +98,37 @@ func TestInvalidateOnEmptyStore(t *testing.T) {
 	s := New(t.TempDir())
 	if err := s.Invalidate(); err != nil {
 		t.Fatalf("Invalidate on empty store: %v", err)
+	}
+}
+
+// TestInvalidateSurfacesRemoveErrors guards against the regression where
+// os.Remove failures inside the walk callback were swallowed, causing
+// Invalidate to report success while leaving stale entries on disk.
+func TestInvalidateSurfacesRemoveErrors(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("directory permission semantics differ on Windows")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("root bypasses directory permission checks")
+	}
+
+	root := t.TempDir()
+	s := New(root)
+	key := makeKey(KindIncremental, 0xAB, 0x01)
+	if err := s.Put(key, []byte("payload")); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	// Strip write permission on the entry's parent so os.Remove fails with
+	// EACCES. We restore permissions in cleanup so TempDir can be removed.
+	entryDir := filepath.Dir(s.entryPath(key))
+	if err := os.Chmod(entryDir, 0o555); err != nil {
+		t.Fatalf("chmod readonly: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(entryDir, 0o755) })
+
+	if err := s.Invalidate(); err == nil {
+		t.Fatal("expected Invalidate to surface os.Remove error, got nil")
 	}
 }
 


### PR DESCRIPTION
## Summary

- `FileStore.Invalidate` walked the store root, called `os.Remove` on each matching `.bin` shard, and discarded the error. A failed remove (permission denied, locked file on Windows, transient FS error) left a stale cache entry on disk while `Invalidate` returned `nil`, so the next analyzer run served stale findings/oracle results with no signal that invalidation was partial.
- Capture the error in a small helper that treats `os.IsNotExist` as success (matching the existing pattern in `Stats` directly below) and propagate everything else through `filepath.Walk`.
- Adds a regression test (`TestInvalidateSurfacesRemoveErrors`) that strips write permission on the entry's parent directory and asserts `Invalidate` returns an error. Verified the test fails on the prior code.

## Test plan

- [x] `go test ./internal/store/ -count=1`
- [x] Confirmed `TestInvalidateSurfacesRemoveErrors` fails before the fix
- [x] `go vet ./...`
- [x] `golangci-lint run ./...`
- [x] `go test ./... -count=1`