### PR TITLE
refactor(rules): ComposeRememberWithoutKey gates on resolved androidx.compose remember

### DIFF
--- a/docs/java-support-readiness.yml
+++ b/docs/java-support-readiness.yml
@@ -170,6 +170,9 @@ rules:
     status: supported
     fixtures:
       - internal/rules/android_correctness_test.go
+  ComposeRememberWithoutKey:
+    status: not-applicable
+    reason: "Targets Kotlin Compose `remember { … }` blocks; Compose is Kotlin-only."
   CursorLoopWithColumnIndexInLoop:
     status: supported
     fixtures:

--- a/internal/rules/compose_test.go
+++ b/internal/rules/compose_test.go
@@ -1,6 +1,16 @@
 package rules_test
 
-import "testing"
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/kaeawc/krit/internal/oracle"
+	api "github.com/kaeawc/krit/internal/rules/api"
+	"github.com/kaeawc/krit/internal/rules"
+	"github.com/kaeawc/krit/internal/scanner"
+	"github.com/kaeawc/krit/internal/typeinfer"
+)
 
 func TestComposeColumnRowInScrollable_Positive(t *testing.T) {
 	findings := runRuleByName(t, "ComposeColumnRowInScrollable", `
@@ -661,6 +671,81 @@ fun Example() {
 	if len(findings) != 0 {
 		t.Fatalf("expected no findings, got %d: %v", len(findings), findings)
 	}
+}
+
+// Oracle resolves `remember` to a non-Compose callable → suppressed.
+func TestComposeRememberWithoutKey_OracleSuppressesNonComposeRemember(t *testing.T) {
+	findings := runComposeRememberWithCallTarget(t, `
+package test
+fun Example(userName: String) {
+    val cached = remember { "hello " + userName }
+}
+`, "remember", "com.acme.local.Caching.remember")
+	if len(findings) != 0 {
+		t.Fatalf("expected oracle to suppress non-Compose remember, got %d: %v", len(findings), findings)
+	}
+}
+
+// Oracle confirms androidx.compose.runtime.remember → fires.
+func TestComposeRememberWithoutKey_OracleConfirmsComposeRemember(t *testing.T) {
+	findings := runComposeRememberWithCallTarget(t, `
+package test
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+@Composable
+fun Example(userName: String) {
+    val cached = remember { "hello " + userName }
+}
+`, "remember", "androidx.compose.runtime.remember")
+	if len(findings) != 1 {
+		t.Fatalf("expected oracle-confirmed Compose remember to fire, got %d: %v", len(findings), findings)
+	}
+}
+
+// Pins NeedsOracleCallTargets + OracleCallTargets filter on the rule.
+func TestComposeRememberWithoutKey_DeclaresOracleCallTargets(t *testing.T) {
+	var rule *api.Rule
+	for _, r := range api.Registry {
+		if r.ID == "ComposeRememberWithoutKey" {
+			rule = r
+			break
+		}
+	}
+	if rule == nil {
+		t.Fatal("rule not registered")
+	}
+	if !rule.Needs.Has(api.NeedsOracleCallTargets) {
+		t.Errorf("missing NeedsOracleCallTargets: Needs=%b", rule.Needs)
+	}
+	if rule.OracleCallTargets == nil || len(rule.OracleCallTargets.CalleeNames) == 0 {
+		t.Errorf("OracleCallTargets must list `remember`, got %+v", rule.OracleCallTargets)
+	}
+}
+
+func runComposeRememberWithCallTarget(t *testing.T, code string, callText string, target string) []scanner.Finding {
+	t.Helper()
+	file := parseInline(t, code)
+	resolver := typeinfer.NewResolver()
+	resolver.IndexFilesParallel([]*scanner.File{file}, 1)
+	fake := oracle.NewFakeOracle()
+	fake.CallTargets[file.Path] = map[string]string{}
+	file.FlatWalkNodes(0, "call_expression", func(idx uint32) {
+		txt := strings.TrimSpace(file.FlatNodeText(idx))
+		if strings.HasPrefix(txt, callText+" ") || strings.HasPrefix(txt, callText+"(") || strings.HasPrefix(txt, callText+"{") {
+			key := fmt.Sprintf("%d:%d", file.FlatRow(idx)+1, file.FlatCol(idx)+1)
+			fake.CallTargets[file.Path][key] = target
+		}
+	})
+	composite := oracle.NewCompositeResolver(fake, resolver)
+	for _, r := range api.Registry {
+		if r.ID == "ComposeRememberWithoutKey" {
+			d := rules.NewDispatcher([]*api.Rule{r}, composite)
+			cols := d.Run(file)
+			return cols.Findings()
+		}
+	}
+	t.Fatalf("rule not found in registry")
+	return nil
 }
 
 func TestComposeLaunchedEffectWithoutKeys_Positive_Unit(t *testing.T) {

--- a/internal/rules/compose_test.go
+++ b/internal/rules/compose_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 
 	"github.com/kaeawc/krit/internal/oracle"
-	api "github.com/kaeawc/krit/internal/rules/api"
 	"github.com/kaeawc/krit/internal/rules"
+	api "github.com/kaeawc/krit/internal/rules/api"
 	"github.com/kaeawc/krit/internal/scanner"
 	"github.com/kaeawc/krit/internal/typeinfer"
 )

--- a/internal/rules/java_support.go
+++ b/internal/rules/java_support.go
@@ -72,6 +72,7 @@ var javaSupportReadiness = JavaSupportMatrix{
 		"CollectInOnCreateWithoutLifecycle":    {Status: api.LanguageSupportNotApplicable, Reason: "Targets Kotlin coroutines `Flow.collect` calls in Android lifecycle callbacks; Java lifecycle code doesn't use the Kotlin Flow API."},
 		"CommitPrefEdits":                      {Status: api.LanguageSupportSupported, Fixtures: []string{"internal/rules/android_correctness_test.go"}},
 		"CommitTransaction":                    {Status: api.LanguageSupportSupported, Fixtures: []string{"internal/rules/android_correctness_test.go"}},
+		"ComposeRememberWithoutKey":            {Status: api.LanguageSupportNotApplicable, Reason: "Targets Kotlin Compose `remember { … }` blocks; Compose is Kotlin-only."},
 		"CursorLoopWithColumnIndexInLoop":      {Status: api.LanguageSupportSupported, Fixtures: []string{"internal/rules/resource_cost_test.go"}},
 		"DatabaseInstanceRecreated":            {Status: api.LanguageSupportSupported, Fixtures: []string{"internal/rules/resource_cost_test.go"}},
 		"DatabaseQueryOnMainThread":            {Status: api.LanguageSupportSupported, Fixtures: []string{"internal/rules/database_test.go"}},

--- a/internal/rules/registry_compose.go
+++ b/internal/rules/registry_compose.go
@@ -3,7 +3,9 @@ package rules
 import (
 	"strings"
 
+	"github.com/kaeawc/krit/internal/oracle"
 	api "github.com/kaeawc/krit/internal/rules/api"
+	"github.com/kaeawc/krit/internal/scanner"
 )
 
 func registerComposeRules() {
@@ -292,6 +294,11 @@ func registerComposeRememberWithoutKey() {
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
 		NodeTypes: []string{"call_expression"}, Confidence: 0.75, Implementation: r,
+		Needs: api.NeedsTypeInfo | api.NeedsOracleCallTargets,
+		OracleCallTargets: &api.OracleCallTargetFilter{
+			CalleeNames: []string{"remember"},
+		},
+		OracleDeclarationNeeds: &api.OracleDeclarationProfile{},
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			if flatCallNameAny(file, idx) != "remember" {
@@ -308,10 +315,35 @@ func registerComposeRememberWithoutKey() {
 			if !ok {
 				return
 			}
+			// Gate on resolved call-target FQN; falls back to AST evidence when oracle is silent.
+			var oracleLookup oracle.Lookup
+			if cr, ok := ctx.Resolver.(*oracle.CompositeResolver); ok {
+				oracleLookup = cr.Oracle()
+			}
+			if !composeRememberOracleConfirmed(oracleLookup, file, idx) {
+				return
+			}
 			ctx.EmitAt(file.FlatRow(idx)+1, file.FlatCol(idx)+1,
 				"remember { } reads enclosing parameter "+paramName+" but has no keys; the cached value won't update when "+paramName+" changes. Pass remember("+paramName+") { ... }.")
 		},
 	})
+}
+
+// composeRememberOracleConfirmed accepts the call when the oracle
+// is silent or it resolves the `remember` callee to the
+// `androidx.compose.runtime.remember` family. A project-local
+// `remember` function resolves to a different FQN and is filtered
+// out — the AST token match alone would have flagged it.
+func composeRememberOracleConfirmed(lookup oracle.Lookup, file *scanner.File, idx uint32) bool {
+	if lookup == nil {
+		return true
+	}
+	target := oracleLookupCallTargetFlat(lookup, file, idx)
+	if target == "" {
+		return true
+	}
+	return strings.HasPrefix(target, "androidx.compose.runtime.remember") ||
+		strings.HasPrefix(target, "androidx.compose.runtime.RememberKt.remember")
 }
 
 func registerComposeLaunchedEffectWithoutKeys() {


### PR DESCRIPTION
## Summary
Migrates the Go-side `ComposeRememberWithoutKey` rule from pure AST token matching to consume the oracle's resolved call-target FQN. The rule now fires only when `remember { … }` resolves to a callable in the `androidx.compose.runtime.remember` family — project-local `remember` functions (or other matching simple names) are suppressed.

**Completes the four-rule migration** ([#523](https://github.com/kaeawc/krit/pull/523) InjectDispatcher, [#524](https://github.com/kaeawc/krit/pull/524) CastNullableToNonNullableType, [#525](https://github.com/kaeawc/krit/pull/525) CollectInOnCreateWithoutLifecycle, this one). FIR-side checkers + `TestFirPilotParity` stay in place as worked examples for future custom-Kotlin-rules-via-plugin work.

## What changed
- `Needs` adds `NeedsTypeInfo | NeedsOracleCallTargets`.
- `OracleCallTargetFilter{CalleeNames: ["remember"]}` narrows the JVM-side call-target index.
- Empty `OracleDeclarationProfile` (no declarations needed).
- `composeRememberOracleConfirmed` accepts when oracle is silent OR the resolved target prefix is `androidx.compose.runtime.remember` / `androidx.compose.runtime.RememberKt.remember`.

## Backend symmetry
Same Go-side rule under both KAA and FIR. Apples-to-apples comparison continues to hold.

## Tests
- `…_OracleSuppressesNonComposeRemember` — non-Compose callTarget → no finding.
- `…_OracleConfirmsComposeRemember` — Compose callTarget → fires.
- `…_DeclaresOracleCallTargets` — pins capability + filter wiring.
- Existing positive/negative tests still pass: AST fallback preserves behavior when the oracle is silent.

Java support recorded as not-applicable in both `internal/rules/java_support.go` and `docs/java-support-readiness.yml` (Compose is Kotlin-only).

## Test plan
- [x] `go build -o krit ./cmd/krit/ && go vet ./... && golangci-lint run ./...` (0 issues).
- [x] `go test ./... -count=1` — full suite green.