### PR TITLE
refactor(rules): CollectInOnCreateWithoutLifecycle gates on resolved Flow.collect call-target

### DIFF
--- a/docs/java-support-readiness.yml
+++ b/docs/java-support-readiness.yml
@@ -159,6 +159,9 @@ rules:
     status: supported
     fixtures:
       - internal/rules/android_correctness_test.go
+  CollectInOnCreateWithoutLifecycle:
+    status: not-applicable
+    reason: "Targets Kotlin coroutines `Flow.collect` calls in Android lifecycle callbacks; Java lifecycle code doesn't use the Kotlin Flow API."
   CommitPrefEdits:
     status: supported
     fixtures:

--- a/internal/rules/coroutines_test.go
+++ b/internal/rules/coroutines_test.go
@@ -100,6 +100,81 @@ class ExampleActivity {
 	}
 }
 
+// Oracle resolves `collect` to a non-Flow callable → suppressed.
+func TestCollectInOnCreateWithoutLifecycle_OracleSuppressesNonFlowCollect(t *testing.T) {
+	findings := runCollectInOnCreateWithCallTarget(t, `
+package test
+class ExampleActivity {
+    fun onCreate() {
+        items.collect { render(it) }
+    }
+}
+`, "items.collect", "com.acme.local.Collector.collect")
+	if len(findings) != 0 {
+		t.Fatalf("expected oracle to suppress non-Flow collect, got %d: %v", len(findings), findings)
+	}
+}
+
+// Oracle confirms Flow.collect → fires.
+func TestCollectInOnCreateWithoutLifecycle_OracleConfirmsFlowCollect(t *testing.T) {
+	findings := runCollectInOnCreateWithCallTarget(t, `
+package test
+class ExampleActivity {
+    fun onCreate() {
+        vm.state.collect { render(it) }
+    }
+}
+`, "vm.state.collect", "kotlinx.coroutines.flow.FlowKt.collect")
+	if len(findings) != 1 {
+		t.Fatalf("expected oracle-confirmed Flow.collect to fire, got %d: %v", len(findings), findings)
+	}
+}
+
+// Pins NeedsOracleCallTargets + OracleCallTargets filter on the rule.
+func TestCollectInOnCreateWithoutLifecycle_DeclaresOracleCallTargets(t *testing.T) {
+	var rule *api.Rule
+	for _, r := range api.Registry {
+		if r.ID == "CollectInOnCreateWithoutLifecycle" {
+			rule = r
+			break
+		}
+	}
+	if rule == nil {
+		t.Fatal("rule not registered")
+	}
+	if !rule.Needs.Has(api.NeedsOracleCallTargets) {
+		t.Errorf("missing NeedsOracleCallTargets: Needs=%b", rule.Needs)
+	}
+	if rule.OracleCallTargets == nil || len(rule.OracleCallTargets.CalleeNames) == 0 {
+		t.Errorf("OracleCallTargets must list `collect`, got %+v", rule.OracleCallTargets)
+	}
+}
+
+func runCollectInOnCreateWithCallTarget(t *testing.T, code string, callText string, target string) []scanner.Finding {
+	t.Helper()
+	file := parseInline(t, code)
+	resolver := typeinfer.NewResolver()
+	resolver.IndexFilesParallel([]*scanner.File{file}, 1)
+	fake := oracle.NewFakeOracle()
+	fake.CallTargets[file.Path] = map[string]string{}
+	file.FlatWalkNodes(0, "call_expression", func(idx uint32) {
+		if strings.HasPrefix(strings.TrimSpace(file.FlatNodeText(idx)), callText) {
+			key := fmt.Sprintf("%d:%d", file.FlatRow(idx)+1, file.FlatCol(idx)+1)
+			fake.CallTargets[file.Path][key] = target
+		}
+	})
+	composite := oracle.NewCompositeResolver(fake, resolver)
+	for _, r := range api.Registry {
+		if r.ID == "CollectInOnCreateWithoutLifecycle" {
+			d := rules.NewDispatcher([]*api.Rule{r}, composite)
+			cols := d.Run(file)
+			return cols.Findings()
+		}
+	}
+	t.Fatalf("rule not found in registry")
+	return nil
+}
+
 // --- GlobalCoroutineUsage ---
 
 func TestGlobalCoroutineUsage_Positive(t *testing.T) {

--- a/internal/rules/java_support.go
+++ b/internal/rules/java_support.go
@@ -69,6 +69,7 @@ var javaSupportReadiness = JavaSupportMatrix{
 		"BroadcastReceiverExportedFlagMissing": {Status: api.LanguageSupportSupported, Fixtures: []string{"internal/rules/android_security_test.go"}},
 		"BufferedReadWithoutBuffer":            {Status: api.LanguageSupportSupported, Fixtures: []string{"internal/rules/resource_cost_test.go"}},
 		"CheckResult":                          {Status: api.LanguageSupportSupported, Fixtures: []string{"internal/rules/android_correctness_test.go"}},
+		"CollectInOnCreateWithoutLifecycle":    {Status: api.LanguageSupportNotApplicable, Reason: "Targets Kotlin coroutines `Flow.collect` calls in Android lifecycle callbacks; Java lifecycle code doesn't use the Kotlin Flow API."},
 		"CommitPrefEdits":                      {Status: api.LanguageSupportSupported, Fixtures: []string{"internal/rules/android_correctness_test.go"}},
 		"CommitTransaction":                    {Status: api.LanguageSupportSupported, Fixtures: []string{"internal/rules/android_correctness_test.go"}},
 		"CursorLoopWithColumnIndexInLoop":      {Status: api.LanguageSupportSupported, Fixtures: []string{"internal/rules/resource_cost_test.go"}},

--- a/internal/rules/registry_coroutines.go
+++ b/internal/rules/registry_coroutines.go
@@ -46,6 +46,11 @@ func registerCoroutinesCollectInOnCreateWithoutLifecycle() {
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
 		NodeTypes: []string{"call_expression"}, Confidence: 0.75, Implementation: r,
+		Needs: api.NeedsTypeInfo | api.NeedsOracleCallTargets,
+		OracleCallTargets: &api.OracleCallTargetFilter{
+			CalleeNames: []string{"collect"},
+		},
+		OracleDeclarationNeeds: &api.OracleDeclarationProfile{},
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			navExpr, _ := flatCallExpressionParts(file, idx)
@@ -59,10 +64,52 @@ func registerCoroutinesCollectInOnCreateWithoutLifecycle() {
 			if hasAncestorCallNamedFlat(file, idx, "repeatOnLifecycle") {
 				return
 			}
+			// Gate on resolved call-target FQN; falls back to AST evidence when oracle is silent.
+			var oracleLookup oracle.Lookup
+			if cr, ok := ctx.Resolver.(*oracle.CompositeResolver); ok {
+				oracleLookup = cr.Oracle()
+			}
+			if !collectInOnCreateOracleConfirmed(oracleLookup, file, idx) {
+				return
+			}
 			ctx.EmitAt(file.FlatRow(idx)+1, file.FlatCol(idx)+1,
 				"Flow.collect inside onCreate/onStart/onViewCreated should be wrapped in repeatOnLifecycle to stop collecting when the lifecycle is stopped.")
 		},
 	})
+}
+
+// collectInOnCreateOracleConfirmed accepts the call only when the
+// oracle has no opinion or it resolves the `collect` callee to a
+// real Flow-ish callable. The token match alone fires on any
+// `something.collect { ... }` (e.g. project-local collect on a
+// List), which the oracle gate filters out.
+func collectInOnCreateOracleConfirmed(lookup oracle.Lookup, file *scanner.File, idx uint32) bool {
+	if lookup == nil {
+		return true
+	}
+	target := oracleLookupCallTargetFlat(lookup, file, idx)
+	if target == "" {
+		return true
+	}
+	for _, prefix := range collectInOnCreateFlowReceivers {
+		if strings.HasPrefix(target, prefix+".") || target == prefix+".collect" {
+			return true
+		}
+	}
+	return false
+}
+
+// collectInOnCreateFlowReceivers are the Flow-family receivers whose
+// `collect` extension the rule cares about. Project-local `collect`
+// methods on unrelated types resolve to a different FQN and are
+// filtered out.
+var collectInOnCreateFlowReceivers = []string{
+	"kotlinx.coroutines.flow.Flow",
+	"kotlinx.coroutines.flow.FlowKt",
+	"kotlinx.coroutines.flow.SharedFlow",
+	"kotlinx.coroutines.flow.StateFlow",
+	"kotlinx.coroutines.flow.MutableSharedFlow",
+	"kotlinx.coroutines.flow.MutableStateFlow",
 }
 
 func registerCoroutinesGlobalCoroutineUsage() {


### PR DESCRIPTION
## Summary
Migrates the Go-side `CollectInOnCreateWithoutLifecycle` rule from pure AST token matching to consume the oracle's resolved call-target FQN. The rule now fires only when `.collect { … }` resolves to one of the `kotlinx.coroutines.flow.*` callables — project-local `collect` methods on unrelated types (e.g. `List.collect`, a domain `Collector`) are suppressed.

Third of four pilot-rule migrations to oracle-fact consumption. The FIR-side `FlowCollectInOnCreate` checker stays in place.

## What changed
- `Needs` adds `NeedsTypeInfo | NeedsOracleCallTargets`.
- `OracleCallTargetFilter{CalleeNames: ["collect"]}` narrows the JVM-side call-target index.
- Empty `OracleDeclarationProfile` (no declarations needed).
- `collectInOnCreateOracleConfirmed` accepts when oracle is silent OR the resolved target prefix matches one of the Flow-family receivers (`kotlinx.coroutines.flow.Flow`, `FlowKt`, `SharedFlow`, `StateFlow`, plus their mutable variants).

## Backend symmetry
Same Go-side rule under both KAA and FIR. Apples-to-apples comparison stays possible.

## Tests
- `…_OracleSuppressesNonFlowCollect` — non-Flow callTarget → no finding.
- `…_OracleConfirmsFlowCollect` — Flow.collect callTarget → fires.
- `…_DeclaresOracleCallTargets` — pins capability + filter wiring.
- Existing positive/negative tests still pass: AST fallback preserves behavior when oracle is silent.

Java support recorded as not-applicable in both `internal/rules/java_support.go` and `docs/java-support-readiness.yml` — the rule targets Kotlin Flow on Android, not Java lifecycle code.

## Test plan
- [x] `go build -o krit ./cmd/krit/ && go vet ./... && golangci-lint run ./...` (0 issues).
- [x] `go test ./... -count=1` — full suite green.