### PR TITLE
refactor(rules): LongLogTag/LogTagMismatch gate on resolved Log FQN

### DIFF
--- a/docs/java-support-readiness.yml
+++ b/docs/java-support-readiness.yml
@@ -322,6 +322,12 @@ rules:
     status: supported
     fixtures:
       - internal/rules/security_test.go
+  LogTagMismatch:
+    status: pending
+    reason: Kotlin class_declaration coverage only; Java parity for class-bodied TAG/Log.x callers still needs implementation.
+  LongLogTag:
+    status: pending
+    reason: Kotlin call_expression coverage only; Java method_invocation parity for android.util.Log receivers still needs implementation.
   MaxChainedCallsOnSameLine:
     status: supported
     fixtures:

--- a/internal/cli/rules/testdata/coverage_java.golden
+++ b/internal/cli/rules/testdata/coverage_java.golden
@@ -6,8 +6,8 @@ AbstractClassCanBeInterface                     style                partial    
 
 Total: 784 rule(s)
   supported: 119
-  partial: 450
-  pending: 144
+  partial: 448
+  pending: 146
   needs-design: 0
   not-applicable: 50
   (unclassified): 21

--- a/internal/rules/android_source_misc_test.go
+++ b/internal/rules/android_source_misc_test.go
@@ -1,8 +1,11 @@
 package rules_test
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 
+	"github.com/kaeawc/krit/internal/oracle"
 	"github.com/kaeawc/krit/internal/rules"
 	api "github.com/kaeawc/krit/internal/rules/api"
 	"github.com/kaeawc/krit/internal/scanner"
@@ -201,6 +204,121 @@ class PaymentFragment {
 			t.Fatal("expected finding for mismatched ::class.java.simpleName")
 		}
 	})
+}
+
+// Oracle resolves the Log call to a non-Android callable → suppressed.
+func TestLongLogTag_OracleSuppressesNonAndroidLog(t *testing.T) {
+	findings := runLogTagWithCallTarget(t, "LongLogTag", `
+package test
+fun foo() {
+    Log.d("ThisIsAVeryLongTagNameThatExceeds", "msg")
+}
+`, "Log.d", "com.acme.local.Log.d")
+	if len(findings) != 0 {
+		t.Fatalf("expected oracle to suppress non-Android Log.d, got %d: %v", len(findings), findings)
+	}
+}
+
+// Oracle confirms android.util.Log.d → fires.
+func TestLongLogTag_OracleConfirmsAndroidLog(t *testing.T) {
+	findings := runLogTagWithCallTarget(t, "LongLogTag", `
+package test
+fun foo() {
+    Log.d("ThisIsAVeryLongTagNameThatExceeds", "msg")
+}
+`, "Log.d", "android.util.Log.d")
+	if len(findings) != 1 {
+		t.Fatalf("expected oracle-confirmed Log.d to fire, got %d: %v", len(findings), findings)
+	}
+}
+
+func TestLongLogTag_DeclaresOracleCallTargets(t *testing.T) {
+	assertLogTagOracleCapability(t, "LongLogTag")
+}
+
+// Oracle resolves the Log.d(TAG, …) call to a non-Android callable → suppressed.
+func TestLogTagMismatch_OracleSuppressesNonAndroidLog(t *testing.T) {
+	findings := runLogTagWithCallTarget(t, "LogTagMismatch", `
+package test
+class MyActivity {
+    companion object {
+        const val TAG = "WrongName"
+    }
+    fun foo() {
+        Log.d(TAG, "message")
+    }
+}
+`, "Log.d", "com.acme.local.Log.d")
+	if len(findings) != 0 {
+		t.Fatalf("expected oracle to suppress non-Android Log.d, got %d: %v", len(findings), findings)
+	}
+}
+
+// Oracle confirms android.util.Log.d → fires.
+func TestLogTagMismatch_OracleConfirmsAndroidLog(t *testing.T) {
+	findings := runLogTagWithCallTarget(t, "LogTagMismatch", `
+package test
+class MyActivity {
+    companion object {
+        const val TAG = "WrongName"
+    }
+    fun foo() {
+        Log.d(TAG, "message")
+    }
+}
+`, "Log.d", "android.util.Log.d")
+	if len(findings) != 1 {
+		t.Fatalf("expected oracle-confirmed Log.d to fire, got %d: %v", len(findings), findings)
+	}
+}
+
+func TestLogTagMismatch_DeclaresOracleCallTargets(t *testing.T) {
+	assertLogTagOracleCapability(t, "LogTagMismatch")
+}
+
+func assertLogTagOracleCapability(t *testing.T, ruleID string) {
+	t.Helper()
+	var rule *api.Rule
+	for _, r := range api.Registry {
+		if r.ID == ruleID {
+			rule = r
+			break
+		}
+	}
+	if rule == nil {
+		t.Fatalf("%s rule not registered", ruleID)
+	}
+	if !rule.Needs.Has(api.NeedsOracleCallTargets) {
+		t.Errorf("%s missing NeedsOracleCallTargets: Needs=%b", ruleID, rule.Needs)
+	}
+	if rule.OracleCallTargets == nil || len(rule.OracleCallTargets.CalleeNames) == 0 {
+		t.Errorf("%s OracleCallTargets must list Log level names, got %+v", ruleID, rule.OracleCallTargets)
+	}
+}
+
+func runLogTagWithCallTarget(t *testing.T, ruleID, code, callText, target string) []scanner.Finding {
+	t.Helper()
+	file := parseInline(t, code)
+	resolver := typeinfer.NewResolver()
+	resolver.IndexFilesParallel([]*scanner.File{file}, 1)
+	fake := oracle.NewFakeOracle()
+	fake.CallTargets[file.Path] = map[string]string{}
+	file.FlatWalkNodes(0, "call_expression", func(idx uint32) {
+		if strings.Contains(strings.TrimSpace(file.FlatNodeText(idx)), callText) {
+			key := fmt.Sprintf("%d:%d", file.FlatRow(idx)+1, file.FlatCol(idx)+1)
+			fake.CallTargets[file.Path][key] = target
+		}
+	})
+	composite := oracle.NewCompositeResolver(fake, resolver)
+	for _, r := range api.Registry {
+		if r.ID == ruleID {
+			d := rules.NewDispatcher([]*api.Rule{r}, composite)
+			cols := d.Run(file)
+			return cols.Findings()
+		}
+	}
+	t.Fatalf("rule %s not found in registry", ruleID)
+	return nil
 }
 
 // =====================================================================

--- a/internal/rules/java_support.go
+++ b/internal/rules/java_support.go
@@ -110,6 +110,8 @@ var javaSupportReadiness = JavaSupportMatrix{
 		"JacksonDefaultTyping":                 {Status: api.LanguageSupportSupported, Fixtures: []string{"internal/rules/security_test.go"}},
 		"JdbcStatementExecute":                 {Status: api.LanguageSupportSupported, Fixtures: []string{"internal/rules/security_test.go"}},
 		"LogPii":                               {Status: api.LanguageSupportSupported, Fixtures: []string{"internal/rules/security_test.go"}},
+		"LogTagMismatch":                       {Status: api.LanguageSupportPending, Reason: "Kotlin class_declaration coverage only; Java parity for class-bodied TAG/Log.x callers still needs implementation."},
+		"LongLogTag":                           {Status: api.LanguageSupportPending, Reason: "Kotlin call_expression coverage only; Java method_invocation parity for android.util.Log receivers still needs implementation."},
 		"MaxChainedCallsOnSameLine":            {Status: api.LanguageSupportSupported, Fixtures: []string{"internal/rules/style_format_test.go"}},
 		"MaxLineLength":                        {Status: api.LanguageSupportSupported, Fixtures: []string{"internal/rules/style_format_test.go"}},
 		"MissingPackageDeclaration":            {Status: api.LanguageSupportSupported, Fixtures: []string{"internal/rules/potentialbugs_lifecycle_test.go"}},

--- a/internal/rules/registry_android_source.go
+++ b/internal/rules/registry_android_source.go
@@ -40,6 +40,21 @@ func showToastOracleConfirmed(lookup oracle.Lookup, file *scanner.File, idx uint
 	return target == "android.widget.Toast.makeText"
 }
 
+// logCallOracleConfirmed accepts when the oracle is silent or resolves
+// the `.v/.d/.i/.w/.e/.wtf(...)` call to `android.util.Log.<level>`.
+// A project-local `Log` class with the same level-named methods
+// resolves to a different FQN and is filtered out.
+func logCallOracleConfirmed(lookup oracle.Lookup, file *scanner.File, call uint32) bool {
+	if lookup == nil {
+		return true
+	}
+	target := oracleLookupCallTargetFlat(lookup, file, call)
+	if target == "" {
+		return true
+	}
+	return strings.HasPrefix(target, "android.util.Log.")
+}
+
 func registerAndroidSourceRules() {
 
 	// --- from android_source.go ---
@@ -322,6 +337,11 @@ func registerAndroidSourceRules() {
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Description(), Sev: api.Severity(r.Sev),
 			NodeTypes: []string{"call_expression"}, Confidence: 0.75, Implementation: r,
+			Needs: api.NeedsTypeInfo | api.NeedsOracleCallTargets,
+			OracleCallTargets: &api.OracleCallTargetFilter{
+				CalleeNames: []string{"v", "d", "i", "w", "e", "wtf"},
+			},
+			OracleDeclarationNeeds: &api.OracleDeclarationProfile{},
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				if !isReceiverNamed(file, idx, "Log") || !logMethodNames[flatCallExpressionName(file, idx)] {
@@ -334,10 +354,19 @@ func registerAndroidSourceRules() {
 				if !ok {
 					return
 				}
-				if len(tag) > 23 {
-					ctx.EmitAt(file.FlatRow(idx)+1, 1,
-						"Log tag \""+tag+"\" exceeds the 23 character limit.")
+				if len(tag) <= 23 {
+					return
 				}
+				// Gate on resolved call-target FQN; falls back to AST evidence when oracle is silent.
+				var oracleLookup oracle.Lookup
+				if cr, ok := ctx.Resolver.(*oracle.CompositeResolver); ok {
+					oracleLookup = cr.Oracle()
+				}
+				if !logCallOracleConfirmed(oracleLookup, file, idx) {
+					return
+				}
+				ctx.EmitAt(file.FlatRow(idx)+1, 1,
+					"Log tag \""+tag+"\" exceeds the 23 character limit.")
 			},
 		})
 	}
@@ -351,6 +380,11 @@ func registerAndroidSourceRules() {
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Description(), Sev: api.Severity(r.Sev),
 			NodeTypes: []string{"class_declaration"}, Confidence: 0.75, Implementation: r,
+			Needs: api.NeedsTypeInfo | api.NeedsOracleCallTargets,
+			OracleCallTargets: &api.OracleCallTargetFilter{
+				CalleeNames: []string{"v", "d", "i", "w", "e", "wtf"},
+			},
+			OracleDeclarationNeeds: &api.OracleDeclarationProfile{},
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				if scanner.IsTestFile(file.Path) {
@@ -375,6 +409,10 @@ func registerAndroidSourceRules() {
 				// nodes in the class body instead of regex-scanning the whole
 				// class text — the regex version matched `Log.d(TAG, x)`
 				// inside string literals or comments in unrelated methods.
+				var oracleLookup oracle.Lookup
+				if cr, ok := ctx.Resolver.(*oracle.CompositeResolver); ok {
+					oracleLookup = cr.Oracle()
+				}
 				classUsesTagInLog := false
 				file.FlatWalkNodes(idx, "call_expression", func(call uint32) {
 					if classUsesTagInLog {
@@ -389,9 +427,13 @@ func registerAndroidSourceRules() {
 					args := flatCallKeyArguments(file, call)
 					firstArg := flatPositionalValueArgument(file, args, 0)
 					expr := flatValueArgumentExpression(file, firstArg)
-					if expr != 0 && file.FlatType(expr) == "simple_identifier" && file.FlatNodeText(expr) == "TAG" {
-						classUsesTagInLog = true
+					if expr == 0 || file.FlatType(expr) != "simple_identifier" || file.FlatNodeText(expr) != "TAG" {
+						return
 					}
+					if !logCallOracleConfirmed(oracleLookup, file, call) {
+						return
+					}
+					classUsesTagInLog = true
 				})
 				if !classUsesTagInLog {
 					return


### PR DESCRIPTION
## Summary
- LongLogTag and LogTagMismatch previously relied on AST-only `Log.<level>(…)` matching, which produced false positives whenever a project-local `Log` class shadowed `android.util.Log` with the same level-named methods.
- Both rules now declare `NeedsTypeInfo | NeedsOracleCallTargets` with the level callee names (`v`, `d`, `i`, `w`, `e`, `wtf`) and consult the oracle to confirm the resolved call target is rooted at `android.util.Log.` before emitting. Source-only callers are unaffected — the check still fires when the oracle is silent.
- Records pending Java parity in both `java_support.go` and `docs/java-support-readiness.yml`, refreshes the coverage golden, and adds oracle positive/negative + capability declaration tests for each rule.

This is tier-1 item 6 of the Android oracle migration set; follow-ups continue from PRs #523/#525/#526/#528/#529/#530/#531/#532.

## Test plan
- [x] \`go test ./internal/rules/ -run 'LogTag|LongLogTag' -count=1\`
- [x] \`go vet ./...\`
- [x] \`golangci-lint run ./...\`
- [x] \`make lint-rules\`
- [x] \`KRIT_UPDATE_GOLDEN=1 go test ./internal/cli/rules/ -count=1\`