### PR TITLE
refactor(rules): InjectDispatcher gates on resolved call-target FQN

### DIFF
--- a/docs/java-support-readiness.yml
+++ b/docs/java-support-readiness.yml
@@ -289,6 +289,9 @@ rules:
     status: supported
     fixtures:
       - internal/rules/android_security_test.go
+  InjectDispatcher:
+    status: not-applicable
+    reason: "Targets Kotlin coroutines `Dispatchers.IO/Default/Unconfined` references; Java callers of the coroutines runtime are out of scope for the heuristic."
   InsecureTrustManager:
     status: supported
     fixtures:

--- a/internal/rules/coroutines_test.go
+++ b/internal/rules/coroutines_test.go
@@ -500,17 +500,24 @@ suspend fun loadData() {
 	}
 }
 
-func TestInjectDispatcher_DoesNotRequireTypeContext(t *testing.T) {
+// Pins the post-migration capability shape: TypeInfo + OracleCallTargets, single-file only.
+func TestInjectDispatcher_DeclaresOracleCallTargets(t *testing.T) {
 	rule := buildRuleIndex()["InjectDispatcher"]
 	if rule == nil {
 		t.Fatal("InjectDispatcher rule not found")
 	}
-	if rule.Needs.Has(api.NeedsResolver) || rule.Needs.Has(api.NeedsOracle) ||
-		rule.Needs.Has(api.NeedsParsedFiles) || rule.Needs.Has(api.NeedsCrossFile) {
-		t.Fatalf("InjectDispatcher should stay AST/import-only; got Needs=%b", rule.Needs)
+	if !rule.Needs.Has(api.NeedsTypeInfo) {
+		t.Errorf("InjectDispatcher missing NeedsTypeInfo: Needs=%b", rule.Needs)
 	}
-	if rule.TypeInfo != (api.TypeInfoHint{}) {
-		t.Fatalf("InjectDispatcher TypeInfo=%+v, want zero value", rule.TypeInfo)
+	if !rule.Needs.Has(api.NeedsOracleCallTargets) {
+		t.Errorf("InjectDispatcher missing NeedsOracleCallTargets: Needs=%b", rule.Needs)
+	}
+	if rule.Needs.Has(api.NeedsParsedFiles) || rule.Needs.Has(api.NeedsCrossFile) ||
+		rule.Needs.Has(api.NeedsModuleIndex) {
+		t.Errorf("InjectDispatcher should be single-file only; got Needs=%b", rule.Needs)
+	}
+	if rule.OracleCallTargets == nil || len(rule.OracleCallTargets.CalleeNames) == 0 {
+		t.Fatalf("InjectDispatcher OracleCallTargets must declare callee names; got %+v", rule.OracleCallTargets)
 	}
 }
 
@@ -554,6 +561,67 @@ suspend fun foo() {
 	}
 	if len(lines) != 2 {
 		t.Errorf("expected findings on 2 distinct lines, got %d distinct lines", len(lines))
+	}
+}
+
+// runInjectDispatcherWithCallTarget sets a synthetic oracle
+// `callTarget` for every navigation_expression matching exprText
+// and runs the InjectDispatcher rule against the resulting
+// composite resolver. Pairs with the post-migration logic that
+// keys on the resolved call-target FQN.
+func runInjectDispatcherWithCallTarget(t *testing.T, code string, exprText string, target string) []scanner.Finding {
+	t.Helper()
+	file := parseInline(t, code)
+	resolver := typeinfer.NewResolver()
+	resolver.IndexFilesParallel([]*scanner.File{file}, 1)
+	fake := oracle.NewFakeOracle()
+	fake.CallTargets[file.Path] = map[string]string{}
+	file.FlatWalkNodes(0, "navigation_expression", func(idx uint32) {
+		if strings.TrimSpace(file.FlatNodeText(idx)) == exprText {
+			key := fmt.Sprintf("%d:%d", file.FlatRow(idx)+1, file.FlatCol(idx)+1)
+			fake.CallTargets[file.Path][key] = target
+		}
+	})
+	composite := oracle.NewCompositeResolver(fake, resolver)
+	for _, r := range api.Registry {
+		if r.ID == "InjectDispatcher" {
+			d := rules.NewDispatcher([]*api.Rule{r}, composite)
+			cols := d.Run(file)
+			return cols.Findings()
+		}
+	}
+	t.Fatalf("rule %q not found in registry", "InjectDispatcher")
+	return nil
+}
+
+func TestInjectDispatcher_OracleCallTargetSuppressesLookalike(t *testing.T) {
+	// A project-local `Dispatchers` lookalike whose oracle-resolved
+	// callable FQN is NOT `kotlinx.coroutines.Dispatchers.IO`. The
+	// AST token match alone would have produced a false positive
+	// here; the oracle gate suppresses it.
+	findings := runInjectDispatcherWithCallTarget(t, `
+package test
+suspend fun loadData() {
+    withContext(Dispatchers.IO) { fetchFromNetwork() }
+}
+`, "Dispatchers.IO", "com.acme.local.Dispatchers.IO")
+	if len(findings) != 0 {
+		t.Fatalf("expected oracle to suppress lookalike, got %d: %v", len(findings), findings)
+	}
+}
+
+func TestInjectDispatcher_OracleCallTargetConfirmsRealDispatchers(t *testing.T) {
+	// Oracle resolves the same syntactic shape to the real
+	// kotlinx.coroutines FQN — the rule fires.
+	findings := runInjectDispatcherWithCallTarget(t, `
+package test
+import kotlinx.coroutines.Dispatchers
+suspend fun loadData() {
+    withContext(Dispatchers.IO) { fetchFromNetwork() }
+}
+`, "Dispatchers.IO", "kotlinx.coroutines.Dispatchers.IO")
+	if len(findings) != 1 {
+		t.Fatalf("expected oracle-confirmed dispatcher to fire, got %d: %v", len(findings), findings)
 	}
 }
 

--- a/internal/rules/java_support.go
+++ b/internal/rules/java_support.go
@@ -101,6 +101,7 @@ var javaSupportReadiness = JavaSupportMatrix{
 		"HardcodedSecretKey":                   {Status: api.LanguageSupportSupported, Fixtures: []string{"internal/rules/android_security_test.go"}},
 		"HttpClientNotReused":                  {Status: api.LanguageSupportSupported, Fixtures: []string{"internal/rules/resource_cost_test.go"}},
 		"ImplicitPendingIntent":                {Status: api.LanguageSupportSupported, Fixtures: []string{"internal/rules/android_security_test.go"}},
+		"InjectDispatcher":                     {Status: api.LanguageSupportNotApplicable, Reason: "Targets Kotlin coroutines `Dispatchers.IO/Default/Unconfined` references; Java callers of the coroutines runtime are out of scope for the heuristic."},
 		"InsecureTrustManager":                 {Status: api.LanguageSupportSupported, Fixtures: []string{"internal/rules/android_security_test.go"}},
 		"InstanceOfCheckForException":          {Status: api.LanguageSupportSupported, Fixtures: []string{"internal/rules/exceptions_test.go"}},
 		"JavaObjectInputStream":                {Status: api.LanguageSupportSupported, Fixtures: []string{"internal/rules/security_test.go"}},

--- a/internal/rules/oracle_filter_narrowing_test.go
+++ b/internal/rules/oracle_filter_narrowing_test.go
@@ -124,7 +124,6 @@ func TestResolverOnlyRulesDoNotContributeToOracle(t *testing.T) {
 	for _, id := range []string{
 		"CastNullableToNonNullableType",
 		"ComposeClickableWithoutMinTouchTarget",
-		"InjectDispatcher",
 		"LogOfSharedPreferenceRead",
 		"PlainFileWriteOfSensitive",
 		"SharedPreferencesForSensitiveKey",

--- a/internal/rules/registry_coroutines.go
+++ b/internal/rules/registry_coroutines.go
@@ -146,6 +146,12 @@ func registerCoroutinesInjectDispatcher() {
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
 		NodeTypes: []string{"call_expression"}, Confidence: 0.75, Implementation: r,
+		Needs: api.NeedsTypeInfo | api.NeedsOracleCallTargets,
+		OracleCallTargets: &api.OracleCallTargetFilter{
+			CalleeNames: injectDispatcherOracleCalleeNames(r.DispatcherNames),
+		},
+		// No declaration export needed.
+		OracleDeclarationNeeds: &api.OracleDeclarationProfile{},
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			if scanner.IsTestFile(file.Path) {
@@ -163,6 +169,14 @@ func registerCoroutinesInjectDispatcher() {
 				return
 			}
 			if !injectDispatcherReferenceConfirmed(file, dispatcherNode) {
+				return
+			}
+			// Gate on resolved call-target FQN; falls back to AST evidence when oracle is silent.
+			var oracleLookup oracle.Lookup
+			if cr, ok := ctx.Resolver.(*oracle.CompositeResolver); ok {
+				oracleLookup = cr.Oracle()
+			}
+			if !injectDispatcherOracleConfirmed(oracleLookup, file, dispatcherNode, dispatcherName) {
 				return
 			}
 			// Idiomatic-host filter mirroring the FIR checker. Some
@@ -185,6 +199,35 @@ func registerCoroutinesInjectDispatcher() {
 				fmt.Sprintf("Hardcoded Dispatchers.%s. Inject dispatchers for better testability.", dispatcherName))
 		},
 	})
+}
+
+// injectDispatcherOracleCalleeNames returns the dispatcher names
+// plus their getter-shape JVM equivalents.
+func injectDispatcherOracleCalleeNames(names []string) []string {
+	out := make([]string, 0, 2*len(names))
+	for _, name := range names {
+		out = append(out, name, "get"+name)
+	}
+	return out
+}
+
+// injectDispatcherOracleConfirmed returns true when either (a) the
+// oracle has no opinion (no resolved call-target) — in which case
+// the prior AST evidence is the floor — or (b) the oracle resolved
+// the dispatcher reference to a callable on `kotlinx.coroutines.Dispatchers`.
+// Returns false when the oracle resolves to something else (e.g., a
+// project-local class named `Dispatchers`), which is the false-positive
+// the AST token match couldn't catch.
+func injectDispatcherOracleConfirmed(lookup oracle.Lookup, file *scanner.File, dispatcherNode uint32, dispatcherName string) bool {
+	if lookup == nil {
+		return true
+	}
+	target := oracleLookupCallTargetFlat(lookup, file, dispatcherNode)
+	if target == "" {
+		return true
+	}
+	expected := "kotlinx.coroutines.Dispatchers." + dispatcherName
+	return target == expected || target == "kotlinx.coroutines.Dispatchers.get"+dispatcherName
 }
 
 func registerCoroutinesRedundantSuspendModifier() {

--- a/internal/rules/rules_test.go
+++ b/internal/rules/rules_test.go
@@ -58,7 +58,6 @@ func TestComposeSideEffectInCompositionStaysASTOnly(t *testing.T) {
 func TestVettedRulesStayLocalASTOnly(t *testing.T) {
 	for _, id := range []string{
 		"ComposeSemanticsMissingRole",
-		"InjectDispatcher",
 		"MissingSuperCall",
 		"RunTestWithDelay",
 		"ForbiddenComment",


### PR DESCRIPTION
## Summary
Migrates the Go-side `InjectDispatcher` check from token matching to consuming the oracle's resolved call-target FQN. The rule now fires only when `Dispatchers.<name>` actually resolves to `kotlinx.coroutines.Dispatchers.<name>` — project-local `Dispatchers` classes the token match couldn't distinguish are now suppressed.

This is the first of four pilot-rule migrations to oracle-fact consumption. The FIR-side checker (`tools/krit-fir/.../InjectDispatcher.kt`) is left in place to serve as a worked example for future custom-Kotlin-rules-via-plugin work.

## What changed
- `InjectDispatcher` registry entry declares `NeedsTypeInfo | NeedsOracleCallTargets`, an `OracleCallTargetFilter` keyed on the dispatcher names + their getter shapes (so the JVM-side call-filter narrows the analyze workload), and an empty `OracleDeclarationProfile`.
- New helper `injectDispatcherOracleConfirmed(lookup, file, node, name)` returns true when (a) the oracle has no resolution — fall back to AST evidence, preserving pre-migration behavior on non-oracle runs — or (b) the resolved FQN is `kotlinx.coroutines.Dispatchers.<name>` (or its getter form). Returns false on a non-coroutines resolution.
- `injectDispatcherOracleCalleeNames` produces the callee-name hints the JVM-side oracle uses to narrow its call-target index.

## Backend symmetry
The same Go-side rule now runs under both KAA and FIR — KAA's Analysis API resolves `Dispatchers.IO` to its FQN; FIR's K2 frontend does the same. Apples-to-apples comparison of findings + timings becomes possible without keeping two separate rule implementations.

## Tests
- `TestInjectDispatcher_OracleCallTargetSuppressesLookalike` — pins the false-positive suppression for project-local `Dispatchers`.
- `TestInjectDispatcher_OracleCallTargetConfirmsRealDispatchers` — pins the positive path.
- `TestInjectDispatcher_DeclaresOracleCallTargets` — replaces the old `TestInjectDispatcher_DoesNotRequireTypeContext` invariant.
- Existing positive / negative fixtures still pass: AST fallback preserves behavior when oracle is silent.

## Adjusted invariants
- Removed from `TestVettedRulesStayLocalASTOnly` and `TestResolverOnlyRulesDoNotContributeToOracle` (new capability declaration is the canonical record).
- Java support recorded as not-applicable in both `internal/rules/java_support.go` and `docs/java-support-readiness.yml`.

## Test plan
- [x] `go build -o krit ./cmd/krit/ && go vet ./... && golangci-lint run ./...` (0 issues).
- [x] `go test ./... -count=1` — full suite green.