### PR TITLE
fix(pipeline): re-emit module-aware findings on warm rerun

### DIFF
--- a/internal/pipeline/warm_path.go
+++ b/internal/pipeline/warm_path.go
@@ -70,7 +70,17 @@ func RulesNeedParsedSource(activeRules []*api.Rule, allowCrossFileWithoutParsed 
 	}
 	if (!allowCrossFileWithoutParsed && caps.Has(api.NeedsParsedFiles)) ||
 		(!allowCrossFileWithoutParsed && caps.Has(api.NeedsCrossFile)) ||
-		caps.Has(api.NeedsAggregate) {
+		caps.Has(api.NeedsAggregate) ||
+		caps.Has(api.NeedsModuleIndex) {
+		// NeedsModuleIndex rules (ModuleDeadCode, PackageDependencyCycle,
+		// VersionCatalogUnused, ...) build their per-module index from
+		// parseResult.SourceFiles(). On a warm rerun with no source
+		// changes the cache-miss-only parse path leaves SourceFiles
+		// empty, the per-module ModuleFiles map ends up empty, and the
+		// module-aware phase silently emits zero findings even though
+		// the cached global code index still holds every symbol. Treat
+		// module-aware rules as needing parsed source so the warm path
+		// re-parses on rerun.
 		return true
 	}
 	return api.NeedsJavaFacts(activeRules)

--- a/internal/pipeline/warm_path_test.go
+++ b/internal/pipeline/warm_path_test.go
@@ -1,0 +1,32 @@
+package pipeline
+
+import (
+	"testing"
+
+	"github.com/kaeawc/krit/internal/cache"
+	api "github.com/kaeawc/krit/internal/rules/api"
+)
+
+// TestRulesNeedParsedSource_ModuleIndexForcesParsedSource is the
+// regression guard for the warm-rerun module-aware finding drop. Before
+// the fix, a rule that only declared NeedsModuleIndex took the
+// cache-miss-only parse path on warm reruns; with zero misses
+// parseResult.SourceFiles() was empty, the per-module ModuleFiles map
+// was empty, and module-aware findings (ModuleDeadCode,
+// PackageDependencyCycle, VersionCatalogUnused, ...) silently dropped
+// to zero. The fix treats module-aware rules as needing parsed source
+// so the warm path re-parses on rerun.
+func TestRulesNeedParsedSource_ModuleIndexForcesParsedSource(t *testing.T) {
+	moduleRule := api.FakeRule("ModuleAware", api.WithNeeds(api.NeedsModuleIndex))
+	if !RulesNeedParsedSource([]*api.Rule{moduleRule}, true, true) {
+		t.Fatal("NeedsModuleIndex rule must force parsed source on warm rerun; otherwise the per-module index sees an empty file set and emits zero findings")
+	}
+	cacheResult := &cache.Result{
+		TotalCached: 1,
+		TotalFiles:  1,
+		CachedPaths: map[string]bool{"a.kt": true},
+	}
+	if CanParseOnlyCacheMisses([]*api.Rule{moduleRule}, cacheResult, true, true, true) {
+		t.Fatal("CanParseOnlyCacheMisses must return false for NeedsModuleIndex rules")
+	}
+}


### PR DESCRIPTION
## Summary
\`NeedsModuleIndex\` rules (ModuleDeadCode, PackageDependencyCycle, VersionCatalogUnused, ...) silently dropped to zero findings on a warm rerun whenever no other rule independently forced parsed source. The warm path's cache-miss-only parse short-circuit (\`CanParseOnlyCacheMisses\` → \`RulesNeedParsedSource\`) treated module-aware rules as cacheable, so on a no-change rerun \`parseResult.SourceFiles()\` came back empty. Module index construction then saw an empty file set, the per-module \`ModuleFiles\` map ended up empty, and module-aware rules emitted nothing — even though the cached global code index still held every symbol.

## Repro

Against \`~/kaeawc/android-build\` (47 .kt files), invoking with any flag set that didn't activate another parsed-source rule (e.g. \`--oracle-backend kaa\`):

| Run | Before fix | After fix |
|---|---:|---:|
| Cold (\`--clear-cache\` then run) | 142 findings | 142 findings |
| Warm rerun | **95 findings** (47 module-aware lost) | 142 findings |

The 47-finding gap was deterministically 46× \`ModuleDeadCode\` + 1× \`PackageDependencyCycle\` — exactly the rules that depend on \`pmi.ModuleFiles\` being populated.

## Fix
\`RulesNeedParsedSource\` now returns true when any active rule declares \`NeedsModuleIndex\`. The warm path re-parses on rerun for these rules, restoring correctness. Speedup is preserved for project configurations without module-aware rules active.

## Test plan
- [x] New: \`TestRulesNeedParsedSource_ModuleIndexForcesParsedSource\` asserts the gate flips for \`NeedsModuleIndex\` and that \`CanParseOnlyCacheMisses\` returns false in the same shape.
- [x] \`go test ./internal/pipeline/ -count=1\`
- [x] \`go test ./... -count=1 -timeout 600s\` (full suite green)
- [x] \`go vet ./...\` / \`golangci-lint run ./...\`
- [x] End-to-end repro against android-build: cold=142, warm=142 after fix.