### PR TITLE
refactor(rules): CommitTransaction gates on resolved FragmentManager.beginTransaction FQN

### DIFF
--- a/internal/rules/android_correctness_test.go
+++ b/internal/rules/android_correctness_test.go
@@ -1,7 +1,15 @@
 package rules_test
 
 import (
+	"fmt"
+	"strings"
 	"testing"
+
+	"github.com/kaeawc/krit/internal/oracle"
+	"github.com/kaeawc/krit/internal/rules"
+	api "github.com/kaeawc/krit/internal/rules/api"
+	"github.com/kaeawc/krit/internal/scanner"
+	"github.com/kaeawc/krit/internal/typeinfer"
 )
 
 // ---------------------------------------------------------------------------
@@ -434,6 +442,79 @@ class Screen {
 			t.Fatalf("expected 0 findings for javac-confirmed local lookalike, got %d", len(findings))
 		}
 	})
+}
+
+// Oracle resolves `.beginTransaction()` to a non-FragmentManager callable → suppressed.
+func TestCommitTransaction_OracleSuppressesNonFragmentManager(t *testing.T) {
+	findings := runCommitTransactionWithCallTarget(t, `
+package test
+fun show() {
+    val tx = db.beginTransaction()
+    tx.run()
+}
+`, "db.beginTransaction", "com.acme.local.Database.beginTransaction")
+	if len(findings) != 0 {
+		t.Fatalf("expected oracle to suppress non-FragmentManager beginTransaction, got %d: %v", len(findings), findings)
+	}
+}
+
+// Oracle confirms androidx FragmentManager.beginTransaction → fires.
+func TestCommitTransaction_OracleConfirmsFragmentManager(t *testing.T) {
+	findings := runCommitTransactionWithCallTarget(t, `
+package test
+fun show() {
+    val tx = supportFragmentManager.beginTransaction()
+    tx.replace(R.id.container, fragment)
+}
+`, "supportFragmentManager.beginTransaction", "androidx.fragment.app.FragmentManager.beginTransaction")
+	if len(findings) != 1 {
+		t.Fatalf("expected oracle-confirmed FragmentManager.beginTransaction to fire, got %d: %v", len(findings), findings)
+	}
+}
+
+// Pins NeedsOracleCallTargets + OracleCallTargets filter on the rule.
+func TestCommitTransaction_DeclaresOracleCallTargets(t *testing.T) {
+	var rule *api.Rule
+	for _, r := range api.Registry {
+		if r.ID == "CommitTransaction" {
+			rule = r
+			break
+		}
+	}
+	if rule == nil {
+		t.Fatal("CommitTransaction rule not registered")
+	}
+	if !rule.Needs.Has(api.NeedsOracleCallTargets) {
+		t.Errorf("missing NeedsOracleCallTargets: Needs=%b", rule.Needs)
+	}
+	if rule.OracleCallTargets == nil || len(rule.OracleCallTargets.CalleeNames) == 0 {
+		t.Errorf("OracleCallTargets must list `beginTransaction`, got %+v", rule.OracleCallTargets)
+	}
+}
+
+func runCommitTransactionWithCallTarget(t *testing.T, code string, callText string, target string) []scanner.Finding {
+	t.Helper()
+	file := parseInline(t, code)
+	resolver := typeinfer.NewResolver()
+	resolver.IndexFilesParallel([]*scanner.File{file}, 1)
+	fake := oracle.NewFakeOracle()
+	fake.CallTargets[file.Path] = map[string]string{}
+	file.FlatWalkNodes(0, "call_expression", func(idx uint32) {
+		if strings.Contains(strings.TrimSpace(file.FlatNodeText(idx)), callText) {
+			key := fmt.Sprintf("%d:%d", file.FlatRow(idx)+1, file.FlatCol(idx)+1)
+			fake.CallTargets[file.Path][key] = target
+		}
+	})
+	composite := oracle.NewCompositeResolver(fake, resolver)
+	for _, r := range api.Registry {
+		if r.ID == "CommitTransaction" {
+			d := rules.NewDispatcher([]*api.Rule{r}, composite)
+			cols := d.Run(file)
+			return cols.Findings()
+		}
+	}
+	t.Fatalf("rule not found in registry")
+	return nil
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/rules/registry_android_correctness.go
+++ b/internal/rules/registry_android_correctness.go
@@ -4,6 +4,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/kaeawc/krit/internal/oracle"
 	api "github.com/kaeawc/krit/internal/rules/api"
 	"github.com/kaeawc/krit/internal/scanner"
 	"github.com/kaeawc/krit/internal/typeinfer"
@@ -137,8 +138,13 @@ func registerAndroidCorrectnessCommitTransaction() {
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Description(), Sev: api.Severity(r.Sev),
 		NodeTypes: []string{"call_expression", "method_invocation"},
 		Languages: []scanner.Language{scanner.LangKotlin, scanner.LangJava}, Confidence: 0.8, Implementation: r,
-		JavaFacts:         &api.JavaFactProfile{ReceiverTypesForCallees: []string{"beginTransaction"}},
-		NeedsLibraryFacts: true,
+		Needs: api.NeedsTypeInfo | api.NeedsOracleCallTargets,
+		OracleCallTargets: &api.OracleCallTargetFilter{
+			CalleeNames: []string{"beginTransaction"},
+		},
+		OracleDeclarationNeeds: &api.OracleDeclarationProfile{},
+		JavaFacts:              &api.JavaFactProfile{ReceiverTypesForCallees: []string{"beginTransaction"}},
+		NeedsLibraryFacts:      true,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			if file.FlatType(idx) == "method_invocation" {
@@ -159,9 +165,35 @@ func registerAndroidCorrectnessCommitTransaction() {
 				functionHasReceiverCallAfter(file, fn, idx, txVar, commitTransactionNames, nil) {
 				return
 			}
+			// Gate on resolved call-target FQN; falls back to AST evidence when oracle is silent.
+			var oracleLookup oracle.Lookup
+			if cr, ok := ctx.Resolver.(*oracle.CompositeResolver); ok {
+				oracleLookup = cr.Oracle()
+			}
+			if !commitTransactionOracleConfirmed(oracleLookup, file, idx) {
+				return
+			}
 			ctx.EmitAt(file.FlatRow(idx)+1, 1, "FragmentTransaction without commit(). Call commit() or commitAllowingStateLoss().")
 		},
 	})
+}
+
+// commitTransactionOracleConfirmed accepts when the oracle is silent
+// or it resolves `.beginTransaction()` to one of the FragmentManager
+// implementations. A project-local `beginTransaction()` (e.g. on a
+// database wrapper or domain transactional API) resolves to a
+// different FQN and is filtered out.
+func commitTransactionOracleConfirmed(lookup oracle.Lookup, file *scanner.File, idx uint32) bool {
+	if lookup == nil {
+		return true
+	}
+	target := oracleLookupCallTargetFlat(lookup, file, idx)
+	if target == "" {
+		return true
+	}
+	return target == "androidx.fragment.app.FragmentManager.beginTransaction" ||
+		target == "android.app.FragmentManager.beginTransaction" ||
+		target == "android.support.v4.app.FragmentManager.beginTransaction"
 }
 
 func registerAndroidCorrectnessAssert() {


### PR DESCRIPTION
## Summary
Migrates the Kotlin path of the `CommitTransaction` rule from pure AST token matching to consume the oracle's resolved call-target FQN. The rule fires only when `.beginTransaction()` resolves to one of the FragmentManager implementations (androidx, framework, or v4 support). Project-local `beginTransaction()` methods are suppressed.

**Second of six tier-1 Android oracle migrations**, same recipe as #523/#525/#526/#528.

## Changes
- `Needs` adds `NeedsTypeInfo | NeedsOracleCallTargets`.
- `OracleCallTargetFilter{CalleeNames: ["beginTransaction"]}` narrows the JVM-side call-target index.
- Empty `OracleDeclarationProfile`.
- `commitTransactionOracleConfirmed` accepts when oracle is silent OR the resolved target matches `androidx.fragment.app.FragmentManager.beginTransaction` / `android.app.FragmentManager.beginTransaction` / `android.support.v4.app.FragmentManager.beginTransaction`.
- Java path retains its existing `JavaFacts` semantic-call gate.

## Tests
- `…_OracleSuppressesNonFragmentManager` — non-FragmentManager callTarget → no finding.
- `…_OracleConfirmsFragmentManager` — FragmentManager callTarget → fires.
- `…_DeclaresOracleCallTargets` — pins capability + filter wiring.

## Test plan
- [x] `go vet ./... && golangci-lint run ./...` (0 issues).
- [x] `go test ./... -count=1` — full suite green.