### PR TITLE
refactor(rules): CommitPrefEdits gates on resolved SharedPreferences.edit FQN

### DIFF
--- a/internal/rules/android_correctness_test.go
+++ b/internal/rules/android_correctness_test.go
@@ -1,7 +1,15 @@
 package rules_test
 
 import (
+	"fmt"
+	"strings"
 	"testing"
+
+	"github.com/kaeawc/krit/internal/oracle"
+	"github.com/kaeawc/krit/internal/rules"
+	api "github.com/kaeawc/krit/internal/rules/api"
+	"github.com/kaeawc/krit/internal/scanner"
+	"github.com/kaeawc/krit/internal/typeinfer"
 )
 
 // ---------------------------------------------------------------------------
@@ -325,6 +333,79 @@ class Store {
 			t.Fatalf("expected 0 findings for same simple-name javac-confirmed lookalike, got %d", len(findings))
 		}
 	})
+}
+
+// Oracle resolves `.edit()` to a non-SharedPreferences callable → suppressed.
+func TestCommitPrefEdits_OracleSuppressesNonSharedPreferencesEdit(t *testing.T) {
+	findings := runCommitPrefEditsWithCallTarget(t, `
+package test
+fun save() {
+    val editor = collection.edit()
+    editor.add("item")
+}
+`, "collection.edit", "com.acme.local.Collection.edit")
+	if len(findings) != 0 {
+		t.Fatalf("expected oracle to suppress non-SharedPreferences edit, got %d: %v", len(findings), findings)
+	}
+}
+
+// Oracle confirms android.content.SharedPreferences.edit → fires.
+func TestCommitPrefEdits_OracleConfirmsSharedPreferencesEdit(t *testing.T) {
+	findings := runCommitPrefEditsWithCallTarget(t, `
+package test
+fun save() {
+    val editor = prefs.edit()
+    editor.putString("key", "value")
+}
+`, "prefs.edit", "android.content.SharedPreferences.edit")
+	if len(findings) != 1 {
+		t.Fatalf("expected oracle-confirmed SharedPreferences.edit to fire, got %d: %v", len(findings), findings)
+	}
+}
+
+// Pins NeedsOracleCallTargets + OracleCallTargets filter on the rule.
+func TestCommitPrefEdits_DeclaresOracleCallTargets(t *testing.T) {
+	var rule *api.Rule
+	for _, r := range api.Registry {
+		if r.ID == "CommitPrefEdits" {
+			rule = r
+			break
+		}
+	}
+	if rule == nil {
+		t.Fatal("CommitPrefEdits rule not registered")
+	}
+	if !rule.Needs.Has(api.NeedsOracleCallTargets) {
+		t.Errorf("missing NeedsOracleCallTargets: Needs=%b", rule.Needs)
+	}
+	if rule.OracleCallTargets == nil || len(rule.OracleCallTargets.CalleeNames) == 0 {
+		t.Errorf("OracleCallTargets must list `edit`, got %+v", rule.OracleCallTargets)
+	}
+}
+
+func runCommitPrefEditsWithCallTarget(t *testing.T, code string, callText string, target string) []scanner.Finding {
+	t.Helper()
+	file := parseInline(t, code)
+	resolver := typeinfer.NewResolver()
+	resolver.IndexFilesParallel([]*scanner.File{file}, 1)
+	fake := oracle.NewFakeOracle()
+	fake.CallTargets[file.Path] = map[string]string{}
+	file.FlatWalkNodes(0, "call_expression", func(idx uint32) {
+		if strings.Contains(strings.TrimSpace(file.FlatNodeText(idx)), callText) {
+			key := fmt.Sprintf("%d:%d", file.FlatRow(idx)+1, file.FlatCol(idx)+1)
+			fake.CallTargets[file.Path][key] = target
+		}
+	})
+	composite := oracle.NewCompositeResolver(fake, resolver)
+	for _, r := range api.Registry {
+		if r.ID == "CommitPrefEdits" {
+			d := rules.NewDispatcher([]*api.Rule{r}, composite)
+			cols := d.Run(file)
+			return cols.Findings()
+		}
+	}
+	t.Fatalf("rule not found in registry")
+	return nil
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/rules/registry_android_correctness.go
+++ b/internal/rules/registry_android_correctness.go
@@ -4,6 +4,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/kaeawc/krit/internal/oracle"
 	api "github.com/kaeawc/krit/internal/rules/api"
 	"github.com/kaeawc/krit/internal/scanner"
 	"github.com/kaeawc/krit/internal/typeinfer"
@@ -101,8 +102,13 @@ func registerAndroidCorrectnessCommitPrefEdits() {
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Description(), Sev: api.Severity(r.Sev),
 		NodeTypes: []string{"call_expression", "method_invocation"},
 		Languages: []scanner.Language{scanner.LangKotlin, scanner.LangJava}, Confidence: 0.8, Implementation: r,
-		JavaFacts:         &api.JavaFactProfile{ReceiverTypesForCallees: []string{"edit"}},
-		NeedsLibraryFacts: true,
+		Needs: api.NeedsTypeInfo | api.NeedsOracleCallTargets,
+		OracleCallTargets: &api.OracleCallTargetFilter{
+			CalleeNames: []string{"edit"},
+		},
+		OracleDeclarationNeeds: &api.OracleDeclarationProfile{},
+		JavaFacts:              &api.JavaFactProfile{ReceiverTypesForCallees: []string{"edit"}},
+		NeedsLibraryFacts:      true,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			if file.FlatType(idx) == "method_invocation" {
@@ -126,9 +132,35 @@ func registerAndroidCorrectnessCommitPrefEdits() {
 				functionHasReceiverCallAfter(file, fn, idx, editorVar, commitOrApplyNames, editorFinalizeCallShape) {
 				return
 			}
+			// Gate on resolved call-target FQN; falls back to AST evidence when oracle is silent.
+			var oracleLookup oracle.Lookup
+			if cr, ok := ctx.Resolver.(*oracle.CompositeResolver); ok {
+				oracleLookup = cr.Oracle()
+			}
+			if !commitPrefEditsOracleConfirmed(oracleLookup, file, idx) {
+				return
+			}
 			ctx.EmitAt(file.FlatRow(idx)+1, 1, "SharedPreferences.edit() without commit() or apply().")
 		},
 	})
+}
+
+// commitPrefEditsOracleConfirmed accepts when the oracle is silent
+// or it resolves the `.edit()` call to `SharedPreferences.edit` or
+// one of the androidx.core KTX extensions. A `.edit(n)` on a
+// Collection or a project-local `edit` extension resolves to a
+// different FQN and is filtered out.
+func commitPrefEditsOracleConfirmed(lookup oracle.Lookup, file *scanner.File, idx uint32) bool {
+	if lookup == nil {
+		return true
+	}
+	target := oracleLookupCallTargetFlat(lookup, file, idx)
+	if target == "" {
+		return true
+	}
+	return target == "android.content.SharedPreferences.edit" ||
+		strings.HasPrefix(target, "androidx.core.content.SharedPreferencesKt.edit") ||
+		strings.HasPrefix(target, "androidx.core.content.ContextKt.edit")
 }
 
 func registerAndroidCorrectnessCommitTransaction() {


### PR DESCRIPTION
## Summary
Migrates the Kotlin path of the `CommitPrefEdits` rule from pure AST token matching to consume the oracle's resolved call-target FQN. The rule fires only when `.edit()` resolves to `android.content.SharedPreferences.edit` or the androidx KTX extension. Project-local `edit()` methods (Collection, builder DSLs, etc.) are suppressed.

**First of six tier-1 Android oracle migrations** following the pattern from #523/#525/#526. (Note: previous PR #527 was opened from the wrong branch and merged a no-op; this one carries the actual CommitPrefEdits commit.)

## Changes
- `Needs` adds `NeedsTypeInfo | NeedsOracleCallTargets`.
- `OracleCallTargetFilter{CalleeNames: ["edit"]}` narrows the JVM-side call-target index.
- Empty `OracleDeclarationProfile` (no declarations needed).
- `commitPrefEditsOracleConfirmed` accepts on `android.content.SharedPreferences.edit`, `androidx.core.content.SharedPreferencesKt.edit`, or `androidx.core.content.ContextKt.edit`.
- Java path retains its existing `JavaFacts` semantic-call gate.

## Tests
- `…_OracleSuppressesNonSharedPreferencesEdit` — non-Android callTarget → no finding.
- `…_OracleConfirmsSharedPreferencesEdit` — Android callTarget → fires.
- `…_DeclaresOracleCallTargets` — pins capability + filter wiring.

## Test plan
- [x] `go build -o krit ./cmd/krit/ && go vet ./... && golangci-lint run ./...` (0 issues).
- [x] `go test ./... -count=1` — full suite green.