### PR TITLE
refactor(rules): CommitPrefEdits gates on resolved SharedPreferences.edit FQN

### DIFF
--- a/internal/oracle/instrumentation.go
+++ b/internal/oracle/instrumentation.go
@@ -34,6 +34,14 @@ type InvocationOptions struct {
 	// through a partial JVM reanalyze instead of letting it ride on a
 	// stale cached entry. Empty preserves the pre-#NNN behavior.
 	ForcedMisses []string
+	// Classpath is the user-configured JVM classpath (krit.yml
+	// `oracle.classpath` + the `CLASSPATH` env var). Forwarded to
+	// the daemon as `--classpath <joined>`. Both backends accept
+	// this flag today — the krit-types daemon resolved it before
+	// the FIR migration; the krit-fir one-shot CLI gains a
+	// `--classpath` parser alongside this field landing. Empty
+	// preserves the existing source-tree-discovery fallback.
+	Classpath []string
 }
 
 func (o InvocationOptions) tracker() perf.Tracker {

--- a/internal/oracle/invoke.go
+++ b/internal/oracle/invoke.go
@@ -288,6 +288,13 @@ func InvokeWithFilesWithOptions(jarPath string, sourceDirs []string, outputPath,
 	if filesListPath != "" {
 		args = append(args, "--files", filesListPath)
 	}
+	if len(opts.Classpath) > 0 {
+		// Both backends parse `--classpath <joined>` as the user-
+		// configured classpath. Joined with the OS path separator so
+		// the daemon-side parser (which splits on `:` / `;`) stays
+		// consistent with the env var convention.
+		args = append(args, "--classpath", strings.Join(opts.Classpath, string(os.PathListSeparator)))
+	}
 	callFilterPath, cleanupCallFilter, err := writeCallFilterArg(opts, tracker)
 	if err != nil {
 		return "", fmt.Errorf("call filter: %w", err)

--- a/internal/pipeline/index.go
+++ b/internal/pipeline/index.go
@@ -1134,6 +1134,11 @@ func (p IndexPhase) runJvmAnalyze(in IndexInput, oracleRules []*api.Rule, scanPa
 		DeclarationProfile: &declarationProfileSummary,
 		DisableDiagnostics: !in.OracleDiagnostics || !rules.NeedsOracleDiagnostics(oracleRules),
 		ForcedMisses:       in.StaleOraclePaths,
+		// Forwards `oracle.classpath` + CLASSPATH env to the spawned
+		// JVM. Both krit-types and krit-fir parse `--classpath` on
+		// their one-shot CLI, so the same args vector drives either
+		// backend. Empty preserves source-tree discovery.
+		Classpath: in.OracleClasspath,
 	}
 	var res string
 	var err error

--- a/tests/parity/oracle_backend_parity_test.go
+++ b/tests/parity/oracle_backend_parity_test.go
@@ -78,6 +78,69 @@ func runOneShot(t *testing.T, jar, srcDir, outputPath string) *oracle.Data {
 	return &data
 }
 
+// TestOracleBackendAcceptsClasspathFlag asserts that both backends'
+// one-shot CLIs accept `--classpath` and analyze succeeds with the
+// supplied JAR(s) on the classpath. Without this gate a typo on
+// either side would break `oracle.InvokeWithFilesWithOptions` for
+// every project that ships an explicit classpath.
+//
+// The classpath supplied is kotlin-stdlib (the dependency every
+// Kotlin source set needs anyway). KAA's Analysis API ignores the
+// flag in favor of its own classpath wiring; FIR uses it directly to
+// configure K2's compilation environment. Both must finish without
+// error.
+func TestOracleBackendAcceptsClasspathFlag(t *testing.T) {
+	root := repoRoot(t)
+	kaaJar := oracle.FindJar([]string{root})
+	if kaaJar == "" {
+		t.Skip("krit-types jar not found")
+	}
+	firJar := firchecks.FindFirJar([]string{root})
+	if firJar == "" || !isExecutableJar(firJar) {
+		t.Skip("krit-fir jar not found")
+	}
+	stdlib := findKotlinStdlib()
+	if stdlib == "" {
+		t.Skip("kotlin-stdlib jar not found in Gradle cache")
+	}
+
+	tmp := t.TempDir()
+	srcDir := filepath.Join(tmp, "src")
+	if err := os.MkdirAll(srcDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(srcDir, "Sample.kt"), []byte("package x\nclass Sample\n"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	for _, tc := range []struct {
+		name string
+		jar  string
+	}{
+		{name: "kaa", jar: kaaJar},
+		{name: "fir", jar: firJar},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			out := filepath.Join(tmp, tc.name+".json")
+			opts := oracle.InvocationOptions{Classpath: []string{stdlib}}
+			if _, err := oracle.InvokeWithFilesWithOptions(tc.jar, []string{srcDir}, out, "", false, opts); err != nil {
+				t.Fatalf("%s with --classpath: %v", tc.name, err)
+			}
+			raw, err := os.ReadFile(out)
+			if err != nil {
+				t.Fatalf("read %s output: %v", tc.name, err)
+			}
+			var data oracle.Data
+			if err := json.Unmarshal(raw, &data); err != nil {
+				t.Fatalf("parse %s: %v\n%s", tc.name, err, string(raw))
+			}
+			if data.Version != 1 {
+				t.Errorf("%s version = %d, want 1", tc.name, data.Version)
+			}
+		})
+	}
+}
+
 func assertOracleParity(t *testing.T, kaa, fir *oracle.Data) {
 	t.Helper()
 	// Version + kotlinVersion are baked into both backends at

--- a/tools/krit-fir/build.gradle.kts
+++ b/tools/krit-fir/build.gradle.kts
@@ -37,6 +37,12 @@ tasks.shadowJar {
     }
     minimize {
         exclude(dependency("org.jetbrains.kotlin:kotlin-compiler:.*"))
+        // kotlin-stdlib carries runtime support classes (e.g.
+        // `NoWhenBranchMatchedException`) that Kotlin codegen emits
+        // references to without the minimizer seeing a direct call
+        // site. Excluding stdlib from minimization keeps those
+        // classes in the shadow jar so the launcher can initialize.
+        exclude(dependency("org.jetbrains.kotlin:kotlin-stdlib:.*"))
     }
 }
 

--- a/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/Main.kt
+++ b/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/Main.kt
@@ -40,7 +40,9 @@ fun main(args: Array<String>) {
         exitProcess(0)
     }
 
-    // One-shot CLI: krit-fir --sources DIR[,DIR...] --output FILE [--files LIST_FILE]
+    // One-shot CLI:
+    //   krit-fir --sources DIR[,DIR...] --output FILE
+    //            [--files LIST_FILE] [--classpath JAR[:JAR...]]
     // Mirrors krit-types' one-shot surface so `oracle.InvokeWithFiles`
     // can drive either backend with the same arg vector.
     val sources = extractCliValue(args, "--sources")?.split(",")?.map { it.trim() }?.filter { it.isNotEmpty() }
@@ -49,11 +51,23 @@ fun main(args: Array<String>) {
         printOneShotUsage()
         exitProcess(2)
     }
-    runOneShot(sources, output, filesListPath = extractCliValue(args, "--files"))
+    val classpath = extractCliValue(args, "--classpath", "-cp")
+        ?.split(java.io.File.pathSeparator)
+        ?.map { it.trim() }
+        ?.filter { it.isNotEmpty() }
+        .orEmpty()
+    runOneShot(
+        sources = sources,
+        outputPath = output,
+        filesListPath = extractCliValue(args, "--files"),
+        classpath = classpath,
+    )
     exitProcess(0)
 }
 
-private fun extractCliValue(args: Array<String>, vararg flags: String): String? {
+// `internal` so unit tests in the same module can verify the
+// arg-vector parser without driving a JVM subprocess.
+internal fun extractCliValue(args: Array<String>, vararg flags: String): String? {
     for ((i, arg) in args.withIndex()) {
         if (arg in flags && i + 1 < args.size) return args[i + 1]
     }
@@ -65,13 +79,19 @@ private fun printOneShotUsage() {
         """
         |Usage:
         |  krit-fir --daemon [--port N]
-        |  krit-fir --sources DIR[,DIR...] --output FILE [--files LIST_FILE]
+        |  krit-fir --sources DIR[,DIR...] --output FILE
+        |           [--files LIST_FILE] [--classpath JAR[${java.io.File.pathSeparatorChar}JAR...]]
         """.trimMargin(),
     )
 }
 
-private fun runOneShot(sources: List<String>, outputPath: String, filesListPath: String?) {
-    val session = AnalysisSession(sources, emptyList())
+private fun runOneShot(
+    sources: List<String>,
+    outputPath: String,
+    filesListPath: String?,
+    classpath: List<String>,
+) {
+    val session = AnalysisSession(sources, classpath)
     val files = if (filesListPath.isNullOrBlank()) {
         emptyList()
     } else {

--- a/tools/krit-fir/src/test/kotlin/dev/jasonpearson/krit/fir/OneShotCliTest.kt
+++ b/tools/krit-fir/src/test/kotlin/dev/jasonpearson/krit/fir/OneShotCliTest.kt
@@ -1,0 +1,51 @@
+package dev.jasonpearson.krit.fir
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * Pins the krit-fir one-shot CLI argv parser. The parser is small
+ * but it lives on the hot path `oracle.InvokeWithFilesWithOptions`
+ * shells out through, so a regression that drops the `--classpath`
+ * flag would silently break type resolution in every project that
+ * relies on a non-default classpath.
+ */
+class OneShotCliTest {
+
+    @Test
+    fun extractCliValueReturnsFirstMatchingFlag() {
+        val args = arrayOf(
+            "--sources", "/a,/b",
+            "--output", "/tmp/out.json",
+            "--classpath", "/jars/x.jar:/jars/y.jar",
+        )
+        assertEquals("/a,/b", extractCliValue(args, "--sources"))
+        assertEquals("/tmp/out.json", extractCliValue(args, "--output", "-o"))
+        assertEquals("/jars/x.jar:/jars/y.jar", extractCliValue(args, "--classpath", "-cp"))
+    }
+
+    @Test
+    fun extractCliValueAcceptsAliasFlags() {
+        // Short alias matches just like the long form so the parser
+        // is symmetric with krit-types' `--output` / `-o` and
+        // `--classpath` / `-cp`.
+        val args = arrayOf("-o", "/tmp/out.json", "-cp", "/jars/single.jar")
+        assertEquals("/tmp/out.json", extractCliValue(args, "--output", "-o"))
+        assertEquals("/jars/single.jar", extractCliValue(args, "--classpath", "-cp"))
+    }
+
+    @Test
+    fun extractCliValueReturnsNullWhenFlagMissing() {
+        val args = arrayOf("--sources", "/a")
+        assertNull(extractCliValue(args, "--classpath"))
+    }
+
+    @Test
+    fun extractCliValueReturnsNullWhenFlagHasNoValue() {
+        // A trailing flag with no value reads past the end of args
+        // — the parser must not pick up an out-of-bounds value.
+        val args = arrayOf("--sources", "/a", "--classpath")
+        assertNull(extractCliValue(args, "--classpath"))
+    }
+}


### PR DESCRIPTION
## Summary
Migrates the Kotlin path of the `CommitPrefEdits` rule from pure AST token matching to consume the oracle's resolved call-target FQN. The rule now fires only when `.edit()` resolves to `android.content.SharedPreferences.edit` or the androidx KTX extension — project-local methods named `edit()` (e.g. `Collection.edit`, builder DSLs) are suppressed.

**First of six tier-1 Android oracle migrations** following the pattern from #523/#525/#526.

## What changed
- `Needs` adds `NeedsTypeInfo | NeedsOracleCallTargets`.
- `OracleCallTargetFilter{CalleeNames: ["edit"]}` narrows the JVM-side call-target index.
- Empty `OracleDeclarationProfile` (no declarations needed).
- `commitPrefEditsOracleConfirmed` accepts when oracle is silent OR the resolved target is `android.content.SharedPreferences.edit` / `androidx.core.content.SharedPreferencesKt.edit` / `androidx.core.content.ContextKt.edit`.
- The Java path retains its existing `JavaFacts` semantic-call gate unchanged.

## Tests
- `…_OracleSuppressesNonSharedPreferencesEdit` — non-Android callTarget → no finding.
- `…_OracleConfirmsSharedPreferencesEdit` — Android callTarget → fires.
- `…_DeclaresOracleCallTargets` — pins capability + filter wiring.
- Existing positive/negative + Java tests still pass: AST fallback preserves behavior when oracle is silent.

## Test plan
- [x] `go build -o krit ./cmd/krit/ && go vet ./... && golangci-lint run ./...` (0 issues).
- [x] `go test ./... -count=1` — full suite green.