### PR TITLE
refactor(rules): ShowToast gates on resolved Toast.makeText FQN

### DIFF
--- a/docs/java-support-readiness.yml
+++ b/docs/java-support-readiness.yml
@@ -403,6 +403,9 @@ rules:
   SetTextI18n:
     status: pending
     reason: Kotlin call_expression coverage only; Java method_invocation parity for TextView/Button receivers still needs implementation.
+  ShowToast:
+    status: pending
+    reason: Kotlin call_expression coverage only; Java method_invocation parity for Toast.makeText receivers still needs implementation.
   SimpleDateFormat:
     status: supported
     fixtures:

--- a/internal/cli/rules/testdata/coverage_java.golden
+++ b/internal/cli/rules/testdata/coverage_java.golden
@@ -6,8 +6,8 @@ AbstractClassCanBeInterface                     style                partial    
 
 Total: 784 rule(s)
   supported: 119
-  partial: 451
-  pending: 143
+  partial: 450
+  pending: 144
   needs-design: 0
   not-applicable: 50
   (unclassified): 21

--- a/internal/rules/android_source_test.go
+++ b/internal/rules/android_source_test.go
@@ -239,6 +239,80 @@ class Foo {
 	})
 }
 
+// Oracle resolves `Toast.makeText` to a non-Android callable → suppressed.
+func TestShowToast_OracleSuppressesNonAndroidToast(t *testing.T) {
+	findings := runShowToastWithCallTarget(t, `
+package test
+class Foo {
+    fun notify() {
+        Toast.makeText(context, "Hello", Toast.LENGTH_SHORT)
+    }
+}
+`, "Toast.makeText", "com.acme.local.Toast.makeText")
+	if len(findings) != 0 {
+		t.Fatalf("expected oracle to suppress non-Android Toast.makeText, got %d: %v", len(findings), findings)
+	}
+}
+
+// Oracle confirms android.widget.Toast.makeText → fires.
+func TestShowToast_OracleConfirmsAndroidToast(t *testing.T) {
+	findings := runShowToastWithCallTarget(t, `
+package test
+class Foo {
+    fun notify() {
+        Toast.makeText(context, "Hello", Toast.LENGTH_SHORT)
+    }
+}
+`, "Toast.makeText", "android.widget.Toast.makeText")
+	if len(findings) != 1 {
+		t.Fatalf("expected oracle-confirmed Toast.makeText to fire, got %d: %v", len(findings), findings)
+	}
+}
+
+func TestShowToast_DeclaresOracleCallTargets(t *testing.T) {
+	var rule *api.Rule
+	for _, r := range api.Registry {
+		if r.ID == "ShowToast" {
+			rule = r
+			break
+		}
+	}
+	if rule == nil {
+		t.Fatal("ShowToast rule not registered")
+	}
+	if !rule.Needs.Has(api.NeedsOracleCallTargets) {
+		t.Errorf("missing NeedsOracleCallTargets: Needs=%b", rule.Needs)
+	}
+	if rule.OracleCallTargets == nil || len(rule.OracleCallTargets.CalleeNames) == 0 {
+		t.Errorf("OracleCallTargets must list `makeText`, got %+v", rule.OracleCallTargets)
+	}
+}
+
+func runShowToastWithCallTarget(t *testing.T, code string, callText string, target string) []scanner.Finding {
+	t.Helper()
+	file := parseInline(t, code)
+	resolver := typeinfer.NewResolver()
+	resolver.IndexFilesParallel([]*scanner.File{file}, 1)
+	fake := oracle.NewFakeOracle()
+	fake.CallTargets[file.Path] = map[string]string{}
+	file.FlatWalkNodes(0, "call_expression", func(idx uint32) {
+		if strings.Contains(strings.TrimSpace(file.FlatNodeText(idx)), callText) {
+			key := fmt.Sprintf("%d:%d", file.FlatRow(idx)+1, file.FlatCol(idx)+1)
+			fake.CallTargets[file.Path][key] = target
+		}
+	})
+	composite := oracle.NewCompositeResolver(fake, resolver)
+	for _, r := range api.Registry {
+		if r.ID == "ShowToast" {
+			d := rules.NewDispatcher([]*api.Rule{r}, composite)
+			cols := d.Run(file)
+			return cols.Findings()
+		}
+	}
+	t.Fatalf("rule not found in registry")
+	return nil
+}
+
 func TestSparseArray(t *testing.T) {
 	t.Run("flags HashMap with Int key", func(t *testing.T) {
 		findings := runRuleByName(t, "UseSparseArrays", `

--- a/internal/rules/java_support.go
+++ b/internal/rules/java_support.go
@@ -131,6 +131,7 @@ var javaSupportReadiness = JavaSupportMatrix{
 		"ServiceCast":                          {Status: api.LanguageSupportPending, Reason: "Kotlin as_expression coverage only; Java cast-expression parity for getSystemService receivers still needs implementation."},
 		"SetJavaScriptEnabled":                 {Status: api.LanguageSupportSupported, Fixtures: []string{"internal/rules/android_base_test.go"}},
 		"SetTextI18n":                          {Status: api.LanguageSupportPending, Reason: "Kotlin call_expression coverage only; Java method_invocation parity for TextView/Button receivers still needs implementation."},
+		"ShowToast":                            {Status: api.LanguageSupportPending, Reason: "Kotlin call_expression coverage only; Java method_invocation parity for Toast.makeText receivers still needs implementation."},
 		"SimpleDateFormat":                     {Status: api.LanguageSupportSupported, Fixtures: []string{"internal/rules/android_correctness_test.go"}},
 		"SpacingAfterPackageAndImports":        {Status: api.LanguageSupportSupported, Fixtures: []string{"tests/fixtures/fixable/per-rule/SpacingAfterPackageAndImports.java"}},
 		"StaticIv":                             {Status: api.LanguageSupportSupported, Fixtures: []string{"internal/rules/android_security_test.go"}},

--- a/internal/rules/registry_android_source.go
+++ b/internal/rules/registry_android_source.go
@@ -25,6 +25,21 @@ func serviceCastOracleConfirmed(lookup oracle.Lookup, file *scanner.File, call u
 		target == "androidx.core.content.ContextCompat.getSystemService"
 }
 
+// showToastOracleConfirmed accepts when the oracle is silent or
+// resolves `Toast.makeText(...)` to `android.widget.Toast.makeText`.
+// A project-local `Toast` class with a `makeText` factory resolves
+// to a different FQN and is filtered out.
+func showToastOracleConfirmed(lookup oracle.Lookup, file *scanner.File, idx uint32) bool {
+	if lookup == nil {
+		return true
+	}
+	target := oracleLookupCallTargetFlat(lookup, file, idx)
+	if target == "" {
+		return true
+	}
+	return target == "android.widget.Toast.makeText"
+}
+
 func registerAndroidSourceRules() {
 
 	// --- from android_source.go ---
@@ -154,6 +169,11 @@ func registerAndroidSourceRules() {
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Description(), Sev: api.Severity(r.Sev),
 			NodeTypes: []string{"call_expression"}, Confidence: 0.85, Implementation: r,
+			Needs: api.NeedsTypeInfo | api.NeedsOracleCallTargets,
+			OracleCallTargets: &api.OracleCallTargetFilter{
+				CalleeNames: []string{"makeText"},
+			},
+			OracleDeclarationNeeds: &api.OracleDeclarationProfile{},
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				if flatCallExpressionName(file, idx) != "makeText" {
@@ -163,6 +183,14 @@ func registerAndroidSourceRules() {
 					return
 				}
 				if toastMakeTextIsShown(file, idx) {
+					return
+				}
+				// Gate on resolved call-target FQN; falls back to AST evidence when oracle is silent.
+				var oracleLookup oracle.Lookup
+				if cr, ok := ctx.Resolver.(*oracle.CompositeResolver); ok {
+					oracleLookup = cr.Oracle()
+				}
+				if !showToastOracleConfirmed(oracleLookup, file, idx) {
 					return
 				}
 				ctx.EmitAt(file.FlatRow(idx)+1, 1,


### PR DESCRIPTION
## Summary
Migrates `ShowToast` from pure AST token matching to consume the oracle's resolved call-target FQN. The rule fires only when `Toast.makeText(...)` resolves to `android.widget.Toast.makeText`. Project-local `Toast` classes (mocks, custom UI utilities) are suppressed.

**Fourth of six tier-1 Android oracle migrations**.

## Changes
- `Needs` adds `NeedsTypeInfo | NeedsOracleCallTargets`.
- `OracleCallTargetFilter{CalleeNames: ["makeText"]}` narrows the JVM-side call-target index.
- Empty `OracleDeclarationProfile`.
- `showToastOracleConfirmed` accepts when oracle is silent OR resolves to `android.widget.Toast.makeText`.

## Tests
- `…_OracleSuppressesNonAndroidToast` — non-Android callTarget → no finding.
- `…_OracleConfirmsAndroidToast` — Android callTarget → fires.
- `…_DeclaresOracleCallTargets` — pins capability + filter wiring.

Java support classified as `pending`; coverage `golden` refreshed.

## Test plan
- [x] `go vet ./... && golangci-lint run ./...` (0 issues).
- [x] `go test ./... -count=1` — full suite green.