### PR TITLE
fix(mcp): surface scanner.ScanFiles parse errors in analyze tool

### DIFF
--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -912,6 +912,49 @@ func TestAnalyzeProjectInvalidPaths(t *testing.T) {
 	}
 }
 
+// TestAnalyzeProjectSurfacesParseErrors guards against the regression where
+// scanner.ScanFiles' per-file error slice was silently discarded, causing
+// the MCP analyze tool to report success with empty findings when no file
+// could be parsed.
+func TestAnalyzeProjectSurfacesParseErrors(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root bypasses file permission checks")
+	}
+
+	tmp := t.TempDir()
+	unreadable := tmp + "/locked.kt"
+	if err := os.WriteFile(unreadable, []byte("fun main() {}\n"), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	if err := os.Chmod(unreadable, 0o000); err != nil {
+		t.Fatalf("chmod 000: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(unreadable, 0o644) })
+
+	args, _ := json.Marshal(analyzeArgs{Mode: "project", Paths: []string{tmp}})
+	responses := runServer(t, Request{
+		JSONRPC: "2.0",
+		ID:      float64(1),
+		Method:  "tools/call",
+		Params:  mustJSON(t, ToolCallParams{Name: "analyze", Arguments: args}),
+	})
+
+	if len(responses) != 1 {
+		t.Fatalf("expected 1 response, got %d", len(responses))
+	}
+	data, _ := json.Marshal(responses[0].Result)
+	var result ToolResult
+	if err := json.Unmarshal(data, &result); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+	if !result.IsError {
+		t.Fatalf("expected error result for unparseable file; got success: %+v", result)
+	}
+	if len(result.Content) == 0 || !strings.Contains(result.Content[0].Text, "scanning files") {
+		t.Fatalf("expected error to mention scanning files, got %+v", result.Content)
+	}
+}
+
 func TestAnalyzeProjectMissingPaths(t *testing.T) {
 	args, _ := json.Marshal(analyzeArgs{Mode: "project",
 		Paths: []string{},

--- a/internal/mcp/tool_analyze.go
+++ b/internal/mcp/tool_analyze.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"os"
 	"sort"
+	"strings"
 
 	"github.com/kaeawc/krit/internal/android"
 	"github.com/kaeawc/krit/internal/librarymodel"
@@ -114,7 +115,10 @@ func (s *Server) analyzeProject(args analyzeArgs) ToolResult {
 		return errorResult("no Kotlin files found in the specified paths")
 	}
 
-	files, _ := scanner.ScanFiles(context.Background(), ktFiles, 4)
+	files, parseErrs := scanner.ScanFiles(context.Background(), ktFiles, 4)
+	if len(files) == 0 && len(parseErrs) > 0 {
+		return errorResult("scanning files: " + joinErrors(parseErrs))
+	}
 
 	type fileResult struct {
 		File     string `json:"file"`
@@ -164,12 +168,14 @@ func (s *Server) analyzeProject(args analyzeArgs) ToolResult {
 		TotalFindings int          `json:"totalFindings"`
 		TopRules      []ruleCount  `json:"topRules"`
 		PerFile       []fileResult `json:"perFile,omitempty"`
+		ParseErrors   []string     `json:"parseErrors,omitempty"`
 	}
 
 	summary := summaryJSON{
 		TotalFiles:    len(files),
 		TotalFindings: allColumns.Len(),
 		TopRules:      topRules,
+		ParseErrors:   errorStrings(parseErrs),
 	}
 
 	if format == "detailed" {
@@ -338,7 +344,10 @@ func (s *Server) analyzeAndroid(args analyzeArgs) ToolResult {
 // analyzeImpact counts findings per rule for either a buffer or a path set.
 // Useful for "how loud would enabling rule X be?" before flipping config.
 func (s *Server) analyzeImpact(args analyzeArgs) ToolResult {
-	var allColumns scanner.FindingColumns
+	var (
+		allColumns scanner.FindingColumns
+		parseErrs  []error
+	)
 
 	switch {
 	case args.Code != "":
@@ -356,7 +365,11 @@ func (s *Server) analyzeImpact(args analyzeArgs) ToolResult {
 		if len(ktFiles) == 0 {
 			return errorResult("no Kotlin files found in the specified paths")
 		}
-		files, _ := scanner.ScanFiles(context.Background(), ktFiles, 4)
+		var files []*scanner.File
+		files, parseErrs = scanner.ScanFiles(context.Background(), ktFiles, 4)
+		if len(files) == 0 && len(parseErrs) > 0 {
+			return errorResult("scanning files: " + joinErrors(parseErrs))
+		}
 		collector := scanner.NewFindingCollector(len(files) * 8)
 		for _, f := range files {
 			cols, _ := s.analyzer.Dispatcher.RunColumnsWithStats(f)
@@ -414,10 +427,44 @@ func (s *Server) analyzeImpact(args analyzeArgs) ToolResult {
 	type impactResult struct {
 		TotalFindings int         `json:"totalFindings"`
 		Rules         []impactRow `json:"rules"`
+		ParseErrors   []string    `json:"parseErrors,omitempty"`
 	}
 
 	return jsonResult(impactResult{
 		TotalFindings: allColumns.Len(),
 		Rules:         rows,
+		ParseErrors:   errorStrings(parseErrs),
 	})
+}
+
+// joinErrors renders parse errors as a single bounded-length message for
+// inclusion in errorResult, keeping the first few errors and noting any
+// overflow so callers see representative failures without runaway text.
+func joinErrors(errs []error) string {
+	const limit = 3
+	if len(errs) == 0 {
+		return ""
+	}
+	parts := make([]string, 0, limit+1)
+	for i, e := range errs {
+		if i >= limit {
+			parts = append(parts, "... and more")
+			break
+		}
+		parts = append(parts, e.Error())
+	}
+	return strings.Join(parts, "; ")
+}
+
+// errorStrings converts a slice of errors to their string forms, returning
+// nil for an empty input so the JSON `omitempty` tag elides the field.
+func errorStrings(errs []error) []string {
+	if len(errs) == 0 {
+		return nil
+	}
+	out := make([]string, len(errs))
+	for i, e := range errs {
+		out[i] = e.Error()
+	}
+	return out
 }


### PR DESCRIPTION
## Summary

- `analyzeProject` and `analyzeImpact` in `internal/mcp/tool_analyze.go` discarded the `[]error` returned alongside `[]*File` from `scanner.ScanFiles`. An unreadable / malformed / unparseable `.kt` file produced an MCP response with zero findings and `IsError: false` — a false negative for LLM callers making decisions off the result. Every other failure mode in this handler already returns `errorResult`, so this was an inconsistency, not a documented best-effort path.
- If every file failed to parse, return `errorResult` with a bounded summary of the first few errors (helper caps message length).
- If only some failed, surface the per-file error strings in a new `parseErrors` field on `summaryJSON` / `impactResult` so callers can detect partial failure without breaking the existing schema.
- Adds `TestAnalyzeProjectSurfacesParseErrors` covering the all-files-fail path via a `chmod 000` fixture. Verified the test fails on the prior code.

Note on the original bug-list triage: the second return value of `Dispatcher.RunColumnsWithStats` is `RunStats`, not `error`, so the other two `_, _` sites flagged in the find-bugs list are not a swallow. Left unchanged.

## Test plan

- [x] `go test ./internal/mcp/ -count=1`
- [x] Confirmed `TestAnalyzeProjectSurfacesParseErrors` fails before the fix
- [x] `go vet ./...`
- [x] `golangci-lint run ./...`
- [x] `go build ./...`