### PR TITLE
refactor(rules): CheckResult gates on resolved callee FQN

### DIFF
--- a/internal/rules/android_correctness_test.go
+++ b/internal/rules/android_correctness_test.go
@@ -750,6 +750,76 @@ class Strings {
 	})
 }
 
+// Oracle resolves `.replace(...)` to a non-String callable → suppressed.
+func TestCheckResult_OracleSuppressesNonStringReplace(t *testing.T) {
+	findings := runCheckResultWithCallTarget(t, `
+package test
+fun example(value: MutableValue) {
+    value.replace("a", "b")
+}
+`, "value.replace", "com.acme.MutableValue.replace")
+	if len(findings) != 0 {
+		t.Fatalf("expected oracle to suppress non-String replace, got %d: %v", len(findings), findings)
+	}
+}
+
+// Oracle confirms kotlin.text.StringsKt.format → fires.
+func TestCheckResult_OracleConfirmsStringFormat(t *testing.T) {
+	findings := runCheckResultWithCallTarget(t, `
+package test
+fun example() {
+    String.format("hello %s", "world")
+}
+`, "String.format", "kotlin.text.StringsKt.format")
+	if len(findings) != 1 {
+		t.Fatalf("expected oracle-confirmed StringsKt.format to fire, got %d: %v", len(findings), findings)
+	}
+}
+
+func TestCheckResult_DeclaresOracleCallTargets(t *testing.T) {
+	var rule *api.Rule
+	for _, r := range api.Registry {
+		if r.ID == "CheckResult" {
+			rule = r
+			break
+		}
+	}
+	if rule == nil {
+		t.Fatal("CheckResult rule not registered")
+	}
+	if !rule.Needs.Has(api.NeedsOracleCallTargets) {
+		t.Errorf("missing NeedsOracleCallTargets: Needs=%b", rule.Needs)
+	}
+	if rule.OracleCallTargets == nil || len(rule.OracleCallTargets.CalleeNames) == 0 {
+		t.Errorf("OracleCallTargets must list the watched callees, got %+v", rule.OracleCallTargets)
+	}
+}
+
+func runCheckResultWithCallTarget(t *testing.T, code string, callText string, target string) []scanner.Finding {
+	t.Helper()
+	file := parseInline(t, code)
+	resolver := typeinfer.NewResolver()
+	resolver.IndexFilesParallel([]*scanner.File{file}, 1)
+	fake := oracle.NewFakeOracle()
+	fake.CallTargets[file.Path] = map[string]string{}
+	file.FlatWalkNodes(0, "call_expression", func(idx uint32) {
+		if strings.Contains(strings.TrimSpace(file.FlatNodeText(idx)), callText) {
+			key := fmt.Sprintf("%d:%d", file.FlatRow(idx)+1, file.FlatCol(idx)+1)
+			fake.CallTargets[file.Path][key] = target
+		}
+	})
+	composite := oracle.NewCompositeResolver(fake, resolver)
+	for _, r := range api.Registry {
+		if r.ID == "CheckResult" {
+			d := rules.NewDispatcher([]*api.Rule{r}, composite)
+			cols := d.Run(file)
+			return cols.Findings()
+		}
+	}
+	t.Fatalf("rule not found in registry")
+	return nil
+}
+
 // ---------------------------------------------------------------------------
 // ShiftFlags (CheckLines)
 // ---------------------------------------------------------------------------

--- a/internal/rules/registry_android_correctness.go
+++ b/internal/rules/registry_android_correctness.go
@@ -248,8 +248,13 @@ func registerAndroidCorrectnessCheckResult() {
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Description(), Sev: api.Severity(r.Sev),
 		NodeTypes: []string{"call_expression", "method_invocation"},
 		Languages: []scanner.Language{scanner.LangKotlin, scanner.LangJava}, Confidence: 0.8, Implementation: r,
-		JavaFacts:         &api.JavaFactProfile{ReturnTypesForCallees: []string{"animate", "buildUpon", "edit", "format", "trim", "replace"}},
-		NeedsLibraryFacts: true,
+		Needs: api.NeedsTypeInfo | api.NeedsOracleCallTargets,
+		OracleCallTargets: &api.OracleCallTargetFilter{
+			CalleeNames: []string{"animate", "buildUpon", "edit", "format", "trim", "replace"},
+		},
+		OracleDeclarationNeeds: &api.OracleDeclarationProfile{},
+		JavaFacts:              &api.JavaFactProfile{ReturnTypesForCallees: []string{"animate", "buildUpon", "edit", "format", "trim", "replace"}},
+		NeedsLibraryFacts:      true,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			if strings.HasSuffix(file.Path, ".gradle.kts") {
@@ -271,10 +276,76 @@ func registerAndroidCorrectnessCheckResult() {
 			if name == "format" && !isReceiverNamed(file, idx, "String") {
 				return
 			}
+			// Gate on resolved call-target FQN; falls back to AST evidence when oracle is silent.
+			var oracleLookup oracle.Lookup
+			if cr, ok := ctx.Resolver.(*oracle.CompositeResolver); ok {
+				oracleLookup = cr.Oracle()
+			}
+			if !checkResultOracleConfirmed(oracleLookup, file, idx, name) {
+				return
+			}
 			ctx.EmitAt(file.FlatRow(idx)+1, 1,
 				"The result of this call is not used. Check if the return value should be consumed.")
 		},
 	})
+}
+
+// checkResultOracleConfirmed accepts when the oracle is silent or
+// the resolved call-target FQN matches a known API whose return
+// value should not be discarded. Project-local methods with the
+// same simple names (e.g. a builder DSL's `replace()` that mutates
+// in place) resolve to a different FQN and are filtered out.
+func checkResultOracleConfirmed(lookup oracle.Lookup, file *scanner.File, idx uint32, name string) bool {
+	if lookup == nil {
+		return true
+	}
+	target := oracleLookupCallTargetFlat(lookup, file, idx)
+	if target == "" {
+		return true
+	}
+	expected, ok := checkResultExpectedFQNs[name]
+	if !ok {
+		return true
+	}
+	for _, fqn := range expected {
+		if target == fqn {
+			return true
+		}
+	}
+	return false
+}
+
+// checkResultExpectedFQNs maps each watched callee name to the
+// concrete library FQN(s) whose ignored return values are bugs.
+// Order is the most likely real call first; the list short-circuits
+// on first match.
+var checkResultExpectedFQNs = map[string][]string{
+	"format": {
+		"kotlin.text.StringsKt.format",
+		"java.lang.String.format",
+	},
+	"trim": {
+		"kotlin.text.StringsKt.trim",
+		"kotlin.CharSequence.trim",
+		"kotlin.String.trim",
+		"java.lang.String.trim",
+	},
+	"replace": {
+		"kotlin.text.StringsKt.replace",
+		"kotlin.text.replace",
+		"java.lang.String.replace",
+	},
+	"animate": {
+		"android.view.View.animate",
+	},
+	"buildUpon": {
+		"android.net.Uri.buildUpon",
+	},
+	"edit": {
+		"android.content.SharedPreferences.edit",
+		"androidx.core.content.SharedPreferencesKt.edit",
+		"androidx.core.content.ContextKt.edit",
+	},
 }
 
 func registerAndroidCorrectnessShiftFlags() {


### PR DESCRIPTION
## Summary
Migrates the Kotlin path of `CheckResult` from pure AST token matching to consume the oracle's resolved call-target FQN. The rule fires only when the discarded-result call resolves to a concrete library FQN whose return value is meant to be consumed (`StringsKt.format`, `String.replace`, `View.animate`, `Uri.buildUpon`, `SharedPreferences.edit`, etc.). Project-local methods with the same simple names resolve to a different FQN and are filtered out.

**Fifth of six tier-1 Android oracle migrations**.

## Changes
- `Needs` adds `NeedsTypeInfo | NeedsOracleCallTargets`.
- `OracleCallTargetFilter{CalleeNames: ["animate", "buildUpon", "edit", "format", "trim", "replace"]}` narrows the JVM-side call-target index.
- Empty `OracleDeclarationProfile`.
- `checkResultOracleConfirmed` + `checkResultExpectedFQNs` accept when the oracle is silent OR the resolved target matches one of the library FQNs whose return value should not be discarded.
- Java path retains its existing `JavaFacts` semantic-call gate.

## Tests
- `…_OracleSuppressesNonStringReplace` — non-String callTarget → no finding.
- `…_OracleConfirmsStringFormat` — StringsKt callTarget → fires.
- `…_DeclaresOracleCallTargets` — pins capability + filter wiring.

CheckResult already has `Supported` Java classification; no java_support.go / yaml / golden updates needed.

## Test plan
- [x] `go vet ./... && golangci-lint run ./...` (0 issues).
- [x] `go test ./... -count=1` — full suite green.