### PR TITLE
refactor(rules): ServiceCast gates on resolved Context.getSystemService FQN

### DIFF
--- a/docs/java-support-readiness.yml
+++ b/docs/java-support-readiness.yml
@@ -393,6 +393,9 @@ rules:
     status: supported
     fixtures:
       - internal/rules/android_source_test.go
+  ServiceCast:
+    status: pending
+    reason: "Kotlin as_expression coverage only; Java cast-expression parity for getSystemService receivers still needs implementation."
   SetJavaScriptEnabled:
     status: supported
     fixtures:

--- a/internal/cli/rules/testdata/coverage_java.golden
+++ b/internal/cli/rules/testdata/coverage_java.golden
@@ -6,8 +6,8 @@ AbstractClassCanBeInterface                     style                partial    
 
 Total: 784 rule(s)
   supported: 119
-  partial: 452
-  pending: 142
+  partial: 451
+  pending: 143
   needs-design: 0
   not-applicable: 50
   (unclassified): 21

--- a/internal/rules/android_source_test.go
+++ b/internal/rules/android_source_test.go
@@ -1,8 +1,15 @@
 package rules_test
 
 import (
+	"fmt"
 	"strings"
 	"testing"
+
+	"github.com/kaeawc/krit/internal/oracle"
+	"github.com/kaeawc/krit/internal/rules"
+	api "github.com/kaeawc/krit/internal/rules/api"
+	"github.com/kaeawc/krit/internal/scanner"
+	"github.com/kaeawc/krit/internal/typeinfer"
 )
 
 func TestFragmentConstructor(t *testing.T) {
@@ -114,6 +121,81 @@ class Foo {
 			t.Fatalf("expected 0 findings, got %d", len(findings))
 		}
 	})
+}
+
+// Oracle resolves `getSystemService(...)` to a non-Context callable → suppressed.
+func TestServiceCast_OracleSuppressesNonContext(t *testing.T) {
+	findings := runServiceCastWithCallTarget(t, `
+package test
+class Foo {
+    fun setup() {
+        val mgr = getSystemService(ALARM_SERVICE) as PowerManager
+    }
+}
+`, "getSystemService", "com.acme.local.Registry.getSystemService")
+	if len(findings) != 0 {
+		t.Fatalf("expected oracle to suppress non-Context getSystemService, got %d: %v", len(findings), findings)
+	}
+}
+
+// Oracle confirms android.content.Context.getSystemService → fires.
+func TestServiceCast_OracleConfirmsContext(t *testing.T) {
+	findings := runServiceCastWithCallTarget(t, `
+package test
+class Foo {
+    fun setup() {
+        val mgr = getSystemService(ALARM_SERVICE) as PowerManager
+    }
+}
+`, "getSystemService", "android.content.Context.getSystemService")
+	if len(findings) != 1 {
+		t.Fatalf("expected oracle-confirmed Context.getSystemService to fire, got %d: %v", len(findings), findings)
+	}
+}
+
+// Pins NeedsOracleCallTargets + filter on the rule.
+func TestServiceCast_DeclaresOracleCallTargets(t *testing.T) {
+	var rule *api.Rule
+	for _, r := range api.Registry {
+		if r.ID == "ServiceCast" {
+			rule = r
+			break
+		}
+	}
+	if rule == nil {
+		t.Fatal("ServiceCast rule not registered")
+	}
+	if !rule.Needs.Has(api.NeedsOracleCallTargets) {
+		t.Errorf("missing NeedsOracleCallTargets: Needs=%b", rule.Needs)
+	}
+	if rule.OracleCallTargets == nil || len(rule.OracleCallTargets.CalleeNames) == 0 {
+		t.Errorf("OracleCallTargets must list `getSystemService`, got %+v", rule.OracleCallTargets)
+	}
+}
+
+func runServiceCastWithCallTarget(t *testing.T, code string, callText string, target string) []scanner.Finding {
+	t.Helper()
+	file := parseInline(t, code)
+	resolver := typeinfer.NewResolver()
+	resolver.IndexFilesParallel([]*scanner.File{file}, 1)
+	fake := oracle.NewFakeOracle()
+	fake.CallTargets[file.Path] = map[string]string{}
+	file.FlatWalkNodes(0, "call_expression", func(idx uint32) {
+		if strings.Contains(strings.TrimSpace(file.FlatNodeText(idx)), callText) {
+			key := fmt.Sprintf("%d:%d", file.FlatRow(idx)+1, file.FlatCol(idx)+1)
+			fake.CallTargets[file.Path][key] = target
+		}
+	})
+	composite := oracle.NewCompositeResolver(fake, resolver)
+	for _, r := range api.Registry {
+		if r.ID == "ServiceCast" {
+			d := rules.NewDispatcher([]*api.Rule{r}, composite)
+			cols := d.Run(file)
+			return cols.Findings()
+		}
+	}
+	t.Fatalf("rule not found in registry")
+	return nil
 }
 
 func TestShowToast(t *testing.T) {

--- a/internal/rules/java_support.go
+++ b/internal/rules/java_support.go
@@ -128,6 +128,7 @@ var javaSupportReadiness = JavaSupportMatrix{
 		"RuntimeExecUnsafeShape":               {Status: api.LanguageSupportSupported, Fixtures: []string{"internal/rules/security_test.go"}},
 		"RsaNoPadding":                         {Status: api.LanguageSupportSupported, Fixtures: []string{"internal/rules/android_security_test.go"}},
 		"SecureRandom":                         {Status: api.LanguageSupportSupported, Fixtures: []string{"internal/rules/android_source_test.go"}},
+		"ServiceCast":                          {Status: api.LanguageSupportPending, Reason: "Kotlin as_expression coverage only; Java cast-expression parity for getSystemService receivers still needs implementation."},
 		"SetJavaScriptEnabled":                 {Status: api.LanguageSupportSupported, Fixtures: []string{"internal/rules/android_base_test.go"}},
 		"SetTextI18n":                          {Status: api.LanguageSupportPending, Reason: "Kotlin call_expression coverage only; Java method_invocation parity for TextView/Button receivers still needs implementation."},
 		"SimpleDateFormat":                     {Status: api.LanguageSupportSupported, Fixtures: []string{"internal/rules/android_correctness_test.go"}},

--- a/internal/rules/registry_android_source.go
+++ b/internal/rules/registry_android_source.go
@@ -3,9 +3,27 @@ package rules
 import (
 	"strings"
 
+	"github.com/kaeawc/krit/internal/oracle"
 	api "github.com/kaeawc/krit/internal/rules/api"
 	"github.com/kaeawc/krit/internal/scanner"
 )
+
+// serviceCastOracleConfirmed accepts when the oracle is silent or
+// resolves the `.getSystemService(...)` call to `Context.getSystemService`
+// (or `ContextCompat.getSystemService` from androidx.core). A
+// project-local `getSystemService` resolves to a different FQN and
+// is filtered out.
+func serviceCastOracleConfirmed(lookup oracle.Lookup, file *scanner.File, call uint32) bool {
+	if lookup == nil {
+		return true
+	}
+	target := oracleLookupCallTargetFlat(lookup, file, call)
+	if target == "" {
+		return true
+	}
+	return target == "android.content.Context.getSystemService" ||
+		target == "androidx.core.content.ContextCompat.getSystemService"
+}
 
 func registerAndroidSourceRules() {
 
@@ -67,6 +85,11 @@ func registerAndroidSourceRules() {
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Description(), Sev: api.Severity(r.Sev),
 			NodeTypes: []string{"as_expression"}, Confidence: 0.9, Implementation: r,
+			Needs: api.NeedsTypeInfo | api.NeedsOracleCallTargets,
+			OracleCallTargets: &api.OracleCallTargetFilter{
+				CalleeNames: []string{"getSystemService"},
+			},
+			OracleDeclarationNeeds: &api.OracleDeclarationProfile{},
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				// First named child is the source expression; we want
@@ -106,6 +129,14 @@ func registerAndroidSourceRules() {
 					}
 				}
 				if castType == "" || castType == expectedType {
+					return
+				}
+				// Gate on resolved call-target FQN; falls back to AST evidence when oracle is silent.
+				var oracleLookup oracle.Lookup
+				if cr, ok := ctx.Resolver.(*oracle.CompositeResolver); ok {
+					oracleLookup = cr.Oracle()
+				}
+				if !serviceCastOracleConfirmed(oracleLookup, file, call) {
 					return
 				}
 				ctx.EmitAt(file.FlatRow(idx)+1, 1,


### PR DESCRIPTION
## Summary
Migrates `ServiceCast` from pure AST token matching to consume the oracle's resolved call-target FQN. The rule fires only when `getSystemService(...)` resolves to `android.content.Context.getSystemService` or `androidx.core.content.ContextCompat.getSystemService`. Project-local `getSystemService()` methods (custom DI registries, service-locator wrappers) are suppressed.

**Third of six tier-1 Android oracle migrations**, same recipe as #523/#525/#526/#528/#529.

## Changes
- `Needs` adds `NeedsTypeInfo | NeedsOracleCallTargets`.
- `OracleCallTargetFilter{CalleeNames: ["getSystemService"]}` narrows the JVM-side call-target index.
- Empty `OracleDeclarationProfile`.
- `serviceCastOracleConfirmed` accepts when oracle is silent OR resolves to `Context.getSystemService` / `ContextCompat.getSystemService`.

## Tests
- `…_OracleSuppressesNonContext` — non-Android callTarget → no finding.
- `…_OracleConfirmsContext` — Android callTarget → fires.
- `…_DeclaresOracleCallTargets` — pins capability + filter wiring.

Java support classified as `pending` for `ServiceCast` in both `java_support.go` and `java-support-readiness.yml`; the coverage `golden` file is refreshed.

## Test plan
- [x] `go vet ./... && golangci-lint run ./...` (0 issues).
- [x] `go test ./... -count=1` — full suite green.