### PR TITLE
refactor(rules): CastNullableToNonNullableType consults oracle expression types

### DIFF
--- a/internal/rules/oracle_filter_narrowing_test.go
+++ b/internal/rules/oracle_filter_narrowing_test.go
@@ -122,7 +122,6 @@ func TestOracleCallTargetFilterDefaultRulesEnabled(t *testing.T) {
 
 func TestResolverOnlyRulesDoNotContributeToOracle(t *testing.T) {
 	for _, id := range []string{
-		"CastNullableToNonNullableType",
 		"ComposeClickableWithoutMinTouchTarget",
 		"LogOfSharedPreferenceRead",
 		"PlainFileWriteOfSensitive",

--- a/internal/rules/potentialbugs_nullsafety_casts.go
+++ b/internal/rules/potentialbugs_nullsafety_casts.go
@@ -1236,8 +1236,7 @@ func (r *CastNullableToNonNullableTypeRule) check(ctx *api.Context) {
 	if targetType.IsNullable() {
 		return
 	}
-	sourceNullable := ctx.Resolver.IsNullableFlat(cast.source, file)
-	if sourceNullable == nil || !*sourceNullable {
+	if !castNullableToNonNullableSourceIsNullable(ctx, cast.source) {
 		return
 	}
 
@@ -1250,6 +1249,36 @@ func (r *CastNullableToNonNullableTypeRule) check(ctx *api.Context) {
 		Replacement: "as?",
 	}
 	ctx.Emit(f)
+}
+
+// castNullableToNonNullableSourceIsNullable consults the oracle's
+// expression-type fact at source, falling back to the resolver.
+func castNullableToNonNullableSourceIsNullable(ctx *api.Context, source uint32) bool {
+	if composite, ok := ctx.Resolver.(*oracle.CompositeResolver); ok {
+		line := ctx.File.FlatRow(source) + 1
+		col := ctx.File.FlatCol(source) + 1
+		if exprType := composite.Oracle().LookupExpression(ctx.File.Path, line, col); exprType != nil {
+			return exprType.IsNullable()
+		}
+	}
+	nullable := ctx.Resolver.IsNullableFlat(source, ctx.File)
+	return nullable != nil && *nullable
+}
+
+// ExpressionPositions selects cast LHS positions for oracle pre-resolution.
+func (r *CastNullableToNonNullableTypeRule) ExpressionPositions(file *scanner.File) []uint32 {
+	if file == nil {
+		return nil
+	}
+	var out []uint32
+	file.FlatWalkNodes(0, "as_expression", func(idx uint32) {
+		cast, ok := unsafeCastExpressionPartsFlat(file, idx)
+		if !ok || cast.safe || cast.source == 0 {
+			return
+		}
+		out = append(out, cast.source)
+	})
+	return out
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/rules/potentialbugs_nullsafety_test.go
+++ b/internal/rules/potentialbugs_nullsafety_test.go
@@ -1382,6 +1382,97 @@ fun convert() {
 	}
 }
 
+// Oracle reports nullable LHS → rule fires.
+func TestCastNullableToNonNullableType_OracleExpressionTypeMarksSourceNullable(t *testing.T) {
+	findings := runCastNullableWithOracleExprType(t, `
+package test
+fun convert(unknownReceiver: String?): String {
+    return unknownReceiver.something() as String
+}
+`, "unknownReceiver.something()", &typeinfer.ResolvedType{
+		Name:     "String",
+		FQN:      "kotlin.String",
+		Kind:     typeinfer.TypeClass,
+		Nullable: true,
+	})
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding when oracle reports nullable source, got %d: %v", len(findings), findings)
+	}
+}
+
+// Oracle reports non-nullable LHS → no finding.
+func TestCastNullableToNonNullableType_OracleExpressionTypeSuppressesNonNullableSource(t *testing.T) {
+	findings := runCastNullableWithOracleExprType(t, `
+package test
+fun convert(unknownReceiver: String?): String {
+    return unknownReceiver.something() as String
+}
+`, "unknownReceiver.something()", &typeinfer.ResolvedType{
+		Name:     "String",
+		FQN:      "kotlin.String",
+		Kind:     typeinfer.TypeClass,
+		Nullable: false,
+	})
+	if len(findings) != 0 {
+		t.Fatalf("expected oracle non-nullable source to suppress finding, got %d: %v", len(findings), findings)
+	}
+}
+
+// Pins NeedsOracleExprType + ExprPositions on the rule.
+func TestCastNullableToNonNullableType_DeclaresOracleExprType(t *testing.T) {
+	var rule *api.Rule
+	for _, r := range api.Registry {
+		if r.ID == "CastNullableToNonNullableType" {
+			rule = r
+			break
+		}
+	}
+	if rule == nil {
+		t.Fatal("CastNullableToNonNullableType rule not registered")
+	}
+	if !rule.Needs.Has(api.NeedsOracleExprType) {
+		t.Errorf("missing NeedsOracleExprType: Needs=%b", rule.Needs)
+	}
+	if rule.ExprPositions == nil {
+		t.Error("ExprPositions selector must be set so the oracle pre-resolves cast LHS positions")
+	}
+}
+
+// runCastNullableWithOracleExprType plants `typ` at the cast LHS
+// matching `lhsText` and runs CastNullableToNonNullableType.
+func runCastNullableWithOracleExprType(t *testing.T, code string, lhsText string, typ *typeinfer.ResolvedType) []scanner.Finding {
+	t.Helper()
+	file := parseInline(t, code)
+	resolver := typeinfer.NewResolver()
+	resolver.IndexFilesParallel([]*scanner.File{file}, 1)
+	fake := oracle.NewFakeOracle()
+	fake.Expressions[file.Path] = map[string]*typeinfer.ResolvedType{}
+	file.FlatWalkNodes(0, "as_expression", func(idx uint32) {
+		var source uint32
+		for child := file.FlatFirstChild(idx); child != 0; child = file.FlatNextSib(child) {
+			if file.FlatIsNamed(child) {
+				source = child
+				break
+			}
+		}
+		if source == 0 || strings.TrimSpace(file.FlatNodeText(source)) != lhsText {
+			return
+		}
+		key := fmt.Sprintf("%d:%d", file.FlatRow(source)+1, file.FlatCol(source)+1)
+		fake.Expressions[file.Path][key] = typ
+	})
+	composite := oracle.NewCompositeResolver(fake, resolver)
+	for _, r := range api.Registry {
+		if r.ID == "CastNullableToNonNullableType" {
+			d := rules.NewDispatcher([]*api.Rule{r}, composite)
+			cols := d.Run(file)
+			return cols.Findings()
+		}
+	}
+	t.Fatalf("rule %q not found in registry", "CastNullableToNonNullableType")
+	return nil
+}
+
 // --- CastToNullableType ---
 
 func TestCastToNullableType_Positive(t *testing.T) {

--- a/internal/rules/registry_potentialbugs_nullsafety_casts.go
+++ b/internal/rules/registry_potentialbugs_nullsafety_casts.go
@@ -46,10 +46,12 @@ func registerPotentialbugsNullsafetyCastsRules() {
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
 			NodeTypes: []string{"as_expression"}, Confidence: 0.75, Fix: api.FixIdiomatic,
-			Needs:          api.NeedsResolver,
-			TypeInfo:       api.TypeInfoHint{PreferBackend: api.PreferResolver, Required: true},
-			Implementation: r,
-			Check:          r.check,
+			Needs:                  api.NeedsTypeInfo | api.NeedsOracleExprType,
+			TypeInfo:               api.TypeInfoHint{PreferBackend: api.PreferAny, Required: true},
+			ExprPositions:          r.ExpressionPositions,
+			OracleDeclarationNeeds: &api.OracleDeclarationProfile{},
+			Implementation:         r,
+			Check:                  r.check,
 		})
 	}
 	{


### PR DESCRIPTION
## Summary
Migrates the Go-side `CastNullableToNonNullableType` rule from source-resolver-only nullability inference to the oracle's resolved expression type at the cast LHS. The oracle's nullability beats the local resolver for cross-file and library-typed LHS expressions the source resolver can't see; the local resolver remains the fallback when the oracle has no opinion.

Second of four pilot-rule migrations to oracle-fact consumption. The FIR-side `UnsafeCastWhenNullable` checker (`tools/krit-fir/.../checkers/UnsafeCastWhenNullable.kt`) stays in place.

## What changed
- `Needs` adds `NeedsOracleExprType`.
- `TypeInfo.PreferBackend` flips from `PreferResolver` to `PreferAny` so the dispatcher hands the `CompositeResolver` to the check (the previous setting unwrapped the composite, hiding the oracle).
- `ExprPositions` selector (`r.ExpressionPositions`) points at the cast LHS positions; the pipeline pre-resolves expression types at those positions during its expression-resolution pass.
- `OracleDeclarationNeeds` is the empty profile (the rule inspects no declarations).
- `castNullableToNonNullableSourceIsNullable` queries `composite.Oracle().LookupExpression(file, line, col)` first, falls back to `ctx.Resolver.IsNullableFlat` when the oracle has no fact.

## Backend symmetry
Same Go-side rule under both KAA and FIR. KAA's Analysis API resolves nullability via type inference; FIR's K2 frontend does the same. Apples-to-apples comparison stays possible.

## Tests
- `TestCastNullableToNonNullableType_OracleExpressionTypeMarksSourceNullable` — oracle marks LHS nullable → finding emitted.
- `TestCastNullableToNonNullableType_OracleExpressionTypeSuppressesNonNullableSource` — oracle marks LHS non-nullable → suppressed even though the local resolver might disagree.
- `TestCastNullableToNonNullableType_DeclaresOracleExprType` — pins `NeedsOracleExprType` + `ExprPositions` wiring.
- Existing positive / negative fixtures still pass: the source-resolver fallback preserves behavior when the oracle is silent.

## Adjusted invariants
- Removed from `TestResolverOnlyRulesDoNotContributeToOracle` since the rule now contributes ExprType to the oracle's narrowing profile.

## Test plan
- [x] `go build -o krit ./cmd/krit/ && go vet ./... && golangci-lint run ./...` (0 issues).
- [x] `go test ./... -count=1` — full suite green.