### PR TITLE
refactor(rules): replace magic confidence floats with named tier constants

### DIFF
--- a/internal/rules/accessibility.go
+++ b/internal/rules/accessibility.go
@@ -23,7 +23,7 @@ type AnimatorDurationIgnoresScaleRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Accessibility rule. Detection matches on Compose/View API call shapes
 // and argument labels by name rather than by resolved type. Classified per
 // roadmap/17.
-func (r *AnimatorDurationIgnoresScaleRule) Confidence() float64 { return 0.75 }
+func (r *AnimatorDurationIgnoresScaleRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func animatorDurationScaleReferenced(ctx *api.Context, anchor uint32) bool {
 	if ctx.File == nil {
@@ -237,7 +237,7 @@ type ComposeClickableWithoutMinTouchTargetRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Accessibility rule. Detection matches on Compose/View API call shapes
 // and argument labels by name rather than by resolved type. Classified per
 // roadmap/17.
-func (r *ComposeClickableWithoutMinTouchTargetRule) Confidence() float64 { return 0.75 }
+func (r *ComposeClickableWithoutMinTouchTargetRule) Confidence() float64 { return api.ConfidenceMedium }
 
 type composeModifierCall struct {
 	name string
@@ -415,7 +415,9 @@ type ComposeDecorativeImageContentDescriptionRule struct {
 	BaseRule
 }
 
-func (r *ComposeDecorativeImageContentDescriptionRule) Confidence() float64 { return 0.75 }
+func (r *ComposeDecorativeImageContentDescriptionRule) Confidence() float64 {
+	return api.ConfidenceMedium
+}
 
 var composeImageCallNames = map[string]bool{
 	"Image":      true,
@@ -431,7 +433,9 @@ type ComposeIconButtonMissingContentDescriptionRule struct {
 	BaseRule
 }
 
-func (r *ComposeIconButtonMissingContentDescriptionRule) Confidence() float64 { return 0.75 }
+func (r *ComposeIconButtonMissingContentDescriptionRule) Confidence() float64 {
+	return api.ConfidenceMedium
+}
 
 var composeContentDescriptionCalls = map[string]bool{
 	"Icon":       true,
@@ -600,7 +604,7 @@ type ComposeRawTextLiteralRule struct {
 	CustomPreviewPrefixes []string
 }
 
-func (r *ComposeRawTextLiteralRule) Confidence() float64 { return 0.75 }
+func (r *ComposeRawTextLiteralRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func composeRawTextLiteralNonProductionFile(path string) bool {
 	if scanner.IsTestFile(path) {
@@ -628,7 +632,7 @@ type ComposeSemanticsMissingRoleRule struct {
 	CustomPreviewPrefixes []string
 }
 
-func (r *ComposeSemanticsMissingRoleRule) Confidence() float64 { return 0.75 }
+func (r *ComposeSemanticsMissingRoleRule) Confidence() float64 { return api.ConfidenceMedium }
 
 var composeInteractionModifiers = map[string]bool{
 	"clickable":  true,
@@ -654,7 +658,7 @@ type ComposeTextFieldMissingLabelRule struct {
 	BaseRule
 }
 
-func (r *ComposeTextFieldMissingLabelRule) Confidence() float64 { return 0.75 }
+func (r *ComposeTextFieldMissingLabelRule) Confidence() float64 { return api.ConfidenceMedium }
 
 var composeTextFieldCalls = map[string]bool{
 	"TextField":         true,
@@ -690,7 +694,7 @@ type ToastForAccessibilityAnnouncementRule struct {
 	BaseRule
 }
 
-func (r *ToastForAccessibilityAnnouncementRule) Confidence() float64 { return 0.75 }
+func (r *ToastForAccessibilityAnnouncementRule) Confidence() float64 { return api.ConfidenceMedium }
 
 var a11yFunctionPatterns = []string{
 	"accessibility", "announce", "a11y",

--- a/internal/rules/android.go
+++ b/internal/rules/android.go
@@ -94,7 +94,7 @@ type ContentDescriptionRule struct {
 // lists of API names) rather than type resolution, so project-
 // specific wrapper APIs can cause false positives or negatives.
 // Classified per roadmap/17.
-func (r *ContentDescriptionRule) Confidence() float64 { return 0.75 }
+func (r *ContentDescriptionRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // HardcodedTextRule detects hardcoded strings that should use resources.
 type HardcodedTextRule struct {
@@ -108,7 +108,7 @@ type HardcodedTextRule struct {
 // lists of API names) rather than type resolution, so project-
 // specific wrapper APIs can cause false positives or negatives.
 // Classified per roadmap/17.
-func (r *HardcodedTextRule) Confidence() float64 { return 0.75 }
+func (r *HardcodedTextRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // hardcodedTextAndroidImportPrefixes are the import package prefixes
 // that signal a file participates in Android UI / Compose code. The
@@ -298,7 +298,7 @@ type LogDetectorRule struct {
 // lists of API names) rather than type resolution, so project-
 // specific wrapper APIs can cause false positives or negatives.
 // Classified per roadmap/17.
-func (r *LogDetectorRule) Confidence() float64 { return 0.75 }
+func (r *LogDetectorRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // SdCardPathRule detects hardcoded /sdcard paths.
 type SdCardPathRule struct {
@@ -312,7 +312,7 @@ type SdCardPathRule struct {
 // lists of API names) rather than type resolution, so project-
 // specific wrapper APIs can cause false positives or negatives.
 // Classified per roadmap/17.
-func (r *SdCardPathRule) Confidence() float64 { return 0.75 }
+func (r *SdCardPathRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // WakelockRule detects WakeLock usage without proper release.
 type WakelockRule struct {
@@ -326,7 +326,7 @@ type WakelockRule struct {
 // lists of API names) rather than type resolution, so project-
 // specific wrapper APIs can cause false positives or negatives.
 // Classified per roadmap/17.
-func (r *WakelockRule) Confidence() float64 { return 0.75 }
+func (r *WakelockRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // SetJavaScriptEnabledRule detects setJavaScriptEnabled(true) calls.
 type SetJavaScriptEnabledRule struct {
@@ -340,7 +340,7 @@ type SetJavaScriptEnabledRule struct {
 // lists of API names) rather than type resolution, so project-
 // specific wrapper APIs can cause false positives or negatives.
 // Classified per roadmap/17.
-func (r *SetJavaScriptEnabledRule) Confidence() float64 { return 0.75 }
+func (r *SetJavaScriptEnabledRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // ExportedServiceRule detects exported services without permission.
 type ExportedServiceRule struct {
@@ -354,7 +354,7 @@ type ExportedServiceRule struct {
 // lists of API names) rather than type resolution, so project-
 // specific wrapper APIs can cause false positives or negatives.
 // Classified per roadmap/17.
-func (r *ExportedServiceRule) Confidence() float64 { return 0.75 }
+func (r *ExportedServiceRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *ExportedServiceRule) check(ctx *api.Context) {
 	file, idx := ctx.File, ctx.Idx
@@ -380,7 +380,7 @@ type PrivateKeyRule struct {
 // lists of API names) rather than type resolution, so project-
 // specific wrapper APIs can cause false positives or negatives.
 // Classified per roadmap/17.
-func (r *PrivateKeyRule) Confidence() float64 { return 0.75 }
+func (r *PrivateKeyRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *PrivateKeyRule) check(ctx *api.Context) {
 	file := ctx.File
@@ -409,7 +409,7 @@ type ObsoleteLayoutParamsRule struct {
 // lists of API names) rather than type resolution, so project-
 // specific wrapper APIs can cause false positives or negatives.
 // Classified per roadmap/17.
-func (r *ObsoleteLayoutParamsRule) Confidence() float64 { return 0.75 }
+func (r *ObsoleteLayoutParamsRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // ViewHolderRule detects RecyclerView.Adapter subclasses that do not
 // implement the ViewHolder pattern (missing ViewHolder or onCreateViewHolder).
@@ -424,4 +424,4 @@ type ViewHolderRule struct {
 // lists of API names) rather than type resolution, so project-
 // specific wrapper APIs can cause false positives or negatives.
 // Classified per roadmap/17.
-func (r *ViewHolderRule) Confidence() float64 { return 0.75 }
+func (r *ViewHolderRule) Confidence() float64 { return api.ConfidenceMedium }

--- a/internal/rules/android_correctness.go
+++ b/internal/rules/android_correctness.go
@@ -64,7 +64,7 @@ type DefaultLocaleRule struct {
 // lists of API names) rather than type resolution, so project-
 // specific wrapper APIs can cause false positives or negatives.
 // Classified per roadmap/17.
-func (r *DefaultLocaleRule) Confidence() float64 { return 0.75 }
+func (r *DefaultLocaleRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // CommitPrefEditsRule detects SharedPreferences.edit() without .commit() or .apply().
 type CommitPrefEditsRule struct {
@@ -78,7 +78,7 @@ type CommitPrefEditsRule struct {
 // lists of API names) rather than type resolution, so project-
 // specific wrapper APIs can cause false positives or negatives.
 // Classified per roadmap/17.
-func (r *CommitPrefEditsRule) Confidence() float64 { return 0.75 }
+func (r *CommitPrefEditsRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // CommitTransactionRule detects FragmentTransaction without .commit().
 type CommitTransactionRule struct {
@@ -92,7 +92,7 @@ type CommitTransactionRule struct {
 // lists of API names) rather than type resolution, so project-
 // specific wrapper APIs can cause false positives or negatives.
 // Classified per roadmap/17.
-func (r *CommitTransactionRule) Confidence() float64 { return 0.75 }
+func (r *CommitTransactionRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // AssertRule detects assert statements (disabled on Android).
 type AssertRule struct {
@@ -106,7 +106,7 @@ type AssertRule struct {
 // lists of API names) rather than type resolution, so project-
 // specific wrapper APIs can cause false positives or negatives.
 // Classified per roadmap/17.
-func (r *AssertRule) Confidence() float64 { return 0.75 }
+func (r *AssertRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // CheckResultRule detects ignoring return values annotated with @CheckResult.
 type CheckResultRule struct {
@@ -120,7 +120,7 @@ type CheckResultRule struct {
 // lists of API names) rather than type resolution, so project-
 // specific wrapper APIs can cause false positives or negatives.
 // Classified per roadmap/17.
-func (r *CheckResultRule) Confidence() float64 { return 0.75 }
+func (r *CheckResultRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // ShiftFlagsRule detects flag constants not using shift operators.
 type ShiftFlagsRule struct {
@@ -134,7 +134,7 @@ type ShiftFlagsRule struct {
 // lists of API names) rather than type resolution, so project-
 // specific wrapper APIs can cause false positives or negatives.
 // Classified per roadmap/17.
-func (r *ShiftFlagsRule) Confidence() float64 { return 0.75 }
+func (r *ShiftFlagsRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // UniqueConstantsRule detects duplicate annotation constant values.
 type UniqueConstantsRule struct {
@@ -148,7 +148,7 @@ type UniqueConstantsRule struct {
 // lists of API names) rather than type resolution, so project-
 // specific wrapper APIs can cause false positives or negatives.
 // Classified per roadmap/17.
-func (r *UniqueConstantsRule) Confidence() float64 { return 0.75 }
+func (r *UniqueConstantsRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // WrongThreadRule detects UI operations on wrong thread.
 type WrongThreadRule struct {
@@ -162,7 +162,7 @@ type WrongThreadRule struct {
 // lists of API names) rather than type resolution, so project-
 // specific wrapper APIs can cause false positives or negatives.
 // Classified per roadmap/17.
-func (r *WrongThreadRule) Confidence() float64 { return 0.75 }
+func (r *WrongThreadRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // SQLiteStringRule detects SQL string issues (using string instead of TEXT).
 type SQLiteStringRule struct {
@@ -176,7 +176,7 @@ type SQLiteStringRule struct {
 // lists of API names) rather than type resolution, so project-
 // specific wrapper APIs can cause false positives or negatives.
 // Classified per roadmap/17.
-func (r *SQLiteStringRule) Confidence() float64 { return 0.75 }
+func (r *SQLiteStringRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // RegisteredRule detects Activity/Service/BroadcastReceiver/ContentProvider subclasses
 // and flags them with a reminder to register in AndroidManifest.xml.
@@ -192,7 +192,7 @@ type RegisteredRule struct {
 // lists of API names) rather than type resolution, so project-
 // specific wrapper APIs can cause false positives or negatives.
 // Classified per roadmap/17.
-func (r *RegisteredRule) Confidence() float64 { return 0.75 }
+func (r *RegisteredRule) Confidence() float64 { return api.ConfidenceMedium }
 
 var androidComponentBases = map[string]string{
 	"Activity":             "Activity",
@@ -486,7 +486,7 @@ type NestedScrollingRule struct {
 // lists of API names) rather than type resolution, so project-
 // specific wrapper APIs can cause false positives or negatives.
 // Classified per roadmap/17.
-func (r *NestedScrollingRule) Confidence() float64 { return 0.75 }
+func (r *NestedScrollingRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // ScrollViewCountRule detects ScrollView with multiple children.
 // Primarily XML (see ScrollViewCountResourceRule); the Kotlin source
@@ -502,7 +502,7 @@ type ScrollViewCountRule struct {
 // lists of API names) rather than type resolution, so project-
 // specific wrapper APIs can cause false positives or negatives.
 // Classified per roadmap/17.
-func (r *ScrollViewCountRule) Confidence() float64 { return 0.75 }
+func (r *ScrollViewCountRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // SimpleDateFormatRule detects SimpleDateFormat without Locale.
 type SimpleDateFormatRule struct {
@@ -516,7 +516,7 @@ type SimpleDateFormatRule struct {
 // lists of API names) rather than type resolution, so project-
 // specific wrapper APIs can cause false positives or negatives.
 // Classified per roadmap/17.
-func (r *SimpleDateFormatRule) Confidence() float64 { return 0.75 }
+func (r *SimpleDateFormatRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // SetTextI18nRule detects setText() with hardcoded text.
 type SetTextI18nRule struct {
@@ -536,7 +536,7 @@ type StopShipRule struct {
 // lists of API names) rather than type resolution, so project-
 // specific wrapper APIs can cause false positives or negatives.
 // Classified per roadmap/17.
-func (r *StopShipRule) Confidence() float64 { return 0.75 }
+func (r *StopShipRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *StopShipRule) check(ctx *api.Context) {
 	file := ctx.File
@@ -560,7 +560,7 @@ type WrongCallRule struct {
 // lists of API names) rather than type resolution, so project-
 // specific wrapper APIs can cause false positives or negatives.
 // Classified per roadmap/17.
-func (r *WrongCallRule) Confidence() float64 { return 0.75 }
+func (r *WrongCallRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // Remaining rules are in android_correctness_checks.go
 

--- a/internal/rules/android_correctness_checks.go
+++ b/internal/rules/android_correctness_checks.go
@@ -26,7 +26,7 @@ type OverrideAbstractRule struct {
 // lists of API names) rather than type resolution, so project-
 // specific wrapper APIs can cause false positives or negatives.
 // Classified per roadmap/17.
-func (r *OverrideAbstractRule) Confidence() float64 { return 0.75 }
+func (r *OverrideAbstractRule) Confidence() float64 { return api.ConfidenceMedium }
 
 var abstractClassRequirements = map[string][]string{"Service": {"onBind"}, "BroadcastReceiver": {"onReceive"}, "ContentProvider": {"onCreate", "query", "insert", "update", "delete", "getType"}}
 
@@ -41,7 +41,7 @@ type ParcelCreatorRule struct {
 // lists of API names) rather than type resolution, so project-
 // specific wrapper APIs can cause false positives or negatives.
 // Classified per roadmap/17.
-func (r *ParcelCreatorRule) Confidence() float64 { return 0.75 }
+func (r *ParcelCreatorRule) Confidence() float64 { return api.ConfidenceMedium }
 
 type SwitchIntDefRule struct {
 	FlatDispatchBase
@@ -54,7 +54,7 @@ type SwitchIntDefRule struct {
 // lists of API names) rather than type resolution, so project-
 // specific wrapper APIs can cause false positives or negatives.
 // Classified per roadmap/17.
-func (r *SwitchIntDefRule) Confidence() float64 { return 0.75 }
+func (r *SwitchIntDefRule) Confidence() float64 { return api.ConfidenceMedium }
 
 type TextViewEditsRule struct {
 	FlatDispatchBase
@@ -67,7 +67,7 @@ type TextViewEditsRule struct {
 // lists of API names) rather than type resolution, so project-
 // specific wrapper APIs can cause false positives or negatives.
 // Classified per roadmap/17.
-func (r *TextViewEditsRule) Confidence() float64 { return 0.75 }
+func (r *TextViewEditsRule) Confidence() float64 { return api.ConfidenceMedium }
 
 type WrongViewCastRule struct {
 	FlatDispatchBase
@@ -105,7 +105,7 @@ var wrongViewCastSupertypes = map[string][]string{
 // lists of API names) rather than type resolution, so project-
 // specific wrapper APIs can cause false positives or negatives.
 // Classified per roadmap/17.
-func (r *WrongViewCastRule) Confidence() float64 { return 0.75 }
+func (r *WrongViewCastRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *WrongViewCastRule) NodeTypes() []string {
 	return []string{"call_expression", "as_expression", "cast_expression", "local_variable_declaration"}
@@ -508,7 +508,7 @@ var deprecatedApis = []deprecatedAPIEntry{{"AsyncTask", "AsyncTask is deprecated
 // lists of API names) rather than type resolution, so project-
 // specific wrapper APIs can cause false positives or negatives.
 // Classified per roadmap/17.
-func (r *DeprecatedRule) Confidence() float64 { return 0.75 }
+func (r *DeprecatedRule) Confidence() float64 { return api.ConfidenceMedium }
 
 type RangeRule struct {
 	FlatDispatchBase
@@ -521,7 +521,7 @@ func (r *RangeRule) NodeTypes() []string { return []string{"call_expression"} }
 // structural and requires an explicit API/range anchor, but framework
 // calls still depend on type-oracle call-target availability.
 // Classified per roadmap/17.
-func (r *RangeRule) Confidence() float64 { return 0.75 }
+func (r *RangeRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *RangeRule) check(ctx *api.Context) {
 	file := ctx.File
@@ -1219,7 +1219,7 @@ var resourceMethodExpected = map[string]string{"getString": "string", "getText":
 // lists of API names) rather than type resolution, so project-
 // specific wrapper APIs can cause false positives or negatives.
 // Classified per roadmap/17.
-func (r *ResourceTypeRule) Confidence() float64 { return 0.75 }
+func (r *ResourceTypeRule) Confidence() float64 { return api.ConfidenceMedium }
 
 type ResourceAsColorRule struct {
 	FlatDispatchBase
@@ -1232,7 +1232,7 @@ type ResourceAsColorRule struct {
 // lists of API names) rather than type resolution, so project-
 // specific wrapper APIs can cause false positives or negatives.
 // Classified per roadmap/17.
-func (r *ResourceAsColorRule) Confidence() float64 { return 0.75 }
+func (r *ResourceAsColorRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // ioCallNames is the set of known IO/network type and method names whose
 // presence in a @MainThread function indicates a likely thread violation.
@@ -1257,7 +1257,7 @@ type SupportAnnotationUsageRule struct {
 // lists of API names) rather than type resolution, so project-
 // specific wrapper APIs can cause false positives or negatives.
 // Classified per roadmap/17.
-func (r *SupportAnnotationUsageRule) Confidence() float64 { return 0.75 }
+func (r *SupportAnnotationUsageRule) Confidence() float64 { return api.ConfidenceMedium }
 
 type AccidentalOctalRule struct {
 	FlatDispatchBase
@@ -1270,7 +1270,7 @@ type AccidentalOctalRule struct {
 // lists of API names) rather than type resolution, so project-
 // specific wrapper APIs can cause false positives or negatives.
 // Classified per roadmap/17.
-func (r *AccidentalOctalRule) Confidence() float64 { return 0.75 }
+func (r *AccidentalOctalRule) Confidence() float64 { return api.ConfidenceMedium }
 
 type AppCompatMethodRule struct {
 	FlatDispatchBase
@@ -1283,7 +1283,7 @@ type AppCompatMethodRule struct {
 // lists of API names) rather than type resolution, so project-
 // specific wrapper APIs can cause false positives or negatives.
 // Classified per roadmap/17.
-func (r *AppCompatMethodRule) Confidence() float64 { return 0.75 }
+func (r *AppCompatMethodRule) Confidence() float64 { return api.ConfidenceMedium }
 
 type CustomViewStyleableRule struct {
 	FlatDispatchBase
@@ -1296,7 +1296,7 @@ type CustomViewStyleableRule struct {
 // lists of API names) rather than type resolution, so project-
 // specific wrapper APIs can cause false positives or negatives.
 // Classified per roadmap/17.
-func (r *CustomViewStyleableRule) Confidence() float64 { return 0.9 }
+func (r *CustomViewStyleableRule) Confidence() float64 { return api.ConfidenceHigher }
 
 type InnerclassSeparatorRule struct {
 	FlatDispatchBase
@@ -1309,7 +1309,7 @@ type InnerclassSeparatorRule struct {
 // lists of API names) rather than type resolution, so project-
 // specific wrapper APIs can cause false positives or negatives.
 // Classified per roadmap/17.
-func (r *InnerclassSeparatorRule) Confidence() float64 { return 0.75 }
+func (r *InnerclassSeparatorRule) Confidence() float64 { return api.ConfidenceMedium }
 
 type ObjectAnimatorBindingRule struct {
 	FlatDispatchBase
@@ -1323,7 +1323,7 @@ var knownAnimatorProperties = map[string]bool{
 	"elevation": true, "pivotX": true, "pivotY": true,
 }
 
-func (r *ObjectAnimatorBindingRule) Confidence() float64 { return 0.75 }
+func (r *ObjectAnimatorBindingRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *ObjectAnimatorBindingRule) check(ctx *api.Context) {
 	file := ctx.File
@@ -1600,7 +1600,7 @@ type OnClickRule struct {
 // lists of API names) rather than type resolution, so project-
 // specific wrapper APIs can cause false positives or negatives.
 // Classified per roadmap/17.
-func (r *OnClickRule) Confidence() float64 { return 0.75 }
+func (r *OnClickRule) Confidence() float64 { return api.ConfidenceMedium }
 
 type PropertyEscapeRule struct {
 	FlatDispatchBase
@@ -1613,7 +1613,7 @@ type PropertyEscapeRule struct {
 // lists of API names) rather than type resolution, so project-
 // specific wrapper APIs can cause false positives or negatives.
 // Classified per roadmap/17.
-func (r *PropertyEscapeRule) Confidence() float64 { return 0.75 }
+func (r *PropertyEscapeRule) Confidence() float64 { return api.ConfidenceMedium }
 
 type ShortAlarmRule struct {
 	FlatDispatchBase
@@ -1626,7 +1626,7 @@ type ShortAlarmRule struct {
 // lists of API names) rather than type resolution, so project-
 // specific wrapper APIs can cause false positives or negatives.
 // Classified per roadmap/17.
-func (r *ShortAlarmRule) Confidence() float64 { return 0.75 }
+func (r *ShortAlarmRule) Confidence() float64 { return api.ConfidenceMedium }
 
 type LocalSuppressRule struct {
 	FlatDispatchBase
@@ -1641,7 +1641,7 @@ var knownLintIssueIDs = map[string]bool{"NewApi": true, "InlinedApi": true, "Ove
 // lists of API names) rather than type resolution, so project-
 // specific wrapper APIs can cause false positives or negatives.
 // Classified per roadmap/17.
-func (r *LocalSuppressRule) Confidence() float64 { return 0.75 }
+func (r *LocalSuppressRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // pluralsCountNames is the set of identifiers whose presence as a when-subject
 // suggests manual pluralization.
@@ -1667,4 +1667,4 @@ type PluralsCandidateRule struct {
 // lists of API names) rather than type resolution, so project-
 // specific wrapper APIs can cause false positives or negatives.
 // Classified per roadmap/17.
-func (r *PluralsCandidateRule) Confidence() float64 { return 0.75 }
+func (r *PluralsCandidateRule) Confidence() float64 { return api.ConfidenceMedium }

--- a/internal/rules/android_gradle.go
+++ b/internal/rules/android_gradle.go
@@ -178,7 +178,7 @@ type GradlePluginCompatibilityRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Android Gradle rule. Detection scans Groovy/Kotlin DSL build scripts via
 // line/regex matching; build-script shape varies by project and plugin
 // version. Classified per roadmap/17.
-func (r *GradlePluginCompatibilityRule) Confidence() float64 { return 0.75 }
+func (r *GradlePluginCompatibilityRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *GradlePluginCompatibilityRule) check(ctx *api.Context) {
 	path, content, cfg := ctx.GradlePath, ctx.GradleContent, ctx.GradleConfig
@@ -217,7 +217,7 @@ var sdkPropertyNames = []string{
 // Confidence reports a tier-2 (medium) base confidence. Android Gradle rule. Detection scans Groovy/Kotlin DSL build scripts via
 // line/regex matching; build-script shape varies by project and plugin
 // version. Classified per roadmap/17.
-func (r *StringIntegerRule) Confidence() float64 { return 0.75 }
+func (r *StringIntegerRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *StringIntegerRule) check(ctx *api.Context) {
 	path, content, _ := ctx.GradlePath, ctx.GradleContent, ctx.GradleConfig
@@ -363,7 +363,7 @@ type RemoteVersionRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Android Gradle rule. Detection scans Groovy/Kotlin DSL build scripts via
 // line/regex matching; build-script shape varies by project and plugin
 // version. Classified per roadmap/17.
-func (r *RemoteVersionRule) Confidence() float64 { return 0.75 }
+func (r *RemoteVersionRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *RemoteVersionRule) check(ctx *api.Context) {
 	path, content, cfg := ctx.GradlePath, ctx.GradleContent, ctx.GradleConfig
@@ -395,7 +395,7 @@ type DynamicVersionRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Android Gradle rule. Detection scans Groovy/Kotlin DSL build scripts via
 // line/regex matching; build-script shape varies by project and plugin
 // version. Classified per roadmap/17.
-func (r *DynamicVersionRule) Confidence() float64 { return 0.75 }
+func (r *DynamicVersionRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *DynamicVersionRule) check(ctx *api.Context) {
 	path, content, cfg := ctx.GradlePath, ctx.GradleContent, ctx.GradleConfig
@@ -610,7 +610,7 @@ const defaultOldTargetAPIThreshold = 33
 // Confidence reports a tier-2 (medium) base confidence. Android Gradle rule. Detection scans Groovy/Kotlin DSL build scripts via
 // line/regex matching; build-script shape varies by project and plugin
 // version. Classified per roadmap/17.
-func (r *GradleOldTargetAPIRule) Confidence() float64 { return 0.75 }
+func (r *GradleOldTargetAPIRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *GradleOldTargetAPIRule) check(ctx *api.Context) {
 	path, content, cfg := ctx.GradlePath, ctx.GradleContent, ctx.GradleConfig
@@ -645,7 +645,7 @@ type DeprecatedDependencyRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Android Gradle rule. Detection scans Groovy/Kotlin DSL build scripts via
 // line/regex matching; build-script shape varies by project and plugin
 // version. Classified per roadmap/17.
-func (r *DeprecatedDependencyRule) Confidence() float64 { return 0.75 }
+func (r *DeprecatedDependencyRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *DeprecatedDependencyRule) check(ctx *api.Context) {
 	path, content, cfg := ctx.GradlePath, ctx.GradleContent, ctx.GradleConfig
@@ -676,7 +676,7 @@ type MavenLocalRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Android Gradle rule. Detection scans Groovy/Kotlin DSL build scripts via
 // line/regex matching; build-script shape varies by project and plugin
 // version. Classified per roadmap/17.
-func (r *MavenLocalRule) Confidence() float64 { return 0.75 }
+func (r *MavenLocalRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *MavenLocalRule) check(ctx *api.Context) {
 	path, content, _ := ctx.GradlePath, ctx.GradleContent, ctx.GradleConfig
@@ -705,7 +705,7 @@ const defaultMinSdkTooLowThreshold = 21
 // Confidence reports a tier-2 (medium) base confidence. Android Gradle rule. Detection scans Groovy/Kotlin DSL build scripts via
 // line/regex matching; build-script shape varies by project and plugin
 // version. Classified per roadmap/17.
-func (r *MinSdkTooLowRule) Confidence() float64 { return 0.75 }
+func (r *MinSdkTooLowRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *MinSdkTooLowRule) check(ctx *api.Context) {
 	path, content, cfg := ctx.GradlePath, ctx.GradleContent, ctx.GradleConfig
@@ -747,7 +747,7 @@ var deprecatedConfigs = map[string]string{
 // Confidence reports a tier-2 (medium) base confidence. Android Gradle rule. Detection scans Groovy/Kotlin DSL build scripts via
 // line/regex matching; build-script shape varies by project and plugin
 // version. Classified per roadmap/17.
-func (r *GradleDeprecatedRule) Confidence() float64 { return 0.75 }
+func (r *GradleDeprecatedRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *GradleDeprecatedRule) check(ctx *api.Context) {
 	path, content, _ := ctx.GradlePath, ctx.GradleContent, ctx.GradleConfig
@@ -805,7 +805,7 @@ var groovyStyleDSL = map[string]string{
 // Confidence reports a tier-2 (medium) base confidence. Android Gradle rule. Detection scans Groovy/Kotlin DSL build scripts via
 // line/regex matching; build-script shape varies by project and plugin
 // version. Classified per roadmap/17.
-func (r *GradleGetterRule) Confidence() float64 { return 0.75 }
+func (r *GradleGetterRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *GradleGetterRule) check(ctx *api.Context) {
 	path, content, _ := ctx.GradlePath, ctx.GradleContent, ctx.GradleConfig
@@ -854,7 +854,7 @@ type GradlePathRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Android Gradle rule. Detection scans Groovy/Kotlin DSL build scripts via
 // line/regex matching; build-script shape varies by project and plugin
 // version. Classified per roadmap/17.
-func (r *GradlePathRule) Confidence() float64 { return 0.75 }
+func (r *GradlePathRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // gradlePathCallContains reports whether a line contains a files() or
 // fileTree() call whose string argument contains needle. We locate the
@@ -918,7 +918,7 @@ type GradleOverridesRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Android Gradle rule. Detection scans Groovy/Kotlin DSL build scripts via
 // line/regex matching; build-script shape varies by project and plugin
 // version. Classified per roadmap/17.
-func (r *GradleOverridesRule) Confidence() float64 { return 0.75 }
+func (r *GradleOverridesRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *GradleOverridesRule) check(ctx *api.Context) {
 	path, content, cfg := ctx.GradlePath, ctx.GradleContent, ctx.GradleConfig
@@ -948,7 +948,7 @@ type GradleIdeErrorRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Android Gradle rule. Detection scans Groovy/Kotlin DSL build scripts via
 // line/regex matching; build-script shape varies by project and plugin
 // version. Classified per roadmap/17.
-func (r *GradleIdeErrorRule) Confidence() float64 { return 0.75 }
+func (r *GradleIdeErrorRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *GradleIdeErrorRule) check(ctx *api.Context) {
 	path, content, _ := ctx.GradlePath, ctx.GradleContent, ctx.GradleConfig
@@ -986,7 +986,7 @@ var agpVersionRe = regexp.MustCompile(`com\.android\.tools\.build:gradle:(\d+)\.
 // Confidence reports a tier-2 (medium) base confidence. Android Gradle rule. Detection scans Groovy/Kotlin DSL build scripts via
 // line/regex matching; build-script shape varies by project and plugin
 // version. Classified per roadmap/17.
-func (r *AndroidGradlePluginVersionRule) Confidence() float64 { return 0.75 }
+func (r *AndroidGradlePluginVersionRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *AndroidGradlePluginVersionRule) check(ctx *api.Context) {
 	path, content, _ := ctx.GradlePath, ctx.GradleContent, ctx.GradleConfig
@@ -1133,7 +1133,7 @@ func versionLessThan(major, minor, patch, minMajor, minMinor, minPatch int) bool
 // Confidence reports a tier-2 (medium) base confidence. Android Gradle rule. Detection scans Groovy/Kotlin DSL build scripts via
 // line/regex matching; build-script shape varies by project and plugin
 // version. Classified per roadmap/17.
-func (r *NewerVersionAvailableRule) Confidence() float64 { return 0.75 }
+func (r *NewerVersionAvailableRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *NewerVersionAvailableRule) check(ctx *api.Context) {
 	path, content, cfg := ctx.GradlePath, ctx.GradleContent, ctx.GradleConfig

--- a/internal/rules/android_i18n.go
+++ b/internal/rules/android_i18n.go
@@ -13,7 +13,7 @@ type ByteOrderMarkRule struct{ AndroidRule }
 // Confidence bumps this line rule from the 0.75 line-rule default to
 // 0.95 — the BOM check is a literal three-byte compare at the start
 // of the file content. No heuristic path.
-func (r *ByteOrderMarkRule) Confidence() float64 { return 0.95 }
+func (r *ByteOrderMarkRule) Confidence() float64 { return api.ConfidenceVeryHigh }
 
 func (r *ByteOrderMarkRule) check(ctx *api.Context) {
 	file := ctx.File

--- a/internal/rules/android_icons.go
+++ b/internal/rules/android_icons.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/kaeawc/krit/internal/android"
 	"github.com/kaeawc/krit/internal/librarymodel"
+	api "github.com/kaeawc/krit/internal/rules/api"
 	"github.com/kaeawc/krit/internal/scanner"
 )
 
@@ -32,7 +33,7 @@ type IconNoDpiRule struct {
 	AndroidRule
 }
 
-func (r *IconNoDpiRule) Confidence() float64 { return 0.75 }
+func (r *IconNoDpiRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // IconDuplicatesConfigRule detects identical icons across different configuration folders.
 type IconDuplicatesConfigRule struct {
@@ -40,7 +41,7 @@ type IconDuplicatesConfigRule struct {
 	AndroidRule
 }
 
-func (r *IconDuplicatesConfigRule) Confidence() float64 { return 0.75 }
+func (r *IconDuplicatesConfigRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // IconDensitiesRule checks for missing density variants.
 type IconDensitiesRule struct {
@@ -48,7 +49,7 @@ type IconDensitiesRule struct {
 	AndroidRule
 }
 
-func (r *IconDensitiesRule) Confidence() float64 { return 0.75 }
+func (r *IconDensitiesRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // IconDipSizeRule checks that icon dimensions match expected DPI ratios.
 type IconDipSizeRule struct {
@@ -56,7 +57,7 @@ type IconDipSizeRule struct {
 	AndroidRule
 }
 
-func (r *IconDipSizeRule) Confidence() float64 { return 0.75 }
+func (r *IconDipSizeRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // IconDuplicatesRule detects identical images across densities.
 type IconDuplicatesRule struct {
@@ -64,7 +65,7 @@ type IconDuplicatesRule struct {
 	AndroidRule
 }
 
-func (r *IconDuplicatesRule) Confidence() float64 { return 0.75 }
+func (r *IconDuplicatesRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // GifUsageRule detects GIF files in resources.
 type GifUsageRule struct {
@@ -72,7 +73,7 @@ type GifUsageRule struct {
 	AndroidRule
 }
 
-func (r *GifUsageRule) Confidence() float64 { return 0.75 }
+func (r *GifUsageRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // ConvertToWebpRule detects large PNGs that could be smaller as WebP.
 type ConvertToWebpRule struct {
@@ -80,7 +81,7 @@ type ConvertToWebpRule struct {
 	AndroidRule
 }
 
-func (r *ConvertToWebpRule) Confidence() float64 { return 0.75 }
+func (r *ConvertToWebpRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // IconMissingDensityFolderRule detects missing density folders.
 type IconMissingDensityFolderRule struct {
@@ -88,7 +89,7 @@ type IconMissingDensityFolderRule struct {
 	AndroidRule
 }
 
-func (r *IconMissingDensityFolderRule) Confidence() float64 { return 0.75 }
+func (r *IconMissingDensityFolderRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // IconExpectedSizeRule checks that launcher icons have expected sizes.
 type IconExpectedSizeRule struct {
@@ -96,7 +97,7 @@ type IconExpectedSizeRule struct {
 	AndroidRule
 }
 
-func (r *IconExpectedSizeRule) Confidence() float64 { return 0.75 }
+func (r *IconExpectedSizeRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // IconExtensionRule detects icon files whose extension does not match the contents.
 type IconExtensionRule struct {
@@ -104,7 +105,7 @@ type IconExtensionRule struct {
 	AndroidRule
 }
 
-func (r *IconExtensionRule) Confidence() float64 { return 0.75 }
+func (r *IconExtensionRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // IconLocationRule detects bitmap icons placed in density-independent drawable folders.
 type IconLocationRule struct {
@@ -112,7 +113,7 @@ type IconLocationRule struct {
 	AndroidRule
 }
 
-func (r *IconLocationRule) Confidence() float64 { return 0.75 }
+func (r *IconLocationRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // IconMixedNinePatchRule detects PNG and 9-patch files with the same resource name.
 type IconMixedNinePatchRule struct {
@@ -120,7 +121,7 @@ type IconMixedNinePatchRule struct {
 	AndroidRule
 }
 
-func (r *IconMixedNinePatchRule) Confidence() float64 { return 0.75 }
+func (r *IconMixedNinePatchRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // IconXMLAndPngRule detects drawable XML and bitmap files with the same resource name.
 type IconXMLAndPngRule struct {
@@ -128,7 +129,7 @@ type IconXMLAndPngRule struct {
 	AndroidRule
 }
 
-func (r *IconXMLAndPngRule) Confidence() float64 { return 0.75 }
+func (r *IconXMLAndPngRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // IconColorsRule checks notification and action bar icon color constraints.
 type IconColorsRule struct {
@@ -136,7 +137,7 @@ type IconColorsRule struct {
 	AndroidRule
 }
 
-func (r *IconColorsRule) Confidence() float64 { return 0.75 }
+func (r *IconColorsRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // IconLauncherShapeRule checks launcher icon shape transparency.
 type IconLauncherShapeRule struct {
@@ -144,7 +145,7 @@ type IconLauncherShapeRule struct {
 	AndroidRule
 }
 
-func (r *IconLauncherShapeRule) Confidence() float64 { return 0.75 }
+func (r *IconLauncherShapeRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // --- IconIndex-backed check functions ---
 

--- a/internal/rules/android_manifest_security.go
+++ b/internal/rules/android_manifest_security.go
@@ -93,7 +93,7 @@ type DeepLinkMissingAutoVerifyRule struct {
 	AndroidRule
 }
 
-func (r *DeepLinkMissingAutoVerifyRule) Confidence() float64 { return 0.85 }
+func (r *DeepLinkMissingAutoVerifyRule) Confidence() float64 { return api.ConfidenceHigh }
 
 func (r *DeepLinkMissingAutoVerifyRule) check(ctx *api.Context) {
 	m := ctx.Manifest
@@ -550,7 +550,7 @@ type NetworkSecurityConfigDebugOverridesRule struct {
 	AndroidRule
 }
 
-func (r *NetworkSecurityConfigDebugOverridesRule) Confidence() float64 { return 0.85 }
+func (r *NetworkSecurityConfigDebugOverridesRule) Confidence() float64 { return api.ConfidenceHigh }
 
 func (r *InsecureBaseConfigurationManifestRule) check(ctx *api.Context) {
 	m := ctx.Manifest

--- a/internal/rules/android_performance.go
+++ b/internal/rules/android_performance.go
@@ -49,7 +49,7 @@ var drawAllocationAllocTypes = map[string]bool{
 // literals, comments, and multi-line signatures. Unqualified type-name
 // matching against the fixed allow-list keeps this pattern-based
 // without KAA type resolution. Classified per roadmap/17.
-func (r *DrawAllocationRule) Confidence() float64 { return 0.85 }
+func (r *DrawAllocationRule) Confidence() float64 { return api.ConfidenceHigh }
 
 func (r *DrawAllocationRule) check(ctx *api.Context) {
 	file := ctx.File
@@ -124,7 +124,7 @@ func (r *FieldGetterRule) NodeTypes() []string {
 // lists of API names) rather than type resolution, so project-
 // specific wrapper APIs can cause false positives or negatives.
 // Classified per roadmap/17.
-func (r *FieldGetterRule) Confidence() float64 { return 0.75 }
+func (r *FieldGetterRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *FieldGetterRule) check(ctx *api.Context) {
 	file := ctx.File
@@ -221,7 +221,7 @@ type FloatMathRule struct {
 
 // Confidence reports a tier-2 (medium) base confidence for structural match.
 // With type resolver verifying FQN: 1.0. Classified per roadmap/17.
-func (r *FloatMathRule) Confidence() float64 { return 0.75 }
+func (r *FloatMathRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *FloatMathRule) NodeTypes() []string { return []string{"navigation_expression"} }
 
@@ -241,7 +241,7 @@ type HandlerLeakRule struct {
 
 // Confidence reports a tier-2 (medium) base confidence for structural match.
 // With type resolver verifying Handler inheritance: 0.90+. Classified per roadmap/17.
-func (r *HandlerLeakRule) Confidence() float64 { return 0.75 }
+func (r *HandlerLeakRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *HandlerLeakRule) NodeTypes() []string {
 	return []string{"class_declaration", "object_literal", "object_creation_expression"}
@@ -607,7 +607,7 @@ var recycleTypeSet = map[string]struct{}{
 // lists of API names) rather than type resolution, so project-
 // specific wrapper APIs can cause false positives or negatives.
 // Classified per roadmap/17.
-func (r *RecycleRule) Confidence() float64 { return 0.75 }
+func (r *RecycleRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *RecycleRule) check(ctx *api.Context) {
 	file := ctx.File

--- a/internal/rules/android_requires_api.go
+++ b/internal/rules/android_requires_api.go
@@ -16,7 +16,7 @@ type RequiresAPIViolationRule struct {
 	AndroidRule
 }
 
-func (r *RequiresAPIViolationRule) Confidence() float64 { return 0.90 }
+func (r *RequiresAPIViolationRule) Confidence() float64 { return api.ConfidenceHigher }
 
 type requiresAPIIndex struct {
 	levels map[string]int

--- a/internal/rules/android_resource_a11y.go
+++ b/internal/rules/android_resource_a11y.go
@@ -27,7 +27,7 @@ type HardcodedValuesResourceRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Android accessibility resource rule. Detection flags missing
 // contentDescription, importantForAccessibility, and focusable attributes
 // via structural checks. Classified per roadmap/17.
-func (r *HardcodedValuesResourceRule) Confidence() float64 { return 0.75 }
+func (r *HardcodedValuesResourceRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *HardcodedValuesResourceRule) check(ctx *api.Context) {
 	idx := ctx.ResourceIndex
@@ -70,7 +70,7 @@ var imageViewTypes = map[string]bool{
 // Confidence reports a tier-2 (medium) base confidence. Android accessibility resource rule. Detection flags missing
 // contentDescription, importantForAccessibility, and focusable attributes
 // via structural checks. Classified per roadmap/17.
-func (r *MissingContentDescriptionResourceRule) Confidence() float64 { return 0.75 }
+func (r *MissingContentDescriptionResourceRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *MissingContentDescriptionResourceRule) check(ctx *api.Context) {
 	idx := ctx.ResourceIndex
@@ -109,7 +109,7 @@ type LabelForResourceRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Android accessibility resource rule. Detection flags missing
 // contentDescription, importantForAccessibility, and focusable attributes
 // via structural checks. Classified per roadmap/17.
-func (r *LabelForResourceRule) Confidence() float64 { return 0.75 }
+func (r *LabelForResourceRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *LabelForResourceRule) check(ctx *api.Context) {
 	idx := ctx.ResourceIndex
@@ -215,7 +215,7 @@ func isContainerView(viewType string) bool {
 // Confidence reports a tier-2 (medium) base confidence. Android accessibility resource rule. Detection flags missing
 // contentDescription, importantForAccessibility, and focusable attributes
 // via structural checks. Classified per roadmap/17.
-func (r *ClickableViewAccessibilityResourceRule) Confidence() float64 { return 0.75 }
+func (r *ClickableViewAccessibilityResourceRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *ClickableViewAccessibilityResourceRule) check(ctx *api.Context) {
 	idx := ctx.ResourceIndex
@@ -258,7 +258,7 @@ type BackButtonResourceRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Android accessibility resource rule. Detection flags missing
 // contentDescription, importantForAccessibility, and focusable attributes
 // via structural checks. Classified per roadmap/17.
-func (r *BackButtonResourceRule) Confidence() float64 { return 0.75 }
+func (r *BackButtonResourceRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *BackButtonResourceRule) check(ctx *api.Context) {
 	idx := ctx.ResourceIndex
@@ -293,7 +293,7 @@ type ButtonCaseResourceRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Android accessibility resource rule. Detection flags missing
 // contentDescription, importantForAccessibility, and focusable attributes
 // via structural checks. Classified per roadmap/17.
-func (r *ButtonCaseResourceRule) Confidence() float64 { return 0.75 }
+func (r *ButtonCaseResourceRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *ButtonCaseResourceRule) check(ctx *api.Context) {
 	idx := ctx.ResourceIndex
@@ -344,7 +344,7 @@ func isCancelButton(v *android.View) bool {
 // Confidence reports a tier-2 (medium) base confidence. Android accessibility resource rule. Detection flags missing
 // contentDescription, importantForAccessibility, and focusable attributes
 // via structural checks. Classified per roadmap/17.
-func (r *ButtonOrderResourceRule) Confidence() float64 { return 0.75 }
+func (r *ButtonOrderResourceRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *ButtonOrderResourceRule) check(ctx *api.Context) {
 	idx := ctx.ResourceIndex
@@ -387,7 +387,7 @@ type ButtonStyleResourceRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Android accessibility resource rule. Detection flags missing
 // contentDescription, importantForAccessibility, and focusable attributes
 // via structural checks. Classified per roadmap/17.
-func (r *ButtonStyleResourceRule) Confidence() float64 { return 0.75 }
+func (r *ButtonStyleResourceRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *ButtonStyleResourceRule) check(ctx *api.Context) {
 	idx := ctx.ResourceIndex
@@ -418,7 +418,7 @@ type LayoutClickableWithoutMinSizeRule struct {
 	AndroidRule
 }
 
-func (r *LayoutClickableWithoutMinSizeRule) Confidence() float64 { return 0.75 }
+func (r *LayoutClickableWithoutMinSizeRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *LayoutClickableWithoutMinSizeRule) check(ctx *api.Context) {
 	idx := ctx.ResourceIndex
@@ -461,7 +461,7 @@ type LayoutEditTextMissingImportanceRule struct {
 	AndroidRule
 }
 
-func (r *LayoutEditTextMissingImportanceRule) Confidence() float64 { return 0.75 }
+func (r *LayoutEditTextMissingImportanceRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *LayoutEditTextMissingImportanceRule) check(ctx *api.Context) {
 	idx := ctx.ResourceIndex
@@ -490,7 +490,7 @@ type LayoutImportantForAccessibilityNoRule struct {
 	AndroidRule
 }
 
-func (r *LayoutImportantForAccessibilityNoRule) Confidence() float64 { return 0.75 }
+func (r *LayoutImportantForAccessibilityNoRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *LayoutImportantForAccessibilityNoRule) check(ctx *api.Context) {
 	idx := ctx.ResourceIndex
@@ -518,7 +518,7 @@ type LayoutAutofillHintMismatchRule struct {
 	AndroidRule
 }
 
-func (r *LayoutAutofillHintMismatchRule) Confidence() float64 { return 0.75 }
+func (r *LayoutAutofillHintMismatchRule) Confidence() float64 { return api.ConfidenceMedium }
 
 var inputTypeToAutofillHint = map[string]string{
 	"textEmailAddress":  "emailAddress",
@@ -560,7 +560,7 @@ type LayoutMinTouchTargetInButtonRowRule struct {
 	AndroidRule
 }
 
-func (r *LayoutMinTouchTargetInButtonRowRule) Confidence() float64 { return 0.75 }
+func (r *LayoutMinTouchTargetInButtonRowRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *LayoutMinTouchTargetInButtonRowRule) check(ctx *api.Context) {
 	idx := ctx.ResourceIndex
@@ -631,7 +631,7 @@ type StringNotSelectableRule struct {
 	AndroidRule
 }
 
-func (r *StringNotSelectableRule) Confidence() float64 { return 0.75 }
+func (r *StringNotSelectableRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *StringNotSelectableRule) check(ctx *api.Context) {
 	idx := ctx.ResourceIndex
@@ -678,7 +678,7 @@ type StringRepeatedInContentDescriptionRule struct {
 	AndroidRule
 }
 
-func (r *StringRepeatedInContentDescriptionRule) Confidence() float64 { return 0.75 }
+func (r *StringRepeatedInContentDescriptionRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *StringRepeatedInContentDescriptionRule) check(ctx *api.Context) {
 	idx := ctx.ResourceIndex
@@ -736,7 +736,7 @@ type StringSpanInContentDescriptionRule struct {
 	AndroidRule
 }
 
-func (r *StringSpanInContentDescriptionRule) Confidence() float64 { return 0.75 }
+func (r *StringSpanInContentDescriptionRule) Confidence() float64 { return api.ConfidenceMedium }
 
 var htmlTagInStringRe = regexp.MustCompile(`<(b|i|u|em|strong|br|a|span|font|big|small|sup|sub|strike|tt)\b`)
 

--- a/internal/rules/android_resource_ids.go
+++ b/internal/rules/android_resource_ids.go
@@ -24,7 +24,7 @@ type DuplicateIDsResourceRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Android resource-id rule. Detection flags R.id/R.layout usage patterns
 // and naming conventions via structural checks on resources. Classified
 // per roadmap/17.
-func (r *DuplicateIDsResourceRule) Confidence() float64 { return 0.75 }
+func (r *DuplicateIDsResourceRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *DuplicateIDsResourceRule) check(ctx *api.Context) {
 	idx := ctx.ResourceIndex
@@ -90,7 +90,7 @@ func isValidAndroidID(id string) bool {
 // Confidence reports a tier-2 (medium) base confidence. Android resource-id rule. Detection flags R.id/R.layout usage patterns
 // and naming conventions via structural checks on resources. Classified
 // per roadmap/17.
-func (r *InvalidIDResourceRule) Confidence() float64 { return 0.75 }
+func (r *InvalidIDResourceRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *InvalidIDResourceRule) check(ctx *api.Context) {
 	idx := ctx.ResourceIndex
@@ -124,7 +124,7 @@ type MissingIDResourceRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Android resource-id rule. Detection flags R.id/R.layout usage patterns
 // and naming conventions via structural checks on resources. Classified
 // per roadmap/17.
-func (r *MissingIDResourceRule) Confidence() float64 { return 0.75 }
+func (r *MissingIDResourceRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *MissingIDResourceRule) check(ctx *api.Context) {
 	idx := ctx.ResourceIndex
@@ -214,7 +214,7 @@ var idPrefixToType = map[string][]string{
 // Confidence reports a tier-2 (medium) base confidence. Android resource-id rule. Detection flags R.id/R.layout usage patterns
 // and naming conventions via structural checks on resources. Classified
 // per roadmap/17.
-func (r *CutPasteIDResourceRule) Confidence() float64 { return 0.75 }
+func (r *CutPasteIDResourceRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *CutPasteIDResourceRule) check(ctx *api.Context) {
 	idx := ctx.ResourceIndex
@@ -283,7 +283,7 @@ type DuplicateIncludedIDsResourceRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Android resource-id rule. Detection flags R.id/R.layout usage patterns
 // and naming conventions via structural checks on resources. Classified
 // per roadmap/17.
-func (r *DuplicateIncludedIDsResourceRule) Confidence() float64 { return 0.75 }
+func (r *DuplicateIncludedIDsResourceRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *DuplicateIncludedIDsResourceRule) check(ctx *api.Context) {
 	idx := ctx.ResourceIndex
@@ -420,7 +420,7 @@ var knownAndroidAttrs = map[string]bool{
 // Confidence reports a tier-2 (medium) base confidence. Android resource-id rule. Detection flags R.id/R.layout usage patterns
 // and naming conventions via structural checks on resources. Classified
 // per roadmap/17.
-func (r *MissingPrefixResourceRule) Confidence() float64 { return 0.75 }
+func (r *MissingPrefixResourceRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *MissingPrefixResourceRule) check(ctx *api.Context) {
 	idx := ctx.ResourceIndex
@@ -490,7 +490,7 @@ func levenshtein(a, b string) int {
 // Confidence reports a tier-2 (medium) base confidence. Android resource-id rule. Detection flags R.id/R.layout usage patterns
 // and naming conventions via structural checks on resources. Classified
 // per roadmap/17.
-func (r *NamespaceTypoResourceRule) Confidence() float64 { return 0.75 }
+func (r *NamespaceTypoResourceRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *NamespaceTypoResourceRule) check(ctx *api.Context) {
 	idx := ctx.ResourceIndex
@@ -537,7 +537,7 @@ const resPackagePrefix = "http://schemas.android.com/apk/res/"
 // Confidence reports a tier-2 (medium) base confidence. Android resource-id rule. Detection flags R.id/R.layout usage patterns
 // and naming conventions via structural checks on resources. Classified
 // per roadmap/17.
-func (r *ResAutoResourceRule) Confidence() float64 { return 0.75 }
+func (r *ResAutoResourceRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *ResAutoResourceRule) check(ctx *api.Context) {
 	idx := ctx.ResourceIndex
@@ -573,7 +573,7 @@ type UnusedNamespaceResourceRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Android resource-id rule. Detection flags R.id/R.layout usage patterns
 // and naming conventions via structural checks on resources. Classified
 // per roadmap/17.
-func (r *UnusedNamespaceResourceRule) Confidence() float64 { return 0.75 }
+func (r *UnusedNamespaceResourceRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *UnusedNamespaceResourceRule) check(ctx *api.Context) {
 	idx := ctx.ResourceIndex
@@ -638,7 +638,7 @@ type IllegalResourceRefResourceRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Android resource-id rule. Detection flags R.id/R.layout usage patterns
 // and naming conventions via structural checks on resources. Classified
 // per roadmap/17.
-func (r *IllegalResourceRefResourceRule) Confidence() float64 { return 0.75 }
+func (r *IllegalResourceRefResourceRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *IllegalResourceRefResourceRule) check(ctx *api.Context) {
 	idx := ctx.ResourceIndex
@@ -744,7 +744,7 @@ var wrongCaseFixes = map[string]string{
 // Confidence reports a tier-2 (medium) base confidence. Android resource-id rule. Detection flags R.id/R.layout usage patterns
 // and naming conventions via structural checks on resources. Classified
 // per roadmap/17.
-func (r *WrongCaseResourceRule) Confidence() float64 { return 0.75 }
+func (r *WrongCaseResourceRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *WrongCaseResourceRule) check(ctx *api.Context) {
 	idx := ctx.ResourceIndex
@@ -782,7 +782,7 @@ type WrongFolderResourceRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Android resource-id rule. Detection flags R.id/R.layout usage patterns
 // and naming conventions via structural checks on resources. Classified
 // per roadmap/17.
-func (r *WrongFolderResourceRule) Confidence() float64 { return 0.75 }
+func (r *WrongFolderResourceRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *WrongFolderResourceRule) check(ctx *api.Context) {
 	idx := ctx.ResourceIndex
@@ -843,7 +843,7 @@ func isValidResFolderName(folder string) bool {
 // Confidence reports a tier-2 (medium) base confidence. Android resource-id rule. Detection flags R.id/R.layout usage patterns
 // and naming conventions via structural checks on resources. Classified
 // per roadmap/17.
-func (r *InvalidResourceFolderResourceRule) Confidence() float64 { return 0.75 }
+func (r *InvalidResourceFolderResourceRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *InvalidResourceFolderResourceRule) check(ctx *api.Context) {
 	idx := ctx.ResourceIndex
@@ -886,7 +886,7 @@ type AppCompatResourceRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Android resource-id rule. Detection flags R.id/R.layout usage patterns
 // and naming conventions via structural checks on resources. Classified
 // per roadmap/17.
-func (r *AppCompatResourceRule) Confidence() float64 { return 0.75 }
+func (r *AppCompatResourceRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *AppCompatResourceRule) check(ctx *api.Context) {
 	idx := ctx.ResourceIndex

--- a/internal/rules/android_resource_layout.go
+++ b/internal/rules/android_resource_layout.go
@@ -27,7 +27,7 @@ type TooManyViewsResourceRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Android layout resource rule. Detection flags layout-file anti-patterns
 // (nesting depth, unnecessary containers, missing constraints) via
 // structural checks on layout XML. Classified per roadmap/17.
-func (r *TooManyViewsResourceRule) Confidence() float64 { return 0.75 }
+func (r *TooManyViewsResourceRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *TooManyViewsResourceRule) check(ctx *api.Context) {
 	idx := ctx.ResourceIndex
@@ -61,7 +61,7 @@ type TooDeepLayoutResourceRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Android layout resource rule. Detection flags layout-file anti-patterns
 // (nesting depth, unnecessary containers, missing constraints) via
 // structural checks on layout XML. Classified per roadmap/17.
-func (r *TooDeepLayoutResourceRule) Confidence() float64 { return 0.75 }
+func (r *TooDeepLayoutResourceRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *TooDeepLayoutResourceRule) check(ctx *api.Context) {
 	idx := ctx.ResourceIndex
@@ -95,7 +95,7 @@ type UselessParentResourceRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Android layout resource rule. Detection flags layout-file anti-patterns
 // (nesting depth, unnecessary containers, missing constraints) via
 // structural checks on layout XML. Classified per roadmap/17.
-func (r *UselessParentResourceRule) Confidence() float64 { return 0.75 }
+func (r *UselessParentResourceRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *UselessParentResourceRule) check(ctx *api.Context) {
 	idx := ctx.ResourceIndex
@@ -156,7 +156,7 @@ type UselessLeafResourceRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Android layout resource rule. Detection flags layout-file anti-patterns
 // (nesting depth, unnecessary containers, missing constraints) via
 // structural checks on layout XML. Classified per roadmap/17.
-func (r *UselessLeafResourceRule) Confidence() float64 { return 0.75 }
+func (r *UselessLeafResourceRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *UselessLeafResourceRule) check(ctx *api.Context) {
 	idx := ctx.ResourceIndex
@@ -195,7 +195,7 @@ type NestedScrollingResourceRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Android layout resource rule. Detection flags layout-file anti-patterns
 // (nesting depth, unnecessary containers, missing constraints) via
 // structural checks on layout XML. Classified per roadmap/17.
-func (r *NestedScrollingResourceRule) Confidence() float64 { return 0.75 }
+func (r *NestedScrollingResourceRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *NestedScrollingResourceRule) check(ctx *api.Context) {
 	idx := ctx.ResourceIndex
@@ -233,7 +233,7 @@ type ScrollViewCountResourceRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Android layout resource rule. Detection flags layout-file anti-patterns
 // (nesting depth, unnecessary containers, missing constraints) via
 // structural checks on layout XML. Classified per roadmap/17.
-func (r *ScrollViewCountResourceRule) Confidence() float64 { return 0.75 }
+func (r *ScrollViewCountResourceRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *ScrollViewCountResourceRule) check(ctx *api.Context) {
 	idx := ctx.ResourceIndex
@@ -267,7 +267,7 @@ type ScrollViewSizeResourceRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Android layout resource rule. Detection flags layout-file anti-patterns
 // (nesting depth, unnecessary containers, missing constraints) via
 // structural checks on layout XML. Classified per roadmap/17.
-func (r *ScrollViewSizeResourceRule) Confidence() float64 { return 0.75 }
+func (r *ScrollViewSizeResourceRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *ScrollViewSizeResourceRule) check(ctx *api.Context) {
 	idx := ctx.ResourceIndex
@@ -312,7 +312,7 @@ type RequiredSizeResourceRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Android layout resource rule. Detection flags layout-file anti-patterns
 // (nesting depth, unnecessary containers, missing constraints) via
 // structural checks on layout XML. Classified per roadmap/17.
-func (r *RequiredSizeResourceRule) Confidence() float64 { return 0.75 }
+func (r *RequiredSizeResourceRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *RequiredSizeResourceRule) check(ctx *api.Context) {
 	idx := ctx.ResourceIndex
@@ -379,7 +379,7 @@ type OrientationResourceRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Android layout resource rule. Detection flags layout-file anti-patterns
 // (nesting depth, unnecessary containers, missing constraints) via
 // structural checks on layout XML. Classified per roadmap/17.
-func (r *OrientationResourceRule) Confidence() float64 { return 0.75 }
+func (r *OrientationResourceRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *OrientationResourceRule) check(ctx *api.Context) {
 	idx := ctx.ResourceIndex
@@ -470,7 +470,7 @@ var adapterViewTypes = map[string]bool{
 // Confidence reports a tier-2 (medium) base confidence. Android layout resource rule. Detection flags layout-file anti-patterns
 // (nesting depth, unnecessary containers, missing constraints) via
 // structural checks on layout XML. Classified per roadmap/17.
-func (r *AdapterViewChildrenResourceRule) Confidence() float64 { return 0.75 }
+func (r *AdapterViewChildrenResourceRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *AdapterViewChildrenResourceRule) check(ctx *api.Context) {
 	idx := ctx.ResourceIndex
@@ -503,7 +503,7 @@ type IncludeLayoutParamResourceRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Android layout resource rule. Detection flags layout-file anti-patterns
 // (nesting depth, unnecessary containers, missing constraints) via
 // structural checks on layout XML. Classified per roadmap/17.
-func (r *IncludeLayoutParamResourceRule) Confidence() float64 { return 0.75 }
+func (r *IncludeLayoutParamResourceRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *IncludeLayoutParamResourceRule) check(ctx *api.Context) {
 	idx := ctx.ResourceIndex
@@ -541,7 +541,7 @@ type UseCompoundDrawablesResourceRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Android layout resource rule. Detection flags layout-file anti-patterns
 // (nesting depth, unnecessary containers, missing constraints) via
 // structural checks on layout XML. Classified per roadmap/17.
-func (r *UseCompoundDrawablesResourceRule) Confidence() float64 { return 0.75 }
+func (r *UseCompoundDrawablesResourceRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *UseCompoundDrawablesResourceRule) check(ctx *api.Context) {
 	idx := ctx.ResourceIndex
@@ -593,7 +593,7 @@ type InconsistentLayoutResourceRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Android layout resource rule. Detection flags layout-file anti-patterns
 // (nesting depth, unnecessary containers, missing constraints) via
 // structural checks on layout XML. Classified per roadmap/17.
-func (r *InconsistentLayoutResourceRule) Confidence() float64 { return 0.75 }
+func (r *InconsistentLayoutResourceRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *InconsistentLayoutResourceRule) check(ctx *api.Context) {
 	idx := ctx.ResourceIndex

--- a/internal/rules/android_resource_rtl.go
+++ b/internal/rules/android_resource_rtl.go
@@ -32,7 +32,7 @@ var rtlReplacements = map[string]string{
 // Confidence reports a tier-2 (medium) base confidence. Android RTL resource rule. Detection flags start/end vs left/right
 // attribute usage and bidi markers via attribute presence checks.
 // Classified per roadmap/17.
-func (r *RtlHardcodedResourceRule) Confidence() float64 { return 0.75 }
+func (r *RtlHardcodedResourceRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *RtlHardcodedResourceRule) check(ctx *api.Context) {
 	idx := ctx.ResourceIndex
@@ -154,7 +154,7 @@ func hasSingleEdgeConstraint(v *android.View) bool {
 // Confidence reports a tier-2 (medium) base confidence. Android RTL resource rule. Detection flags start/end vs left/right
 // attribute usage and bidi markers via attribute presence checks.
 // Classified per roadmap/17.
-func (r *RtlSymmetryResourceRule) Confidence() float64 { return 0.75 }
+func (r *RtlSymmetryResourceRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *RtlSymmetryResourceRule) check(ctx *api.Context) {
 	idx := ctx.ResourceIndex
@@ -195,7 +195,7 @@ type RtlSuperscriptResourceRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Android RTL resource rule. Detection flags start/end vs left/right
 // attribute usage and bidi markers via attribute presence checks.
 // Classified per roadmap/17.
-func (r *RtlSuperscriptResourceRule) Confidence() float64 { return 0.75 }
+func (r *RtlSuperscriptResourceRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *RtlSuperscriptResourceRule) check(ctx *api.Context) {
 	idx := ctx.ResourceIndex
@@ -245,7 +245,7 @@ func verticalConstraintKey(v *android.View) string {
 // Confidence reports a tier-2 (medium) base confidence. Android RTL resource rule. Detection flags start/end vs left/right
 // attribute usage and bidi markers via attribute presence checks.
 // Classified per roadmap/17.
-func (r *RelativeOverlapResourceRule) Confidence() float64 { return 0.75 }
+func (r *RelativeOverlapResourceRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *RelativeOverlapResourceRule) check(ctx *api.Context) {
 	idx := ctx.ResourceIndex
@@ -317,7 +317,7 @@ var relativeConstraintAttrs = []string{
 // Confidence reports a tier-2 (medium) base confidence. Android RTL resource rule. Detection flags start/end vs left/right
 // attribute usage and bidi markers via attribute presence checks.
 // Classified per roadmap/17.
-func (r *NotSiblingResourceRule) Confidence() float64 { return 0.75 }
+func (r *NotSiblingResourceRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *NotSiblingResourceRule) check(ctx *api.Context) {
 	idx := ctx.ResourceIndex

--- a/internal/rules/android_resource_style.go
+++ b/internal/rules/android_resource_style.go
@@ -141,7 +141,7 @@ func isLayoutHeightAttr(name string) bool {
 // Confidence reports a tier-2 (medium) base confidence. Android style/theme resource rule. Detection flags style inheritance
 // anti-patterns and attribute mismatches via structural checks on style
 // XML. Classified per roadmap/17.
-func (r *PxUsageResourceRule) Confidence() float64 { return 0.75 }
+func (r *PxUsageResourceRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *PxUsageResourceRule) check(ctx *api.Context) {
 	idx := ctx.ResourceIndex
@@ -221,7 +221,7 @@ func isDpValue(val string) bool {
 // Confidence reports a tier-2 (medium) base confidence. Android style/theme resource rule. Detection flags style inheritance
 // anti-patterns and attribute mismatches via structural checks on style
 // XML. Classified per roadmap/17.
-func (r *SpUsageResourceRule) Confidence() float64 { return 0.75 }
+func (r *SpUsageResourceRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *SpUsageResourceRule) check(ctx *api.Context) {
 	idx := ctx.ResourceIndex
@@ -305,7 +305,7 @@ func parseSpValue(val string) (float64, bool) {
 // Confidence reports a tier-2 (medium) base confidence. Android style/theme resource rule. Detection flags style inheritance
 // anti-patterns and attribute mismatches via structural checks on style
 // XML. Classified per roadmap/17.
-func (r *SmallSpResourceRule) Confidence() float64 { return 0.75 }
+func (r *SmallSpResourceRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *SmallSpResourceRule) check(ctx *api.Context) {
 	idx := ctx.ResourceIndex
@@ -405,7 +405,7 @@ func isNumeric(s string) bool {
 // Confidence reports a tier-2 (medium) base confidence. Android style/theme resource rule. Detection flags style inheritance
 // anti-patterns and attribute mismatches via structural checks on style
 // XML. Classified per roadmap/17.
-func (r *InOrMmUsageResourceRule) Confidence() float64 { return 0.75 }
+func (r *InOrMmUsageResourceRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *InOrMmUsageResourceRule) check(ctx *api.Context) {
 	idx := ctx.ResourceIndex
@@ -478,7 +478,7 @@ func isNegativeMargin(val string) bool {
 // Confidence reports a tier-2 (medium) base confidence. Android style/theme resource rule. Detection flags style inheritance
 // anti-patterns and attribute mismatches via structural checks on style
 // XML. Classified per roadmap/17.
-func (r *NegativeMarginResourceRule) Confidence() float64 { return 0.75 }
+func (r *NegativeMarginResourceRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *NegativeMarginResourceRule) check(ctx *api.Context) {
 	idx := ctx.ResourceIndex
@@ -599,7 +599,7 @@ type DisableBaselineAlignmentResourceRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Android style/theme resource rule. Detection flags style inheritance
 // anti-patterns and attribute mismatches via structural checks on style
 // XML. Classified per roadmap/17.
-func (r *DisableBaselineAlignmentResourceRule) Confidence() float64 { return 0.75 }
+func (r *DisableBaselineAlignmentResourceRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *DisableBaselineAlignmentResourceRule) check(ctx *api.Context) {
 	idx := ctx.ResourceIndex
@@ -693,7 +693,7 @@ type InefficientWeightResourceRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Android style/theme resource rule. Detection flags style inheritance
 // anti-patterns and attribute mismatches via structural checks on style
 // XML. Classified per roadmap/17.
-func (r *InefficientWeightResourceRule) Confidence() float64 { return 0.75 }
+func (r *InefficientWeightResourceRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *InefficientWeightResourceRule) check(ctx *api.Context) {
 	idx := ctx.ResourceIndex
@@ -738,7 +738,7 @@ type NestedWeightsResourceRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Android style/theme resource rule. Detection flags style inheritance
 // anti-patterns and attribute mismatches via structural checks on style
 // XML. Classified per roadmap/17.
-func (r *NestedWeightsResourceRule) Confidence() float64 { return 0.75 }
+func (r *NestedWeightsResourceRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *NestedWeightsResourceRule) check(ctx *api.Context) {
 	idx := ctx.ResourceIndex
@@ -799,7 +799,7 @@ type ObsoleteLayoutParamsResourceRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Android style/theme resource rule. Detection flags style inheritance
 // anti-patterns and attribute mismatches via structural checks on style
 // XML. Classified per roadmap/17.
-func (r *ObsoleteLayoutParamsResourceRule) Confidence() float64 { return 0.75 }
+func (r *ObsoleteLayoutParamsResourceRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *ObsoleteLayoutParamsResourceRule) check(ctx *api.Context) {
 	idx := ctx.ResourceIndex
@@ -844,7 +844,7 @@ type MergeRootFrameResourceRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Android style/theme resource rule. Detection flags style inheritance
 // anti-patterns and attribute mismatches via structural checks on style
 // XML. Classified per roadmap/17.
-func (r *MergeRootFrameResourceRule) Confidence() float64 { return 0.75 }
+func (r *MergeRootFrameResourceRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *MergeRootFrameResourceRule) check(ctx *api.Context) {
 	idx := ctx.ResourceIndex
@@ -906,7 +906,7 @@ func isTransparentBackground(bg string) bool {
 // Confidence reports a tier-2 (medium) base confidence. Android style/theme resource rule. Detection flags style inheritance
 // anti-patterns and attribute mismatches via structural checks on style
 // XML. Classified per roadmap/17.
-func (r *OverdrawResourceRule) Confidence() float64 { return 0.75 }
+func (r *OverdrawResourceRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *OverdrawResourceRule) check(ctx *api.Context) {
 	idx := ctx.ResourceIndex
@@ -944,7 +944,7 @@ type AlwaysShowActionResourceRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Android style/theme resource rule. Detection flags style inheritance
 // anti-patterns and attribute mismatches via structural checks on style
 // XML. Classified per roadmap/17.
-func (r *AlwaysShowActionResourceRule) Confidence() float64 { return 0.75 }
+func (r *AlwaysShowActionResourceRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *AlwaysShowActionResourceRule) check(ctx *api.Context) {
 	idx := ctx.ResourceIndex
@@ -977,7 +977,7 @@ type StateListReachableResourceRule struct {
 	AndroidRule
 }
 
-func (r *StateListReachableResourceRule) Confidence() float64 { return 0.75 }
+func (r *StateListReachableResourceRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *StateListReachableResourceRule) check(ctx *api.Context) {
 	idx := ctx.ResourceIndex

--- a/internal/rules/android_resource_values.go
+++ b/internal/rules/android_resource_values.go
@@ -30,7 +30,7 @@ type WebViewInScrollViewResourceRule struct {
 }
 
 // Confidence reports a tier-2 (medium) base confidence.
-func (r *WebViewInScrollViewResourceRule) Confidence() float64 { return 0.75 }
+func (r *WebViewInScrollViewResourceRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *WebViewInScrollViewResourceRule) check(ctx *api.Context) {
 	idx := ctx.ResourceIndex
@@ -67,7 +67,7 @@ type OnClickResourceRule struct {
 }
 
 // Confidence reports a tier-2 (medium) base confidence.
-func (r *OnClickResourceRule) Confidence() float64 { return 0.75 }
+func (r *OnClickResourceRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *OnClickResourceRule) check(ctx *api.Context) {
 	idx := ctx.ResourceIndex
@@ -94,7 +94,7 @@ type TextFieldsResourceRule struct {
 }
 
 // Confidence reports a tier-2 (medium) base confidence.
-func (r *TextFieldsResourceRule) Confidence() float64 { return 0.75 }
+func (r *TextFieldsResourceRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *TextFieldsResourceRule) check(ctx *api.Context) {
 	idx := ctx.ResourceIndex
@@ -133,7 +133,7 @@ var apiLevelAttrs = map[string]int{
 }
 
 // Confidence reports a tier-2 (medium) base confidence.
-func (r *UnusedAttributeResourceRule) Confidence() float64 { return 0.75 }
+func (r *UnusedAttributeResourceRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *UnusedAttributeResourceRule) check(ctx *api.Context) {
 	idx := ctx.ResourceIndex
@@ -199,7 +199,7 @@ var languageExpectedRegions = map[string][]string{
 }
 
 // Confidence reports a tier-2 (medium) base confidence.
-func (r *WrongRegionResourceRule) Confidence() float64 { return 0.75 }
+func (r *WrongRegionResourceRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *WrongRegionResourceRule) check(ctx *api.Context) {
 	idx := ctx.ResourceIndex
@@ -272,7 +272,7 @@ type LocaleConfigStaleResourceRule struct {
 }
 
 // Confidence reports a tier-2 (medium) base confidence.
-func (r *LocaleConfigStaleResourceRule) Confidence() float64 { return 0.75 }
+func (r *LocaleConfigStaleResourceRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *LocaleConfigStaleResourceRule) check(ctx *api.Context) {
 	idx := ctx.ResourceIndex
@@ -517,7 +517,7 @@ type MissingQuantityResourceRule struct {
 }
 
 // Confidence reports a tier-2 (medium) base confidence.
-func (r *MissingQuantityResourceRule) Confidence() float64 { return 0.75 }
+func (r *MissingQuantityResourceRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *MissingQuantityResourceRule) check(ctx *api.Context) {
 	idx := ctx.ResourceIndex
@@ -550,7 +550,7 @@ var unusedEnglishQuantities = map[string]bool{
 }
 
 // Confidence reports a tier-2 (medium) base confidence.
-func (r *UnusedQuantityResourceRule) Confidence() float64 { return 0.75 }
+func (r *UnusedQuantityResourceRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *UnusedQuantityResourceRule) check(ctx *api.Context) {
 	idx := ctx.ResourceIndex
@@ -579,7 +579,7 @@ type ImpliedQuantityResourceRule struct {
 }
 
 // Confidence reports a tier-2 (medium) base confidence.
-func (r *ImpliedQuantityResourceRule) Confidence() float64 { return 0.75 }
+func (r *ImpliedQuantityResourceRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *ImpliedQuantityResourceRule) check(ctx *api.Context) {
 	idx := ctx.ResourceIndex
@@ -617,7 +617,7 @@ var validConversions = map[byte]bool{
 }
 
 // Confidence reports a tier-2 (medium) base confidence.
-func (r *StringFormatInvalidResourceRule) Confidence() float64 { return 0.75 }
+func (r *StringFormatInvalidResourceRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *StringFormatInvalidResourceRule) check(ctx *api.Context) {
 	idx := ctx.ResourceIndex
@@ -716,7 +716,7 @@ type StringFormatCountResourceRule struct {
 }
 
 // Confidence reports a tier-2 (medium) base confidence.
-func (r *StringFormatCountResourceRule) Confidence() float64 { return 0.75 }
+func (r *StringFormatCountResourceRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *StringFormatCountResourceRule) check(ctx *api.Context) {
 	idx := ctx.ResourceIndex
@@ -795,7 +795,7 @@ type StringFormatMatchesResourceRule struct {
 }
 
 // Confidence reports a tier-2 (medium) base confidence.
-func (r *StringFormatMatchesResourceRule) Confidence() float64 { return 0.75 }
+func (r *StringFormatMatchesResourceRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *StringFormatMatchesResourceRule) check(ctx *api.Context) {
 	idx := ctx.ResourceIndex
@@ -901,7 +901,7 @@ type StringFormatTrivialResourceRule struct {
 }
 
 // Confidence reports a tier-2 (medium) base confidence.
-func (r *StringFormatTrivialResourceRule) Confidence() float64 { return 0.75 }
+func (r *StringFormatTrivialResourceRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *StringFormatTrivialResourceRule) check(ctx *api.Context) {
 	idx := ctx.ResourceIndex
@@ -1020,7 +1020,7 @@ type StringNotLocalizableResourceRule struct {
 }
 
 // Confidence reports a tier-2 (medium) base confidence.
-func (r *StringNotLocalizableResourceRule) Confidence() float64 { return 0.75 }
+func (r *StringNotLocalizableResourceRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *StringNotLocalizableResourceRule) check(ctx *api.Context) {
 	idx := ctx.ResourceIndex
@@ -1110,7 +1110,7 @@ type GoogleAPIKeyInResourcesRule struct {
 }
 
 // Confidence reports a tier-2 (medium) base confidence.
-func (r *GoogleAPIKeyInResourcesRule) Confidence() float64 { return 0.75 }
+func (r *GoogleAPIKeyInResourcesRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *GoogleAPIKeyInResourcesRule) check(ctx *api.Context) {
 	idx := ctx.ResourceIndex
@@ -1177,7 +1177,7 @@ type InconsistentArraysResourceRule struct {
 }
 
 // Confidence reports a tier-2 (medium) base confidence.
-func (r *InconsistentArraysResourceRule) Confidence() float64 { return 0.75 }
+func (r *InconsistentArraysResourceRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *InconsistentArraysResourceRule) check(ctx *api.Context) {
 	idx := ctx.ResourceIndex
@@ -1204,7 +1204,7 @@ type StringTrailingWhitespaceResourceRule struct {
 }
 
 // Confidence reports a tier-2 (medium) base confidence.
-func (r *StringTrailingWhitespaceResourceRule) Confidence() float64 { return 0.85 }
+func (r *StringTrailingWhitespaceResourceRule) Confidence() float64 { return api.ConfidenceHigh }
 
 func (r *StringTrailingWhitespaceResourceRule) check(ctx *api.Context) {
 	idx := ctx.ResourceIndex
@@ -1241,7 +1241,7 @@ type StringResourceMissingPositionalRule struct {
 }
 
 // Confidence reports a tier-2 (medium) base confidence.
-func (r *StringResourceMissingPositionalRule) Confidence() float64 { return 0.85 }
+func (r *StringResourceMissingPositionalRule) Confidence() float64 { return api.ConfidenceHigh }
 
 func (r *StringResourceMissingPositionalRule) check(ctx *api.Context) {
 	idx := ctx.ResourceIndex
@@ -1341,7 +1341,7 @@ type ExtraTextResourceRule struct {
 }
 
 // Confidence reports a tier-2 (medium) base confidence.
-func (r *ExtraTextResourceRule) Confidence() float64 { return 0.75 }
+func (r *ExtraTextResourceRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *ExtraTextResourceRule) check(ctx *api.Context) {
 	idx := ctx.ResourceIndex
@@ -1370,7 +1370,7 @@ var localeFolderBadRe = regexp.MustCompile(`^values-(?:[a-z0-9]+-)*([a-z]{2})_([
 // Confidence reports a tier-3 (high) base confidence: the rule matches against
 // actual `res/values-*/` directory names from `os.ReadDir`, not source text,
 // so the only error path is a filesystem read failure.
-func (r *LocaleFolderRule) Confidence() float64 { return 0.95 }
+func (r *LocaleFolderRule) Confidence() float64 { return api.ConfidenceVeryHigh }
 
 func (r *LocaleFolderRule) check(ctx *api.Context) {
 	forEachValuesQualifierDir(ctx, func(resRoot, name string) {
@@ -1397,7 +1397,7 @@ var alpha3FolderRe = regexp.MustCompile(`^values-([a-z]{3})(?:-|$)`)
 // Confidence reports a tier-3 (high) base confidence: the 3→2 letter mapping
 // is a closed allow-list, so an unknown 3-letter token (`mcc`, `xyz`, ...)
 // cannot trigger a false positive.
-func (r *UseAlpha2Rule) Confidence() float64 { return 0.95 }
+func (r *UseAlpha2Rule) Confidence() float64 { return api.ConfidenceVeryHigh }
 
 func (r *UseAlpha2Rule) check(ctx *api.Context) {
 	forEachValuesQualifierDir(ctx, func(resRoot, name string) {

--- a/internal/rules/android_security.go
+++ b/internal/rules/android_security.go
@@ -403,37 +403,37 @@ type ImplicitPendingIntentRule struct {
 // confirms the receiver is javax.crypto.Cipher via import presence or
 // the absence of a same-file user-defined Cipher class. Algorithm
 // inspection uses the literal's parsed content, not regex slicing.
-func (r *GetInstanceRule) Confidence() float64 { return 0.85 }
+func (r *GetInstanceRule) Confidence() float64 { return api.ConfidenceHigh }
 
-func (r *WeakMessageDigestRule) Confidence() float64 { return 0.85 }
+func (r *WeakMessageDigestRule) Confidence() float64 { return api.ConfidenceHigh }
 
-func (r *WeakMacAlgorithmRule) Confidence() float64 { return 0.85 }
+func (r *WeakMacAlgorithmRule) Confidence() float64 { return api.ConfidenceHigh }
 
-func (r *WeakKeySizeRule) Confidence() float64 { return 0.75 }
+func (r *WeakKeySizeRule) Confidence() float64 { return api.ConfidenceMedium }
 
-func (r *StaticIvRule) Confidence() float64 { return 0.8 }
+func (r *StaticIvRule) Confidence() float64 { return api.ConfidenceMediumHigh }
 
-func (r *HardcodedSecretKeyRule) Confidence() float64 { return 0.85 }
+func (r *HardcodedSecretKeyRule) Confidence() float64 { return api.ConfidenceHigh }
 
-func (r *HardcodedHTTPURLRule) Confidence() float64 { return 0.85 }
+func (r *HardcodedHTTPURLRule) Confidence() float64 { return api.ConfidenceHigh }
 
-func (r *StartActivityWithUntrustedIntentRule) Confidence() float64 { return 0.75 }
+func (r *StartActivityWithUntrustedIntentRule) Confidence() float64 { return api.ConfidenceMedium }
 
-func (r *RsaNoPaddingRule) Confidence() float64 { return 0.85 }
+func (r *RsaNoPaddingRule) Confidence() float64 { return api.ConfidenceHigh }
 
-func (r *PrngFromSystemTimeRule) Confidence() float64 { return 0.75 }
+func (r *PrngFromSystemTimeRule) Confidence() float64 { return api.ConfidenceMedium }
 
-func (r *OkHTTPDisableSslValidationRule) Confidence() float64 { return 0.75 }
+func (r *OkHTTPDisableSslValidationRule) Confidence() float64 { return api.ConfidenceMedium }
 
-func (r *DisableCertificatePinningRule) Confidence() float64 { return 0.85 }
+func (r *DisableCertificatePinningRule) Confidence() float64 { return api.ConfidenceHigh }
 
-func (r *AllowAllHostnameVerifierRule) Confidence() float64 { return 0.85 }
+func (r *AllowAllHostnameVerifierRule) Confidence() float64 { return api.ConfidenceHigh }
 
-func (r *BroadcastReceiverExportedFlagMissingRule) Confidence() float64 { return 0.85 }
+func (r *BroadcastReceiverExportedFlagMissingRule) Confidence() float64 { return api.ConfidenceHigh }
 
-func (r *InsecureTrustManagerRule) Confidence() float64 { return 0.85 }
+func (r *InsecureTrustManagerRule) Confidence() float64 { return api.ConfidenceHigh }
 
-func (r *ImplicitPendingIntentRule) Confidence() float64 { return 0.85 }
+func (r *ImplicitPendingIntentRule) Confidence() float64 { return api.ConfidenceHigh }
 
 var getInstanceInsecureAlgoTokens = []string{"ECB", "DES", "RC2", "RC4"}
 
@@ -2107,7 +2107,7 @@ type ExportedContentProviderRule struct {
 // lists of API names) rather than type resolution, so project-
 // specific wrapper APIs can cause false positives or negatives.
 // Classified per roadmap/17.
-func (r *ExportedContentProviderRule) Confidence() float64 { return 0.75 }
+func (r *ExportedContentProviderRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func exportedPermissionEnforcedInClass(file *scanner.File, classIdx uint32) bool {
 	body, _ := file.FlatFindChild(classIdx, "class_body")
@@ -2165,7 +2165,7 @@ type ExportedReceiverRule struct {
 // lists of API names) rather than type resolution, so project-
 // specific wrapper APIs can cause false positives or negatives.
 // Classified per roadmap/17.
-func (r *ExportedReceiverRule) Confidence() float64 { return 0.75 }
+func (r *ExportedReceiverRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *ExportedReceiverRule) check(ctx *api.Context) {
 	file, idx := ctx.File, ctx.Idx
@@ -2191,7 +2191,7 @@ type GrantAllUrisRule struct {
 // lists of API names) rather than type resolution, so project-
 // specific wrapper APIs can cause false positives or negatives.
 // Classified per roadmap/17.
-func (r *GrantAllUrisRule) Confidence() float64 { return 0.75 }
+func (r *GrantAllUrisRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *GrantAllUrisRule) check(ctx *api.Context) {
 	file, idx := ctx.File, ctx.Idx
@@ -2325,7 +2325,7 @@ type UnprotectedDynamicReceiverRule struct {
 	AndroidRule
 }
 
-func (r *UnprotectedDynamicReceiverRule) Confidence() float64 { return 0.75 }
+func (r *UnprotectedDynamicReceiverRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *UnprotectedDynamicReceiverRule) check(ctx *api.Context) {
 	file := ctx.File

--- a/internal/rules/android_security_misc.go
+++ b/internal/rules/android_security_misc.go
@@ -22,7 +22,7 @@ var easterEggRe = regexp.MustCompile(`(?i)\b(easter\s*egg|cheat\s*code|secret\s*
 // lists of API names) rather than type resolution, so project-
 // specific wrapper APIs can cause false positives or negatives.
 // Classified per roadmap/17.
-func (r *EasterEggRule) Confidence() float64 { return 0.75 }
+func (r *EasterEggRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *EasterEggRule) check(ctx *api.Context) {
 	file := ctx.File
@@ -45,7 +45,7 @@ type TrustedServerRule struct{ AndroidRule }
 // override bodies, and matches a short allow-list of known trust-all
 // hostname-verifier identifiers. Both paths avoid the comment/string
 // false positives that the previous line scan was prone to.
-func (r *TrustedServerRule) Confidence() float64 { return 0.95 }
+func (r *TrustedServerRule) Confidence() float64 { return api.ConfidenceVeryHigh }
 
 var trustedServerInsecureIdentifiers = map[string]bool{
 	"TrustAllCertificates":        true,
@@ -174,7 +174,7 @@ type WorldReadableFilesRule struct{ AndroidRule }
 // simple_identifier nodes means matches inside comments or string
 // literals can no longer occur — those live under line_comment /
 // string_content, which tree-sitter does not treat as identifiers.
-func (r *WorldReadableFilesRule) Confidence() float64 { return 0.95 }
+func (r *WorldReadableFilesRule) Confidence() float64 { return api.ConfidenceVeryHigh }
 
 func (r *WorldReadableFilesRule) check(ctx *api.Context) {
 	if worldReadableIdentifierMatch(ctx, "MODE_WORLD_READABLE") {
@@ -191,7 +191,7 @@ type WorldWriteableFilesRule struct{ AndroidRule }
 // simple_identifier nodes means matches inside comments or string
 // literals can no longer occur — those live under line_comment /
 // string_content, which tree-sitter does not treat as identifiers.
-func (r *WorldWriteableFilesRule) Confidence() float64 { return 0.95 }
+func (r *WorldWriteableFilesRule) Confidence() float64 { return api.ConfidenceVeryHigh }
 
 func (r *WorldWriteableFilesRule) check(ctx *api.Context) {
 	if worldReadableIdentifierMatch(ctx, "MODE_WORLD_WRITEABLE") ||

--- a/internal/rules/android_security_secure_random.go
+++ b/internal/rules/android_security_secure_random.go
@@ -15,7 +15,7 @@ type SecureRandomRule struct {
 	AndroidRule
 }
 
-func (r *SecureRandomRule) Confidence() float64 { return 0.85 }
+func (r *SecureRandomRule) Confidence() float64 { return api.ConfidenceHigh }
 
 func (r *SecureRandomRule) check(ctx *api.Context) {
 	file := ctx.File

--- a/internal/rules/android_source.go
+++ b/internal/rules/android_source.go
@@ -35,7 +35,7 @@ type FragmentConstructorRule struct {
 // lists of API names) rather than type resolution, so project-
 // specific wrapper APIs can cause false positives or negatives.
 // Classified per roadmap/17.
-func (r *FragmentConstructorRule) Confidence() float64 { return 0.75 }
+func (r *FragmentConstructorRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // fragmentSuperclasses covers common Fragment base classes.
 var fragmentSuperclasses = []string{
@@ -128,7 +128,7 @@ type GetSignaturesRule struct {
 // lists of API names) rather than type resolution, so project-
 // specific wrapper APIs can cause false positives or negatives.
 // Classified per roadmap/17.
-func (r *GetSignaturesRule) Confidence() float64 { return 0.75 }
+func (r *GetSignaturesRule) Confidence() float64 { return api.ConfidenceMedium }
 
 const getSignaturesFlagValue int64 = 0x40
 
@@ -259,7 +259,7 @@ type SparseArrayRule struct {
 // lists of API names) rather than type resolution, so project-
 // specific wrapper APIs can cause false positives or negatives.
 // Classified per roadmap/17.
-func (r *SparseArrayRule) Confidence() float64 { return 0.9 }
+func (r *SparseArrayRule) Confidence() float64 { return api.ConfidenceHigher }
 
 // =====================================================================
 // 4. UseValueOfRule
@@ -279,7 +279,7 @@ type UseValueOfRule struct {
 // lists of API names) rather than type resolution, so project-
 // specific wrapper APIs can cause false positives or negatives.
 // Classified per roadmap/17.
-func (r *UseValueOfRule) Confidence() float64 { return 0.9 }
+func (r *UseValueOfRule) Confidence() float64 { return api.ConfidenceHigher }
 
 var boxedPrimitiveConstructors = map[string]bool{
 	"Integer":   true,
@@ -411,7 +411,7 @@ type LogTagLengthRule struct {
 // lists of API names) rather than type resolution, so project-
 // specific wrapper APIs can cause false positives or negatives.
 // Classified per roadmap/17.
-func (r *LogTagLengthRule) Confidence() float64 { return 0.9 }
+func (r *LogTagLengthRule) Confidence() float64 { return api.ConfidenceHigher }
 
 // resolveLogTagStringValue resolves the string value of a Log tag
 // argument expression. It handles direct string literals as well as
@@ -482,7 +482,7 @@ type LogTagMismatchRule struct {
 // lists of API names) rather than type resolution, so project-
 // specific wrapper APIs can cause false positives or negatives.
 // Classified per roadmap/17.
-func (r *LogTagMismatchRule) Confidence() float64 { return 0.75 }
+func (r *LogTagMismatchRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // findDirectCompanionTag searches the direct children of a class_declaration
 // for a companion_object containing a TAG constant, returning its string value.
@@ -594,7 +594,7 @@ type NonInternationalizedSmsRule struct {
 // lists of API names) rather than type resolution, so project-
 // specific wrapper APIs can cause false positives or negatives.
 // Classified per roadmap/17.
-func (r *NonInternationalizedSmsRule) Confidence() float64 { return 0.75 }
+func (r *NonInternationalizedSmsRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func nonInternationalizedSmsCallFlat(file *scanner.File, call uint32) bool {
 	name := flatCallExpressionName(file, call)
@@ -658,7 +658,7 @@ type ServiceCastRule struct {
 // lists of API names) rather than type resolution, so project-
 // specific wrapper APIs can cause false positives or negatives.
 // Classified per roadmap/17.
-func (r *ServiceCastRule) Confidence() float64 { return 0.75 }
+func (r *ServiceCastRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // serviceCastMap maps service constant names to their correct manager types.
 var serviceCastMap = map[string]string{
@@ -713,7 +713,7 @@ type ToastRule struct {
 // lists of API names) rather than type resolution, so project-
 // specific wrapper APIs can cause false positives or negatives.
 // Classified per roadmap/17.
-func (r *ToastRule) Confidence() float64 { return 0.85 }
+func (r *ToastRule) Confidence() float64 { return api.ConfidenceHigh }
 
 func toastMakeTextIsShown(file *scanner.File, call uint32) bool {
 	if ancestorCallNameMatches(file, call, "show") {

--- a/internal/rules/android_source_extra.go
+++ b/internal/rules/android_source_extra.go
@@ -196,7 +196,7 @@ type ViewConstructorRule struct {
 // lists of API names) rather than type resolution, so project-
 // specific wrapper APIs can cause false positives or negatives.
 // Classified per roadmap/17.
-func (r *ViewConstructorRule) Confidence() float64 { return 0.75 }
+func (r *ViewConstructorRule) Confidence() float64 { return api.ConfidenceMedium }
 
 var viewSuperclasses = []string{"View", "ViewGroup", "TextView", "ImageView", "LinearLayout", "RelativeLayout", "FrameLayout", "ConstraintLayout", "RecyclerView", "SurfaceView", "EditText", "Button", "ScrollView", "HorizontalScrollView", "AppBarLayout", "CoordinatorLayout", "CardView", "Toolbar"}
 
@@ -307,7 +307,7 @@ func (r *ViewTagRule) NodeTypes() []string { return []string{"call_expression"} 
 // Confidence reports a high-confidence semantic check. The rule now anchors
 // on setTag call expressions, verifies the receiver is a View, and classifies
 // the tagged value by resolved type instead of variable names.
-func (r *ViewTagRule) Confidence() float64 { return 0.85 }
+func (r *ViewTagRule) Confidence() float64 { return api.ConfidenceHigh }
 
 var viewTagReceiverTypes = []string{
 	"android.view.View",
@@ -576,7 +576,7 @@ type WrongImportRule struct {
 // syntactic — an import_header's `identifier` child carries the exact
 // dotted FQN. No symbol resolution is needed and no source-text
 // heuristics are involved.
-func (r *WrongImportRule) Confidence() float64 { return 0.95 }
+func (r *WrongImportRule) Confidence() float64 { return api.ConfidenceVeryHigh }
 
 // check runs per import_header node. It flags `import android.R` and
 // any `import android.R.<anything>` (e.g. `android.R.layout`) because
@@ -635,7 +635,7 @@ func (r *LayoutInflationRule) NodeTypes() []string { return []string{"call_expre
 // Confidence reports a high-confidence AST/resource-backed check. The
 // remaining uncertainty is limited to intentional no-parent contexts that do
 // not have a precise type signal in tree-sitter-only analysis.
-func (r *LayoutInflationRule) Confidence() float64 { return 0.85 }
+func (r *LayoutInflationRule) Confidence() float64 { return api.ConfidenceHigh }
 
 func (r *LayoutInflationRule) check(ctx *api.Context) {
 	file := ctx.File
@@ -857,7 +857,7 @@ func (r *MissingPermissionRule) NodeTypes() []string { return []string{"call_exp
 // structural or resolved Android API anchor and a same-permission guard proof,
 // but can still run with source-level type evidence when KAA call targets are
 // unavailable.
-func (r *MissingPermissionRule) Confidence() float64 { return 0.75 }
+func (r *MissingPermissionRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *MissingPermissionRule) check(ctx *api.Context) {
 	file := ctx.File
@@ -1592,7 +1592,7 @@ func (r *WrongConstantRule) NodeTypes() []string { return []string{"call_express
 
 // Confidence is medium-high: findings require a structural call plus either a
 // resolved Android framework target or same-file constant-set annotation.
-func (r *WrongConstantRule) Confidence() float64 { return 0.85 }
+func (r *WrongConstantRule) Confidence() float64 { return api.ConfidenceHigh }
 
 func (r *WrongConstantRule) check(ctx *api.Context) {
 	if ctx.File.FlatType(ctx.Idx) != "call_expression" {
@@ -2077,7 +2077,7 @@ type InstantiatableRule struct {
 // lists of API names) rather than type resolution, so project-
 // specific wrapper APIs can cause false positives or negatives.
 // Classified per roadmap/17.
-func (r *InstantiatableRule) Confidence() float64 { return 0.75 }
+func (r *InstantiatableRule) Confidence() float64 { return api.ConfidenceMedium }
 
 var componentSuperclasses = []string{"Activity", "AppCompatActivity", "ComponentActivity", "FragmentActivity", "Service", "IntentService", "BroadcastReceiver", "ContentProvider", "Application"}
 
@@ -2092,7 +2092,7 @@ type RtlAwareRule struct {
 // lists of API names) rather than type resolution, so project-
 // specific wrapper APIs can cause false positives or negatives.
 // Classified per roadmap/17.
-func (r *RtlAwareRule) Confidence() float64 { return 0.75 }
+func (r *RtlAwareRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // rtlAwareMethods maps View member names to their RTL-aware replacements.
 // Keys are bare callee identifiers; the rule uses flatCallExpressionName
@@ -2115,7 +2115,7 @@ type RtlFieldAccessRule struct {
 // lists of API names) rather than type resolution, so project-
 // specific wrapper APIs can cause false positives or negatives.
 // Classified per roadmap/17.
-func (r *RtlFieldAccessRule) Confidence() float64 { return 0.75 }
+func (r *RtlFieldAccessRule) Confidence() float64 { return api.ConfidenceMedium }
 
 var rtlFieldNames = []string{"mLeft", "mRight", "mPaddingLeft", "mPaddingRight"}
 
@@ -2130,7 +2130,7 @@ type GridLayoutRule struct {
 // lists of API names) rather than type resolution, so project-
 // specific wrapper APIs can cause false positives or negatives.
 // Classified per roadmap/17.
-func (r *GridLayoutRule) Confidence() float64 { return 0.85 }
+func (r *GridLayoutRule) Confidence() float64 { return api.ConfidenceHigh }
 
 type MangledCRLFRule struct {
 	LineBase
@@ -2140,7 +2140,7 @@ type MangledCRLFRule struct {
 // Confidence bumps this line rule from the 0.75 line-rule default to
 // 0.95 -- mixed line endings is a literal substring check on the
 // file bytes. Deterministic with no heuristic path.
-func (r *MangledCRLFRule) Confidence() float64 { return 0.95 }
+func (r *MangledCRLFRule) Confidence() float64 { return api.ConfidenceVeryHigh }
 
 func (r *MangledCRLFRule) check(ctx *api.Context) {
 	file := ctx.File
@@ -2163,7 +2163,7 @@ type ResourceNameRule struct {
 // lists of API names) rather than type resolution, so project-
 // specific wrapper APIs can cause false positives or negatives.
 // Classified per roadmap/17.
-func (r *ResourceNameRule) Confidence() float64 { return 0.9 }
+func (r *ResourceNameRule) Confidence() float64 { return api.ConfidenceHigher }
 
 var snakeCaseRe = regexp.MustCompile(`^[a-z][a-z0-9_]*$`)
 
@@ -2178,7 +2178,7 @@ type ProguardRule struct {
 // lists of API names) rather than type resolution, so project-
 // specific wrapper APIs can cause false positives or negatives.
 // Classified per roadmap/17.
-func (r *ProguardRule) Confidence() float64 { return 0.75 }
+func (r *ProguardRule) Confidence() float64 { return api.ConfidenceMedium }
 
 type ProguardSplitRule struct {
 	LineBase
@@ -2196,7 +2196,7 @@ var (
 // lists of API names) rather than type resolution, so project-
 // specific wrapper APIs can cause false positives or negatives.
 // Classified per roadmap/17.
-func (r *ProguardSplitRule) Confidence() float64 { return 0.75 }
+func (r *ProguardSplitRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *ProguardSplitRule) check(ctx *api.Context) {
 	file := ctx.File
@@ -2221,7 +2221,7 @@ type NfcTechWhitespaceRule struct {
 // lists of API names) rather than type resolution, so project-
 // specific wrapper APIs can cause false positives or negatives.
 // Classified per roadmap/17.
-func (r *NfcTechWhitespaceRule) Confidence() float64 { return 0.75 }
+func (r *NfcTechWhitespaceRule) Confidence() float64 { return api.ConfidenceMedium }
 
 var nfcTechRe = regexp.MustCompile(`<tech>\s+\S+|<tech>\S+\s+</tech>`)
 
@@ -2236,7 +2236,7 @@ type LibraryCustomViewRule struct {
 // lists of API names) rather than type resolution, so project-
 // specific wrapper APIs can cause false positives or negatives.
 // Classified per roadmap/17.
-func (r *LibraryCustomViewRule) Confidence() float64 { return 0.75 }
+func (r *LibraryCustomViewRule) Confidence() float64 { return api.ConfidenceMedium }
 
 var hardcodedNsRe = regexp.MustCompile(`http://schemas\.android\.com/apk/res/[a-z][a-z0-9_.]+`)
 
@@ -2251,4 +2251,4 @@ type UnknownIDInLayoutRule struct {
 // lists of API names) rather than type resolution, so project-
 // specific wrapper APIs can cause false positives or negatives.
 // Classified per roadmap/17.
-func (r *UnknownIDInLayoutRule) Confidence() float64 { return 0.9 }
+func (r *UnknownIDInLayoutRule) Confidence() float64 { return api.ConfidenceHigher }

--- a/internal/rules/android_truly_random.go
+++ b/internal/rules/android_truly_random.go
@@ -21,7 +21,7 @@ type TrulyRandomRule struct {
 // to an imported or fully-qualified java.security.SecureRandom reference, so
 // local lookalikes no longer fire; project-specific wrapper APIs named
 // SecureRandom can still produce false negatives when not imported.
-func (r *TrulyRandomRule) Confidence() float64 { return 0.85 }
+func (r *TrulyRandomRule) Confidence() float64 { return api.ConfidenceHigh }
 
 func (r *TrulyRandomRule) check(ctx *api.Context) {
 	file := ctx.File

--- a/internal/rules/android_usability.go
+++ b/internal/rules/android_usability.go
@@ -3,6 +3,7 @@ package rules
 import (
 	"strings"
 
+	api "github.com/kaeawc/krit/internal/rules/api"
 	"github.com/kaeawc/krit/internal/scanner"
 )
 
@@ -32,7 +33,7 @@ type NewAPIRule struct {
 // lists of API names) rather than type resolution, so project-
 // specific wrapper APIs can cause false positives or negatives.
 // Classified per roadmap/17.
-func (r *NewAPIRule) Confidence() float64 { return 0.75 }
+func (r *NewAPIRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // newAPITable maps method/class names to their introduction API level.
 var newAPITable = map[string]int{
@@ -69,7 +70,7 @@ type InlinedAPIRule struct {
 // lists of API names) rather than type resolution, so project-
 // specific wrapper APIs can cause false positives or negatives.
 // Classified per roadmap/17.
-func (r *InlinedAPIRule) Confidence() float64 { return 0.75 }
+func (r *InlinedAPIRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // inlinedAPIEntry pairs a constant pattern with its introduction API level.
 type inlinedAPIEntry struct {
@@ -120,7 +121,7 @@ var overrideMethodNames = map[string]bool{
 // lists of API names) rather than type resolution, so project-
 // specific wrapper APIs can cause false positives or negatives.
 // Classified per roadmap/17.
-func (r *OverrideRule) Confidence() float64 { return 0.75 }
+func (r *OverrideRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func overrideEnclosingAndroidComponentFlat(file *scanner.File, fn uint32) bool {
 	classDecl, ok := flatEnclosingAncestor(file, fn, "class_declaration")
@@ -156,7 +157,7 @@ type UnusedResourcesRule struct {
 // lists of API names) rather than type resolution, so project-
 // specific wrapper APIs can cause false positives or negatives.
 // Classified per roadmap/17.
-func (r *UnusedResourcesRule) Confidence() float64 { return 0.75 }
+func (r *UnusedResourcesRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func unusedResourceReferenceFlat(file *scanner.File, idx uint32) (resType string, resName string, ok bool) {
 	path := contactsIdentifierPathFlat(file, idx)

--- a/internal/rules/android_webview_allow_content_access.go
+++ b/internal/rules/android_webview_allow_content_access.go
@@ -14,7 +14,7 @@ type WebViewAllowContentAccessRule struct {
 	AndroidRule
 }
 
-func (r *WebViewAllowContentAccessRule) Confidence() float64 { return 0.85 }
+func (r *WebViewAllowContentAccessRule) Confidence() float64 { return api.ConfidenceHigh }
 
 const webViewAllowContentAccessMessage = "Avoid enabling WebSettings.allowContentAccess; the content:// URI scheme grants the WebView access to content providers and is rarely required on modern Android."
 

--- a/internal/rules/android_webview_allow_file_access.go
+++ b/internal/rules/android_webview_allow_file_access.go
@@ -16,7 +16,7 @@ type WebViewAllowFileAccessRule struct {
 	AndroidRule
 }
 
-func (r *WebViewAllowFileAccessRule) Confidence() float64 { return 0.85 }
+func (r *WebViewAllowFileAccessRule) Confidence() float64 { return api.ConfidenceHigh }
 
 const webViewAllowFileAccessMessage = "Avoid enabling WebSettings.allowFileAccess; file URL access is disabled by default since API 30 and enabling it allows javascript-served file:// URLs to read other local files."
 

--- a/internal/rules/android_webview_debugging_enabled.go
+++ b/internal/rules/android_webview_debugging_enabled.go
@@ -14,7 +14,7 @@ type WebViewDebuggingEnabledRule struct {
 	AndroidRule
 }
 
-func (r *WebViewDebuggingEnabledRule) Confidence() float64 { return 0.8 }
+func (r *WebViewDebuggingEnabledRule) Confidence() float64 { return api.ConfidenceMediumHigh }
 
 const webViewDebuggingEnabledMessage = "Guard WebView.setWebContentsDebuggingEnabled(true) behind BuildConfig.DEBUG or ApplicationInfo.FLAG_DEBUGGABLE."
 

--- a/internal/rules/android_webview_file_access_from_file_urls.go
+++ b/internal/rules/android_webview_file_access_from_file_urls.go
@@ -14,7 +14,7 @@ type WebViewFileAccessFromFileUrlsRule struct {
 	AndroidRule
 }
 
-func (r *WebViewFileAccessFromFileUrlsRule) Confidence() float64 { return 0.85 }
+func (r *WebViewFileAccessFromFileUrlsRule) Confidence() float64 { return api.ConfidenceHigh }
 
 const webViewFileAccessFromFileUrlsMessage = "Avoid enabling WebSettings.allowFileAccessFromFileURLs; pages loaded from file:// URLs can read other file:// documents, enabling local-file exfiltration via XSS."
 

--- a/internal/rules/android_webview_mixed_content_allow_all.go
+++ b/internal/rules/android_webview_mixed_content_allow_all.go
@@ -16,7 +16,7 @@ type WebViewMixedContentAllowAllRule struct {
 	AndroidRule
 }
 
-func (r *WebViewMixedContentAllowAllRule) Confidence() float64 { return 0.9 }
+func (r *WebViewMixedContentAllowAllRule) Confidence() float64 { return api.ConfidenceHigher }
 
 const webViewMixedContentAllowAllMessage = "Avoid setting WebSettings.mixedContentMode to MIXED_CONTENT_ALWAYS_ALLOW; it permits http subresources on https pages and enables TLS stripping. Prefer MIXED_CONTENT_NEVER_ALLOW or MIXED_CONTENT_COMPATIBILITY_MODE."
 

--- a/internal/rules/android_webview_universal_access_from_file_urls.go
+++ b/internal/rules/android_webview_universal_access_from_file_urls.go
@@ -15,7 +15,7 @@ type WebViewUniversalAccessFromFileUrlsRule struct {
 	AndroidRule
 }
 
-func (r *WebViewUniversalAccessFromFileUrlsRule) Confidence() float64 { return 0.9 }
+func (r *WebViewUniversalAccessFromFileUrlsRule) Confidence() float64 { return api.ConfidenceHigher }
 
 const webViewUniversalAccessFromFileUrlsMessage = "Avoid enabling WebSettings.allowUniversalAccessFromFileURLs; pages loaded from file:// URLs can read arbitrary cross-origin URLs, exposing local data."
 

--- a/internal/rules/api/confidence.go
+++ b/internal/rules/api/confidence.go
@@ -1,0 +1,17 @@
+package api
+
+// Confidence tier constants for rule-reported confidence scores.
+// Values are preserved verbatim from the literals that previously
+// appeared inline in each rule's Confidence() method; this file is a
+// rename, not a re-tuning. Outlier values that did not fit a tier
+// (e.g. 0.55, 0.65, 0.99) remain as literals at the call site.
+const (
+	ConfidenceLow           = 0.5
+	ConfidenceMediumLow     = 0.6
+	ConfidenceMediumLowPlus = 0.7
+	ConfidenceMedium        = 0.75
+	ConfidenceMediumHigh    = 0.8
+	ConfidenceHigh          = 0.85
+	ConfidenceHigher        = 0.9
+	ConfidenceVeryHigh      = 0.95
+)

--- a/internal/rules/comments.go
+++ b/internal/rules/comments.go
@@ -205,7 +205,7 @@ type AbsentOrWrongFileLicenseRule struct {
 // Confidence holds the 0.95 dispatch default. Documentation/comment rule. Detection checks presence and
 // well-formedness of doc comments on declarations — purely structural. No
 // heuristic path. Classified per roadmap/17.
-func (r *AbsentOrWrongFileLicenseRule) Confidence() float64 { return 0.95 }
+func (r *AbsentOrWrongFileLicenseRule) Confidence() float64 { return api.ConfidenceVeryHigh }
 
 func (r *AbsentOrWrongFileLicenseRule) check(ctx *api.Context) {
 	file := ctx.File
@@ -397,7 +397,7 @@ func buildDeprecatedAnnotation(message string) string {
 // Confidence holds the 0.95 dispatch default. Documentation/comment rule. Detection checks presence and
 // well-formedness of doc comments on declarations — purely structural. No
 // heuristic path. Classified per roadmap/17.
-func (r *DeprecatedBlockTagRule) Confidence() float64 { return 0.95 }
+func (r *DeprecatedBlockTagRule) Confidence() float64 { return api.ConfidenceVeryHigh }
 
 // DocumentationOverPrivateFunctionRule detects KDoc on private functions.
 type DocumentationOverPrivateFunctionRule struct {
@@ -408,7 +408,7 @@ type DocumentationOverPrivateFunctionRule struct {
 // Confidence holds the 0.95 dispatch default. Documentation/comment rule. Detection checks presence and
 // well-formedness of doc comments on declarations — purely structural. No
 // heuristic path. Classified per roadmap/17.
-func (r *DocumentationOverPrivateFunctionRule) Confidence() float64 { return 0.95 }
+func (r *DocumentationOverPrivateFunctionRule) Confidence() float64 { return api.ConfidenceVeryHigh }
 
 // DocumentationOverPrivatePropertyRule detects KDoc on private properties.
 type DocumentationOverPrivatePropertyRule struct {
@@ -419,7 +419,7 @@ type DocumentationOverPrivatePropertyRule struct {
 // Confidence holds the 0.95 dispatch default. Documentation/comment rule. Detection checks presence and
 // well-formedness of doc comments on declarations — purely structural. No
 // heuristic path. Classified per roadmap/17.
-func (r *DocumentationOverPrivatePropertyRule) Confidence() float64 { return 0.95 }
+func (r *DocumentationOverPrivatePropertyRule) Confidence() float64 { return api.ConfidenceVeryHigh }
 
 // EndOfSentenceFormatRule checks KDoc first sentence ends with proper punctuation.
 type EndOfSentenceFormatRule struct {
@@ -434,7 +434,7 @@ type EndOfSentenceFormatRule struct {
 // Confidence holds the 0.95 dispatch default. Documentation/comment rule. Detection checks presence and
 // well-formedness of doc comments on declarations — purely structural. No
 // heuristic path. Classified per roadmap/17.
-func (r *EndOfSentenceFormatRule) Confidence() float64 { return 0.95 }
+func (r *EndOfSentenceFormatRule) Confidence() float64 { return api.ConfidenceVeryHigh }
 
 // KDocReferencesNonPublicPropertyRule finds KDoc [ref] to non-public properties.
 type KDocReferencesNonPublicPropertyRule struct {
@@ -445,7 +445,7 @@ type KDocReferencesNonPublicPropertyRule struct {
 // Confidence holds the 0.95 dispatch default. Documentation/comment rule. Detection checks presence and
 // well-formedness of doc comments on declarations — purely structural. No
 // heuristic path. Classified per roadmap/17.
-func (r *KDocReferencesNonPublicPropertyRule) Confidence() float64 { return 0.95 }
+func (r *KDocReferencesNonPublicPropertyRule) Confidence() float64 { return api.ConfidenceVeryHigh }
 
 var kdocRefRe = regexp.MustCompile(`\[([A-Za-z_][A-Za-z0-9_]*)\]`)
 
@@ -462,7 +462,7 @@ var paramTagRe = regexp.MustCompile(`@param\s+([A-Za-z_][A-Za-z0-9_]*)`)
 // Confidence holds the 0.95 dispatch default. Documentation/comment rule. Detection checks presence and
 // well-formedness of doc comments on declarations — purely structural. No
 // heuristic path. Classified per roadmap/17.
-func (r *OutdatedDocumentationRule) Confidence() float64 { return 0.95 }
+func (r *OutdatedDocumentationRule) Confidence() float64 { return api.ConfidenceVeryHigh }
 
 // outdatedDocCollectTypeParameterNamesFlat returns the type-parameter
 // identifiers declared on a function (e.g. `T`, `R` in `fun <T, R> map`).
@@ -507,7 +507,7 @@ type UndocumentedPublicClassRule struct {
 // Confidence holds the 0.95 dispatch default. Documentation/comment rule. Detection checks presence and
 // well-formedness of doc comments on declarations — purely structural. No
 // heuristic path. Classified per roadmap/17.
-func (r *UndocumentedPublicClassRule) Confidence() float64 { return 0.95 }
+func (r *UndocumentedPublicClassRule) Confidence() float64 { return api.ConfidenceVeryHigh }
 
 // UndocumentedPublicFunctionRule detects public functions without KDoc.
 type UndocumentedPublicFunctionRule struct {
@@ -518,7 +518,7 @@ type UndocumentedPublicFunctionRule struct {
 // Confidence holds the 0.95 dispatch default. Documentation/comment rule. Detection checks presence and
 // well-formedness of doc comments on declarations — purely structural. No
 // heuristic path. Classified per roadmap/17.
-func (r *UndocumentedPublicFunctionRule) Confidence() float64 { return 0.95 }
+func (r *UndocumentedPublicFunctionRule) Confidence() float64 { return api.ConfidenceVeryHigh }
 
 // UndocumentedPublicPropertyRule detects public properties without KDoc.
 type UndocumentedPublicPropertyRule struct {
@@ -529,4 +529,4 @@ type UndocumentedPublicPropertyRule struct {
 // Confidence holds the 0.95 dispatch default. Documentation/comment rule. Detection checks presence and
 // well-formedness of doc comments on declarations — purely structural. No
 // heuristic path. Classified per roadmap/17.
-func (r *UndocumentedPublicPropertyRule) Confidence() float64 { return 0.95 }
+func (r *UndocumentedPublicPropertyRule) Confidence() float64 { return api.ConfidenceVeryHigh }

--- a/internal/rules/complexity.go
+++ b/internal/rules/complexity.go
@@ -260,7 +260,7 @@ func (*LongMethodRule) Description() string {
 // preference that varies by codebase — a given value may be
 // conservative in some contexts and lax in others. Classified per
 // roadmap/17.
-func (r *LongMethodRule) Confidence() float64 { return 0.75 }
+func (r *LongMethodRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // longMethodDeclarationLineFlat returns the 1-based line number of the `fun`
 // keyword within a function_declaration node. It walks the node's direct
@@ -549,7 +549,7 @@ type LargeClassRule struct {
 // preference that varies by codebase — a given value may be
 // conservative in some contexts and lax in others. Classified per
 // roadmap/17.
-func (r *LargeClassRule) Confidence() float64 { return 0.75 }
+func (r *LargeClassRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // NestedBlockDepthRule detects excessive nesting.
 type NestedBlockDepthRule struct {
@@ -565,7 +565,7 @@ type NestedBlockDepthRule struct {
 // preference that varies by codebase — a given value may be
 // conservative in some contexts and lax in others. Classified per
 // roadmap/17.
-func (r *NestedBlockDepthRule) Confidence() float64 { return 0.75 }
+func (r *NestedBlockDepthRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // nestedBlockDepthExceedsFlat returns the function's max nesting depth
 // (read from the shared complexityMetricsCache populated once per
@@ -693,7 +693,7 @@ var decisionTypes = map[string]bool{
 // preference that varies by codebase — a given value may be
 // conservative in some contexts and lax in others. Classified per
 // roadmap/17.
-func (r *CyclomaticComplexMethodRule) Confidence() float64 { return 0.75 }
+func (r *CyclomaticComplexMethodRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func isPureBooleanPredicateFlat(file *scanner.File, fn uint32) bool {
 	body, _ := file.FlatFindChild(fn, "function_body")
@@ -923,7 +923,7 @@ var cognitiveTypes = map[string]bool{
 // preference that varies by codebase — a given value may be
 // conservative in some contexts and lax in others. Classified per
 // roadmap/17.
-func (r *CognitiveComplexMethodRule) Confidence() float64 { return 0.75 }
+func (r *CognitiveComplexMethodRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // ComplexConditionRule detects conditions with too many logical operators.
 type ComplexConditionRule struct {
@@ -965,7 +965,7 @@ func countLogicalOperatorsOutsideBodiesFlat(file *scanner.File, root uint32) int
 // preference that varies by codebase — a given value may be
 // conservative in some contexts and lax in others. Classified per
 // roadmap/17.
-func (r *ComplexConditionRule) Confidence() float64 { return 0.75 }
+func (r *ComplexConditionRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func isPureDisjunctionOrConjunctionFlat(file *scanner.File, root uint32) bool {
 	hasConj := false
@@ -1014,7 +1014,7 @@ type ComplexInterfaceRule struct {
 // preference that varies by codebase — a given value may be
 // conservative in some contexts and lax in others. Classified per
 // roadmap/17.
-func (r *ComplexInterfaceRule) Confidence() float64 { return 0.75 }
+func (r *ComplexInterfaceRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // LabeledExpressionRule detects return@label, break@label, continue@label.
 type LabeledExpressionRule struct {
@@ -1030,7 +1030,7 @@ type LabeledExpressionRule struct {
 // preference that varies by codebase — a given value may be
 // conservative in some contexts and lax in others. Classified per
 // roadmap/17.
-func (r *LabeledExpressionRule) Confidence() float64 { return 0.75 }
+func (r *LabeledExpressionRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // labeledExpressionLabelIgnored reports whether the label-node text matches
 // any name in the ignored list. Tree-sitter Kotlin emits a `label` node for
@@ -1071,7 +1071,7 @@ type LongParameterListRule struct {
 // preference that varies by codebase — a given value may be
 // conservative in some contexts and lax in others. Classified per
 // roadmap/17.
-func (r *LongParameterListRule) Confidence() float64 { return 0.75 }
+func (r *LongParameterListRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // paramHasIgnoredAnnotationFlat reports whether the parameter at idx
 // carries any annotation whose simple name matches one of the names in
@@ -1145,7 +1145,7 @@ type MethodOverloadingRule struct {
 // preference that varies by codebase — a given value may be
 // conservative in some contexts and lax in others. Classified per
 // roadmap/17.
-func (r *MethodOverloadingRule) Confidence() float64 { return 0.75 }
+func (r *MethodOverloadingRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *MethodOverloadingRule) checkScopeFlat(ctx *api.Context, node uint32) {
 	file := ctx.File
@@ -1211,7 +1211,7 @@ type NamedArgumentsRule struct {
 // preference that varies by codebase — a given value may be
 // conservative in some contexts and lax in others. Classified per
 // roadmap/17.
-func (r *NamedArgumentsRule) Confidence() float64 { return 0.75 }
+func (r *NamedArgumentsRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // NestedScopeFunctionsRule detects nested scope functions (apply, also, let, run, with).
 type NestedScopeFunctionsRule struct {
@@ -1252,7 +1252,7 @@ func nestedScopeFunctionsActiveSet(configured []string) map[string]bool {
 // preference that varies by codebase — a given value may be
 // conservative in some contexts and lax in others. Classified per
 // roadmap/17.
-func (r *NestedScopeFunctionsRule) Confidence() float64 { return 0.75 }
+func (r *NestedScopeFunctionsRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func extractCallNameFlat(file *scanner.File, idx uint32) string {
 	for i := 0; i < file.FlatChildCount(idx); i++ {
@@ -1294,7 +1294,7 @@ type ReplaceSafeCallChainWithRunRule struct {
 // preference that varies by codebase — a given value may be
 // conservative in some contexts and lax in others. Classified per
 // roadmap/17.
-func (r *ReplaceSafeCallChainWithRunRule) Confidence() float64 { return 0.75 }
+func (r *ReplaceSafeCallChainWithRunRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func countSafeCallsInChainFlat(file *scanner.File, idx uint32) int {
 	if file.FlatType(idx) != "navigation_expression" {
@@ -1342,7 +1342,7 @@ type StringLiteralDuplicationRule struct {
 // preference that varies by codebase — a given value may be
 // conservative in some contexts and lax in others. Classified per
 // roadmap/17.
-func (r *StringLiteralDuplicationRule) Confidence() float64 { return 0.75 }
+func (r *StringLiteralDuplicationRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // stringLiteralUnquote strips the surrounding quote delimiters from a
 // Kotlin string literal's raw text so that user-supplied
@@ -1410,7 +1410,7 @@ type TooManyFunctionsRule struct {
 // preference that varies by codebase — a given value may be
 // conservative in some contexts and lax in others. Classified per
 // roadmap/17.
-func (r *TooManyFunctionsRule) Confidence() float64 { return 0.75 }
+func (r *TooManyFunctionsRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *TooManyFunctionsRule) shouldCountFunctionFlat(fnNode uint32, file *scanner.File) bool {
 	if r.IgnorePrivate && file.FlatHasModifier(fnNode, "private") {

--- a/internal/rules/compose.go
+++ b/internal/rules/compose.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"strings"
 
+	api "github.com/kaeawc/krit/internal/rules/api"
 	"github.com/kaeawc/krit/internal/scanner"
 )
 
@@ -25,7 +26,7 @@ type ComposeColumnRowInScrollableRule struct {
 // 'verticalScroll', 'LazyColumn', 'rememberSaveable') rather than type
 // resolution, so any project symbol with a matching name or token can
 // produce a false match. Classified per roadmap/17.
-func (r *ComposeColumnRowInScrollableRule) Confidence() float64 { return 0.75 }
+func (r *ComposeColumnRowInScrollableRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // ComposeDerivedStateMisuseRule detects derivedStateOf around direct boolean
 // comparisons of Compose state reads. Those reads already trigger
@@ -40,7 +41,7 @@ type ComposeDerivedStateMisuseRule struct {
 // 'verticalScroll', 'LazyColumn', 'rememberSaveable') rather than type
 // resolution, so any project symbol with a matching name or token can
 // produce a false match. Classified per roadmap/17.
-func (r *ComposeDerivedStateMisuseRule) Confidence() float64 { return 0.75 }
+func (r *ComposeDerivedStateMisuseRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func composeDerivedStateBodyFlat(file *scanner.File, idx uint32) uint32 {
 	callSuffix, _ := file.FlatFindChild(idx, "call_suffix")
@@ -298,7 +299,7 @@ type ComposeLambdaCapturesUnstableStateRule struct {
 // 'verticalScroll', 'LazyColumn', 'rememberSaveable') rather than type
 // resolution, so any project symbol with a matching name or token can
 // produce a false match. Classified per roadmap/17.
-func (r *ComposeLambdaCapturesUnstableStateRule) Confidence() float64 { return 0.75 }
+func (r *ComposeLambdaCapturesUnstableStateRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func composeIsNamedArgumentLambdaFlat(file *scanner.File, node uint32, argName string) bool {
 	if file == nil || node == 0 || file.FlatType(node) != "lambda_literal" {
@@ -424,7 +425,7 @@ var composeFillMaxAxisNames = map[string]struct{}{
 // 'verticalScroll', 'LazyColumn', 'rememberSaveable') rather than type
 // resolution, so any project symbol with a matching name or token can
 // produce a false match. Classified per roadmap/17.
-func (r *ComposeModifierFillAfterSizeRule) Confidence() float64 { return 0.75 }
+func (r *ComposeModifierFillAfterSizeRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // ComposeModifierBackgroundAfterClipRule flags `Modifier.background(...).clip(...)`
 // where the background is drawn in the un-clipped rectangular region instead
@@ -438,7 +439,7 @@ type ComposeModifierBackgroundAfterClipRule struct {
 // 'verticalScroll', 'LazyColumn', 'rememberSaveable') rather than type
 // resolution, so any project symbol with a matching name or token can
 // produce a false match. Classified per roadmap/17.
-func (r *ComposeModifierBackgroundAfterClipRule) Confidence() float64 { return 0.75 }
+func (r *ComposeModifierBackgroundAfterClipRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // ComposeModifierClickableBeforePaddingRule flags
 // `Modifier.clickable { }.padding(...)` — the click area excludes the padding
@@ -452,7 +453,7 @@ type ComposeModifierClickableBeforePaddingRule struct {
 // 'verticalScroll', 'LazyColumn', 'rememberSaveable') rather than type
 // resolution, so any project symbol with a matching name or token can
 // produce a false match. Classified per roadmap/17.
-func (r *ComposeModifierClickableBeforePaddingRule) Confidence() float64 { return 0.75 }
+func (r *ComposeModifierClickableBeforePaddingRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // composeEnclosingLambdaArgumentName walks up from idx looking for the
 // nearest lambda_literal ancestor that is itself a named value_argument, and
@@ -552,7 +553,7 @@ type ComposeRememberWithoutKeyRule struct {
 // 'verticalScroll', 'LazyColumn', 'rememberSaveable') rather than type
 // resolution, so any project symbol with a matching name or token can
 // produce a false match. Classified per roadmap/17.
-func (r *ComposeRememberWithoutKeyRule) Confidence() float64 { return 0.75 }
+func (r *ComposeRememberWithoutKeyRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // ComposeLaunchedEffectWithoutKeysRule flags `LaunchedEffect(Unit) { f(param) }`
 // where the effect body references an enclosing parameter but the keys are
@@ -567,7 +568,7 @@ type ComposeLaunchedEffectWithoutKeysRule struct {
 // 'verticalScroll', 'LazyColumn', 'rememberSaveable') rather than type
 // resolution, so any project symbol with a matching name or token can
 // produce a false match. Classified per roadmap/17.
-func (r *ComposeLaunchedEffectWithoutKeysRule) Confidence() float64 { return 0.75 }
+func (r *ComposeLaunchedEffectWithoutKeysRule) Confidence() float64 { return api.ConfidenceMedium }
 
 var composeConstantKeyTexts = map[string]struct{}{
 	"Unit":  {},
@@ -602,7 +603,7 @@ var composeUnstableCollectionTypes = map[string]struct{}{
 // 'verticalScroll', 'LazyColumn', 'rememberSaveable') rather than type
 // resolution, so any project symbol with a matching name or token can
 // produce a false match. Classified per roadmap/17.
-func (r *ComposeUnstableParameterRule) Confidence() float64 { return 0.75 }
+func (r *ComposeUnstableParameterRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func composeUnstableParameterShouldSkipFunctionFlat(file *scanner.File, fn uint32) bool {
 	if file == nil || fn == 0 {
@@ -700,7 +701,7 @@ var composeSaverSafeBuiltins = map[string]struct{}{
 // 'verticalScroll', 'LazyColumn', 'rememberSaveable') rather than type
 // resolution, so any project symbol with a matching name or token can
 // produce a false match. Classified per roadmap/17.
-func (r *ComposeRememberSaveableNonParcelableRule) Confidence() float64 { return 0.75 }
+func (r *ComposeRememberSaveableNonParcelableRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // ComposeSideEffectInCompositionRule flags direct assignments inside a
 // @Composable function body that aren't wrapped in a recognized effect
@@ -718,7 +719,7 @@ type ComposeSideEffectInCompositionRule struct {
 // 'verticalScroll', 'LazyColumn', 'rememberSaveable') rather than type
 // resolution, so any project symbol with a matching name or token can
 // produce a false match. Classified per roadmap/17.
-func (r *ComposeSideEffectInCompositionRule) Confidence() float64 { return 0.75 }
+func (r *ComposeSideEffectInCompositionRule) Confidence() float64 { return api.ConfidenceMedium }
 
 var composePreviewAnnotationNames = []string{
 	"Preview",
@@ -1096,7 +1097,7 @@ type ComposeModifierPassedThenChainedRule struct {
 // 'verticalScroll', 'LazyColumn', 'rememberSaveable') rather than type
 // resolution, so any project symbol with a matching name or token can
 // produce a false match. Classified per roadmap/17.
-func (r *ComposeModifierPassedThenChainedRule) Confidence() float64 { return 0.75 }
+func (r *ComposeModifierPassedThenChainedRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // composeHasModifierParameter reports whether the given function_declaration
 // declares a parameter named exactly `modifier` of type `Modifier`.
@@ -1138,7 +1139,7 @@ type ComposeDisposableEffectMissingDisposeRule struct {
 // 'verticalScroll', 'LazyColumn', 'rememberSaveable') rather than type
 // resolution, so any project symbol with a matching name or token can
 // produce a false match. Classified per roadmap/17.
-func (r *ComposeDisposableEffectMissingDisposeRule) Confidence() float64 { return 0.75 }
+func (r *ComposeDisposableEffectMissingDisposeRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // ComposePreviewWithBackingStateRule flags `@Preview @Composable fun
 // FooPreview()` whose body calls a runtime state holder like
@@ -1161,7 +1162,7 @@ var composeRuntimeStateHolderCalls = map[string]struct{}{
 // 'verticalScroll', 'LazyColumn', 'rememberSaveable') rather than type
 // resolution, so any project symbol with a matching name or token can
 // produce a false match. Classified per roadmap/17.
-func (r *ComposePreviewWithBackingStateRule) Confidence() float64 { return 0.75 }
+func (r *ComposePreviewWithBackingStateRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // ComposeStatefulDefaultParameterRule flags `@Composable fun Foo(state:
 // MyState = MyState())` — the `MyState()` default allocates a fresh instance
@@ -1178,7 +1179,7 @@ type ComposeStatefulDefaultParameterRule struct {
 // 'verticalScroll', 'LazyColumn', 'rememberSaveable') rather than type
 // resolution, so any project symbol with a matching name or token can
 // produce a false match. Classified per roadmap/17.
-func (r *ComposeStatefulDefaultParameterRule) Confidence() float64 { return 0.75 }
+func (r *ComposeStatefulDefaultParameterRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // ComposeMutableStateInCompositionRule flags `val count = mutableStateOf(0)`
 // as a local property inside a @Composable function. Without a surrounding
@@ -1193,7 +1194,7 @@ type ComposeMutableStateInCompositionRule struct {
 // 'verticalScroll', 'LazyColumn', 'rememberSaveable') rather than type
 // resolution, so any project symbol with a matching name or token can
 // produce a false match. Classified per roadmap/17.
-func (r *ComposeMutableStateInCompositionRule) Confidence() float64 { return 0.75 }
+func (r *ComposeMutableStateInCompositionRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // ComposeStringResourceInsideLambdaRule flags `stringResource(...)` calls
 // nested inside a callback-style named-argument lambda (e.g. `onClick = {
@@ -1209,7 +1210,7 @@ type ComposeStringResourceInsideLambdaRule struct {
 // 'verticalScroll', 'LazyColumn', 'rememberSaveable') rather than type
 // resolution, so any project symbol with a matching name or token can
 // produce a false match. Classified per roadmap/17.
-func (r *ComposeStringResourceInsideLambdaRule) Confidence() float64 { return 0.75 }
+func (r *ComposeStringResourceInsideLambdaRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // ComposeMutableDefaultArgumentRule flags `@Composable fun Foo(items:
 // MutableList<X> = mutableListOf())` — the mutable default evaluates on each
@@ -1235,7 +1236,7 @@ var composeMutableCollectionFactories = map[string]struct{}{
 // 'verticalScroll', 'LazyColumn', 'rememberSaveable') rather than type
 // resolution, so any project symbol with a matching name or token can
 // produce a false match. Classified per roadmap/17.
-func (r *ComposeMutableDefaultArgumentRule) Confidence() float64 { return 0.75 }
+func (r *ComposeMutableDefaultArgumentRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // ComposePreviewAnnotationMissingRule flags `@Composable fun FooPreview()`
 // whose name ends in "Preview" but which is missing the `@Preview`
@@ -1250,4 +1251,4 @@ type ComposePreviewAnnotationMissingRule struct {
 // 'verticalScroll', 'LazyColumn', 'rememberSaveable') rather than type
 // resolution, so any project symbol with a matching name or token can
 // produce a false match. Classified per roadmap/17.
-func (r *ComposePreviewAnnotationMissingRule) Confidence() float64 { return 0.75 }
+func (r *ComposePreviewAnnotationMissingRule) Confidence() float64 { return api.ConfidenceMedium }

--- a/internal/rules/coroutines.go
+++ b/internal/rules/coroutines.go
@@ -28,7 +28,7 @@ var lifecycleCollectCallbacks = map[string]bool{
 // Confidence reports a tier-2 (medium) base confidence. Coroutines rule. Detection matches kotlinx.coroutines call shapes via
 // name lists and structural patterns; project wrappers can escape or
 // collide. Classified per roadmap/17.
-func (r *CollectInOnCreateWithoutLifecycleRule) Confidence() float64 { return 0.75 }
+func (r *CollectInOnCreateWithoutLifecycleRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func hasAncestorCallNamedFlat(file *scanner.File, idx uint32, name string) bool {
 	for p, ok := file.FlatParent(idx); ok; p, ok = file.FlatParent(p) {
@@ -59,7 +59,7 @@ func (*GlobalCoroutineUsageRule) Description() string {
 // Confidence reports a tier-2 (medium) base confidence. Coroutines rule. Detection matches kotlinx.coroutines call shapes via
 // name lists and structural patterns; project wrappers can escape or
 // collide. Classified per roadmap/17.
-func (r *GlobalCoroutineUsageRule) Confidence() float64 { return 0.75 }
+func (r *GlobalCoroutineUsageRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // InjectDispatcherRule detects hardcoded Dispatchers.IO/Default/Unconfined in call expressions.
 type InjectDispatcherRule struct {
@@ -77,7 +77,7 @@ type InjectDispatcherRule struct {
 // trip the rule if the test-injected default happens to be a
 // Dispatchers constant. Medium confidence reflects the DI-awareness
 // gap noted in roadmap/17.
-func (r *InjectDispatcherRule) Confidence() float64 { return 0.75 }
+func (r *InjectDispatcherRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func directCallArgumentsFlat(file *scanner.File, idx uint32) uint32 {
 	for i := 0; i < file.FlatNamedChildCount(idx); i++ {
@@ -289,7 +289,7 @@ type RedundantSuspendModifierRule struct {
 // and the rule suppresses the finding, so the remaining positives are
 // reliable but the rule may miss cases where the suspend modifier is
 // genuinely redundant.
-func (r *RedundantSuspendModifierRule) Confidence() float64 { return 0.75 }
+func (r *RedundantSuspendModifierRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // Known suspend functions from the standard library / coroutines.
 var knownSuspendFunctions = map[string]bool{
@@ -463,7 +463,7 @@ var coroutineBuilders = map[string]bool{
 // Confidence reports a tier-2 (medium) base confidence. Coroutines rule. Detection matches kotlinx.coroutines call shapes via
 // name lists and structural patterns; project wrappers can escape or
 // collide. Classified per roadmap/17.
-func (r *SleepInsteadOfDelayRule) Confidence() float64 { return 0.75 }
+func (r *SleepInsteadOfDelayRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func isInsideSuspendContextFlat(file *scanner.File, idx uint32) bool {
 	for p, ok := file.FlatParent(idx); ok; p, ok = file.FlatParent(p) {
@@ -523,7 +523,7 @@ type CoroutineLaunchedInTestWithoutRunTestRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Coroutines rule. Detection matches kotlinx.coroutines call shapes via
 // name lists and structural patterns; project wrappers can escape or
 // collide. Classified per roadmap/17.
-func (r *CoroutineLaunchedInTestWithoutRunTestRule) Confidence() float64 { return 0.75 }
+func (r *CoroutineLaunchedInTestWithoutRunTestRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // SuspendFunInFinallySectionRule detects suspend calls in finally blocks.
 type SuspendFunInFinallySectionRule struct {
@@ -534,7 +534,7 @@ type SuspendFunInFinallySectionRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Coroutines rule. Detection matches kotlinx.coroutines call shapes via
 // name lists and structural patterns; project wrappers can escape or
 // collide. Classified per roadmap/17.
-func (r *SuspendFunInFinallySectionRule) Confidence() float64 { return 0.75 }
+func (r *SuspendFunInFinallySectionRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // SuspendFunSwallowedCancellationRule detects catching CancellationException without rethrow.
 type SuspendFunSwallowedCancellationRule struct {
@@ -546,7 +546,7 @@ type SuspendFunSwallowedCancellationRule struct {
 // catch blocks swallow CancellationException without rethrow is structural
 // but depends on the resolver to recognize aliases of
 // CancellationException. Classified per roadmap/17.
-func (r *SuspendFunSwallowedCancellationRule) Confidence() float64 { return 0.75 }
+func (r *SuspendFunSwallowedCancellationRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func enclosingTryExpressionFlat(file *scanner.File, idx uint32) uint32 {
 	if file == nil || idx == 0 {
@@ -627,7 +627,7 @@ type SuspendFunWithCoroutineScopeReceiverRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Coroutines rule. Detection matches kotlinx.coroutines call shapes via
 // name lists and structural patterns; project wrappers can escape or
 // collide. Classified per roadmap/17.
-func (r *SuspendFunWithCoroutineScopeReceiverRule) Confidence() float64 { return 0.75 }
+func (r *SuspendFunWithCoroutineScopeReceiverRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func hasSuspendModifierFlat(file *scanner.File, idx uint32) bool {
 	return file.FlatHasModifier(idx, "suspend")
@@ -645,7 +645,7 @@ type ChannelReceiveWithoutCloseRule struct {
 	BaseRule
 }
 
-func (r *ChannelReceiveWithoutCloseRule) Confidence() float64 { return 0.75 }
+func (r *ChannelReceiveWithoutCloseRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // CollectionsSynchronizedListIterationRule detects iteration over synchronized wrappers without external sync.
 type CollectionsSynchronizedListIterationRule struct {
@@ -653,7 +653,7 @@ type CollectionsSynchronizedListIterationRule struct {
 	BaseRule
 }
 
-func (r *CollectionsSynchronizedListIterationRule) Confidence() float64 { return 0.75 }
+func (r *CollectionsSynchronizedListIterationRule) Confidence() float64 { return api.ConfidenceMedium }
 
 var synchronizedCollectionFactories = map[string]bool{
 	"synchronizedList": true, "synchronizedSet": true, "synchronizedMap": true,
@@ -665,7 +665,7 @@ type ConcurrentModificationIterationRule struct {
 	BaseRule
 }
 
-func (r *ConcurrentModificationIterationRule) Confidence() float64 { return 0.75 }
+func (r *ConcurrentModificationIterationRule) Confidence() float64 { return api.ConfidenceMedium }
 
 var mutatingMethods = map[string]bool{
 	"remove": true, "add": true, "addAll": true, "removeAll": true, "clear": true,
@@ -677,7 +677,9 @@ type CoroutineScopeCreatedButNeverCancelledRule struct {
 	BaseRule
 }
 
-func (r *CoroutineScopeCreatedButNeverCancelledRule) Confidence() float64 { return 0.75 }
+func (r *CoroutineScopeCreatedButNeverCancelledRule) Confidence() float64 {
+	return api.ConfidenceMedium
+}
 
 // DeferredAwaitInFinallyRule detects .await() calls inside finally blocks.
 type DeferredAwaitInFinallyRule struct {
@@ -685,7 +687,7 @@ type DeferredAwaitInFinallyRule struct {
 	BaseRule
 }
 
-func (r *DeferredAwaitInFinallyRule) Confidence() float64 { return 0.75 }
+func (r *DeferredAwaitInFinallyRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // FlowWithoutFlowOnRule detects flow chains with collect but no flowOn.
 type FlowWithoutFlowOnRule struct {
@@ -693,7 +695,7 @@ type FlowWithoutFlowOnRule struct {
 	BaseRule
 }
 
-func (r *FlowWithoutFlowOnRule) Confidence() float64 { return 0.75 }
+func (r *FlowWithoutFlowOnRule) Confidence() float64 { return api.ConfidenceMedium }
 
 var flowTerminalOps = map[string]bool{
 	"collect": true, "first": true, "toList": true, "toSet": true, "single": true,
@@ -710,7 +712,7 @@ type SynchronizedOnStringRule struct {
 	BaseRule
 }
 
-func (r *SynchronizedOnStringRule) Confidence() float64 { return 0.75 }
+func (r *SynchronizedOnStringRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // SynchronizedOnBoxedPrimitiveRule detects synchronized() on boxed primitives.
 type SynchronizedOnBoxedPrimitiveRule struct {
@@ -718,7 +720,7 @@ type SynchronizedOnBoxedPrimitiveRule struct {
 	BaseRule
 }
 
-func (r *SynchronizedOnBoxedPrimitiveRule) Confidence() float64 { return 0.75 }
+func (r *SynchronizedOnBoxedPrimitiveRule) Confidence() float64 { return api.ConfidenceMedium }
 
 var boxedPrimitiveTypes = map[string]bool{
 	"Int": true, "Long": true, "Short": true, "Byte": true,
@@ -760,7 +762,7 @@ type SynchronizedOnNonFinalRule struct {
 	BaseRule
 }
 
-func (r *SynchronizedOnNonFinalRule) Confidence() float64 { return 0.75 }
+func (r *SynchronizedOnNonFinalRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func isVarPropertyInScope(file *scanner.File, fromIdx uint32, varName string) bool {
 	classDecl, ok := flatEnclosingAncestor(file, fromIdx, "class_declaration", "object_declaration")
@@ -791,7 +793,7 @@ type VolatileMissingOnDclRule struct {
 	BaseRule
 }
 
-func (r *VolatileMissingOnDclRule) Confidence() float64 { return 0.75 }
+func (r *VolatileMissingOnDclRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // countDclNullChecks counts `propName == null` (or `null == propName`)
 // equality expressions inside the class where the identifier resolves to the
@@ -882,7 +884,7 @@ type MutableStateInObjectRule struct {
 	BaseRule
 }
 
-func (r *MutableStateInObjectRule) Confidence() float64 { return 0.75 }
+func (r *MutableStateInObjectRule) Confidence() float64 { return api.ConfidenceMedium }
 
 var threadSafeTypes = map[string]bool{
 	"AtomicInteger": true, "AtomicLong": true, "AtomicBoolean": true,
@@ -1066,7 +1068,7 @@ type StateFlowMutableLeakRule struct {
 	BaseRule
 }
 
-func (r *StateFlowMutableLeakRule) Confidence() float64 { return 0.75 }
+func (r *StateFlowMutableLeakRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func stateFlowMutableLeakHasKotlinxEvidence(file *scanner.File, propText string) bool {
 	content := string(file.Content)
@@ -1081,7 +1083,7 @@ type SharedFlowWithoutReplayRule struct {
 	BaseRule
 }
 
-func (r *SharedFlowWithoutReplayRule) Confidence() float64 { return 0.75 }
+func (r *SharedFlowWithoutReplayRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // StateFlowCompareByReferenceRule detects .map{}.distinctUntilChanged() on StateFlow.
 type StateFlowCompareByReferenceRule struct {
@@ -1089,7 +1091,7 @@ type StateFlowCompareByReferenceRule struct {
 	BaseRule
 }
 
-func (r *StateFlowCompareByReferenceRule) Confidence() float64 { return 0.75 }
+func (r *StateFlowCompareByReferenceRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // ---------------------------------------------------------------------------
 // Batch 4: coroutine scope / context rules
@@ -1101,7 +1103,7 @@ type GlobalScopeLaunchInViewModelRule struct {
 	BaseRule
 }
 
-func (r *GlobalScopeLaunchInViewModelRule) Confidence() float64 { return 0.75 }
+func (r *GlobalScopeLaunchInViewModelRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // SupervisorScopeInEventHandlerRule detects supervisorScope with a single child operation.
 type SupervisorScopeInEventHandlerRule struct {
@@ -1109,7 +1111,7 @@ type SupervisorScopeInEventHandlerRule struct {
 	BaseRule
 }
 
-func (r *SupervisorScopeInEventHandlerRule) Confidence() float64 { return 0.75 }
+func (r *SupervisorScopeInEventHandlerRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // WithContextInSuspendFunctionNoopRule detects nested withContext with the same dispatcher.
 type WithContextInSuspendFunctionNoopRule struct {
@@ -1117,7 +1119,7 @@ type WithContextInSuspendFunctionNoopRule struct {
 	BaseRule
 }
 
-func (r *WithContextInSuspendFunctionNoopRule) Confidence() float64 { return 0.75 }
+func (r *WithContextInSuspendFunctionNoopRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func extractWithContextDispatcher(ctx *api.Context, callIdx uint32) string {
 	if ctx.File == nil {
@@ -1317,7 +1319,9 @@ type LaunchWithoutCoroutineExceptionHandlerRule struct {
 	BaseRule
 }
 
-func (r *LaunchWithoutCoroutineExceptionHandlerRule) Confidence() float64 { return 0.75 }
+func (r *LaunchWithoutCoroutineExceptionHandlerRule) Confidence() float64 {
+	return api.ConfidenceMedium
+}
 
 // ---------------------------------------------------------------------------
 // Batch 5: cross-module rule
@@ -1330,7 +1334,7 @@ type MainDispatcherInLibraryCodeRule struct {
 }
 
 func (r *MainDispatcherInLibraryCodeRule) IsFixable() bool     { return false }
-func (r *MainDispatcherInLibraryCodeRule) Confidence() float64 { return 0.75 }
+func (r *MainDispatcherInLibraryCodeRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *MainDispatcherInLibraryCodeRule) check(ctx *api.Context) {
 	pmi := ctx.ModuleIndex

--- a/internal/rules/coroutines/suspend_fun_flow_return.go
+++ b/internal/rules/coroutines/suspend_fun_flow_return.go
@@ -16,7 +16,7 @@ type SuspendFunWithFlowReturnTypeRule struct {
 }
 
 // Confidence reports a tier-2 (medium) base confidence. Coroutines rule.
-func (r *SuspendFunWithFlowReturnTypeRule) Confidence() float64 { return 0.85 }
+func (r *SuspendFunWithFlowReturnTypeRule) Confidence() float64 { return api.ConfidenceHigh }
 
 // IsFixable marks this rule as auto-fixable: stripping the suspend modifier.
 func (r *SuspendFunWithFlowReturnTypeRule) IsFixable() bool { return true }

--- a/internal/rules/correctness_abstract.go
+++ b/internal/rules/correctness_abstract.go
@@ -37,7 +37,7 @@ type AbstractMemberNotImplementedRule struct {
 	BaseRule
 }
 
-func (r *AbstractMemberNotImplementedRule) Confidence() float64 { return 0.8 }
+func (r *AbstractMemberNotImplementedRule) Confidence() float64 { return api.ConfidenceMediumHigh }
 
 func (r *AbstractMemberNotImplementedRule) check(ctx *api.Context) {
 	idx, file := ctx.Idx, ctx.File

--- a/internal/rules/correctness_override.go
+++ b/internal/rules/correctness_override.go
@@ -32,7 +32,7 @@ type OverrideSignatureMismatchRule struct {
 	BaseRule
 }
 
-func (r *OverrideSignatureMismatchRule) Confidence() float64 { return 0.85 }
+func (r *OverrideSignatureMismatchRule) Confidence() float64 { return api.ConfidenceHigh }
 
 func (r *OverrideSignatureMismatchRule) check(ctx *api.Context) {
 	idx, file := ctx.Idx, ctx.File

--- a/internal/rules/database.go
+++ b/internal/rules/database.go
@@ -25,7 +25,7 @@ type DatabaseInstanceRecreatedRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Database/Room rule. Detection matches on annotation names and function
 // calls without confirming the declared type is a Room DAO or entity.
 // Classified per roadmap/17.
-func (r *DatabaseInstanceRecreatedRule) Confidence() float64 { return 0.75 }
+func (r *DatabaseInstanceRecreatedRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // DaoNotInterfaceRule detects Room DAOs declared as abstract classes.
 type DaoNotInterfaceRule struct {
@@ -36,7 +36,7 @@ type DaoNotInterfaceRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Database/Room rule. Detection matches on annotation names and function
 // calls without confirming the declared type is a Room DAO or entity.
 // Classified per roadmap/17.
-func (r *DaoNotInterfaceRule) Confidence() float64 { return 0.75 }
+func (r *DaoNotInterfaceRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // DaoWithoutAnnotationsRule detects Room DAO member functions that are missing
 // any Room operation annotation.
@@ -48,7 +48,7 @@ type DaoWithoutAnnotationsRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Database/Room rule. Detection matches on annotation names and function
 // calls without confirming the declared type is a Room DAO or entity.
 // Classified per roadmap/17.
-func (r *DaoWithoutAnnotationsRule) Confidence() float64 { return 0.75 }
+func (r *DaoWithoutAnnotationsRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func daoFunctionHasAllowedAnnotationFlat(file *scanner.File, idx uint32) bool {
 	return hasAnnotationFlat(file, idx, "Query") ||
@@ -67,7 +67,7 @@ type ForeignKeyWithoutOnDeleteRule struct {
 
 // Confidence reports a tier-2 (medium) base confidence. Detection is
 // name-based and may match unrelated ForeignKey constructors.
-func (r *ForeignKeyWithoutOnDeleteRule) Confidence() float64 { return 0.75 }
+func (r *ForeignKeyWithoutOnDeleteRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func foreignKeyHasOnDeleteArg(file *scanner.File, args uint32) bool {
 	if args == 0 {
@@ -95,7 +95,7 @@ type JdbcResultSetLeakedFromFunctionRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Database/Room rule. Detection matches on annotation names and function
 // calls without confirming the declared type is a Room DAO or entity.
 // Classified per roadmap/17.
-func (r *JdbcResultSetLeakedFromFunctionRule) Confidence() float64 { return 0.75 }
+func (r *JdbcResultSetLeakedFromFunctionRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func functionReturnsResultSetFlat(file *scanner.File, idx uint32) bool {
 	typeText := strings.TrimSpace(directExplicitTypeTextFlat(file, idx))
@@ -131,7 +131,7 @@ type SqliteCursorWithoutCloseRule struct {
 
 // Confidence reports a tier-2 (medium) base confidence. Detection matches on
 // method name without confirming the receiver is SQLiteDatabase.
-func (r *SqliteCursorWithoutCloseRule) Confidence() float64 { return 0.75 }
+func (r *SqliteCursorWithoutCloseRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // sqliteCursorCallFlat reports whether the property initializer at idx has a
 // top-level call_expression named rawQuery or query, and if so returns the
@@ -164,7 +164,7 @@ func sqliteCursorRHSWrappedInUseFlat(file *scanner.File, idx uint32) bool {
 // Confidence reports a tier-2 (medium) base confidence. Database/Room rule. Detection matches on annotation names and function
 // calls without confirming the declared type is a Room DAO or entity.
 // Classified per roadmap/17.
-func (r *JdbcPreparedStatementNotClosedRule) Confidence() float64 { return 0.75 }
+func (r *JdbcPreparedStatementNotClosedRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func jdbcPreparedStatementCallFlat(file *scanner.File, idx uint32) bool {
 	found := false
@@ -273,12 +273,12 @@ type EntityMutableColumnRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Database/Room rule.
 // Detection matches on annotation names without confirming the parameter
 // resolves to a Room @Entity class.
-func (r *RoomConflictStrategyReplaceOnFkRule) Confidence() float64 { return 0.75 }
+func (r *RoomConflictStrategyReplaceOnFkRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // Confidence reports a tier-2 (medium) base confidence. Database/Room rule. Detection matches on annotation names and function
 // calls without confirming the declared type is a Room DAO or entity.
 // Classified per roadmap/17.
-func (r *EntityMutableColumnRule) Confidence() float64 { return 0.75 }
+func (r *EntityMutableColumnRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func classParameterIsVarFlat(file *scanner.File, param uint32) bool {
 	bpk, _ := file.FlatFindChild(param, "binding_pattern_kind")
@@ -389,7 +389,7 @@ type RoomMultipleWritesMissingTransactionRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Database/Room rule.
 // Detection is name-based against sibling DAO methods and does not resolve
 // types across files.
-func (r *RoomMultipleWritesMissingTransactionRule) Confidence() float64 { return 0.75 }
+func (r *RoomMultipleWritesMissingTransactionRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // daoWriteAnnotatedSiblings returns a set of sibling function names in the
 // enclosing DAO class body that are annotated @Insert/@Update/@Delete.
@@ -428,7 +428,7 @@ type RoomSuspendQueryInTransactionRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Database/Room rule.
 // Detection is name-based against sibling DAO suspend @Query methods and does
 // not resolve types across files.
-func (r *RoomSuspendQueryInTransactionRule) Confidence() float64 { return 0.75 }
+func (r *RoomSuspendQueryInTransactionRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // daoSuspendQueryAnnotatedSiblings returns sibling function names in the
 // enclosing DAO class body that are `suspend` and annotated `@Query`.
@@ -469,7 +469,7 @@ type EntityPrimaryKeyNotStableRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Database/Room rule.
 // Detection matches on annotation names without confirming the declared type
 // is a Room entity. Classified per roadmap/17.
-func (r *EntityPrimaryKeyNotStableRule) Confidence() float64 { return 0.75 }
+func (r *EntityPrimaryKeyNotStableRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func entityPrimaryKeyAutoGeneratedFlat(file *scanner.File, idx uint32) bool {
 	text := findAnnotationTextFlat(file, idx, "PrimaryKey")
@@ -516,7 +516,7 @@ type RoomFallbackToDestructiveMigrationRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Database/Room rule.
 // Detection matches on annotation names without confirming the annotated
 // class is androidx.room.Database.
-func (r *RoomExportSchemaDisabledRule) Confidence() float64 { return 0.75 }
+func (r *RoomExportSchemaDisabledRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func roomDatabaseExportSchemaDisabledFlat(file *scanner.File, idx uint32) bool {
 	text := findAnnotationTextFlat(file, idx, "Database")
@@ -539,7 +539,7 @@ type RoomEntityChangedMigrationMissingRule struct {
 // Confidence reports a tier-3 (low) base confidence. Detection cannot tell
 // when a column was introduced; pre-existing columns left out of migration
 // SQL also match. Inactive by default.
-func (r *RoomEntityChangedMigrationMissingRule) Confidence() float64 { return 0.6 }
+func (r *RoomEntityChangedMigrationMissingRule) Confidence() float64 { return api.ConfidenceMediumLow }
 
 func (r *RoomEntityChangedMigrationMissingRule) check(ctx *api.Context) {
 	index := ctx.CodeIndex
@@ -745,7 +745,7 @@ type RoomRelationWithoutIndexRule struct {
 
 // Confidence reports a tier-2 (medium) base confidence. Detection matches on
 // annotation names without confirming the resolved type is a Room entity.
-func (r *RoomRelationWithoutIndexRule) Confidence() float64 { return 0.75 }
+func (r *RoomRelationWithoutIndexRule) Confidence() float64 { return api.ConfidenceMedium }
 
 type roomEntityFacts struct {
 	indexed map[string]struct{}
@@ -1187,7 +1187,9 @@ type RoomMigrationUsesExecSQLWithInterpolationRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Detection matches
 // on the call name and an enclosing supertype named `Migration`, without
 // confirming androidx.room.migration.Migration resolves the type.
-func (r *RoomMigrationUsesExecSQLWithInterpolationRule) Confidence() float64 { return 0.85 }
+func (r *RoomMigrationUsesExecSQLWithInterpolationRule) Confidence() float64 {
+	return api.ConfidenceHigh
+}
 
 func enclosingMigrationOwnerFlat(file *scanner.File, idx uint32) bool {
 	for cur, ok := file.FlatParent(idx); ok; cur, ok = file.FlatParent(cur) {
@@ -1217,7 +1219,7 @@ func enclosingMigrationOwnerFlat(file *scanner.File, idx uint32) bool {
 	return false
 }
 
-func (r *RoomFallbackToDestructiveMigrationRule) Confidence() float64 { return 0.85 }
+func (r *RoomFallbackToDestructiveMigrationRule) Confidence() float64 { return api.ConfidenceHigh }
 
 // RoomQueryMissingWhereForUpdateRule detects @Query("UPDATE ...") or
 // @Query("DELETE ...") whose SQL text omits a WHERE clause, unless the DAO
@@ -1230,7 +1232,7 @@ type RoomQueryMissingWhereForUpdateRule struct {
 // Confidence reports a tier-2 (medium) base confidence. The check matches on
 // annotation name and SQL keywords without confirming the annotated function
 // is a Room DAO member.
-func (r *RoomQueryMissingWhereForUpdateRule) Confidence() float64 { return 0.85 }
+func (r *RoomQueryMissingWhereForUpdateRule) Confidence() float64 { return api.ConfidenceHigh }
 
 var (
 	roomQueryMissingWhereSQLPattern = regexp.MustCompile(`(?is)^\s*(UPDATE|DELETE)\b`)
@@ -1294,7 +1296,7 @@ type RoomSelectStarWithoutLimitRule struct {
 // Confidence reports a tier-2 (medium) base confidence. The check matches on
 // annotation name and SQL text, plus a textual return-type check, without
 // confirming the annotated function is a Room DAO member.
-func (r *RoomSelectStarWithoutLimitRule) Confidence() float64 { return 0.85 }
+func (r *RoomSelectStarWithoutLimitRule) Confidence() float64 { return api.ConfidenceHigh }
 
 var (
 	roomSelectStarPattern   = regexp.MustCompile(`(?is)^\s*SELECT\s+\*`)
@@ -1377,7 +1379,7 @@ type RoomQueryWithLikeMissingEscapeRule struct {
 // Confidence reports a tier-3 (low) base confidence. The check operates on
 // annotation text without confirming the function is a Room DAO member, and
 // rule semantics depend on the developer's intent for the LIKE pattern.
-func (r *RoomQueryWithLikeMissingEscapeRule) Confidence() float64 { return 0.7 }
+func (r *RoomQueryWithLikeMissingEscapeRule) Confidence() float64 { return api.ConfidenceMediumLowPlus }
 
 var (
 	roomLikeBareBindPattern = regexp.MustCompile(`(?i)\bLIKE\s+:([A-Za-z_][A-Za-z0-9_]*)`)
@@ -1427,7 +1429,7 @@ func (r *RoomFlowQueryWithoutDistinctRule) IsFixable() bool { return false }
 // matched by identifier and may collide with same-named methods on non-DAO
 // receivers; callers that hold the Flow in an intermediate variable are
 // not flagged.
-func (r *RoomFlowQueryWithoutDistinctRule) Confidence() float64 { return 0.6 }
+func (r *RoomFlowQueryWithoutDistinctRule) Confidence() float64 { return api.ConfidenceMediumLow }
 
 func roomFlowReturnTypeFlat(file *scanner.File, idx uint32) bool {
 	if file == nil || idx == 0 {

--- a/internal/rules/deadcode.go
+++ b/internal/rules/deadcode.go
@@ -37,7 +37,7 @@ func (r *DeadCodeRule) IsFixable() bool { return false }
 // relies on the cross-file code index to detect unreferenced symbols
 // and then filters framework entry points, overrides, tests, lifecycle
 // methods, and DI declarations that are consumed by generated code.
-func (r *DeadCodeRule) Confidence() float64 { return 0.75 }
+func (r *DeadCodeRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // check runs against the full code index.
 func (r *DeadCodeRule) check(ctx *api.Context) {

--- a/internal/rules/deadcode_module.go
+++ b/internal/rules/deadcode_module.go
@@ -68,7 +68,7 @@ func (r *ModuleDeadCodeRule) IsFixable() bool { return false }
 // Confidence reports a tier-2 (medium) base confidence for the same
 // reason as DeadCode: the module-aware analyzer relies on index evidence
 // and local generated-use filters rather than a full compiler model.
-func (r *ModuleDeadCodeRule) Confidence() float64 { return 0.75 }
+func (r *ModuleDeadCodeRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *ModuleDeadCodeRule) ModuleAwareNeeds() ModuleAwareNeeds {
 	return ModuleAwareNeeds{

--- a/internal/rules/di_anvil.go
+++ b/internal/rules/di_anvil.go
@@ -17,7 +17,7 @@ type AnvilMergeComponentEmptyScopeRule struct {
 // Confidence reports a tier-2 (medium) base confidence. DI hygiene rule. Detection uses annotation and import patterns for
 // Dagger/Hilt/Anvil; project-specific DI aliases are not followed.
 // Classified per roadmap/17.
-func (r *AnvilMergeComponentEmptyScopeRule) Confidence() float64 { return 0.75 }
+func (r *AnvilMergeComponentEmptyScopeRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *AnvilMergeComponentEmptyScopeRule) check(ctx *api.Context) {
 	index := ctx.CodeIndex
@@ -91,4 +91,4 @@ type AnvilContributesBindingWithoutScopeRule struct {
 // Confidence reports a tier-2 (medium) base confidence. DI hygiene rule. Detection uses annotation and import patterns for
 // Dagger/Hilt/Anvil; project-specific DI aliases are not followed.
 // Classified per roadmap/17.
-func (r *AnvilContributesBindingWithoutScopeRule) Confidence() float64 { return 0.75 }
+func (r *AnvilContributesBindingWithoutScopeRule) Confidence() float64 { return api.ConfidenceMedium }

--- a/internal/rules/di_cycles.go
+++ b/internal/rules/di_cycles.go
@@ -14,7 +14,7 @@ type DiCycleDetectionRule struct {
 	BaseRule
 }
 
-func (r *DiCycleDetectionRule) Confidence() float64 { return 0.75 }
+func (r *DiCycleDetectionRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *DiCycleDetectionRule) check(ctx *api.Context) {
 	if len(ctx.ParsedFiles) == 0 {

--- a/internal/rules/di_duplication.go
+++ b/internal/rules/di_duplication.go
@@ -18,7 +18,7 @@ type IntoMapDuplicateKeyRule struct {
 }
 
 // Confidence reports a tier-2 (medium) base confidence. DI hygiene rule.
-func (r *IntoMapDuplicateKeyRule) Confidence() float64 { return 0.7 }
+func (r *IntoMapDuplicateKeyRule) Confidence() float64 { return api.ConfidenceMediumLowPlus }
 
 // IntoSetDuplicateTypeRule detects two or more @IntoSet @Provides functions in
 // the same enclosing module/component that return the same concrete impl
@@ -31,7 +31,7 @@ type IntoSetDuplicateTypeRule struct {
 // Confidence reports a tier-3 (lower) base confidence. Detection compares the
 // final returned-expression callee text; aliases and indirection are not
 // followed.
-func (r *IntoSetDuplicateTypeRule) Confidence() float64 { return 0.5 }
+func (r *IntoSetDuplicateTypeRule) Confidence() float64 { return api.ConfidenceLow }
 
 func (r *IntoMapDuplicateKeyRule) check(ctx *api.Context) {
 	index := ctx.CodeIndex

--- a/internal/rules/di_hilt.go
+++ b/internal/rules/di_hilt.go
@@ -1,6 +1,7 @@
 package rules
 
 import (
+	api "github.com/kaeawc/krit/internal/rules/api"
 	"github.com/kaeawc/krit/internal/scanner"
 )
 
@@ -14,7 +15,7 @@ type HiltEntryPointOnNonInterfaceRule struct {
 // Confidence reports a tier-2 (medium) base confidence. DI hygiene rule. Detection uses annotation and import patterns for
 // Dagger/Hilt/Anvil; project-specific DI aliases are not followed.
 // Classified per roadmap/17.
-func (r *HiltEntryPointOnNonInterfaceRule) Confidence() float64 { return 0.75 }
+func (r *HiltEntryPointOnNonInterfaceRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func hiltEntryPointDeclarationFlat(file *scanner.File, idx uint32) (kind, name string, line int, ok bool) {
 	if file == nil || !hasAnnotationFlat(file, idx, "EntryPoint") {
@@ -88,7 +89,7 @@ type HiltInstallInMismatchRule struct {
 }
 
 // Confidence reports a tier-2 (medium) base confidence. DI hygiene rule.
-func (r *HiltInstallInMismatchRule) Confidence() float64 { return 0.75 }
+func (r *HiltInstallInMismatchRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // hiltComponentScopes maps Hilt component class names to the scope annotations
 // they own. The scopes are stored as a set for fast membership checks.
@@ -124,7 +125,7 @@ type HiltSingletonWithActivityDepRule struct {
 }
 
 // Confidence reports a tier-2 (medium) base confidence. DI hygiene rule.
-func (r *HiltSingletonWithActivityDepRule) Confidence() float64 { return 0.75 }
+func (r *HiltSingletonWithActivityDepRule) Confidence() float64 { return api.ConfidenceMedium }
 
 var hiltSingletonActivityScopedTypes = map[string]struct{}{
 	"Activity":                  {},

--- a/internal/rules/di_hygiene.go
+++ b/internal/rules/di_hygiene.go
@@ -64,7 +64,7 @@ type BindsMismatchedArityRule struct {
 // Confidence reports a tier-2 (medium) base confidence. DI hygiene rule. Detection uses annotation and import patterns for
 // Dagger/Hilt/Anvil; project-specific DI aliases are not followed.
 // Classified per roadmap/17.
-func (r *BindsMismatchedArityRule) Confidence() float64 { return 0.75 }
+func (r *BindsMismatchedArityRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func anvilContributedInterfaceScopesFlat(file *scanner.File) map[string]string {
 	scopes := make(map[string]string)
@@ -161,7 +161,7 @@ type DeadBindingsRule struct {
 // Confidence reports a tier-3 (lower) base confidence. Reachability is approximated
 // from source-visible @Inject sites and component method exposures; project-specific
 // DI machinery (assisted factories, multibindings, generated code) is not modeled.
-func (r *DeadBindingsRule) Confidence() float64 { return 0.5 }
+func (r *DeadBindingsRule) Confidence() float64 { return api.ConfidenceLow }
 
 var deadBindingComponentAnnotations = []string{
 	"Component", "Subcomponent", "MergeComponent", "MergeSubcomponent",
@@ -392,7 +392,7 @@ type InjectOnAbstractClassRule struct {
 }
 
 // Confidence reports a tier-2 (medium) base confidence. DI hygiene rule.
-func (r *InjectOnAbstractClassRule) Confidence() float64 { return 0.75 }
+func (r *InjectOnAbstractClassRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // ProviderInsteadOfLazyRule detects constructor parameters typed Provider<T>
 // whose `.get()` is called exactly once across the class body. Lazy<T> matches
@@ -403,7 +403,7 @@ type ProviderInsteadOfLazyRule struct {
 }
 
 // Confidence reports a tier-2 (medium) base confidence. DI hygiene rule.
-func (r *ProviderInsteadOfLazyRule) Confidence() float64 { return 0.6 }
+func (r *ProviderInsteadOfLazyRule) Confidence() float64 { return api.ConfidenceMediumLow }
 
 // LazyInsteadOfDirectRule detects constructor parameters typed Lazy<T> whose
 // `.get()` is called unconditionally at class-init time. Direct injection is
@@ -414,7 +414,7 @@ type LazyInsteadOfDirectRule struct {
 }
 
 // Confidence reports a tier-2 (medium) base confidence. DI hygiene rule.
-func (r *LazyInsteadOfDirectRule) Confidence() float64 { return 0.6 }
+func (r *LazyInsteadOfDirectRule) Confidence() float64 { return api.ConfidenceMediumLow }
 
 // classParameterNameAndType returns the simple identifier name and the
 // last-segment unqualified type name of a primary-constructor `class_parameter`.
@@ -512,7 +512,7 @@ type SubcomponentNotInstalledRule struct {
 
 // Confidence reports a tier-3 (lower) base confidence. Detection follows
 // return-type text only; cross-module install graphs are not modeled.
-func (r *SubcomponentNotInstalledRule) Confidence() float64 { return 0.5 }
+func (r *SubcomponentNotInstalledRule) Confidence() float64 { return api.ConfidenceLow }
 
 func (r *SubcomponentNotInstalledRule) check(ctx *api.Context) {
 	index := ctx.CodeIndex
@@ -636,7 +636,7 @@ type BindsInsteadOfProvidesRule struct {
 }
 
 // Confidence reports a tier-2 (medium) base confidence. DI hygiene rule.
-func (r *BindsInsteadOfProvidesRule) Confidence() float64 { return 0.7 }
+func (r *BindsInsteadOfProvidesRule) Confidence() float64 { return api.ConfidenceMediumLowPlus }
 
 // BindsReturnTypeMatchesParamRule detects `@Binds` functions whose parameter
 // type equals the return type — a no-op binding that Dagger rejects.
@@ -646,7 +646,7 @@ type BindsReturnTypeMatchesParamRule struct {
 }
 
 // Confidence reports a tier-2 (medium) base confidence. DI hygiene rule.
-func (r *BindsReturnTypeMatchesParamRule) Confidence() float64 { return 0.75 }
+func (r *BindsReturnTypeMatchesParamRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // firstFunctionParameterNameAndType returns the (name, type) of the first
 // parameter of `fn` (a function_declaration). Returns ("", "") if absent.
@@ -713,7 +713,7 @@ type ComponentMissingModuleRule struct {
 // Confidence reports a tier-3 (lower) base confidence. Detection follows
 // @Provides/@Binds return types and @Inject constructor parameters in source;
 // generated code, multibindings, and assisted factories are not modeled.
-func (r *ComponentMissingModuleRule) Confidence() float64 { return 0.5 }
+func (r *ComponentMissingModuleRule) Confidence() float64 { return api.ConfidenceLow }
 
 type componentMissingModuleProvider struct {
 	moduleName string
@@ -1022,7 +1022,7 @@ type SingletonOnMutableClassRule struct {
 }
 
 // Confidence reports a tier-2 (medium) base confidence. DI hygiene rule.
-func (r *SingletonOnMutableClassRule) Confidence() float64 { return 0.75 }
+func (r *SingletonOnMutableClassRule) Confidence() float64 { return api.ConfidenceMedium }
 
 var singletonScopeAnnotationNames = []string{
 	"Singleton",
@@ -1093,7 +1093,7 @@ type MetroFactoryDeclarationShapeRule struct {
 }
 
 // Confidence reports a tier-2 (medium) base confidence. DI hygiene rule.
-func (r *MetroFactoryDeclarationShapeRule) Confidence() float64 { return 0.75 }
+func (r *MetroFactoryDeclarationShapeRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func hasMetroFactoryAnnotationFlat(file *scanner.File, idx uint32) bool {
 	if file == nil || idx == 0 {
@@ -1112,7 +1112,7 @@ type ScopeOnParameterizedClassRule struct {
 }
 
 // Confidence reports a tier-2 (medium) base confidence. DI hygiene rule.
-func (r *ScopeOnParameterizedClassRule) Confidence() float64 { return 0.75 }
+func (r *ScopeOnParameterizedClassRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // scopeAnnotationNames lists annotations that mark a DI scope. The list mirrors
 // commonly used Hilt/Dagger scopes plus Anvil/Metro variants.
@@ -1150,7 +1150,7 @@ type MissingJvmSuppressWildcardsRule struct {
 }
 
 // Confidence reports a tier-2 (medium) base confidence. DI hygiene rule.
-func (r *MissingJvmSuppressWildcardsRule) Confidence() float64 { return 0.75 }
+func (r *MissingJvmSuppressWildcardsRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func multibindingReturnNeedsJvmSuppress(typeText string) (string, bool) {
 	s := strings.TrimSpace(typeText)
@@ -1192,7 +1192,7 @@ type ModuleWithNonStaticProvidesRule struct {
 }
 
 // Confidence reports a tier-2 (medium) base confidence. DI hygiene rule.
-func (r *ModuleWithNonStaticProvidesRule) Confidence() float64 { return 0.75 }
+func (r *ModuleWithNonStaticProvidesRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // IntoMapMissingKeyRule detects @IntoMap @Provides/@Binds functions that lack
 // a `@*Key(...)` annotation. Without a key annotation, Dagger fails at code
@@ -1203,7 +1203,7 @@ type IntoMapMissingKeyRule struct {
 }
 
 // Confidence reports a tier-2 (medium) base confidence. DI hygiene rule.
-func (r *IntoMapMissingKeyRule) Confidence() float64 { return 0.75 }
+func (r *IntoMapMissingKeyRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // hasMapKeyAnnotationFlat returns true when any annotation on idx is named
 // `@*Key` (e.g. @StringKey, @ClassKey, @IntKey, custom @FooKey). Built-in
@@ -1258,7 +1258,7 @@ type IntoSetOnNonSetReturnRule struct {
 }
 
 // Confidence reports a tier-2 (medium) base confidence. DI hygiene rule.
-func (r *IntoSetOnNonSetReturnRule) Confidence() float64 { return 0.75 }
+func (r *IntoSetOnNonSetReturnRule) Confidence() float64 { return api.ConfidenceMedium }
 
 var intoSetCollectionWrapperTypes = map[string]struct{}{
 	"List":              {},

--- a/internal/rules/dispatcher.go
+++ b/internal/rules/dispatcher.go
@@ -557,7 +557,7 @@ func (d *Dispatcher) RunColumnsWithStats(file *scanner.File) (scanner.FindingCol
 					stats.Errors = append(stats.Errors, DispatchError{RuleName: r.ID, FilePath: filePathOrEmpty(file), PanicValue: rec})
 				}
 			}()
-			ctx := &api.Context{File: file, Rule: r, DefaultConfidence: 0.75, Collector: collector, LibraryFacts: d.libraryFacts, JavaFacts: javaFileFacts, JavaSourceIndex: javaSourceIndex, JavaSemanticFacts: d.javaSemanticFacts, Facts: d.fileFacts}
+			ctx := &api.Context{File: file, Rule: r, DefaultConfidence: api.ConfidenceMedium, Collector: collector, LibraryFacts: d.libraryFacts, JavaFacts: javaFileFacts, JavaSourceIndex: javaSourceIndex, JavaSemanticFacts: d.javaSemanticFacts, Facts: d.fileFacts}
 			if r.Needs.Has(api.NeedsResolver) {
 				ctx.Resolver = resolver
 			}
@@ -614,7 +614,7 @@ func safeCheckV2NodeColumnar(r *api.Rule, idx uint32, node *scanner.FlatNode, fi
 		Node:              node,
 		Idx:               idx,
 		Rule:              r,
-		DefaultConfidence: 0.95,
+		DefaultConfidence: api.ConfidenceVeryHigh,
 		Collector:         collector,
 		LibraryFacts:      libraryFacts,
 		JavaFacts:         javaFileFacts,
@@ -1013,7 +1013,7 @@ func (d *Dispatcher) runProjectRule(r *api.Rule, file *scanner.File, populate fu
 	}()
 	collector := scanner.NewFindingCollector(0)
 	javaFileFacts, javaSourceIndex := javaContextFactsForFile(file)
-	ctx := &api.Context{File: file, Rule: r, DefaultConfidence: 0.75, Collector: collector, LibraryFacts: d.libraryFacts, JavaFacts: javaFileFacts, JavaSourceIndex: javaSourceIndex, JavaSemanticFacts: d.javaSemanticFacts, Facts: d.fileFacts}
+	ctx := &api.Context{File: file, Rule: r, DefaultConfidence: api.ConfidenceMedium, Collector: collector, LibraryFacts: d.libraryFacts, JavaFacts: javaFileFacts, JavaSourceIndex: javaSourceIndex, JavaSemanticFacts: d.javaSemanticFacts, Facts: d.fileFacts}
 	if r.Needs.Has(api.NeedsResolver) {
 		if resolver, ok := d.resolveForRule(r); ok {
 			ctx.Resolver = resolver
@@ -1048,7 +1048,7 @@ func safeCheckV2ResourceNodeColumnar(r *api.Rule, idx uint32, node *scanner.Flat
 		Node:              node,
 		Idx:               idx,
 		Rule:              r,
-		DefaultConfidence: 0.95,
+		DefaultConfidence: api.ConfidenceVeryHigh,
 		ResourceIndex:     resourceIndex,
 		Collector:         collector,
 		LibraryFacts:      libraryFacts,

--- a/internal/rules/emptyblocks.go
+++ b/internal/rules/emptyblocks.go
@@ -90,7 +90,7 @@ type EmptyCatchBlockRule struct {
 // Confidence holds the 0.95 dispatch default. Empty-block rule. Detection checks AST child count for
 // statements/expressions inside a block — purely structural. No heuristic
 // path. Classified per roadmap/17.
-func (r *EmptyCatchBlockRule) Confidence() float64 { return 0.95 }
+func (r *EmptyCatchBlockRule) Confidence() float64 { return api.ConfidenceVeryHigh }
 
 // EmptyClassBlockRule detects classes with empty body.
 type EmptyClassBlockRule struct {
@@ -101,7 +101,7 @@ type EmptyClassBlockRule struct {
 // Confidence holds the 0.95 dispatch default. Empty-block rule. Detection checks AST child count for
 // statements/expressions inside a block — purely structural. No heuristic
 // path. Classified per roadmap/17.
-func (r *EmptyClassBlockRule) Confidence() float64 { return 0.95 }
+func (r *EmptyClassBlockRule) Confidence() float64 { return api.ConfidenceVeryHigh }
 
 // EmptyDefaultConstructorRule detects explicit empty default constructors.
 type EmptyDefaultConstructorRule struct {
@@ -112,7 +112,7 @@ type EmptyDefaultConstructorRule struct {
 // Confidence holds the 0.95 dispatch default. Empty-block rule. Detection checks AST child count for
 // statements/expressions inside a block — purely structural. No heuristic
 // path. Classified per roadmap/17.
-func (r *EmptyDefaultConstructorRule) Confidence() float64 { return 0.95 }
+func (r *EmptyDefaultConstructorRule) Confidence() float64 { return api.ConfidenceVeryHigh }
 
 // EmptyDoWhileBlockRule detects do-while loops with empty body.
 type EmptyDoWhileBlockRule struct {
@@ -123,7 +123,7 @@ type EmptyDoWhileBlockRule struct {
 // Confidence holds the 0.95 dispatch default. Empty-block rule. Detection checks AST child count for
 // statements/expressions inside a block — purely structural. No heuristic
 // path. Classified per roadmap/17.
-func (r *EmptyDoWhileBlockRule) Confidence() float64 { return 0.95 }
+func (r *EmptyDoWhileBlockRule) Confidence() float64 { return api.ConfidenceVeryHigh }
 
 // EmptyElseBlockRule detects else blocks with empty body.
 type EmptyElseBlockRule struct {
@@ -134,7 +134,7 @@ type EmptyElseBlockRule struct {
 // Confidence holds the 0.95 dispatch default. Empty-block rule. Detection checks AST child count for
 // statements/expressions inside a block — purely structural. No heuristic
 // path. Classified per roadmap/17.
-func (r *EmptyElseBlockRule) Confidence() float64 { return 0.95 }
+func (r *EmptyElseBlockRule) Confidence() float64 { return api.ConfidenceVeryHigh }
 
 // EmptyFinallyBlockRule detects finally blocks with empty body.
 type EmptyFinallyBlockRule struct {
@@ -145,7 +145,7 @@ type EmptyFinallyBlockRule struct {
 // Confidence holds the 0.95 dispatch default. Empty-block rule. Detection checks AST child count for
 // statements/expressions inside a block — purely structural. No heuristic
 // path. Classified per roadmap/17.
-func (r *EmptyFinallyBlockRule) Confidence() float64 { return 0.95 }
+func (r *EmptyFinallyBlockRule) Confidence() float64 { return api.ConfidenceVeryHigh }
 
 // EmptyForBlockRule detects for loops with empty body.
 type EmptyForBlockRule struct {
@@ -156,7 +156,7 @@ type EmptyForBlockRule struct {
 // Confidence holds the 0.95 dispatch default. Empty-block rule. Detection checks AST child count for
 // statements/expressions inside a block — purely structural. No heuristic
 // path. Classified per roadmap/17.
-func (r *EmptyForBlockRule) Confidence() float64 { return 0.95 }
+func (r *EmptyForBlockRule) Confidence() float64 { return api.ConfidenceVeryHigh }
 
 // EmptyFunctionBlockRule detects functions with empty body.
 type EmptyFunctionBlockRule struct {
@@ -168,7 +168,7 @@ type EmptyFunctionBlockRule struct {
 // Confidence holds the 0.95 dispatch default. Empty-block rule. Detection checks AST child count for
 // statements/expressions inside a block — purely structural. No heuristic
 // path. Classified per roadmap/17.
-func (r *EmptyFunctionBlockRule) Confidence() float64 { return 0.95 }
+func (r *EmptyFunctionBlockRule) Confidence() float64 { return api.ConfidenceVeryHigh }
 
 // EmptyIfBlockRule detects if blocks with empty body.
 type EmptyIfBlockRule struct {
@@ -179,7 +179,7 @@ type EmptyIfBlockRule struct {
 // Confidence holds the 0.95 dispatch default. Empty-block rule. Detection checks AST child count for
 // statements/expressions inside a block — purely structural. No heuristic
 // path. Classified per roadmap/17.
-func (r *EmptyIfBlockRule) Confidence() float64 { return 0.95 }
+func (r *EmptyIfBlockRule) Confidence() float64 { return api.ConfidenceVeryHigh }
 
 // EmptyInitBlockRule detects init blocks with empty body.
 type EmptyInitBlockRule struct {
@@ -190,7 +190,7 @@ type EmptyInitBlockRule struct {
 // Confidence holds the 0.95 dispatch default. Empty-block rule. Detection checks AST child count for
 // statements/expressions inside a block — purely structural. No heuristic
 // path. Classified per roadmap/17.
-func (r *EmptyInitBlockRule) Confidence() float64 { return 0.95 }
+func (r *EmptyInitBlockRule) Confidence() float64 { return api.ConfidenceVeryHigh }
 
 // EmptyKotlinFileRule detects files with no meaningful code.
 type EmptyKotlinFileRule struct {
@@ -201,7 +201,7 @@ type EmptyKotlinFileRule struct {
 // Confidence bumps this line rule from the 0.75 line-rule default to
 // 0.95 — the check walks the AST root for any non-package/import/
 // comment child, which is a precise structural determination.
-func (r *EmptyKotlinFileRule) Confidence() float64 { return 0.95 }
+func (r *EmptyKotlinFileRule) Confidence() float64 { return api.ConfidenceVeryHigh }
 
 func (r *EmptyKotlinFileRule) check(ctx *api.Context) {
 	file := ctx.File
@@ -263,7 +263,7 @@ type EmptySecondaryConstructorRule struct {
 // Confidence holds the 0.95 dispatch default. Empty-block rule. Detection checks AST child count for
 // statements/expressions inside a block — purely structural. No heuristic
 // path. Classified per roadmap/17.
-func (r *EmptySecondaryConstructorRule) Confidence() float64 { return 0.95 }
+func (r *EmptySecondaryConstructorRule) Confidence() float64 { return api.ConfidenceVeryHigh }
 
 // EmptyTryBlockRule detects try blocks with empty body.
 type EmptyTryBlockRule struct {
@@ -274,7 +274,7 @@ type EmptyTryBlockRule struct {
 // Confidence holds the 0.95 dispatch default. Empty-block rule. Detection checks AST child count for
 // statements/expressions inside a block — purely structural. No heuristic
 // path. Classified per roadmap/17.
-func (r *EmptyTryBlockRule) Confidence() float64 { return 0.95 }
+func (r *EmptyTryBlockRule) Confidence() float64 { return api.ConfidenceVeryHigh }
 
 // EmptyWhenBlockRule detects when expressions with empty body.
 type EmptyWhenBlockRule struct {
@@ -285,7 +285,7 @@ type EmptyWhenBlockRule struct {
 // Confidence holds the 0.95 dispatch default. Empty-block rule. Detection checks AST child count for
 // statements/expressions inside a block — purely structural. No heuristic
 // path. Classified per roadmap/17.
-func (r *EmptyWhenBlockRule) Confidence() float64 { return 0.95 }
+func (r *EmptyWhenBlockRule) Confidence() float64 { return api.ConfidenceVeryHigh }
 
 // EmptyWhileBlockRule detects while loops with empty body.
 type EmptyWhileBlockRule struct {
@@ -296,4 +296,4 @@ type EmptyWhileBlockRule struct {
 // Confidence holds the 0.95 dispatch default. Empty-block rule. Detection checks AST child count for
 // statements/expressions inside a block — purely structural. No heuristic
 // path. Classified per roadmap/17.
-func (r *EmptyWhileBlockRule) Confidence() float64 { return 0.95 }
+func (r *EmptyWhileBlockRule) Confidence() float64 { return api.ConfidenceVeryHigh }

--- a/internal/rules/exceptions.go
+++ b/internal/rules/exceptions.go
@@ -47,7 +47,7 @@ func (r *ExceptionRaisedInUnexpectedLocationRule) includesMethod(name string) bo
 // Confidence reports a tier-2 (medium) base confidence. Exceptions rule. Detection matches exception type names and catch/ throw
 // shapes via structural AST + name-list lookups. Classified per
 // roadmap/17.
-func (r *ExceptionRaisedInUnexpectedLocationRule) Confidence() float64 { return 0.75 }
+func (r *ExceptionRaisedInUnexpectedLocationRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // InstanceOfCheckForExceptionRule detects `is SomeException` inside catch blocks.
 type InstanceOfCheckForExceptionRule struct {
@@ -63,7 +63,7 @@ var (
 // Confidence reports a tier-2 (medium) base confidence. Exceptions rule. Detection matches exception type names and catch/ throw
 // shapes via structural AST + name-list lookups. Classified per
 // roadmap/17.
-func (r *InstanceOfCheckForExceptionRule) Confidence() float64 { return 0.75 }
+func (r *InstanceOfCheckForExceptionRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func isInsideWhenDispatchOnCatchVarFlat(file *scanner.File, isNode uint32, caughtVar string) bool {
 	for p, ok := file.FlatParent(isNode); ok; p, ok = file.FlatParent(p) {
@@ -101,7 +101,7 @@ type NotImplementedDeclarationRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Exceptions rule. Detection matches exception type names and catch/ throw
 // shapes via structural AST + name-list lookups. Classified per
 // roadmap/17.
-func (r *NotImplementedDeclarationRule) Confidence() float64 { return 0.75 }
+func (r *NotImplementedDeclarationRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // isKotlinTODOCall reports whether the call_expression at idx is a call to
 // `kotlin.TODO()` — either the unqualified `TODO(...)` (kotlin's TODO is
@@ -137,7 +137,7 @@ type RethrowCaughtExceptionRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Exceptions rule. Detection matches exception type names and catch/ throw
 // shapes via structural AST + name-list lookups. Classified per
 // roadmap/17.
-func (r *RethrowCaughtExceptionRule) Confidence() float64 { return 0.75 }
+func (r *RethrowCaughtExceptionRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // ReturnFromFinallyRule detects return statements inside finally blocks.
 type ReturnFromFinallyRule struct {
@@ -149,7 +149,7 @@ type ReturnFromFinallyRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Exceptions rule. Detection matches exception type names and catch/ throw
 // shapes via structural AST + name-list lookups. Classified per
 // roadmap/17.
-func (r *ReturnFromFinallyRule) Confidence() float64 { return 0.75 }
+func (r *ReturnFromFinallyRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // SwallowedExceptionRule detects catch blocks that either never use the exception
 // variable or that throw a new exception without passing the original as the cause.
@@ -166,7 +166,7 @@ type SwallowedExceptionRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Exceptions rule. Detection matches exception type names and catch/ throw
 // shapes via structural AST + name-list lookups. Classified per
 // roadmap/17.
-func (r *SwallowedExceptionRule) Confidence() float64 { return 0.75 }
+func (r *SwallowedExceptionRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *SwallowedExceptionRule) makeUnusedFindingFlat(ctx *api.Context, caughtVar string) {
 	idx, file := ctx.Idx, ctx.File
@@ -1128,7 +1128,7 @@ type ThrowingExceptionFromFinallyRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Exceptions rule. Detection matches exception type names and catch/ throw
 // shapes via structural AST + name-list lookups. Classified per
 // roadmap/17.
-func (r *ThrowingExceptionFromFinallyRule) Confidence() float64 { return 0.75 }
+func (r *ThrowingExceptionFromFinallyRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // ThrowingExceptionsWithoutMessageOrCauseRule detects throw Exception() with no args.
 // Uses tree-sitter dispatch to find call_expression nodes, then checks if the parent
@@ -1157,7 +1157,9 @@ var defaultExceptionsRequiringMessage = map[string]bool{
 // Confidence reports a tier-2 (medium) base confidence. Exceptions rule. Detection matches exception type names and catch/ throw
 // shapes via structural AST + name-list lookups. Classified per
 // roadmap/17.
-func (r *ThrowingExceptionsWithoutMessageOrCauseRule) Confidence() float64 { return 0.75 }
+func (r *ThrowingExceptionsWithoutMessageOrCauseRule) Confidence() float64 {
+	return api.ConfidenceMedium
+}
 
 func (r *ThrowingExceptionsWithoutMessageOrCauseRule) exceptionAllowlist() map[string]bool {
 	if !experiment.Enabled("exceptions-allowlist-cache") || len(r.Exceptions) == 0 {
@@ -1217,7 +1219,7 @@ type ThrowingNewInstanceOfSameExceptionRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Exceptions rule. Detection matches exception type names and catch/ throw
 // shapes via structural AST + name-list lookups. Classified per
 // roadmap/17.
-func (r *ThrowingNewInstanceOfSameExceptionRule) Confidence() float64 { return 0.75 }
+func (r *ThrowingNewInstanceOfSameExceptionRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // ThrowingExceptionInMainRule detects throw in main function.
 type ThrowingExceptionInMainRule struct {
@@ -1228,7 +1230,7 @@ type ThrowingExceptionInMainRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Exceptions rule. Detection matches exception type names and catch/ throw
 // shapes via structural AST + name-list lookups. Classified per
 // roadmap/17.
-func (r *ThrowingExceptionInMainRule) Confidence() float64 { return 0.75 }
+func (r *ThrowingExceptionInMainRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // ErrorUsageWithThrowableRule detects error(throwable) calls.
 type ErrorUsageWithThrowableRule struct {
@@ -1239,7 +1241,7 @@ type ErrorUsageWithThrowableRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Exceptions rule. Detection matches exception type names and catch/ throw
 // shapes via structural AST + name-list lookups. Classified per
 // roadmap/17.
-func (r *ErrorUsageWithThrowableRule) Confidence() float64 { return 0.75 }
+func (r *ErrorUsageWithThrowableRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func errorUsageWithThrowableArgument(ctx *api.Context, idx uint32) (string, bool) {
 	if ctx.File == nil || !errorUsageWithThrowableDirectErrorCall(ctx.File, idx) {
@@ -1339,7 +1341,7 @@ type ObjectExtendsThrowableRule struct {
 // Confidence reports a tier-2 (medium) base confidence — relies on
 // resolver to determine supertypes; falls back to name-based heuristics on
 // the `Throwable` identifier. Classified per roadmap/17.
-func (r *ObjectExtendsThrowableRule) Confidence() float64 { return 0.75 }
+func (r *ObjectExtendsThrowableRule) Confidence() float64 { return api.ConfidenceMedium }
 
 var throwableBaseTypes = []string{"Throwable", "Exception", "Error", "RuntimeException",
 	"IllegalStateException", "IllegalArgumentException", "IOException",

--- a/internal/rules/hotspot.go
+++ b/internal/rules/hotspot.go
@@ -21,7 +21,7 @@ type GodClassOrModuleRule struct {
 
 // Confidence reports a tier-2 (medium) base confidence. Hotspot rule. Detection uses cross-file fan-in/fan-out metrics whose
 // threshold is a project-sensitive heuristic. Classified per roadmap/17.
-func (r *GodClassOrModuleRule) Confidence() float64 { return 0.75 }
+func (r *GodClassOrModuleRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // Walks `import_header` AST nodes instead of `file.Lines` so the count
 // excludes `import ` text inside block comments, KDoc, and raw-string
@@ -74,7 +74,7 @@ type FanInFanOutHotspotRule struct {
 
 // Confidence reports a tier-2 (medium) base confidence. Hotspot rule. Detection uses cross-file fan-in/fan-out metrics whose
 // threshold is a project-sensitive heuristic. Classified per roadmap/17.
-func (r *FanInFanOutHotspotRule) Confidence() float64 { return 0.75 }
+func (r *FanInFanOutHotspotRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *FanInFanOutHotspotRule) check(ctx *api.Context) {
 	index := ctx.CodeIndex

--- a/internal/rules/i18n_locale_default_for_formatting.go
+++ b/internal/rules/i18n_locale_default_for_formatting.go
@@ -15,7 +15,7 @@ type LocaleGetDefaultForFormattingRule struct {
 	BaseRule
 }
 
-func (r *LocaleGetDefaultForFormattingRule) Confidence() float64 { return 0.8 }
+func (r *LocaleGetDefaultForFormattingRule) Confidence() float64 { return api.ConfidenceMediumHigh }
 
 // isPersistenceOrNetworkFormatterReceiver returns true if the receiver of a
 // `.withLocale(...)` call is a known machine-readable formatter constant. The

--- a/internal/rules/i18n_markup.go
+++ b/internal/rules/i18n_markup.go
@@ -27,7 +27,7 @@ type TranslatableMarkupMismatchRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Markup
 // detection is regex-based; literal `**` or `<b ` lookalikes in
 // translator text can occasionally produce false positives.
-func (r *TranslatableMarkupMismatchRule) Confidence() float64 { return 0.8 }
+func (r *TranslatableMarkupMismatchRule) Confidence() float64 { return api.ConfidenceMediumHigh }
 
 type markupStyle struct {
 	html bool

--- a/internal/rules/i18n_plurals.go
+++ b/internal/rules/i18n_plurals.go
@@ -34,7 +34,7 @@ type PluralsBuiltWithIfElseRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Heuristic shape
 // match: identifier name + literal-1 comparison + string-producing
 // branches. Classified per roadmap/17.
-func (r *PluralsBuiltWithIfElseRule) Confidence() float64 { return 0.75 }
+func (r *PluralsBuiltWithIfElseRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *PluralsBuiltWithIfElseRule) check(ctx *api.Context) {
 	idx, file := ctx.Idx, ctx.File
@@ -134,7 +134,7 @@ type PluralsMissingZeroRule struct {
 
 // Confidence reports a tier-3 (high) base confidence — locale-folder gating
 // plus a literal child-tag check leaves little room for misidentification.
-func (r *PluralsMissingZeroRule) Confidence() float64 { return 0.9 }
+func (r *PluralsMissingZeroRule) Confidence() float64 { return api.ConfidenceHigher }
 
 // pluralsZeroFormLocales lists language tags where CLDR specifies a `zero`
 // plural category. Russian is included per the cluster spec even though

--- a/internal/rules/i18n_string_concat.go
+++ b/internal/rules/i18n_string_concat.go
@@ -19,7 +19,7 @@ type StringConcatForTranslationRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Detection
 // matches the call name `stringResource` without resolving the import
 // site, so a same-named project symbol may produce a false match.
-func (r *StringConcatForTranslationRule) Confidence() float64 { return 0.75 }
+func (r *StringConcatForTranslationRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *StringConcatForTranslationRule) check(ctx *api.Context) {
 	idx, file := ctx.Idx, ctx.File

--- a/internal/rules/i18n_string_contains_html_without_cdata.go
+++ b/internal/rules/i18n_string_contains_html_without_cdata.go
@@ -34,7 +34,7 @@ type StringContainsHTMLWithoutCDATARule struct {
 	AndroidRule
 }
 
-func (r *StringContainsHTMLWithoutCDATARule) Confidence() float64 { return 0.9 }
+func (r *StringContainsHTMLWithoutCDATARule) Confidence() float64 { return api.ConfidenceHigher }
 
 // htmlMarkupChildTags is the set of child element tags that, when present
 // inside a <string> resource without being wrapped in <![CDATA[...]]>,

--- a/internal/rules/i18n_string_resource_placeholder_order.go
+++ b/internal/rules/i18n_string_resource_placeholder_order.go
@@ -21,7 +21,7 @@ type StringResourcePlaceholderOrderRule struct {
 	AndroidRule
 }
 
-func (r *StringResourcePlaceholderOrderRule) Confidence() float64 { return 0.9 }
+func (r *StringResourcePlaceholderOrderRule) Confidence() float64 { return api.ConfidenceHigher }
 
 func (r *StringResourcePlaceholderOrderRule) check(ctx *api.Context) {
 	if ctx.ResourceIndex == nil {

--- a/internal/rules/i18n_string_template.go
+++ b/internal/rules/i18n_string_template.go
@@ -19,7 +19,7 @@ type StringTemplateForTranslationRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Detection
 // matches the call name `stringResource` without resolving the import
 // site, so a same-named project symbol may produce a false match.
-func (r *StringTemplateForTranslationRule) Confidence() float64 { return 0.75 }
+func (r *StringTemplateForTranslationRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *StringTemplateForTranslationRule) check(ctx *api.Context) {
 	idx, file := ctx.Idx, ctx.File

--- a/internal/rules/i18n_text_direction.go
+++ b/internal/rules/i18n_text_direction.go
@@ -22,7 +22,7 @@ type TextDirectionLiteralInStringRule struct {
 // Confidence reports a tier-3 (high) base confidence. The BIDI control
 // codepoints have no other meaning in a string literal, so a literal
 // match is unambiguous.
-func (r *TextDirectionLiteralInStringRule) Confidence() float64 { return 0.9 }
+func (r *TextDirectionLiteralInStringRule) Confidence() float64 { return api.ConfidenceHigher }
 
 func (r *TextDirectionLiteralInStringRule) check(ctx *api.Context) {
 	idx, file := ctx.Idx, ctx.File

--- a/internal/rules/i18n_unicode_normalization.go
+++ b/internal/rules/i18n_unicode_normalization.go
@@ -20,7 +20,7 @@ type UnicodeNormalizationMissingRule struct {
 // Confidence reports a tier-3 (low) base confidence. The rule cannot
 // resolve the receiver type, so a `List<T>.contains` inside a search
 // function may match. The default-inactive setting compensates.
-func (r *UnicodeNormalizationMissingRule) Confidence() float64 { return 0.5 }
+func (r *UnicodeNormalizationMissingRule) Confidence() float64 { return api.ConfidenceLow }
 
 func (r *UnicodeNormalizationMissingRule) check(ctx *api.Context) {
 	idx, file := ctx.Idx, ctx.File

--- a/internal/rules/i18n_upperlower.go
+++ b/internal/rules/i18n_upperlower.go
@@ -21,7 +21,7 @@ type UpperLowerInvariantMisuseRule struct {
 // Confidence reports a tier-2 (medium) base confidence because the rule
 // matches on method name without type resolution; same-named local
 // helpers will produce false positives.
-func (r *UpperLowerInvariantMisuseRule) Confidence() float64 { return 0.75 }
+func (r *UpperLowerInvariantMisuseRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *UpperLowerInvariantMisuseRule) check(ctx *api.Context) {
 	idx, file := ctx.Idx, ctx.File

--- a/internal/rules/kdoc_link_validation.go
+++ b/internal/rules/kdoc_link_validation.go
@@ -14,7 +14,7 @@ type KdocLinkValidationRule struct {
 }
 
 // Confidence reflects source-index lookup with conservative external-library skips.
-func (r *KdocLinkValidationRule) Confidence() float64 { return 0.90 }
+func (r *KdocLinkValidationRule) Confidence() float64 { return api.ConfidenceHigher }
 
 func (r *KdocLinkValidationRule) check(ctx *api.Context) {
 	if ctx.CodeIndex == nil || len(ctx.ParsedFiles) == 0 {

--- a/internal/rules/layer_dependency_violation.go
+++ b/internal/rules/layer_dependency_violation.go
@@ -20,7 +20,7 @@ type LayerDependencyViolationRule struct {
 // Confidence is 0.95 — given a well-defined layer matrix, the check is
 // a deterministic graph walk. False positives only occur from misconfigured
 // layer definitions, not from algorithm imprecision.
-func (r *LayerDependencyViolationRule) Confidence() float64 { return 0.95 }
+func (r *LayerDependencyViolationRule) Confidence() float64 { return api.ConfidenceVeryHigh }
 
 func (r *LayerDependencyViolationRule) ModuleAwareNeeds() ModuleAwareNeeds {
 	return ModuleAwareNeeds{NeedsDependencies: true}

--- a/internal/rules/library.go
+++ b/internal/rules/library.go
@@ -3,6 +3,7 @@ package rules
 import (
 	"strings"
 
+	api "github.com/kaeawc/krit/internal/rules/api"
 	"github.com/kaeawc/krit/internal/scanner"
 )
 
@@ -16,7 +17,7 @@ type ForbiddenPublicDataClassRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Library-hygiene rule. Detection matches on known library package names
 // and API shapes without confirming the actual import target. Classified
 // per roadmap/17.
-func (r *ForbiddenPublicDataClassRule) Confidence() float64 { return 0.75 }
+func (r *ForbiddenPublicDataClassRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // LibraryEntitiesShouldNotBePublicRule detects public top-level classes, functions,
 // and properties that could be internal in library code.
@@ -28,7 +29,7 @@ type LibraryEntitiesShouldNotBePublicRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Library-hygiene rule. Detection matches on known library package names
 // and API shapes without confirming the actual import target. Classified
 // per roadmap/17.
-func (r *LibraryEntitiesShouldNotBePublicRule) Confidence() float64 { return 0.75 }
+func (r *LibraryEntitiesShouldNotBePublicRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // LibraryCodeMustSpecifyReturnTypeRule detects public functions and properties
 // without explicit return types. In libraries, implicit return types are part of
@@ -41,7 +42,7 @@ type LibraryCodeMustSpecifyReturnTypeRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Library-hygiene rule. Detection matches on known library package names
 // and API shapes without confirming the actual import target. Classified
 // per roadmap/17.
-func (r *LibraryCodeMustSpecifyReturnTypeRule) Confidence() float64 { return 0.75 }
+func (r *LibraryCodeMustSpecifyReturnTypeRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // hasExplicitType checks whether a function_declaration or property_declaration
 // has an explicit type annotation by looking for a ":" token followed by a type node.

--- a/internal/rules/licensing.go
+++ b/internal/rules/licensing.go
@@ -46,7 +46,7 @@ type OssLicensesNotIncludedInAndroidRule struct {
 // Detection combines Gradle plugin-list parsing with attribution-file
 // presence; vendored licenses under non-standard names produce false
 // positives. Classified per roadmap/17.
-func (r *OssLicensesNotIncludedInAndroidRule) Confidence() float64 { return 0.75 }
+func (r *OssLicensesNotIncludedInAndroidRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *OssLicensesNotIncludedInAndroidRule) check(ctx *api.Context) {
 	path, content, cfg := ctx.GradlePath, ctx.GradleContent, ctx.GradleConfig
@@ -127,7 +127,7 @@ type CopyrightYearOutdatedRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Licensing rule. Detection scans file headers and manifests for license
 // markers via regex; custom or non-English headers can produce false
 // negatives. Classified per roadmap/17.
-func (r *CopyrightYearOutdatedRule) Confidence() float64 { return 0.75 }
+func (r *CopyrightYearOutdatedRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *CopyrightYearOutdatedRule) check(ctx *api.Context) {
 	file := ctx.File
@@ -219,7 +219,7 @@ type MissingSpdxIdentifierRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Licensing rule. Detection scans file headers and manifests for license
 // markers via regex; custom or non-English headers can produce false
 // negatives. Classified per roadmap/17.
-func (r *MissingSpdxIdentifierRule) Confidence() float64 { return 0.75 }
+func (r *MissingSpdxIdentifierRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *MissingSpdxIdentifierRule) check(ctx *api.Context) {
 	file := ctx.File
@@ -253,7 +253,7 @@ type SpdxIdentifierMismatchWithProjectRule struct {
 // Confidence reports a tier-1 (high) base confidence. Detection compares the
 // SPDX id parsed from the file header to the configured project license; both
 // values are explicit, leaving little room for false positives.
-func (r *SpdxIdentifierMismatchWithProjectRule) Confidence() float64 { return 0.9 }
+func (r *SpdxIdentifierMismatchWithProjectRule) Confidence() float64 { return api.ConfidenceHigher }
 
 func (r *SpdxIdentifierMismatchWithProjectRule) check(ctx *api.Context) {
 	if r.ProjectLicense == "" {
@@ -478,7 +478,7 @@ type SpdxIdentifierInvalidRule struct {
 // Confidence reports a tier-1 (high) base confidence. False positives are
 // limited to licenses trimmed from the embedded set; users can add them via
 // additionalIdentifiers.
-func (r *SpdxIdentifierInvalidRule) Confidence() float64 { return 0.9 }
+func (r *SpdxIdentifierInvalidRule) Confidence() float64 { return api.ConfidenceHigher }
 
 func (r *SpdxIdentifierInvalidRule) check(ctx *api.Context) {
 	file := ctx.File
@@ -686,7 +686,7 @@ type OptInMarkerNotRecognisedRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Licensing rule. The
 // embedded marker list cannot enumerate every project-local OptIn marker, so
 // callers can extend it via configuration. Classified per roadmap/17.
-func (r *OptInMarkerNotRecognisedRule) Confidence() float64 { return 0.7 }
+func (r *OptInMarkerNotRecognisedRule) Confidence() float64 { return api.ConfidenceMediumLowPlus }
 
 func (r *OptInMarkerNotRecognisedRule) check(ctx *api.Context) {
 	idx, file := ctx.Idx, ctx.File
@@ -747,7 +747,7 @@ type OptInMarkerExposedPubliclyRule struct {
 // Confidence reports a tier-1 (high) base confidence. The detection is fully
 // AST-driven: we match `@OptIn` annotations whose target declaration has no
 // non-public visibility modifier.
-func (r *OptInMarkerExposedPubliclyRule) Confidence() float64 { return 0.9 }
+func (r *OptInMarkerExposedPubliclyRule) Confidence() float64 { return api.ConfidenceHigher }
 
 // optInAnnotationTarget walks up from an `@OptIn` annotation node to the
 // declaration it is attached to. Returns the declaration index and true when
@@ -781,7 +781,7 @@ type OptInWithoutJustificationRule struct {
 }
 
 // Confidence reports a tier-2 (medium) base confidence. Licensing rule.
-func (r *OptInWithoutJustificationRule) Confidence() float64 { return 0.75 }
+func (r *OptInWithoutJustificationRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *OptInWithoutJustificationRule) check(ctx *api.Context) {
 	idx, file := ctx.Idx, ctx.File
@@ -807,7 +807,7 @@ type SuppressedWarningWithoutJustificationRule struct {
 }
 
 // Confidence reports a tier-2 (medium) base confidence. Licensing rule.
-func (r *SuppressedWarningWithoutJustificationRule) Confidence() float64 { return 0.75 }
+func (r *SuppressedWarningWithoutJustificationRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *SuppressedWarningWithoutJustificationRule) check(ctx *api.Context) {
 	idx, file := ctx.Idx, ctx.File
@@ -835,7 +835,7 @@ type RequiresOptInWithoutMessageRule struct {
 
 // Confidence reports a tier-1 (high) base confidence. The check is a pure AST
 // match on `@RequiresOptIn(...)` argument labels.
-func (r *RequiresOptInWithoutMessageRule) Confidence() float64 { return 0.9 }
+func (r *RequiresOptInWithoutMessageRule) Confidence() float64 { return api.ConfidenceHigher }
 
 func (r *RequiresOptInWithoutMessageRule) check(ctx *api.Context) {
 	idx, file := ctx.Idx, ctx.File
@@ -870,7 +870,7 @@ type RequiresOptInWithoutLevelRule struct {
 // Confidence reports a tier-1 (high) base confidence. The detection is
 // AST-driven: we match `annotation class` declarations carrying a
 // `@RequiresOptIn` annotation and inspect its `level = ...` argument.
-func (r *RequiresOptInWithoutLevelRule) Confidence() float64 { return 0.9 }
+func (r *RequiresOptInWithoutLevelRule) Confidence() float64 { return api.ConfidenceHigher }
 
 func (r *RequiresOptInWithoutLevelRule) check(ctx *api.Context) {
 	idx, file := ctx.Idx, ctx.File
@@ -1002,7 +1002,7 @@ func licenseIsIncompatible(projectLicense, depLicense string) bool {
 // Confidence reports a tier-2 (medium) base confidence. Licensing rule. Detection scans file headers and manifests for license
 // markers via regex; custom or non-English headers can produce false
 // negatives. Classified per roadmap/17.
-func (r *DependencyLicenseUnknownRule) Confidence() float64 { return 0.75 }
+func (r *DependencyLicenseUnknownRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *DependencyLicenseUnknownRule) check(ctx *api.Context) {
 	path, content, cfg := ctx.GradlePath, ctx.GradleContent, ctx.GradleConfig
@@ -1046,7 +1046,7 @@ type LgplStaticLinkingInApkRule struct {
 
 // Confidence reports a tier-2 (medium) base confidence. Licensing rule keyed on
 // an embedded LGPL artifact registry; coverage depends on registry breadth.
-func (r *LgplStaticLinkingInApkRule) Confidence() float64 { return 0.75 }
+func (r *LgplStaticLinkingInApkRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *LgplStaticLinkingInApkRule) check(ctx *api.Context) {
 	path, content, cfg := ctx.GradlePath, ctx.GradleContent, ctx.GradleConfig
@@ -1104,7 +1104,7 @@ type DependencyLicenseIncompatibleRule struct {
 // Detection relies on the embedded license registry and the configured
 // project license; missing or stale registry entries can produce false
 // negatives. Classified per roadmap/17.
-func (r *DependencyLicenseIncompatibleRule) Confidence() float64 { return 0.75 }
+func (r *DependencyLicenseIncompatibleRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *DependencyLicenseIncompatibleRule) check(ctx *api.Context) {
 	path, content, cfg := ctx.GradlePath, ctx.GradleContent, ctx.GradleConfig
@@ -1159,7 +1159,7 @@ type NoticeFileOutOfDateRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Licensing rule.
 // Detection scans a NOTICE file for artifact identifiers; custom phrasing
 // can produce false negatives.
-func (r *NoticeFileOutOfDateRule) Confidence() float64 { return 0.75 }
+func (r *NoticeFileOutOfDateRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *NoticeFileOutOfDateRule) check(ctx *api.Context) {
 	path, content, cfg := ctx.GradlePath, ctx.GradleContent, ctx.GradleConfig

--- a/internal/rules/logging.go
+++ b/internal/rules/logging.go
@@ -18,7 +18,7 @@ type LogLevelGuardMissingRule struct {
 
 // Confidence reports a tier-2 (medium) base confidence. Observability rule. Detection pattern-matches logging/metrics API call
 // shapes without confirming the receiver type. Classified per roadmap/17.
-func (r *LogLevelGuardMissingRule) Confidence() float64 { return 0.75 }
+func (r *LogLevelGuardMissingRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func logLevelGuardMessageNodeFlat(file *scanner.File, call uint32) uint32 {
 	if file == nil || call == 0 {
@@ -735,7 +735,7 @@ type LogWithoutCorrelationIDRule struct {
 
 // Confidence reports a tier-2 (medium) base confidence. Observability rule. Detection pattern-matches logging/metrics API call
 // shapes without confirming the receiver type. Classified per roadmap/17.
-func (r *LogWithoutCorrelationIDRule) Confidence() float64 { return 0.75 }
+func (r *LogWithoutCorrelationIDRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // NullableStructuredFieldRule detects addKeyValue fields that pass nullable
 // safe-call expressions without an explicit fallback value.
@@ -744,7 +744,7 @@ type NullableStructuredFieldRule struct {
 	BaseRule
 }
 
-func (r *NullableStructuredFieldRule) Confidence() float64 { return 0.75 }
+func (r *NullableStructuredFieldRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *NullableStructuredFieldRule) shouldFlag(file *scanner.File, idx uint32) bool {
 	if file == nil || idx == 0 || file.FlatType(idx) != "call_expression" {
@@ -848,7 +848,7 @@ type LoggerWithoutLoggerFieldRule struct {
 
 // Confidence reports a tier-2 (medium) base confidence. Observability rule. Detection pattern-matches logging/metrics API call
 // shapes without confirming the receiver type. Classified per roadmap/17.
-func (r *LoggerWithoutLoggerFieldRule) Confidence() float64 { return 0.75 }
+func (r *LoggerWithoutLoggerFieldRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // LoggerInterpolatedMessageRule detects SLF4J/Logback/log4j-style logger calls
 // whose message argument is a Kotlin string template with interpolations.
@@ -865,7 +865,7 @@ type LoggerInterpolatedMessageRule struct {
 
 // Confidence reports a tier-2 (medium) base confidence. Observability rule. Detection pattern-matches logging/metrics API call
 // shapes without confirming the receiver type. Classified per roadmap/17.
-func (r *LoggerInterpolatedMessageRule) Confidence() float64 { return 0.75 }
+func (r *LoggerInterpolatedMessageRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // loggerLevelMethods are the SLF4J-style log level method names that take a
 // message template as the first argument.
@@ -1062,7 +1062,7 @@ type UnstructuredErrorLogRule struct {
 	Methods []string
 }
 
-func (r *UnstructuredErrorLogRule) Confidence() float64 { return 0.6 }
+func (r *UnstructuredErrorLogRule) Confidence() float64 { return api.ConfidenceMediumLow }
 
 func (r *UnstructuredErrorLogRule) methodEnabled(method string) bool {
 	if len(r.Methods) == 0 {
@@ -1186,7 +1186,7 @@ type TraceIDLoggedAsPlainMessageRule struct {
 	Identifiers []string
 }
 
-func (r *TraceIDLoggedAsPlainMessageRule) Confidence() float64 { return 0.75 }
+func (r *TraceIDLoggedAsPlainMessageRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *TraceIDLoggedAsPlainMessageRule) identifierSet() map[string]bool {
 	defaults := []string{"traceId", "trace_id", "spanId", "span_id", "requestId", "request_id", "correlationId", "correlation_id"}
@@ -1285,7 +1285,7 @@ type StructuredLogKeyMixedCaseRule struct {
 	ThresholdPercent int
 }
 
-func (r *StructuredLogKeyMixedCaseRule) Confidence() float64 { return 0.75 }
+func (r *StructuredLogKeyMixedCaseRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // structuredLogKeyDecision carries the per-file majority/minority verdict.
 // Empty strings mean "no finding for this file".
@@ -1387,7 +1387,7 @@ type LoggerStringConcatRule struct {
 
 // Confidence reports a tier-2 (medium) base confidence. Detection
 // pattern-matches logger call shapes without confirming the receiver type.
-func (r *LoggerStringConcatRule) Confidence() float64 { return 0.75 }
+func (r *LoggerStringConcatRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // loggerStringConcatMessageArgFlat returns the message argument of `call` when
 // it is a positional or named `+` concatenation that includes a string literal
@@ -1453,7 +1453,7 @@ type MdcPutNoRemoveRule struct {
 
 // Confidence reports a tier-2 (medium) base confidence. Observability rule. Detection pattern-matches logging/metrics API call
 // shapes without confirming the receiver type. Classified per roadmap/17.
-func (r *MdcPutNoRemoveRule) Confidence() float64 { return 0.75 }
+func (r *MdcPutNoRemoveRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // mdcStaticKeyFlat returns the literal value of `call`'s first positional
 // argument when that argument is a non-interpolated string literal. Used by
@@ -1532,7 +1532,7 @@ type MdcAcrossCoroutineBoundaryRule struct {
 
 // Confidence reports a tier-2 (medium) base confidence. Observability rule. Detection pattern-matches logging/metrics API call
 // shapes without confirming the receiver type. Classified per roadmap/17.
-func (r *MdcAcrossCoroutineBoundaryRule) Confidence() float64 { return 0.75 }
+func (r *MdcAcrossCoroutineBoundaryRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // firstUnpropagatedCoroutineBuilderAfterFlat walks subsequent siblings of a
 // statement-level call_expression and returns the first sibling call that

--- a/internal/rules/metrics.go
+++ b/internal/rules/metrics.go
@@ -3,6 +3,7 @@ package rules
 import (
 	"strings"
 
+	api "github.com/kaeawc/krit/internal/rules/api"
 	"github.com/kaeawc/krit/internal/scanner"
 )
 
@@ -13,7 +14,7 @@ type MetricTimerOutsideBlockRule struct {
 	BaseRule
 }
 
-func (r *MetricTimerOutsideBlockRule) Confidence() float64 { return 0.75 }
+func (r *MetricTimerOutsideBlockRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *MetricTimerOutsideBlockRule) shouldFlag(file *scanner.File, idx uint32) bool {
 	if file == nil || idx == 0 || file.FlatType(idx) != "call_expression" {
@@ -44,7 +45,7 @@ type MetricTagHighCardinalityRule struct {
 	Keys []string
 }
 
-func (r *MetricTagHighCardinalityRule) Confidence() float64 { return 0.75 }
+func (r *MetricTagHighCardinalityRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *MetricTagHighCardinalityRule) shouldFlag(file *scanner.File, idx uint32) (string, bool) {
 	if file == nil || idx == 0 || file.FlatType(idx) != "call_expression" {
@@ -87,7 +88,7 @@ type MetricNameMissingUnitRule struct {
 	Suffixes []string
 }
 
-func (r *MetricNameMissingUnitRule) Confidence() float64 { return 0.75 }
+func (r *MetricNameMissingUnitRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *MetricNameMissingUnitRule) shouldFlag(file *scanner.File, idx uint32) (string, bool) {
 	if file == nil || idx == 0 || file.FlatType(idx) != "call_expression" {
@@ -115,7 +116,7 @@ type MetricCounterNotMonotonicRule struct {
 	BaseRule
 }
 
-func (r *MetricCounterNotMonotonicRule) Confidence() float64 { return 0.75 }
+func (r *MetricCounterNotMonotonicRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *MetricCounterNotMonotonicRule) shouldFlag(file *scanner.File, idx uint32) bool {
 	if file == nil || idx == 0 || file.FlatType(idx) != "call_expression" {

--- a/internal/rules/module_dependency_cycle.go
+++ b/internal/rules/module_dependency_cycle.go
@@ -19,7 +19,7 @@ type ModuleDependencyCycleRule struct {
 
 // Confidence is 0.95 — Tarjan SCC on the parsed module graph is
 // deterministic and precise. A reported cycle is a real cycle.
-func (r *ModuleDependencyCycleRule) Confidence() float64 { return 0.95 }
+func (r *ModuleDependencyCycleRule) Confidence() float64 { return api.ConfidenceVeryHigh }
 
 func (r *ModuleDependencyCycleRule) ModuleAwareNeeds() ModuleAwareNeeds {
 	return ModuleAwareNeeds{NeedsDependencies: true}

--- a/internal/rules/module_template_conformance.go
+++ b/internal/rules/module_template_conformance.go
@@ -22,7 +22,7 @@ type ModuleTemplateConformanceRule struct {
 
 // Confidence reports a tier-2 (medium) base confidence. The rule relies on
 // Gradle settings/build-script text parsing rather than a full Gradle model.
-func (r *ModuleTemplateConformanceRule) Confidence() float64 { return 0.75 }
+func (r *ModuleTemplateConformanceRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *ModuleTemplateConformanceRule) ModuleAwareNeeds() ModuleAwareNeeds {
 	return ModuleAwareNeeds{NeedsDependencies: true}

--- a/internal/rules/naming.go
+++ b/internal/rules/naming.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/kaeawc/krit/internal/experiment"
+	api "github.com/kaeawc/krit/internal/rules/api"
 	"github.com/kaeawc/krit/internal/scanner"
 )
 
@@ -20,7 +21,7 @@ type ClassNamingRule struct {
 // Confidence holds the 0.95 dispatch default. Naming rule. Detection regex-matches the declared identifier, which is
 // deterministic — the identifier is what it is. No heuristic path.
 // Classified per roadmap/17.
-func (r *ClassNamingRule) Confidence() float64 { return 0.95 }
+func (r *ClassNamingRule) Confidence() float64 { return api.ConfidenceVeryHigh }
 
 // FunctionNamingRule checks function names match a pattern.
 type FunctionNamingRule struct {
@@ -37,7 +38,7 @@ type FunctionNamingRule struct {
 // Confidence holds the 0.95 dispatch default. Naming rule. Detection regex-matches the declared identifier, which is
 // deterministic — the identifier is what it is. No heuristic path.
 // Classified per roadmap/17.
-func (r *FunctionNamingRule) Confidence() float64 { return 0.95 }
+func (r *FunctionNamingRule) Confidence() float64 { return api.ConfidenceVeryHigh }
 
 func functionDeclarationHasExplicitReturnTypeFlat(file *scanner.File, idx uint32) bool {
 	seenParams := false
@@ -107,7 +108,7 @@ type VariableNamingRule struct {
 // Confidence holds the 0.95 dispatch default. Naming rule. Detection regex-matches the declared identifier, which is
 // deterministic — the identifier is what it is. No heuristic path.
 // Classified per roadmap/17.
-func (r *VariableNamingRule) Confidence() float64 { return 0.95 }
+func (r *VariableNamingRule) Confidence() float64 { return api.ConfidenceVeryHigh }
 
 func variableNamingIsFunctionLocalPropertyFlat(file *scanner.File, idx uint32) bool {
 	for p, ok := file.FlatParent(idx); ok; p, ok = file.FlatParent(p) {
@@ -131,7 +132,7 @@ type PackageNamingRule struct {
 // Confidence holds the 0.95 dispatch default. Naming rule. Detection regex-matches the declared identifier, which is
 // deterministic — the identifier is what it is. No heuristic path.
 // Classified per roadmap/17.
-func (r *PackageNamingRule) Confidence() float64 { return 0.95 }
+func (r *PackageNamingRule) Confidence() float64 { return api.ConfidenceVeryHigh }
 
 // EnumNamingRule checks enum entry names.
 type EnumNamingRule struct {
@@ -143,7 +144,7 @@ type EnumNamingRule struct {
 // Confidence holds the 0.95 dispatch default. Naming rule. Detection regex-matches the declared identifier, which is
 // deterministic — the identifier is what it is. No heuristic path.
 // Classified per roadmap/17.
-func (r *EnumNamingRule) Confidence() float64 { return 0.95 }
+func (r *EnumNamingRule) Confidence() float64 { return api.ConfidenceVeryHigh }
 
 func isTestSupportFile(path string) bool {
 	if scanner.IsTestFile(path) {
@@ -168,7 +169,7 @@ type BooleanPropertyNamingRule struct {
 // Confidence holds the 0.95 dispatch default. Naming rule. Detection regex-matches the declared identifier, which is
 // deterministic — the identifier is what it is. No heuristic path.
 // Classified per roadmap/17.
-func (r *BooleanPropertyNamingRule) Confidence() float64 { return 0.95 }
+func (r *BooleanPropertyNamingRule) Confidence() float64 { return api.ConfidenceVeryHigh }
 
 func isBooleanPropertyFlat(file *scanner.File, idx uint32) bool {
 	declaredType := extractPropertyTypeFlat(file, idx)
@@ -198,7 +199,7 @@ type ConstructorParameterNamingRule struct {
 // Confidence holds the 0.95 dispatch default. Naming rule. Detection regex-matches the declared identifier, which is
 // deterministic — the identifier is what it is. No heuristic path.
 // Classified per roadmap/17.
-func (r *ConstructorParameterNamingRule) Confidence() float64 { return 0.95 }
+func (r *ConstructorParameterNamingRule) Confidence() float64 { return api.ConfidenceVeryHigh }
 
 // ForbiddenClassNameRule flags disallowed class names.
 type ForbiddenClassNameRule struct {
@@ -210,7 +211,7 @@ type ForbiddenClassNameRule struct {
 // Confidence holds the 0.95 dispatch default. Naming rule. Detection regex-matches the declared identifier, which is
 // deterministic — the identifier is what it is. No heuristic path.
 // Classified per roadmap/17.
-func (r *ForbiddenClassNameRule) Confidence() float64 { return 0.95 }
+func (r *ForbiddenClassNameRule) Confidence() float64 { return api.ConfidenceVeryHigh }
 
 // FunctionNameMaxLengthRule flags function names exceeding a max length.
 type FunctionNameMaxLengthRule struct {
@@ -222,7 +223,7 @@ type FunctionNameMaxLengthRule struct {
 // Confidence holds the 0.95 dispatch default. Naming rule. Detection regex-matches the declared identifier, which is
 // deterministic — the identifier is what it is. No heuristic path.
 // Classified per roadmap/17.
-func (r *FunctionNameMaxLengthRule) Confidence() float64 { return 0.95 }
+func (r *FunctionNameMaxLengthRule) Confidence() float64 { return api.ConfidenceVeryHigh }
 
 // FunctionNameMinLengthRule flags function names below a min length.
 type FunctionNameMinLengthRule struct {
@@ -234,7 +235,7 @@ type FunctionNameMinLengthRule struct {
 // Confidence holds the 0.95 dispatch default. Naming rule. Detection regex-matches the declared identifier, which is
 // deterministic — the identifier is what it is. No heuristic path.
 // Classified per roadmap/17.
-func (r *FunctionNameMinLengthRule) Confidence() float64 { return 0.95 }
+func (r *FunctionNameMinLengthRule) Confidence() float64 { return api.ConfidenceVeryHigh }
 
 // FunctionParameterNamingRule checks function parameter names.
 type FunctionParameterNamingRule struct {
@@ -247,7 +248,7 @@ type FunctionParameterNamingRule struct {
 // Confidence holds the 0.95 dispatch default. Naming rule. Detection regex-matches the declared identifier, which is
 // deterministic — the identifier is what it is. No heuristic path.
 // Classified per roadmap/17.
-func (r *FunctionParameterNamingRule) Confidence() float64 { return 0.95 }
+func (r *FunctionParameterNamingRule) Confidence() float64 { return api.ConfidenceVeryHigh }
 
 // InvalidPackageDeclarationRule checks that the package declaration matches the directory structure.
 type InvalidPackageDeclarationRule struct {
@@ -260,7 +261,7 @@ type InvalidPackageDeclarationRule struct {
 // Confidence holds the 0.95 dispatch default. Naming rule. Detection regex-matches the declared identifier, which is
 // deterministic — the identifier is what it is. No heuristic path.
 // Classified per roadmap/17.
-func (r *InvalidPackageDeclarationRule) Confidence() float64 { return 0.95 }
+func (r *InvalidPackageDeclarationRule) Confidence() float64 { return api.ConfidenceVeryHigh }
 
 func invalidPackageDeclarationIgnoredPath(path string) bool {
 	normalized := filepath.ToSlash(path)
@@ -288,7 +289,7 @@ type LambdaParameterNamingRule struct {
 // Confidence holds the 0.95 dispatch default. Naming rule. Detection regex-matches the declared identifier, which is
 // deterministic — the identifier is what it is. No heuristic path.
 // Classified per roadmap/17.
-func (r *LambdaParameterNamingRule) Confidence() float64 { return 0.95 }
+func (r *LambdaParameterNamingRule) Confidence() float64 { return api.ConfidenceVeryHigh }
 
 // MatchingDeclarationNameRule checks that a file with a single non-private
 // top-level class or object has a filename matching that declaration's name.
@@ -307,7 +308,7 @@ type MatchingDeclarationNameRule struct {
 // Confidence holds the 0.95 dispatch default. Naming rule. Detection regex-matches the declared identifier, which is
 // deterministic — the identifier is what it is. No heuristic path.
 // Classified per roadmap/17.
-func (r *MatchingDeclarationNameRule) Confidence() float64 { return 0.95 }
+func (r *MatchingDeclarationNameRule) Confidence() float64 { return api.ConfidenceVeryHigh }
 
 // fileNameWithoutSuffix strips multiplatform and .kt/.kts suffixes from a path.
 // For example "Foo.android.kt" with target "android" yields "Foo".
@@ -332,7 +333,7 @@ type MemberNameEqualsClassNameRule struct {
 // Confidence holds the 0.95 dispatch default. Naming rule. Detection regex-matches the declared identifier, which is
 // deterministic — the identifier is what it is. No heuristic path.
 // Classified per roadmap/17.
-func (r *MemberNameEqualsClassNameRule) Confidence() float64 { return 0.95 }
+func (r *MemberNameEqualsClassNameRule) Confidence() float64 { return api.ConfidenceVeryHigh }
 
 // NoNameShadowingRule flags inner declarations that shadow outer ones.
 // NoNameShadowing behavior:
@@ -353,7 +354,7 @@ type NoNameShadowingRule struct {
 // flow collectors, builder DSLs). Medium confidence keeps it in
 // --min-confidence=medium pipelines but lets strict pipelines filter
 // it out of their default gate.
-func (r *NoNameShadowingRule) Confidence() float64 { return 0.75 }
+func (r *NoNameShadowingRule) Confidence() float64 { return api.ConfidenceMedium }
 
 type noNameShadowFindingKey struct {
 	line int
@@ -1277,7 +1278,7 @@ type NonBooleanPropertyPrefixedWithIsRule struct {
 // Confidence holds the 0.95 dispatch default. Naming rule. Detection regex-matches the declared identifier, which is
 // deterministic — the identifier is what it is. No heuristic path.
 // Classified per roadmap/17.
-func (r *NonBooleanPropertyPrefixedWithIsRule) Confidence() float64 { return 0.95 }
+func (r *NonBooleanPropertyPrefixedWithIsRule) Confidence() float64 { return api.ConfidenceVeryHigh }
 
 // ObjectPropertyNamingRule checks property names inside object declarations.
 type ObjectPropertyNamingRule struct {
@@ -1291,7 +1292,7 @@ type ObjectPropertyNamingRule struct {
 // Confidence holds the 0.95 dispatch default. Naming rule. Detection regex-matches the declared identifier, which is
 // deterministic — the identifier is what it is. No heuristic path.
 // Classified per roadmap/17.
-func (r *ObjectPropertyNamingRule) Confidence() float64 { return 0.95 }
+func (r *ObjectPropertyNamingRule) Confidence() float64 { return api.ConfidenceVeryHigh }
 
 // TopLevelPropertyNamingRule checks top-level property names.
 type TopLevelPropertyNamingRule struct {
@@ -1305,7 +1306,7 @@ type TopLevelPropertyNamingRule struct {
 // Confidence holds the 0.95 dispatch default. Naming rule. Detection regex-matches the declared identifier, which is
 // deterministic — the identifier is what it is. No heuristic path.
 // Classified per roadmap/17.
-func (r *TopLevelPropertyNamingRule) Confidence() float64 { return 0.95 }
+func (r *TopLevelPropertyNamingRule) Confidence() float64 { return api.ConfidenceVeryHigh }
 
 // VariableMaxLengthRule flags variable names that are too long.
 type VariableMaxLengthRule struct {
@@ -1317,7 +1318,7 @@ type VariableMaxLengthRule struct {
 // Confidence holds the 0.95 dispatch default. Naming rule. Detection regex-matches the declared identifier, which is
 // deterministic — the identifier is what it is. No heuristic path.
 // Classified per roadmap/17.
-func (r *VariableMaxLengthRule) Confidence() float64 { return 0.95 }
+func (r *VariableMaxLengthRule) Confidence() float64 { return api.ConfidenceVeryHigh }
 
 // VariableMinLengthRule flags variable names that are too short.
 type VariableMinLengthRule struct {
@@ -1329,7 +1330,7 @@ type VariableMinLengthRule struct {
 // Confidence holds the 0.95 dispatch default. Naming rule. Detection regex-matches the declared identifier, which is
 // deterministic — the identifier is what it is. No heuristic path.
 // Classified per roadmap/17.
-func (r *VariableMinLengthRule) Confidence() float64 { return 0.95 }
+func (r *VariableMinLengthRule) Confidence() float64 { return api.ConfidenceVeryHigh }
 
 func walkFunctionParametersFlat(file *scanner.File, idx uint32, visit func(uint32)) {
 	if file == nil || idx == 0 {

--- a/internal/rules/package_dependency_cycle.go
+++ b/internal/rules/package_dependency_cycle.go
@@ -34,7 +34,7 @@ func (r *PackageDependencyCycleRule) check(ctx *api.Context) {
 // Confidence holds the 0.95 dispatch default — cycle detection on
 // the package-level import graph is a precise Tarjan/DFS result; a
 // reported cycle is a real cycle. No heuristic path.
-func (r *PackageDependencyCycleRule) Confidence() float64 { return 0.95 }
+func (r *PackageDependencyCycleRule) Confidence() float64 { return api.ConfidenceVeryHigh }
 
 func (r *PackageDependencyCycleRule) ModuleAwareNeeds() ModuleAwareNeeds {
 	return ModuleAwareNeeds{NeedsFiles: true}

--- a/internal/rules/package_naming_convention_drift.go
+++ b/internal/rules/package_naming_convention_drift.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	api "github.com/kaeawc/krit/internal/rules/api"
 	"github.com/kaeawc/krit/internal/scanner"
 	"github.com/kaeawc/krit/internal/sourceheader"
 )
@@ -21,7 +22,7 @@ type PackageNamingConventionDriftRule struct {
 // Confidence holds the 0.95 dispatch default — package-header drift
 // is a purely structural comparison against the expected prefix
 // derived from the source root path. No heuristic path.
-func (r *PackageNamingConventionDriftRule) Confidence() float64 { return 0.95 }
+func (r *PackageNamingConventionDriftRule) Confidence() float64 { return api.ConfidenceVeryHigh }
 
 func packageHeaderNameFlat(file *scanner.File, idx uint32) string {
 	if idNode, ok := file.FlatFindChild(idx, "identifier"); ok {

--- a/internal/rules/performance.go
+++ b/internal/rules/performance.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/kaeawc/krit/internal/oracle"
+	api "github.com/kaeawc/krit/internal/rules/api"
 	"github.com/kaeawc/krit/internal/scanner"
 	"github.com/kaeawc/krit/internal/typeinfer"
 )
@@ -26,7 +27,7 @@ var bitmapDecodeMethods = map[string]bool{
 // Confidence reports a tier-2 (medium) base confidence. Performance rule. Detection pattern-matches anti-patterns (allocation in
 // loops, primitive boxing, collection chains) with optional resolver
 // support; fallback is heuristic. Classified per roadmap/17.
-func (r *BitmapDecodeWithoutOptionsRule) Confidence() float64 { return 0.75 }
+func (r *BitmapDecodeWithoutOptionsRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // ArrayPrimitiveRule detects Array<Int> etc. instead of IntArray.
 // With type inference: verifies the type argument resolves to a primitive type
@@ -40,7 +41,7 @@ type ArrayPrimitiveRule struct {
 // Array<Int>/Array<Long> that should be IntArray/LongArray; needs resolver
 // for generic receivers, falls back to text match. Classified per
 // roadmap/17.
-func (r *ArrayPrimitiveRule) Confidence() float64 { return 0.75 }
+func (r *ArrayPrimitiveRule) Confidence() float64 { return api.ConfidenceMedium }
 
 var primitiveArrayTypes = map[string]string{
 	"Int":     "IntArray",
@@ -130,7 +131,7 @@ type CouldBeSequenceRule struct {
 // collection chains that should use asSequence(); chain-length heuristic is
 // conservative but the threshold is a style call. Classified per
 // roadmap/17.
-func (r *CouldBeSequenceRule) Confidence() float64 { return 0.75 }
+func (r *CouldBeSequenceRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // collectionTypes that benefit from asSequence() conversion.
 var sequenceCandidateTypes = map[string]bool{
@@ -433,7 +434,7 @@ type ForEachOnRangeRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Performance rule. Detection pattern-matches anti-patterns (allocation in
 // loops, primitive boxing, collection chains) with optional resolver
 // support; fallback is heuristic. Classified per roadmap/17.
-func (r *ForEachOnRangeRule) Confidence() float64 { return 0.75 }
+func (r *ForEachOnRangeRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // rangeInfixOps are the infix operators that create ranges in Kotlin.
 var rangeInfixOps = map[string]bool{
@@ -575,7 +576,7 @@ type SpreadOperatorRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Performance rule. Detection pattern-matches anti-patterns (allocation in
 // loops, primitive boxing, collection chains) with optional resolver
 // support; fallback is heuristic. Classified per roadmap/17.
-func (r *SpreadOperatorRule) Confidence() float64 { return 0.75 }
+func (r *SpreadOperatorRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func spreadOperatorShouldReportFlat(file *scanner.File, idx uint32) bool {
 	if file == nil || idx == 0 {
@@ -678,7 +679,7 @@ type UnnecessaryInitOnArrayRule struct {
 // inspects only array-constructor call expressions and single-expression
 // init lambdas; confidence remains medium because the constructor target may
 // be unresolved in parser-only runs.
-func (r *UnnecessaryInitOnArrayRule) Confidence() float64 { return 0.75 }
+func (r *UnnecessaryInitOnArrayRule) Confidence() float64 { return api.ConfidenceMedium }
 
 var arrayDefaultKinds = map[string]string{
 	"IntArray":     "zero",
@@ -832,7 +833,7 @@ type UnnecessaryPartOfBinaryExpressionRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Performance rule. Detection pattern-matches anti-patterns (allocation in
 // loops, primitive boxing, collection chains) with optional resolver
 // support; fallback is heuristic. Classified per roadmap/17.
-func (r *UnnecessaryPartOfBinaryExpressionRule) Confidence() float64 { return 0.75 }
+func (r *UnnecessaryPartOfBinaryExpressionRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // UnnecessaryTemporaryInstantiationRule detects Integer.valueOf(x).toString() etc.
 type UnnecessaryTemporaryInstantiationRule struct {
@@ -843,7 +844,7 @@ type UnnecessaryTemporaryInstantiationRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Performance rule. Detection pattern-matches anti-patterns (allocation in
 // loops, primitive boxing, collection chains) with optional resolver
 // support; fallback is heuristic. Classified per roadmap/17.
-func (r *UnnecessaryTemporaryInstantiationRule) Confidence() float64 { return 0.75 }
+func (r *UnnecessaryTemporaryInstantiationRule) Confidence() float64 { return api.ConfidenceMedium }
 
 var tempInstantiationPrefixNeedles = [][]byte{
 	[]byte("Integer"), []byte("Long"), []byte("Short"), []byte("Byte"),
@@ -937,7 +938,7 @@ type UnnecessaryTypeCastingRule struct {
 // Confidence reports a tier-2 (medium) base confidence — flags casts
 // that are no-ops; needs the resolver to confirm the source type matches
 // the target, falls back to textual comparison. Classified per roadmap/17.
-func (r *UnnecessaryTypeCastingRule) Confidence() float64 { return 0.75 }
+func (r *UnnecessaryTypeCastingRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func safeCastExpressionParts(file *scanner.File, idx uint32) (source, target uint32, ok bool) {
 	if file == nil || idx == 0 || file.FlatType(idx) != "as_expression" {

--- a/internal/rules/potentialbugs_exceptions.go
+++ b/internal/rules/potentialbugs_exceptions.go
@@ -21,7 +21,7 @@ type PrintStackTraceRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Potential-bugs exceptions rule. Detection matches exception type names
 // and throw/catch shapes; name-only fallback fires on project types
 // sharing the same simple name. Classified per roadmap/17.
-func (r *PrintStackTraceRule) Confidence() float64 { return 0.75 }
+func (r *PrintStackTraceRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func printStackTraceReceiverIsThrowable(ctx *api.Context, call uint32) bool {
 	if ctx.File == nil {
@@ -433,7 +433,7 @@ type TooGenericExceptionThrownRule struct {
 // Confidence reports a tier-2 (medium) base confidence — matches on
 // thrown-exception names; name-only fallback false-positives on
 // project-defined exceptions with the same name. Classified per roadmap/17.
-func (r *TooGenericExceptionThrownRule) Confidence() float64 { return 0.75 }
+func (r *TooGenericExceptionThrownRule) Confidence() float64 { return api.ConfidenceMedium }
 
 var defaultGenericThrownNames = []string{"Exception", "Throwable", "Error", "RuntimeException"}
 
@@ -560,7 +560,7 @@ type UnreachableCatchBlockRule struct {
 // Confidence reports a tier-2 (medium) base confidence — catch-block
 // reachability depends on the thrown-type hierarchy from the resolver;
 // heuristic fallback uses name containment. Classified per roadmap/17.
-func (r *UnreachableCatchBlockRule) Confidence() float64 { return 0.75 }
+func (r *UnreachableCatchBlockRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *UnreachableCatchBlockRule) checkFlatNode(ctx *api.Context) {
 	idx, file := ctx.Idx, ctx.File
@@ -926,7 +926,7 @@ type MissingReturnRule struct {
 	BaseRule
 }
 
-func (r *MissingReturnRule) Confidence() float64 { return 0.85 }
+func (r *MissingReturnRule) Confidence() float64 { return api.ConfidenceHigh }
 
 func missingReturnDeclaredType(file *scanner.File, fn uint32) (typeIdx uint32, body uint32) {
 	foundParams := false

--- a/internal/rules/potentialbugs_lifecycle.go
+++ b/internal/rules/potentialbugs_lifecycle.go
@@ -24,7 +24,7 @@ type ExitOutsideMainRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Potential-bugs lifecycle rule. Detection matches framework lifecycle
 // hook shapes by name and annotation; project-specific wrappers can escape
 // detection. Classified per roadmap/17.
-func (r *ExitOutsideMainRule) Confidence() float64 { return 0.75 }
+func (r *ExitOutsideMainRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // ---------------------------------------------------------------------------
 // ExplicitGarbageCollectionCallRule detects System.gc() calls.
@@ -37,7 +37,7 @@ type ExplicitGarbageCollectionCallRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Potential-bugs lifecycle rule. Detection matches framework lifecycle
 // hook shapes by name and annotation; project-specific wrappers can escape
 // detection. Classified per roadmap/17.
-func (r *ExplicitGarbageCollectionCallRule) Confidence() float64 { return 0.75 }
+func (r *ExplicitGarbageCollectionCallRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func javaSourceResolvesSimpleType(file *scanner.File, simpleName, fqn string) bool {
 	facts := javafacts.SourceFactsForFile(file)
@@ -99,7 +99,7 @@ type InvalidRangeRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Potential-bugs lifecycle rule. Detection matches framework lifecycle
 // hook shapes by name and annotation; project-specific wrappers can escape
 // detection. Classified per roadmap/17.
-func (r *InvalidRangeRule) Confidence() float64 { return 0.75 }
+func (r *InvalidRangeRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // ---------------------------------------------------------------------------
 // IteratorHasNextCallsNextMethodRule detects hasNext() calling next().
@@ -112,7 +112,7 @@ type IteratorHasNextCallsNextMethodRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Potential-bugs lifecycle rule. Detection matches framework lifecycle
 // hook shapes by name and annotation; project-specific wrappers can escape
 // detection. Classified per roadmap/17.
-func (r *IteratorHasNextCallsNextMethodRule) Confidence() float64 { return 0.75 }
+func (r *IteratorHasNextCallsNextMethodRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // ---------------------------------------------------------------------------
 // IteratorNotThrowingNoSuchElementExceptionRule detects next() without throw.
@@ -125,7 +125,9 @@ type IteratorNotThrowingNoSuchElementExceptionRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Potential-bugs lifecycle rule. Detection matches framework lifecycle
 // hook shapes by name and annotation; project-specific wrappers can escape
 // detection. Classified per roadmap/17.
-func (r *IteratorNotThrowingNoSuchElementExceptionRule) Confidence() float64 { return 0.75 }
+func (r *IteratorNotThrowingNoSuchElementExceptionRule) Confidence() float64 {
+	return api.ConfidenceMedium
+}
 
 // enclosingImplementsIterator returns true if the node's enclosing class
 // has a delegation specifier naming Iterator / MutableIterator / ListIterator
@@ -295,7 +297,7 @@ type LateinitUsageRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Potential-bugs lifecycle rule. Detection matches framework lifecycle
 // hook shapes by name and annotation; project-specific wrappers can escape
 // detection. Classified per roadmap/17.
-func (r *LateinitUsageRule) Confidence() float64 { return 0.75 }
+func (r *LateinitUsageRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // ---------------------------------------------------------------------------
 // MissingPackageDeclarationRule detects Kotlin/Java source files without package statements.
@@ -309,7 +311,7 @@ type MissingPackageDeclarationRule struct {
 // check asks tree-sitter whether the file's root has a package_header
 // (Kotlin) or package_declaration (Java) child. Deterministic with no
 // heuristic path and no dependence on line-level comment detection.
-func (r *MissingPackageDeclarationRule) Confidence() float64 { return 0.95 }
+func (r *MissingPackageDeclarationRule) Confidence() float64 { return api.ConfidenceVeryHigh }
 
 func (r *MissingPackageDeclarationRule) check(ctx *api.Context) {
 	idx, file := ctx.Idx, ctx.File
@@ -392,7 +394,7 @@ type MissingSuperCallRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Potential-bugs lifecycle rule. Detection matches framework lifecycle
 // hook shapes by name and annotation; project-specific wrappers can escape
 // detection. Classified per roadmap/17.
-func (r *MissingSuperCallRule) Confidence() float64 { return 0.75 }
+func (r *MissingSuperCallRule) Confidence() float64 { return api.ConfidenceMedium }
 
 var missingSuperCallLifecycleMethodsByOwner = map[string]map[string]bool{
 	"Activity":          missingSuperCallActivityLifecycleMethods,
@@ -622,7 +624,7 @@ type MissingUseCallRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Potential-bugs lifecycle rule. Detection matches framework lifecycle
 // hook shapes by name and annotation; project-specific wrappers can escape
 // detection. Classified per roadmap/17.
-func (r *MissingUseCallRule) Confidence() float64 { return 0.75 }
+func (r *MissingUseCallRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // Known Closeable/AutoCloseable types commonly constructed directly.
 var closeableTypes = map[string]bool{

--- a/internal/rules/potentialbugs_misc.go
+++ b/internal/rules/potentialbugs_misc.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/kaeawc/krit/internal/filefacts"
 	"github.com/kaeawc/krit/internal/oracle"
+	api "github.com/kaeawc/krit/internal/rules/api"
 	"github.com/kaeawc/krit/internal/scanner"
 	"github.com/kaeawc/krit/internal/typeinfer"
 )
@@ -37,7 +38,7 @@ type DeprecationRule struct {
 // Confidence reports a tier-2 (medium) base confidence — matches on
 // deprecation markers and annotations via pattern, with resolver-backed
 // type checks used only when available. Classified per roadmap/17.
-func (r *DeprecationRule) Confidence() float64 { return 0.75 }
+func (r *DeprecationRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // deprecatedDeclIndex returns the per-file index of deprecated
 // declarations, computed once per file per run via the shared
@@ -272,7 +273,7 @@ type HasPlatformTypeRule struct {
 // when the resolver cannot determine the return type. Findings from that
 // fallback path carry known false-positive risk on identifiers that
 // happen to start with those prefixes but are not Java interop.
-func (r *HasPlatformTypeRule) Confidence() float64 { return 0.75 }
+func (r *HasPlatformTypeRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // ---------------------------------------------------------------------------
 // IgnoredReturnValueRule detects call expressions whose non-Unit return value
@@ -295,7 +296,7 @@ type IgnoredReturnValueRule struct {
 // target. When the resolver is unavailable it falls back to name-based
 // heuristics against ReturnValueTypes/IgnoreFunctionCall lists, which
 // can miss custom wrapper APIs or fire on look-alike names.
-func (r *IgnoredReturnValueRule) Confidence() float64 { return 0.75 }
+func (r *IgnoredReturnValueRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // returnValueTypes that should always be flagged when discarded.
 var returnValueFQNs = map[string]bool{
@@ -1425,7 +1426,7 @@ type ImplicitDefaultLocaleRule struct {
 // defined non-String method with one of those names will produce a
 // false positive. Accuracy improves when a type resolver is wired in
 // but the current implementation is structural-only.
-func (r *ImplicitDefaultLocaleRule) Confidence() float64 { return 0.75 }
+func (r *ImplicitDefaultLocaleRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // implicitLocaleMethods are case-conversion methods that use the default
 // locale when called without arguments and therefore warrant a warning.
@@ -1491,7 +1492,7 @@ type LocaleDefaultForCurrencyRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Potential-bugs rule. Detection uses structural AST patterns and optional
 // resolver-backed type checks; fallback path is heuristic. Classified per
 // roadmap/17.
-func (r *LocaleDefaultForCurrencyRule) Confidence() float64 { return 0.75 }
+func (r *LocaleDefaultForCurrencyRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func enclosingClassNameFlat(file *scanner.File, idx uint32) string {
 	for current, ok := file.FlatParent(idx); ok; current, ok = file.FlatParent(current) {
@@ -1527,7 +1528,7 @@ type HardcodedDateFormatRule struct {
 	BaseRule
 }
 
-func (r *HardcodedDateFormatRule) Confidence() float64 { return 0.85 }
+func (r *HardcodedDateFormatRule) Confidence() float64 { return api.ConfidenceHigh }
 
 // HardcodedNumberFormatRule detects DecimalFormat(pattern) constructors and
 // NumberFormat.getInstance() calls without an explicit Locale. Without one,
@@ -1538,4 +1539,4 @@ type HardcodedNumberFormatRule struct {
 	BaseRule
 }
 
-func (r *HardcodedNumberFormatRule) Confidence() float64 { return 0.85 }
+func (r *HardcodedNumberFormatRule) Confidence() float64 { return api.ConfidenceHigh }

--- a/internal/rules/potentialbugs_nullsafety_bangbang.go
+++ b/internal/rules/potentialbugs_nullsafety_bangbang.go
@@ -634,7 +634,7 @@ type MapGetWithNotNullAssertionRule struct {
 // Confidence reports a tier-2 (medium) base confidence — tree-sitter
 // structural check backed by resolver/source type confirmation that the
 // receiver is Map-like. Classified per roadmap/17.
-func (r *MapGetWithNotNullAssertionRule) Confidence() float64 { return 0.75 }
+func (r *MapGetWithNotNullAssertionRule) Confidence() float64 { return api.ConfidenceMedium }
 
 type mapGetBangAccess struct {
 	access   uint32

--- a/internal/rules/potentialbugs_nullsafety_casts.go
+++ b/internal/rules/potentialbugs_nullsafety_casts.go
@@ -27,7 +27,7 @@ type UnsafeCastRule struct {
 // Confidence reports a tier-1 base confidence. The oracle-backed path mirrors
 // the Kotlin compiler's CAST_NEVER_SUCCEEDS diagnostic; the non-oracle fallback
 // is intentionally limited to final, disjoint types.
-func (r *UnsafeCastRule) Confidence() float64 { return 0.95 }
+func (r *UnsafeCastRule) Confidence() float64 { return api.ConfidenceVeryHigh }
 
 type unsafeCastExpressionParts struct {
 	source uint32
@@ -1211,7 +1211,7 @@ type CastNullableToNonNullableTypeRule struct {
 
 // Confidence reports a tier-2 (medium) base confidence. The rule is
 // resolver-backed so it only reports when source nullability is known.
-func (r *CastNullableToNonNullableTypeRule) Confidence() float64 { return 0.75 }
+func (r *CastNullableToNonNullableTypeRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *CastNullableToNonNullableTypeRule) check(ctx *api.Context) {
 	idx, file := ctx.Idx, ctx.File
@@ -1292,7 +1292,7 @@ type CastToNullableTypeRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Potential-bugs null safety rule. Detection leans on structural patterns
 // around nullable expressions and has a heuristic fallback when the
 // resolver is absent. Classified per roadmap/17.
-func (r *CastToNullableTypeRule) Confidence() float64 { return 0.75 }
+func (r *CastToNullableTypeRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *CastToNullableTypeRule) check(ctx *api.Context) {
 	idx, file := ctx.Idx, ctx.File

--- a/internal/rules/potentialbugs_nullsafety_redundant.go
+++ b/internal/rules/potentialbugs_nullsafety_redundant.go
@@ -25,7 +25,7 @@ type UnnecessaryNotNullCheckRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Potential-bugs null safety rule. Detection leans on structural patterns
 // around nullable expressions and has a heuristic fallback when the
 // resolver is absent. Classified per roadmap/17.
-func (r *UnnecessaryNotNullCheckRule) Confidence() float64 { return 0.75 }
+func (r *UnnecessaryNotNullCheckRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // isMutableVarProperty returns true if the given name is declared as `var`
 // in the file's AST. Kotlin cannot smart-cast mutable properties because their
@@ -540,7 +540,7 @@ type UnnecessaryNotNullOperatorRule struct {
 // Confidence reports a tier-2 (medium) base confidence — flags !! on a
 // non-null type; relies on resolver for nullability. Heuristic fallback is
 // conservative but noisy. Classified per roadmap/17.
-func (r *UnnecessaryNotNullOperatorRule) Confidence() float64 { return 0.75 }
+func (r *UnnecessaryNotNullOperatorRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *UnnecessaryNotNullOperatorRule) check(ctx *api.Context) {
 	idx, file := ctx.Idx, ctx.File
@@ -989,7 +989,7 @@ type UnnecessarySafeCallRule struct {
 // Confidence reports a tier-2 (medium) base confidence — flags ?. on a
 // non-null receiver; needs resolver for nullability, falls back to
 // name-based heuristic. Classified per roadmap/17.
-func (r *UnnecessarySafeCallRule) Confidence() float64 { return 0.75 }
+func (r *UnnecessarySafeCallRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *UnnecessarySafeCallRule) check(ctx *api.Context) {
 	idx, file := ctx.Idx, ctx.File
@@ -1610,7 +1610,7 @@ type NullCheckOnMutablePropertyRule struct {
 // Confidence reports a tier-2 (medium) base confidence — distinguishing
 // val vs var requires type resolution of the receiver. Heuristic fallback
 // uses declaration patterns. Classified per roadmap/17.
-func (r *NullCheckOnMutablePropertyRule) Confidence() float64 { return 0.75 }
+func (r *NullCheckOnMutablePropertyRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *NullCheckOnMutablePropertyRule) check(ctx *api.Context) {
 	idx, file := ctx.Idx, ctx.File
@@ -1666,7 +1666,7 @@ type NullableToStringCallRule struct {
 // Confidence reports a tier-2 (medium) base confidence — needs resolver
 // to know whether the receiver is nullable; heuristic fallback matches
 // common null-returning APIs. Classified per roadmap/17.
-func (r *NullableToStringCallRule) Confidence() float64 { return 0.75 }
+func (r *NullableToStringCallRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *NullableToStringCallRule) NodeTypes() []string {
 	return []string{"call_expression", "string_literal"}
@@ -1911,7 +1911,7 @@ type UselessElvisOnNonNullRule struct {
 	BaseRule
 }
 
-func (r *UselessElvisOnNonNullRule) Confidence() float64 { return 0.85 }
+func (r *UselessElvisOnNonNullRule) Confidence() float64 { return api.ConfidenceHigh }
 
 func (r *UselessElvisOnNonNullRule) check(ctx *api.Context) {
 	idx, file := ctx.Idx, ctx.File

--- a/internal/rules/potentialbugs_properties.go
+++ b/internal/rules/potentialbugs_properties.go
@@ -17,7 +17,7 @@ type PropertyUsedBeforeDeclarationRule struct {
 
 // Confidence reports a tier-2 (medium) base confidence. Potential-bugs properties rule. Detection is structural with heuristic
 // fallbacks for flow-dependent cases. Classified per roadmap/17.
-func (r *PropertyUsedBeforeDeclarationRule) Confidence() float64 { return 0.75 }
+func (r *PropertyUsedBeforeDeclarationRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // ---------------------------------------------------------------------------
 // UnconditionalJumpStatementInLoopRule detects loop with unconditional return/break.
@@ -29,7 +29,7 @@ type UnconditionalJumpStatementInLoopRule struct {
 
 // Confidence reports a tier-2 (medium) base confidence. Potential-bugs properties rule. Detection is structural with heuristic
 // fallbacks for flow-dependent cases. Classified per roadmap/17.
-func (r *UnconditionalJumpStatementInLoopRule) Confidence() float64 { return 0.75 }
+func (r *UnconditionalJumpStatementInLoopRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // ---------------------------------------------------------------------------
 // UnnamedParameterUseRule detects function calls with many unnamed params.
@@ -42,7 +42,7 @@ type UnnamedParameterUseRule struct {
 
 // Confidence reports a tier-2 (medium) base confidence. Potential-bugs properties rule. Detection is structural with heuristic
 // fallbacks for flow-dependent cases. Classified per roadmap/17.
-func (r *UnnamedParameterUseRule) Confidence() float64 { return 0.75 }
+func (r *UnnamedParameterUseRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // ---------------------------------------------------------------------------
 // UnusedUnaryOperatorRule detects standalone +x or -x as expression statements
@@ -57,7 +57,7 @@ type UnusedUnaryOperatorRule struct {
 
 // Confidence reports a tier-2 (medium) base confidence. Potential-bugs properties rule. Detection is structural with heuristic
 // fallbacks for flow-dependent cases. Classified per roadmap/17.
-func (r *UnusedUnaryOperatorRule) Confidence() float64 { return 0.75 }
+func (r *UnusedUnaryOperatorRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // flatIsLastNamedChildOf checks if child is the last named child of parent.
 func flatIsLastNamedChildOf(file *scanner.File, child, parent uint32) bool {
@@ -121,7 +121,7 @@ type UselessPostfixExpressionRule struct {
 // after the value is produced, so the increment/decrement has no
 // observable effect. Tree-sitter gives us this shape directly; no text
 // heuristics are involved.
-func (r *UselessPostfixExpressionRule) Confidence() float64 { return 0.95 }
+func (r *UselessPostfixExpressionRule) Confidence() float64 { return api.ConfidenceVeryHigh }
 
 // checkUselessPostfixFlat runs on jump_expression. Fires when the shape is
 // `return <simple_identifier>++` or `return <simple_identifier>--`. The

--- a/internal/rules/potentialbugs_smartcast.go
+++ b/internal/rules/potentialbugs_smartcast.go
@@ -36,7 +36,7 @@ type SmartCastInvalidatedRule struct {
 	BaseRule
 }
 
-func (r *SmartCastInvalidatedRule) Confidence() float64 { return 0.85 }
+func (r *SmartCastInvalidatedRule) Confidence() float64 { return api.ConfidenceHigh }
 
 // smartCastIfNullCheckedVar returns the simple identifier name being
 // non-null-checked by the if's condition, or "" when the shape doesn't

--- a/internal/rules/potentialbugs_types.go
+++ b/internal/rules/potentialbugs_types.go
@@ -508,7 +508,7 @@ func ifExpressionIsFirstStatementInFunction(file *scanner.File, ifExpr uint32, f
 // Confidence reports a tier-2 (medium) base confidence — flags === / !==
 // on value types; needs resolver to confirm operand types, falls back to a
 // name-based heuristic. Classified per roadmap/17.
-func (r *AvoidReferentialEqualityRule) Confidence() float64 { return 0.75 }
+func (r *AvoidReferentialEqualityRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // ---------------------------------------------------------------------------
 // DoubleMutabilityForCollectionRule detects var with mutable collection type.
@@ -525,7 +525,7 @@ type DoubleMutabilityForCollectionRule struct {
 // AST/import evidence, but won't detect the pattern when the collection is
 // returned from a wrapper function. Medium confidence matches the known
 // scope-analysis gap.
-func (r *DoubleMutabilityForCollectionRule) Confidence() float64 { return 0.75 }
+func (r *DoubleMutabilityForCollectionRule) Confidence() float64 { return api.ConfidenceMedium }
 
 var defaultDoubleMutableTypes = []string{
 	"MutableList", "MutableSet", "MutableMap", "MutableCollection",
@@ -726,7 +726,7 @@ type EqualsAlwaysReturnsTrueOrFalseRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Potential-bugs types rule. Detection pattern-matches type-related
 // constructs; resolver usage when available improves precision but
 // fallback is heuristic. Classified per roadmap/17.
-func (r *EqualsAlwaysReturnsTrueOrFalseRule) Confidence() float64 { return 0.75 }
+func (r *EqualsAlwaysReturnsTrueOrFalseRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // ---------------------------------------------------------------------------
 // EqualsWithHashCodeExistRule detects equals without hashCode or vice versa.
@@ -739,7 +739,7 @@ type EqualsWithHashCodeExistRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Potential-bugs types rule. Detection pattern-matches type-related
 // constructs; resolver usage when available improves precision but
 // fallback is heuristic. Classified per roadmap/17.
-func (r *EqualsWithHashCodeExistRule) Confidence() float64 { return 0.75 }
+func (r *EqualsWithHashCodeExistRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // ---------------------------------------------------------------------------
 // WrongEqualsTypeParameterRule detects equals(other: String) instead of Any?.
@@ -1125,7 +1125,7 @@ type ImplicitUnitReturnTypeRule struct {
 // omit ': Unit' — a convention mismatch rather than a bug, but one that
 // produces noise on Compose codebases. Medium confidence keeps it off
 // default-strict gates without taking it out of the rule set.
-func (r *ImplicitUnitReturnTypeRule) Confidence() float64 { return 0.75 }
+func (r *ImplicitUnitReturnTypeRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // ---------------------------------------------------------------------------
 // ElseCaseInsteadOfExhaustiveWhenRule detects when with else on enum/sealed.
@@ -1142,7 +1142,7 @@ type ElseCaseInsteadOfExhaustiveWhenRule struct {
 // resolver it checks if sealed/enum variants are fully covered; fallback
 // flags any when-with-else-using-is, which is noisier. Classified per
 // roadmap/17.
-func (r *ElseCaseInsteadOfExhaustiveWhenRule) Confidence() float64 { return 0.75 }
+func (r *ElseCaseInsteadOfExhaustiveWhenRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // whenElseBranchDeletionFix returns a byte-mode Fix that removes the
 // `else -> ...` when_entry from a when_expression along with surrounding
@@ -1408,7 +1408,7 @@ type NoElseInWhenSealedRule struct {
 	BaseRule
 }
 
-func (r *NoElseInWhenSealedRule) Confidence() float64 { return 0.9 }
+func (r *NoElseInWhenSealedRule) Confidence() float64 { return api.ConfidenceHigher }
 
 // whenConditionEnumEntryName extracts the entry name from a value-style
 // when_condition like `Color.RED` (navigation_expression) or a bare
@@ -1511,7 +1511,7 @@ type NonExhaustiveWhenRule struct {
 	BaseRule
 }
 
-func (r *NonExhaustiveWhenRule) Confidence() float64 { return 0.9 }
+func (r *NonExhaustiveWhenRule) Confidence() float64 { return api.ConfidenceHigher }
 
 // whenIsUsedAsExpression walks parents through transparent wrappers
 // (parenthesized_expression, annotated_expression) and inspects the

--- a/internal/rules/precompile_deprecated_symbol_used_error.go
+++ b/internal/rules/precompile_deprecated_symbol_used_error.go
@@ -21,7 +21,7 @@ type PrecompileDeprecatedSymbolUsedErrorRule struct {
 	BaseRule
 }
 
-func (r *PrecompileDeprecatedSymbolUsedErrorRule) Confidence() float64 { return 0.95 }
+func (r *PrecompileDeprecatedSymbolUsedErrorRule) Confidence() float64 { return api.ConfidenceVeryHigh }
 
 func (r *PrecompileDeprecatedSymbolUsedErrorRule) check(ctx *api.Context) {
 	idx, file := ctx.Idx, ctx.File

--- a/internal/rules/precompile_duplicate_declaration.go
+++ b/internal/rules/precompile_duplicate_declaration.go
@@ -31,7 +31,7 @@ type PrecompileDuplicateDeclarationRule struct {
 	BaseRule
 }
 
-func (r *PrecompileDuplicateDeclarationRule) Confidence() float64 { return 0.9 }
+func (r *PrecompileDuplicateDeclarationRule) Confidence() float64 { return api.ConfidenceHigher }
 
 func (r *PrecompileDuplicateDeclarationRule) check(ctx *api.Context) {
 	idx, file := ctx.Idx, ctx.File

--- a/internal/rules/precompile_duplicate_label.go
+++ b/internal/rules/precompile_duplicate_label.go
@@ -25,7 +25,7 @@ type PrecompileDuplicateLabelRule struct {
 	BaseRule
 }
 
-func (r *PrecompileDuplicateLabelRule) Confidence() float64 { return 0.95 }
+func (r *PrecompileDuplicateLabelRule) Confidence() float64 { return api.ConfidenceVeryHigh }
 
 func (r *PrecompileDuplicateLabelRule) check(ctx *api.Context) {
 	idx, file := ctx.Idx, ctx.File

--- a/internal/rules/precompile_unreachable_code.go
+++ b/internal/rules/precompile_unreachable_code.go
@@ -20,7 +20,7 @@ type PrecompileUnreachableCodeRule struct {
 	BaseRule
 }
 
-func (r *PrecompileUnreachableCodeRule) Confidence() float64 { return 0.95 }
+func (r *PrecompileUnreachableCodeRule) Confidence() float64 { return api.ConfidenceVeryHigh }
 
 func (r *PrecompileUnreachableCodeRule) check(ctx *api.Context) {
 	idx, file := ctx.Idx, ctx.File

--- a/internal/rules/privacy_analytics.go
+++ b/internal/rules/privacy_analytics.go
@@ -26,7 +26,7 @@ type AnalyticsEventWithPiiParamNameRule struct {
 	BaseRule
 }
 
-func (r *AnalyticsEventWithPiiParamNameRule) Confidence() float64 { return 0.75 }
+func (r *AnalyticsEventWithPiiParamNameRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // AnalyticsUserIDFromPiiRule flags calls to user-ID setters whose argument
 // is a property named email, phoneNumber, username, etc.
@@ -35,7 +35,7 @@ type AnalyticsUserIDFromPiiRule struct {
 	BaseRule
 }
 
-func (r *AnalyticsUserIDFromPiiRule) Confidence() float64 { return 0.75 }
+func (r *AnalyticsUserIDFromPiiRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // CrashlyticsCustomKeyWithPiiRule flags setCustomKey calls where the key
 // name matches PII patterns.
@@ -44,7 +44,7 @@ type CrashlyticsCustomKeyWithPiiRule struct {
 	BaseRule
 }
 
-func (r *CrashlyticsCustomKeyWithPiiRule) Confidence() float64 { return 0.75 }
+func (r *CrashlyticsCustomKeyWithPiiRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // FirebaseRemoteConfigDefaultsWithPiiRule flags setDefaults/setDefaultsAsync
 // calls whose map keys match PII patterns.
@@ -53,7 +53,7 @@ type FirebaseRemoteConfigDefaultsWithPiiRule struct {
 	BaseRule
 }
 
-func (r *FirebaseRemoteConfigDefaultsWithPiiRule) Confidence() float64 { return 0.75 }
+func (r *FirebaseRemoteConfigDefaultsWithPiiRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // AnalyticsCallWithoutConsentGateRule flags analytics event calls that are not
 // guarded by a consent/privacy/GDPR check.
@@ -62,7 +62,7 @@ type AnalyticsCallWithoutConsentGateRule struct {
 	BaseRule
 }
 
-func (r *AnalyticsCallWithoutConsentGateRule) Confidence() float64 { return 0.75 }
+func (r *AnalyticsCallWithoutConsentGateRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func isAnalyticsEventMethod(name string) bool {
 	switch name {

--- a/internal/rules/privacy_permissions.go
+++ b/internal/rules/privacy_permissions.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"unicode"
 
+	api "github.com/kaeawc/krit/internal/rules/api"
 	"github.com/kaeawc/krit/internal/scanner"
 )
 
@@ -20,7 +21,7 @@ type AdMobInitializedBeforeConsentRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Privacy/permissions rule. Detection pattern-matches sensitive API call
 // shapes and annotation names without cross-checking project permission
 // contracts. Classified per roadmap/17.
-func (r *AdMobInitializedBeforeConsentRule) Confidence() float64 { return 0.75 }
+func (r *AdMobInitializedBeforeConsentRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func privacyClassDirectlyExtendsFlat(file *scanner.File, idx uint32, typeName string) bool {
 	if file == nil || idx == 0 {
@@ -92,7 +93,9 @@ type BiometricAuthNotFallingBackToDeviceCredentialRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Privacy/permissions rule. Detection pattern-matches sensitive API call
 // shapes and annotation names without cross-checking project permission
 // contracts. Classified per roadmap/17.
-func (r *BiometricAuthNotFallingBackToDeviceCredentialRule) Confidence() float64 { return 0.75 }
+func (r *BiometricAuthNotFallingBackToDeviceCredentialRule) Confidence() float64 {
+	return api.ConfidenceMedium
+}
 
 func biometricPromptAllowsDeviceCredentialFlat(file *scanner.File, idx uint32) bool {
 	allowsFallback := false
@@ -182,7 +185,7 @@ type ContactsAccessWithoutPermissionUIRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Privacy/permissions rule. Detection pattern-matches sensitive API call
 // shapes and annotation names without cross-checking project permission
 // contracts. Classified per roadmap/17.
-func (r *ContactsAccessWithoutPermissionUIRule) Confidence() float64 { return 0.75 }
+func (r *ContactsAccessWithoutPermissionUIRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func isContactsPhoneContentURIFlat(file *scanner.File, idx uint32) bool {
 	return contactsQualifiedReferenceMatchesFlat(file, idx, []string{"ContactsContract", "CommonDataKinds", "Phone", "CONTENT_URI"})
@@ -506,7 +509,7 @@ type LocationBackgroundWithoutRationaleRule struct {
 	BaseRule
 }
 
-func (r *LocationBackgroundWithoutRationaleRule) Confidence() float64 { return 0.75 }
+func (r *LocationBackgroundWithoutRationaleRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func privacyExpressionIsBackgroundLocationPermissionFlat(file *scanner.File, idx uint32) bool {
 	idx = flatUnwrapParenExpr(file, idx)
@@ -684,7 +687,7 @@ type ScreenshotNotBlockedOnLoginScreenRule struct {
 	BaseRule
 }
 
-func (r *ScreenshotNotBlockedOnLoginScreenRule) Confidence() float64 { return 0.75 }
+func (r *ScreenshotNotBlockedOnLoginScreenRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func privacyClassExtendsActivity(file *scanner.File, idx uint32) bool {
 	for child := file.FlatFirstChild(idx); child != 0; child = file.FlatNextSib(child) {
@@ -790,4 +793,4 @@ type ClipboardOnSensitiveInputTypeRule struct {
 	BaseRule
 }
 
-func (r *ClipboardOnSensitiveInputTypeRule) Confidence() float64 { return 0.75 }
+func (r *ClipboardOnSensitiveInputTypeRule) Confidence() float64 { return api.ConfidenceMedium }

--- a/internal/rules/privacy_storage.go
+++ b/internal/rules/privacy_storage.go
@@ -18,7 +18,7 @@ type SharedPreferencesForSensitiveKeyRule struct {
 	BaseRule
 }
 
-func (r *SharedPreferencesForSensitiveKeyRule) Confidence() float64 { return 0.75 }
+func (r *SharedPreferencesForSensitiveKeyRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *SharedPreferencesForSensitiveKeyRule) check(ctx *api.Context) {
 	idx, file := ctx.Idx, ctx.File
@@ -68,7 +68,7 @@ type PlainFileWriteOfSensitiveRule struct {
 	BaseRule
 }
 
-func (r *PlainFileWriteOfSensitiveRule) Confidence() float64 { return 0.75 }
+func (r *PlainFileWriteOfSensitiveRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *PlainFileWriteOfSensitiveRule) check(ctx *api.Context) {
 	idx, file := ctx.Idx, ctx.File
@@ -100,7 +100,7 @@ type LogOfSharedPreferenceReadRule struct {
 	BaseRule
 }
 
-func (r *LogOfSharedPreferenceReadRule) Confidence() float64 { return 0.75 }
+func (r *LogOfSharedPreferenceReadRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *LogOfSharedPreferenceReadRule) check(ctx *api.Context) {
 	idx, file := ctx.Idx, ctx.File

--- a/internal/rules/public_to_internal_leaky_abstraction.go
+++ b/internal/rules/public_to_internal_leaky_abstraction.go
@@ -21,7 +21,9 @@ type PublicToInternalLeakyAbstractionRule struct {
 // Confidence is 0.70 — the heuristic still admits real false positives like
 // type-safe wrappers, adapters, and DI holders. Medium confidence keeps
 // reviewers honest.
-func (r *PublicToInternalLeakyAbstractionRule) Confidence() float64 { return 0.70 }
+func (r *PublicToInternalLeakyAbstractionRule) Confidence() float64 {
+	return api.ConfidenceMediumLowPlus
+}
 
 // leakyClassExcludedModifiers lists every class-declaration modifier that
 // disqualifies the rule. Visibility modifiers (private/internal/protected)

--- a/internal/rules/registry_accessibility.go
+++ b/internal/rules/registry_accessibility.go
@@ -17,7 +17,7 @@ func registerAccessibilityRules() {
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
 			NodeTypes:  []string{"call_expression", "assignment"},
 			Needs:      api.NeedsTypeInfo | api.NeedsOracleCallTargets,
-			Confidence: 0.75, Implementation: r,
+			Confidence: api.ConfidenceMedium, Implementation: r,
 			OracleCallTargets: &api.OracleCallTargetFilter{CalleeNames: []string{
 				"ofArgb", "ofFloat", "ofInt", "ofObject", "setDuration",
 			}},
@@ -50,7 +50,7 @@ func registerAccessibilityRules() {
 		}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"call_expression"}, LexicalCalleeNames: []string{"clickable"}, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"call_expression"}, LexicalCalleeNames: []string{"clickable"}, Confidence: api.ConfidenceMedium, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				if flatCallNameAny(file, idx) != "clickable" {
@@ -80,7 +80,7 @@ func registerAccessibilityRules() {
 		}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"call_expression"}, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"call_expression"}, Confidence: api.ConfidenceMedium, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				name := flatCallName(file, idx)
@@ -118,7 +118,7 @@ func registerAccessibilityRules() {
 		}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"call_expression"}, Confidence: 0.9, Implementation: r,
+			NodeTypes: []string{"call_expression"}, Confidence: api.ConfidenceHigher, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				if !composeContentDescriptionFileMayUse(file) {
@@ -188,7 +188,7 @@ func registerAccessibilityRules() {
 		}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"call_expression"}, Confidence: 0.9, Implementation: r,
+			NodeTypes: []string{"call_expression"}, Confidence: api.ConfidenceHigher, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				name := flatCallName(file, idx)
@@ -232,7 +232,7 @@ func registerAccessibilityRules() {
 		}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"call_expression"}, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"call_expression"}, Confidence: api.ConfidenceMedium, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				navExpr, args := flatCallExpressionParts(file, idx)
@@ -274,7 +274,7 @@ func registerAccessibilityRules() {
 		}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"call_expression"}, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"call_expression"}, Confidence: api.ConfidenceMedium, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				name := flatCallName(file, idx)
@@ -306,7 +306,7 @@ func registerAccessibilityRules() {
 		}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"call_expression"}, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"call_expression"}, Confidence: api.ConfidenceMedium, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				navExpr, _ := flatCallExpressionParts(file, idx)

--- a/internal/rules/registry_android_correctness.go
+++ b/internal/rules/registry_android_correctness.go
@@ -101,7 +101,7 @@ func registerAndroidCorrectnessCommitPrefEdits() {
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Description(), Sev: api.Severity(r.Sev),
 		NodeTypes: []string{"call_expression", "method_invocation"},
-		Languages: []scanner.Language{scanner.LangKotlin, scanner.LangJava}, Confidence: 0.8, Implementation: r,
+		Languages: []scanner.Language{scanner.LangKotlin, scanner.LangJava}, Confidence: api.ConfidenceMediumHigh, Implementation: r,
 		Needs: api.NeedsTypeInfo | api.NeedsOracleCallTargets,
 		OracleCallTargets: &api.OracleCallTargetFilter{
 			CalleeNames: []string{"edit"},
@@ -168,7 +168,7 @@ func registerAndroidCorrectnessCommitTransaction() {
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Description(), Sev: api.Severity(r.Sev),
 		NodeTypes: []string{"call_expression", "method_invocation"},
-		Languages: []scanner.Language{scanner.LangKotlin, scanner.LangJava}, Confidence: 0.8, Implementation: r,
+		Languages: []scanner.Language{scanner.LangKotlin, scanner.LangJava}, Confidence: api.ConfidenceMediumHigh, Implementation: r,
 		Needs: api.NeedsTypeInfo | api.NeedsOracleCallTargets,
 		OracleCallTargets: &api.OracleCallTargetFilter{
 			CalleeNames: []string{"beginTransaction"},
@@ -247,7 +247,7 @@ func registerAndroidCorrectnessCheckResult() {
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Description(), Sev: api.Severity(r.Sev),
 		NodeTypes: []string{"call_expression", "method_invocation"},
-		Languages: []scanner.Language{scanner.LangKotlin, scanner.LangJava}, Confidence: 0.8, Implementation: r,
+		Languages: []scanner.Language{scanner.LangKotlin, scanner.LangJava}, Confidence: api.ConfidenceMediumHigh, Implementation: r,
 		Needs: api.NeedsTypeInfo | api.NeedsOracleCallTargets,
 		OracleCallTargets: &api.OracleCallTargetFilter{
 			CalleeNames: []string{"animate", "buildUpon", "edit", "format", "trim", "replace"},
@@ -412,7 +412,7 @@ func registerAndroidCorrectnessUniqueConstants() {
 	r := &UniqueConstantsRule{AndroidRule: alcRule("UniqueConstants", "Overlapping enumeration constants", ALSError, 6)}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Description(), Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"annotation"}, Confidence: 0.9, Implementation: r,
+		NodeTypes: []string{"annotation"}, Confidence: api.ConfidenceHigher, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			ctor, _ := file.FlatFindChild(idx, "constructor_invocation")
@@ -456,7 +456,7 @@ func registerAndroidCorrectnessWrongThread() {
 	}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Description(), Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"function_declaration"}, Confidence: 0.75, Implementation: r,
+		NodeTypes: []string{"function_declaration"}, Confidence: api.ConfidenceMedium, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			// Check if the function has a @WorkerThread annotation. The
@@ -653,7 +653,7 @@ func registerAndroidCorrectnessSetTextI18n() {
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Description(), Sev: api.Severity(r.Sev),
 		NodeTypes:  []string{"call_expression"},
 		Needs:      api.NeedsTypeInfo,
-		Confidence: 0.75, Implementation: r,
+		Confidence: api.ConfidenceMedium, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			if flatCallExpressionName(file, idx) != "setText" {

--- a/internal/rules/registry_android_correctness_checks.go
+++ b/internal/rules/registry_android_correctness_checks.go
@@ -35,7 +35,7 @@ func registerAndroidCorrectnessChecksOverrideAbstract() {
 	r := &OverrideAbstractRule{AndroidRule: alcRule("OverrideAbstract", "Missing abstract method overrides", ALSError, 6)}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Description(), Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"class_declaration"}, Confidence: 0.9, Implementation: r,
+		NodeTypes: []string{"class_declaration"}, Confidence: api.ConfidenceHigher, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			// The class must itself be concrete. `abstract class Foo : Service`
@@ -76,7 +76,7 @@ func registerAndroidCorrectnessChecksParcelCreator() {
 	r := &ParcelCreatorRule{AndroidRule: alcRule("ParcelCreator", "Missing Parcelable CREATOR field", ALSError, 3)}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Description(), Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"class_declaration"}, Confidence: 0.9, Implementation: r,
+		NodeTypes: []string{"class_declaration"}, Confidence: api.ConfidenceHigher, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			if !classHasSupertypeNamed(file, idx, "Parcelable") {
@@ -386,7 +386,7 @@ func registerAndroidCorrectnessChecksCustomViewStyleable() {
 	r := &CustomViewStyleableRule{AndroidRule: alcRule("CustomViewStyleable", "Mismatched Styleable/Custom View Name", ALSWarning, 6)}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Description(), Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"call_expression"}, Confidence: 0.9, Implementation: r,
+		NodeTypes: []string{"call_expression"}, Confidence: api.ConfidenceHigher, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			if flatCallExpressionName(file, idx) != "obtainStyledAttributes" {

--- a/internal/rules/registry_android_resource_style.go
+++ b/internal/rules/registry_android_resource_style.go
@@ -99,7 +99,7 @@ func registerAndroidResourceStyleRules() {
 		}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Description(), Sev: api.Severity(r.Sev),
-			Needs: api.NeedsResources, AndroidDeps: uint32(r.AndroidDependencies()), Confidence: 0.75, Implementation: r,
+			Needs: api.NeedsResources, AndroidDeps: uint32(r.AndroidDependencies()), Confidence: api.ConfidenceMedium, Implementation: r,
 			Check: r.check,
 		})
 	}

--- a/internal/rules/registry_android_rules.go
+++ b/internal/rules/registry_android_rules.go
@@ -19,7 +19,7 @@ func registerAndroidRules() {
 		}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Description(), Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"call_expression"}, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"call_expression"}, Confidence: api.ConfidenceMedium, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				name := flatCallExpressionName(file, idx)
@@ -46,7 +46,7 @@ func registerAndroidRules() {
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Description(), Sev: api.Severity(r.Sev),
 			NodeTypes:  []string{"call_expression"},
 			Needs:      api.NeedsTypeInfo | api.NeedsOracleCallTargets,
-			Confidence: 0.75, Implementation: r,
+			Confidence: api.ConfidenceMedium, Implementation: r,
 			OracleCallTargets:      &api.OracleCallTargetFilter{CalleeNames: []string{"preferredWidth", "preferredHeight", "preferredSize"}},
 			OracleDeclarationNeeds: &api.OracleDeclarationProfile{},
 			Check: func(ctx *api.Context) {
@@ -69,7 +69,7 @@ func registerAndroidRules() {
 		}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Description(), Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"class_declaration"}, Needs: api.NeedsResolver, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"class_declaration"}, Needs: api.NeedsResolver, Confidence: api.ConfidenceMedium, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				if !isRecyclerAdapterClassFlat(ctx, idx) {
@@ -92,7 +92,7 @@ func registerAndroidRules() {
 		}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Description(), Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"call_expression"}, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"call_expression"}, Confidence: api.ConfidenceMedium, Implementation: r,
 			Check: r.check,
 		})
 	}
@@ -107,7 +107,7 @@ func registerAndroidRules() {
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Description(), Sev: api.Severity(r.Sev),
 			NodeTypes:  []string{"call_expression"},
 			Needs:      api.NeedsTypeInfo,
-			Confidence: 0.75, Implementation: r,
+			Confidence: api.ConfidenceMedium, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				// Test sources frequently log without guards on purpose
@@ -136,7 +136,7 @@ func registerAndroidRules() {
 		}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Description(), Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"string_literal"}, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"string_literal"}, Confidence: api.ConfidenceMedium, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				if flatContainsStringInterpolation(file, idx) {
@@ -165,7 +165,7 @@ func registerAndroidRules() {
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Description(), Sev: api.Severity(r.Sev),
 			NodeTypes:  []string{"call_expression"},
 			Needs:      api.NeedsTypeInfo | api.NeedsOracleCallTargets,
-			Confidence: 0.75, Implementation: r,
+			Confidence: api.ConfidenceMedium, Implementation: r,
 			OracleCallTargets:      &api.OracleCallTargetFilter{CalleeNames: []string{"acquire", "release"}},
 			OracleDeclarationNeeds: &api.OracleDeclarationProfile{},
 			Check: func(ctx *api.Context) {
@@ -208,7 +208,7 @@ func registerAndroidRules() {
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Description(), Sev: api.Severity(r.Sev),
 			NodeTypes: []string{"call_expression", "method_invocation", "assignment"},
 			Needs:     api.NeedsTypeInfo | api.NeedsOracleCallTargets,
-			Languages: []scanner.Language{scanner.LangKotlin, scanner.LangJava}, Confidence: 0.9, Implementation: r,
+			Languages: []scanner.Language{scanner.LangKotlin, scanner.LangJava}, Confidence: api.ConfidenceHigher, Implementation: r,
 			JavaFacts:              &api.JavaFactProfile{ReceiverTypesForCallees: []string{"setJavaScriptEnabled"}},
 			NeedsLibraryFacts:      true,
 			OracleCallTargets:      &api.OracleCallTargetFilter{CalleeNames: []string{"setJavaScriptEnabled"}},

--- a/internal/rules/registry_android_source.go
+++ b/internal/rules/registry_android_source.go
@@ -67,7 +67,7 @@ func registerAndroidSourceRules() {
 		}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Description(), Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"class_declaration"}, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"class_declaration"}, Confidence: api.ConfidenceMedium, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				if file.FlatHasModifier(idx, "abstract") ||
@@ -114,7 +114,7 @@ func registerAndroidSourceRules() {
 		}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Description(), Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"as_expression"}, Confidence: 0.9, Implementation: r,
+			NodeTypes: []string{"as_expression"}, Confidence: api.ConfidenceHigher, Implementation: r,
 			Needs: api.NeedsTypeInfo | api.NeedsOracleCallTargets,
 			OracleCallTargets: &api.OracleCallTargetFilter{
 				CalleeNames: []string{"getSystemService"},
@@ -183,7 +183,7 @@ func registerAndroidSourceRules() {
 		}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Description(), Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"call_expression"}, Confidence: 0.85, Implementation: r,
+			NodeTypes: []string{"call_expression"}, Confidence: api.ConfidenceHigh, Implementation: r,
 			Needs: api.NeedsTypeInfo | api.NeedsOracleCallTargets,
 			OracleCallTargets: &api.OracleCallTargetFilter{
 				CalleeNames: []string{"makeText"},
@@ -242,7 +242,7 @@ func registerAndroidSourceRules() {
 		}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Description(), Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"call_expression"}, Confidence: 0.9, Implementation: r,
+			NodeTypes: []string{"call_expression"}, Confidence: api.ConfidenceHigher, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				if flatCallExpressionName(file, idx) != "HashMap" {
@@ -315,7 +315,7 @@ func registerAndroidSourceRules() {
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Description(), Sev: api.Severity(r.Sev),
 			NodeTypes:  []string{"call_expression", "object_creation_expression"},
 			Languages:  []scanner.Language{scanner.LangKotlin, scanner.LangJava},
-			Confidence: 0.9, Fix: api.FixIdiomatic, Implementation: r,
+			Confidence: api.ConfidenceHigher, Fix: api.FixIdiomatic, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				switch file.FlatType(idx) {
@@ -336,7 +336,7 @@ func registerAndroidSourceRules() {
 		}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Description(), Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"call_expression"}, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"call_expression"}, Confidence: api.ConfidenceMedium, Implementation: r,
 			Needs: api.NeedsTypeInfo | api.NeedsOracleCallTargets,
 			OracleCallTargets: &api.OracleCallTargetFilter{
 				CalleeNames: []string{"v", "d", "i", "w", "e", "wtf"},
@@ -379,7 +379,7 @@ func registerAndroidSourceRules() {
 		}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Description(), Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"class_declaration"}, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"class_declaration"}, Confidence: api.ConfidenceMedium, Implementation: r,
 			Needs: api.NeedsTypeInfo | api.NeedsOracleCallTargets,
 			OracleCallTargets: &api.OracleCallTargetFilter{
 				CalleeNames: []string{"v", "d", "i", "w", "e", "wtf"},

--- a/internal/rules/registry_android_source_extra.go
+++ b/internal/rules/registry_android_source_extra.go
@@ -14,7 +14,7 @@ func registerAndroidSourceExtraRules() {
 		r := &ViewConstructorRule{AndroidRule: AndroidRule{BaseRule: BaseRule{RuleName: "ViewConstructor", RuleSetName: androidRuleSet, Sev: "warning"}, IssueID: "ViewConstructor", Brief: "Missing View constructors", Category: ALCCorrectness, ALSeverity: ALSWarning, Priority: 6, Origin: "AOSP Android Lint"}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Description(), Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"class_declaration"}, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"class_declaration"}, Confidence: api.ConfidenceMedium, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				if file.FlatHasModifier(idx, "abstract") {
@@ -157,7 +157,7 @@ func registerAndroidSourceExtraRules() {
 		r := &InstantiatableRule{AndroidRule: AndroidRule{BaseRule: BaseRule{RuleName: "Instantiatable", RuleSetName: androidRuleSet, Sev: "error"}, IssueID: "Instantiatable", Brief: "Registered class not instantiatable", Category: ALCCorrectness, ALSeverity: ALSError, Priority: 6, Origin: "AOSP Android Lint"}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Description(), Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"class_declaration"}, Confidence: 0.9, Implementation: r,
+			NodeTypes: []string{"class_declaration"}, Confidence: api.ConfidenceHigher, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				isComponent := false
@@ -191,7 +191,7 @@ func registerAndroidSourceExtraRules() {
 		r := &RtlAwareRule{AndroidRule: AndroidRule{BaseRule: BaseRule{RuleName: "RtlAware", RuleSetName: androidRuleSet, Sev: "warning"}, IssueID: "RtlAware", Brief: "Using non-RTL-aware View methods", Category: ALCRTL, ALSeverity: ALSWarning, Priority: 5, Origin: "AOSP Android Lint"}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Description(), Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"call_expression"}, Confidence: 0.9, Implementation: r,
+			NodeTypes: []string{"call_expression"}, Confidence: api.ConfidenceHigher, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				name := flatCallExpressionName(file, idx)
@@ -206,7 +206,7 @@ func registerAndroidSourceExtraRules() {
 		r := &RtlFieldAccessRule{AndroidRule: AndroidRule{BaseRule: BaseRule{RuleName: "RtlFieldAccess", RuleSetName: androidRuleSet, Sev: "warning"}, IssueID: "RtlFieldAccess", Brief: "Direct field access of non-RTL-aware View fields", Category: ALCRTL, ALSeverity: ALSWarning, Priority: 5, Origin: "AOSP Android Lint"}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Description(), Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"string_literal"}, Confidence: 0.9, Implementation: r,
+			NodeTypes: []string{"string_literal"}, Confidence: api.ConfidenceHigher, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				if flatContainsStringInterpolation(file, idx) {
@@ -227,7 +227,7 @@ func registerAndroidSourceExtraRules() {
 		r := &GridLayoutRule{AndroidRule: AndroidRule{BaseRule: BaseRule{RuleName: "GridLayout", RuleSetName: androidRuleSet, Sev: "error"}, IssueID: "GridLayout", Brief: "GridLayout without columnCount", Category: ALCCorrectness, ALSeverity: ALSError, Priority: 4, Origin: "AOSP Android Lint"}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Description(), Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"call_expression"}, Confidence: 0.85, Implementation: r,
+			NodeTypes: []string{"call_expression"}, Confidence: api.ConfidenceHigh, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				if flatCallExpressionName(file, idx) != "GridLayout" {
@@ -255,7 +255,7 @@ func registerAndroidSourceExtraRules() {
 		r := &MangledCRLFRule{AndroidRule: AndroidRule{BaseRule: BaseRule{RuleName: "MangledCRLF", RuleSetName: androidRuleSet, Sev: "warning"}, IssueID: "MangledCRLF", Brief: "Mixed line endings in file", Category: ALCCorrectness, ALSeverity: ALSWarning, Priority: 3, Origin: "AOSP Android Lint"}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Description(), Sev: api.Severity(r.Sev),
-			Needs: api.NeedsLinePass, Confidence: 0.75, Implementation: r,
+			Needs: api.NeedsLinePass, Confidence: api.ConfidenceMedium, Implementation: r,
 			Check: r.check,
 		})
 	}
@@ -263,7 +263,7 @@ func registerAndroidSourceExtraRules() {
 		r := &ResourceNameRule{AndroidRule: AndroidRule{BaseRule: BaseRule{RuleName: "ResourceName", RuleSetName: androidRuleSet, Sev: "warning"}, IssueID: "ResourceName", Brief: "Resource name not in snake_case", Category: ALCCorrectness, ALSeverity: ALSWarning, Priority: 4, Origin: "AOSP Android Lint"}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Description(), Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"navigation_expression"}, Confidence: 0.9, Implementation: r,
+			NodeTypes: []string{"navigation_expression"}, Confidence: api.ConfidenceHigher, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				// Structural R.<kind>.<name> decomposition. Require the nav
@@ -288,7 +288,7 @@ func registerAndroidSourceExtraRules() {
 		r := &ProguardRule{AndroidRule: AndroidRule{BaseRule: BaseRule{RuleName: "Proguard", RuleSetName: androidRuleSet, Sev: "warning"}, IssueID: "Proguard", Brief: "Obsolete proguard.cfg reference", Category: ALCCorrectness, ALSeverity: ALSWarning, Priority: 4, Origin: "AOSP Android Lint"}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Description(), Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"string_literal"}, Confidence: 0.9, Implementation: r,
+			NodeTypes: []string{"string_literal"}, Confidence: api.ConfidenceHigher, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				if flatContainsStringInterpolation(file, idx) {
@@ -312,7 +312,7 @@ func registerAndroidSourceExtraRules() {
 		r := &NfcTechWhitespaceRule{AndroidRule: AndroidRule{BaseRule: BaseRule{RuleName: "NfcTechWhitespace", RuleSetName: androidRuleSet, Sev: "error"}, IssueID: "NfcTechWhitespace", Brief: "Whitespace in NFC tech-list", Category: ALCCorrectness, ALSeverity: ALSError, Priority: 6, Origin: "AOSP Android Lint"}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Description(), Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"string_literal"}, Confidence: 0.9, Implementation: r,
+			NodeTypes: []string{"string_literal"}, Confidence: api.ConfidenceHigher, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				if flatContainsStringInterpolation(file, idx) {
@@ -329,7 +329,7 @@ func registerAndroidSourceExtraRules() {
 		r := &LibraryCustomViewRule{AndroidRule: AndroidRule{BaseRule: BaseRule{RuleName: "LibraryCustomView", RuleSetName: androidRuleSet, Sev: "warning"}, IssueID: "LibraryCustomView", Brief: "Custom view using hardcoded namespace", Category: ALCCorrectness, ALSeverity: ALSWarning, Priority: 6, Origin: "AOSP Android Lint"}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Description(), Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"string_literal"}, Confidence: 0.9, Implementation: r,
+			NodeTypes: []string{"string_literal"}, Confidence: api.ConfidenceHigher, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				if flatContainsStringInterpolation(file, idx) {
@@ -346,7 +346,7 @@ func registerAndroidSourceExtraRules() {
 		r := &UnknownIDInLayoutRule{AndroidRule: AndroidRule{BaseRule: BaseRule{RuleName: "UnknownIdInLayout", RuleSetName: androidRuleSet, Sev: "warning"}, IssueID: "UnknownIdInLayout", Brief: "Reference to unknown @id in layout", Category: ALCCorrectness, ALSeverity: ALSWarning, Priority: 6, Origin: "AOSP Android Lint"}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Description(), Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"navigation_expression"}, Confidence: 0.9, Implementation: r,
+			NodeTypes: []string{"navigation_expression"}, Confidence: api.ConfidenceHigher, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				segments := flatNavigationChainIdentifiers(file, idx)

--- a/internal/rules/registry_android_usability.go
+++ b/internal/rules/registry_android_usability.go
@@ -22,7 +22,7 @@ func registerAndroidUsabilityRules() {
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Description(), Sev: api.Severity(r.Sev),
 			NodeTypes:  []string{"call_expression", "simple_identifier", "user_type", "navigation_expression"},
 			Needs:      api.NeedsTypeInfo | api.NeedsOracleCallTargets,
-			Confidence: 0.75, Implementation: r,
+			Confidence: api.ConfidenceMedium, Implementation: r,
 			OracleCallTargets:      &api.OracleCallTargetFilter{CalleeNames: []string{"setElevation", "getSystemService", "setDecorFitsSystemWindows", "requestPermissions", "checkSelfPermission", "getColor", "getDrawable", "setTranslationZ", "setClipToOutline", "createNotificationChannel"}},
 			OracleDeclarationNeeds: &api.OracleDeclarationProfile{},
 			Check: func(ctx *api.Context) {
@@ -58,7 +58,7 @@ func registerAndroidUsabilityRules() {
 		}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Description(), Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"simple_identifier", "navigation_expression"}, Needs: api.NeedsTypeInfo, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"simple_identifier", "navigation_expression"}, Needs: api.NeedsTypeInfo, Confidence: api.ConfidenceMedium, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				line := file.FlatRow(idx)

--- a/internal/rules/registry_comments.go
+++ b/internal/rules/registry_comments.go
@@ -32,7 +32,7 @@ func registerCommentsRules() {
 		r := &DeprecatedBlockTagRule{BaseRule: BaseRule{RuleName: "DeprecatedBlockTag", RuleSetName: "comments", Sev: "warning", Desc: "Detects @deprecated KDoc tags that should use the @Deprecated annotation instead."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"multiline_comment"}, Confidence: 0.95, Fix: api.FixIdiomatic, Implementation: r,
+			NodeTypes: []string{"multiline_comment"}, Confidence: api.ConfidenceVeryHigh, Fix: api.FixIdiomatic, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				if scanner.IsTestFile(file.Path) || isGradleBuildScript(file.Path) {
@@ -58,7 +58,7 @@ func registerCommentsRules() {
 		r := &DocumentationOverPrivateFunctionRule{BaseRule: BaseRule{RuleName: "DocumentationOverPrivateFunction", RuleSetName: "comments", Sev: "warning", Desc: "Detects KDoc documentation on private functions where it is unnecessary."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"function_declaration"}, Confidence: 0.95, Fix: api.FixIdiomatic, Implementation: r,
+			NodeTypes: []string{"function_declaration"}, Confidence: api.ConfidenceVeryHigh, Fix: api.FixIdiomatic, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				if !isPrivateDeclarationFlat(file, idx) {
@@ -86,7 +86,7 @@ func registerCommentsRules() {
 		r := &DocumentationOverPrivatePropertyRule{BaseRule: BaseRule{RuleName: "DocumentationOverPrivateProperty", RuleSetName: "comments", Sev: "warning", Desc: "Detects KDoc documentation on private properties where it is unnecessary."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"property_declaration"}, Confidence: 0.95, Fix: api.FixIdiomatic, Implementation: r,
+			NodeTypes: []string{"property_declaration"}, Confidence: api.ConfidenceVeryHigh, Fix: api.FixIdiomatic, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				if !isPrivateDeclarationFlat(file, idx) {
@@ -114,7 +114,7 @@ func registerCommentsRules() {
 		r := &EndOfSentenceFormatRule{BaseRule: BaseRule{RuleName: "EndOfSentenceFormat", RuleSetName: "comments", Sev: "warning", Desc: "Detects KDoc first sentences that do not end with proper punctuation."}, Pattern: regexp.MustCompile(`([.?!][ \t\n\r])|([.?!]$)`)}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"multiline_comment"}, Confidence: 0.95, Fix: api.FixCosmetic, Implementation: r,
+			NodeTypes: []string{"multiline_comment"}, Confidence: api.ConfidenceVeryHigh, Fix: api.FixCosmetic, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				if scanner.IsTestFile(file.Path) || isGradleBuildScript(file.Path) {
@@ -152,7 +152,7 @@ func registerCommentsRules() {
 		r := &KDocReferencesNonPublicPropertyRule{BaseRule: BaseRule{RuleName: "KDocReferencesNonPublicProperty", RuleSetName: "comments", Sev: "warning", Desc: "Detects KDoc bracket references that point to non-public properties."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"multiline_comment"}, Confidence: 0.95, Implementation: r,
+			NodeTypes: []string{"multiline_comment"}, Confidence: api.ConfidenceVeryHigh, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				if !flatIsKDoc(file, idx) {
@@ -207,7 +207,7 @@ func registerCommentsRules() {
 		r := &OutdatedDocumentationRule{BaseRule: BaseRule{RuleName: "OutdatedDocumentation", RuleSetName: "comments", Sev: "warning", Desc: "Detects @param tags in KDoc that do not match the actual function parameters."}, MatchDeclarationsOrder: true, MatchTypeParameters: true}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"function_declaration"}, Confidence: 0.95, Fix: api.FixCosmetic, Implementation: r,
+			NodeTypes: []string{"function_declaration"}, Confidence: api.ConfidenceVeryHigh, Fix: api.FixCosmetic, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				prev, ok := flatPrecedingKDoc(file, idx)
@@ -303,7 +303,7 @@ func registerCommentsRules() {
 		r := &UndocumentedPublicClassRule{BaseRule: BaseRule{RuleName: "UndocumentedPublicClass", RuleSetName: "comments", Sev: "warning", Desc: "Detects public classes that are missing KDoc documentation."}, SearchInNestedClass: true, SearchInInnerClass: true, SearchInInnerObject: true, SearchInInnerInterface: true}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"class_declaration"}, Confidence: 0.95, Implementation: r,
+			NodeTypes: []string{"class_declaration"}, Confidence: api.ConfidenceVeryHigh, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				if !isPublicDeclarationFlat(file, idx) {
@@ -330,7 +330,7 @@ func registerCommentsRules() {
 		r := &UndocumentedPublicFunctionRule{BaseRule: BaseRule{RuleName: "UndocumentedPublicFunction", RuleSetName: "comments", Sev: "warning", Desc: "Detects public functions that are missing KDoc documentation."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"function_declaration"}, Confidence: 0.95, Implementation: r,
+			NodeTypes: []string{"function_declaration"}, Confidence: api.ConfidenceVeryHigh, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				if !isPublicDeclarationFlat(file, idx) {
@@ -352,7 +352,7 @@ func registerCommentsRules() {
 		r := &UndocumentedPublicPropertyRule{BaseRule: BaseRule{RuleName: "UndocumentedPublicProperty", RuleSetName: "comments", Sev: "warning", Desc: "Detects public properties that are missing KDoc documentation."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"property_declaration"}, Confidence: 0.95, Implementation: r,
+			NodeTypes: []string{"property_declaration"}, Confidence: api.ConfidenceVeryHigh, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				if !isPublicDeclarationFlat(file, idx) {

--- a/internal/rules/registry_complexity.go
+++ b/internal/rules/registry_complexity.go
@@ -16,7 +16,7 @@ func registerComplexityRules() {
 		r := &LongMethodRule{BaseRule: BaseRule{RuleName: "LongMethod", RuleSetName: "complexity", Sev: "warning", Desc: "Detects functions that exceed a configurable line count threshold."}, AllowedLines: 60}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Description(), Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"function_declaration"}, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"function_declaration"}, Confidence: api.ConfidenceMedium, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				if scanner.IsTestFile(file.Path) {
@@ -63,7 +63,7 @@ func registerComplexityRules() {
 		r := &LargeClassRule{BaseRule: BaseRule{RuleName: "LargeClass", RuleSetName: "complexity", Sev: "warning", Desc: "Detects classes that exceed a configurable line count threshold."}, AllowedLines: 600}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"class_declaration"}, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"class_declaration"}, Confidence: api.ConfidenceMedium, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				if scanner.IsTestFile(file.Path) {
@@ -86,7 +86,7 @@ func registerComplexityRules() {
 		r := &NestedBlockDepthRule{BaseRule: BaseRule{RuleName: "NestedBlockDepth", RuleSetName: "complexity", Sev: "warning", Desc: "Detects functions with excessive nesting depth of control flow blocks."}, AllowedDepth: 4}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"function_declaration"}, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"function_declaration"}, Confidence: api.ConfidenceMedium, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				depth, line, exceeded := nestedBlockDepthExceedsFlat(file, idx, r.AllowedDepth)
@@ -114,7 +114,7 @@ func registerComplexityRules() {
 		}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Description(), Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"function_declaration"}, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"function_declaration"}, Confidence: api.ConfidenceMedium, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				if r.IgnoreLocalFunctions && functionIsLocalFlat(file, idx) {
@@ -148,7 +148,7 @@ func registerComplexityRules() {
 		r := &CognitiveComplexMethodRule{BaseRule: BaseRule{RuleName: "CognitiveComplexMethod", RuleSetName: "complexity", Sev: "warning", Desc: "Detects functions whose cognitive complexity exceeds a configurable threshold, weighting nesting depth."}, AllowedComplexity: 15}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"function_declaration"}, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"function_declaration"}, Confidence: api.ConfidenceMedium, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				metrics := getComplexityMetricsFlat(idx, file)
@@ -164,7 +164,7 @@ func registerComplexityRules() {
 		r := &ComplexConditionRule{BaseRule: BaseRule{RuleName: "ComplexCondition", RuleSetName: "complexity", Sev: "warning", Desc: "Detects conditions with too many mixed logical operators."}, AllowedConditions: 3}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"if_expression", "while_statement"}, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"if_expression", "while_statement"}, Confidence: api.ConfidenceMedium, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				condOps := countLogicalOperatorsOutsideBodiesFlat(file, idx)
@@ -182,7 +182,7 @@ func registerComplexityRules() {
 		r := &ComplexInterfaceRule{BaseRule: BaseRule{RuleName: "ComplexInterface", RuleSetName: "complexity", Sev: "warning", Desc: "Detects interfaces with too many member declarations."}, AllowedDefinitions: 10, IncludePrivateDeclarations: false, IncludeStaticDeclarations: false}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"class_declaration"}, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"class_declaration"}, Confidence: api.ConfidenceMedium, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				if !file.FlatHasChildOfType(idx, "interface") {
@@ -205,7 +205,7 @@ func registerComplexityRules() {
 		r := &LabeledExpressionRule{BaseRule: BaseRule{RuleName: "LabeledExpression", RuleSetName: "complexity", Sev: "warning", Desc: "Detects labeled expressions such as return@label, break@label, and continue@label."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"label"}, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"label"}, Confidence: api.ConfidenceMedium, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				labelText := strings.TrimSpace(file.FlatNodeText(idx))
@@ -221,7 +221,7 @@ func registerComplexityRules() {
 		r := &LongParameterListRule{BaseRule: BaseRule{RuleName: "LongParameterList", RuleSetName: "complexity", Sev: "warning", Desc: "Detects functions or constructors with too many parameters."}, AllowedFunctionParameters: 5, AllowedConstructorParameters: 6, IgnoreDefaultParameters: false, IgnoreDataClasses: true}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"function_declaration", "class_declaration"}, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"function_declaration", "class_declaration"}, Confidence: api.ConfidenceMedium, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				if scanner.IsTestFile(file.Path) {
@@ -312,7 +312,7 @@ func registerComplexityRules() {
 		r := &MethodOverloadingRule{BaseRule: BaseRule{RuleName: "MethodOverloading", RuleSetName: "complexity", Sev: "warning", Desc: "Detects methods with too many overloads of the same name in a scope."}, AllowedOverloads: 6}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"source_file"}, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"source_file"}, Confidence: api.ConfidenceMedium, Implementation: r,
 			Check: func(ctx *api.Context) {
 				r.checkScopeFlat(ctx, ctx.Idx)
 			},
@@ -322,7 +322,7 @@ func registerComplexityRules() {
 		r := &NamedArgumentsRule{BaseRule: BaseRule{RuleName: "NamedArguments", RuleSetName: "complexity", Sev: "warning", Desc: "Detects function calls with too many unnamed positional arguments."}, AllowedArguments: 3}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"call_expression"}, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"call_expression"}, Confidence: api.ConfidenceMedium, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				if scanner.IsTestFile(file.Path) || isGradleBuildScript(file.Path) {
@@ -372,7 +372,7 @@ func registerComplexityRules() {
 		r := &NestedScopeFunctionsRule{BaseRule: BaseRule{RuleName: "NestedScopeFunctions", RuleSetName: "complexity", Sev: "warning", Desc: "Detects excessively nested Kotlin scope functions like apply, also, let, run, and with."}, AllowedDepth: 1}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"call_expression"}, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"call_expression"}, Confidence: api.ConfidenceMedium, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				active := nestedScopeFunctionsActiveSet(r.Functions)
@@ -400,7 +400,7 @@ func registerComplexityRules() {
 		r := &ReplaceSafeCallChainWithRunRule{BaseRule: BaseRule{RuleName: "ReplaceSafeCallChainWithRun", RuleSetName: "complexity", Sev: "warning", Desc: "Detects chains of three or more safe calls (?.) that could be simplified with ?.run { }."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"navigation_expression"}, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"navigation_expression"}, Confidence: api.ConfidenceMedium, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				if parent, ok := file.FlatParent(idx); ok {
@@ -425,7 +425,7 @@ func registerComplexityRules() {
 		r := &StringLiteralDuplicationRule{BaseRule: BaseRule{RuleName: "StringLiteralDuplication", RuleSetName: "complexity", Sev: "warning", Desc: "Detects string literals that appear more than a configurable number of times in a file."}, AllowedDuplications: 2, AllowedWithLengthLessThan: 5}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"source_file"}, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"source_file"}, Confidence: api.ConfidenceMedium, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				// Compile the configured ignore-regex once per file walk.
@@ -475,7 +475,7 @@ func registerComplexityRules() {
 		r := &TooManyFunctionsRule{BaseRule: BaseRule{RuleName: "TooManyFunctions", RuleSetName: "complexity", Sev: "warning", Desc: "Detects files or classes that declare too many functions."}, AllowedFunctionsPerFile: 11, IgnoreOverridden: false}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"source_file"}, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"source_file"}, Confidence: api.ConfidenceMedium, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				topLevelCount := 0

--- a/internal/rules/registry_compose.go
+++ b/internal/rules/registry_compose.go
@@ -34,7 +34,7 @@ func registerComposeColumnRowInScrollable() {
 	r := &ComposeColumnRowInScrollableRule{BaseRule: BaseRule{RuleName: "ComposeColumnRowInScrollable", RuleSetName: "compose", Sev: "warning", Desc: "Detects nested same-axis scroll containers such as Column with verticalScroll containing LazyColumn."}}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"call_expression"}, Confidence: 0.75, Implementation: r,
+		NodeTypes: []string{"call_expression"}, Confidence: api.ConfidenceMedium, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			call := file.FlatChild(idx, 0)
@@ -88,7 +88,7 @@ func registerComposeDerivedStateMisuse() {
 	r := &ComposeDerivedStateMisuseRule{BaseRule: BaseRule{RuleName: "ComposeDerivedStateMisuse", RuleSetName: "compose", Sev: "warning", Desc: "Detects unnecessary derivedStateOf wrapping a direct boolean comparison of Compose state reads."}}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"call_expression"}, LexicalCalleeNames: []string{"derivedStateOf"}, Confidence: 0.75, Implementation: r,
+		NodeTypes: []string{"call_expression"}, LexicalCalleeNames: []string{"derivedStateOf"}, Confidence: api.ConfidenceMedium, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			if flatCallExpressionName(file, idx) != "derivedStateOf" {
@@ -115,7 +115,7 @@ func registerComposeLambdaCapturesUnstableState() {
 	r := &ComposeLambdaCapturesUnstableStateRule{BaseRule: BaseRule{RuleName: "ComposeLambdaCapturesUnstableState", RuleSetName: "compose", Sev: "warning", Desc: "Detects inline onClick lambdas in lazy item builders that capture the current item without hoisting through remember."}}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"lambda_literal"}, Confidence: 0.75, Implementation: r,
+		NodeTypes: []string{"lambda_literal"}, Confidence: api.ConfidenceMedium, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			if !composeIsNamedArgumentLambdaFlat(file, idx, "onClick") {
@@ -140,7 +140,7 @@ func registerComposeModifierFillAfterSize() {
 	r := &ComposeModifierFillAfterSizeRule{BaseRule: BaseRule{RuleName: "ComposeModifierFillAfterSize", RuleSetName: "compose", Sev: "info", Desc: "Detects Modifier chains where fillMaxWidth/Height/Size follows size(), overriding the explicit size."}}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"call_expression"}, LexicalCalleeNames: []string{"fillMaxHeight", "fillMaxSize", "fillMaxWidth"}, Confidence: 0.75, Implementation: r,
+		NodeTypes: []string{"call_expression"}, LexicalCalleeNames: []string{"fillMaxHeight", "fillMaxSize", "fillMaxWidth"}, Confidence: api.ConfidenceMedium, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			if _, ok := composeFillMaxAxisNames[flatCallExpressionName(file, idx)]; !ok {
@@ -160,7 +160,7 @@ func registerComposeModifierBackgroundAfterClip() {
 	r := &ComposeModifierBackgroundAfterClipRule{BaseRule: BaseRule{RuleName: "ComposeModifierBackgroundAfterClip", RuleSetName: "compose", Sev: "warning", Desc: "Detects Modifier chains where background() is applied before clip(), painting outside the clip shape."}}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"call_expression"}, LexicalCalleeNames: []string{"clip"}, Confidence: 0.75, Implementation: r,
+		NodeTypes: []string{"call_expression"}, LexicalCalleeNames: []string{"clip"}, Confidence: api.ConfidenceMedium, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			if flatCallExpressionName(file, idx) != "clip" {
@@ -180,7 +180,7 @@ func registerComposeModifierClickableBeforePadding() {
 	r := &ComposeModifierClickableBeforePaddingRule{BaseRule: BaseRule{RuleName: "ComposeModifierClickableBeforePadding", RuleSetName: "compose", Sev: "warning", Desc: "Detects Modifier chains where clickable is applied before padding, excluding the padding region from the click area."}}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"call_expression"}, LexicalCalleeNames: []string{"padding"}, Confidence: 0.75, Implementation: r,
+		NodeTypes: []string{"call_expression"}, LexicalCalleeNames: []string{"padding"}, Confidence: api.ConfidenceMedium, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			if flatCallExpressionName(file, idx) != "padding" {
@@ -200,7 +200,7 @@ func registerComposePreviewAnnotationMissing() {
 	r := &ComposePreviewAnnotationMissingRule{BaseRule: BaseRule{RuleName: "ComposePreviewAnnotationMissing", RuleSetName: "compose", Sev: "info", Desc: "Detects @Composable functions whose name ends in Preview but lack the @Preview annotation."}}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"function_declaration"}, Confidence: 0.75, Implementation: r,
+		NodeTypes: []string{"function_declaration"}, Confidence: api.ConfidenceMedium, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			if !flatHasAnnotationNamed(file, idx, "Composable") {
@@ -227,7 +227,7 @@ func registerComposeMutableDefaultArgument() {
 	r := &ComposeMutableDefaultArgumentRule{BaseRule: BaseRule{RuleName: "ComposeMutableDefaultArgument", RuleSetName: "compose", Sev: "warning", Desc: "Detects @Composable parameters with mutable collection defaults that re-evaluate on each recomposition."}}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"function_declaration"}, Confidence: 0.75, Implementation: r,
+		NodeTypes: []string{"function_declaration"}, Confidence: api.ConfidenceMedium, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			if !flatHasAnnotationNamed(file, idx, "Composable") {
@@ -270,7 +270,7 @@ func registerComposeStringResourceInsideLambda() {
 	r := &ComposeStringResourceInsideLambdaRule{BaseRule: BaseRule{RuleName: "ComposeStringResourceInsideLambda", RuleSetName: "compose", Sev: "warning", Desc: "Detects stringResource() calls inside callback lambdas where the composition-only API will crash at runtime."}}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"call_expression"}, Confidence: 0.75, Implementation: r,
+		NodeTypes: []string{"call_expression"}, Confidence: api.ConfidenceMedium, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			if flatCallExpressionName(file, idx) != "stringResource" {
@@ -293,7 +293,7 @@ func registerComposeRememberWithoutKey() {
 	r := &ComposeRememberWithoutKeyRule{BaseRule: BaseRule{RuleName: "ComposeRememberWithoutKey", RuleSetName: "compose", Sev: "warning", Desc: "Detects remember blocks that reference enclosing parameters but have no keys, causing stale cached values."}}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"call_expression"}, Confidence: 0.75, Implementation: r,
+		NodeTypes: []string{"call_expression"}, Confidence: api.ConfidenceMedium, Implementation: r,
 		Needs: api.NeedsTypeInfo | api.NeedsOracleCallTargets,
 		OracleCallTargets: &api.OracleCallTargetFilter{
 			CalleeNames: []string{"remember"},
@@ -350,7 +350,7 @@ func registerComposeLaunchedEffectWithoutKeys() {
 	r := &ComposeLaunchedEffectWithoutKeysRule{BaseRule: BaseRule{RuleName: "ComposeLaunchedEffectWithoutKeys", RuleSetName: "compose", Sev: "warning", Desc: "Detects LaunchedEffect blocks keyed only on constants whose body reads enclosing parameters that change."}}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"call_expression"}, Confidence: 0.75, Implementation: r,
+		NodeTypes: []string{"call_expression"}, Confidence: api.ConfidenceMedium, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			if flatCallNameAny(file, idx) != "LaunchedEffect" {
@@ -387,7 +387,7 @@ func registerComposeMutableStateInComposition() {
 	r := &ComposeMutableStateInCompositionRule{BaseRule: BaseRule{RuleName: "ComposeMutableStateInComposition", RuleSetName: "compose", Sev: "warning", Desc: "Detects mutableStateOf() used as a plain local without remember, causing state loss on every recomposition."}}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"property_declaration"}, Confidence: 0.75, Implementation: r,
+		NodeTypes: []string{"property_declaration"}, Confidence: api.ConfidenceMedium, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			fn, ok := flatEnclosingFunction(file, idx)
@@ -424,7 +424,7 @@ func registerComposeStatefulDefaultParameter() {
 	r := &ComposeStatefulDefaultParameterRule{BaseRule: BaseRule{RuleName: "ComposeStatefulDefaultParameter", RuleSetName: "compose", Sev: "warning", Desc: "Detects @Composable parameters with constructor-call defaults that allocate fresh instances every recomposition."}}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"function_declaration"}, Confidence: 0.75, Implementation: r,
+		NodeTypes: []string{"function_declaration"}, Confidence: api.ConfidenceMedium, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			if !flatHasAnnotationNamed(file, idx, "Composable") {
@@ -471,7 +471,7 @@ func registerComposePreviewWithBackingState() {
 	r := &ComposePreviewWithBackingStateRule{BaseRule: BaseRule{RuleName: "ComposePreviewWithBackingState", RuleSetName: "compose", Sev: "warning", Desc: "Detects @Preview functions that call runtime state holders like hiltViewModel() or collectAsState() which fail in the preview renderer."}}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"function_declaration"}, Confidence: 0.75, Implementation: r,
+		NodeTypes: []string{"function_declaration"}, Confidence: api.ConfidenceMedium, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			if !flatHasAnnotationNamed(file, idx, "Preview") {
@@ -503,7 +503,7 @@ func registerComposeDisposableEffectMissingDispose() {
 	r := &ComposeDisposableEffectMissingDisposeRule{BaseRule: BaseRule{RuleName: "ComposeDisposableEffectMissingDispose", RuleSetName: "compose", Sev: "warning", Desc: "Detects DisposableEffect blocks whose body does not end with onDispose, causing resource leaks."}}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"call_expression"}, Confidence: 0.75, Implementation: r,
+		NodeTypes: []string{"call_expression"}, Confidence: api.ConfidenceMedium, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			if flatCallNameAny(file, idx) != "DisposableEffect" {
@@ -539,7 +539,7 @@ func registerComposeModifierPassedThenChained() {
 	r := &ComposeModifierPassedThenChainedRule{BaseRule: BaseRule{RuleName: "ComposeModifierPassedThenChained", RuleSetName: "compose", Sev: "warning", Desc: "Detects @Composable functions that declare a modifier parameter but never use it, starting fresh Modifier chains instead."}}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"function_declaration"}, Confidence: 0.75, Implementation: r,
+		NodeTypes: []string{"function_declaration"}, Confidence: api.ConfidenceMedium, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			if !flatHasAnnotationNamed(file, idx, "Composable") {
@@ -603,7 +603,7 @@ func registerComposeSideEffectInComposition() {
 	}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"assignment"}, Confidence: 0.75, Implementation: r,
+		NodeTypes: []string{"assignment"}, Confidence: api.ConfidenceMedium, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			fn, ok := flatEnclosingFunction(file, idx)
@@ -644,7 +644,7 @@ func registerComposeUnstableParameter() {
 	r := &ComposeUnstableParameterRule{BaseRule: BaseRule{RuleName: "ComposeUnstableParameter", RuleSetName: "compose", Sev: "warning", Desc: "Detects @Composable function parameters using mutable collection types that prevent recomposition skipping."}}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"function_declaration"}, Confidence: 0.75, Implementation: r,
+		NodeTypes: []string{"function_declaration"}, Confidence: api.ConfidenceMedium, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			if !flatHasAnnotationNamed(file, idx, "Composable") {
@@ -688,7 +688,7 @@ func registerComposeRememberSaveableNonParcelable() {
 	r := &ComposeRememberSaveableNonParcelableRule{BaseRule: BaseRule{RuleName: "ComposeRememberSaveableNonParcelable", RuleSetName: "compose", Sev: "warning", Desc: "Detects rememberSaveable blocks constructing non-primitive types without an explicit saver argument."}}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"call_expression"}, Confidence: 0.75, Implementation: r,
+		NodeTypes: []string{"call_expression"}, Confidence: api.ConfidenceMedium, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			if flatCallNameAny(file, idx) != "rememberSaveable" {

--- a/internal/rules/registry_coroutines.go
+++ b/internal/rules/registry_coroutines.go
@@ -45,7 +45,7 @@ func registerCoroutinesCollectInOnCreateWithoutLifecycle() {
 	r := &CollectInOnCreateWithoutLifecycleRule{BaseRule: BaseRule{RuleName: "CollectInOnCreateWithoutLifecycle", RuleSetName: "coroutines", Sev: "warning", Desc: "Detects Flow.collect calls in lifecycle callbacks that are not wrapped by repeatOnLifecycle."}}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"call_expression"}, Confidence: 0.75, Implementation: r,
+		NodeTypes: []string{"call_expression"}, Confidence: api.ConfidenceMedium, Implementation: r,
 		Needs: api.NeedsTypeInfo | api.NeedsOracleCallTargets,
 		OracleCallTargets: &api.OracleCallTargetFilter{
 			CalleeNames: []string{"collect"},
@@ -116,7 +116,7 @@ func registerCoroutinesGlobalCoroutineUsage() {
 	r := &GlobalCoroutineUsageRule{BaseRule: BaseRule{RuleName: "GlobalCoroutineUsage", RuleSetName: "coroutines", Sev: "warning", Desc: "Detects GlobalScope.launch/async usage instead of structured concurrency with a proper CoroutineScope."}}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Description(), Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"call_expression", "navigation_expression"}, Confidence: 0.75, Fix: api.FixIdiomatic, Implementation: r,
+		NodeTypes: []string{"call_expression", "navigation_expression"}, Confidence: api.ConfidenceMedium, Fix: api.FixIdiomatic, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			switch file.FlatType(idx) {
@@ -192,7 +192,7 @@ func registerCoroutinesInjectDispatcher() {
 	r := &InjectDispatcherRule{BaseRule: BaseRule{RuleName: "InjectDispatcher", RuleSetName: "coroutines", Sev: "warning", Desc: "Detects hardcoded Dispatchers.IO/Default/Unconfined passed as arguments instead of injected dispatchers."}, DispatcherNames: []string{"IO", "Default", "Unconfined", "Main"}}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"call_expression"}, Confidence: 0.75, Implementation: r,
+		NodeTypes: []string{"call_expression"}, Confidence: api.ConfidenceMedium, Implementation: r,
 		Needs: api.NeedsTypeInfo | api.NeedsOracleCallTargets,
 		OracleCallTargets: &api.OracleCallTargetFilter{
 			CalleeNames: injectDispatcherOracleCalleeNames(r.DispatcherNames),
@@ -281,7 +281,7 @@ func registerCoroutinesRedundantSuspendModifier() {
 	r := &RedundantSuspendModifierRule{BaseRule: BaseRule{RuleName: "RedundantSuspendModifier", RuleSetName: "coroutines", Sev: "warning", Desc: "Detects suspend functions that contain no suspend calls in their body."}}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"function_declaration"}, Confidence: 0.75, Fix: api.FixIdiomatic, Implementation: r,
+		NodeTypes: []string{"function_declaration"}, Confidence: api.ConfidenceMedium, Fix: api.FixIdiomatic, Implementation: r,
 		Needs:  api.NeedsTypeInfo | api.NeedsOracleCallTargets | api.NeedsOracleSuspendMarkers,
 		Oracle: &api.OracleFilter{Identifiers: []string{"suspend"}},
 		OracleCallTargets: &api.OracleCallTargetFilter{
@@ -428,7 +428,7 @@ func registerCoroutinesSleepInsteadOfDelay() {
 	r := &SleepInsteadOfDelayRule{BaseRule: BaseRule{RuleName: "SleepInsteadOfDelay", RuleSetName: "coroutines", Sev: "warning", Desc: "Detects Thread.sleep() usage inside suspend functions or coroutine builder lambdas instead of delay()."}}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"call_expression"}, Confidence: 0.75, Fix: api.FixIdiomatic, Implementation: r,
+		NodeTypes: []string{"call_expression"}, Confidence: api.ConfidenceMedium, Fix: api.FixIdiomatic, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			if file.FlatChildCount(idx) == 0 {
@@ -475,7 +475,7 @@ func registerCoroutinesCoroutineLaunchedInTestWithoutRunTest() {
 	r := &CoroutineLaunchedInTestWithoutRunTestRule{BaseRule: BaseRule{RuleName: "CoroutineLaunchedInTestWithoutRunTest", RuleSetName: "coroutines", Sev: "warning", Desc: "Detects launch/async calls in @Test functions that are not wrapped in runTest."}}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"function_declaration"}, Confidence: 0.75, Implementation: r,
+		NodeTypes: []string{"function_declaration"}, Confidence: api.ConfidenceMedium, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			if !hasAnnotationFlat(file, idx, "Test") {
@@ -500,7 +500,7 @@ func registerCoroutinesSuspendFunInFinallySection() {
 	r := &SuspendFunInFinallySectionRule{BaseRule: BaseRule{RuleName: "SuspendFunInFinallySection", RuleSetName: "coroutines", Sev: "warning", Desc: "Detects suspend function calls inside finally blocks that may not execute if the coroutine is cancelled."}}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"finally_block"}, Confidence: 0.75, Implementation: r,
+		NodeTypes: []string{"finally_block"}, Confidence: api.ConfidenceMedium, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			file.FlatWalkNodes(idx, "call_expression", func(callNode uint32) {
@@ -522,7 +522,7 @@ func registerCoroutinesSuspendFunSwallowedCancellation() {
 	r := &SuspendFunSwallowedCancellationRule{BaseRule: BaseRule{RuleName: "SuspendFunSwallowedCancellation", RuleSetName: "coroutines", Sev: "warning", Desc: "Detects catch blocks that catch CancellationException without rethrowing, breaking structured concurrency."}}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"catch_block"}, Confidence: 0.75, Fix: api.FixIdiomatic, Implementation: r,
+		NodeTypes: []string{"catch_block"}, Confidence: api.ConfidenceMedium, Fix: api.FixIdiomatic, Implementation: r,
 		Needs: api.NeedsTypeInfo |
 			api.NeedsOracleCallTargets |
 			api.NeedsOracleSuspendMarkers,
@@ -588,7 +588,7 @@ func registerCoroutinesSuspendFunWithCoroutineScopeReceiver() {
 	r := &SuspendFunWithCoroutineScopeReceiverRule{BaseRule: BaseRule{RuleName: "SuspendFunWithCoroutineScopeReceiver", RuleSetName: "coroutines", Sev: "warning", Desc: "Detects functions that are both suspend and extension on CoroutineScope, which should be one or the other."}}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"function_declaration"}, Confidence: 0.75, Fix: api.FixIdiomatic, Implementation: r,
+		NodeTypes: []string{"function_declaration"}, Confidence: api.ConfidenceMedium, Fix: api.FixIdiomatic, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			if !hasSuspendModifierFlat(file, idx) {
@@ -631,7 +631,7 @@ func registerCoroutinesChannelReceiveWithoutClose() {
 	r := &ChannelReceiveWithoutCloseRule{BaseRule: BaseRule{RuleName: "ChannelReceiveWithoutClose", RuleSetName: "coroutines", Sev: "warning", Desc: "Detects Channel properties in a class that are never closed, leaking the receiver coroutine."}}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"property_declaration"}, Confidence: 0.85, Implementation: r,
+		NodeTypes: []string{"property_declaration"}, Confidence: api.ConfidenceHigh, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			// The property's initializer must be a direct call to
@@ -662,7 +662,7 @@ func registerCoroutinesCollectionsSynchronizedListIteration() {
 	r := &CollectionsSynchronizedListIterationRule{BaseRule: BaseRule{RuleName: "CollectionsSynchronizedListIteration", RuleSetName: "coroutines", Sev: "warning", Desc: "Detects iteration over Collections.synchronized* wrappers without external synchronization."}}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"for_statement"}, Confidence: 0.75, Implementation: r,
+		NodeTypes: []string{"for_statement"}, Confidence: api.ConfidenceMedium, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			forText := file.FlatNodeText(idx)
@@ -689,7 +689,7 @@ func registerCoroutinesConcurrentModificationIteration() {
 	r := &ConcurrentModificationIterationRule{BaseRule: BaseRule{RuleName: "ConcurrentModificationIteration", RuleSetName: "coroutines", Sev: "warning", Desc: "Detects collection mutation inside for loops that causes ConcurrentModificationException."}}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"for_statement"}, Confidence: 0.75, Implementation: r,
+		NodeTypes: []string{"for_statement"}, Confidence: api.ConfidenceMedium, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			iterableNode := uint32(0)
@@ -728,7 +728,7 @@ func registerCoroutinesCoroutineScopeCreatedButNeverCancelled() {
 	r := &CoroutineScopeCreatedButNeverCancelledRule{BaseRule: BaseRule{RuleName: "CoroutineScopeCreatedButNeverCancelled", RuleSetName: "coroutines", Sev: "warning", Desc: "Detects CoroutineScope properties in a class that are never cancelled, leaking coroutines."}}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"property_declaration"}, Confidence: 0.85, Implementation: r,
+		NodeTypes: []string{"property_declaration"}, Confidence: api.ConfidenceHigh, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			// Initializer must be a direct `CoroutineScope(...)` call.
@@ -758,7 +758,7 @@ func registerCoroutinesDeferredAwaitInFinally() {
 	r := &DeferredAwaitInFinallyRule{BaseRule: BaseRule{RuleName: "DeferredAwaitInFinally", RuleSetName: "coroutines", Sev: "warning", Desc: "Detects Deferred.await() calls inside finally blocks that can throw and mask the original exception."}}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"call_expression"}, Confidence: 0.75, Implementation: r,
+		NodeTypes: []string{"call_expression"}, Confidence: api.ConfidenceMedium, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			navExpr, _ := flatCallExpressionParts(file, idx)
@@ -782,7 +782,7 @@ func registerCoroutinesFlowWithoutFlowOn() {
 	r := &FlowWithoutFlowOnRule{BaseRule: BaseRule{RuleName: "FlowWithoutFlowOn", RuleSetName: "coroutines", Sev: "warning", Desc: "Detects flow chains with a terminal operator but no flowOn, risking execution on the wrong dispatcher."}}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"call_expression"}, Confidence: 0.75, Implementation: r,
+		NodeTypes: []string{"call_expression"}, Confidence: api.ConfidenceMedium, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			navExpr, _ := flatCallExpressionParts(file, idx)
@@ -810,7 +810,7 @@ func registerCoroutinesSynchronizedOnString() {
 	r := &SynchronizedOnStringRule{BaseRule: BaseRule{RuleName: "SynchronizedOnString", RuleSetName: "coroutines", Sev: "warning", Desc: "Detects synchronized() blocks using a string literal as the lock monitor."}}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"call_expression"}, Confidence: 0.75, Implementation: r,
+		NodeTypes: []string{"call_expression"}, Confidence: api.ConfidenceMedium, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			if flatCallExpressionName(file, idx) != "synchronized" {
@@ -840,7 +840,7 @@ func registerCoroutinesSynchronizedOnBoxedPrimitive() {
 	r := &SynchronizedOnBoxedPrimitiveRule{BaseRule: BaseRule{RuleName: "SynchronizedOnBoxedPrimitive", RuleSetName: "coroutines", Sev: "warning", Desc: "Detects synchronized() blocks using a boxed primitive value as the lock monitor."}}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"call_expression"}, Confidence: 0.75, Implementation: r,
+		NodeTypes: []string{"call_expression"}, Confidence: api.ConfidenceMedium, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			if flatCallExpressionName(file, idx) != "synchronized" {
@@ -881,7 +881,7 @@ func registerCoroutinesSynchronizedOnNonFinal() {
 	r := &SynchronizedOnNonFinalRule{BaseRule: BaseRule{RuleName: "SynchronizedOnNonFinal", RuleSetName: "coroutines", Sev: "warning", Desc: "Detects synchronized() blocks using a var property as the lock, which can change the monitor object."}}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"call_expression"}, Confidence: 0.75, Implementation: r,
+		NodeTypes: []string{"call_expression"}, Confidence: api.ConfidenceMedium, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			if flatCallExpressionName(file, idx) != "synchronized" {
@@ -912,7 +912,7 @@ func registerCoroutinesVolatileMissingOnDcl() {
 	r := &VolatileMissingOnDclRule{BaseRule: BaseRule{RuleName: "VolatileMissingOnDcl", RuleSetName: "coroutines", Sev: "warning", Desc: "Detects double-checked locking patterns on a var property without @Volatile annotation."}}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"property_declaration"}, Confidence: 0.75, Implementation: r,
+		NodeTypes: []string{"property_declaration"}, Confidence: api.ConfidenceMedium, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			isVar := false
@@ -958,7 +958,7 @@ func registerCoroutinesMutableStateInObject() {
 	r := &MutableStateInObjectRule{BaseRule: BaseRule{RuleName: "MutableStateInObject", RuleSetName: "coroutines", Sev: "warning", Desc: "Detects mutable var properties inside object declarations that are shared mutable state without synchronization."}}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"object_declaration"}, Confidence: 0.75, Implementation: r,
+		NodeTypes: []string{"object_declaration"}, Confidence: api.ConfidenceMedium, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			if file.FlatType(idx) == "companion_object" {
@@ -1005,7 +1005,7 @@ func registerCoroutinesStateFlowMutableLeak() {
 	r := &StateFlowMutableLeakRule{BaseRule: BaseRule{RuleName: "StateFlowMutableLeak", RuleSetName: "coroutines", Sev: "warning", Desc: "Detects publicly exposed MutableStateFlow properties that should be private with a read-only StateFlow accessor."}}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"property_declaration"}, Confidence: 0.75, Implementation: r,
+		NodeTypes: []string{"property_declaration"}, Confidence: api.ConfidenceMedium, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			propText := file.FlatNodeText(idx)
@@ -1036,7 +1036,7 @@ func registerCoroutinesSharedFlowWithoutReplay() {
 	r := &SharedFlowWithoutReplayRule{BaseRule: BaseRule{RuleName: "SharedFlowWithoutReplay", RuleSetName: "coroutines", Sev: "info", Desc: "Detects MutableSharedFlow() created with default configuration that has no replay or buffer capacity."}}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"property_declaration"}, Confidence: 0.75, Implementation: r,
+		NodeTypes: []string{"property_declaration"}, Confidence: api.ConfidenceMedium, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			propText := file.FlatNodeText(idx)
@@ -1062,7 +1062,7 @@ func registerCoroutinesStateFlowCompareByReference() {
 	r := &StateFlowCompareByReferenceRule{BaseRule: BaseRule{RuleName: "StateFlowCompareByReference", RuleSetName: "coroutines", Sev: "info", Desc: "Detects redundant .distinctUntilChanged() after .map{} on StateFlow, which already deduplicates by equality."}}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"call_expression"}, Confidence: 0.75, Implementation: r,
+		NodeTypes: []string{"call_expression"}, Confidence: api.ConfidenceMedium, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			navExpr, _ := flatCallExpressionParts(file, idx)
@@ -1087,7 +1087,7 @@ func registerCoroutinesGlobalScopeLaunchInViewModel() {
 	r := &GlobalScopeLaunchInViewModelRule{BaseRule: BaseRule{RuleName: "GlobalScopeLaunchInViewModel", RuleSetName: "coroutines", Sev: "warning", Desc: "Detects GlobalScope.launch/async inside ViewModel or Presenter classes instead of viewModelScope."}}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"call_expression"}, Confidence: 0.75, Implementation: r,
+		NodeTypes: []string{"call_expression"}, Confidence: api.ConfidenceMedium, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			receiver := flatReceiverNameFromCall(file, idx)
@@ -1116,7 +1116,7 @@ func registerCoroutinesSupervisorScopeInEventHandler() {
 	r := &SupervisorScopeInEventHandlerRule{BaseRule: BaseRule{RuleName: "SupervisorScopeInEventHandler", RuleSetName: "coroutines", Sev: "info", Desc: "Detects supervisorScope with a single child operation where supervisor semantics provide no benefit."}}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"call_expression"}, Confidence: 0.75, Implementation: r,
+		NodeTypes: []string{"call_expression"}, Confidence: api.ConfidenceMedium, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			if flatCallNameAny(file, idx) != "supervisorScope" {
@@ -1158,7 +1158,7 @@ func registerCoroutinesWithContextInSuspendFunctionNoop() {
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
 		NodeTypes:  []string{"call_expression"},
 		Languages:  []scanner.Language{scanner.LangKotlin},
-		Confidence: 0.75, Implementation: r,
+		Confidence: api.ConfidenceMedium, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			if flatCallExpressionName(file, idx) != "withContext" {
@@ -1186,7 +1186,7 @@ func registerCoroutinesLaunchWithoutCoroutineExceptionHandler() {
 	r := &LaunchWithoutCoroutineExceptionHandlerRule{BaseRule: BaseRule{RuleName: "LaunchWithoutCoroutineExceptionHandler", RuleSetName: "coroutines", Sev: "info", Desc: "Detects launch blocks containing throw statements but no CoroutineExceptionHandler to catch uncaught exceptions."}}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"call_expression"}, Confidence: 0.75, Implementation: r,
+		NodeTypes: []string{"call_expression"}, Confidence: api.ConfidenceMedium, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			callee := flatCallNameAny(file, idx)

--- a/internal/rules/registry_correctness_abstract.go
+++ b/internal/rules/registry_correctness_abstract.go
@@ -11,7 +11,7 @@ func registerCorrectnessAbstractRules() {
 		r := &AbstractMemberNotImplementedRule{BaseRule: BaseRule{RuleName: "AbstractMemberNotImplemented", RuleSetName: "potential-bugs", Sev: "error", Desc: "Detects concrete classes that fail to implement abstract members declared on a supertype."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"class_declaration"}, Confidence: 0.8, Implementation: r,
+			NodeTypes: []string{"class_declaration"}, Confidence: api.ConfidenceMediumHigh, Implementation: r,
 			Needs: api.NeedsResolver,
 			Tags:  []string{"precompile"},
 			Check: r.check,

--- a/internal/rules/registry_correctness_override.go
+++ b/internal/rules/registry_correctness_override.go
@@ -11,7 +11,7 @@ func registerCorrectnessOverrideRules() {
 		r := &OverrideSignatureMismatchRule{BaseRule: BaseRule{RuleName: "OverrideSignatureMismatch", RuleSetName: "potential-bugs", Sev: "error", Desc: "Detects 'override' functions whose parameter count does not match any supertype member with the same name."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"function_declaration"}, Confidence: 0.85, Implementation: r,
+			NodeTypes: []string{"function_declaration"}, Confidence: api.ConfidenceHigh, Implementation: r,
 			Needs: api.NeedsResolver,
 			Tags:  []string{"precompile"},
 			Check: r.check,

--- a/internal/rules/registry_database.go
+++ b/internal/rules/registry_database.go
@@ -15,7 +15,7 @@ func registerDatabaseRules() {
 		r := &DatabaseInstanceRecreatedRule{BaseRule: BaseRule{RuleName: "DatabaseInstanceRecreated", RuleSetName: "resource-cost", Sev: "warning", Desc: "Detects Room.databaseBuilder calls inside regular functions that recreate the database on each invocation."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"call_expression", "method_invocation"}, Languages: []scanner.Language{scanner.LangKotlin, scanner.LangJava}, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"call_expression", "method_invocation"}, Languages: []scanner.Language{scanner.LangKotlin, scanner.LangJava}, Confidence: api.ConfidenceMedium, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				if !isRoomDatabaseBuilderCallFlat(file, idx) {
@@ -39,7 +39,7 @@ func registerDatabaseRules() {
 		r := &DaoNotInterfaceRule{BaseRule: BaseRule{RuleName: "DaoNotInterface", RuleSetName: "database", Sev: "info", Desc: "Detects Room DAOs declared as abstract classes instead of interfaces."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"class_declaration"}, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"class_declaration"}, Confidence: api.ConfidenceMedium, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				if !hasAnnotationFlat(file, idx, "Dao") {
@@ -60,7 +60,7 @@ func registerDatabaseRules() {
 		r := &DaoWithoutAnnotationsRule{BaseRule: BaseRule{RuleName: "DaoWithoutAnnotations", RuleSetName: "database", Sev: "warning", Desc: "Detects Room DAO member functions missing required annotations like @Query, @Insert, @Update, or @Delete."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"class_declaration"}, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"class_declaration"}, Confidence: api.ConfidenceMedium, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				if !hasAnnotationFlat(file, idx, "Dao") {
@@ -95,7 +95,7 @@ func registerDatabaseRules() {
 		r := &ForeignKeyWithoutOnDeleteRule{BaseRule: BaseRule{RuleName: "ForeignKeyWithoutOnDelete", RuleSetName: "database", Sev: "warning", Desc: "Detects Room @ForeignKey(...) without an onDelete argument; the default NO_ACTION usually leaves stale rows."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"call_expression", "constructor_invocation"}, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"call_expression", "constructor_invocation"}, Confidence: api.ConfidenceMedium, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				var args uint32
@@ -135,7 +135,7 @@ func registerDatabaseRules() {
 		r := &JdbcResultSetLeakedFromFunctionRule{BaseRule: BaseRule{RuleName: "JdbcResultSetLeakedFromFunction", RuleSetName: "database", Sev: "warning", Desc: "Detects functions whose declared return type is java.sql.ResultSet; callers almost always forget to close the ResultSet."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"function_declaration"}, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"function_declaration"}, Confidence: api.ConfidenceMedium, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				if !functionHasBodyFlat(file, idx) {
@@ -156,7 +156,7 @@ func registerDatabaseRules() {
 		r := &EntityPrimaryKeyNotStableRule{BaseRule: BaseRule{RuleName: "EntityPrimaryKeyNotStable", RuleSetName: "database", Sev: "warning", Desc: "Detects @Entity @PrimaryKey declared as var without autoGenerate = true; mutable primary keys break equals/hashCode."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"class_parameter", "property_declaration"}, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"class_parameter", "property_declaration"}, Confidence: api.ConfidenceMedium, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				if !hasAnnotationFlat(file, idx, "PrimaryKey") {
@@ -184,7 +184,7 @@ func registerDatabaseRules() {
 		r := &EntityMutableColumnRule{BaseRule: BaseRule{RuleName: "EntityMutableColumn", RuleSetName: "database", Sev: "info", Desc: "Detects Room @Entity class primary-constructor parameters declared as var, which prevents straightforward copy-on-write."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"class_declaration"}, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"class_declaration"}, Confidence: api.ConfidenceMedium, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				if !hasAnnotationFlat(file, idx, "Entity") {
@@ -284,7 +284,7 @@ func registerDatabaseRules() {
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
 			NodeTypes: []string{"property_declaration"}, Needs: api.NeedsResolver,
-			Confidence: 0.75, Implementation: r,
+			Confidence: api.ConfidenceMedium, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				cursorName := extractIdentifierFlat(file, idx)
@@ -552,7 +552,7 @@ func registerDatabaseRules() {
 		r := &JdbcPreparedStatementNotClosedRule{BaseRule: BaseRule{RuleName: "JdbcPreparedStatementNotClosed", RuleSetName: "database", Sev: "warning", Desc: "Detects JDBC prepared statements assigned to local properties without .use {} or .close() in the same scope."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"property_declaration"}, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"property_declaration"}, Confidence: api.ConfidenceMedium, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				stmtName := extractIdentifierFlat(file, idx)

--- a/internal/rules/registry_di_hygiene.go
+++ b/internal/rules/registry_di_hygiene.go
@@ -30,7 +30,7 @@ func registerDiHygieneRules() {
 		r := &AnvilContributesBindingWithoutScopeRule{BaseRule: BaseRule{RuleName: "AnvilContributesBindingWithoutScope", RuleSetName: diHygieneRuleSet, Sev: "warning", Desc: "Detects @ContributesBinding scope mismatches with the @ContributesTo scope on the bound interface."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"class_declaration", "object_declaration"}, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"class_declaration", "object_declaration"}, Confidence: api.ConfidenceMedium, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				bindingScope := anvilAnnotationScopeFlat(file, idx, "ContributesBinding")
@@ -63,7 +63,7 @@ func registerDiHygieneRules() {
 		r := &BindsMismatchedArityRule{BaseRule: BaseRule{RuleName: "BindsMismatchedArity", RuleSetName: diHygieneRuleSet, Sev: "warning", Desc: "Detects @Binds functions that do not declare exactly one parameter as required by Dagger."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"function_declaration"}, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"function_declaration"}, Confidence: api.ConfidenceMedium, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				if !hasAnnotationFlat(file, idx, "Binds") {
@@ -567,7 +567,7 @@ func registerDiHygieneRules() {
 		r := &HiltEntryPointOnNonInterfaceRule{BaseRule: BaseRule{RuleName: "HiltEntryPointOnNonInterface", RuleSetName: diHygieneRuleSet, Sev: "warning", Desc: "Detects Hilt @EntryPoint annotations on classes or objects instead of interfaces."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"class_declaration", "object_declaration", "prefix_expression"}, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"class_declaration", "object_declaration", "prefix_expression"}, Confidence: api.ConfidenceMedium, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				kind, name, line, ok := hiltEntryPointDeclarationFlat(file, idx)

--- a/internal/rules/registry_emptyblocks.go
+++ b/internal/rules/registry_emptyblocks.go
@@ -35,7 +35,7 @@ func registerEmptyblocksEmptyCatchBlock() {
 	// developer can write a real handler.
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"catch_block", "catch_clause"}, Languages: []scanner.Language{scanner.LangKotlin, scanner.LangJava}, Confidence: 0.95, Fix: api.FixNone, Implementation: r,
+		NodeTypes: []string{"catch_block", "catch_clause"}, Languages: []scanner.Language{scanner.LangKotlin, scanner.LangJava}, Confidence: api.ConfidenceVeryHigh, Fix: api.FixNone, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			if !isBlockEmptyFlat(file, idx) {
@@ -60,7 +60,7 @@ func registerEmptyblocksEmptyClassBlock() {
 	r := &EmptyClassBlockRule{BaseRule: BaseRule{RuleName: "EmptyClassBlock", RuleSetName: "empty-blocks", Sev: "warning", Desc: "Detects class declarations with an empty body that can have their braces removed."}}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"class_body"}, Languages: []scanner.Language{scanner.LangKotlin}, Confidence: 0.95, Fix: api.FixSemantic, Implementation: r,
+		NodeTypes: []string{"class_body"}, Languages: []scanner.Language{scanner.LangKotlin}, Confidence: api.ConfidenceVeryHigh, Fix: api.FixSemantic, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			if scanner.IsTestFile(file.Path) {
@@ -98,7 +98,7 @@ func registerEmptyblocksEmptyDefaultConstructor() {
 	r := &EmptyDefaultConstructorRule{BaseRule: BaseRule{RuleName: "EmptyDefaultConstructor", RuleSetName: "empty-blocks", Sev: "warning", Desc: "Detects explicit empty default constructors that are redundant and can be removed."}}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"class_declaration"}, Confidence: 0.95, Fix: api.FixSemantic, Implementation: r,
+		NodeTypes: []string{"class_declaration"}, Confidence: api.ConfidenceVeryHigh, Fix: api.FixSemantic, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			if file.FlatHasModifier(idx, "annotation") {
@@ -147,7 +147,7 @@ func registerEmptyblocksEmptyDoWhileBlock() {
 	r := &EmptyDoWhileBlockRule{BaseRule: BaseRule{RuleName: "EmptyDoWhileBlock", RuleSetName: "empty-blocks", Sev: "warning", Desc: "Detects do-while loops with an empty body."}}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"do_while_statement", "do_statement"}, Languages: []scanner.Language{scanner.LangKotlin, scanner.LangJava}, Confidence: 0.95, Fix: api.FixNone, Implementation: r,
+		NodeTypes: []string{"do_while_statement", "do_statement"}, Languages: []scanner.Language{scanner.LangKotlin, scanner.LangJava}, Confidence: api.ConfidenceVeryHigh, Fix: api.FixNone, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			if !isBlockEmptyFlat(file, idx) {
@@ -164,7 +164,7 @@ func registerEmptyblocksEmptyElseBlock() {
 	r := &EmptyElseBlockRule{BaseRule: BaseRule{RuleName: "EmptyElseBlock", RuleSetName: "empty-blocks", Sev: "warning", Desc: "Detects else blocks with an empty body."}}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"if_expression", "if_statement"}, Languages: []scanner.Language{scanner.LangKotlin, scanner.LangJava}, Confidence: 0.95, Fix: api.FixSemantic, Implementation: r,
+		NodeTypes: []string{"if_expression", "if_statement"}, Languages: []scanner.Language{scanner.LangKotlin, scanner.LangJava}, Confidence: api.ConfidenceVeryHigh, Fix: api.FixSemantic, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			if file.Language == scanner.LangJava {
@@ -245,7 +245,7 @@ func registerEmptyblocksEmptyFinallyBlock() {
 	r := &EmptyFinallyBlockRule{BaseRule: BaseRule{RuleName: "EmptyFinallyBlock", RuleSetName: "empty-blocks", Sev: "warning", Desc: "Detects finally blocks with an empty body that serve no purpose."}}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"finally_block", "finally_clause"}, Languages: []scanner.Language{scanner.LangKotlin, scanner.LangJava}, Confidence: 0.95, Fix: api.FixNone, Implementation: r,
+		NodeTypes: []string{"finally_block", "finally_clause"}, Languages: []scanner.Language{scanner.LangKotlin, scanner.LangJava}, Confidence: api.ConfidenceVeryHigh, Fix: api.FixNone, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			if !isBlockEmptyFlat(file, idx) {
@@ -262,7 +262,7 @@ func registerEmptyblocksEmptyForBlock() {
 	r := &EmptyForBlockRule{BaseRule: BaseRule{RuleName: "EmptyForBlock", RuleSetName: "empty-blocks", Sev: "warning", Desc: "Detects for loops with an empty body."}}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"for_statement", "enhanced_for_statement"}, Languages: []scanner.Language{scanner.LangKotlin, scanner.LangJava}, Confidence: 0.95, Fix: api.FixNone, Implementation: r,
+		NodeTypes: []string{"for_statement", "enhanced_for_statement"}, Languages: []scanner.Language{scanner.LangKotlin, scanner.LangJava}, Confidence: api.ConfidenceVeryHigh, Fix: api.FixNone, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			if file.Language == scanner.LangJava {
@@ -296,7 +296,7 @@ func registerEmptyblocksEmptyFunctionBlock() {
 	r := &EmptyFunctionBlockRule{BaseRule: BaseRule{RuleName: "EmptyFunctionBlock", RuleSetName: "empty-blocks", Sev: "warning", Desc: "Detects function declarations with an empty body."}, IgnoreOverridden: false}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"function_declaration", "method_declaration"}, Languages: []scanner.Language{scanner.LangKotlin, scanner.LangJava}, Confidence: 0.95, Fix: api.FixSemantic, Implementation: r,
+		NodeTypes: []string{"function_declaration", "method_declaration"}, Languages: []scanner.Language{scanner.LangKotlin, scanner.LangJava}, Confidence: api.ConfidenceVeryHigh, Fix: api.FixSemantic, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			if file.Language == scanner.LangJava {
@@ -395,7 +395,7 @@ func registerEmptyblocksEmptyIfBlock() {
 	r := &EmptyIfBlockRule{BaseRule: BaseRule{RuleName: "EmptyIfBlock", RuleSetName: "empty-blocks", Sev: "warning", Desc: "Detects if blocks with an empty body."}}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"if_expression", "if_statement"}, Languages: []scanner.Language{scanner.LangKotlin, scanner.LangJava}, Confidence: 0.95, Fix: api.FixNone, Implementation: r,
+		NodeTypes: []string{"if_expression", "if_statement"}, Languages: []scanner.Language{scanner.LangKotlin, scanner.LangJava}, Confidence: api.ConfidenceVeryHigh, Fix: api.FixNone, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			text := file.FlatNodeText(idx)
@@ -432,7 +432,7 @@ func registerEmptyblocksEmptyInitBlock() {
 	r := &EmptyInitBlockRule{BaseRule: BaseRule{RuleName: "EmptyInitBlock", RuleSetName: "empty-blocks", Sev: "warning", Desc: "Detects init blocks with an empty body that can be removed."}}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"anonymous_initializer"}, Confidence: 0.95, Fix: api.FixSemantic, Implementation: r,
+		NodeTypes: []string{"anonymous_initializer"}, Confidence: api.ConfidenceVeryHigh, Fix: api.FixSemantic, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			if !isBlockEmptyFlat(file, idx) {
@@ -465,7 +465,7 @@ func registerEmptyblocksEmptySecondaryConstructor() {
 	r := &EmptySecondaryConstructorRule{BaseRule: BaseRule{RuleName: "EmptySecondaryConstructor", RuleSetName: "empty-blocks", Sev: "warning", Desc: "Detects secondary constructors with an empty body."}}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"secondary_constructor"}, Confidence: 0.95, Fix: api.FixSemantic, Implementation: r,
+		NodeTypes: []string{"secondary_constructor"}, Confidence: api.ConfidenceVeryHigh, Fix: api.FixSemantic, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			nodeText := file.FlatNodeText(idx)
@@ -499,7 +499,7 @@ func registerEmptyblocksEmptyTryBlock() {
 	r := &EmptyTryBlockRule{BaseRule: BaseRule{RuleName: "EmptyTryBlock", RuleSetName: "empty-blocks", Sev: "warning", Desc: "Detects try blocks with an empty body."}}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"try_expression", "try_statement"}, Languages: []scanner.Language{scanner.LangKotlin, scanner.LangJava}, Confidence: 0.95, Fix: api.FixNone, Implementation: r,
+		NodeTypes: []string{"try_expression", "try_statement"}, Languages: []scanner.Language{scanner.LangKotlin, scanner.LangJava}, Confidence: api.ConfidenceVeryHigh, Fix: api.FixNone, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			text := file.FlatNodeText(idx)
@@ -543,7 +543,7 @@ func registerEmptyblocksEmptyWhenBlock() {
 	r := &EmptyWhenBlockRule{BaseRule: BaseRule{RuleName: "EmptyWhenBlock", RuleSetName: "empty-blocks", Sev: "warning", Desc: "Detects when expressions with no entries."}}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"when_expression"}, Confidence: 0.95, Fix: api.FixNone, Implementation: r,
+		NodeTypes: []string{"when_expression"}, Confidence: api.ConfidenceVeryHigh, Fix: api.FixNone, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			hasEntries := false
@@ -569,7 +569,7 @@ func registerEmptyblocksEmptyWhileBlock() {
 	r := &EmptyWhileBlockRule{BaseRule: BaseRule{RuleName: "EmptyWhileBlock", RuleSetName: "empty-blocks", Sev: "warning", Desc: "Detects while loops with an empty body."}}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"while_statement"}, Languages: []scanner.Language{scanner.LangKotlin, scanner.LangJava}, Confidence: 0.95, Fix: api.FixNone, Implementation: r,
+		NodeTypes: []string{"while_statement"}, Languages: []scanner.Language{scanner.LangKotlin, scanner.LangJava}, Confidence: api.ConfidenceVeryHigh, Fix: api.FixNone, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			if !isBlockEmptyFlat(file, idx) {

--- a/internal/rules/registry_exceptions.go
+++ b/internal/rules/registry_exceptions.go
@@ -16,7 +16,7 @@ func registerExceptionsRules() {
 		r := &ExceptionRaisedInUnexpectedLocationRule{BaseRule: BaseRule{RuleName: "ExceptionRaisedInUnexpectedLocation", RuleSetName: "exceptions", Sev: "warning", Desc: "Detects throw statements inside equals, hashCode, toString, or finalize methods."}, MethodNames: []string{"equals", "hashCode", "toString", "finalize"}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"function_declaration", "method_declaration"}, Languages: []scanner.Language{scanner.LangKotlin, scanner.LangJava}, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"function_declaration", "method_declaration"}, Languages: []scanner.Language{scanner.LangKotlin, scanner.LangJava}, Confidence: api.ConfidenceMedium, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				name := extractIdentifierFlat(file, idx)
@@ -34,7 +34,7 @@ func registerExceptionsRules() {
 		r := &InstanceOfCheckForExceptionRule{BaseRule: BaseRule{RuleName: "InstanceOfCheckForException", RuleSetName: "exceptions", Sev: "warning", Desc: "Detects instanceof/is checks for exception types inside catch blocks instead of using specific catch clauses."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"catch_block", "catch_clause"}, Languages: []scanner.Language{scanner.LangKotlin, scanner.LangJava}, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"catch_block", "catch_clause"}, Languages: []scanner.Language{scanner.LangKotlin, scanner.LangJava}, Confidence: api.ConfidenceMedium, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				catchVarName := extractCaughtVarNameFlat(file, idx)
@@ -83,7 +83,7 @@ func registerExceptionsRules() {
 		r := &NotImplementedDeclarationRule{BaseRule: BaseRule{RuleName: "NotImplementedDeclaration", RuleSetName: "exceptions", Sev: "warning", Desc: "Detects TODO() calls that throw NotImplementedError at runtime."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"call_expression"}, Languages: []scanner.Language{scanner.LangKotlin}, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"call_expression"}, Languages: []scanner.Language{scanner.LangKotlin}, Confidence: api.ConfidenceMedium, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				if !isKotlinTODOCall(file, idx) {
@@ -98,7 +98,7 @@ func registerExceptionsRules() {
 		r := &RethrowCaughtExceptionRule{BaseRule: BaseRule{RuleName: "RethrowCaughtException", RuleSetName: "exceptions", Sev: "warning", Desc: "Detects catch blocks whose only statement is rethrowing the caught exception, making the catch block useless."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"catch_block", "catch_clause"}, Languages: []scanner.Language{scanner.LangKotlin, scanner.LangJava}, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"catch_block", "catch_clause"}, Languages: []scanner.Language{scanner.LangKotlin, scanner.LangJava}, Confidence: api.ConfidenceMedium, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				caughtVar := extractCaughtVarNameFlat(file, idx)
@@ -141,7 +141,7 @@ func registerExceptionsRules() {
 		r := &ReturnFromFinallyRule{BaseRule: BaseRule{RuleName: "ReturnFromFinally", RuleSetName: "exceptions", Sev: "warning", Desc: "Detects return statements inside finally blocks that can swallow exceptions from the try/catch."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"finally_block", "finally_clause"}, Languages: []scanner.Language{scanner.LangKotlin, scanner.LangJava}, Confidence: 0.75, Fix: api.FixNone, Implementation: r,
+			NodeTypes: []string{"finally_block", "finally_clause"}, Languages: []scanner.Language{scanner.LangKotlin, scanner.LangJava}, Confidence: api.ConfidenceMedium, Fix: api.FixNone, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				returnTypes := []string{"jump_expression"}
@@ -187,7 +187,7 @@ func registerExceptionsRules() {
 		r := &ThrowingExceptionFromFinallyRule{BaseRule: BaseRule{RuleName: "ThrowingExceptionFromFinally", RuleSetName: "exceptions", Sev: "warning", Desc: "Detects throw statements inside finally blocks that can mask exceptions from the try/catch."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"finally_block", "finally_clause"}, Languages: []scanner.Language{scanner.LangKotlin, scanner.LangJava}, Confidence: 0.75, Fix: api.FixNone, Implementation: r,
+			NodeTypes: []string{"finally_block", "finally_clause"}, Languages: []scanner.Language{scanner.LangKotlin, scanner.LangJava}, Confidence: api.ConfidenceMedium, Fix: api.FixNone, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				walkThrowExpressionsFlat(file, idx, func(throwNode uint32) {
@@ -202,7 +202,7 @@ func registerExceptionsRules() {
 		r := &ThrowingExceptionsWithoutMessageOrCauseRule{BaseRule: BaseRule{RuleName: "ThrowingExceptionsWithoutMessageOrCause", RuleSetName: "exceptions", Sev: "warning", Desc: "Detects common exception types thrown without a descriptive message or cause argument."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"call_expression"}, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"call_expression"}, Confidence: api.ConfidenceMedium, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				isThrow := false
@@ -264,7 +264,7 @@ func registerExceptionsRules() {
 		r := &ThrowingNewInstanceOfSameExceptionRule{BaseRule: BaseRule{RuleName: "ThrowingNewInstanceOfSameException", RuleSetName: "exceptions", Sev: "warning", Desc: "Detects catch blocks that throw a new instance of the same exception type instead of rethrowing the original."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"catch_block", "catch_clause"}, Languages: []scanner.Language{scanner.LangKotlin, scanner.LangJava}, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"catch_block", "catch_clause"}, Languages: []scanner.Language{scanner.LangKotlin, scanner.LangJava}, Confidence: api.ConfidenceMedium, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				caughtType := extractCaughtTypeNameFlat(file, idx)
@@ -296,7 +296,7 @@ func registerExceptionsRules() {
 		r := &ThrowingExceptionInMainRule{BaseRule: BaseRule{RuleName: "ThrowingExceptionInMain", RuleSetName: "exceptions", Sev: "warning", Desc: "Detects throw statements inside the main() function instead of graceful error handling."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"function_declaration", "method_declaration"}, Languages: []scanner.Language{scanner.LangKotlin, scanner.LangJava}, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"function_declaration", "method_declaration"}, Languages: []scanner.Language{scanner.LangKotlin, scanner.LangJava}, Confidence: api.ConfidenceMedium, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				name := extractIdentifierFlat(file, idx)
@@ -314,7 +314,7 @@ func registerExceptionsRules() {
 		r := &ErrorUsageWithThrowableRule{BaseRule: BaseRule{RuleName: "ErrorUsageWithThrowable", RuleSetName: "exceptions", Sev: "warning", Desc: "Detects error() calls that pass a Throwable argument instead of using throw directly."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"call_expression"}, Needs: api.NeedsTypeInfo, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"call_expression"}, Needs: api.NeedsTypeInfo, Confidence: api.ConfidenceMedium, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				argText, ok := errorUsageWithThrowableArgument(ctx, idx)
@@ -330,7 +330,7 @@ func registerExceptionsRules() {
 		r := &ObjectExtendsThrowableRule{BaseRule: BaseRule{RuleName: "ObjectExtendsThrowable", RuleSetName: "exceptions", Sev: "warning", Desc: "Detects Kotlin object declarations that extend Throwable, which are singletons that lose stack trace information."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"object_declaration"}, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"object_declaration"}, Confidence: api.ConfidenceMedium, Implementation: r,
 			Needs: api.NeedsResolver,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File

--- a/internal/rules/registry_library.go
+++ b/internal/rules/registry_library.go
@@ -14,7 +14,7 @@ func registerLibraryRules() {
 		r := &ForbiddenPublicDataClassRule{BaseRule: BaseRule{RuleName: "ForbiddenPublicDataClass", RuleSetName: "libraries", Sev: "warning", Desc: "Detects public data classes in library code whose exposed properties make the API hard to evolve."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"class_declaration"}, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"class_declaration"}, Confidence: api.ConfidenceMedium, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				if !file.FlatHasModifier(idx, "data") {
@@ -32,7 +32,7 @@ func registerLibraryRules() {
 		r := &LibraryEntitiesShouldNotBePublicRule{BaseRule: BaseRule{RuleName: "LibraryEntitiesShouldNotBePublic", RuleSetName: "libraries", Sev: "warning", Desc: "Detects public top-level declarations in library code that could be made internal."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"class_declaration", "function_declaration", "property_declaration"}, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"class_declaration", "function_declaration", "property_declaration"}, Confidence: api.ConfidenceMedium, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				parent, ok := file.FlatParent(idx)
@@ -55,7 +55,7 @@ func registerLibraryRules() {
 		r := &LibraryCodeMustSpecifyReturnTypeRule{BaseRule: BaseRule{RuleName: "LibraryCodeMustSpecifyReturnType", RuleSetName: "libraries", Sev: "warning", Desc: "Detects public functions and properties in library code without explicit return type annotations."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"function_declaration", "property_declaration"}, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"function_declaration", "property_declaration"}, Confidence: api.ConfidenceMedium, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				parent, ok := file.FlatParent(idx)

--- a/internal/rules/registry_naming.go
+++ b/internal/rules/registry_naming.go
@@ -39,7 +39,7 @@ func registerNamingClassNaming() {
 	r := &ClassNamingRule{BaseRule: BaseRule{RuleName: "ClassNaming", RuleSetName: "naming", Sev: "warning", Desc: "Detects class names that do not match the expected naming pattern."}, Pattern: regexp.MustCompile(`^[A-Z][a-zA-Z0-9]*$`)}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"class_declaration"}, Confidence: 0.95, Implementation: r,
+		NodeTypes: []string{"class_declaration"}, Confidence: api.ConfidenceVeryHigh, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			if scanner.IsTestFile(file.Path) {
@@ -69,7 +69,7 @@ func registerNamingFunctionNaming() {
 	}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"function_declaration"}, Confidence: 0.95, Implementation: r,
+		NodeTypes: []string{"function_declaration"}, Confidence: api.ConfidenceVeryHigh, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			if scanner.IsTestFile(file.Path) {
@@ -125,7 +125,7 @@ func registerNamingVariableNaming() {
 	r := &VariableNamingRule{BaseRule: BaseRule{RuleName: "VariableNaming", RuleSetName: "naming", Sev: "warning", Desc: "Detects local variable names that do not match the expected naming pattern."}, Pattern: regexp.MustCompile(`^[a-z][A-Za-z0-9]*$`)}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"property_declaration"}, Confidence: 0.95, Implementation: r,
+		NodeTypes: []string{"property_declaration"}, Confidence: api.ConfidenceVeryHigh, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			if !variableNamingIsFunctionLocalPropertyFlat(file, idx) {
@@ -161,7 +161,7 @@ func registerNamingPackageNaming() {
 	r := &PackageNamingRule{BaseRule: BaseRule{RuleName: "PackageNaming", RuleSetName: "naming", Sev: "warning", Desc: "Detects package names that do not match the expected naming pattern."}, Pattern: regexp.MustCompile(`^[a-z][a-zA-Z0-9_]*(\.[a-z][a-zA-Z0-9_]*)*$`)}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"package_header"}, Confidence: 0.95, Implementation: r,
+		NodeTypes: []string{"package_header"}, Confidence: api.ConfidenceVeryHigh, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			var pkg string
@@ -192,7 +192,7 @@ func registerNamingEnumNaming() {
 	r := &EnumNamingRule{BaseRule: BaseRule{RuleName: "EnumNaming", RuleSetName: "naming", Sev: "warning", Desc: "Detects enum entry names that do not match the expected naming pattern."}, Pattern: regexp.MustCompile(`^[A-Z][_a-zA-Z0-9]*$`)}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"enum_entry"}, Confidence: 0.95, Implementation: r,
+		NodeTypes: []string{"enum_entry"}, Confidence: api.ConfidenceVeryHigh, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			name := extractIdentifierFlat(file, idx)
@@ -207,7 +207,7 @@ func registerNamingBooleanPropertyNaming() {
 	r := &BooleanPropertyNamingRule{BaseRule: BaseRule{RuleName: "BooleanPropertyNaming", RuleSetName: "naming", Sev: "warning", Desc: "Detects Boolean properties that do not start with an allowed prefix like is, has, or are."}}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"property_declaration"}, Confidence: 0.95, Fix: api.FixSemantic, Implementation: r,
+		NodeTypes: []string{"property_declaration"}, Confidence: api.ConfidenceVeryHigh, Fix: api.FixSemantic, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			if scanner.IsTestFile(file.Path) || !isPublicDeclarationFlat(file, idx) {
@@ -249,7 +249,7 @@ func registerNamingConstructorParameterNaming() {
 	r := &ConstructorParameterNamingRule{BaseRule: BaseRule{RuleName: "ConstructorParameterNaming", RuleSetName: "naming", Sev: "warning", Desc: "Detects constructor val/var parameter names that do not match the expected naming pattern."}, Pattern: regexp.MustCompile(`^[a-z][A-Za-z0-9]*$`)}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"primary_constructor"}, Confidence: 0.95, Implementation: r,
+		NodeTypes: []string{"primary_constructor"}, Confidence: api.ConfidenceVeryHigh, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			for i := 0; i < file.FlatChildCount(idx); i++ {
@@ -285,7 +285,7 @@ func registerNamingForbiddenClassName() {
 	r := &ForbiddenClassNameRule{BaseRule: BaseRule{RuleName: "ForbiddenClassName", RuleSetName: "naming", Sev: "warning", Desc: "Detects class names that match a configured list of disallowed names."}, ForbiddenNames: []string{"Manager", "Helper", "Util", "Utils"}}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"class_declaration"}, Confidence: 0.95, Implementation: r,
+		NodeTypes: []string{"class_declaration"}, Confidence: api.ConfidenceVeryHigh, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			if len(r.ForbiddenNames) == 0 {
@@ -307,7 +307,7 @@ func registerNamingFunctionNameMaxLength() {
 	r := &FunctionNameMaxLengthRule{BaseRule: BaseRule{RuleName: "FunctionNameMaxLength", RuleSetName: "naming", Sev: "warning", Desc: "Detects function names that exceed the configured maximum length."}, MaxLength: 30}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"function_declaration"}, Confidence: 0.95, Implementation: r,
+		NodeTypes: []string{"function_declaration"}, Confidence: api.ConfidenceVeryHigh, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			if scanner.IsTestFile(file.Path) {
@@ -325,7 +325,7 @@ func registerNamingFunctionNameMinLength() {
 	r := &FunctionNameMinLengthRule{BaseRule: BaseRule{RuleName: "FunctionNameMinLength", RuleSetName: "naming", Sev: "warning", Desc: "Detects function names that are shorter than the configured minimum length."}, MinLength: 3}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"function_declaration"}, Confidence: 0.95, Implementation: r,
+		NodeTypes: []string{"function_declaration"}, Confidence: api.ConfidenceVeryHigh, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			name := extractIdentifierFlat(file, idx)
@@ -343,7 +343,7 @@ func registerNamingFunctionParameterNaming() {
 	r := &FunctionParameterNamingRule{BaseRule: BaseRule{RuleName: "FunctionParameterNaming", RuleSetName: "naming", Sev: "warning", Desc: "Detects function parameter names that do not match the expected naming pattern."}, Pattern: regexp.MustCompile(`^[a-z][A-Za-z0-9]*$`)}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"function_declaration"}, Confidence: 0.95, Implementation: r,
+		NodeTypes: []string{"function_declaration"}, Confidence: api.ConfidenceVeryHigh, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			paramsNode, _ := file.FlatFindChild(idx, "function_value_parameters")
@@ -367,7 +367,7 @@ func registerNamingInvalidPackageDeclaration() {
 	r := &InvalidPackageDeclarationRule{BaseRule: BaseRule{RuleName: "InvalidPackageDeclaration", RuleSetName: "naming", Sev: "warning", Desc: "Detects package declarations that do not match the file directory structure."}}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"package_header"}, Confidence: 0.95, Implementation: r,
+		NodeTypes: []string{"package_header"}, Confidence: api.ConfidenceVeryHigh, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			if invalidPackageDeclarationIgnoredPath(file.Path) {
@@ -425,7 +425,7 @@ func registerNamingLambdaParameterNaming() {
 	r := &LambdaParameterNamingRule{BaseRule: BaseRule{RuleName: "LambdaParameterNaming", RuleSetName: "naming", Sev: "warning", Desc: "Detects lambda parameter names that do not match the expected naming pattern."}, Pattern: regexp.MustCompile(`^[a-z][A-Za-z0-9]*$|^_$`)}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"lambda_literal"}, Confidence: 0.95, Implementation: r,
+		NodeTypes: []string{"lambda_literal"}, Confidence: api.ConfidenceVeryHigh, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			paramsNode, _ := file.FlatFindChild(idx, "lambda_parameters")
@@ -464,7 +464,7 @@ func registerNamingMatchingDeclarationName() {
 	}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"source_file"}, Confidence: 0.95, Implementation: r,
+		NodeTypes: []string{"source_file"}, Confidence: api.ConfidenceVeryHigh, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			if strings.HasSuffix(file.Path, ".kts") {
@@ -576,7 +576,7 @@ func registerNamingMemberNameEqualsClassName() {
 	r := &MemberNameEqualsClassNameRule{BaseRule: BaseRule{RuleName: "MemberNameEqualsClassName", RuleSetName: "naming", Sev: "warning", Desc: "Detects class members whose name is the same as the containing class name."}}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"class_declaration"}, Confidence: 0.95, Implementation: r,
+		NodeTypes: []string{"class_declaration"}, Confidence: api.ConfidenceVeryHigh, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			className := extractIdentifierFlat(file, idx)
@@ -605,7 +605,7 @@ func registerNamingNoNameShadowing() {
 	r := &NoNameShadowingRule{BaseRule: BaseRule{RuleName: "NoNameShadowing", RuleSetName: "naming", Sev: "warning", Desc: "Detects inner declarations that shadow an outer declaration with the same name."}}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"source_file"}, Confidence: 0.75, Implementation: r,
+		NodeTypes: []string{"source_file"}, Confidence: api.ConfidenceMedium, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			var findings []scanner.Finding
@@ -626,7 +626,7 @@ func registerNamingNonBooleanPropertyPrefixedWithIs() {
 	r := &NonBooleanPropertyPrefixedWithIsRule{BaseRule: BaseRule{RuleName: "NonBooleanPropertyPrefixedWithIs", RuleSetName: "naming", Sev: "warning", Desc: "Detects non-Boolean properties whose name starts with the is prefix."}}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"property_declaration"}, Confidence: 0.95, Implementation: r,
+		NodeTypes: []string{"property_declaration"}, Confidence: api.ConfidenceVeryHigh, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			name := extractIdentifierFlat(file, idx)
@@ -648,7 +648,7 @@ func registerNamingObjectPropertyNaming() {
 	r := &ObjectPropertyNamingRule{BaseRule: BaseRule{RuleName: "ObjectPropertyNaming", RuleSetName: "naming", Sev: "warning", Desc: "Detects property names inside object declarations that do not match the expected naming pattern."}, ConstPattern: regexp.MustCompile(`^[A-Z][_A-Z0-9]*$`), PropertyPattern: regexp.MustCompile(`^[a-z][A-Za-z0-9]*$`)}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"object_declaration", "companion_object"}, Confidence: 0.95, Implementation: r,
+		NodeTypes: []string{"object_declaration", "companion_object"}, Confidence: api.ConfidenceVeryHigh, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			classBody, _ := file.FlatFindChild(idx, "class_body")
@@ -690,7 +690,7 @@ func registerNamingTopLevelPropertyNaming() {
 	r := &TopLevelPropertyNamingRule{BaseRule: BaseRule{RuleName: "TopLevelPropertyNaming", RuleSetName: "naming", Sev: "warning", Desc: "Detects top-level property names that do not match the expected naming pattern."}, ConstPattern: regexp.MustCompile(`^[A-Z][_A-Za-z0-9]*$`), PropertyPattern: regexp.MustCompile(`^[a-z][A-Za-z0-9]*$`)}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"property_declaration"}, Confidence: 0.95, Implementation: r,
+		NodeTypes: []string{"property_declaration"}, Confidence: api.ConfidenceVeryHigh, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			parent, ok := file.FlatParent(idx)
@@ -726,7 +726,7 @@ func registerNamingVariableMaxLength() {
 	r := &VariableMaxLengthRule{BaseRule: BaseRule{RuleName: "VariableMaxLength", RuleSetName: "naming", Sev: "warning", Desc: "Detects variable names that exceed the configured maximum length."}, MaxLength: 64}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"property_declaration"}, Confidence: 0.95, Implementation: r,
+		NodeTypes: []string{"property_declaration"}, Confidence: api.ConfidenceVeryHigh, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			if !file.FlatHasAncestorOfType(idx, "function_body") {
@@ -744,7 +744,7 @@ func registerNamingVariableMinLength() {
 	r := &VariableMinLengthRule{BaseRule: BaseRule{RuleName: "VariableMinLength", RuleSetName: "naming", Sev: "warning", Desc: "Detects variable names that are shorter than the configured minimum length."}, MinLength: 2}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"property_declaration"}, Confidence: 0.95, Implementation: r,
+		NodeTypes: []string{"property_declaration"}, Confidence: api.ConfidenceVeryHigh, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			if !file.FlatHasAncestorOfType(idx, "function_body") {

--- a/internal/rules/registry_observability.go
+++ b/internal/rules/registry_observability.go
@@ -11,7 +11,7 @@ func registerObservabilityRules() {
 		r := &LogLevelGuardMissingRule{BaseRule: BaseRule{RuleName: "LogLevelGuardMissing", RuleSetName: "observability", Sev: "info", Desc: "Detects debug/trace log messages with interpolated calls not guarded by a log-level check."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"call_expression"}, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"call_expression"}, Confidence: api.ConfidenceMedium, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				level := compactLoggerLevel(flatCallExpressionName(file, idx))
@@ -44,7 +44,7 @@ func registerObservabilityRules() {
 		r := &LogWithoutCorrelationIDRule{BaseRule: BaseRule{RuleName: "LogWithoutCorrelationId", RuleSetName: "observability", Sev: "info", Desc: "Detects logger calls inside coroutine builders whose context does not include MDCContext."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"call_expression"}, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"call_expression"}, Confidence: api.ConfidenceMedium, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				builderName, args, lambda := coroutineBuilderPartsFlat(file, idx)
@@ -192,7 +192,7 @@ func registerObservabilityRules() {
 		r := &MdcAcrossCoroutineBoundaryRule{BaseRule: BaseRule{RuleName: "MdcAcrossCoroutineBoundary", RuleSetName: "observability", Sev: "warning", Desc: "Detects MDC.put(...) followed by a coroutine builder without MDCContext(); MDC values do not propagate across dispatchers."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"call_expression"}, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"call_expression"}, Confidence: api.ConfidenceMedium, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				if flatCallExpressionName(file, idx) != "put" {
@@ -214,7 +214,7 @@ func registerObservabilityRules() {
 		r := &LoggerInterpolatedMessageRule{BaseRule: BaseRule{RuleName: "LoggerInterpolatedMessage", RuleSetName: "observability", Sev: "warning", Desc: "Detects SLF4J/Logback/log4j logger calls whose message uses Kotlin string interpolation instead of parameterized placeholders."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"call_expression"}, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"call_expression"}, Confidence: api.ConfidenceMedium, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				method := flatCallExpressionName(file, idx)
@@ -301,7 +301,7 @@ func registerObservabilityRules() {
 		r := &LoggerStringConcatRule{BaseRule: BaseRule{RuleName: "LoggerStringConcat", RuleSetName: "observability", Sev: "warning", Desc: "Detects SLF4J/Logback/log4j logger calls whose message uses `+` string concatenation instead of parameterized placeholders."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"call_expression"}, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"call_expression"}, Confidence: api.ConfidenceMedium, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				method := flatCallExpressionName(file, idx)
@@ -325,7 +325,7 @@ func registerObservabilityRules() {
 		r := &LoggerWithoutLoggerFieldRule{BaseRule: BaseRule{RuleName: "LoggerWithoutLoggerField", RuleSetName: "observability", Sev: "warning", Desc: "Detects LoggerFactory.getLogger() calls inside function bodies instead of a class-level logger field."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"call_expression"}, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"call_expression"}, Confidence: api.ConfidenceMedium, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				if flatCallExpressionName(file, idx) != "getLogger" {
@@ -345,7 +345,7 @@ func registerObservabilityRules() {
 		r := &MdcPutNoRemoveRule{BaseRule: BaseRule{RuleName: "MdcPutNoRemove", RuleSetName: "observability", Sev: "warning", Desc: "Detects MDC.put(...) inside a function with no matching MDC.remove(...), MDC.clear(), or MDCCloseable, which leaks values across reused threads."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"call_expression"}, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"call_expression"}, Confidence: api.ConfidenceMedium, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				if flatCallExpressionName(file, idx) != "put" {

--- a/internal/rules/registry_package_naming_convention_drift.go
+++ b/internal/rules/registry_package_naming_convention_drift.go
@@ -14,7 +14,7 @@ func registerPackageNamingConventionDriftRules() {
 		r := &PackageNamingConventionDriftRule{BaseRule: BaseRule{RuleName: "PackageNamingConventionDrift", RuleSetName: "architecture", Sev: "info", Desc: "Detects Kotlin source files whose package declaration does not match the directory path under src/main/kotlin."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"package_header"}, Confidence: 0.95, Implementation: r,
+			NodeTypes: []string{"package_header"}, Confidence: api.ConfidenceVeryHigh, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				pkg := packageHeaderNameFlat(file, idx)

--- a/internal/rules/registry_performance.go
+++ b/internal/rules/registry_performance.go
@@ -20,7 +20,7 @@ func registerPerformanceRules() {
 		r := &ArrayPrimitiveRule{BaseRule: BaseRule{RuleName: "ArrayPrimitive", RuleSetName: "performance", Sev: "warning", Desc: "Detects Array<Int> and similar boxed primitive arrays that should use IntArray, LongArray, etc."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"user_type", "call_expression"}, Confidence: 0.75, Fix: api.FixIdiomatic, Implementation: r,
+			NodeTypes: []string{"user_type", "call_expression"}, Confidence: api.ConfidenceMedium, Fix: api.FixIdiomatic, Implementation: r,
 			Needs: api.NeedsResolver,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
@@ -89,7 +89,7 @@ func registerPerformanceRules() {
 		r := &BitmapDecodeWithoutOptionsRule{BaseRule: BaseRule{RuleName: "BitmapDecodeWithoutOptions", RuleSetName: "performance", Sev: "warning", Desc: "Detects BitmapFactory.decode* calls without BitmapFactory.Options, which may decode full-size bitmaps."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"call_expression"}, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"call_expression"}, Confidence: api.ConfidenceMedium, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				navExpr, args := flatCallExpressionParts(file, idx)
@@ -129,7 +129,7 @@ func registerPerformanceRules() {
 		r := &CouldBeSequenceRule{BaseRule: BaseRule{RuleName: "CouldBeSequence", RuleSetName: "performance", Sev: "warning", Desc: "Detects collection operation chains that could use sequences to avoid intermediate allocations."}, AllowedOperations: 2}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"call_expression"}, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"call_expression"}, Confidence: api.ConfidenceMedium, Implementation: r,
 			Needs:                  api.NeedsTypeInfo | api.NeedsOracleCallTargets,
 			Oracle:                 &api.OracleFilter{Identifiers: sequenceCollectionOperationNames()},
 			OracleCallTargets:      &api.OracleCallTargetFilter{CalleeNames: sequenceCollectionOperationNames()},
@@ -188,7 +188,7 @@ func registerPerformanceRules() {
 		r := &ForEachOnRangeRule{BaseRule: BaseRule{RuleName: "ForEachOnRange", RuleSetName: "performance", Sev: "warning", Desc: "Detects (range).forEach patterns that should use a simple for loop to avoid lambda overhead."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"call_expression"}, Confidence: 0.75, Fix: api.FixIdiomatic, Implementation: r,
+			NodeTypes: []string{"call_expression"}, Confidence: api.ConfidenceMedium, Fix: api.FixIdiomatic, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				name := flatCallExpressionName(file, idx)
@@ -217,7 +217,7 @@ func registerPerformanceRules() {
 		r := &SpreadOperatorRule{BaseRule: BaseRule{RuleName: "SpreadOperator", RuleSetName: "performance", Sev: "warning", Desc: "Detects the spread operator (*array) in function calls which creates an array copy."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"spread_expression"}, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"spread_expression"}, Confidence: api.ConfidenceMedium, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				if !spreadOperatorShouldReportFlat(file, idx) {
@@ -232,7 +232,7 @@ func registerPerformanceRules() {
 		r := &UnnecessaryInitOnArrayRule{BaseRule: BaseRule{RuleName: "UnnecessaryInitOnArray", RuleSetName: "performance", Sev: "warning", Desc: "Detects IntArray(n) { 0 } and similar array initializations where the init value is already the default."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"call_expression"}, Confidence: 0.75, Fix: api.FixIdiomatic, Implementation: r,
+			NodeTypes: []string{"call_expression"}, Confidence: api.ConfidenceMedium, Fix: api.FixIdiomatic, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				_, lambda, ok := unnecessaryInitArrayDefaultLambdaFlat(file, idx)
@@ -250,7 +250,7 @@ func registerPerformanceRules() {
 		r := &UnnecessaryPartOfBinaryExpressionRule{BaseRule: BaseRule{RuleName: "UnnecessaryPartOfBinaryExpression", RuleSetName: "performance", Sev: "warning", Desc: "Detects redundant parts of binary expressions like x && true or x || false."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"conjunction_expression", "disjunction_expression"}, Confidence: 0.75, Fix: api.FixIdiomatic, Implementation: r,
+			NodeTypes: []string{"conjunction_expression", "disjunction_expression"}, Confidence: api.ConfidenceMedium, Fix: api.FixIdiomatic, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				if file.FlatNamedChildCount(idx) < 2 {
@@ -299,7 +299,7 @@ func registerPerformanceRules() {
 		r := &UnnecessaryTemporaryInstantiationRule{BaseRule: BaseRule{RuleName: "UnnecessaryTemporaryInstantiation", RuleSetName: "performance", Sev: "warning", Desc: "Detects temporary wrapper instantiations like Integer.valueOf(x).toString() that can be simplified."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"call_expression"}, Confidence: 0.75, Fix: api.FixIdiomatic, Implementation: r,
+			NodeTypes: []string{"call_expression"}, Confidence: api.ConfidenceMedium, Fix: api.FixIdiomatic, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				src := file.FlatNodeBytes(idx)
@@ -349,7 +349,7 @@ func registerPerformanceRules() {
 		r := &UnnecessaryTypeCastingRule{BaseRule: BaseRule{RuleName: "UnnecessaryTypeCasting", RuleSetName: "performance", Sev: "warning", Desc: "Detects safe casts immediately compared with null and redundant casts to an already-known type."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"equality_expression", "as_expression"}, Confidence: 0.75, Fix: api.FixIdiomatic, Implementation: r,
+			NodeTypes: []string{"equality_expression", "as_expression"}, Confidence: api.ConfidenceMedium, Fix: api.FixIdiomatic, Implementation: r,
 			Needs: api.NeedsResolver,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File

--- a/internal/rules/registry_potentialbugs_exceptions.go
+++ b/internal/rules/registry_potentialbugs_exceptions.go
@@ -14,7 +14,7 @@ func registerPotentialbugsExceptionsRules() {
 		r := &PrintStackTraceRule{BaseRule: BaseRule{RuleName: "PrintStackTrace", RuleSetName: "exceptions", Sev: "warning", Desc: "Detects printStackTrace() calls that should use a logger instead."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"call_expression"}, Confidence: 0.75, Fix: api.FixIdiomatic, Implementation: r,
+			NodeTypes: []string{"call_expression"}, Confidence: api.ConfidenceMedium, Fix: api.FixIdiomatic, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				if strings.HasSuffix(file.Path, ".gradle.kts") {
@@ -66,7 +66,7 @@ func registerPotentialbugsExceptionsRules() {
 		r := &UnreachableCatchBlockRule{BaseRule: BaseRule{RuleName: "UnreachableCatchBlock", RuleSetName: "potential-bugs", Sev: "warning", Desc: "Detects catch blocks that are unreachable because a more general exception type is caught above."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"try_expression"}, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"try_expression"}, Confidence: api.ConfidenceMedium, Implementation: r,
 			Needs: api.NeedsResolver,
 			Tags:  []string{"precompile"},
 			Check: r.checkFlatNode,
@@ -76,7 +76,7 @@ func registerPotentialbugsExceptionsRules() {
 		r := &MissingReturnRule{BaseRule: BaseRule{RuleName: "MissingReturn", RuleSetName: "potential-bugs", Sev: "error", Desc: "Detects block-bodied functions with a non-Unit return type whose body does not terminate on every path."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"function_declaration"}, Confidence: 0.85, Implementation: r,
+			NodeTypes: []string{"function_declaration"}, Confidence: api.ConfidenceHigh, Implementation: r,
 			Needs: api.NeedsResolver,
 			Tags:  []string{"precompile"},
 			Check: r.check,

--- a/internal/rules/registry_potentialbugs_lifecycle.go
+++ b/internal/rules/registry_potentialbugs_lifecycle.go
@@ -15,7 +15,7 @@ func registerPotentialbugsLifecycleRules() {
 		r := &ExitOutsideMainRule{BaseRule: BaseRule{RuleName: "ExitOutsideMain", RuleSetName: "potential-bugs", Sev: "warning", Desc: "Detects exitProcess() or System.exit() calls outside of the main function."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"call_expression", "method_invocation"}, Languages: []scanner.Language{scanner.LangKotlin, scanner.LangJava}, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"call_expression", "method_invocation"}, Languages: []scanner.Language{scanner.LangKotlin, scanner.LangJava}, Confidence: api.ConfidenceMedium, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				if !exitOutsideMainCallMatches(file, idx) {
@@ -33,7 +33,7 @@ func registerPotentialbugsLifecycleRules() {
 		r := &ExplicitGarbageCollectionCallRule{BaseRule: BaseRule{RuleName: "ExplicitGarbageCollectionCall", RuleSetName: "potential-bugs", Sev: "warning", Desc: "Detects explicit calls to System.gc() or Runtime.getRuntime().gc() which rarely improve performance."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"call_expression", "method_invocation"}, Languages: []scanner.Language{scanner.LangKotlin, scanner.LangJava}, Confidence: 0.75, Fix: api.FixIdiomatic, Implementation: r,
+			NodeTypes: []string{"call_expression", "method_invocation"}, Languages: []scanner.Language{scanner.LangKotlin, scanner.LangJava}, Confidence: api.ConfidenceMedium, Fix: api.FixIdiomatic, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				text := file.FlatNodeText(idx)
@@ -101,7 +101,7 @@ func registerPotentialbugsLifecycleRules() {
 		r := &InvalidRangeRule{BaseRule: BaseRule{RuleName: "InvalidRange", RuleSetName: "potential-bugs", Sev: "warning", Desc: "Detects backwards ranges like 10..1 that produce empty ranges instead of using downTo."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"range_expression"}, Confidence: 0.75, Fix: api.FixIdiomatic, Implementation: r,
+			NodeTypes: []string{"range_expression"}, Confidence: api.ConfidenceMedium, Fix: api.FixIdiomatic, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				if file.FlatChildCount(idx) < 3 {
@@ -135,7 +135,7 @@ func registerPotentialbugsLifecycleRules() {
 		r := &IteratorHasNextCallsNextMethodRule{BaseRule: BaseRule{RuleName: "IteratorHasNextCallsNextMethod", RuleSetName: "potential-bugs", Sev: "warning", Desc: "Detects hasNext() implementations that call next(), which modifies iterator state."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"function_declaration"}, Needs: api.NeedsResolver, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"function_declaration"}, Needs: api.NeedsResolver, Confidence: api.ConfidenceMedium, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				name := extractIdentifierFlat(file, idx)
@@ -169,7 +169,7 @@ func registerPotentialbugsLifecycleRules() {
 		r := &IteratorNotThrowingNoSuchElementExceptionRule{BaseRule: BaseRule{RuleName: "IteratorNotThrowingNoSuchElementException", RuleSetName: "potential-bugs", Sev: "warning", Desc: "Detects Iterator.next() implementations that do not throw NoSuchElementException when exhausted."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"function_declaration"}, Needs: api.NeedsResolver, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"function_declaration"}, Needs: api.NeedsResolver, Confidence: api.ConfidenceMedium, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				name := extractIdentifierFlat(file, idx)
@@ -194,7 +194,7 @@ func registerPotentialbugsLifecycleRules() {
 		r := &LateinitUsageRule{BaseRule: BaseRule{RuleName: "LateinitUsage", RuleSetName: "potential-bugs", Sev: "warning", Desc: "Detects lateinit var usage and suggests lazy initialization or nullable types instead."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"property_declaration"}, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"property_declaration"}, Confidence: api.ConfidenceMedium, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				if scanner.IsTestFile(file.Path) {
@@ -241,7 +241,7 @@ func registerPotentialbugsLifecycleRules() {
 		}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"function_declaration"}, Confidence: 0.75, Fix: api.FixIdiomatic, Implementation: r,
+			NodeTypes: []string{"function_declaration"}, Confidence: api.ConfidenceMedium, Fix: api.FixIdiomatic, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				if !file.FlatHasModifier(idx, "override") {
@@ -310,7 +310,7 @@ func registerPotentialbugsLifecycleRules() {
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
 			NodeTypes:  []string{"call_expression"},
 			Needs:      api.NeedsTypeInfo | api.NeedsOracleCallTargets,
-			Confidence: 0.75, Implementation: r,
+			Confidence: api.ConfidenceMedium, Implementation: r,
 			OracleCallTargets:      &api.OracleCallTargetFilter{CalleeNames: closeableConstructorCallees()},
 			OracleDeclarationNeeds: &api.OracleDeclarationProfile{},
 			Check: func(ctx *api.Context) {

--- a/internal/rules/registry_potentialbugs_misc.go
+++ b/internal/rules/registry_potentialbugs_misc.go
@@ -17,7 +17,7 @@ func registerPotentialbugsMiscRules() {
 		r := &DeprecationRule{BaseRule: BaseRule{RuleName: "Deprecation", RuleSetName: "potential-bugs", Sev: "warning", Desc: "Detects usage of deprecated functions, classes, or properties."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"call_expression", "navigation_expression", "user_type"}, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"call_expression", "navigation_expression", "user_type"}, Confidence: api.ConfidenceMedium, Implementation: r,
 			Needs:             api.NeedsTypeInfo | api.NeedsOracleCallTargets,
 			OracleCallTargets: &api.OracleCallTargetFilter{AnnotatedIdentifiers: []string{"Deprecated"}},
 			// Narrow by the "Deprecated" token — captures @Deprecated,
@@ -115,7 +115,7 @@ func registerPotentialbugsMiscRules() {
 		r := &HasPlatformTypeRule{BaseRule: BaseRule{RuleName: "HasPlatformType", RuleSetName: "potential-bugs", Sev: "warning", Desc: "Detects public functions with expression bodies that lack an explicit return type, risking platform type exposure from Java interop."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"function_declaration"}, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"function_declaration"}, Confidence: api.ConfidenceMedium, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				if scanner.IsTestFile(file.Path) {
@@ -176,7 +176,7 @@ func registerPotentialbugsMiscRules() {
 		r := &IgnoredReturnValueRule{BaseRule: BaseRule{RuleName: "IgnoredReturnValue", RuleSetName: "potential-bugs", Sev: "warning", Desc: "Detects discarded return values from functional operations or @CheckReturnValue-annotated functions."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"call_expression"}, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"call_expression"}, Confidence: api.ConfidenceMedium, Implementation: r,
 			Needs: api.NeedsTypeInfo | api.NeedsOracleCallTargets,
 			OracleCallTargets: &api.OracleCallTargetFilter{
 				DiscardedOnly:        true,
@@ -311,7 +311,7 @@ func registerPotentialbugsMiscRules() {
 		r := &ImplicitDefaultLocaleRule{BaseRule: BaseRule{RuleName: "ImplicitDefaultLocale", RuleSetName: "potential-bugs", Sev: "warning", Desc: "Detects locale-sensitive string methods called without an explicit Locale argument."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"call_expression"}, Confidence: 0.75, Fix: api.FixSemantic, Implementation: r,
+			NodeTypes: []string{"call_expression"}, Confidence: api.ConfidenceMedium, Fix: api.FixSemantic, Implementation: r,
 			Needs: api.NeedsTypeInfo,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
@@ -428,7 +428,7 @@ func registerPotentialbugsMiscRules() {
 		r := &LocaleDefaultForCurrencyRule{BaseRule: BaseRule{RuleName: "LocaleDefaultForCurrency", RuleSetName: "potential-bugs", Sev: "warning", Desc: "Detects Currency.getInstance(Locale.getDefault()) in money-related classes where currency should come from business data."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"call_expression"}, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"call_expression"}, Confidence: api.ConfidenceMedium, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				className := enclosingClassNameFlat(file, idx)

--- a/internal/rules/registry_potentialbugs_nullsafety_bangbang.go
+++ b/internal/rules/registry_potentialbugs_nullsafety_bangbang.go
@@ -14,7 +14,7 @@ func registerPotentialbugsNullsafetyBangbangRules() {
 		}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"postfix_expression"}, Confidence: 0.85,
+			NodeTypes: []string{"postfix_expression"}, Confidence: api.ConfidenceHigh,
 			Implementation: r,
 			Check:          r.check,
 		})
@@ -23,7 +23,7 @@ func registerPotentialbugsNullsafetyBangbangRules() {
 		r := &MapGetWithNotNullAssertionRule{BaseRule: BaseRule{RuleName: "MapGetWithNotNullAssertionOperator", RuleSetName: "potential-bugs", Sev: "warning", Desc: "Detects map[key]!! usage and suggests getValue() or safe alternatives."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"postfix_expression"}, Confidence: 0.75, Fix: api.FixIdiomatic,
+			NodeTypes: []string{"postfix_expression"}, Confidence: api.ConfidenceMedium, Fix: api.FixIdiomatic,
 			Needs: api.NeedsTypeInfo |
 				api.NeedsOracleCallTargets |
 				api.NeedsOracleSupertypes |

--- a/internal/rules/registry_potentialbugs_nullsafety_casts.go
+++ b/internal/rules/registry_potentialbugs_nullsafety_casts.go
@@ -14,7 +14,7 @@ func registerPotentialbugsNullsafetyCastsRules() {
 		}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"as_expression"}, Confidence: 0.95, Fix: api.FixSemantic,
+			NodeTypes: []string{"as_expression"}, Confidence: api.ConfidenceVeryHigh, Fix: api.FixSemantic,
 			Needs: api.NeedsTypeInfo |
 				api.NeedsOracleCallTargets |
 				api.NeedsOracleDiagnostics,
@@ -45,7 +45,7 @@ func registerPotentialbugsNullsafetyCastsRules() {
 		r := &CastNullableToNonNullableTypeRule{BaseRule: BaseRule{RuleName: "CastNullableToNonNullableType", RuleSetName: "potential-bugs", Sev: "warning", Desc: "Detects casting a nullable expression to a non-nullable type using 'as Type'."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"as_expression"}, Confidence: 0.75, Fix: api.FixIdiomatic,
+			NodeTypes: []string{"as_expression"}, Confidence: api.ConfidenceMedium, Fix: api.FixIdiomatic,
 			Needs:                  api.NeedsTypeInfo | api.NeedsOracleExprType,
 			TypeInfo:               api.TypeInfoHint{PreferBackend: api.PreferAny, Required: true},
 			ExprPositions:          r.ExpressionPositions,
@@ -58,7 +58,7 @@ func registerPotentialbugsNullsafetyCastsRules() {
 		r := &CastToNullableTypeRule{BaseRule: BaseRule{RuleName: "CastToNullableType", RuleSetName: "potential-bugs", Sev: "warning", Desc: "Detects casts to nullable types like 'as Type?' which always succeed and may hide bugs."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"as_expression"}, Confidence: 0.75, Fix: api.FixIdiomatic, Implementation: r,
+			NodeTypes: []string{"as_expression"}, Confidence: api.ConfidenceMedium, Fix: api.FixIdiomatic, Implementation: r,
 			Check: r.check,
 		})
 	}

--- a/internal/rules/registry_potentialbugs_nullsafety_redundant.go
+++ b/internal/rules/registry_potentialbugs_nullsafety_redundant.go
@@ -11,7 +11,7 @@ func registerPotentialbugsNullsafetyRedundantRules() {
 		r := &UnnecessaryNotNullCheckRule{BaseRule: BaseRule{RuleName: "UnnecessaryNotNullCheck", RuleSetName: "potential-bugs", Sev: "warning", Desc: "Detects unnecessary null checks on expressions that are already non-nullable."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"equality_expression"}, Confidence: 0.75, Fix: api.FixIdiomatic, Implementation: r,
+			NodeTypes: []string{"equality_expression"}, Confidence: api.ConfidenceMedium, Fix: api.FixIdiomatic, Implementation: r,
 			Needs:         api.NeedsResolver,
 			Check:         r.check,
 			ExprPositions: r.ExpressionPositions,
@@ -21,7 +21,7 @@ func registerPotentialbugsNullsafetyRedundantRules() {
 		r := &UnnecessaryNotNullOperatorRule{BaseRule: BaseRule{RuleName: "UnnecessaryNotNullOperator", RuleSetName: "potential-bugs", Sev: "warning", Desc: "Detects the !! operator applied to expressions that are already non-nullable."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"postfix_expression"}, Confidence: 0.75, Fix: api.FixIdiomatic,
+			NodeTypes: []string{"postfix_expression"}, Confidence: api.ConfidenceMedium, Fix: api.FixIdiomatic,
 			Needs:          api.NeedsResolver,
 			Implementation: r,
 			Check:          r.check,
@@ -32,7 +32,7 @@ func registerPotentialbugsNullsafetyRedundantRules() {
 		r := &UnnecessarySafeCallRule{BaseRule: BaseRule{RuleName: "UnnecessarySafeCall", RuleSetName: "potential-bugs", Sev: "warning", Desc: "Detects the ?. safe-call operator applied to expressions that are already non-nullable."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"navigation_expression"}, Confidence: 0.75, Fix: api.FixIdiomatic,
+			NodeTypes: []string{"navigation_expression"}, Confidence: api.ConfidenceMedium, Fix: api.FixIdiomatic,
 			Needs: api.NeedsResolver, Implementation: r,
 			Check:         r.check,
 			ExprPositions: r.ExpressionPositions,
@@ -64,7 +64,7 @@ func registerPotentialbugsNullsafetyRedundantRules() {
 		r := &NullableToStringCallRule{BaseRule: BaseRule{RuleName: "NullableToStringCall", RuleSetName: "potential-bugs", Sev: "warning", Desc: "Detects .toString() calls on nullable receivers that may produce the string \"null\"."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"call_expression", "string_literal"}, Confidence: 0.75,
+			NodeTypes: []string{"call_expression", "string_literal"}, Confidence: api.ConfidenceMedium,
 			Needs:             api.NeedsTypeInfo | api.NeedsOracleCallTargets,
 			Oracle:            &api.OracleFilter{Identifiers: []string{"toString", "$"}},
 			Implementation:    r,

--- a/internal/rules/registry_potentialbugs_properties.go
+++ b/internal/rules/registry_potentialbugs_properties.go
@@ -15,7 +15,7 @@ func registerPotentialbugsPropertiesRules() {
 		r := &PropertyUsedBeforeDeclarationRule{BaseRule: BaseRule{RuleName: "PropertyUsedBeforeDeclaration", RuleSetName: "potential-bugs", Sev: "warning", Desc: "Detects class properties referenced in initializers or init blocks before they are declared."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"class_body"}, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"class_body"}, Confidence: api.ConfidenceMedium, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				type propInfo struct {
@@ -104,7 +104,7 @@ func registerPotentialbugsPropertiesRules() {
 		r := &UnconditionalJumpStatementInLoopRule{BaseRule: BaseRule{RuleName: "UnconditionalJumpStatementInLoop", RuleSetName: "potential-bugs", Sev: "warning", Desc: "Detects loops containing an unconditional return, break, or throw that causes the loop to execute only once."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"for_statement", "while_statement", "do_while_statement"}, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"for_statement", "while_statement", "do_while_statement"}, Confidence: api.ConfidenceMedium, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				body, _ := file.FlatFindChild(idx, "statements")
@@ -146,7 +146,7 @@ func registerPotentialbugsPropertiesRules() {
 		r := &UnnamedParameterUseRule{BaseRule: BaseRule{RuleName: "UnnamedParameterUse", RuleSetName: "potential-bugs", Sev: "warning", Desc: "Detects function calls with many unnamed parameters where named parameters would improve readability."}, AllowSingleParamUse: true}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"call_expression"}, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"call_expression"}, Confidence: api.ConfidenceMedium, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				if scanner.IsTestFile(file.Path) || isGradleBuildScript(file.Path) {
@@ -193,7 +193,7 @@ func registerPotentialbugsPropertiesRules() {
 		r := &UnusedUnaryOperatorRule{BaseRule: BaseRule{RuleName: "UnusedUnaryOperator", RuleSetName: "potential-bugs", Sev: "warning", Desc: "Detects standalone unary +x or -x expressions whose result is never used."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"prefix_expression"}, Confidence: 0.75, Fix: api.FixSemantic, Implementation: r,
+			NodeTypes: []string{"prefix_expression"}, Confidence: api.ConfidenceMedium, Fix: api.FixSemantic, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				if file.FlatChildCount(idx) < 2 {

--- a/internal/rules/registry_potentialbugs_smartcast.go
+++ b/internal/rules/registry_potentialbugs_smartcast.go
@@ -11,7 +11,7 @@ func registerPotentialbugsSmartCastRules() {
 		r := &SmartCastInvalidatedRule{BaseRule: BaseRule{RuleName: "SmartCastInvalidated", RuleSetName: "potential-bugs", Sev: "error", Desc: "Detects smart-cast variables that are reassigned and then used without re-checking, which the compiler reports as SMARTCAST_IMPOSSIBLE."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"if_expression"}, Confidence: 0.85, Implementation: r,
+			NodeTypes: []string{"if_expression"}, Confidence: api.ConfidenceHigh, Implementation: r,
 			Tags:  []string{"precompile"},
 			Check: r.check,
 		})

--- a/internal/rules/registry_potentialbugs_types.go
+++ b/internal/rules/registry_potentialbugs_types.go
@@ -19,7 +19,7 @@ func registerPotentialbugsTypesRules() {
 		}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"equality_expression"}, Confidence: 0.75, Fix: api.FixIdiomatic, Implementation: r,
+			NodeTypes: []string{"equality_expression"}, Confidence: api.ConfidenceMedium, Fix: api.FixIdiomatic, Implementation: r,
 			Needs: api.NeedsResolver,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
@@ -138,7 +138,7 @@ func registerPotentialbugsTypesRules() {
 		r := &DoubleMutabilityForCollectionRule{BaseRule: BaseRule{RuleName: "DoubleMutabilityForCollection", RuleSetName: "potential-bugs", Sev: "warning", Desc: "Detects var declarations with mutable collection types, creating double mutability."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"property_declaration"}, Confidence: 0.75, Fix: api.FixIdiomatic, Implementation: r,
+			NodeTypes: []string{"property_declaration"}, Confidence: api.ConfidenceMedium, Fix: api.FixIdiomatic, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				if scanner.IsTestFile(file.Path) {
@@ -181,7 +181,7 @@ func registerPotentialbugsTypesRules() {
 		r := &EqualsAlwaysReturnsTrueOrFalseRule{BaseRule: BaseRule{RuleName: "EqualsAlwaysReturnsTrueOrFalse", RuleSetName: "potential-bugs", Sev: "warning", Desc: "Detects equals() implementations that always return true or always return false."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"function_declaration"}, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"function_declaration"}, Confidence: api.ConfidenceMedium, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				name := extractIdentifierFlat(file, idx)
@@ -230,7 +230,7 @@ func registerPotentialbugsTypesRules() {
 		r := &EqualsWithHashCodeExistRule{BaseRule: BaseRule{RuleName: "EqualsWithHashCodeExist", RuleSetName: "potential-bugs", Sev: "warning", Desc: "Detects classes that override equals() without hashCode() or vice versa."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"class_declaration"}, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"class_declaration"}, Confidence: api.ConfidenceMedium, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				body, _ := file.FlatFindChild(idx, "class_body")
@@ -274,7 +274,7 @@ func registerPotentialbugsTypesRules() {
 		r := &WrongEqualsTypeParameterRule{BaseRule: BaseRule{RuleName: "WrongEqualsTypeParameter", RuleSetName: "potential-bugs", Sev: "warning", Desc: "Detects equals() with a parameter type other than Any?, which does not properly override the contract."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"function_declaration"}, Confidence: 0.85, Fix: api.FixIdiomatic, Implementation: r,
+			NodeTypes: []string{"function_declaration"}, Confidence: api.ConfidenceHigh, Fix: api.FixIdiomatic, Implementation: r,
 			Check: r.check,
 		})
 	}
@@ -300,7 +300,7 @@ func registerPotentialbugsTypesRules() {
 		r := &ImplicitUnitReturnTypeRule{BaseRule: BaseRule{RuleName: "ImplicitUnitReturnType", RuleSetName: "potential-bugs", Sev: "warning", Desc: "Detects block-body functions that implicitly return Unit without an explicit return type."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"function_declaration"}, Confidence: 0.75, Fix: api.FixIdiomatic, Implementation: r,
+			NodeTypes: []string{"function_declaration"}, Confidence: api.ConfidenceMedium, Fix: api.FixIdiomatic, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				if scanner.IsTestFile(file.Path) || file.FlatHasModifier(idx, "override") {
@@ -355,7 +355,7 @@ func registerPotentialbugsTypesRules() {
 		r := &NoElseInWhenSealedRule{BaseRule: BaseRule{RuleName: "NoElseInWhenSealed", RuleSetName: "potential-bugs", Sev: "warning", Desc: "Detects when expressions on sealed classes or enums that are missing variants and have no else branch."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"when_expression"}, Confidence: 0.9, Implementation: r,
+			NodeTypes: []string{"when_expression"}, Confidence: api.ConfidenceHigher, Implementation: r,
 			Needs: api.NeedsResolver,
 			Tags:  []string{"precompile"},
 			Check: func(ctx *api.Context) {
@@ -383,7 +383,7 @@ func registerPotentialbugsTypesRules() {
 		r := &NonExhaustiveWhenRule{BaseRule: BaseRule{RuleName: "NonExhaustiveWhen", RuleSetName: "potential-bugs", Sev: "warning", Desc: "Detects 'when' used as an expression on a sealed/enum/Boolean subject without an else branch and missing one or more variants."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"when_expression"}, Confidence: 0.9, Implementation: r,
+			NodeTypes: []string{"when_expression"}, Confidence: api.ConfidenceHigher, Implementation: r,
 			Needs: api.NeedsResolver,
 			Tags:  []string{"precompile"},
 			Check: func(ctx *api.Context) {
@@ -432,7 +432,7 @@ func registerPotentialbugsTypesRules() {
 		r := &ElseCaseInsteadOfExhaustiveWhenRule{BaseRule: BaseRule{RuleName: "ElseCaseInsteadOfExhaustiveWhen", RuleSetName: "potential-bugs", Sev: "warning", Desc: "Detects when expressions on sealed classes or enums that use an else branch instead of exhaustive matching."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"when_expression"}, Confidence: 0.75, Fix: api.FixIdiomatic, Implementation: r,
+			NodeTypes: []string{"when_expression"}, Confidence: api.ConfidenceMedium, Fix: api.FixIdiomatic, Implementation: r,
 			Needs: api.NeedsResolver,
 			Tags:  []string{"precompile"},
 			Check: func(ctx *api.Context) {

--- a/internal/rules/registry_privacy_analytics.go
+++ b/internal/rules/registry_privacy_analytics.go
@@ -11,7 +11,7 @@ func registerPrivacyAnalyticsRules() {
 		r := &AnalyticsEventWithPiiParamNameRule{BaseRule: BaseRule{RuleName: "AnalyticsEventWithPiiParamName", RuleSetName: privacyRuleSet, Sev: "warning", Desc: "Detects analytics event parameters whose key names match PII patterns like email, phone, or SSN."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"call_expression"}, Needs: api.NeedsResolver, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"call_expression"}, Needs: api.NeedsResolver, Confidence: api.ConfidenceMedium, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				name := flatCallExpressionName(file, idx)
@@ -65,7 +65,7 @@ func registerPrivacyAnalyticsRules() {
 		r := &AnalyticsUserIDFromPiiRule{BaseRule: BaseRule{RuleName: "AnalyticsUserIdFromPii", RuleSetName: privacyRuleSet, Sev: "warning", Desc: "Detects user-ID setter calls whose argument is a PII property like email or phoneNumber."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"call_expression"}, Needs: api.NeedsResolver, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"call_expression"}, Needs: api.NeedsResolver, Confidence: api.ConfidenceMedium, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				name := flatCallExpressionName(file, idx)
@@ -100,7 +100,7 @@ func registerPrivacyAnalyticsRules() {
 		r := &CrashlyticsCustomKeyWithPiiRule{BaseRule: BaseRule{RuleName: "CrashlyticsCustomKeyWithPii", RuleSetName: privacyRuleSet, Sev: "warning", Desc: "Detects Crashlytics setCustomKey calls where the key name matches PII patterns."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"call_expression"}, Needs: api.NeedsResolver, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"call_expression"}, Needs: api.NeedsResolver, Confidence: api.ConfidenceMedium, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				if flatCallExpressionName(file, idx) != "setCustomKey" {
@@ -136,7 +136,7 @@ func registerPrivacyAnalyticsRules() {
 		r := &FirebaseRemoteConfigDefaultsWithPiiRule{BaseRule: BaseRule{RuleName: "FirebaseRemoteConfigDefaultsWithPii", RuleSetName: privacyRuleSet, Sev: "info", Desc: "Detects Firebase Remote Config default map keys that match PII patterns."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"call_expression"}, Needs: api.NeedsResolver, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"call_expression"}, Needs: api.NeedsResolver, Confidence: api.ConfidenceMedium, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				name := flatCallExpressionName(file, idx)
@@ -169,7 +169,7 @@ func registerPrivacyAnalyticsRules() {
 		r := &AnalyticsCallWithoutConsentGateRule{BaseRule: BaseRule{RuleName: "AnalyticsCallWithoutConsentGate", RuleSetName: privacyRuleSet, Sev: "info", Desc: "Detects analytics event calls that are not guarded by a consent or GDPR check."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"call_expression"}, Needs: api.NeedsResolver, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"call_expression"}, Needs: api.NeedsResolver, Confidence: api.ConfidenceMedium, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				name := flatCallExpressionName(file, idx)

--- a/internal/rules/registry_privacy_permissions.go
+++ b/internal/rules/registry_privacy_permissions.go
@@ -11,7 +11,7 @@ func registerPrivacyPermissionsRules() {
 		r := &AdMobInitializedBeforeConsentRule{BaseRule: BaseRule{RuleName: "AdMobInitializedBeforeConsent", RuleSetName: privacyRuleSet, Sev: "warning", Desc: "Detects MobileAds.initialize() in Application.onCreate before any consent info update call."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Description(), Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"call_expression"}, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"call_expression"}, Confidence: api.ConfidenceMedium, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				navExpr, _ := flatCallExpressionParts(file, idx)
@@ -41,7 +41,7 @@ func registerPrivacyPermissionsRules() {
 		r := &BiometricAuthNotFallingBackToDeviceCredentialRule{BaseRule: BaseRule{RuleName: "BiometricAuthNotFallingBackToDeviceCredential", RuleSetName: privacyRuleSet, Sev: "info", Desc: "Detects BiometricPrompt.authenticate() calls whose PromptInfo lacks device credential fallback."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Description(), Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"call_expression"}, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"call_expression"}, Confidence: api.ConfidenceMedium, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				if !biometricAuthenticateReceiverMatchesFlat(file, idx) {
@@ -68,7 +68,7 @@ func registerPrivacyPermissionsRules() {
 		r := &ContactsAccessWithoutPermissionUIRule{BaseRule: BaseRule{RuleName: "ContactsAccessWithoutPermissionUi", RuleSetName: privacyRuleSet, Sev: "warning", Desc: "Detects contacts queries not gated behind a RequestPermission activity-result callback."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Description(), Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"call_expression"}, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"call_expression"}, Confidence: api.ConfidenceMedium, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				if flatCallExpressionName(file, idx) != "query" {
@@ -104,7 +104,7 @@ func registerPrivacyPermissionsRules() {
 		r := &LocationBackgroundWithoutRationaleRule{BaseRule: BaseRule{RuleName: "LocationBackgroundWithoutRationale", RuleSetName: privacyRuleSet, Sev: "warning", Desc: "Detects ACCESS_BACKGROUND_LOCATION requests without a shouldShowRequestPermissionRationale call."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Description(), Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"call_expression"}, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"call_expression"}, Confidence: api.ConfidenceMedium, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				name := flatCallExpressionName(file, idx)
@@ -130,7 +130,7 @@ func registerPrivacyPermissionsRules() {
 		r := &ScreenshotNotBlockedOnLoginScreenRule{BaseRule: BaseRule{RuleName: "ScreenshotNotBlockedOnLoginScreen", RuleSetName: privacyRuleSet, Sev: "warning", Desc: "Detects sensitive screens (login, payment, PIN) that do not set FLAG_SECURE to block screenshots."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Description(), Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"class_declaration", "function_declaration"}, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"class_declaration", "function_declaration"}, Confidence: api.ConfidenceMedium, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				nodeType := file.FlatType(idx)
@@ -172,7 +172,7 @@ func registerPrivacyPermissionsRules() {
 		r := &ClipboardOnSensitiveInputTypeRule{BaseRule: BaseRule{RuleName: "ClipboardOnSensitiveInputType", RuleSetName: privacyRuleSet, Sev: "warning", Desc: "Detects clipboard writes from variables whose names suggest passwords or credentials."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Description(), Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"call_expression"}, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"call_expression"}, Confidence: api.ConfidenceMedium, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				if flatCallExpressionName(file, idx) != "setPrimaryClip" {

--- a/internal/rules/registry_privacy_storage.go
+++ b/internal/rules/registry_privacy_storage.go
@@ -11,7 +11,7 @@ func registerPrivacyStorageRules() {
 		r := &SharedPreferencesForSensitiveKeyRule{BaseRule: BaseRule{RuleName: "SharedPreferencesForSensitiveKey", RuleSetName: privacyRuleSet, Sev: "warning", Desc: "Detects SharedPreferences put calls with key names matching sensitive patterns like token, password, or secret."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"call_expression"}, Needs: api.NeedsResolver, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"call_expression"}, Needs: api.NeedsResolver, Confidence: api.ConfidenceMedium, Implementation: r,
 			TypeInfo: api.TypeInfoHint{PreferBackend: api.PreferResolver, Required: true},
 			Check:    r.check,
 		})
@@ -20,7 +20,7 @@ func registerPrivacyStorageRules() {
 		r := &PlainFileWriteOfSensitiveRule{BaseRule: BaseRule{RuleName: "PlainFileWriteOfSensitive", RuleSetName: privacyRuleSet, Sev: "warning", Desc: "Detects plain-file writes to paths containing sensitive terms without using EncryptedFile."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"call_expression"}, Needs: api.NeedsResolver, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"call_expression"}, Needs: api.NeedsResolver, Confidence: api.ConfidenceMedium, Implementation: r,
 			TypeInfo: api.TypeInfoHint{PreferBackend: api.PreferResolver, Required: true},
 			Check:    r.check,
 		})
@@ -29,7 +29,7 @@ func registerPrivacyStorageRules() {
 		r := &LogOfSharedPreferenceReadRule{BaseRule: BaseRule{RuleName: "LogOfSharedPreferenceRead", RuleSetName: privacyRuleSet, Sev: "warning", Desc: "Detects logger calls that directly pass SharedPreferences values with sensitive keys."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"call_expression"}, Needs: api.NeedsResolver, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"call_expression"}, Needs: api.NeedsResolver, Confidence: api.ConfidenceMedium, Implementation: r,
 			TypeInfo: api.TypeInfoHint{PreferBackend: api.PreferResolver, Required: true},
 			Check:    r.check,
 		})

--- a/internal/rules/registry_release_engineering.go
+++ b/internal/rules/registry_release_engineering.go
@@ -17,7 +17,7 @@ func registerReleaseEngineeringRules() {
 		r := &BuildConfigDebugInLibraryRule{BaseRule: BaseRule{RuleName: "BuildConfigDebugInLibrary", RuleSetName: releaseEngineeringRuleSet, Sev: "warning", Desc: "Detects BuildConfig.DEBUG references inside Android library modules where the value is always false in release."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"navigation_expression"}, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"navigation_expression"}, Confidence: api.ConfidenceMedium, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				if !isBuildConfigDebugReferenceFlat(file, idx) {
@@ -34,7 +34,7 @@ func registerReleaseEngineeringRules() {
 		r := &BuildConfigDebugInvertedRule{BaseRule: BaseRule{RuleName: "BuildConfigDebugInverted", RuleSetName: releaseEngineeringRuleSet, Sev: "warning", Desc: "Detects negated BuildConfig.DEBUG guards wrapping logging calls that likely invert a debug-only check."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"if_expression"}, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"if_expression"}, Confidence: api.ConfidenceMedium, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				condition, body := ifConditionAndThenBodyFlat(file, idx)
@@ -52,7 +52,7 @@ func registerReleaseEngineeringRules() {
 		r := &AllProjectsBlockRule{BaseRule: BaseRule{RuleName: "AllProjectsBlock", RuleSetName: releaseEngineeringRuleSet, Sev: "warning", Desc: "Detects deprecated allprojects {} blocks in Gradle build scripts."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"call_expression"}, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"call_expression"}, Confidence: api.ConfidenceMedium, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				if !isGradleBuildScript(file.Path) {
@@ -69,7 +69,7 @@ func registerReleaseEngineeringRules() {
 		r := &HardcodedEnvironmentNameRule{BaseRule: BaseRule{RuleName: "HardcodedEnvironmentName", RuleSetName: releaseEngineeringRuleSet, Sev: "warning", Desc: "Detects hardcoded environment names like 'dev', 'staging', or 'prod' passed to config APIs."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"call_expression"}, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"call_expression"}, Confidence: api.ConfidenceMedium, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				funcName := flatCallExpressionName(file, idx)
@@ -100,7 +100,7 @@ func registerReleaseEngineeringRules() {
 		r := &DebugToastInProductionRule{BaseRule: BaseRule{RuleName: "DebugToastInProduction", RuleSetName: releaseEngineeringRuleSet, Sev: "warning", Desc: "Detects Toast.makeText calls whose message starts with debug-related prefixes in production code."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"call_expression"}, Confidence: 0.85, Implementation: r,
+			NodeTypes: []string{"call_expression"}, Confidence: api.ConfidenceHigh, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				if scanner.IsTestFile(file.Path) {
@@ -141,7 +141,7 @@ func registerReleaseEngineeringRules() {
 		r := &PrintlnInProductionRule{BaseRule: BaseRule{RuleName: "PrintlnInProduction", RuleSetName: releaseEngineeringRuleSet, Sev: "warning", Desc: "Detects println or print calls in production code that should use a logging framework."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"call_expression"}, Confidence: 0.85, Implementation: r,
+			NodeTypes: []string{"call_expression"}, Confidence: api.ConfidenceHigh, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				if printlnNonProductionPath(file.Path) {
@@ -174,7 +174,7 @@ func registerReleaseEngineeringRules() {
 		r := &PrintStackTraceInProductionRule{BaseRule: BaseRule{RuleName: "PrintStackTraceInProduction", RuleSetName: releaseEngineeringRuleSet, Sev: "warning", Desc: "Detects printStackTrace() calls in code that has a logging framework available."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"call_expression"}, Confidence: 0.85, Implementation: r,
+			NodeTypes: []string{"call_expression"}, Confidence: api.ConfidenceHigh, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				if scanner.IsTestFile(file.Path) {
@@ -195,7 +195,7 @@ func registerReleaseEngineeringRules() {
 		r := &NonASCIIIdentifierRule{BaseRule: BaseRule{RuleName: "NonAsciiIdentifier", RuleSetName: releaseEngineeringRuleSet, Sev: "info", Desc: "Detects class, function, or property names containing non-ASCII characters."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"class_declaration", "function_declaration", "property_declaration"}, Confidence: 0.95, Implementation: r,
+			NodeTypes: []string{"class_declaration", "function_declaration", "property_declaration"}, Confidence: api.ConfidenceVeryHigh, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				if scanner.IsTestFile(file.Path) {
@@ -226,7 +226,7 @@ func registerReleaseEngineeringRules() {
 		r := &HardcodedLogTagRule{BaseRule: BaseRule{RuleName: "HardcodedLogTag", RuleSetName: releaseEngineeringRuleSet, Sev: "info", Desc: "Detects Log tag string literals matching the enclosing class name instead of using a companion TAG constant."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"call_expression"}, Confidence: 0.80, Implementation: r,
+			NodeTypes: []string{"call_expression"}, Confidence: api.ConfidenceMediumHigh, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				name := flatCallExpressionName(file, idx)

--- a/internal/rules/registry_resource_cost.go
+++ b/internal/rules/registry_resource_cost.go
@@ -16,7 +16,7 @@ func registerResourceCostRules() {
 		r := &BufferedReadWithoutBufferRule{BaseRule: BaseRule{RuleName: "BufferedReadWithoutBuffer", RuleSetName: "resource-cost", Sev: "info", Desc: "Detects FileInputStream.read() without BufferedInputStream wrapping for efficient reads."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"call_expression", "method_invocation"}, Languages: []scanner.Language{scanner.LangKotlin, scanner.LangJava}, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"call_expression", "method_invocation"}, Languages: []scanner.Language{scanner.LangKotlin, scanner.LangJava}, Confidence: api.ConfidenceMedium, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				name := databaseCallName(file, idx)
@@ -41,7 +41,7 @@ func registerResourceCostRules() {
 		r := &CursorLoopWithColumnIndexInLoopRule{BaseRule: BaseRule{RuleName: "CursorLoopWithColumnIndexInLoop", RuleSetName: "resource-cost", Sev: "warning", Desc: "Detects getColumnIndex() calls inside cursor while-loops that should be hoisted before the loop."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"while_statement"}, Languages: []scanner.Language{scanner.LangKotlin, scanner.LangJava}, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"while_statement"}, Languages: []scanner.Language{scanner.LangKotlin, scanner.LangJava}, Confidence: api.ConfidenceMedium, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				if !whileConditionHasCallName(file, idx, "moveToNext") {
@@ -87,7 +87,7 @@ func registerResourceCostRules() {
 		r := &OkHTTPClientCreatedPerCallRule{BaseRule: BaseRule{RuleName: "OkHttpClientCreatedPerCall", RuleSetName: "resource-cost", Sev: "warning", Desc: "Detects OkHttpClient construction in function bodies instead of reusing a singleton instance."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"call_expression", "method_invocation", "object_creation_expression"}, Languages: []scanner.Language{scanner.LangKotlin, scanner.LangJava}, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"call_expression", "method_invocation", "object_creation_expression"}, Languages: []scanner.Language{scanner.LangKotlin, scanner.LangJava}, Confidence: api.ConfidenceMedium, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				if scanner.IsTestFile(file.Path) {
@@ -139,7 +139,7 @@ func registerResourceCostRules() {
 		r := &OkHTTPCallExecuteSyncRule{BaseRule: BaseRule{RuleName: "OkHttpCallExecuteSync", RuleSetName: "resource-cost", Sev: "warning", Desc: "Detects synchronous OkHttp Call.execute() inside suspend functions that block the coroutine thread."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"call_expression"}, Languages: []scanner.Language{scanner.LangKotlin, scanner.LangJava}, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"call_expression"}, Languages: []scanner.Language{scanner.LangKotlin, scanner.LangJava}, Confidence: api.ConfidenceMedium, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				name := flatCallExpressionName(file, idx)
@@ -172,7 +172,7 @@ func registerResourceCostRules() {
 		r := &RetrofitCreateInHotPathRule{BaseRule: BaseRule{RuleName: "RetrofitCreateInHotPath", RuleSetName: "resource-cost", Sev: "warning", Desc: "Detects Retrofit.Builder().build().create() in function bodies instead of a singleton or @Provides."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"call_expression", "method_invocation"}, Languages: []scanner.Language{scanner.LangKotlin, scanner.LangJava}, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"call_expression", "method_invocation"}, Languages: []scanner.Language{scanner.LangKotlin, scanner.LangJava}, Confidence: api.ConfidenceMedium, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				name := databaseCallName(file, idx)
@@ -207,7 +207,7 @@ func registerResourceCostRules() {
 		r := &HTTPClientNotReusedRule{BaseRule: BaseRule{RuleName: "HttpClientNotReused", RuleSetName: "resource-cost", Sev: "warning", Desc: "Detects Java HttpClient.newHttpClient() in function bodies without singleton reuse."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"call_expression", "method_invocation"}, Languages: []scanner.Language{scanner.LangKotlin, scanner.LangJava}, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"call_expression", "method_invocation"}, Languages: []scanner.Language{scanner.LangKotlin, scanner.LangJava}, Confidence: api.ConfidenceMedium, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				name := databaseCallName(file, idx)
@@ -238,7 +238,7 @@ func registerResourceCostRules() {
 		r := &DatabaseQueryOnMainThreadRule{BaseRule: BaseRule{RuleName: "DatabaseQueryOnMainThread", RuleSetName: "resource-cost", Sev: "warning", Desc: "Detects SQLiteDatabase query calls in code with positive main-thread evidence."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			Needs: api.NeedsParsedFiles, Confidence: 0.75, Implementation: r,
+			Needs: api.NeedsParsedFiles, Confidence: api.ConfidenceMedium, Implementation: r,
 			NeedsLibraryFacts: true,
 			Check:             r.checkParsedFiles,
 		})
@@ -247,7 +247,7 @@ func registerResourceCostRules() {
 		r := &RoomLoadsAllWhereFirstUsedRule{BaseRule: BaseRule{RuleName: "RoomLoadsAllWhereFirstUsed", RuleSetName: "resource-cost", Sev: "warning", Desc: "Detects getAll().first() patterns that load an entire table for a single element instead of using LIMIT 1."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			Needs: api.NeedsParsedFiles, Confidence: 0.75, Implementation: r,
+			Needs: api.NeedsParsedFiles, Confidence: api.ConfidenceMedium, Implementation: r,
 			NeedsLibraryFacts: true,
 			Check:             r.checkParsedFiles,
 		})
@@ -315,7 +315,7 @@ func registerResourceCostRules() {
 		r := &LazyColumnInsideColumnRule{BaseRule: BaseRule{RuleName: "LazyColumnInsideColumn", RuleSetName: "resource-cost", Sev: "warning", Desc: "Detects LazyColumn or LazyRow nested inside a scrollable Column or Row causing measurement issues."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"call_expression"}, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"call_expression"}, Confidence: api.ConfidenceMedium, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				name := flatCallNameAny(file, idx)
@@ -352,7 +352,7 @@ func registerResourceCostRules() {
 		r := &RecyclerViewInLazyColumnRule{BaseRule: BaseRule{RuleName: "RecyclerViewInLazyColumn", RuleSetName: "resource-cost", Sev: "warning", Desc: "Detects AndroidView wrapping a RecyclerView inside a LazyColumn or LazyRow causing nested scrolling conflicts."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"call_expression"}, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"call_expression"}, Confidence: api.ConfidenceMedium, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				name := flatCallNameAny(file, idx)
@@ -430,7 +430,7 @@ func registerResourceCostRules() {
 		r := &ImageLoaderNoMemoryCacheRule{BaseRule: BaseRule{RuleName: "ImageLoaderNoMemoryCache", RuleSetName: "resource-cost", Sev: "info", Desc: "Detects image loaders configured to skip the memory cache, causing repeated decoding and GC pressure."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"call_expression"}, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"call_expression"}, Confidence: api.ConfidenceMedium, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				name := flatCallExpressionName(file, idx)
@@ -449,7 +449,7 @@ func registerResourceCostRules() {
 		r := &ComposePainterResourceInLoopRule{BaseRule: BaseRule{RuleName: "ComposePainterResourceInLoop", RuleSetName: "resource-cost", Sev: "warning", Desc: "Detects painterResource() calls inside list or loop lambdas that create a fresh painter per iteration."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"call_expression"}, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"call_expression"}, Confidence: api.ConfidenceMedium, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				name := flatCallExpressionName(file, idx)
@@ -471,7 +471,7 @@ func registerResourceCostRules() {
 		r := &ComposeRememberInListRule{BaseRule: BaseRule{RuleName: "ComposeRememberInList", RuleSetName: "resource-cost", Sev: "warning", Desc: "Detects remember {} inside items {} without a key argument, causing recomputation on list reorder."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"call_expression"}, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"call_expression"}, Confidence: api.ConfidenceMedium, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				name := flatCallExpressionName(file, idx)
@@ -501,7 +501,7 @@ func registerResourceCostRules() {
 		r := &PeriodicWorkRequestLessThan15MinRule{BaseRule: BaseRule{RuleName: "PeriodicWorkRequestLessThan15Min", RuleSetName: "resource-cost", Sev: "warning", Desc: "Detects PeriodicWorkRequest intervals below the 15-minute minimum enforced by WorkManager."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"call_expression"}, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"call_expression"}, Confidence: api.ConfidenceMedium, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				name := flatCallExpressionName(file, idx)
@@ -544,7 +544,7 @@ func registerResourceCostRules() {
 		r := &WorkManagerNoBackoffRule{BaseRule: BaseRule{RuleName: "WorkManagerNoBackoff", RuleSetName: "resource-cost", Sev: "info", Desc: "Detects OneTimeWorkRequest chains without a setBackoffCriteria policy for retryable work."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"call_expression"}, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"call_expression"}, Confidence: api.ConfidenceMedium, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				name := flatCallExpressionName(file, idx)
@@ -569,7 +569,7 @@ func registerResourceCostRules() {
 		r := &WorkManagerUniquePolicyKeepButReplaceIntendedRule{BaseRule: BaseRule{RuleName: "WorkManagerUniquePolicyKeepButReplaceIntended", RuleSetName: "resource-cost", Sev: "info", Desc: "Detects enqueueUniqueWork with KEEP policy followed by cancel logic where REPLACE may be intended."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"call_expression"}, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"call_expression"}, Confidence: api.ConfidenceMedium, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				name := flatCallExpressionName(file, idx)

--- a/internal/rules/registry_security.go
+++ b/internal/rules/registry_security.go
@@ -297,7 +297,7 @@ func registerSecurityRules() {
 		r := &FileFromUntrustedPathRule{BaseRule: BaseRule{RuleName: "FileFromUntrustedPath", RuleSetName: "security", Sev: "info", Desc: "Detects File construction from untrusted input in extraction or download functions without path traversal guards."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"call_expression"}, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"call_expression"}, Confidence: api.ConfidenceMedium, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				if flatCallExpressionName(file, idx) != "File" {
@@ -340,7 +340,7 @@ func registerSecurityRules() {
 		r := &ZipSlipUncheckedRule{BaseRule: BaseRule{RuleName: "ZipSlipUnchecked", RuleSetName: "security", Sev: "info", Desc: "Detects zip extraction loops that build a destination File from an entry name without a canonical-path containment check."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"call_expression"}, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"call_expression"}, Confidence: api.ConfidenceMedium, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				name := flatCallExpressionName(file, idx)
@@ -384,7 +384,7 @@ func registerSecurityRules() {
 		r := &HardcodedGcpServiceAccountRule{BaseRule: BaseRule{RuleName: "HardcodedGcpServiceAccount", RuleSetName: "security", Sev: "warning", Desc: "Detects embedded GCP service-account JSON or private keys committed into source files."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"string_literal"}, Languages: []scanner.Language{scanner.LangKotlin, scanner.LangJava}, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"string_literal"}, Languages: []scanner.Language{scanner.LangKotlin, scanner.LangJava}, Confidence: api.ConfidenceMedium, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				lowerPath := strings.ToLower(file.Path)
@@ -404,7 +404,7 @@ func registerSecurityRules() {
 		r := &HardcodedBearerTokenRule{BaseRule: BaseRule{RuleName: "HardcodedBearerToken", RuleSetName: "security", Sev: "warning", Desc: "Detects bearer authorization strings with hardcoded tokens embedded directly in source code."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"string_literal"}, Languages: []scanner.Language{scanner.LangKotlin, scanner.LangJava}, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"string_literal"}, Languages: []scanner.Language{scanner.LangKotlin, scanner.LangJava}, Confidence: api.ConfidenceMedium, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				text := file.FlatNodeText(idx)

--- a/internal/rules/registry_style_braces.go
+++ b/internal/rules/registry_style_braces.go
@@ -11,7 +11,7 @@ func registerStyleBracesRules() {
 		r := &BracesOnIfStatementsRule{BaseRule: BaseRule{RuleName: "BracesOnIfStatements", RuleSetName: "style", Sev: "warning", Desc: "Detects if/else statements that are missing braces around their bodies."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"if_expression"}, Confidence: 0.75, Fix: api.FixCosmetic, Implementation: r,
+			NodeTypes: []string{"if_expression"}, Confidence: api.ConfidenceMedium, Fix: api.FixCosmetic, Implementation: r,
 			Check: r.check,
 		})
 	}
@@ -19,7 +19,7 @@ func registerStyleBracesRules() {
 		r := &BracesOnWhenStatementsRule{BaseRule: BaseRule{RuleName: "BracesOnWhenStatements", RuleSetName: "style", Sev: "warning", Desc: "Detects when branches that are missing braces around their bodies."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"when_entry"}, Confidence: 0.75, Fix: api.FixCosmetic, Implementation: r,
+			NodeTypes: []string{"when_entry"}, Confidence: api.ConfidenceMedium, Fix: api.FixCosmetic, Implementation: r,
 			Check: r.check,
 		})
 	}
@@ -27,7 +27,7 @@ func registerStyleBracesRules() {
 		r := &MandatoryBracesLoopsRule{BaseRule: BaseRule{RuleName: "MandatoryBracesLoops", RuleSetName: "style", Sev: "warning", Desc: "Detects for, while, and do-while loops that are missing braces around their bodies."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"for_statement", "while_statement", "do_while_statement"}, Confidence: 0.75, Fix: api.FixCosmetic, Implementation: r,
+			NodeTypes: []string{"for_statement", "while_statement", "do_while_statement"}, Confidence: api.ConfidenceMedium, Fix: api.FixCosmetic, Implementation: r,
 			Check: r.check,
 		})
 	}

--- a/internal/rules/registry_style_classes.go
+++ b/internal/rules/registry_style_classes.go
@@ -27,7 +27,7 @@ func registerStyleAbstractClassCanBeConcreteClass() {
 	r := &AbstractClassCanBeConcreteClassRule{BaseRule: BaseRule{RuleName: "AbstractClassCanBeConcreteClass", RuleSetName: "style", Sev: "warning", Desc: "Detects abstract classes that have no abstract members and could be made concrete."}}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"class_declaration"}, Confidence: 0.75, Fix: api.FixNone, Implementation: r,
+		NodeTypes: []string{"class_declaration"}, Confidence: api.ConfidenceMedium, Fix: api.FixNone, Implementation: r,
 		Needs: api.NeedsResolver,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
@@ -132,7 +132,7 @@ func registerStyleAbstractClassCanBeInterface() {
 	r := &AbstractClassCanBeInterfaceRule{BaseRule: BaseRule{RuleName: "AbstractClassCanBeInterface", RuleSetName: "style", Sev: "warning", Desc: "Detects abstract classes with no state that could be converted to interfaces."}}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"class_declaration"}, Confidence: 0.75, Fix: api.FixNone, Implementation: r,
+		NodeTypes: []string{"class_declaration"}, Confidence: api.ConfidenceMedium, Fix: api.FixNone, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			if !file.FlatHasModifier(idx, "abstract") {
@@ -181,7 +181,7 @@ func registerStyleDataClassShouldBeImmutable() {
 	r := &DataClassShouldBeImmutableRule{BaseRule: BaseRule{RuleName: "DataClassShouldBeImmutable", RuleSetName: "style", Sev: "warning", Desc: "Detects data class properties declared as var instead of val."}}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"class_declaration"}, Confidence: 0.75, Fix: api.FixIdiomatic, Implementation: r,
+		NodeTypes: []string{"class_declaration"}, Confidence: api.ConfidenceMedium, Fix: api.FixIdiomatic, Implementation: r,
 		Needs: api.NeedsResolver,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
@@ -246,7 +246,7 @@ func registerStyleDataClassContainsFunctions() {
 	r := &DataClassContainsFunctionsRule{BaseRule: BaseRule{RuleName: "DataClassContainsFunctions", RuleSetName: "style", Sev: "warning", Desc: "Detects data classes that contain function members."}, ConversionFunctionPrefix: []string{"to"}}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"class_declaration"}, Confidence: 0.75, Fix: api.FixSemantic, Implementation: r,
+		NodeTypes: []string{"class_declaration"}, Confidence: api.ConfidenceMedium, Fix: api.FixSemantic, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			if !file.FlatHasModifier(idx, "data") {
@@ -283,7 +283,7 @@ func registerStyleProtectedMemberInFinalClass() {
 	r := &ProtectedMemberInFinalClassRule{BaseRule: BaseRule{RuleName: "ProtectedMemberInFinalClass", RuleSetName: "style", Sev: "warning", Desc: "Detects protected members in final classes where they should be private."}}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"class_declaration"}, Confidence: 0.75, Fix: api.FixIdiomatic, Implementation: r,
+		NodeTypes: []string{"class_declaration"}, Confidence: api.ConfidenceMedium, Fix: api.FixIdiomatic, Implementation: r,
 		Needs: api.NeedsResolver,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
@@ -337,7 +337,7 @@ func registerStyleNestedClassesVisibility() {
 	r := &NestedClassesVisibilityRule{BaseRule: BaseRule{RuleName: "NestedClassesVisibility", RuleSetName: "style", Sev: "warning", Desc: "Detects nested classes with explicit public modifier inside internal parent classes."}}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"class_declaration"}, Confidence: 0.75, Fix: api.FixCosmetic, Implementation: r,
+		NodeTypes: []string{"class_declaration"}, Confidence: api.ConfidenceMedium, Fix: api.FixCosmetic, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			parent, ok := file.FlatParent(idx)
@@ -403,7 +403,7 @@ func registerStyleUtilityClassWithPublicConstructor() {
 	r := &UtilityClassWithPublicConstructorRule{BaseRule: BaseRule{RuleName: "UtilityClassWithPublicConstructor", RuleSetName: "style", Sev: "warning", Desc: "Detects utility classes that have a public constructor instead of a private one."}}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"class_declaration"}, Confidence: 0.75, Fix: api.FixIdiomatic, Implementation: r,
+		NodeTypes: []string{"class_declaration"}, Confidence: api.ConfidenceMedium, Fix: api.FixIdiomatic, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			nodeText := file.FlatNodeText(idx)
@@ -491,7 +491,7 @@ func registerStyleOptionalAbstractKeyword() {
 	r := &OptionalAbstractKeywordRule{BaseRule: BaseRule{RuleName: "OptionalAbstractKeyword", RuleSetName: "style", Sev: "warning", Desc: "Detects redundant abstract modifier on interface members where it is implied."}}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"class_declaration"}, Confidence: 0.75, Fix: api.FixCosmetic, Implementation: r,
+		NodeTypes: []string{"class_declaration"}, Confidence: api.ConfidenceMedium, Fix: api.FixCosmetic, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			if !file.FlatHasChildOfType(idx, "interface") {
@@ -558,7 +558,7 @@ func registerStyleClassOrdering() {
 	r := &ClassOrderingRule{BaseRule: BaseRule{RuleName: "ClassOrdering", RuleSetName: "style", Sev: "warning", Desc: "Detects class members that are not in the conventional ordering of properties, init blocks, constructors, functions, and companion objects."}}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"class_body"}, Confidence: 0.75, Implementation: r,
+		NodeTypes: []string{"class_body"}, Confidence: api.ConfidenceMedium, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			const (
@@ -601,7 +601,7 @@ func registerStyleObjectLiteralToLambda() {
 	r := &ObjectLiteralToLambdaRule{BaseRule: BaseRule{RuleName: "ObjectLiteralToLambda", RuleSetName: "style", Sev: "warning", Desc: "Detects object literals implementing a single method that could be converted to a lambda."}}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"object_literal"}, Confidence: 0.75, Implementation: r,
+		NodeTypes: []string{"object_literal"}, Confidence: api.ConfidenceMedium, Implementation: r,
 		Needs: api.NeedsResolver,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
@@ -657,7 +657,7 @@ func registerStyleSerialVersionUIDInSerializableClass() {
 	r := &SerialVersionUIDInSerializableClassRule{BaseRule: BaseRule{RuleName: "SerialVersionUIDInSerializableClass", RuleSetName: "style", Sev: "warning", Desc: "Detects Serializable classes that are missing a serialVersionUID field."}}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"class_declaration"}, Confidence: 0.75, Fix: api.FixIdiomatic, Implementation: r,
+		NodeTypes: []string{"class_declaration"}, Confidence: api.ConfidenceMedium, Fix: api.FixIdiomatic, Implementation: r,
 		Needs: api.NeedsResolver,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File

--- a/internal/rules/registry_style_expressions.go
+++ b/internal/rules/registry_style_expressions.go
@@ -28,7 +28,7 @@ func registerStyleExpressionBodySyntax() {
 	r := &ExpressionBodySyntaxRule{BaseRule: BaseRule{RuleName: "ExpressionBodySyntax", RuleSetName: "style", Sev: "warning", Desc: "Detects single-expression functions that could use expression body syntax with the = operator."}}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"function_declaration"}, Confidence: 0.75, Fix: api.FixIdiomatic, Implementation: r,
+		NodeTypes: []string{"function_declaration"}, Confidence: api.ConfidenceMedium, Fix: api.FixIdiomatic, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			if scanner.IsTestFile(file.Path) {
@@ -72,7 +72,7 @@ func registerStyleReturnCount() {
 	r := &ReturnCountRule{BaseRule: BaseRule{RuleName: "ReturnCount", RuleSetName: "style", Sev: "warning", Desc: "Detects functions with more return statements than the configured maximum."}, Max: 2, ExcludeReturnFromLambda: true}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"function_declaration"}, Confidence: 0.75, Implementation: r,
+		NodeTypes: []string{"function_declaration"}, Confidence: api.ConfidenceMedium, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			name := extractIdentifierFlat(file, idx)
@@ -139,7 +139,7 @@ func registerStyleThrowsCount() {
 	r := &ThrowsCountRule{BaseRule: BaseRule{RuleName: "ThrowsCount", RuleSetName: "style", Sev: "warning", Desc: "Detects functions with more throw statements than the configured maximum."}, Max: 2}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"function_declaration"}, Confidence: 0.75, Implementation: r,
+		NodeTypes: []string{"function_declaration"}, Confidence: api.ConfidenceMedium, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			if hasAnnotationFlat(file, idx, "Throws") {
@@ -170,7 +170,7 @@ func registerStyleCollapsibleIfStatements() {
 	r := &CollapsibleIfStatementsRule{BaseRule: BaseRule{RuleName: "CollapsibleIfStatements", RuleSetName: "style", Sev: "warning", Desc: "Detects nested if statements without else that can be merged with a logical AND."}}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"if_expression"}, Confidence: 0.75, Fix: api.FixIdiomatic, Implementation: r,
+		NodeTypes: []string{"if_expression"}, Confidence: api.ConfidenceMedium, Fix: api.FixIdiomatic, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			// Only collapse plain if/then chains — if the if_expression
@@ -281,7 +281,7 @@ func registerStyleSafeCast() {
 	r := &SafeCastRule{BaseRule: BaseRule{RuleName: "SafeCast", RuleSetName: "style", Sev: "warning", Desc: "Detects is-check followed by unsafe cast patterns that should use safe cast as? instead."}}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"if_expression", "when_expression"}, Confidence: 0.75, Implementation: r,
+		NodeTypes: []string{"if_expression", "when_expression"}, Confidence: api.ConfidenceMedium, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			nodeType := file.FlatType(idx)
@@ -429,7 +429,7 @@ func registerStyleVarCouldBeVal() {
 	r := &VarCouldBeValRule{BaseRule: BaseRule{RuleName: "VarCouldBeVal", RuleSetName: "style", Sev: "warning", Desc: "Detects var properties that are never reassigned and could be declared as val."}, IgnoreLateinitVar: true}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"property_declaration"}, Confidence: 0.75, Fix: api.FixIdiomatic, Implementation: r,
+		NodeTypes: []string{"property_declaration"}, Confidence: api.ConfidenceMedium, Fix: api.FixIdiomatic, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			if scanner.IsTestFile(file.Path) {
@@ -518,7 +518,7 @@ func registerStyleMayBeConstant() {
 	r := &MayBeConstantRule{BaseRule: BaseRule{RuleName: "MayBeConstant", RuleSetName: "style", Sev: "warning", Desc: "Detects top-level val properties with constant initializers that could be declared as const val."}}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"property_declaration"}, Confidence: 0.75, Fix: api.FixIdiomatic, Implementation: r,
+		NodeTypes: []string{"property_declaration"}, Confidence: api.ConfidenceMedium, Fix: api.FixIdiomatic, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			if strings.HasSuffix(file.Path, ".kts") {
@@ -578,7 +578,7 @@ func registerStyleModifierOrder() {
 	r := &ModifierOrderRule{BaseRule: BaseRule{RuleName: "ModifierOrder", RuleSetName: "style", Sev: "warning", Desc: "Detects modifiers that are not in the recommended Kotlin ordering."}}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"modifiers"}, Confidence: 0.75, Fix: api.FixCosmetic, Implementation: r,
+		NodeTypes: []string{"modifiers"}, Confidence: api.ConfidenceMedium, Fix: api.FixCosmetic, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			var mods []string
@@ -625,7 +625,7 @@ func registerStyleFunctionOnlyReturningConstant() {
 	r := &FunctionOnlyReturningConstantRule{BaseRule: BaseRule{RuleName: "FunctionOnlyReturningConstant", RuleSetName: "style", Sev: "warning", Desc: "Detects functions whose body only returns a constant value that could be a const val."}, IgnoreOverridableFunction: true, IgnoreActualFunction: true}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"function_declaration"}, Confidence: 0.75, Fix: api.FixNone, Implementation: r,
+		NodeTypes: []string{"function_declaration"}, Confidence: api.ConfidenceMedium, Fix: api.FixNone, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			if r.IgnoreOverridableFunction &&
@@ -700,7 +700,7 @@ func registerStyleLoopWithTooManyJumpStatements() {
 	r := &LoopWithTooManyJumpStatementsRule{BaseRule: BaseRule{RuleName: "LoopWithTooManyJumpStatements", RuleSetName: "style", Sev: "warning", Desc: "Detects loops containing more break or continue statements than the configured maximum."}, MaxJumps: 1}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"for_statement", "while_statement", "do_while_statement"}, Confidence: 0.75, Implementation: r,
+		NodeTypes: []string{"for_statement", "while_statement", "do_while_statement"}, Confidence: api.ConfidenceMedium, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			jumpCount := 0
@@ -739,7 +739,7 @@ func registerStyleExplicitItLambdaParameter() {
 	r := &ExplicitItLambdaParameterRule{BaseRule: BaseRule{RuleName: "ExplicitItLambdaParameter", RuleSetName: "style", Sev: "warning", Desc: "Detects single-parameter lambdas that explicitly name their parameter it instead of using the implicit it."}}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"lambda_literal"}, Confidence: 0.75, Fix: api.FixCosmetic, Implementation: r,
+		NodeTypes: []string{"lambda_literal"}, Confidence: api.ConfidenceMedium, Fix: api.FixCosmetic, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			paramsNode, _ := file.FlatFindChild(idx, "lambda_parameters")
@@ -805,7 +805,7 @@ func registerStyleExplicitItLambdaMultipleParameters() {
 	r := &ExplicitItLambdaMultipleParametersRule{BaseRule: BaseRule{RuleName: "ExplicitItLambdaMultipleParameters", RuleSetName: "style", Sev: "warning", Desc: "Detects multi-parameter lambdas that use it as a parameter name."}}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"lambda_literal"}, Confidence: 0.75, Fix: api.FixNone, Implementation: r,
+		NodeTypes: []string{"lambda_literal"}, Confidence: api.ConfidenceMedium, Fix: api.FixNone, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			paramsNode, _ := file.FlatFindChild(idx, "lambda_parameters")

--- a/internal/rules/registry_style_expressions_extra.go
+++ b/internal/rules/registry_style_expressions_extra.go
@@ -15,7 +15,7 @@ func registerStyleExpressionsExtraRules() {
 		r := &MultilineLambdaItParameterRule{BaseRule: BaseRule{RuleName: "MultilineLambdaItParameter", RuleSetName: "style", Sev: "warning", Desc: "Detects multiline lambdas that use the implicit it parameter instead of naming it explicitly."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"lambda_literal"}, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"lambda_literal"}, Confidence: api.ConfidenceMedium, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				if scanner.IsTestFile(file.Path) || isGradleBuildScript(file.Path) {
@@ -59,7 +59,7 @@ func registerStyleExpressionsExtraRules() {
 		r := &StringShouldBeRawStringRule{BaseRule: BaseRule{RuleName: "StringShouldBeRawString", RuleSetName: "style", Sev: "warning", Desc: "Detects string literals with many escape characters that would be more readable as raw strings."}, MaxEscapes: 2}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"string_literal"}, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"string_literal"}, Confidence: api.ConfidenceMedium, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				text := file.FlatNodeText(idx)
@@ -78,7 +78,7 @@ func registerStyleExpressionsExtraRules() {
 		r := &CanBeNonNullableRule{BaseRule: BaseRule{RuleName: "CanBeNonNullable", RuleSetName: "style", Sev: "warning", Desc: "Detects nullable types that are initialized with non-null values and never assigned null."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"property_declaration", "function_declaration"}, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"property_declaration", "function_declaration"}, Confidence: api.ConfidenceMedium, Implementation: r,
 			Needs: api.NeedsResolver,
 			Check: func(ctx *api.Context) {
 				switch ctx.File.FlatType(ctx.Idx) {
@@ -110,7 +110,7 @@ func registerStyleExpressionsExtraRules() {
 		r := &NullableBooleanCheckRule{BaseRule: BaseRule{RuleName: "NullableBooleanCheck", RuleSetName: "style", Sev: "warning", Desc: "Detects equality comparisons against Boolean literals like x == true on nullable Booleans."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"equality_expression"}, Confidence: 0.75, Fix: api.FixIdiomatic, Implementation: r,
+			NodeTypes: []string{"equality_expression"}, Confidence: api.ConfidenceMedium, Fix: api.FixIdiomatic, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				if file.FlatChildCount(idx) < 3 {
@@ -154,7 +154,7 @@ func registerStyleExpressionsExtraRules() {
 		r := &RangeUntilInsteadOfRangeToRule{BaseRule: BaseRule{RuleName: "RangeUntilInsteadOfRangeTo", RuleSetName: "style", Sev: "warning", Desc: "Detects usage of the until infix function that can be replaced with the ..< range operator."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"infix_expression"}, Confidence: 0.75, Fix: api.FixIdiomatic, Implementation: r,
+			NodeTypes: []string{"infix_expression"}, Confidence: api.ConfidenceMedium, Fix: api.FixIdiomatic, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				if file.FlatChildCount(idx) < 3 {
@@ -187,7 +187,7 @@ func registerStyleExpressionsExtraRules() {
 		r := &DestructuringDeclarationWithTooManyEntriesRule{BaseRule: BaseRule{RuleName: "DestructuringDeclarationWithTooManyEntries", RuleSetName: "style", Sev: "warning", Desc: "Detects destructuring declarations with more entries than the configured maximum."}, MaxEntries: 3}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"multi_variable_declaration"}, Confidence: 0.75, Implementation: r,
+			NodeTypes: []string{"multi_variable_declaration"}, Confidence: api.ConfidenceMedium, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				count := 0

--- a/internal/rules/registry_style_forbidden.go
+++ b/internal/rules/registry_style_forbidden.go
@@ -26,7 +26,7 @@ func registerStyleWildcardImport() {
 	r := &WildcardImportRule{BaseRule: BaseRule{RuleName: "WildcardImport", RuleSetName: "style", Sev: "warning", Desc: "Detects wildcard import statements that should be replaced with explicit imports."}, ExcludeImports: []string{"java.util.*", "platform.**", "kotlinx.cinterop.*"}}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"import_header", "import_declaration"}, Languages: []scanner.Language{scanner.LangKotlin, scanner.LangJava}, Confidence: 0.95, Implementation: r,
+		NodeTypes: []string{"import_header", "import_declaration"}, Languages: []scanner.Language{scanner.LangKotlin, scanner.LangJava}, Confidence: api.ConfidenceVeryHigh, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			// Skip test files and test-fixture Kotlin sources. Fixtures routinely
@@ -54,7 +54,7 @@ func registerStyleForbiddenComment() {
 	r := &ForbiddenCommentRule{BaseRule: BaseRule{RuleName: "ForbiddenComment", RuleSetName: "style", Sev: "warning", Desc: "Detects comments containing forbidden markers like TODO, FIXME, or STOPSHIP."}, Comments: defaultForbiddenCommentMarkers}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"line_comment", "multiline_comment", "block_comment"}, Languages: []scanner.Language{scanner.LangKotlin, scanner.LangJava}, Confidence: 0.75, Implementation: r,
+		NodeTypes: []string{"line_comment", "multiline_comment", "block_comment"}, Languages: []scanner.Language{scanner.LangKotlin, scanner.LangJava}, Confidence: api.ConfidenceMedium, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			// Justified string match: tree-sitter exposes comments as leaf text
@@ -108,7 +108,7 @@ func registerStyleForbiddenVoid() {
 	r := &ForbiddenVoidRule{BaseRule: BaseRule{RuleName: "ForbiddenVoid", RuleSetName: "style", Sev: "warning", Desc: "Detects usage of the Java Void type that should be replaced with Kotlin Unit."}}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"user_type"}, Confidence: 0.75, Fix: api.FixIdiomatic, Implementation: r,
+		NodeTypes: []string{"user_type"}, Confidence: api.ConfidenceMedium, Fix: api.FixIdiomatic, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			text := file.FlatNodeText(idx)
@@ -174,7 +174,7 @@ func registerStyleForbiddenImport() {
 	r := &ForbiddenImportRule{BaseRule: BaseRule{RuleName: "ForbiddenImport", RuleSetName: "style", Sev: "warning", Desc: "Detects import statements matching configured forbidden patterns."}, Patterns: defaultForbiddenImports}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"import_header", "import_declaration"}, Languages: []scanner.Language{scanner.LangKotlin, scanner.LangJava}, Confidence: 0.75, Fix: api.FixIdiomatic, Implementation: r,
+		NodeTypes: []string{"import_header", "import_declaration"}, Languages: []scanner.Language{scanner.LangKotlin, scanner.LangJava}, Confidence: api.ConfidenceMedium, Fix: api.FixIdiomatic, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			imp := importStatementPath(file, idx)
@@ -227,7 +227,7 @@ func registerStyleForbiddenMethodCall() {
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
 		NodeTypes:  []string{"call_expression"},
 		Needs:      api.NeedsTypeInfo | api.NeedsOracleCallTargets,
-		Confidence: 0.75, Fix: api.FixIdiomatic, Implementation: r,
+		Confidence: api.ConfidenceMedium, Fix: api.FixIdiomatic, Implementation: r,
 		OracleCallTargets:      &api.OracleCallTargetFilter{CalleeNames: []string{"print", "println"}},
 		OracleDeclarationNeeds: &api.OracleDeclarationProfile{},
 		Check: func(ctx *api.Context) {
@@ -263,7 +263,7 @@ func registerStyleForbiddenAnnotation() {
 	r := &ForbiddenAnnotationRule{BaseRule: BaseRule{RuleName: "ForbiddenAnnotation", RuleSetName: "style", Sev: "warning", Desc: "Detects usage of annotations that are configured as forbidden."}, Annotations: defaultForbiddenAnnotations}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"annotation"}, Confidence: 0.75, Fix: api.FixIdiomatic, Implementation: r,
+		NodeTypes: []string{"annotation"}, Confidence: api.ConfidenceMedium, Fix: api.FixIdiomatic, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			for _, ann := range r.Annotations {
@@ -318,7 +318,7 @@ func registerStyleForbiddenNamedParam() {
 	r := &ForbiddenNamedParamRule{BaseRule: BaseRule{RuleName: "ForbiddenNamedParam", RuleSetName: "style", Sev: "warning", Desc: "Detects named arguments in function calls where they should not be used."}, Methods: []string{"require", "check", "assert"}}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"call_expression"}, Confidence: 0.75, Implementation: r,
+		NodeTypes: []string{"call_expression"}, Confidence: api.ConfidenceMedium, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			funcName := flatCallExpressionName(file, idx)
@@ -346,7 +346,7 @@ func registerStyleForbiddenOptIn() {
 	r := &ForbiddenOptInRule{BaseRule: BaseRule{RuleName: "ForbiddenOptIn", RuleSetName: "style", Sev: "warning", Desc: "Detects @OptIn annotations that opt into experimental APIs."}}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"annotation"}, Confidence: 0.9, Fix: api.FixSemantic, Implementation: r,
+		NodeTypes: []string{"annotation"}, Confidence: api.ConfidenceHigher, Fix: api.FixSemantic, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			if annotationFinalName(file, idx) != "OptIn" {
@@ -394,7 +394,7 @@ func registerStyleForbiddenSuppress() {
 	r := &ForbiddenSuppressRule{BaseRule: BaseRule{RuleName: "ForbiddenSuppress", RuleSetName: "style", Sev: "warning", Desc: "Detects @Suppress annotations that silence warnings instead of fixing the underlying issue."}}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"annotation"}, Confidence: 0.9, Fix: api.FixSemantic, Implementation: r,
+		NodeTypes: []string{"annotation"}, Confidence: api.ConfidenceHigher, Fix: api.FixSemantic, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			if annotationFinalName(file, idx) != "Suppress" {
@@ -464,7 +464,7 @@ func registerStyleMagicNumber() {
 	}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"integer_literal", "real_literal", "long_literal", "hex_literal"}, Confidence: 0.75, Implementation: r,
+		NodeTypes: []string{"integer_literal", "real_literal", "long_literal", "hex_literal"}, Confidence: api.ConfidenceMedium, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			// Skip database migration files — they contain frozen-in-time constants

--- a/internal/rules/registry_style_format.go
+++ b/internal/rules/registry_style_format.go
@@ -58,7 +58,7 @@ func registerStyleFormatRules() {
 				"package_declaration", "import_declaration",
 			},
 			Languages:  []scanner.Language{scanner.LangKotlin, scanner.LangJava},
-			Confidence: 0.95,
+			Confidence: api.ConfidenceVeryHigh,
 			Fix:        api.FixCosmetic, Implementation: r,
 			Check: r.check,
 		})
@@ -86,7 +86,7 @@ func registerStyleFormatRules() {
 		r := &UnderscoresInNumericLiteralsRule{BaseRule: BaseRule{RuleName: "UnderscoresInNumericLiterals", RuleSetName: "style", Sev: "warning", Desc: "Detects large numeric literals that should use underscore separators for readability."}, AcceptableLength: 4}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"integer_literal", "long_literal", "decimal_integer_literal"}, Languages: []scanner.Language{scanner.LangKotlin, scanner.LangJava}, Confidence: 0.75, Fix: api.FixCosmetic, Implementation: r,
+			NodeTypes: []string{"integer_literal", "long_literal", "decimal_integer_literal"}, Languages: []scanner.Language{scanner.LangKotlin, scanner.LangJava}, Confidence: api.ConfidenceMedium, Fix: api.FixCosmetic, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				text := file.FlatNodeText(idx)

--- a/internal/rules/registry_style_idiomatic.go
+++ b/internal/rules/registry_style_idiomatic.go
@@ -16,7 +16,7 @@ func registerStyleIdiomaticRules() {
 		r := &UseCheckNotNullRule{BaseRule: BaseRule{RuleName: "UseCheckNotNull", RuleSetName: "style", Sev: "warning", Desc: "Detects check(x != null) calls that should use checkNotNull(x) instead."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"call_expression"}, Confidence: 0.75, Fix: api.FixIdiomatic,
+			NodeTypes: []string{"call_expression"}, Confidence: api.ConfidenceMedium, Fix: api.FixIdiomatic,
 			Needs: api.NeedsResolver, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
@@ -50,7 +50,7 @@ func registerStyleIdiomaticRules() {
 		r := &UseRequireNotNullRule{BaseRule: BaseRule{RuleName: "UseRequireNotNull", RuleSetName: "style", Sev: "warning", Desc: "Detects require(x != null) calls that should use requireNotNull(x) instead."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"call_expression"}, Confidence: 0.75, Fix: api.FixIdiomatic,
+			NodeTypes: []string{"call_expression"}, Confidence: api.ConfidenceMedium, Fix: api.FixIdiomatic,
 			Needs: api.NeedsResolver, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
@@ -84,7 +84,7 @@ func registerStyleIdiomaticRules() {
 		r := &UseCheckOrErrorRule{BaseRule: BaseRule{RuleName: "UseCheckOrError", RuleSetName: "style", Sev: "warning", Desc: "Detects if (!cond) throw IllegalStateException patterns that should use check()."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"if_expression"}, Confidence: 0.75, Fix: api.FixIdiomatic,
+			NodeTypes: []string{"if_expression"}, Confidence: api.ConfidenceMedium, Fix: api.FixIdiomatic,
 			Implementation: r,
 			Check: func(ctx *api.Context) {
 				file := ctx.File
@@ -96,7 +96,7 @@ func registerStyleIdiomaticRules() {
 		r := &UseRequireRule{BaseRule: BaseRule{RuleName: "UseRequire", RuleSetName: "style", Sev: "warning", Desc: "Detects if (!cond) throw IllegalArgumentException patterns that should use require()."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"if_expression"}, Confidence: 0.75, Fix: api.FixIdiomatic,
+			NodeTypes: []string{"if_expression"}, Confidence: api.ConfidenceMedium, Fix: api.FixIdiomatic,
 			Implementation: r,
 			Check: func(ctx *api.Context) {
 				file := ctx.File
@@ -108,7 +108,7 @@ func registerStyleIdiomaticRules() {
 		r := &UseIsNullOrEmptyRule{BaseRule: BaseRule{RuleName: "UseIsNullOrEmpty", RuleSetName: "style", Sev: "warning", Desc: "Detects x == null || x.isEmpty() patterns that should use isNullOrEmpty()."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"disjunction_expression"}, Confidence: 0.75, Fix: api.FixIdiomatic,
+			NodeTypes: []string{"disjunction_expression"}, Confidence: api.ConfidenceMedium, Fix: api.FixIdiomatic,
 			Needs:  api.NeedsTypeInfo | api.NeedsOracleCallTargets,
 			Oracle: &api.OracleFilter{Identifiers: []string{"isEmpty", "count", ".size", ".length", "\"\""}},
 			OracleCallTargets: &api.OracleCallTargetFilter{
@@ -131,7 +131,7 @@ func registerStyleIdiomaticRules() {
 		r := &UseOrEmptyRule{BaseRule: BaseRule{RuleName: "UseOrEmpty", RuleSetName: "style", Sev: "warning", Desc: "Detects x ?: emptyList() patterns that should use .orEmpty() instead."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"elvis_expression"}, Confidence: 0.75, Fix: api.FixIdiomatic,
+			NodeTypes: []string{"elvis_expression"}, Confidence: api.ConfidenceMedium, Fix: api.FixIdiomatic,
 			Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
@@ -182,7 +182,7 @@ func registerStyleIdiomaticRules() {
 		r := &UseAnyOrNoneInsteadOfFindRule{BaseRule: BaseRule{RuleName: "UseAnyOrNoneInsteadOfFind", RuleSetName: "style", Sev: "warning", Desc: "Detects .find {} != null patterns that should use .any {} or .none {} instead."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"equality_expression"}, Confidence: 0.75, Fix: api.FixIdiomatic,
+			NodeTypes: []string{"equality_expression"}, Confidence: api.ConfidenceMedium, Fix: api.FixIdiomatic,
 			Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
@@ -260,7 +260,7 @@ func registerStyleIdiomaticRules() {
 		r := &UseEmptyCounterpartRule{BaseRule: BaseRule{RuleName: "UseEmptyCounterpart", RuleSetName: "style", Sev: "warning", Desc: "Detects listOf(), setOf(), and similar calls with no arguments that should use emptyList(), emptySet(), etc."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"call_expression"}, Confidence: 0.75, Fix: api.FixIdiomatic,
+			NodeTypes: []string{"call_expression"}, Confidence: api.ConfidenceMedium, Fix: api.FixIdiomatic,
 			Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File

--- a/internal/rules/registry_style_idiomatic_data.go
+++ b/internal/rules/registry_style_idiomatic_data.go
@@ -16,7 +16,7 @@ func registerStyleIdiomaticDataRules() {
 		r := &UseArrayLiteralsInAnnotationsRule{BaseRule: BaseRule{RuleName: "UseArrayLiteralsInAnnotations", RuleSetName: "style", Sev: "warning", Desc: "Detects arrayOf() calls in annotations that should use array literal [] syntax."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"annotation"}, Confidence: 0.9, Fix: api.FixIdiomatic, Implementation: r,
+			NodeTypes: []string{"annotation"}, Confidence: api.ConfidenceHigher, Fix: api.FixIdiomatic, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				// Require an actual call to `arrayOf` somewhere under this
@@ -59,7 +59,7 @@ func registerStyleIdiomaticDataRules() {
 		r := &UseSumOfInsteadOfFlatMapSizeRule{BaseRule: BaseRule{RuleName: "UseSumOfInsteadOfFlatMapSize", RuleSetName: "style", Sev: "warning", Desc: "Detects flatMap/map followed by size/count/sum chains that should use sumOf instead."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"call_expression"}, Confidence: 0.75, Fix: api.FixIdiomatic, Implementation: r,
+			NodeTypes: []string{"call_expression"}, Confidence: api.ConfidenceMedium, Fix: api.FixIdiomatic, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				name := flatCallExpressionName(file, idx)
@@ -139,7 +139,7 @@ func registerStyleIdiomaticDataRules() {
 		r := &UseLetRule{BaseRule: BaseRule{RuleName: "UseLet", RuleSetName: "style", Sev: "warning", Desc: "Detects null checks that could be replaced with ?.let {} scope function."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"if_expression"}, Confidence: 0.75, Fix: api.FixNone, Implementation: r,
+			NodeTypes: []string{"if_expression"}, Confidence: api.ConfidenceMedium, Fix: api.FixNone, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				text := file.FlatNodeText(idx)
@@ -153,7 +153,7 @@ func registerStyleIdiomaticDataRules() {
 		r := &UseDataClassRule{BaseRule: BaseRule{RuleName: "UseDataClass", RuleSetName: "style", Sev: "warning", Desc: "Detects classes with only properties in the constructor that could be data classes."}, AllowVars: false}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"class_declaration"}, Confidence: 0.75, Fix: api.FixNone, Implementation: r,
+			NodeTypes: []string{"class_declaration"}, Confidence: api.ConfidenceMedium, Fix: api.FixNone, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				if file.FlatHasModifier(idx, "data") || file.FlatHasModifier(idx, "abstract") || file.FlatHasModifier(idx, "open") || file.FlatHasModifier(idx, "sealed") || file.FlatHasModifier(idx, "enum") || file.FlatHasModifier(idx, "annotation") {
@@ -202,7 +202,7 @@ func registerStyleIdiomaticDataRules() {
 		r := &UseIfInsteadOfWhenRule{BaseRule: BaseRule{RuleName: "UseIfInsteadOfWhen", RuleSetName: "style", Sev: "warning", Desc: "Detects when expressions with two or fewer branches that could be replaced with if."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"when_expression"}, Confidence: 0.75, Fix: api.FixIdiomatic, Implementation: r,
+			NodeTypes: []string{"when_expression"}, Confidence: api.ConfidenceMedium, Fix: api.FixIdiomatic, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				entryCount := 0
@@ -233,7 +233,7 @@ func registerStyleIdiomaticDataRules() {
 		r := &UseIfEmptyOrIfBlankRule{BaseRule: BaseRule{RuleName: "UseIfEmptyOrIfBlank", RuleSetName: "style", Sev: "warning", Desc: "Detects manual isEmpty/isBlank checks that could use .ifEmpty {} or .ifBlank {} instead."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"if_expression"}, Confidence: 0.75, Fix: api.FixIdiomatic, Implementation: r,
+			NodeTypes: []string{"if_expression"}, Confidence: api.ConfidenceMedium, Fix: api.FixIdiomatic, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				var condNode, thenNode, elseNode uint32
@@ -318,7 +318,7 @@ func registerStyleIdiomaticDataRules() {
 		r := &ExplicitCollectionElementAccessMethodRule{BaseRule: BaseRule{RuleName: "ExplicitCollectionElementAccessMethod", RuleSetName: "style", Sev: "warning", Desc: "Detects explicit .get() and .set() calls that should use index operator syntax."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"call_expression"}, Needs: api.NeedsTypeInfo, Confidence: 0.75, Fix: api.FixIdiomatic, Implementation: r,
+			NodeTypes: []string{"call_expression"}, Needs: api.NeedsTypeInfo, Confidence: api.ConfidenceMedium, Fix: api.FixIdiomatic, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				target, ok := semantics.ResolveCallTarget(ctx, idx)
@@ -380,7 +380,7 @@ func registerStyleIdiomaticDataRules() {
 		r := &AlsoCouldBeApplyRule{BaseRule: BaseRule{RuleName: "AlsoCouldBeApply", RuleSetName: "style", Sev: "warning", Desc: "Detects .also {} blocks with multiple it. references that could use .apply {} instead."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"call_expression"}, Confidence: 0.9, Fix: api.FixSemantic, Implementation: r,
+			NodeTypes: []string{"call_expression"}, Confidence: api.ConfidenceHigher, Fix: api.FixSemantic, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				if flatCallExpressionName(file, idx) != "also" {
@@ -403,7 +403,7 @@ func registerStyleIdiomaticDataRules() {
 		r := &EqualsNullCallRule{BaseRule: BaseRule{RuleName: "EqualsNullCall", RuleSetName: "style", Sev: "warning", Desc: "Detects .equals(null) calls that should use == null instead."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"call_expression"}, Confidence: 0.75, Fix: api.FixIdiomatic, Implementation: r,
+			NodeTypes: []string{"call_expression"}, Confidence: api.ConfidenceMedium, Fix: api.FixIdiomatic, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				var navNode uint32

--- a/internal/rules/registry_style_redundant.go
+++ b/internal/rules/registry_style_redundant.go
@@ -25,7 +25,7 @@ func registerStyleRedundantVisibilityModifier() {
 	r := &RedundantVisibilityModifierRule{BaseRule: BaseRule{RuleName: "RedundantVisibilityModifier", RuleSetName: "style", Sev: "warning", Desc: "Detects explicit public modifier which is redundant since public is the default visibility in Kotlin."}}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"modifiers"}, Confidence: 0.75, Fix: api.FixCosmetic, Implementation: r,
+		NodeTypes: []string{"modifiers"}, Confidence: api.ConfidenceMedium, Fix: api.FixCosmetic, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			// Check for "public" and absence of "override" using AST child walking.
@@ -84,7 +84,7 @@ func registerStyleRedundantConstructorKeyword() {
 	r := &RedundantConstructorKeywordRule{BaseRule: BaseRule{RuleName: "RedundantConstructorKeyword", RuleSetName: "style", Sev: "warning", Desc: "Detects unnecessary constructor keyword on primary constructors without annotations or visibility modifiers."}}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"class_declaration"}, Confidence: 0.75, Fix: api.FixCosmetic, Implementation: r,
+		NodeTypes: []string{"class_declaration"}, Confidence: api.ConfidenceMedium, Fix: api.FixCosmetic, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			ctor, _ := file.FlatFindChild(idx, "primary_constructor")
@@ -136,7 +136,7 @@ func registerStyleRedundantExplicitType() {
 	r := &RedundantExplicitTypeRule{BaseRule: BaseRule{RuleName: "RedundantExplicitType", RuleSetName: "style", Sev: "warning", Desc: "Detects explicit type annotations that can be inferred from the initializer."}}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"property_declaration"}, Confidence: 0.75, Needs: api.NeedsResolver, Fix: api.FixCosmetic, Implementation: r,
+		NodeTypes: []string{"property_declaration"}, Confidence: api.ConfidenceMedium, Needs: api.NeedsResolver, Fix: api.FixCosmetic, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			// Must have both an explicit type annotation and an initializer
@@ -239,7 +239,7 @@ func registerStyleUnnecessaryParentheses() {
 	r := &UnnecessaryParenthesesRule{BaseRule: BaseRule{RuleName: "UnnecessaryParentheses", RuleSetName: "style", Sev: "warning", Desc: "Detects unnecessary parentheses around expressions that add no value."}}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"parenthesized_expression"}, Confidence: 0.75, Fix: api.FixCosmetic, Implementation: r,
+		NodeTypes: []string{"parenthesized_expression"}, Confidence: api.ConfidenceMedium, Fix: api.FixCosmetic, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			parent, ok := file.FlatParent(idx)
@@ -363,7 +363,7 @@ func registerStyleUnnecessaryInheritance() {
 	r := &UnnecessaryInheritanceRule{BaseRule: BaseRule{RuleName: "UnnecessaryInheritance", RuleSetName: "style", Sev: "warning", Desc: "Detects unnecessary explicit inheritance from Any which is implicit in Kotlin."}}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"class_declaration"}, Confidence: 0.75, Fix: api.FixIdiomatic, Implementation: r,
+		NodeTypes: []string{"class_declaration"}, Confidence: api.ConfidenceMedium, Fix: api.FixIdiomatic, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			// Look for delegation_specifier children that are `: Any()`
@@ -409,7 +409,7 @@ func registerStyleUnnecessaryInnerClass() {
 	r := &UnnecessaryInnerClassRule{BaseRule: BaseRule{RuleName: "UnnecessaryInnerClass", RuleSetName: "style", Sev: "warning", Desc: "Detects inner classes that do not reference the outer class and could remove the inner modifier."}}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"class_declaration"}, Confidence: 0.75, Fix: api.FixIdiomatic, Implementation: r,
+		NodeTypes: []string{"class_declaration"}, Confidence: api.ConfidenceMedium, Fix: api.FixIdiomatic, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			mods, _ := file.FlatFindChild(idx, "modifiers")
@@ -448,7 +448,7 @@ func registerStyleOptionalUnit() {
 	r := &OptionalUnitRule{BaseRule: BaseRule{RuleName: "OptionalUnit", RuleSetName: "style", Sev: "warning", Desc: "Detects explicit Unit return types and return Unit statements that are redundant."}}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"function_declaration"}, Confidence: 0.75, Fix: api.FixCosmetic, Implementation: r,
+		NodeTypes: []string{"function_declaration"}, Confidence: api.ConfidenceMedium, Fix: api.FixCosmetic, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			// 1. Check for explicit `: Unit` return type annotation.
@@ -513,7 +513,7 @@ func registerStyleUnnecessaryBackticks() {
 	r := &UnnecessaryBackticksRule{BaseRule: BaseRule{RuleName: "UnnecessaryBackticks", RuleSetName: "style", Sev: "warning", Desc: "Detects backtick-quoted identifiers that do not require backticks."}}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"simple_identifier"}, Confidence: 0.75, Fix: api.FixCosmetic, Implementation: r,
+		NodeTypes: []string{"simple_identifier"}, Confidence: api.ConfidenceMedium, Fix: api.FixCosmetic, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			text := file.FlatNodeText(idx)
@@ -555,7 +555,7 @@ func registerStyleUselessCallOnNotNull() {
 	r := &UselessCallOnNotNullRule{BaseRule: BaseRule{RuleName: "UselessCallOnNotNull", RuleSetName: "style", Sev: "warning", Desc: "Detects calls like .orEmpty() or .isNullOrEmpty() on receivers that are already non-null."}}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"call_expression"}, Confidence: 0.75, Needs: api.NeedsResolver, Fix: api.FixIdiomatic, Implementation: r,
+		NodeTypes: []string{"call_expression"}, Confidence: api.ConfidenceMedium, Needs: api.NeedsResolver, Fix: api.FixIdiomatic, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			if file.FlatType(idx) != "call_expression" {

--- a/internal/rules/registry_style_unnecessary.go
+++ b/internal/rules/registry_style_unnecessary.go
@@ -15,7 +15,7 @@ func registerStyleUnnecessaryRules() {
 		r := &RedundantHigherOrderMapUsageRule{BaseRule: BaseRule{RuleName: "RedundantHigherOrderMapUsage", RuleSetName: "style", Sev: "warning", Desc: "Detects identity .map { it } calls that are no-ops and can be removed."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"call_expression"}, Confidence: 0.95, Fix: api.FixIdiomatic, Implementation: r,
+			NodeTypes: []string{"call_expression"}, Confidence: api.ConfidenceVeryHigh, Fix: api.FixIdiomatic, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				if flatCallExpressionName(file, idx) != "map" {
@@ -60,7 +60,7 @@ func registerStyleUnnecessaryRules() {
 		r := &UnnecessaryApplyRule{BaseRule: BaseRule{RuleName: "UnnecessaryApply", RuleSetName: "style", Sev: "warning", Desc: "Detects .apply {} blocks that are empty or do not reference the receiver."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"call_expression"}, Confidence: 0.95, Fix: api.FixIdiomatic, Implementation: r,
+			NodeTypes: []string{"call_expression"}, Confidence: api.ConfidenceVeryHigh, Fix: api.FixIdiomatic, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				if flatCallExpressionName(file, idx) != "apply" {
@@ -106,7 +106,7 @@ func registerStyleUnnecessaryRules() {
 		r := &UnnecessaryLetRule{BaseRule: BaseRule{RuleName: "UnnecessaryLet", RuleSetName: "style", Sev: "warning", Desc: "Detects .let {} calls that are identity transforms or single-call chains replaceable by direct invocation."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"call_expression"}, Confidence: 0.95, Fix: api.FixIdiomatic, Implementation: r,
+			NodeTypes: []string{"call_expression"}, Confidence: api.ConfidenceVeryHigh, Fix: api.FixIdiomatic, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				navNode, _ := flatCallExpressionParts(file, idx)
@@ -182,7 +182,7 @@ func registerStyleUnnecessaryRules() {
 		r := &UnnecessaryFilterRule{BaseRule: BaseRule{RuleName: "UnnecessaryFilter", RuleSetName: "style", Sev: "warning", Desc: "Detects .filter {}.first() chains that can be simplified to .first {} with the predicate."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"call_expression"}, Confidence: 0.95, Fix: api.FixIdiomatic, Implementation: r,
+			NodeTypes: []string{"call_expression"}, Confidence: api.ConfidenceVeryHigh, Fix: api.FixIdiomatic, Implementation: r,
 			Needs: api.NeedsResolver,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
@@ -245,7 +245,7 @@ func registerStyleUnnecessaryRules() {
 		r := &UnnecessaryAnyRule{BaseRule: BaseRule{RuleName: "UnnecessaryAny", RuleSetName: "style", Sev: "warning", Desc: "Detects .any { true } and .filter {}.any() patterns that can be simplified."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"call_expression"}, Confidence: 0.95, Fix: api.FixIdiomatic, Implementation: r,
+			NodeTypes: []string{"call_expression"}, Confidence: api.ConfidenceVeryHigh, Fix: api.FixIdiomatic, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				methodName := flatCallExpressionName(file, idx)
@@ -336,7 +336,7 @@ func registerStyleUnnecessaryRules() {
 		r := &UnnecessaryBracesAroundTrailingLambdaRule{BaseRule: BaseRule{RuleName: "UnnecessaryBracesAroundTrailingLambda", RuleSetName: "style", Sev: "warning", Desc: "Detects empty parentheses before trailing lambdas that can be removed."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"call_expression"}, Confidence: 0.95, Fix: api.FixCosmetic, Implementation: r,
+			NodeTypes: []string{"call_expression"}, Confidence: api.ConfidenceVeryHigh, Fix: api.FixCosmetic, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				if file.FlatChildCount(idx) < 2 {
@@ -382,7 +382,7 @@ func registerStyleUnnecessaryRules() {
 		r := &UnnecessaryFullyQualifiedNameRule{BaseRule: BaseRule{RuleName: "UnnecessaryFullyQualifiedName", RuleSetName: "style", Sev: "warning", Desc: "Detects fully qualified names that are unnecessary because the type is already imported."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"navigation_expression"}, Confidence: 0.95, Fix: api.FixNone, Implementation: r,
+			NodeTypes: []string{"navigation_expression"}, Confidence: api.ConfidenceVeryHigh, Fix: api.FixNone, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				text := file.FlatNodeText(idx)
@@ -417,7 +417,7 @@ func registerStyleUnnecessaryRules() {
 		r := &UnnecessaryReversedRule{BaseRule: BaseRule{RuleName: "UnnecessaryReversed", RuleSetName: "style", Sev: "warning", Desc: "Detects chained sort and reverse calls that can be replaced with a single sort operation."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"call_expression"}, Confidence: 0.95, Fix: api.FixIdiomatic, Implementation: r,
+			NodeTypes: []string{"call_expression"}, Confidence: api.ConfidenceVeryHigh, Fix: api.FixIdiomatic, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				outerMethod := flatCallExpressionName(file, idx)

--- a/internal/rules/registry_style_unused.go
+++ b/internal/rules/registry_style_unused.go
@@ -16,7 +16,7 @@ func registerStyleUnusedRules() {
 		r := &UnusedImportRule{BaseRule: BaseRule{RuleName: "UnusedImport", RuleSetName: "style", Sev: "warning", Desc: "Detects import statements where the imported name is not referenced in the file."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"import_header"}, Confidence: 0.75, Fix: api.FixIdiomatic, Implementation: r,
+			NodeTypes: []string{"import_header"}, Confidence: api.ConfidenceMedium, Fix: api.FixIdiomatic, Implementation: r,
 			Tags: []string{"precompile"},
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
@@ -52,7 +52,7 @@ func registerStyleUnusedRules() {
 		r := &UnusedParameterRule{BaseRule: BaseRule{RuleName: "UnusedParameter", RuleSetName: "style", Sev: "warning", Desc: "Detects function parameters that are never used in the function body."}, AllowedNames: regexp.MustCompile(`^(ignored|expected|_)$`)}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"function_declaration"}, Confidence: 0.95, Fix: api.FixNone, Implementation: r,
+			NodeTypes: []string{"function_declaration"}, Confidence: api.ConfidenceVeryHigh, Fix: api.FixNone, Implementation: r,
 			Tags: []string{"precompile"},
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
@@ -147,7 +147,7 @@ func registerStyleUnusedRules() {
 		r := &UnusedVariableRule{BaseRule: BaseRule{RuleName: "UnusedVariable", RuleSetName: "style", Sev: "warning", Desc: "Detects local variables that are declared but never used."}, AllowedNames: regexp.MustCompile(`^(ignored|_)$`)}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"property_declaration", "variable_declaration"}, Confidence: 0.75, Fix: api.FixNone, Implementation: r,
+			NodeTypes: []string{"property_declaration", "variable_declaration"}, Confidence: api.ConfidenceMedium, Fix: api.FixNone, Implementation: r,
 			Tags: []string{"precompile"},
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
@@ -173,7 +173,7 @@ func registerStyleUnusedRules() {
 		r := &UnusedPrivateClassRule{BaseRule: BaseRule{RuleName: "UnusedPrivateClass", RuleSetName: "style", Sev: "warning", Desc: "Detects private classes that are never referenced in the file."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"class_declaration"}, Confidence: 0.75, Fix: api.FixNone, Implementation: r,
+			NodeTypes: []string{"class_declaration"}, Confidence: api.ConfidenceMedium, Fix: api.FixNone, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				if !file.FlatHasModifier(idx, "private") {
@@ -194,7 +194,7 @@ func registerStyleUnusedRules() {
 		r := &UnusedPrivateFunctionRule{BaseRule: BaseRule{RuleName: "UnusedPrivateFunction", RuleSetName: "style", Sev: "warning", Desc: "Detects private functions that are never called in the file."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"function_declaration"}, Confidence: 0.75, Fix: api.FixNone, Implementation: r,
+			NodeTypes: []string{"function_declaration"}, Confidence: api.ConfidenceMedium, Fix: api.FixNone, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				if scanner.IsTestFile(file.Path) {
@@ -227,7 +227,7 @@ func registerStyleUnusedRules() {
 		r := &UnusedPrivatePropertyRule{BaseRule: BaseRule{RuleName: "UnusedPrivateProperty", RuleSetName: "style", Sev: "warning", Desc: "Detects private properties that are never referenced in the file."}}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"property_declaration"}, Confidence: 0.75, Fix: api.FixNone, Implementation: r,
+			NodeTypes: []string{"property_declaration"}, Confidence: api.ConfidenceMedium, Fix: api.FixNone, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				if !file.FlatHasModifier(idx, "private") {
@@ -259,7 +259,7 @@ func registerStyleUnusedRules() {
 		r := &UnusedPrivateMemberRule{BaseRule: BaseRule{RuleName: "UnusedPrivateMember", RuleSetName: "style", Sev: "warning", Desc: "Detects private members (classes, functions, properties) that are never used."}, IgnoreAnnotated: DefaultUnusedMemberIgnoreAnnotated}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-			NodeTypes: []string{"class_declaration", "function_declaration", "property_declaration"}, Confidence: 0.75, Fix: api.FixNone, Implementation: r,
+			NodeTypes: []string{"class_declaration", "function_declaration", "property_declaration"}, Confidence: api.ConfidenceMedium, Fix: api.FixNone, Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
 				if !file.FlatHasModifier(idx, "private") {

--- a/internal/rules/registry_testing_quality.go
+++ b/internal/rules/registry_testing_quality.go
@@ -49,7 +49,7 @@ func registerTestingQualityAssertEqualsArgumentOrder() {
 	}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"call_expression"}, Confidence: 0.75, Implementation: r,
+		NodeTypes: []string{"call_expression"}, Confidence: api.ConfidenceMedium, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			if flatCallExpressionName(file, idx) != "assertEquals" {
@@ -79,7 +79,7 @@ func registerTestingQualityAssertTrueOnComparison() {
 	}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"call_expression"}, Confidence: 0.75, Implementation: r,
+		NodeTypes: []string{"call_expression"}, Confidence: api.ConfidenceMedium, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			if flatCallExpressionName(file, idx) != "assertTrue" {
@@ -129,7 +129,7 @@ func registerTestingQualityAssertNullableWithNotNullAssertion() {
 	}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"call_expression"}, Confidence: 0.75, Implementation: r,
+		NodeTypes: []string{"call_expression"}, Confidence: api.ConfidenceMedium, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			if !testingQualityRuleShouldRunInFile(file) {
@@ -171,7 +171,7 @@ func registerTestingQualityMockWithoutVerify() {
 	}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"function_declaration"}, Confidence: 0.75, Implementation: r,
+		NodeTypes: []string{"function_declaration"}, Confidence: api.ConfidenceMedium, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			if !testingQualityIsTestFunction(file, idx) {
@@ -253,7 +253,7 @@ func registerTestingQualityRunTestWithDelay() {
 	}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"call_expression"}, Confidence: 0.75, Implementation: r,
+		NodeTypes: []string{"call_expression"}, Confidence: api.ConfidenceMedium, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			if flatCallExpressionName(file, idx) != "delay" {
@@ -289,7 +289,7 @@ func registerTestingQualityRunTestWithThreadSleep() {
 	}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"call_expression"}, Confidence: 0.75, Implementation: r,
+		NodeTypes: []string{"call_expression"}, Confidence: api.ConfidenceMedium, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			name := flatCallExpressionName(file, idx)
@@ -318,7 +318,7 @@ func registerTestingQualityRunBlockingInTest() {
 	}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"call_expression"}, Confidence: 0.75, Implementation: r,
+		NodeTypes: []string{"call_expression"}, Confidence: api.ConfidenceMedium, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			if flatCallExpressionName(file, idx) != "runBlocking" {
@@ -360,7 +360,7 @@ func registerTestingQualityTestDispatcherNotInjected() {
 	}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"navigation_expression"}, Confidence: 0.75, Implementation: r,
+		NodeTypes: []string{"navigation_expression"}, Confidence: api.ConfidenceMedium, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			segments := flatNavigationChainIdentifiers(file, idx)
@@ -386,7 +386,7 @@ func registerTestingQualityTestWithoutAssertion() {
 	}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"function_declaration"}, Confidence: 0.75, Implementation: r,
+		NodeTypes: []string{"function_declaration"}, Confidence: api.ConfidenceMedium, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			if testingQualityIsEditorTemplatePath(file.Path) {
@@ -434,7 +434,7 @@ func registerTestingQualityTestWithOnlyTodo() {
 	}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"function_declaration"}, Confidence: 0.75, Implementation: r,
+		NodeTypes: []string{"function_declaration"}, Confidence: api.ConfidenceMedium, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			if !testingQualityIsTestFunction(file, idx) {
@@ -472,7 +472,7 @@ func registerTestingQualityTestFunctionReturnValue() {
 	}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"function_declaration"}, Confidence: 0.75, Implementation: r,
+		NodeTypes: []string{"function_declaration"}, Confidence: api.ConfidenceMedium, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			if !testingQualityIsTestFunction(file, idx) {
@@ -493,7 +493,7 @@ func registerTestingQualityTestNameContainsUnderscore() {
 	}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"function_declaration"}, Confidence: 0.6, Fix: api.FixCosmetic, Implementation: r,
+		NodeTypes: []string{"function_declaration"}, Confidence: api.ConfidenceMediumLow, Fix: api.FixCosmetic, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			if !testingQualityIsTestFunction(file, idx) {
@@ -542,7 +542,7 @@ func registerTestingQualitySharedMutableStateInObject() {
 	}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"companion_object", "object_declaration"}, Confidence: 0.75, Implementation: r,
+		NodeTypes: []string{"companion_object", "object_declaration"}, Confidence: api.ConfidenceMedium, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			if !testingQualityIsTestFile(file) {
@@ -570,7 +570,7 @@ func registerTestingQualityTestInheritanceDepth() {
 	}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"class_declaration"}, Confidence: 0.6, Implementation: r,
+		NodeTypes: []string{"class_declaration"}, Confidence: api.ConfidenceMediumLow, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			if !testingQualityIsTestFile(file) {
@@ -605,7 +605,7 @@ func registerTestingQualityRelaxedMockUsedForValueClass() {
 	}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"call_expression"}, Confidence: 0.75, Implementation: r,
+		NodeTypes: []string{"call_expression"}, Confidence: api.ConfidenceMedium, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			if flatCallNameAny(file, idx) != "mockk" {
@@ -633,7 +633,7 @@ func registerTestingQualitySpyOnDataClass() {
 	}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"call_expression"}, Confidence: 0.6, Implementation: r,
+		NodeTypes: []string{"call_expression"}, Confidence: api.ConfidenceMediumLow, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			name := flatCallNameAny(file, idx)
@@ -666,7 +666,7 @@ func registerTestingQualityVerifyWithoutMock() {
 	}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"call_expression"}, Confidence: 0.6, Implementation: r,
+		NodeTypes: []string{"call_expression"}, Confidence: api.ConfidenceMediumLow, Implementation: r,
 		Check: func(ctx *api.Context) {
 			idx, file := ctx.Idx, ctx.File
 			if !testingQualityRuleShouldRunInFile(file) {

--- a/internal/rules/release_engineering.go
+++ b/internal/rules/release_engineering.go
@@ -31,7 +31,7 @@ type BuildConfigDebugInLibraryRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Release-engineering rule. Detection scans module metadata and Gradle
 // files for configuration drift and plugin hygiene; matches are
 // project-structure-sensitive. Classified per roadmap/17.
-func (r *BuildConfigDebugInLibraryRule) Confidence() float64 { return 0.75 }
+func (r *BuildConfigDebugInLibraryRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // BuildConfigDebugInvertedRule flags `if (!BuildConfig.DEBUG) { ...logging... }`
 // patterns where debug-only logging appears to be guarded in the opposite
@@ -44,7 +44,7 @@ type BuildConfigDebugInvertedRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Release-engineering rule. Detection scans module metadata and Gradle
 // files for configuration drift and plugin hygiene; matches are
 // project-structure-sensitive. Classified per roadmap/17.
-func (r *BuildConfigDebugInvertedRule) Confidence() float64 { return 0.75 }
+func (r *BuildConfigDebugInvertedRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // AllProjectsBlockRule flags deprecated allprojects { } usage in Gradle build
 // scripts. Convention plugins or settings-level repositories are the
@@ -65,12 +65,12 @@ type HardcodedEnvironmentNameRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Release-engineering rule. Detection scans module metadata and Gradle
 // files for configuration drift and plugin hygiene; matches are
 // project-structure-sensitive. Classified per roadmap/17.
-func (r *AllProjectsBlockRule) Confidence() float64 { return 0.75 }
+func (r *AllProjectsBlockRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // Confidence reports a tier-2 (medium) base confidence. Release-engineering rule. Detection scans module metadata and Gradle
 // files for configuration drift and plugin hygiene; matches are
 // project-structure-sensitive. Classified per roadmap/17.
-func (r *HardcodedEnvironmentNameRule) Confidence() float64 { return 0.75 }
+func (r *HardcodedEnvironmentNameRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // ConventionPluginDeadCodeRule flags precompiled convention plugins declared
 // under build-logic/ or buildSrc/ that are not applied by any module.
@@ -81,7 +81,7 @@ type ConventionPluginDeadCodeRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Release-engineering rule. Detection scans module metadata and Gradle
 // files for configuration drift and plugin hygiene; matches are
 // project-structure-sensitive. Classified per roadmap/17.
-func (r *ConventionPluginDeadCodeRule) Confidence() float64 { return 0.75 }
+func (r *ConventionPluginDeadCodeRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *ConventionPluginDeadCodeRule) ModuleAwareNeeds() ModuleAwareNeeds {
 	return ModuleAwareNeeds{}
@@ -111,7 +111,7 @@ func (r *ConventionPluginDeadCodeRule) check(ctx *api.Context) {
 			Rule:       r.RuleName,
 			Severity:   r.Sev,
 			Message:    fmt.Sprintf("Convention plugin '%s' is defined but never applied by any module build script.", plugin.id),
-			Confidence: 0.9,
+			Confidence: api.ConfidenceHigher,
 		})
 	}
 }
@@ -141,7 +141,7 @@ type GradleBuildContainsTodoRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Release-engineering rule. Detection scans module metadata and Gradle
 // files for configuration drift and plugin hygiene; matches are
 // project-structure-sensitive. Classified per roadmap/17.
-func (r *GradleBuildContainsTodoRule) Confidence() float64 { return 0.75 }
+func (r *GradleBuildContainsTodoRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *GradleBuildContainsTodoRule) check(ctx *api.Context) {
 	for i, raw := range strings.Split(ctx.GradleContent, "\n") {
@@ -164,7 +164,7 @@ func (r *GradleBuildContainsTodoRule) check(ctx *api.Context) {
 // Confidence reports a tier-2 (medium) base confidence. Release-engineering rule. Detection scans module metadata and Gradle
 // files for configuration drift and plugin hygiene; matches are
 // project-structure-sensitive. Classified per roadmap/17.
-func (r *CommentedOutCodeBlockRule) Confidence() float64 { return 0.75 }
+func (r *CommentedOutCodeBlockRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *CommentedOutCodeBlockRule) check(ctx *api.Context) {
 	file := ctx.File
@@ -471,7 +471,7 @@ type CommentedOutImportRule struct {
 	BaseRule
 }
 
-func (r *CommentedOutImportRule) Confidence() float64 { return 0.90 }
+func (r *CommentedOutImportRule) Confidence() float64 { return api.ConfidenceHigher }
 
 // commentedImportRe matches a commented-out Kotlin import body. Requires a
 // dotted-path that conforms to Kotlin import syntax — bare prose like
@@ -540,7 +540,7 @@ type DebugToastInProductionRule struct {
 	BaseRule
 }
 
-func (r *DebugToastInProductionRule) Confidence() float64 { return 0.85 }
+func (r *DebugToastInProductionRule) Confidence() float64 { return api.ConfidenceHigh }
 
 var debugToastPrefixRe = regexp.MustCompile(`(?i)^["'](debug|test|wip)(?:[^A-Za-z0-9]|$)`)
 
@@ -590,7 +590,7 @@ type PrintlnInProductionRule struct {
 	BaseRule
 }
 
-func (r *PrintlnInProductionRule) Confidence() float64 { return 0.85 }
+func (r *PrintlnInProductionRule) Confidence() float64 { return api.ConfidenceHigh }
 
 var printlnNames = map[string]bool{
 	"println": true,
@@ -765,7 +765,7 @@ type PrintStackTraceInProductionRule struct {
 	BaseRule
 }
 
-func (r *PrintStackTraceInProductionRule) Confidence() float64 { return 0.85 }
+func (r *PrintStackTraceInProductionRule) Confidence() float64 { return api.ConfidenceHigh }
 
 var loggingImports = []string{
 	"timber.log.Timber",
@@ -832,7 +832,7 @@ type HardcodedLocalhostURLRule struct {
 // the literal has such an expression child, we refuse to match (we cannot
 // prove the runtime URL is `localhost`). No line scanning, no quote
 // gymnastics.
-func (r *HardcodedLocalhostURLRule) Confidence() float64 { return 0.95 }
+func (r *HardcodedLocalhostURLRule) Confidence() float64 { return api.ConfidenceVeryHigh }
 
 var localhostURLRe = regexp.MustCompile(`^https?://(localhost|127\.0\.0\.1|10\.0\.2\.2)(:\d+)?(/.*)?$`)
 
@@ -870,7 +870,7 @@ type TestOnlyImportInProductionRule struct {
 	BaseRule
 }
 
-func (r *TestOnlyImportInProductionRule) Confidence() float64 { return 0.95 }
+func (r *TestOnlyImportInProductionRule) Confidence() float64 { return api.ConfidenceVeryHigh }
 
 var testOnlyImportPrefixes = []string{
 	"org.mockito.",
@@ -927,7 +927,7 @@ type NonASCIIIdentifierRule struct {
 	BaseRule
 }
 
-func (r *NonASCIIIdentifierRule) Confidence() float64 { return 0.95 }
+func (r *NonASCIIIdentifierRule) Confidence() float64 { return api.ConfidenceVeryHigh }
 
 // HardcodedLogTagRule flags Log.d("ClassName", ...) where the tag matches
 // the enclosing class name instead of using a companion TAG constant.
@@ -936,7 +936,7 @@ type HardcodedLogTagRule struct {
 	BaseRule
 }
 
-func (r *HardcodedLogTagRule) Confidence() float64 { return 0.80 }
+func (r *HardcodedLogTagRule) Confidence() float64 { return api.ConfidenceMediumHigh }
 
 var logLevelMethods = map[string]bool{
 	"v": true, "d": true, "i": true, "w": true, "e": true, "wtf": true,
@@ -997,7 +997,7 @@ type VisibleForTestingCallerInNonTestRule struct {
 	BaseRule
 }
 
-func (r *VisibleForTestingCallerInNonTestRule) Confidence() float64 { return 0.80 }
+func (r *VisibleForTestingCallerInNonTestRule) Confidence() float64 { return api.ConfidenceMediumHigh }
 func (r *VisibleForTestingCallerInNonTestRule) check(ctx *api.Context) {
 	index := ctx.CodeIndex
 	if index == nil {
@@ -1220,7 +1220,7 @@ type OpenForTestingCallerInNonTestRule struct {
 	BaseRule
 }
 
-func (r *OpenForTestingCallerInNonTestRule) Confidence() float64 { return 0.75 }
+func (r *OpenForTestingCallerInNonTestRule) Confidence() float64 { return api.ConfidenceMedium }
 func (r *OpenForTestingCallerInNonTestRule) check(ctx *api.Context) {
 	index := ctx.CodeIndex
 	if index == nil {
@@ -1569,7 +1569,7 @@ type TestFixtureAccessedFromProductionRule struct {
 	BaseRule
 }
 
-func (r *TestFixtureAccessedFromProductionRule) Confidence() float64 { return 0.80 }
+func (r *TestFixtureAccessedFromProductionRule) Confidence() float64 { return api.ConfidenceMediumHigh }
 
 type testFixtureDeclaration struct {
 	qualifiedName string
@@ -2031,7 +2031,7 @@ type TimberTreeNotPlantedRule struct {
 	BaseRule
 }
 
-func (r *TimberTreeNotPlantedRule) Confidence() float64 { return 0.75 }
+func (r *TimberTreeNotPlantedRule) Confidence() float64 { return api.ConfidenceMedium }
 func (r *TimberTreeNotPlantedRule) check(ctx *api.Context) {
 	files := timberProjectFiles(ctx)
 	if len(files) == 0 {

--- a/internal/rules/resource_cost.go
+++ b/internal/rules/resource_cost.go
@@ -42,7 +42,7 @@ type BufferedReadWithoutBufferRule struct {
 	BaseRule
 }
 
-func (r *BufferedReadWithoutBufferRule) Confidence() float64 { return 0.75 }
+func (r *BufferedReadWithoutBufferRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // CursorLoopWithColumnIndexInLoopRule detects getColumnIndex() calls inside
 // cursor.moveToNext() while loops.
@@ -51,7 +51,7 @@ type CursorLoopWithColumnIndexInLoopRule struct {
 	BaseRule
 }
 
-func (r *CursorLoopWithColumnIndexInLoopRule) Confidence() float64 { return 0.75 }
+func (r *CursorLoopWithColumnIndexInLoopRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // ---------------------------------------------------------------------------
 // Batch 2: Network/IO rules
@@ -64,7 +64,7 @@ type OkHTTPClientCreatedPerCallRule struct {
 	BaseRule
 }
 
-func (r *OkHTTPClientCreatedPerCallRule) Confidence() float64 { return 0.75 }
+func (r *OkHTTPClientCreatedPerCallRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // OkHTTPCallExecuteSyncRule detects Call.execute() inside suspend functions
 // where enqueue() with a callback should be used instead.
@@ -73,7 +73,7 @@ type OkHTTPCallExecuteSyncRule struct {
 	BaseRule
 }
 
-func (r *OkHTTPCallExecuteSyncRule) Confidence() float64 { return 0.75 }
+func (r *OkHTTPCallExecuteSyncRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func okHTTPExecuteCallLooksBlocking(file *scanner.File, idx, fn uint32) bool {
 	receiver := databaseCallReceiverName(file, idx)
@@ -232,7 +232,7 @@ type RetrofitCreateInHotPathRule struct {
 	BaseRule
 }
 
-func (r *RetrofitCreateInHotPathRule) Confidence() float64 { return 0.75 }
+func (r *RetrofitCreateInHotPathRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // HTTPClientNotReusedRule detects Java HttpClient.newHttpClient() in function
 // bodies without caching.
@@ -241,7 +241,7 @@ type HTTPClientNotReusedRule struct {
 	BaseRule
 }
 
-func (r *HTTPClientNotReusedRule) Confidence() float64 { return 0.75 }
+func (r *HTTPClientNotReusedRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // ---------------------------------------------------------------------------
 // Batch 3: Database rules
@@ -254,7 +254,7 @@ type DatabaseQueryOnMainThreadRule struct {
 	BaseRule
 }
 
-func (r *DatabaseQueryOnMainThreadRule) Confidence() float64 { return 0.75 }
+func (r *DatabaseQueryOnMainThreadRule) Confidence() float64 { return api.ConfidenceMedium }
 
 var databaseMainThreadFunctionNames = map[string]bool{
 	"afterTextChanged":           true,
@@ -1149,7 +1149,7 @@ type RoomLoadsAllWhereFirstUsedRule struct {
 	BaseRule
 }
 
-func (r *RoomLoadsAllWhereFirstUsedRule) Confidence() float64 { return 0.75 }
+func (r *RoomLoadsAllWhereFirstUsedRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *RoomLoadsAllWhereFirstUsedRule) checkParsedFiles(ctx *api.Context) {
 	if len(ctx.ParsedFiles) == 0 {
@@ -1269,7 +1269,7 @@ type RecyclerAdapterWithoutDiffUtilRule struct {
 	BaseRule
 }
 
-func (r *RecyclerAdapterWithoutDiffUtilRule) Confidence() float64 { return 0.75 }
+func (r *RecyclerAdapterWithoutDiffUtilRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // RecyclerAdapterStableIDsDefaultRule detects RecyclerView.Adapter subclasses
 // that don't call setHasStableIds(true) and don't extend ListAdapter.
@@ -1278,7 +1278,7 @@ type RecyclerAdapterStableIDsDefaultRule struct {
 	BaseRule
 }
 
-func (r *RecyclerAdapterStableIDsDefaultRule) Confidence() float64 { return 0.75 }
+func (r *RecyclerAdapterStableIDsDefaultRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // LazyColumnInsideColumnRule detects LazyColumn nested inside a Column with
 // verticalScroll modifier.
@@ -1287,7 +1287,7 @@ type LazyColumnInsideColumnRule struct {
 	BaseRule
 }
 
-func (r *LazyColumnInsideColumnRule) Confidence() float64 { return 0.75 }
+func (r *LazyColumnInsideColumnRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // RecyclerViewInLazyColumnRule detects AndroidView wrapping a RecyclerView
 // inside a LazyColumn/LazyRow.
@@ -1296,7 +1296,7 @@ type RecyclerViewInLazyColumnRule struct {
 	BaseRule
 }
 
-func (r *RecyclerViewInLazyColumnRule) Confidence() float64 { return 0.75 }
+func (r *RecyclerViewInLazyColumnRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // ---------------------------------------------------------------------------
 // Batch 5: Image Loading rules
@@ -1309,7 +1309,7 @@ type ImageLoadedAtFullSizeInListRule struct {
 	BaseRule
 }
 
-func (r *ImageLoadedAtFullSizeInListRule) Confidence() float64 { return 0.75 }
+func (r *ImageLoadedAtFullSizeInListRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // ImageLoaderNoMemoryCacheRule detects image loaders configured to skip
 // the memory cache.
@@ -1318,7 +1318,7 @@ type ImageLoaderNoMemoryCacheRule struct {
 	BaseRule
 }
 
-func (r *ImageLoaderNoMemoryCacheRule) Confidence() float64 { return 0.75 }
+func (r *ImageLoaderNoMemoryCacheRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // ---------------------------------------------------------------------------
 // Batch 6: Compose rules
@@ -1331,7 +1331,7 @@ type ComposePainterResourceInLoopRule struct {
 	BaseRule
 }
 
-func (r *ComposePainterResourceInLoopRule) Confidence() float64 { return 0.75 }
+func (r *ComposePainterResourceInLoopRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // ComposeRememberInListRule detects remember{} inside items{} lambda
 // without a key argument — causes recomputation on list reordering.
@@ -1340,7 +1340,7 @@ type ComposeRememberInListRule struct {
 	BaseRule
 }
 
-func (r *ComposeRememberInListRule) Confidence() float64 { return 0.75 }
+func (r *ComposeRememberInListRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // ---------------------------------------------------------------------------
 // Batch 7: WorkManager rules
@@ -1353,7 +1353,7 @@ type PeriodicWorkRequestLessThan15MinRule struct {
 	BaseRule
 }
 
-func (r *PeriodicWorkRequestLessThan15MinRule) Confidence() float64 { return 0.75 }
+func (r *PeriodicWorkRequestLessThan15MinRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // WorkManagerNoBackoffRule detects OneTimeWorkRequestBuilder chains without
 // setBackoffCriteria.
@@ -1362,7 +1362,7 @@ type WorkManagerNoBackoffRule struct {
 	BaseRule
 }
 
-func (r *WorkManagerNoBackoffRule) Confidence() float64 { return 0.75 }
+func (r *WorkManagerNoBackoffRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // WorkManagerUniquePolicyKeepButReplaceIntendedRule detects enqueueUniqueWork
 // with ExistingWorkPolicy.KEEP where REPLACE may be intended.
@@ -1371,4 +1371,6 @@ type WorkManagerUniquePolicyKeepButReplaceIntendedRule struct {
 	BaseRule
 }
 
-func (r *WorkManagerUniquePolicyKeepButReplaceIntendedRule) Confidence() float64 { return 0.75 }
+func (r *WorkManagerUniquePolicyKeepButReplaceIntendedRule) Confidence() float64 {
+	return api.ConfidenceMedium
+}

--- a/internal/rules/sample_annotation_freshness.go
+++ b/internal/rules/sample_annotation_freshness.go
@@ -15,7 +15,7 @@ type SampleAnnotationFreshnessRule struct {
 }
 
 // Confidence reflects exact FQN lookup through the cross-file symbol index.
-func (r *SampleAnnotationFreshnessRule) Confidence() float64 { return 0.90 }
+func (r *SampleAnnotationFreshnessRule) Confidence() float64 { return api.ConfidenceHigher }
 
 var kdocSampleTagRe = regexp.MustCompile(`@sample\s+([A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)+)`)
 

--- a/internal/rules/security.go
+++ b/internal/rules/security.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 	"strings"
 
+	api "github.com/kaeawc/krit/internal/rules/api"
 	"github.com/kaeawc/krit/internal/rules/api/evidence"
 	"github.com/kaeawc/krit/internal/scanner"
 )
@@ -89,27 +90,29 @@ type GsonPolymorphicFromJSONRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Security rule. Detection pattern-matches known-insecure API shapes and
 // argument literals without confirming the receiver type. Classified per
 // roadmap/17.
-func (r *ContentProviderQueryWithSelectionInterpolationRule) Confidence() float64 { return 0.75 }
+func (r *ContentProviderQueryWithSelectionInterpolationRule) Confidence() float64 {
+	return api.ConfidenceMedium
+}
 
-func (r *SQLInjectionRawQueryRule) Confidence() float64 { return 0.75 }
+func (r *SQLInjectionRawQueryRule) Confidence() float64 { return api.ConfidenceMedium }
 
-func (r *RuntimeExecUnsafeShapeRule) Confidence() float64 { return 0.75 }
+func (r *RuntimeExecUnsafeShapeRule) Confidence() float64 { return api.ConfidenceMedium }
 
-func (r *RoomRawQueryStringConcatRule) Confidence() float64 { return 0.75 }
+func (r *RoomRawQueryStringConcatRule) Confidence() float64 { return api.ConfidenceMedium }
 
-func (r *ProcessBuilderShellArgRule) Confidence() float64 { return 0.75 }
+func (r *ProcessBuilderShellArgRule) Confidence() float64 { return api.ConfidenceMedium }
 
-func (r *LogPiiRule) Confidence() float64 { return 0.75 }
+func (r *LogPiiRule) Confidence() float64 { return api.ConfidenceMedium }
 
-func (r *JdbcStatementExecuteRule) Confidence() float64 { return 0.75 }
+func (r *JdbcStatementExecuteRule) Confidence() float64 { return api.ConfidenceMedium }
 
-func (r *XMLExternalEntityRule) Confidence() float64 { return 0.75 }
+func (r *XMLExternalEntityRule) Confidence() float64 { return api.ConfidenceMedium }
 
-func (r *JavaObjectInputStreamRule) Confidence() float64 { return 0.8 }
+func (r *JavaObjectInputStreamRule) Confidence() float64 { return api.ConfidenceMediumHigh }
 
-func (r *JacksonDefaultTypingRule) Confidence() float64 { return 0.8 }
+func (r *JacksonDefaultTypingRule) Confidence() float64 { return api.ConfidenceMediumHigh }
 
-func (r *GsonPolymorphicFromJSONRule) Confidence() float64 { return 0.8 }
+func (r *GsonPolymorphicFromJSONRule) Confidence() float64 { return api.ConfidenceMediumHigh }
 
 var defaultLogPiiNamePattern = regexp.MustCompile(`(?i)(password|passwd|token|secret|apiKey|api_key|authHeader|authorization|ssn|pan|cvv|jwt|sessionId|cookie)`)
 
@@ -1305,12 +1308,12 @@ type HardcodedGcpServiceAccountRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Security rule. Detection pattern-matches known-insecure API shapes and
 // argument literals without confirming the receiver type. Classified per
 // roadmap/17.
-func (r *HardcodedGcpServiceAccountRule) Confidence() float64 { return 0.75 }
+func (r *HardcodedGcpServiceAccountRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // Confidence reports a tier-2 (medium) base confidence. Security rule. Detection pattern-matches known-insecure API shapes and
 // argument literals without confirming the receiver type. Classified per
 // roadmap/17.
-func (r *HardcodedBearerTokenRule) Confidence() float64 { return 0.75 }
+func (r *HardcodedBearerTokenRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func extractHardcodedBearerToken(text string) (string, bool) {
 	body, ok := kotlinStringLiteralBody(text)
@@ -1394,7 +1397,7 @@ type TempFileWorldReadableRule struct {
 	BaseRule
 }
 
-func (r *TempFileWorldReadableRule) Confidence() float64 { return 0.75 }
+func (r *TempFileWorldReadableRule) Confidence() float64 { return api.ConfidenceMedium }
 
 var tempFilePermissionSetterNames = map[string]bool{
 	"setReadable":   true,
@@ -1554,7 +1557,7 @@ func isCreateTempFileCall(file *scanner.File, call uint32) bool {
 // Confidence reports a tier-2 (medium) base confidence. Security rule. Detection pattern-matches known-insecure API shapes and
 // argument literals without confirming the receiver type. Classified per
 // roadmap/17.
-func (r *FileFromUntrustedPathRule) Confidence() float64 { return 0.75 }
+func (r *FileFromUntrustedPathRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // ZipSlipUncheckedRule detects classic Zip-slip vulnerabilities where a zip
 // extraction loop builds a destination File from a zip entry name without a
@@ -1567,7 +1570,7 @@ type ZipSlipUncheckedRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Security rule. Detection pattern-matches known-insecure API shapes and
 // argument literals without confirming the receiver type. Classified per
 // roadmap/17.
-func (r *ZipSlipUncheckedRule) Confidence() float64 { return 0.75 }
+func (r *ZipSlipUncheckedRule) Confidence() float64 { return api.ConfidenceMedium }
 
 var zipSlipAPIMarkers = []string{
 	"ZipInputStream",

--- a/internal/rules/security_hardcoded_aws_access_key.go
+++ b/internal/rules/security_hardcoded_aws_access_key.go
@@ -2,6 +2,8 @@ package rules
 
 import (
 	"strings"
+
+	api "github.com/kaeawc/krit/internal/rules/api"
 )
 
 // HardcodedAwsAccessKeyRule detects string literals that look like an AWS
@@ -13,7 +15,7 @@ type HardcodedAwsAccessKeyRule struct {
 	BaseRule
 }
 
-func (r *HardcodedAwsAccessKeyRule) Confidence() float64 { return 0.9 }
+func (r *HardcodedAwsAccessKeyRule) Confidence() float64 { return api.ConfidenceHigher }
 
 // awsAccessKeyPrefixes is the canonical list of AWS access-key ID prefixes.
 // See https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html

--- a/internal/rules/security_hardcoded_jwt.go
+++ b/internal/rules/security_hardcoded_jwt.go
@@ -2,6 +2,8 @@ package rules
 
 import (
 	"strings"
+
+	api "github.com/kaeawc/krit/internal/rules/api"
 )
 
 // HardcodedJwtRule detects string literals that look like a structurally
@@ -14,7 +16,7 @@ type HardcodedJwtRule struct {
 	BaseRule
 }
 
-func (r *HardcodedJwtRule) Confidence() float64 { return 0.85 }
+func (r *HardcodedJwtRule) Confidence() float64 { return api.ConfidenceHigh }
 
 // looksLikeHardcodedJwt reports whether `body` (an unwrapped string-literal
 // body, possibly a Kotlin string template) is a JWT-shaped token that is

--- a/internal/rules/style_braces.go
+++ b/internal/rules/style_braces.go
@@ -137,7 +137,7 @@ type BracesOnIfStatementsRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Style/braces rule. Detection checks AST shape for if/when/else brace
 // presence; the preferred form is a style preference. Classified per
 // roadmap/17.
-func (r *BracesOnIfStatementsRule) Confidence() float64 { return 0.75 }
+func (r *BracesOnIfStatementsRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *BracesOnIfStatementsRule) check(ctx *api.Context) {
 	idx, file := ctx.Idx, ctx.File
@@ -273,7 +273,7 @@ type BracesOnWhenStatementsRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Style/braces rule. Detection checks AST shape for if/when/else brace
 // presence; the preferred form is a style preference. Classified per
 // roadmap/17.
-func (r *BracesOnWhenStatementsRule) Confidence() float64 { return 0.75 }
+func (r *BracesOnWhenStatementsRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *BracesOnWhenStatementsRule) check(ctx *api.Context) {
 	idx, file := ctx.Idx, ctx.File
@@ -395,7 +395,7 @@ type MandatoryBracesLoopsRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Style/braces rule. Detection checks AST shape for if/when/else brace
 // presence; the preferred form is a style preference. Classified per
 // roadmap/17.
-func (r *MandatoryBracesLoopsRule) Confidence() float64 { return 0.75 }
+func (r *MandatoryBracesLoopsRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *MandatoryBracesLoopsRule) check(ctx *api.Context) {
 	idx, file := ctx.Idx, ctx.File

--- a/internal/rules/style_classes.go
+++ b/internal/rules/style_classes.go
@@ -3,6 +3,7 @@ package rules
 import (
 	"strings"
 
+	api "github.com/kaeawc/krit/internal/rules/api"
 	"github.com/kaeawc/krit/internal/scanner"
 	"github.com/kaeawc/krit/internal/typeinfer"
 )
@@ -19,7 +20,7 @@ type AbstractClassCanBeConcreteClassRule struct {
 // abstractness requires knowing all concrete method bodies;
 // resolver-assisted but falls back to structural heuristic. Classified per
 // roadmap/17.
-func (r *AbstractClassCanBeConcreteClassRule) Confidence() float64 { return 0.75 }
+func (r *AbstractClassCanBeConcreteClassRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // AbstractClassCanBeInterfaceRule detects abstract classes with no state.
 type AbstractClassCanBeInterfaceRule struct {
@@ -30,7 +31,7 @@ type AbstractClassCanBeInterfaceRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Style/classes rule. Detection relies on modifier and declaration
 // structure plus (optional) resolver-backed inheritance checks; the
 // fallback path is heuristic. Classified per roadmap/17.
-func (r *AbstractClassCanBeInterfaceRule) Confidence() float64 { return 0.75 }
+func (r *AbstractClassCanBeInterfaceRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func abstractClassCanBeInterfaceClassDeclaresState(file *scanner.File, idx uint32) bool {
 	if file == nil || idx == 0 || file.FlatType(idx) != "class_declaration" {
@@ -218,7 +219,7 @@ type DataClassShouldBeImmutableRule struct {
 // Confidence reports a tier-2 (medium) base confidence — detecting
 // mutable properties in data classes needs type-aware var detection;
 // fallback uses keyword matching. Classified per roadmap/17.
-func (r *DataClassShouldBeImmutableRule) Confidence() float64 { return 0.75 }
+func (r *DataClassShouldBeImmutableRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // mutableCollectionTypes lists types that are mutable collections.
 var mutableCollectionTypes = map[string]bool{
@@ -265,7 +266,7 @@ type DataClassContainsFunctionsRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Style/classes rule. Detection relies on modifier and declaration
 // structure plus (optional) resolver-backed inheritance checks; the
 // fallback path is heuristic. Classified per roadmap/17.
-func (r *DataClassContainsFunctionsRule) Confidence() float64 { return 0.75 }
+func (r *DataClassContainsFunctionsRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // dataClassHasNonConversionFunctionFlat reports whether the class body
 // contains any function whose name does NOT start with one of the
@@ -308,7 +309,7 @@ type ProtectedMemberInFinalClassRule struct {
 // members on non-open classes; class-openness detection depends on declared
 // modifiers plus resolver for inherited finality. Classified per
 // roadmap/17.
-func (r *ProtectedMemberInFinalClassRule) Confidence() float64 { return 0.75 }
+func (r *ProtectedMemberInFinalClassRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func forEachDirectClassMemberFlat(file *scanner.File, body uint32, fn func(uint32)) {
 	if file == nil || body == 0 {
@@ -343,7 +344,7 @@ type NestedClassesVisibilityRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Style/classes rule. Detection relies on modifier and declaration
 // structure plus (optional) resolver-backed inheritance checks; the
 // fallback path is heuristic. Classified per roadmap/17.
-func (r *NestedClassesVisibilityRule) Confidence() float64 { return 0.75 }
+func (r *NestedClassesVisibilityRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // UtilityClassWithPublicConstructorRule detects utility classes with public constructors.
 type UtilityClassWithPublicConstructorRule struct {
@@ -354,7 +355,7 @@ type UtilityClassWithPublicConstructorRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Style/classes rule. Detection relies on modifier and declaration
 // structure plus (optional) resolver-backed inheritance checks; the
 // fallback path is heuristic. Classified per roadmap/17.
-func (r *UtilityClassWithPublicConstructorRule) Confidence() float64 { return 0.75 }
+func (r *UtilityClassWithPublicConstructorRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // OptionalAbstractKeywordRule detects abstract keyword on interface members.
 type OptionalAbstractKeywordRule struct {
@@ -365,7 +366,7 @@ type OptionalAbstractKeywordRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Style/classes rule. Detection relies on modifier and declaration
 // structure plus (optional) resolver-backed inheritance checks; the
 // fallback path is heuristic. Classified per roadmap/17.
-func (r *OptionalAbstractKeywordRule) Confidence() float64 { return 0.75 }
+func (r *OptionalAbstractKeywordRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // ClassOrderingRule checks that class members are in the conventional order.
 type ClassOrderingRule struct {
@@ -376,7 +377,7 @@ type ClassOrderingRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Style/classes rule. Detection relies on modifier and declaration
 // structure plus (optional) resolver-backed inheritance checks; the
 // fallback path is heuristic. Classified per roadmap/17.
-func (r *ClassOrderingRule) Confidence() float64 { return 0.75 }
+func (r *ClassOrderingRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // ObjectLiteralToLambdaRule detects object literals that could be lambdas.
 // With type inference: uses ClassHierarchy to detect SAM interfaces from
@@ -393,7 +394,7 @@ type ObjectLiteralToLambdaRule struct {
 // paths miss project-defined SAM interfaces. The rule also can't
 // easily detect when the object literal captures state or has
 // side-effect init blocks that prevent conversion.
-func (r *ObjectLiteralToLambdaRule) Confidence() float64 { return 0.75 }
+func (r *ObjectLiteralToLambdaRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // extractSupertypeName gets the simple type name from a delegation_specifier node,
 // handling dotted names (e.g., "Foo.Bar") and generics (e.g., "Callable<Int>").
@@ -532,7 +533,7 @@ type SerialVersionUIDInSerializableClassRule struct {
 // Confidence reports a tier-2 (medium) base confidence — Serializable
 // detection uses supertype names; without resolver, falls back to matching
 // `Serializable` in the delegation list. Classified per roadmap/17.
-func (r *SerialVersionUIDInSerializableClassRule) Confidence() float64 { return 0.75 }
+func (r *SerialVersionUIDInSerializableClassRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func flatDirectChildrenOfType(file *scanner.File, idx uint32, nodeType string) []uint32 {
 	var out []uint32

--- a/internal/rules/style_expressions.go
+++ b/internal/rules/style_expressions.go
@@ -19,7 +19,7 @@ type ExpressionBodySyntaxRule struct {
 
 // Confidence reports a tier-2 (medium) base confidence. Style/expression rule. Detection is pattern-based and the preferred form
 // is a style preference. Classified per roadmap/17.
-func (r *ExpressionBodySyntaxRule) Confidence() float64 { return 0.75 }
+func (r *ExpressionBodySyntaxRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // ReturnCountRule limits the number of return statements in a function.
 type ReturnCountRule struct {
@@ -39,7 +39,7 @@ type ReturnCountRule struct {
 // ExcludeReturnFromLambda knobs mitigate but don't eliminate the
 // subjectivity. Medium keeps it out of strict default-confidence
 // gates without removing it from the rule set.
-func (r *ReturnCountRule) Confidence() float64 { return 0.75 }
+func (r *ReturnCountRule) Confidence() float64 { return api.ConfidenceMedium }
 
 type jumpMetrics struct {
 	returns int
@@ -477,7 +477,7 @@ type ThrowsCountRule struct {
 
 // Confidence reports a tier-2 (medium) base confidence. Style/expression rule. Detection is pattern-based and the preferred form
 // is a style preference. Classified per roadmap/17.
-func (r *ThrowsCountRule) Confidence() float64 { return 0.75 }
+func (r *ThrowsCountRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func countJumpExpressionsFlat(root uint32, file *scanner.File, prefix string, limit int, accept func(uint32, string) bool) int {
 	count := 0
@@ -533,7 +533,7 @@ type CollapsibleIfStatementsRule struct {
 
 // Confidence reports a tier-2 (medium) base confidence. Style/expression rule. Detection is pattern-based and the preferred form
 // is a style preference. Classified per roadmap/17.
-func (r *CollapsibleIfStatementsRule) Confidence() float64 { return 0.75 }
+func (r *CollapsibleIfStatementsRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // SafeCastRule detects `if (x is Type) { x as Type }` patterns that should use `x as? Type`.
 // This is distinct from UnsafeCast, which is reserved for casts that can never succeed.
@@ -551,7 +551,7 @@ type SafeCastRule struct {
 // rule and UnsafeCast fire on overlapping locations; medium
 // confidence is appropriate for the redundant-cast half of that
 // pair.
-func (r *SafeCastRule) Confidence() float64 { return 0.75 }
+func (r *SafeCastRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // frameworkAnnotationNames identifies annotations indicating external
 // initialization by a framework — these vars can't be analyzed for mutability.
@@ -628,7 +628,7 @@ type VarCouldBeValRule struct {
 // nuances that flow analysis would catch — e.g. vars reassigned only
 // on one branch of a when, or through a captured lambda. Medium
 // confidence reflects the known analysis gap.
-func (r *VarCouldBeValRule) Confidence() float64 { return 0.75 }
+func (r *VarCouldBeValRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func flatSubtreeHasNodeType(file *scanner.File, idx uint32, nodeType string) bool {
 	if file == nil || idx == 0 || nodeType == "" {
@@ -770,7 +770,7 @@ type MayBeConstantRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Initializers are
 // checked structurally and same-file constant references are resolved when
 // they share the same owner, but the finding remains a style preference.
-func (r *MayBeConstantRule) Confidence() float64 { return 0.75 }
+func (r *MayBeConstantRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func mayBeConstantExpressionFlat(ctx *api.Context, expr uint32) bool {
 	if ctx.File == nil || expr == 0 {
@@ -864,7 +864,7 @@ var modifierOrder = []string{
 
 // Confidence reports a tier-2 (medium) base confidence. Style/expression rule. Detection is pattern-based and the preferred form
 // is a style preference. Classified per roadmap/17.
-func (r *ModifierOrderRule) Confidence() float64 { return 0.75 }
+func (r *ModifierOrderRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func modifierIndex(mod string) int {
 	for i, m := range modifierOrder {
@@ -907,7 +907,7 @@ type FunctionOnlyReturningConstantRule struct {
 
 // Confidence reports a tier-2 (medium) base confidence. Style/expression rule. Detection is pattern-based and the preferred form
 // is a style preference. Classified per roadmap/17.
-func (r *FunctionOnlyReturningConstantRule) Confidence() float64 { return 0.75 }
+func (r *FunctionOnlyReturningConstantRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func isConstant(s string) bool {
 	s = strings.TrimSpace(s)
@@ -987,7 +987,7 @@ type LoopWithTooManyJumpStatementsRule struct {
 
 // Confidence reports a tier-2 (medium) base confidence. Style/expression rule. Detection is pattern-based and the preferred form
 // is a style preference. Classified per roadmap/17.
-func (r *LoopWithTooManyJumpStatementsRule) Confidence() float64 { return 0.75 }
+func (r *LoopWithTooManyJumpStatementsRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // ExplicitItLambdaParameterRule detects `{ it -> ... }` using AST-based analysis.
 // It finds lambda_literal nodes with exactly one parameter named "it" and flags them.
@@ -1000,7 +1000,7 @@ type ExplicitItLambdaParameterRule struct {
 
 // Confidence reports a tier-2 (medium) base confidence. Style/expression rule. Detection is pattern-based and the preferred form
 // is a style preference. Classified per roadmap/17.
-func (r *ExplicitItLambdaParameterRule) Confidence() float64 { return 0.75 }
+func (r *ExplicitItLambdaParameterRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func findArrowInLambdaFlat(file *scanner.File, lambda uint32) uint32 {
 	for i := 0; i < file.FlatChildCount(lambda); i++ {
@@ -1023,7 +1023,7 @@ type ExplicitItLambdaMultipleParametersRule struct {
 
 // Confidence reports a tier-2 (medium) base confidence. Style/expression rule. Detection is pattern-based and the preferred form
 // is a style preference. Classified per roadmap/17.
-func (r *ExplicitItLambdaMultipleParametersRule) Confidence() float64 { return 0.75 }
+func (r *ExplicitItLambdaMultipleParametersRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func isInsideLambdaUnderFlat(child, stopAt uint32, file *scanner.File) bool {
 	for p, ok := file.FlatParent(child); ok && p != stopAt; p, ok = file.FlatParent(p) {

--- a/internal/rules/style_expressions_extra.go
+++ b/internal/rules/style_expressions_extra.go
@@ -19,7 +19,7 @@ type MultilineLambdaItParameterRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Style/expression rule. Detection uses structural pattern matching on
 // expressions; the suggested rewrite's readability is a style call.
 // Classified per roadmap/17.
-func (r *MultilineLambdaItParameterRule) Confidence() float64 { return 0.75 }
+func (r *MultilineLambdaItParameterRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // MultilineRawStringIndentationRule checks raw string indentation.
 type MultilineRawStringIndentationRule struct {
@@ -32,7 +32,7 @@ type MultilineRawStringIndentationRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Style/expression rule. Detection uses structural pattern matching on
 // expressions; the suggested rewrite's readability is a style call.
 // Classified per roadmap/17.
-func (r *MultilineRawStringIndentationRule) Confidence() float64 { return 0.75 }
+func (r *MultilineRawStringIndentationRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *MultilineRawStringIndentationRule) check(ctx *api.Context) {
 	if !isUntrimmedMultilineRawString(ctx, r.TrimmingMethods) {
@@ -52,7 +52,7 @@ type TrimMultilineRawStringRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Style/expression rule. Detection uses structural pattern matching on
 // expressions; the suggested rewrite's readability is a style call.
 // Classified per roadmap/17.
-func (r *TrimMultilineRawStringRule) Confidence() float64 { return 0.75 }
+func (r *TrimMultilineRawStringRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *TrimMultilineRawStringRule) check(ctx *api.Context) {
 	if !isUntrimmedMultilineRawString(ctx, r.TrimmingMethods) {
@@ -120,7 +120,7 @@ var escapeCountRe = regexp.MustCompile(`\\[nrt"\\]`)
 // Confidence reports a tier-2 (medium) base confidence. Style/expression rule. Detection uses structural pattern matching on
 // expressions; the suggested rewrite's readability is a style call.
 // Classified per roadmap/17.
-func (r *StringShouldBeRawStringRule) Confidence() float64 { return 0.75 }
+func (r *StringShouldBeRawStringRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // CanBeNonNullableRule detects nullable types that are never assigned null.
 // Handles two cases:
@@ -142,7 +142,7 @@ func (r *CanBeNonNullableRule) SetResolver(_ typeinfer.TypeResolver) {}
 // Confidence reports a tier-2 (medium) base confidence — detecting which
 // nullable properties are never assigned null requires flow analysis; the
 // fallback is a conservative heuristic. Classified per roadmap/17.
-func (r *CanBeNonNullableRule) Confidence() float64 { return 0.75 }
+func (r *CanBeNonNullableRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *CanBeNonNullableRule) checkPropertyFlat(ctx *api.Context) {
 	idx, file := ctx.Idx, ctx.File
@@ -449,7 +449,7 @@ type DoubleNegativeExpressionRule struct {
 // Confidence: tier-1 — the detection is purely syntactic. prefix_expression
 // with a `!` operator applied to a no-arg call whose callee starts with
 // `isNot`/`isNon` is unambiguously a double negative.
-func (r *DoubleNegativeExpressionRule) Confidence() float64 { return 0.9 }
+func (r *DoubleNegativeExpressionRule) Confidence() float64 { return api.ConfidenceHigher }
 
 // checkDoubleNegativeExpressionFlat runs on a prefix_expression. It fires
 // when the shape is `!<expr>.isNot<Suffix>()` or `!isNon<Suffix>()` — a
@@ -563,7 +563,7 @@ func doubleNegativeLambdaCalleeConfigured(callee string, configured []string) bo
 // expression is an unambiguous double negative. We deliberately do NOT
 // flag multi-statement lambdas or compound expressions where `!` appears
 // inside a larger boolean expression.
-func (r *DoubleNegativeLambdaRule) Confidence() float64 { return 0.9 }
+func (r *DoubleNegativeLambdaRule) Confidence() float64 { return api.ConfidenceHigher }
 
 // checkDoubleNegativeLambdaFlat runs on a call_expression. Fires when the
 // callee is `filterNot` or `none` (qualified or unqualified) and the
@@ -665,7 +665,7 @@ type NullableBooleanCheckRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Style/expression rule. Detection uses structural pattern matching on
 // expressions; the suggested rewrite's readability is a style call.
 // Classified per roadmap/17.
-func (r *NullableBooleanCheckRule) Confidence() float64 { return 0.75 }
+func (r *NullableBooleanCheckRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // RangeUntilInsteadOfRangeToRule detects `until` usage that could use `..<`.
 type RangeUntilInsteadOfRangeToRule struct {
@@ -676,7 +676,7 @@ type RangeUntilInsteadOfRangeToRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Style/expression rule. Detection uses structural pattern matching on
 // expressions; the suggested rewrite's readability is a style call.
 // Classified per roadmap/17.
-func (r *RangeUntilInsteadOfRangeToRule) Confidence() float64 { return 0.75 }
+func (r *RangeUntilInsteadOfRangeToRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // DestructuringDeclarationWithTooManyEntriesRule limits destructuring entries.
 type DestructuringDeclarationWithTooManyEntriesRule struct {
@@ -688,4 +688,6 @@ type DestructuringDeclarationWithTooManyEntriesRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Style/expression rule. Detection uses structural pattern matching on
 // expressions; the suggested rewrite's readability is a style call.
 // Classified per roadmap/17.
-func (r *DestructuringDeclarationWithTooManyEntriesRule) Confidence() float64 { return 0.75 }
+func (r *DestructuringDeclarationWithTooManyEntriesRule) Confidence() float64 {
+	return api.ConfidenceMedium
+}

--- a/internal/rules/style_forbidden.go
+++ b/internal/rules/style_forbidden.go
@@ -22,7 +22,7 @@ type WildcardImportRule struct {
 // imports/methods/annotations via literal string/regex match; false
 // positives arise when project-local names collide with forbidden list
 // entries. Classified per roadmap/17.
-func (r *WildcardImportRule) Confidence() float64 { return 0.75 }
+func (r *WildcardImportRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func wildcardImportExcluded(imp, excl string) bool {
 	imp = strings.TrimSpace(imp)
@@ -67,7 +67,7 @@ var trackedBugTodoCommentPattern = regexp.MustCompile(`\bTODO(?:\s*\(\s*b/\d+\s*
 // imports/methods/annotations via literal string/regex match; false
 // positives arise when project-local names collide with forbidden list
 // entries. Classified per roadmap/17.
-func (r *ForbiddenCommentRule) Confidence() float64 { return 0.75 }
+func (r *ForbiddenCommentRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func forbiddenCommentAllowedByDefault(text, marker string) bool {
 	if marker != "TODO:" {
@@ -88,7 +88,7 @@ type ForbiddenVoidRule struct {
 // imports/methods/annotations via literal string/regex match; false
 // positives arise when project-local names collide with forbidden list
 // entries. Classified per roadmap/17.
-func (r *ForbiddenVoidRule) Confidence() float64 { return 0.75 }
+func (r *ForbiddenVoidRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // javaInteropGenericTypes are Java generic types where Void is the canonical
 // way to say "no result" and Unit is not substitutable.
@@ -126,7 +126,7 @@ var defaultForbiddenImports = []string{
 // imports/methods/annotations via literal string/regex match; false
 // positives arise when project-local names collide with forbidden list
 // entries. Classified per roadmap/17.
-func (r *ForbiddenImportRule) Confidence() float64 { return 0.75 }
+func (r *ForbiddenImportRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // ForbiddenEntry pairs a forbidden value with an optional reason.
 type ForbiddenEntry struct {
@@ -147,7 +147,7 @@ var defaultForbiddenMethods = []string{"print(", "println("}
 // imports/methods/annotations via literal string/regex match; false
 // positives arise when project-local names collide with forbidden list
 // entries. Classified per roadmap/17.
-func (r *ForbiddenMethodCallRule) Confidence() float64 { return 0.75 }
+func (r *ForbiddenMethodCallRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func forbiddenMethodCallMatch(ctx *api.Context, call uint32, methods []string) (string, bool) {
 	if ctx.File == nil || len(methods) == 0 {
@@ -274,7 +274,7 @@ var defaultForbiddenAnnotations = []string{"SuppressWarnings"}
 // imports/methods/annotations via literal string/regex match; false
 // positives arise when project-local names collide with forbidden list
 // entries. Classified per roadmap/17.
-func (r *ForbiddenAnnotationRule) Confidence() float64 { return 0.75 }
+func (r *ForbiddenAnnotationRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // ForbiddenNamedParamRule detects named parameters in certain function calls.
 type ForbiddenNamedParamRule struct {
@@ -287,7 +287,7 @@ type ForbiddenNamedParamRule struct {
 // imports/methods/annotations via literal string/regex match; false
 // positives arise when project-local names collide with forbidden list
 // entries. Classified per roadmap/17.
-func (r *ForbiddenNamedParamRule) Confidence() float64 { return 0.75 }
+func (r *ForbiddenNamedParamRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // ForbiddenOptInRule detects @OptIn annotations.
 type ForbiddenOptInRule struct {
@@ -300,7 +300,7 @@ type ForbiddenOptInRule struct {
 // imports/methods/annotations via literal string/regex match; false
 // positives arise when project-local names collide with forbidden list
 // entries. Classified per roadmap/17.
-func (r *ForbiddenOptInRule) Confidence() float64 { return 0.75 }
+func (r *ForbiddenOptInRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // ForbiddenSuppressRule detects @Suppress annotations.
 type ForbiddenSuppressRule struct {
@@ -313,7 +313,7 @@ type ForbiddenSuppressRule struct {
 // imports/methods/annotations via literal string/regex match; false
 // positives arise when project-local names collide with forbidden list
 // entries. Classified per roadmap/17.
-func (r *ForbiddenSuppressRule) Confidence() float64 { return 0.75 }
+func (r *ForbiddenSuppressRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // MagicNumberRule detects literal numbers in code.
 type MagicNumberRule struct {
@@ -462,7 +462,7 @@ func magicNumberIsHTTPStatusLiteral(file *scanner.File, idx uint32) bool {
 // IgnoreCompanionObjectPropertyDeclaration) are best-effort. Medium
 // confidence lets strict pipelines filter it out while keeping it
 // available for default-severity scans.
-func (r *MagicNumberRule) Confidence() float64 { return 0.75 }
+func (r *MagicNumberRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // magicNumberLiteralTypes is the set of node types dispatched by MagicNumberRule.
 // Used to deduplicate when tree-sitter nests e.g. integer_literal inside long_literal.

--- a/internal/rules/style_format.go
+++ b/internal/rules/style_format.go
@@ -18,7 +18,7 @@ type TrailingWhitespaceRule struct {
 // Confidence bumps this line rule from the 0.75 line-rule default to
 // 0.95 — trailing whitespace is a pure lexical condition with no
 // known false positives.
-func (r *TrailingWhitespaceRule) Confidence() float64 { return 0.95 }
+func (r *TrailingWhitespaceRule) Confidence() float64 { return api.ConfidenceVeryHigh }
 
 var trailingWhitespaceRe = regexp.MustCompile(`[ \t]+$`)
 
@@ -53,7 +53,7 @@ type NoTabsRule struct {
 // Confidence bumps this line rule from the 0.75 line-rule default to
 // 0.95 — presence of a tab character is a pure byte check with no
 // room for interpretation.
-func (r *NoTabsRule) Confidence() float64 { return 0.95 }
+func (r *NoTabsRule) Confidence() float64 { return api.ConfidenceVeryHigh }
 
 func (r *NoTabsRule) check(ctx *api.Context) {
 	file := ctx.File
@@ -94,7 +94,7 @@ type MaxLineLengthRule struct {
 // 0.95 — line length is a deterministic measurement, and the rule
 // already skips test files and gradle scripts where long lines are
 // conventional.
-func (r *MaxLineLengthRule) Confidence() float64 { return 0.95 }
+func (r *MaxLineLengthRule) Confidence() float64 { return api.ConfidenceVeryHigh }
 
 func (r *MaxLineLengthRule) check(ctx *api.Context) {
 	file := ctx.File
@@ -408,7 +408,7 @@ type NewLineAtEndOfFileRule struct {
 // Confidence bumps this line rule from the 0.75 line-rule default to
 // 0.95 — presence/absence of a trailing newline is a single byte check
 // with no room for interpretation.
-func (r *NewLineAtEndOfFileRule) Confidence() float64 { return 0.95 }
+func (r *NewLineAtEndOfFileRule) Confidence() float64 { return api.ConfidenceVeryHigh }
 
 func (r *NewLineAtEndOfFileRule) check(ctx *api.Context) {
 	file := ctx.File
@@ -509,7 +509,7 @@ type MaxChainedCallsOnSameLineRule struct {
 // Confidence is 0.95 — chain depth is computed structurally from the
 // flat AST, so string-literal, decimal, import, and trailing-comment
 // dots no longer count.
-func (r *MaxChainedCallsOnSameLineRule) Confidence() float64 { return 0.95 }
+func (r *MaxChainedCallsOnSameLineRule) Confidence() float64 { return api.ConfidenceVeryHigh }
 
 func (r *MaxChainedCallsOnSameLineRule) check(ctx *api.Context) {
 	file := ctx.File
@@ -688,7 +688,7 @@ type CascadingCallWrappingRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Style/formatting rule. Detection is pattern or regex based on line text;
 // deterministic byte checks have been promoted to tier-1 separately.
 // Classified per roadmap/17.
-func (r *CascadingCallWrappingRule) Confidence() float64 { return 0.75 }
+func (r *CascadingCallWrappingRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *CascadingCallWrappingRule) check(ctx *api.Context) {
 	file := ctx.File
@@ -743,7 +743,7 @@ type UnderscoresInNumericLiteralsRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Style/formatting rule. Detection is pattern or regex based on line text;
 // deterministic byte checks have been promoted to tier-1 separately.
 // Classified per roadmap/17.
-func (r *UnderscoresInNumericLiteralsRule) Confidence() float64 { return 0.75 }
+func (r *UnderscoresInNumericLiteralsRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // formatWithUnderscores inserts underscores every 3 digits from the right for readability.
 func formatWithUnderscores(digits string) string {
@@ -816,7 +816,7 @@ type EqualsOnSignatureLineRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Style/formatting rule. Detection is pattern or regex based on line text;
 // deterministic byte checks have been promoted to tier-1 separately.
 // Classified per roadmap/17.
-func (r *EqualsOnSignatureLineRule) Confidence() float64 { return 0.75 }
+func (r *EqualsOnSignatureLineRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *EqualsOnSignatureLineRule) check(ctx *api.Context) {
 	file := ctx.File

--- a/internal/rules/style_idiomatic.go
+++ b/internal/rules/style_idiomatic.go
@@ -785,7 +785,7 @@ type UseCheckNotNullRule struct {
 // Confidence reports a tier-2 (medium) base confidence — suggests
 // checkNotNull over `if (x == null) throw`; pattern-based with resolver
 // used to confirm nullability when available. Classified per roadmap/17.
-func (r *UseCheckNotNullRule) Confidence() float64 { return 0.75 }
+func (r *UseCheckNotNullRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // UseRequireNotNullRule detects require(x != null) and suggests requireNotNull(x).
 // Uses AST dispatch on call_expression for precise detection, handling both
@@ -799,7 +799,7 @@ type UseRequireNotNullRule struct {
 // Confidence reports a tier-2 (medium) base confidence — suggests
 // requireNotNull over `if (x == null) throw IAE`; pattern-based with
 // resolver confirmation when available. Classified per roadmap/17.
-func (r *UseRequireNotNullRule) Confidence() float64 { return 0.75 }
+func (r *UseRequireNotNullRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // UseCheckOrErrorRule detects `if (!x) throw IllegalStateException`.
 type UseCheckOrErrorRule struct {
@@ -811,7 +811,7 @@ type UseCheckOrErrorRule struct {
 // blocks, null checks, explicit loops) but whether the suggested
 // replacement is actually clearer is context-dependent. Classified per
 // roadmap/17.
-func (r *UseCheckOrErrorRule) Confidence() float64 { return 0.75 }
+func (r *UseCheckOrErrorRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // UseRequireRule detects `if (!x) throw IllegalArgumentException`.
 type UseRequireRule struct {
@@ -823,7 +823,7 @@ type UseRequireRule struct {
 // blocks, null checks, explicit loops) but whether the suggested
 // replacement is actually clearer is context-dependent. Classified per
 // roadmap/17.
-func (r *UseRequireRule) Confidence() float64 { return 0.75 }
+func (r *UseRequireRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // UseIsNullOrEmptyRule detects `x == null || x.isEmpty()` and related patterns
 // such as `x == null || x.count() == 0`, `x == null || x.size == 0`,
@@ -838,7 +838,7 @@ type UseIsNullOrEmptyRule struct {
 // isNullOrEmpty() for `x == null || x.isEmpty()` after semantic receiver
 // checks, with lower-confidence same-file declaration fallback. Classified per
 // roadmap/17.
-func (r *UseIsNullOrEmptyRule) Confidence() float64 { return 0.75 }
+func (r *UseIsNullOrEmptyRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // UseOrEmptyRule detects `x ?: emptyList()` and similar patterns that can use .orEmpty().
 // Handles: emptyList/Set/Map/Array/Sequence(), listOf/setOf/mapOf/sequenceOf/arrayOf() with
@@ -853,7 +853,7 @@ type UseOrEmptyRule struct {
 // blocks, null checks, explicit loops) but whether the suggested
 // replacement is actually clearer is context-dependent. Classified per
 // roadmap/17.
-func (r *UseOrEmptyRule) Confidence() float64 { return 0.75 }
+func (r *UseOrEmptyRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // useOrEmptyFunctions maps callee names that represent empty collections/sequences.
 var useOrEmptyFunctions = map[string]bool{
@@ -902,7 +902,7 @@ var anyOrNoneFindFuncs = map[string]bool{
 // blocks, null checks, explicit loops) but whether the suggested
 // replacement is actually clearer is context-dependent. Classified per
 // roadmap/17.
-func (r *UseAnyOrNoneInsteadOfFindRule) Confidence() float64 { return 0.75 }
+func (r *UseAnyOrNoneInsteadOfFindRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // UseEmptyCounterpartRule detects `listOf()` etc. with no arguments.
 // Uses AST dispatch on call_expression for precise detection, matching
@@ -926,4 +926,4 @@ var emptyCounterparts = map[string]string{
 // blocks, null checks, explicit loops) but whether the suggested
 // replacement is actually clearer is context-dependent. Classified per
 // roadmap/17.
-func (r *UseEmptyCounterpartRule) Confidence() float64 { return 0.75 }
+func (r *UseEmptyCounterpartRule) Confidence() float64 { return api.ConfidenceMedium }

--- a/internal/rules/style_idiomatic_data.go
+++ b/internal/rules/style_idiomatic_data.go
@@ -16,7 +16,7 @@ type UseArrayLiteralsInAnnotationsRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Style/idiomatic rule for collection and data-flow idioms. The detection
 // is pattern-based and the suggested replacement's readability is a style
 // preference. Classified per roadmap/17.
-func (r *UseArrayLiteralsInAnnotationsRule) Confidence() float64 { return 0.75 }
+func (r *UseArrayLiteralsInAnnotationsRule) Confidence() float64 { return api.ConfidenceMedium }
 
 type UseSumOfInsteadOfFlatMapSizeRule struct {
 	FlatDispatchBase
@@ -26,7 +26,7 @@ type UseSumOfInsteadOfFlatMapSizeRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Style/idiomatic rule for collection and data-flow idioms. The detection
 // is pattern-based and the suggested replacement's readability is a style
 // preference. Classified per roadmap/17.
-func (r *UseSumOfInsteadOfFlatMapSizeRule) Confidence() float64 { return 0.75 }
+func (r *UseSumOfInsteadOfFlatMapSizeRule) Confidence() float64 { return api.ConfidenceMedium }
 
 var sumOfSourceCalls = map[string]bool{"flatMap": true, "flatten": true, "map": true}
 
@@ -56,7 +56,7 @@ type UseLetRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Style/idiomatic rule for collection and data-flow idioms. The detection
 // is pattern-based and the suggested replacement's readability is a style
 // preference. Classified per roadmap/17.
-func (r *UseLetRule) Confidence() float64 { return 0.75 }
+func (r *UseLetRule) Confidence() float64 { return api.ConfidenceMedium }
 
 type UseDataClassRule struct {
 	FlatDispatchBase
@@ -67,7 +67,7 @@ type UseDataClassRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Style/idiomatic rule for collection and data-flow idioms. The detection
 // is pattern-based and the suggested replacement's readability is a style
 // preference. Classified per roadmap/17.
-func (r *UseDataClassRule) Confidence() float64 { return 0.75 }
+func (r *UseDataClassRule) Confidence() float64 { return api.ConfidenceMedium }
 
 type UseIfInsteadOfWhenRule struct {
 	FlatDispatchBase
@@ -78,7 +78,7 @@ type UseIfInsteadOfWhenRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Style/idiomatic rule for collection and data-flow idioms. The detection
 // is pattern-based and the suggested replacement's readability is a style
 // preference. Classified per roadmap/17.
-func (r *UseIfInsteadOfWhenRule) Confidence() float64 { return 0.75 }
+func (r *UseIfInsteadOfWhenRule) Confidence() float64 { return api.ConfidenceMedium }
 
 type UseIfEmptyOrIfBlankRule struct {
 	FlatDispatchBase
@@ -88,7 +88,7 @@ type UseIfEmptyOrIfBlankRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Style/idiomatic rule for collection and data-flow idioms. The detection
 // is pattern-based and the suggested replacement's readability is a style
 // preference. Classified per roadmap/17.
-func (r *UseIfEmptyOrIfBlankRule) Confidence() float64 { return 0.75 }
+func (r *UseIfEmptyOrIfBlankRule) Confidence() float64 { return api.ConfidenceMedium }
 
 var ifEmptyOrBlankMethods = map[string]struct {
 	replacement string
@@ -103,7 +103,7 @@ type ExplicitCollectionElementAccessMethodRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Style/idiomatic rule for collection and data-flow idioms. The detection
 // is pattern-based and the suggested replacement's readability is a style
 // preference. Classified per roadmap/17.
-func (r *ExplicitCollectionElementAccessMethodRule) Confidence() float64 { return 0.75 }
+func (r *ExplicitCollectionElementAccessMethodRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func explicitCollectionAccessReceiverSupported(ctx *api.Context, receiver uint32, method string) bool {
 	if ctx.File == nil || receiver == 0 {
@@ -253,7 +253,7 @@ type AlsoCouldBeApplyRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Style/idiomatic rule for collection and data-flow idioms. The detection
 // is pattern-based and the suggested replacement's readability is a style
 // preference. Classified per roadmap/17.
-func (r *AlsoCouldBeApplyRule) Confidence() float64 { return 0.75 }
+func (r *AlsoCouldBeApplyRule) Confidence() float64 { return api.ConfidenceMedium }
 
 type EqualsNullCallRule struct {
 	FlatDispatchBase
@@ -263,4 +263,4 @@ type EqualsNullCallRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Style/idiomatic rule for collection and data-flow idioms. The detection
 // is pattern-based and the suggested replacement's readability is a style
 // preference. Classified per roadmap/17.
-func (r *EqualsNullCallRule) Confidence() float64 { return 0.75 }
+func (r *EqualsNullCallRule) Confidence() float64 { return api.ConfidenceMedium }

--- a/internal/rules/style_redundant.go
+++ b/internal/rules/style_redundant.go
@@ -3,6 +3,7 @@ package rules
 import (
 	"strings"
 
+	api "github.com/kaeawc/krit/internal/rules/api"
 	"github.com/kaeawc/krit/internal/scanner"
 )
 
@@ -15,7 +16,7 @@ type RedundantVisibilityModifierRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Style/redundant rule. Detection flags visible but arguably-redundant
 // modifiers, types, or keywords. Whether removal improves readability is
 // context-dependent. Classified per roadmap/17.
-func (r *RedundantVisibilityModifierRule) Confidence() float64 { return 0.75 }
+func (r *RedundantVisibilityModifierRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // RedundantConstructorKeywordRule detects unnecessary `constructor` keyword.
 // Flags primary constructors that use the explicit `constructor` keyword when
@@ -28,7 +29,7 @@ type RedundantConstructorKeywordRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Style/redundant rule. Detection flags visible but arguably-redundant
 // modifiers, types, or keywords. Whether removal improves readability is
 // context-dependent. Classified per roadmap/17.
-func (r *RedundantConstructorKeywordRule) Confidence() float64 { return 0.75 }
+func (r *RedundantConstructorKeywordRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // RedundantExplicitTypeRule detects type annotations where the type is obvious.
 // With type inference: uses ResolveNode on both the declared type and the initializer
@@ -41,7 +42,7 @@ type RedundantExplicitTypeRule struct {
 // Confidence reports a tier-2 (medium) base confidence — inferring
 // whether the type annotation is necessary requires the resolver; fallback
 // is conservative. Classified per roadmap/17.
-func (r *RedundantExplicitTypeRule) Confidence() float64 { return 0.75 }
+func (r *RedundantExplicitTypeRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *RedundantExplicitTypeRule) buildFixFlat(typeNode uint32, file *scanner.File) *scanner.Fix {
 	typeStart := int(file.FlatStartByte(typeNode))
@@ -77,7 +78,7 @@ type UnnecessaryParenthesesRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Style/redundant rule. Detection flags visible but arguably-redundant
 // modifiers, types, or keywords. Whether removal improves readability is
 // context-dependent. Classified per roadmap/17.
-func (r *UnnecessaryParenthesesRule) Confidence() float64 { return 0.75 }
+func (r *UnnecessaryParenthesesRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func unnParensIsIfConditionFlat(file *scanner.File, node, parent uint32) bool {
 	for i := 0; i < file.FlatChildCount(parent); i++ {
@@ -184,7 +185,7 @@ type UnnecessaryInheritanceRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Style/redundant rule. Detection flags visible but arguably-redundant
 // modifiers, types, or keywords. Whether removal improves readability is
 // context-dependent. Classified per roadmap/17.
-func (r *UnnecessaryInheritanceRule) Confidence() float64 { return 0.75 }
+func (r *UnnecessaryInheritanceRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // UnnecessaryInnerClassRule detects inner classes that don't use the outer reference.
 type UnnecessaryInnerClassRule struct {
@@ -195,7 +196,7 @@ type UnnecessaryInnerClassRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Style/redundant rule. Detection flags visible but arguably-redundant
 // modifiers, types, or keywords. Whether removal improves readability is
 // context-dependent. Classified per roadmap/17.
-func (r *UnnecessaryInnerClassRule) Confidence() float64 { return 0.75 }
+func (r *UnnecessaryInnerClassRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // OptionalUnitRule detects explicit `: Unit` return types on functions
 // and redundant `return Unit` statements inside function bodies.
@@ -207,7 +208,7 @@ type OptionalUnitRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Style/redundant rule. Detection flags visible but arguably-redundant
 // modifiers, types, or keywords. Whether removal improves readability is
 // context-dependent. Classified per roadmap/17.
-func (r *OptionalUnitRule) Confidence() float64 { return 0.75 }
+func (r *OptionalUnitRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // UnnecessaryBackticksRule detects unnecessary backtick-quoted identifiers.
 type UnnecessaryBackticksRule struct {
@@ -218,7 +219,7 @@ type UnnecessaryBackticksRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Style/redundant rule. Detection flags visible but arguably-redundant
 // modifiers, types, or keywords. Whether removal improves readability is
 // context-dependent. Classified per roadmap/17.
-func (r *UnnecessaryBackticksRule) Confidence() float64 { return 0.75 }
+func (r *UnnecessaryBackticksRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func isAllUnderscores(s string) bool {
 	for _, ch := range s {
@@ -283,7 +284,7 @@ type UselessCallOnNotNullRule struct {
 // Confidence reports a tier-2 (medium) base confidence — flags ?-safe
 // calls on provably non-null receivers; resolver-dependent. Classified per
 // roadmap/17.
-func (r *UselessCallOnNotNullRule) Confidence() float64 { return 0.75 }
+func (r *UselessCallOnNotNullRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // uselessNullCalls maps method names that are useless on non-null receivers to
 // their replacement. Empty string means "remove the call entirely".

--- a/internal/rules/style_unused.go
+++ b/internal/rules/style_unused.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/kaeawc/krit/internal/filefacts"
+	api "github.com/kaeawc/krit/internal/rules/api"
 	"github.com/kaeawc/krit/internal/rules/semantics"
 	"github.com/kaeawc/krit/internal/scanner"
 )
@@ -18,7 +19,7 @@ type UnusedImportRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Style/unused rule.
 // Detection uses a structural per-file reference-name index, but it does not
 // fully resolve ambiguous imports.
-func (r *UnusedImportRule) Confidence() float64 { return 0.75 }
+func (r *UnusedImportRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *UnusedImportRule) hasReferenceName(file *scanner.File, name string) bool {
 	if file == nil || name == "" {
@@ -60,7 +61,7 @@ type UnusedParameterRule struct {
 // detected from reference-shaped AST identifiers with local shadowing handled
 // structurally, so comments, strings, and substring collisions do not count as
 // usage.
-func (r *UnusedParameterRule) Confidence() float64 { return 0.95 }
+func (r *UnusedParameterRule) Confidence() float64 { return api.ConfidenceVeryHigh }
 
 type unusedParameterReferenceMatch uint8
 
@@ -430,7 +431,7 @@ type UnusedVariableRule struct {
 // Confidence reports a tier-2 (medium) base confidence. The rule uses
 // scope-aware AST reference matching without type inference, so it skips
 // unresolved local cases instead of emitting high-confidence findings.
-func (r *UnusedVariableRule) Confidence() float64 { return 0.75 }
+func (r *UnusedVariableRule) Confidence() float64 { return api.ConfidenceMedium }
 
 type unusedVariableReferenceMatch uint8
 
@@ -1033,7 +1034,7 @@ type UnusedPrivateClassRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Style/unused rule. Detection uses substring presence in the enclosing
 // scope body to decide whether a declaration is referenced, which
 // false-positives on substring collisions. Classified per roadmap/17.
-func (r *UnusedPrivateClassRule) Confidence() float64 { return 0.75 }
+func (r *UnusedPrivateClassRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // entryPointAnnotationNames lists annotation names that mark a declaration as
 // a framework entry point (called via reflection, preview tooling, test
@@ -1284,7 +1285,7 @@ type UnusedPrivateFunctionRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Style/unused rule. Detection uses substring presence in the enclosing
 // scope body to decide whether a declaration is referenced, which
 // false-positives on substring collisions. Classified per roadmap/17.
-func (r *UnusedPrivateFunctionRule) Confidence() float64 { return 0.75 }
+func (r *UnusedPrivateFunctionRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // UnusedPrivatePropertyRule detects private properties that are never referenced.
 type UnusedPrivatePropertyRule struct {
@@ -1296,7 +1297,7 @@ type UnusedPrivatePropertyRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Style/unused rule. Detection uses substring presence in the enclosing
 // scope body to decide whether a declaration is referenced, which
 // false-positives on substring collisions. Classified per roadmap/17.
-func (r *UnusedPrivatePropertyRule) Confidence() float64 { return 0.75 }
+func (r *UnusedPrivatePropertyRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // UnusedPrivateMemberRule is a combined check for unused private members.
 type UnusedPrivateMemberRule struct {
@@ -1309,4 +1310,4 @@ type UnusedPrivateMemberRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Style/unused rule. Detection uses substring presence in the enclosing
 // scope body to decide whether a declaration is referenced, which
 // false-positives on substring collisions. Classified per roadmap/17.
-func (r *UnusedPrivateMemberRule) Confidence() float64 { return 0.75 }
+func (r *UnusedPrivateMemberRule) Confidence() float64 { return api.ConfidenceMedium }

--- a/internal/rules/supply_catalog.go
+++ b/internal/rules/supply_catalog.go
@@ -23,7 +23,7 @@ type VersionCatalogUnusedRule struct {
 // uses substring match against the dotted accessor form, which is high-recall
 // but can miss exotic reflective uses. The default-inactive policy plus the
 // ignoredAliases escape hatch handle that.
-func (r *VersionCatalogUnusedRule) Confidence() float64 { return 0.75 }
+func (r *VersionCatalogUnusedRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *VersionCatalogUnusedRule) ModuleAwareNeeds() ModuleAwareNeeds {
 	return ModuleAwareNeeds{}
@@ -72,7 +72,7 @@ func (r *VersionCatalogUnusedRule) emitUnused(ctx *api.Context, file string, ent
 			Rule:       r.RuleName,
 			Severity:   r.Sev,
 			Message:    fmt.Sprintf("Version catalog alias '%s' (accessor '%s') is unused; remove it from libs.versions.toml or list it under ignoredAliases.", entry.Alias, accessor),
-			Confidence: 0.85,
+			Confidence: api.ConfidenceHigh,
 		})
 	}
 }

--- a/internal/rules/supply_catalog_buildsrc_mismatch.go
+++ b/internal/rules/supply_catalog_buildsrc_mismatch.go
@@ -21,7 +21,7 @@ type VersionCatalogBuildSrcMismatchRule struct {
 	BaseRule
 }
 
-func (r *VersionCatalogBuildSrcMismatchRule) Confidence() float64 { return 0.8 }
+func (r *VersionCatalogBuildSrcMismatchRule) Confidence() float64 { return api.ConfidenceMediumHigh }
 
 func (r *VersionCatalogBuildSrcMismatchRule) ModuleAwareNeeds() ModuleAwareNeeds {
 	return ModuleAwareNeeds{}

--- a/internal/rules/supply_catalog_duplicate_version.go
+++ b/internal/rules/supply_catalog_duplicate_version.go
@@ -21,7 +21,7 @@ type VersionCatalogDuplicateVersionRule struct {
 
 // Confidence is high — duplicate literal version strings are a
 // straightforward textual fact derived from the parsed catalog.
-func (r *VersionCatalogDuplicateVersionRule) Confidence() float64 { return 0.85 }
+func (r *VersionCatalogDuplicateVersionRule) Confidence() float64 { return api.ConfidenceHigh }
 
 func (r *VersionCatalogDuplicateVersionRule) ModuleAwareNeeds() ModuleAwareNeeds {
 	return ModuleAwareNeeds{}

--- a/internal/rules/supply_catalog_raw_version_in_build.go
+++ b/internal/rules/supply_catalog_raw_version_in_build.go
@@ -18,7 +18,7 @@ type VersionCatalogRawVersionInBuildRule struct {
 	BaseRule
 }
 
-func (r *VersionCatalogRawVersionInBuildRule) Confidence() float64 { return 0.8 }
+func (r *VersionCatalogRawVersionInBuildRule) Confidence() float64 { return api.ConfidenceMediumHigh }
 
 func (r *VersionCatalogRawVersionInBuildRule) ModuleAwareNeeds() ModuleAwareNeeds {
 	return ModuleAwareNeeds{}

--- a/internal/rules/supply_chain.go
+++ b/internal/rules/supply_chain.go
@@ -34,7 +34,7 @@ var compileSDKValueRe = regexp.MustCompile(`^\s*compileSdk(?:Version)?\s*[=(]?\s
 // Confidence reports a tier-2 (medium) base confidence. Supply-chain rule. Detection scans module metadata and dependency
 // catalogs for drift and security issues; matches are
 // project-structure-sensitive. Classified per roadmap/17.
-func (r *CompileSdkMismatchAcrossModulesRule) Confidence() float64 { return 0.75 }
+func (r *CompileSdkMismatchAcrossModulesRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *CompileSdkMismatchAcrossModulesRule) ModuleAwareNeeds() ModuleAwareNeeds {
 	return ModuleAwareNeeds{}
@@ -76,7 +76,7 @@ func (r *CompileSdkMismatchAcrossModulesRule) check(ctx *api.Context) {
 			Rule:       r.RuleName,
 			Severity:   r.Sev,
 			Message:    fmt.Sprintf("Module %s declares compileSdk %d, but another Android module declares %d; align compileSdk across modules to avoid merged builds silently picking the max. Project values: %s.", mod.modulePath, mod.compileSDK, maxCompileSDK, summary),
-			Confidence: 0.95,
+			Confidence: api.ConfidenceVeryHigh,
 		})
 	}
 }

--- a/internal/rules/supply_ci_workflows.go
+++ b/internal/rules/supply_ci_workflows.go
@@ -18,7 +18,7 @@ type GradleWrapperValidationActionRule struct {
 	BaseRule
 }
 
-func (r *GradleWrapperValidationActionRule) Confidence() float64 { return 0.85 }
+func (r *GradleWrapperValidationActionRule) Confidence() float64 { return api.ConfidenceHigh }
 
 func (r *GradleWrapperValidationActionRule) ModuleAwareNeeds() ModuleAwareNeeds {
 	return ModuleAwareNeeds{}

--- a/internal/rules/supply_dependencies.go
+++ b/internal/rules/supply_dependencies.go
@@ -26,7 +26,7 @@ type DependencySnapshotInReleaseRule struct {
 	SuppressUntil    string
 }
 
-func (r *DependencySnapshotInReleaseRule) Confidence() float64 { return 0.9 }
+func (r *DependencySnapshotInReleaseRule) Confidence() float64 { return api.ConfidenceHigher }
 
 func (r *DependencySnapshotInReleaseRule) check(ctx *api.Context) {
 	path, content := ctx.GradlePath, ctx.GradleContent
@@ -78,7 +78,7 @@ type DependencyWithoutGroupRule struct {
 	BaseRule
 }
 
-func (r *DependencyWithoutGroupRule) Confidence() float64 { return 0.9 }
+func (r *DependencyWithoutGroupRule) Confidence() float64 { return api.ConfidenceHigher }
 
 func (r *DependencyWithoutGroupRule) check(ctx *api.Context) {
 	path, content := ctx.GradlePath, ctx.GradleContent
@@ -109,7 +109,7 @@ type DependenciesInRootProjectRule struct {
 	AllowedConfigurations []string
 }
 
-func (r *DependenciesInRootProjectRule) Confidence() float64 { return 0.85 }
+func (r *DependenciesInRootProjectRule) Confidence() float64 { return api.ConfidenceHigh }
 
 // Suggested-fix identifiers and canonical titles for the
 // DependenciesInRootProject rule. The titles are shared between the rule's
@@ -422,7 +422,7 @@ type DependencyFromBintrayRule struct {
 	BaseRule
 }
 
-func (r *DependencyFromBintrayRule) Confidence() float64 { return 0.95 }
+func (r *DependencyFromBintrayRule) Confidence() float64 { return api.ConfidenceVeryHigh }
 
 func (r *DependencyFromBintrayRule) check(ctx *api.Context) {
 	path, content := ctx.GradlePath, ctx.GradleContent
@@ -453,7 +453,7 @@ type DependencyFromJcenterRule struct {
 	BaseRule
 }
 
-func (r *DependencyFromJcenterRule) Confidence() float64 { return 0.95 }
+func (r *DependencyFromJcenterRule) Confidence() float64 { return api.ConfidenceVeryHigh }
 
 func (r *DependencyFromJcenterRule) check(ctx *api.Context) {
 	path, content := ctx.GradlePath, ctx.GradleContent
@@ -493,7 +493,7 @@ var (
 	gradleNamedArgVersionColonRe = regexp.MustCompile(`\bversion\s*:\s*["']([^"']+)["']`)
 )
 
-func (r *DependencyFromHTTPRule) Confidence() float64 { return 0.95 }
+func (r *DependencyFromHTTPRule) Confidence() float64 { return api.ConfidenceVeryHigh }
 
 func (r *DependencyFromHTTPRule) check(ctx *api.Context) {
 	path, content := ctx.GradlePath, ctx.GradleContent

--- a/internal/rules/supply_drift.go
+++ b/internal/rules/supply_drift.go
@@ -19,7 +19,9 @@ type KotlinVersionMismatchAcrossModulesRule struct {
 	BaseRule
 }
 
-func (r *KotlinVersionMismatchAcrossModulesRule) Confidence() float64 { return 0.8 }
+func (r *KotlinVersionMismatchAcrossModulesRule) Confidence() float64 {
+	return api.ConfidenceMediumHigh
+}
 
 func (r *KotlinVersionMismatchAcrossModulesRule) ModuleAwareNeeds() ModuleAwareNeeds {
 	return ModuleAwareNeeds{}
@@ -61,7 +63,7 @@ type JvmTargetMismatchRule struct {
 	BaseRule
 }
 
-func (r *JvmTargetMismatchRule) Confidence() float64 { return 0.85 }
+func (r *JvmTargetMismatchRule) Confidence() float64 { return api.ConfidenceHigh }
 
 func (r *JvmTargetMismatchRule) check(ctx *api.Context) {
 	path, content := ctx.GradlePath, ctx.GradleContent
@@ -285,7 +287,9 @@ type ConventionPluginAppliedToWrongTargetRule struct {
 	PluginTargetMap []string
 }
 
-func (r *ConventionPluginAppliedToWrongTargetRule) Confidence() float64 { return 0.7 }
+func (r *ConventionPluginAppliedToWrongTargetRule) Confidence() float64 {
+	return api.ConfidenceMediumLowPlus
+}
 
 func (r *ConventionPluginAppliedToWrongTargetRule) ModuleAwareNeeds() ModuleAwareNeeds {
 	return ModuleAwareNeeds{}
@@ -445,7 +449,7 @@ type ApplyPluginTwiceRule struct {
 	BaseRule
 }
 
-func (r *ApplyPluginTwiceRule) Confidence() float64 { return 0.85 }
+func (r *ApplyPluginTwiceRule) Confidence() float64 { return api.ConfidenceHigh }
 
 func (r *ApplyPluginTwiceRule) check(ctx *api.Context) {
 	path, content := ctx.GradlePath, ctx.GradleContent
@@ -624,7 +628,7 @@ type ConfigurationsAllSideEffectRule struct {
 	AllowInConventionPlugins bool
 }
 
-func (r *ConfigurationsAllSideEffectRule) Confidence() float64 { return 0.7 }
+func (r *ConfigurationsAllSideEffectRule) Confidence() float64 { return api.ConfidenceMediumLowPlus }
 
 func (r *ConfigurationsAllSideEffectRule) check(ctx *api.Context) {
 	path, content := ctx.GradlePath, ctx.GradleContent

--- a/internal/rules/supply_verification.go
+++ b/internal/rules/supply_verification.go
@@ -17,7 +17,7 @@ type MissingGradleChecksumsRule struct {
 	BaseRule
 }
 
-func (r *MissingGradleChecksumsRule) Confidence() float64 { return 0.9 }
+func (r *MissingGradleChecksumsRule) Confidence() float64 { return api.ConfidenceHigher }
 
 func (r *MissingGradleChecksumsRule) ModuleAwareNeeds() ModuleAwareNeeds {
 	return ModuleAwareNeeds{}
@@ -60,7 +60,7 @@ type DependencyVerificationDisabledRule struct {
 	AllowLenient bool
 }
 
-func (r *DependencyVerificationDisabledRule) Confidence() float64 { return 0.95 }
+func (r *DependencyVerificationDisabledRule) Confidence() float64 { return api.ConfidenceVeryHigh }
 
 func (r *DependencyVerificationDisabledRule) ModuleAwareNeeds() ModuleAwareNeeds {
 	return ModuleAwareNeeds{}

--- a/internal/rules/testing_quality.go
+++ b/internal/rules/testing_quality.go
@@ -23,7 +23,7 @@ type AssertEqualsArgumentOrderRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Testing-quality rule. Detection matches on assertion framework call
 // shapes (JUnit, Truth, Kotest, MockK) by name — cross-library identifier
 // collisions can produce false positives. Classified per roadmap/17.
-func (r *AssertEqualsArgumentOrderRule) Confidence() float64 { return 0.75 }
+func (r *AssertEqualsArgumentOrderRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func testingQualityValueArgumentsFlat(file *scanner.File, args uint32) []uint32 {
 	var valueArgs []uint32
@@ -192,7 +192,7 @@ func untestedPublicAPIDeclarationContext(sym scanner.Symbol, file *scanner.File)
 
 // Confidence reports a tier-2 (medium) base confidence. Testing-quality rule. Detection matches
 // receiverless assertTrue calls and known JUnit receiver qualifiers by AST shape. Classified per roadmap/17.
-func (r *AssertTrueOnComparisonRule) Confidence() float64 { return 0.75 }
+func (r *AssertTrueOnComparisonRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // MixedAssertionLibrariesRule detects files that import both JUnit Assert and
 // Truth APIs in the import header.
@@ -204,7 +204,7 @@ type MixedAssertionLibrariesRule struct {
 // Confidence reports a tier-2 (medium) base confidence. Testing-quality rule. Detection matches on assertion framework call
 // shapes (JUnit, Truth, Kotest, MockK) by name — cross-library identifier
 // collisions can produce false positives. Classified per roadmap/17.
-func (r *MixedAssertionLibrariesRule) Confidence() float64 { return 0.75 }
+func (r *MixedAssertionLibrariesRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *MixedAssertionLibrariesRule) check(ctx *api.Context) {
 	file := ctx.File
@@ -225,7 +225,7 @@ type AssertNullableWithNotNullAssertionRule struct {
 	BaseRule
 }
 
-func (r *AssertNullableWithNotNullAssertionRule) Confidence() float64 { return 0.75 }
+func (r *AssertNullableWithNotNullAssertionRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // ---------------------------------------------------------------------------
 // MockWithoutVerifyRule
@@ -236,7 +236,7 @@ type MockWithoutVerifyRule struct {
 	BaseRule
 }
 
-func (r *MockWithoutVerifyRule) Confidence() float64 { return 0.75 }
+func (r *MockWithoutVerifyRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // ---------------------------------------------------------------------------
 // RunTestWithDelayRule
@@ -247,7 +247,7 @@ type RunTestWithDelayRule struct {
 	BaseRule
 }
 
-func (r *RunTestWithDelayRule) Confidence() float64 { return 0.75 }
+func (r *RunTestWithDelayRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // ---------------------------------------------------------------------------
 // RunTestWithThreadSleepRule
@@ -258,7 +258,7 @@ type RunTestWithThreadSleepRule struct {
 	BaseRule
 }
 
-func (r *RunTestWithThreadSleepRule) Confidence() float64 { return 0.75 }
+func (r *RunTestWithThreadSleepRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // ---------------------------------------------------------------------------
 // RunBlockingInTestRule
@@ -269,7 +269,7 @@ type RunBlockingInTestRule struct {
 	BaseRule
 }
 
-func (r *RunBlockingInTestRule) Confidence() float64 { return 0.75 }
+func (r *RunBlockingInTestRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // ---------------------------------------------------------------------------
 // TestDispatcherNotInjectedRule
@@ -280,7 +280,7 @@ type TestDispatcherNotInjectedRule struct {
 	BaseRule
 }
 
-func (r *TestDispatcherNotInjectedRule) Confidence() float64 { return 0.75 }
+func (r *TestDispatcherNotInjectedRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // ---------------------------------------------------------------------------
 // TestWithoutAssertionRule
@@ -294,7 +294,7 @@ type TestWithoutAssertionRule struct {
 	AssertionMethodPatterns []string
 }
 
-func (r *TestWithoutAssertionRule) Confidence() float64 { return 0.75 }
+func (r *TestWithoutAssertionRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func testingQualityIsEditorTemplatePath(filePath string) bool {
 	filePath = strings.ReplaceAll(filePath, "\\", "/")
@@ -313,7 +313,7 @@ type TestWithOnlyTodoRule struct {
 	BaseRule
 }
 
-func (r *TestWithOnlyTodoRule) Confidence() float64 { return 0.75 }
+func (r *TestWithOnlyTodoRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // ---------------------------------------------------------------------------
 // TestFunctionReturnValueRule
@@ -324,7 +324,7 @@ type TestFunctionReturnValueRule struct {
 	BaseRule
 }
 
-func (r *TestFunctionReturnValueRule) Confidence() float64 { return 0.75 }
+func (r *TestFunctionReturnValueRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // ---------------------------------------------------------------------------
 // TestNameContainsUnderscoreRule
@@ -335,7 +335,7 @@ type TestNameContainsUnderscoreRule struct {
 	BaseRule
 }
 
-func (r *TestNameContainsUnderscoreRule) Confidence() float64 { return 0.6 }
+func (r *TestNameContainsUnderscoreRule) Confidence() float64 { return api.ConfidenceMediumLow }
 
 // ---------------------------------------------------------------------------
 // SharedMutableStateInObjectRule
@@ -346,7 +346,7 @@ type SharedMutableStateInObjectRule struct {
 	BaseRule
 }
 
-func (r *SharedMutableStateInObjectRule) Confidence() float64 { return 0.75 }
+func (r *SharedMutableStateInObjectRule) Confidence() float64 { return api.ConfidenceMedium }
 
 // ---------------------------------------------------------------------------
 // TestInheritanceDepthRule
@@ -357,7 +357,7 @@ type TestInheritanceDepthRule struct {
 	BaseRule
 }
 
-func (r *TestInheritanceDepthRule) Confidence() float64 { return 0.6 }
+func (r *TestInheritanceDepthRule) Confidence() float64 { return api.ConfidenceMediumLow }
 
 // ---------------------------------------------------------------------------
 // RelaxedMockUsedForValueClassRule
@@ -368,7 +368,7 @@ type RelaxedMockUsedForValueClassRule struct {
 	BaseRule
 }
 
-func (r *RelaxedMockUsedForValueClassRule) Confidence() float64 { return 0.75 }
+func (r *RelaxedMockUsedForValueClassRule) Confidence() float64 { return api.ConfidenceMedium }
 
 var primitiveTypes = map[string]bool{
 	"Int": true, "Long": true, "Float": true, "Double": true,
@@ -384,7 +384,7 @@ type SpyOnDataClassRule struct {
 	BaseRule
 }
 
-func (r *SpyOnDataClassRule) Confidence() float64 { return 0.6 }
+func (r *SpyOnDataClassRule) Confidence() float64 { return api.ConfidenceMediumLow }
 
 // ---------------------------------------------------------------------------
 // VerifyWithoutMockRule
@@ -395,7 +395,7 @@ type VerifyWithoutMockRule struct {
 	BaseRule
 }
 
-func (r *VerifyWithoutMockRule) Confidence() float64 { return 0.6 }
+func (r *VerifyWithoutMockRule) Confidence() float64 { return api.ConfidenceMediumLow }
 
 var testingQualityMockCreationCalls = map[string]bool{
 	"mockk":        true,

--- a/internal/rules/tracing.go
+++ b/internal/rules/tracing.go
@@ -3,6 +3,7 @@ package rules
 import (
 	"strings"
 
+	api "github.com/kaeawc/krit/internal/rules/api"
 	"github.com/kaeawc/krit/internal/scanner"
 )
 
@@ -16,7 +17,7 @@ type WithContextWithoutTracingContextRule struct {
 	AllowedDispatchers []string
 }
 
-func (r *WithContextWithoutTracingContextRule) Confidence() float64 { return 0.75 }
+func (r *WithContextWithoutTracingContextRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *WithContextWithoutTracingContextRule) shouldFlag(file *scanner.File, idx uint32) (string, bool) {
 	name, args, lambda := coroutineBuilderPartsFlat(file, idx)
@@ -127,7 +128,7 @@ type SpanStartWithoutFinishRule struct {
 	BaseRule
 }
 
-func (r *SpanStartWithoutFinishRule) Confidence() float64 { return 0.75 }
+func (r *SpanStartWithoutFinishRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *SpanStartWithoutFinishRule) shouldFlag(file *scanner.File, idx uint32) (string, bool) {
 	if file == nil || idx == 0 || file.FlatType(idx) != "property_declaration" {
@@ -216,7 +217,7 @@ type SpanAttributeWithHighCardinalityRule struct {
 	Keys []string
 }
 
-func (r *SpanAttributeWithHighCardinalityRule) Confidence() float64 { return 0.75 }
+func (r *SpanAttributeWithHighCardinalityRule) Confidence() float64 { return api.ConfidenceMedium }
 
 func (r *SpanAttributeWithHighCardinalityRule) shouldFlag(file *scanner.File, idx uint32) (string, bool) {
 	if file == nil || idx == 0 || file.FlatType(idx) != "call_expression" {


### PR DESCRIPTION
## Summary
- Add `internal/rules/api/confidence.go` with 8 named tier constants covering every previously-observed value (0.5/0.6/0.7/0.75/0.8/0.85/0.9/0.95).
- Replace literals in ~700 `Confidence() float64` methods, ~400 registry struct literals, and `DefaultConfidence` assignments in the dispatcher.
- Outlier values (0.42, 0.55, 0.65, 0.99 — 4 cases total) intentionally remain as literals.

This is a pure rename — every constant has the exact value of the literal it replaced, so no rule's emitted confidence changes.

Motivation: 527 of ~700 rules returned the magic literal `0.75`; rebalancing tiers required grepping for floating-point literals. Named tiers make confidence policy auditable and rebalanceable in one place.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...` (0 issues)
- [x] `go test ./... -count=1` (all pass)
- [x] `make lint-rules` (capability gate green)