### PR TITLE
refactor(rules): consolidate gradle/manifest/resource Finding helpers

### DIFF
--- a/internal/rules/android_gradle.go
+++ b/internal/rules/android_gradle.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/kaeawc/krit/internal/android"
 	api "github.com/kaeawc/krit/internal/rules/api"
-	"github.com/kaeawc/krit/internal/scanner"
 )
 
 // GradleBase is an empty marker type embedded by Gradle rule
@@ -26,22 +25,6 @@ type GradleBase struct{}
 
 func (GradleBase) AndroidDependencies() AndroidDataDependency {
 	return AndroidDepGradle
-}
-
-// ---------------------------------------------------------------------------
-// Helper to create a Gradle finding
-// ---------------------------------------------------------------------------
-
-func gradleFinding(path string, line int, rule BaseRule, msg string) scanner.Finding {
-	return scanner.Finding{
-		File:     path,
-		Line:     line,
-		Col:      1,
-		RuleSet:  rule.RuleSetName,
-		Rule:     rule.RuleName,
-		Severity: rule.Sev,
-		Message:  msg,
-	}
 }
 
 // findGradleLine returns the 1-based line number of the first match of re in content, or 0.
@@ -189,7 +172,7 @@ func (r *GradlePluginCompatibilityRule) check(ctx *api.Context) {
 			if line == 0 {
 				line = 1
 			}
-			ctx.Emit(gradleFinding(path, line, r.BaseRule, l.Message))
+			ctx.Emit(baseFinding(path, line, r.BaseRule, l.Message))
 		}
 	}
 }
@@ -223,7 +206,7 @@ func (r *StringIntegerRule) check(ctx *api.Context) {
 	path, content, _ := ctx.GradlePath, ctx.GradleContent, ctx.GradleConfig
 	for i, line := range strings.Split(content, "\n") {
 		if gradleLineHasQuotedIntegerSDKProperty(line) {
-			ctx.Emit(gradleFinding(path, i+1, r.BaseRule,
+			ctx.Emit(baseFinding(path, i+1, r.BaseRule,
 				"SDK version should be an integer, not a string. Remove quotes."))
 		}
 	}
@@ -374,7 +357,7 @@ func (r *RemoteVersionRule) check(ctx *api.Context) {
 			if line == 0 {
 				line = 1
 			}
-			ctx.Emit(gradleFinding(path, line, r.BaseRule,
+			ctx.Emit(baseFinding(path, line, r.BaseRule,
 				fmt.Sprintf("Dependency %s:%s uses non-deterministic version `%s`. Pin to a specific version.",
 					dep.Group, dep.Name, dep.Version)))
 		}
@@ -407,7 +390,7 @@ func (r *DynamicVersionRule) check(ctx *api.Context) {
 			return
 		}
 		emitted[key] = true
-		ctx.Emit(gradleFinding(path, line, r.BaseRule,
+		ctx.Emit(baseFinding(path, line, r.BaseRule,
 			fmt.Sprintf("Dependency %s uses dynamic version `%s`. Pin to a specific version for reproducible builds.",
 				label, version)))
 	}
@@ -625,7 +608,7 @@ func (r *GradleOldTargetAPIRule) check(ctx *api.Context) {
 	if line == 0 {
 		line = 1
 	}
-	ctx.Emit(gradleFinding(path, line, r.BaseRule,
+	ctx.Emit(baseFinding(path, line, r.BaseRule,
 		fmt.Sprintf("targetSdkVersion %d is below the recommended minimum of %d. "+
 			"Update to comply with Google Play requirements.",
 			cfg.TargetSdkVersion, threshold)))
@@ -657,7 +640,7 @@ func (r *DeprecatedDependencyRule) check(ctx *api.Context) {
 				// Try to find the dependency in the content for a better line number
 				line = 1
 			}
-			ctx.Emit(gradleFinding(path, line, r.BaseRule, l.Message))
+			ctx.Emit(baseFinding(path, line, r.BaseRule, l.Message))
 		}
 	}
 }
@@ -684,7 +667,7 @@ func (r *MavenLocalRule) check(ctx *api.Context) {
 	if line == 0 {
 		return
 	}
-	ctx.Emit(gradleFinding(path, line, r.BaseRule,
+	ctx.Emit(baseFinding(path, line, r.BaseRule,
 		"mavenLocal() can cause unreproducible builds; prefer a remote repository or includeBuild."))
 }
 
@@ -720,7 +703,7 @@ func (r *MinSdkTooLowRule) check(ctx *api.Context) {
 	if line == 0 {
 		line = 1
 	}
-	ctx.Emit(gradleFinding(path, line, r.BaseRule,
+	ctx.Emit(baseFinding(path, line, r.BaseRule,
 		fmt.Sprintf("minSdk %d is below the recommended minimum of %d.",
 			cfg.MinSdkVersion, threshold)))
 }
@@ -775,7 +758,7 @@ func (r *GradleDeprecatedRule) check(ctx *api.Context) {
 					continue
 				}
 			}
-			ctx.Emit(gradleFinding(path, i+1, r.BaseRule,
+			ctx.Emit(baseFinding(path, i+1, r.BaseRule,
 				fmt.Sprintf("'%s' is deprecated; use '%s' instead.", name, replacement)))
 			break
 		}
@@ -833,7 +816,7 @@ func (r *GradleGetterRule) check(ctx *api.Context) {
 			if len(rest) == 0 || rest[0] == '=' {
 				continue
 			}
-			ctx.Emit(gradleFinding(path, i+1, r.BaseRule,
+			ctx.Emit(baseFinding(path, i+1, r.BaseRule,
 				fmt.Sprintf("Groovy-style '%s' should be replaced with '%s' in Kotlin DSL.", name, replacement)))
 			break
 		}
@@ -891,13 +874,13 @@ func (r *GradlePathRule) check(ctx *api.Context) {
 			}
 			rest := strings.TrimSpace(line[idx+len(fn):])
 			if len(rest) >= 2 && (rest[0] == '"' || rest[0] == '\'') && rest[1] == '/' {
-				ctx.Emit(gradleFinding(path, i+1, r.BaseRule,
+				ctx.Emit(baseFinding(path, i+1, r.BaseRule,
 					"Avoid absolute paths in files()/fileTree(); use project-relative paths."))
 				break
 			}
 		}
 		if gradlePathCallContains(line, `\`) {
-			ctx.Emit(gradleFinding(path, i+1, r.BaseRule,
+			ctx.Emit(baseFinding(path, i+1, r.BaseRule,
 				"Avoid backslashes in dependency paths; use forward slashes for cross-platform compatibility."))
 		}
 	}
@@ -928,7 +911,7 @@ func (r *GradleOverridesRule) check(ctx *api.Context) {
 		if line == 0 {
 			line = 1
 		}
-		ctx.Emit(gradleFinding(path, line, r.BaseRule,
+		ctx.Emit(baseFinding(path, line, r.BaseRule,
 			"Both minSdk and targetSdk are set in the Gradle build file, overriding any values in AndroidManifest.xml."))
 		return
 	}
@@ -964,7 +947,7 @@ func (r *GradleIdeErrorRule) check(ctx *api.Context) {
 		// Kotlin-legacy: `apply(plugin = "...")` — valid Kotlin but deprecated
 		if strings.HasPrefix(trimmed, "apply plugin:") ||
 			(strings.HasPrefix(trimmed, "apply(") && strings.Contains(trimmed, "plugin")) {
-			ctx.Emit(gradleFinding(path, i+1, r.BaseRule,
+			ctx.Emit(baseFinding(path, i+1, r.BaseRule,
 				"Use the plugins { } block instead of 'apply plugin:' in Kotlin DSL (.kts) files."))
 		}
 	}
@@ -1004,7 +987,7 @@ func (r *AndroidGradlePluginVersionRule) check(ctx *api.Context) {
 		line = 1
 	}
 	version := matches[1] + "." + matches[2] + "." + matches[3]
-	ctx.Emit(gradleFinding(path, line, r.BaseRule,
+	ctx.Emit(baseFinding(path, line, r.BaseRule,
 		fmt.Sprintf("Android Gradle Plugin version %s is too old. Upgrade to at least 7.0.0.", version)))
 }
 
@@ -1154,7 +1137,7 @@ func (r *NewerVersionAvailableRule) check(ctx *api.Context) {
 					if line == 0 {
 						line = 1
 					}
-					ctx.Emit(gradleFinding(path, line, r.BaseRule,
+					ctx.Emit(baseFinding(path, line, r.BaseRule,
 						fmt.Sprintf("A newer version of %s:%s is available. Update from %s to at least %s.",
 							dep.Group, dep.Name, dep.Version, rec.Display)))
 				}

--- a/internal/rules/android_manifest.go
+++ b/internal/rules/android_manifest.go
@@ -9,7 +9,6 @@ package rules
 
 import (
 	"github.com/kaeawc/krit/internal/manifest"
-	"github.com/kaeawc/krit/internal/scanner"
 )
 
 // ---------------------------------------------------------------------------
@@ -42,22 +41,6 @@ func (ManifestBase) Confidence() float64 { return ConfidenceMedium }
 
 func (ManifestBase) AndroidDependencies() AndroidDataDependency {
 	return AndroidDepManifest
-}
-
-// ---------------------------------------------------------------------------
-// Helper to create a manifest finding (no scanner.File needed)
-// ---------------------------------------------------------------------------
-
-func manifestFinding(path string, line int, rule BaseRule, msg string) scanner.Finding {
-	return scanner.Finding{
-		File:     path,
-		Line:     line,
-		Col:      1,
-		RuleSet:  rule.RuleSetName,
-		Rule:     rule.RuleName,
-		Severity: rule.Sev,
-		Message:  msg,
-	}
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/rules/android_manifest_features.go
+++ b/internal/rules/android_manifest_features.go
@@ -32,7 +32,7 @@ func (r *RtlEnabledManifestRule) check(ctx *api.Context) {
 	}
 	app := m.Application
 	if app.SupportsRtl == nil || !*app.SupportsRtl {
-		ctx.Emit(manifestFinding(m.Path, app.Line, r.BaseRule,
+		ctx.Emit(baseFinding(m.Path, app.Line, r.BaseRule,
 			"Missing `android:supportsRtl=\"true\"` on <application>. "+
 				"Add RTL support to ensure proper layout mirroring for RTL languages."))
 		return
@@ -64,7 +64,7 @@ func (r *RtlCompatManifestRule) check(ctx *api.Context) {
 		return
 	}
 	if m.Application.SupportsRtl == nil || !*m.Application.SupportsRtl {
-		ctx.Emit(manifestFinding(m.Path, m.Application.Line, r.BaseRule,
+		ctx.Emit(baseFinding(m.Path, m.Application.Line, r.BaseRule,
 			fmt.Sprintf("targetSdkVersion is %d (>= 17) but `android:supportsRtl` is not set to true. "+
 				"Enable RTL support with `android:supportsRtl=\"true\"` for proper right-to-left layout mirroring.",
 				m.TargetSDK)))
@@ -125,7 +125,7 @@ func (r *AppIndexingErrorManifestRule) check(ctx *api.Context) {
 			if hasHTTPS {
 				missing = "http"
 			}
-			ctx.Emit(manifestFinding(m.Path, act.Line, r.BaseRule,
+			ctx.Emit(baseFinding(m.Path, act.Line, r.BaseRule,
 				fmt.Sprintf("Activity `%s` has a web deep link but is missing the `%s` scheme. "+
 					"Add `<data android:scheme=\"%s\" />` to handle both http and https URLs.",
 					act.Name, missing, missing)))
@@ -170,7 +170,7 @@ func (r *AppIndexingWarningManifestRule) check(ctx *api.Context) {
 			}
 		}
 		if !hasViewAction {
-			ctx.Emit(manifestFinding(m.Path, act.Line, r.BaseRule,
+			ctx.Emit(baseFinding(m.Path, act.Line, r.BaseRule,
 				fmt.Sprintf("Activity `%s` has a BROWSABLE intent filter but no VIEW action. "+
 					"Add `<action android:name=\"android.intent.action.VIEW\" />` to handle deep links properly.",
 					act.Name)))
@@ -220,7 +220,7 @@ func (r *GoogleAppIndexingDeepLinkErrorManifestRule) check(ctx *api.Context) {
 			}
 		}
 		if hasWebScheme && len(act.IntentFilterDataHosts) == 0 {
-			ctx.Emit(manifestFinding(m.Path, act.Line, r.BaseRule,
+			ctx.Emit(baseFinding(m.Path, act.Line, r.BaseRule,
 				fmt.Sprintf("Activity `%s` has an http/https deep link with no host. "+
 					"A web URI with a scheme but no host is malformed. "+
 					"Add `<data android:host=\"...\" />` to the intent filter.",
@@ -268,7 +268,7 @@ func (r *GoogleAppIndexingWarningManifestRule) check(ctx *api.Context) {
 			}
 		}
 	}
-	ctx.Emit(manifestFinding(m.Path, 1, r.BaseRule,
+	ctx.Emit(baseFinding(m.Path, 1, r.BaseRule,
 		"No activity with a VIEW intent filter and http/https data scheme found. "+
 			"Add deep link support to enable Google App Indexing. "+
 			"https://developer.android.com/training/app-indexing"))
@@ -300,7 +300,7 @@ func (r *MissingLeanbackLauncherManifestRule) check(ctx *api.Context) {
 		return
 	}
 	if m.Application == nil {
-		ctx.Emit(manifestFinding(m.Path, 1, r.BaseRule,
+		ctx.Emit(baseFinding(m.Path, 1, r.BaseRule,
 			"App declares `android.software.leanback` feature but has no activity with "+
 				"LEANBACK_LAUNCHER category. Add an activity with "+
 				"`<category android:name=\"android.intent.category.LEANBACK_LAUNCHER\" />`."))
@@ -313,7 +313,7 @@ func (r *MissingLeanbackLauncherManifestRule) check(ctx *api.Context) {
 			}
 		}
 	}
-	ctx.Emit(manifestFinding(m.Path, 1, r.BaseRule,
+	ctx.Emit(baseFinding(m.Path, 1, r.BaseRule,
 		"App declares `android.software.leanback` feature but has no activity with "+
 			"LEANBACK_LAUNCHER category. Add an activity with "+
 			"`<category android:name=\"android.intent.category.LEANBACK_LAUNCHER\" />`."))
@@ -350,7 +350,7 @@ func (r *MissingLeanbackSupportManifestRule) check(ctx *api.Context) {
 			return
 		}
 	}
-	ctx.Emit(manifestFinding(m.Path, 1, r.BaseRule,
+	ctx.Emit(baseFinding(m.Path, 1, r.BaseRule,
 		"App declares `android.software.leanback` feature but does not opt out of touchscreen. "+
 			"TV apps must declare `<uses-feature android:name=\"android.hardware.touchscreen\" "+
 			"android:required=\"false\" />` because TV devices do not have touchscreens."))
@@ -420,7 +420,7 @@ func (r *PermissionImpliesUnsupportedHardwareManifestRule) check(ctx *api.Contex
 	}
 	if len(missing) == 1 {
 		only := missing[0]
-		ctx.Emit(manifestFinding(m.Path, 1, r.BaseRule,
+		ctx.Emit(baseFinding(m.Path, 1, r.BaseRule,
 			fmt.Sprintf("Permission `%s` implies hardware feature `%s`. "+
 				"Declare `<uses-feature android:name=\"%s\" android:required=\"false\" />` "+
 				"to allow installation on devices without this hardware.",
@@ -431,7 +431,7 @@ func (r *PermissionImpliesUnsupportedHardwareManifestRule) check(ctx *api.Contex
 	for _, mf := range missing {
 		parts = append(parts, fmt.Sprintf("`%s` -> `%s`", mf.perm, mf.feature))
 	}
-	ctx.Emit(manifestFinding(m.Path, 1, r.BaseRule,
+	ctx.Emit(baseFinding(m.Path, 1, r.BaseRule,
 		fmt.Sprintf("Permissions imply hardware features that are not declared as optional: %s. "+
 			"Declare each with `<uses-feature android:name=\"…\" android:required=\"false\" />` "+
 			"to allow installation on devices without this hardware.",
@@ -473,7 +473,7 @@ func (r *UnsupportedChromeOsHardwareManifestRule) check(ctx *api.Context) {
 		if strings.EqualFold(f.Required, "false") {
 			continue
 		}
-		ctx.Emit(manifestFinding(m.Path, f.Line, r.BaseRule,
+		ctx.Emit(baseFinding(m.Path, f.Line, r.BaseRule,
 			fmt.Sprintf("`<uses-feature android:name=\"%s\">` is not available on most Chrome OS devices. "+
 				"Set `android:required=\"false\"` to allow installation on Chromebooks.",
 				f.Name)))
@@ -517,7 +517,7 @@ func (r *DeviceAdminManifestRule) check(ctx *api.Context) {
 			}
 		}
 		if !hasDeviceAdminMeta {
-			ctx.Emit(manifestFinding(m.Path, recv.Line, r.BaseRule,
+			ctx.Emit(baseFinding(m.Path, recv.Line, r.BaseRule,
 				fmt.Sprintf("Receiver `%s` handles DEVICE_ADMIN_ENABLED but is missing "+
 					"`<meta-data android:name=\"android.app.device_admin\" android:resource=\"@xml/device_admin\"/>`.",
 					recv.Name)))
@@ -551,7 +551,7 @@ func (r *FullBackupContentManifestRule) check(ctx *api.Context) {
 
 	// When allowBackup is true (or default) and targetSdk >= 23, missing fullBackupContent is an issue
 	if m.TargetSDK >= 23 && app.FullBackupContent == "" {
-		ctx.Emit(manifestFinding(m.Path, app.Line, r.BaseRule,
+		ctx.Emit(baseFinding(m.Path, app.Line, r.BaseRule,
 			"Missing `android:fullBackupContent` attribute on <application>. "+
 				"When allowBackup is true and targetSdkVersion >= 23, specify fullBackupContent "+
 				"to control which files are backed up. "+
@@ -603,7 +603,7 @@ func (r *MissingRegisteredManifestRule) check(ctx *api.Context) {
 	for _, c := range allComponents(m.Application) {
 		invalid, reason := isInvalidComponentName(c.Name)
 		if invalid {
-			ctx.Emit(manifestFinding(m.Path, c.Line, r.BaseRule,
+			ctx.Emit(baseFinding(m.Path, c.Line, r.BaseRule,
 				fmt.Sprintf("Invalid component name `%s` in <%s>: %s.",
 					c.Name, c.Tag, reason)))
 		}

--- a/internal/rules/android_manifest_i18n.go
+++ b/internal/rules/android_manifest_i18n.go
@@ -41,7 +41,7 @@ func (r *LocaleConfigMissingRule) check(ctx *api.Context) {
 		return
 	}
 
-	f := manifestFinding(m.Path, m.Application.Line, r.BaseRule,
+	f := baseFinding(m.Path, m.Application.Line, r.BaseRule,
 		fmt.Sprintf("<application> declares `android:localeConfig=\"%s\"` but `res/xml/%s.xml` is missing.",
 			m.Application.LocaleConfig, resourceName))
 	ctx.Emit(f)

--- a/internal/rules/android_manifest_security.go
+++ b/internal/rules/android_manifest_security.go
@@ -44,14 +44,14 @@ func (r *AllowBackupManifestRule) check(ctx *api.Context) {
 	app := m.Application
 	if app.AllowBackup == nil {
 		// Not set — defaults to true, which is the risky default
-		ctx.Emit(manifestFinding(m.Path, app.Line, r.BaseRule,
+		ctx.Emit(baseFinding(m.Path, app.Line, r.BaseRule,
 			"Missing `android:allowBackup` attribute on <application>. "+
 				"Consider explicitly setting android:allowBackup=\"false\" to disable backup. "+
 				"http://developer.android.com/reference/android/R.attr.html#allowBackup"))
 		return
 	}
 	if *app.AllowBackup {
-		ctx.Emit(manifestFinding(m.Path, app.Line, r.BaseRule,
+		ctx.Emit(baseFinding(m.Path, app.Line, r.BaseRule,
 			"`android:allowBackup=\"true\"` allows app data to be backed up via adb. "+
 				"Set to false if your app handles sensitive data. "+
 				"http://developer.android.com/reference/android/R.attr.html#allowBackup"))
@@ -78,7 +78,7 @@ func (r *DebuggableManifestRule) check(ctx *api.Context) {
 	}
 	app := m.Application
 	if app.Debuggable != nil && *app.Debuggable {
-		ctx.Emit(manifestFinding(m.Path, app.Line, r.BaseRule,
+		ctx.Emit(baseFinding(m.Path, app.Line, r.BaseRule,
 			"`android:debuggable=\"true\"` is set in the manifest. "+
 				"This should be controlled by the build system (debug vs release build type). "+
 				"Remove the debuggable attribute from the manifest."))
@@ -102,7 +102,7 @@ func (r *DeepLinkMissingAutoVerifyRule) check(ctx *api.Context) {
 	}
 	filters := deepLinkMissingAutoVerifyFilters(m.Path)
 	for _, filter := range filters {
-		ctx.Emit(manifestFinding(m.Path, filter.line, r.BaseRule,
+		ctx.Emit(baseFinding(m.Path, filter.line, r.BaseRule,
 			"HTTP(S) deep link intent-filter is missing android:autoVerify=\"true\". Add autoVerify for verified Android App Links."))
 	}
 }
@@ -248,7 +248,7 @@ func (r *ExportedWithoutPermissionRule) check(ctx *api.Context) {
 			// would break the contract with the calling system service.
 			continue
 		}
-		ctx.Emit(manifestFinding(m.Path, c.Line, r.BaseRule,
+		ctx.Emit(baseFinding(m.Path, c.Line, r.BaseRule,
 			fmt.Sprintf("Exported %s `%s` does not require a permission. "+
 				"Add android:permission to restrict access.",
 				c.Tag, c.Name)))
@@ -406,7 +406,7 @@ func (r *MissingExportedFlagRule) check(ctx *api.Context) {
 	components := allComponents(m.Application)
 	for _, c := range components {
 		if c.HasIntentFilter && c.Exported == nil {
-			ctx.Emit(manifestFinding(m.Path, c.Line, r.BaseRule,
+			ctx.Emit(baseFinding(m.Path, c.Line, r.BaseRule,
 				fmt.Sprintf("%s `%s` has an intent-filter but does not set android:exported. "+
 					"Starting with Android 12 (API 31), android:exported must be explicitly set "+
 					"for components with intent-filters.",
@@ -433,7 +433,7 @@ func (r *ExportedServiceManifestRule) check(ctx *api.Context) {
 	}
 	for _, svc := range m.Application.Services {
 		if svc.Exported != nil && *svc.Exported && svc.Permission == "" {
-			ctx.Emit(manifestFinding(m.Path, svc.Line, r.BaseRule,
+			ctx.Emit(baseFinding(m.Path, svc.Line, r.BaseRule,
 				fmt.Sprintf("Exported service `%s` does not require a permission. "+
 					"Any app can bind to it. Add android:permission to restrict access.",
 					svc.Name)))
@@ -464,7 +464,7 @@ func (r *ExportedPreferenceActivityManifestRule) check(ctx *api.Context) {
 		}
 		exported := (act.Exported != nil && *act.Exported) || act.HasIntentFilter
 		if exported {
-			ctx.Emit(manifestFinding(m.Path, act.Line, r.BaseRule,
+			ctx.Emit(baseFinding(m.Path, act.Line, r.BaseRule,
 				fmt.Sprintf("Activity `%s` appears to extend PreferenceActivity and is exported. "+
 					"Exported PreferenceActivity subclasses are vulnerable to fragment injection attacks. "+
 					"Restrict access with android:permission or set android:exported=\"false\".",
@@ -494,7 +494,7 @@ func (r *CleartextTrafficRule) check(ctx *api.Context) {
 		return
 	}
 	if m.Application.UsesCleartextTraffic != nil && *m.Application.UsesCleartextTraffic {
-		ctx.Emit(manifestFinding(m.Path, m.Application.Line, r.BaseRule,
+		ctx.Emit(baseFinding(m.Path, m.Application.Line, r.BaseRule,
 			"`android:usesCleartextTraffic=\"true\"` allows unencrypted HTTP traffic. "+
 				"This is a security risk. Use HTTPS and set usesCleartextTraffic to false, "+
 				"or use a Network Security Config to restrict cleartext to specific domains."))
@@ -524,7 +524,7 @@ func (r *BackupRulesRule) check(ctx *api.Context) {
 		return
 	}
 	if app.FullBackupContent == "" && app.DataExtractionRules == "" {
-		ctx.Emit(manifestFinding(m.Path, app.Line, r.BaseRule,
+		ctx.Emit(baseFinding(m.Path, app.Line, r.BaseRule,
 			"Missing backup configuration. Add `android:fullBackupContent` (API < 31) "+
 				"or `android:dataExtractionRules` (API 31+) to control what data is backed up."))
 		return
@@ -568,7 +568,7 @@ func (r *InsecureBaseConfigurationManifestRule) check(ctx *api.Context) {
 		return
 	}
 	if m.Application.NetworkSecurityConfig == "" {
-		ctx.Emit(manifestFinding(m.Path, m.Application.Line, r.BaseRule,
+		ctx.Emit(baseFinding(m.Path, m.Application.Line, r.BaseRule,
 			"Missing `android:networkSecurityConfig` on <application> with targetSdkVersion >= 28. "+
 				"Add a Network Security Configuration to explicitly control network security behavior. "+
 				"https://developer.android.com/training/articles/security-config"))
@@ -604,7 +604,7 @@ func (r *NetworkSecurityConfigDebugOverridesRule) check(ctx *api.Context) {
 	if debugNode == nil {
 		return
 	}
-	ctx.Emit(manifestFinding(configPath, debugNode.Line, r.BaseRule,
+	ctx.Emit(baseFinding(configPath, debugNode.Line, r.BaseRule,
 		"`<debug-overrides>` is declared in a main/shared network security config. Move debug trust anchors to `src/debug/res/xml/` so they do not ship in release builds."))
 }
 
@@ -631,7 +631,7 @@ func (r *UnprotectedSMSBroadcastReceiverManifestRule) check(ctx *api.Context) {
 		}
 		for _, action := range recv.IntentFilterActions {
 			if action == "android.provider.Telephony.SMS_RECEIVED" {
-				ctx.Emit(manifestFinding(m.Path, recv.Line, r.BaseRule,
+				ctx.Emit(baseFinding(m.Path, recv.Line, r.BaseRule,
 					fmt.Sprintf("Receiver `%s` listens for SMS_RECEIVED but has no android:permission. "+
 						"Add `android:permission=\"android.permission.BROADCAST_SMS\"` to prevent spoofed broadcasts.",
 						recv.Name)))
@@ -690,7 +690,7 @@ func (r *UnsafeProtectedBroadcastReceiverManifestRule) check(ctx *api.Context) {
 		}
 		for _, action := range recv.IntentFilterActions {
 			if protectedBroadcastActions[action] {
-				ctx.Emit(manifestFinding(m.Path, recv.Line, r.BaseRule,
+				ctx.Emit(baseFinding(m.Path, recv.Line, r.BaseRule,
 					fmt.Sprintf("Receiver `%s` listens for protected broadcast `%s` and is exported without a permission. "+
 						"Add android:permission to prevent unauthorized broadcasts.",
 						recv.Name, action)))
@@ -744,7 +744,7 @@ func (r *UseCheckPermissionManifestRule) check(ctx *api.Context) {
 		}
 		for _, action := range svc.IntentFilterActions {
 			if sensitiveServiceActions[action] {
-				ctx.Emit(manifestFinding(m.Path, svc.Line, r.BaseRule,
+				ctx.Emit(baseFinding(m.Path, svc.Line, r.BaseRule,
 					fmt.Sprintf("Exported service `%s` handles sensitive action `%s` "+
 						"without declaring android:permission. "+
 						"Add a permission attribute to restrict access to this service.",
@@ -805,7 +805,7 @@ func (r *ProtectedPermissionsManifestRule) check(ctx *api.Context) {
 			if idx := strings.LastIndex(perm, "."); idx >= 0 {
 				short = perm[idx+1:]
 			}
-			ctx.Emit(manifestFinding(m.Path, 1, r.BaseRule,
+			ctx.Emit(baseFinding(m.Path, 1, r.BaseRule,
 				fmt.Sprintf("Permission `%s` is only granted to system apps. "+
 					"Third-party apps cannot acquire this permission.",
 					short)))
@@ -833,7 +833,7 @@ func (r *ServiceExportedManifestRule) check(ctx *api.Context) {
 	}
 	for _, svc := range m.Application.Services {
 		if svc.Exported != nil && *svc.Exported && svc.Permission == "" {
-			ctx.Emit(manifestFinding(m.Path, svc.Line, r.BaseRule,
+			ctx.Emit(baseFinding(m.Path, svc.Line, r.BaseRule,
 				fmt.Sprintf("Exported service `%s` does not require a permission. "+
 					"Any app can bind to it. Consider adding android:permission.",
 					svc.Name)))

--- a/internal/rules/android_manifest_structure.go
+++ b/internal/rules/android_manifest_structure.go
@@ -33,7 +33,7 @@ func (r *DuplicateActivityManifestRule) check(ctx *api.Context) {
 			continue
 		}
 		if firstLine, ok := seen[act.Name]; ok {
-			ctx.Emit(manifestFinding(m.Path, act.Line, r.BaseRule,
+			ctx.Emit(baseFinding(m.Path, act.Line, r.BaseRule,
 				fmt.Sprintf("Activity `%s` is registered more than once (first at line %d). "+
 					"Duplicate activity declarations cause subtle bugs.",
 					act.Name, firstLine)))
@@ -79,7 +79,7 @@ func (r *WrongManifestParentManifestRule) check(ctx *api.Context) {
 			continue
 		}
 		if elem.ParentTag != expected {
-			ctx.Emit(manifestFinding(m.Path, elem.Line, r.BaseRule,
+			ctx.Emit(baseFinding(m.Path, elem.Line, r.BaseRule,
 				fmt.Sprintf("<%s> should be a child of <%s>, not <%s>.",
 					elem.Tag, expected, elem.ParentTag)))
 		}
@@ -92,7 +92,7 @@ func (r *WrongManifestParentManifestRule) check(ctx *api.Context) {
 				continue
 			}
 			if c.ParentTag != expected {
-				ctx.Emit(manifestFinding(m.Path, c.Line, r.BaseRule,
+				ctx.Emit(baseFinding(m.Path, c.Line, r.BaseRule,
 					fmt.Sprintf("<%s> should be a child of <%s>, not <%s>.",
 						c.Tag, expected, c.ParentTag)))
 			}
@@ -118,12 +118,12 @@ func (r *GradleOverridesManifestRule) check(ctx *api.Context) {
 		return
 	}
 	if m.MinSDK > 0 {
-		ctx.Emit(manifestFinding(m.Path, m.UsesSdk.Line, r.BaseRule,
+		ctx.Emit(baseFinding(m.Path, m.UsesSdk.Line, r.BaseRule,
 			"This `minSdkVersion` value in the manifest is overridden by the value in "+
 				"build.gradle. Remove the value from AndroidManifest.xml."))
 	}
 	if m.TargetSDK > 0 {
-		ctx.Emit(manifestFinding(m.Path, m.UsesSdk.Line, r.BaseRule,
+		ctx.Emit(baseFinding(m.Path, m.UsesSdk.Line, r.BaseRule,
 			"This `targetSdkVersion` value in the manifest is overridden by the value in "+
 				"build.gradle. Remove the value from AndroidManifest.xml."))
 	}
@@ -174,7 +174,7 @@ func (r *UsesSdkManifestRule) check(ctx *api.Context) {
 		}
 	}
 	if m.UsesSdk == nil {
-		ctx.Emit(manifestFinding(m.Path, 1, r.BaseRule,
+		ctx.Emit(baseFinding(m.Path, 1, r.BaseRule,
 			"Manifest is missing a `<uses-sdk>` element. Add `<uses-sdk>` with "+
 				"android:minSdkVersion and android:targetSdkVersion attributes."))
 		return
@@ -202,7 +202,7 @@ func (r *MipmapLauncherRule) check(ctx *api.Context) {
 		return // MissingApplicationIcon handles this case
 	}
 	if strings.HasPrefix(icon, "@drawable/") {
-		ctx.Emit(manifestFinding(m.Path, m.Application.Line, r.BaseRule,
+		ctx.Emit(baseFinding(m.Path, m.Application.Line, r.BaseRule,
 			fmt.Sprintf("Launcher icon `%s` uses @drawable/ instead of @mipmap/. "+
 				"Use @mipmap/ resources for launcher icons to ensure proper density handling.",
 				icon)))
@@ -262,7 +262,7 @@ func (r *UniquePermissionRule) check(ctx *api.Context) {
 	m := ctx.Manifest
 	for _, perm := range m.Permissions {
 		if systemPermissions[perm] {
-			ctx.Emit(manifestFinding(m.Path, 1, r.BaseRule,
+			ctx.Emit(baseFinding(m.Path, 1, r.BaseRule,
 				fmt.Sprintf("Custom permission `%s` collides with a system permission. "+
 					"Use a unique name prefixed with your application package.",
 					perm)))
@@ -318,7 +318,7 @@ func (r *SystemPermissionRule) check(ctx *api.Context) {
 			if idx := strings.LastIndex(perm, "."); idx >= 0 {
 				short = perm[idx+1:]
 			}
-			ctx.Emit(manifestFinding(m.Path, 1, r.BaseRule,
+			ctx.Emit(baseFinding(m.Path, 1, r.BaseRule,
 				fmt.Sprintf("Requesting dangerous permission `%s`. "+
 					"Ensure this permission is necessary and that runtime permission handling is implemented.",
 					short)))
@@ -370,7 +370,7 @@ func (r *ManifestTypoRule) check(ctx *api.Context) {
 	m := ctx.Manifest
 	for _, elem := range m.Elements {
 		if correct, ok := manifestTypos[elem.Tag]; ok {
-			ctx.Emit(manifestFinding(m.Path, elem.Line, r.BaseRule,
+			ctx.Emit(baseFinding(m.Path, elem.Line, r.BaseRule,
 				fmt.Sprintf("Probable typo: `<%s>` should be `<%s>`.",
 					elem.Tag, correct)))
 		}
@@ -399,7 +399,7 @@ func (r *MissingApplicationIconRule) check(ctx *api.Context) {
 		return
 	}
 	if m.Application.Icon == "" {
-		ctx.Emit(manifestFinding(m.Path, m.Application.Line, r.BaseRule,
+		ctx.Emit(baseFinding(m.Path, m.Application.Line, r.BaseRule,
 			"Missing `android:icon` attribute on <application>. "+
 				"Add an icon to ensure the app has a visible launcher icon."))
 		return
@@ -424,7 +424,7 @@ func (r *TargetNewerRule) check(ctx *api.Context) {
 		return // Not set in manifest; Gradle likely controls this
 	}
 	if m.TargetSDK < minRecommendedTargetSDK {
-		ctx.Emit(manifestFinding(m.Path, 1, r.BaseRule,
+		ctx.Emit(baseFinding(m.Path, 1, r.BaseRule,
 			fmt.Sprintf("targetSdkVersion %d is outdated. "+
 				"Target at least API %d for latest security and behavior changes.",
 				m.TargetSDK, minRecommendedTargetSDK)))
@@ -456,7 +456,7 @@ func (r *IntentFilterExportRequiredRule) check(ctx *api.Context) {
 	components := allComponents(m.Application)
 	for _, c := range components {
 		if c.HasIntentFilter && c.Exported == nil {
-			ctx.Emit(manifestFinding(m.Path, c.Line, r.BaseRule,
+			ctx.Emit(baseFinding(m.Path, c.Line, r.BaseRule,
 				fmt.Sprintf("%s `%s` declares an intent-filter but is missing android:exported. "+
 					"API 31+ requires android:exported on all components with intent-filters.",
 					cases.Title(language.Und).String(c.Tag), c.Name)))
@@ -486,7 +486,7 @@ func (r *DuplicateUsesFeatureManifestRule) check(ctx *api.Context) {
 			continue
 		}
 		if firstLine, ok := seen[f.Name]; ok {
-			ctx.Emit(manifestFinding(m.Path, f.Line, r.BaseRule,
+			ctx.Emit(baseFinding(m.Path, f.Line, r.BaseRule,
 				fmt.Sprintf("Duplicate `<uses-feature android:name=\"%s\">` (first at line %d). "+
 					"Remove the duplicate declaration.",
 					f.Name, firstLine)))
@@ -520,7 +520,7 @@ func (r *MultipleUsesSdkManifestRule) check(ctx *api.Context) {
 		}
 	}
 	if count > 1 {
-		ctx.Emit(manifestFinding(m.Path, secondLine, r.BaseRule,
+		ctx.Emit(baseFinding(m.Path, secondLine, r.BaseRule,
 			fmt.Sprintf("Found %d `<uses-sdk>` elements. Only one is allowed per manifest.", count)))
 		return
 	}
@@ -554,7 +554,7 @@ func (r *ManifestOrderManifestRule) check(ctx *api.Context) {
 
 	for _, elem := range m.Elements {
 		if (elem.Tag == "uses-permission" || elem.Tag == "uses-sdk") && elem.Line > appLine {
-			ctx.Emit(manifestFinding(m.Path, elem.Line, r.BaseRule,
+			ctx.Emit(baseFinding(m.Path, elem.Line, r.BaseRule,
 				fmt.Sprintf("`<%s>` appears after `<application>` (line %d). "+
 					"Move `<%s>` before `<application>` for conventional manifest ordering.",
 					elem.Tag, appLine, elem.Tag)))
@@ -625,15 +625,15 @@ func (r *MissingVersionManifestRule) check(ctx *api.Context) {
 	// keys in downstream reporting.
 	switch {
 	case missingCode && missingName:
-		ctx.Emit(manifestFinding(m.Path, 1, r.BaseRule,
+		ctx.Emit(baseFinding(m.Path, 1, r.BaseRule,
 			"Missing `android:versionCode` and `android:versionName` on <manifest>. "+
 				"Set a version code and name for release builds."))
 	case missingCode:
-		ctx.Emit(manifestFinding(m.Path, 1, r.BaseRule,
+		ctx.Emit(baseFinding(m.Path, 1, r.BaseRule,
 			"Missing `android:versionCode` on <manifest>. "+
 				"Set a version code for release builds."))
 	default: // missingName
-		ctx.Emit(manifestFinding(m.Path, 1, r.BaseRule,
+		ctx.Emit(baseFinding(m.Path, 1, r.BaseRule,
 			"Missing `android:versionName` on <manifest>. "+
 				"Set a version name for release builds."))
 	}
@@ -657,7 +657,7 @@ func (r *MockLocationManifestRule) check(ctx *api.Context) {
 	}
 	for _, perm := range m.UsesPermissions {
 		if perm == "android.permission.ACCESS_MOCK_LOCATION" {
-			ctx.Emit(manifestFinding(m.Path, 1, r.BaseRule,
+			ctx.Emit(baseFinding(m.Path, 1, r.BaseRule,
 				"`android.permission.ACCESS_MOCK_LOCATION` should only be declared in a debug-specific "+
 					"manifest, not in the main AndroidManifest.xml."))
 			return
@@ -687,7 +687,7 @@ func (r *UnpackedNativeCodeManifestRule) check(ctx *api.Context) {
 	}
 	app := m.Application
 	if app.ExtractNativeLibs == nil || *app.ExtractNativeLibs {
-		ctx.Emit(manifestFinding(m.Path, app.Line, r.BaseRule,
+		ctx.Emit(baseFinding(m.Path, app.Line, r.BaseRule,
 			"Project uses native libraries but `android:extractNativeLibs` is not set to false. "+
 				"Set `android:extractNativeLibs=\"false\"` on <application> to reduce APK size."))
 		return
@@ -712,7 +712,7 @@ func (r *InvalidUsesTagAttributeManifestRule) check(ctx *api.Context) {
 			continue // not set is OK
 		}
 		if f.Required != "true" && f.Required != "false" {
-			ctx.Emit(manifestFinding(m.Path, f.Line, r.BaseRule,
+			ctx.Emit(baseFinding(m.Path, f.Line, r.BaseRule,
 				fmt.Sprintf("`<uses-feature android:name=\"%s\">` has android:required=\"%s\". "+
 					"Value must be \"true\" or \"false\".",
 					f.Name, f.Required)))

--- a/internal/rules/android_onclick.go
+++ b/internal/rules/android_onclick.go
@@ -189,13 +189,13 @@ func emitOnClickFindings(ctx *api.Context, rule BaseRule, summary *onClickClassS
 		for _, site := range handlersByLayout[layoutName] {
 			method, ok := summary.methods[site.method]
 			if !ok {
-				ctx.Emit(resourceFinding(site.layoutPath, site.line, rule,
+				ctx.Emit(baseFinding(site.layoutPath, site.line, rule,
 					fmt.Sprintf("`android:onClick=\"%s\"` on `%s` has no matching method on `%s`. Declare `fun %s(view: View)` or remove the attribute.",
 						site.method, site.viewType, classDisplayName(summary), site.method)))
 				continue
 			}
 			if method.isPrivate || method.paramCount != 1 || !method.hasViewParam {
-				ctx.Emit(resourceFinding(site.layoutPath, site.line, rule,
+				ctx.Emit(baseFinding(site.layoutPath, site.line, rule,
 					fmt.Sprintf("`android:onClick=\"%s\"` on `%s` requires a public method `fun %s(view: View)` on `%s`. The current signature does not match and will throw NoSuchMethodException at runtime.",
 						site.method, site.viewType, site.method, classDisplayName(summary))))
 			}

--- a/internal/rules/android_resource.go
+++ b/internal/rules/android_resource.go
@@ -16,7 +16,6 @@ package rules
 
 import (
 	"github.com/kaeawc/krit/internal/android"
-	"github.com/kaeawc/krit/internal/scanner"
 )
 
 // Resource-rule marker types. These are empty structs embedded by
@@ -63,22 +62,6 @@ type ValuesExtraTextResourceBase struct{ ResourceBase }
 
 func (ValuesExtraTextResourceBase) AndroidDependencies() AndroidDataDependency {
 	return AndroidDepValuesExtraText
-}
-
-// ---------------------------------------------------------------------------
-// Helper to create a resource finding
-// ---------------------------------------------------------------------------
-
-func resourceFinding(path string, line int, rule BaseRule, msg string) scanner.Finding {
-	return scanner.Finding{
-		File:     path,
-		Line:     line,
-		Col:      1,
-		RuleSet:  rule.RuleSetName,
-		Rule:     rule.RuleName,
-		Severity: rule.Sev,
-		Message:  msg,
-	}
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/rules/android_resource_a11y.go
+++ b/internal/rules/android_resource_a11y.go
@@ -34,7 +34,7 @@ func (r *HardcodedValuesResourceRule) check(ctx *api.Context) {
 	for _, layout := range idx.Layouts {
 		walkViews(layout.RootView, func(v *android.View) {
 			if v.HasHardcodedText() {
-				ctx.Emit(resourceFinding(layout.FilePath, v.Line, r.BaseRule,
+				ctx.Emit(baseFinding(layout.FilePath, v.Line, r.BaseRule,
 					fmt.Sprintf("Hardcoded text `%s` in `%s`. Use a `@string/` resource reference instead for internationalization.",
 						truncate(v.Text, 40), v.Type)))
 			}
@@ -42,7 +42,7 @@ func (r *HardcodedValuesResourceRule) check(ctx *api.Context) {
 			if hint := v.Attributes["android:hint"]; hint != "" &&
 				!strings.HasPrefix(hint, "@string/") &&
 				!strings.HasPrefix(hint, "@android:string/") {
-				ctx.Emit(resourceFinding(layout.FilePath, v.Line, r.BaseRule,
+				ctx.Emit(baseFinding(layout.FilePath, v.Line, r.BaseRule,
 					fmt.Sprintf("Hardcoded hint `%s` in `%s`. Use a `@string/` resource reference instead.",
 						truncate(hint, 40), v.Type)))
 			}
@@ -87,7 +87,7 @@ func (r *MissingContentDescriptionResourceRule) check(ctx *api.Context) {
 				strings.Contains(v.Attributes["tools:ignore"], "ContentDescription") {
 				return
 			}
-			ctx.Emit(resourceFinding(layout.FilePath, v.Line, r.BaseRule,
+			ctx.Emit(baseFinding(layout.FilePath, v.Line, r.BaseRule,
 				fmt.Sprintf("`%s` missing `android:contentDescription` attribute. "+
 					"Set a description for accessibility or use `tools:ignore=\"ContentDescription\"`.",
 					v.Type)))
@@ -151,13 +151,13 @@ func checkLabelFor(v *android.View, path string, rule BaseRule, findings *[]scan
 				id := strings.TrimPrefix(child.ID, "@+id/")
 				id = strings.TrimPrefix(id, "@id/")
 				if !labelForTargets[id] {
-					*findings = append(*findings, resourceFinding(path, child.Line, rule,
+					*findings = append(*findings, baseFinding(path, child.Line, rule,
 						fmt.Sprintf("No sibling has `android:labelFor` pointing to `%s`. "+
 							"Add a label for accessibility.", child.ID)))
 				}
 			} else {
 				// EditText without an ID can't be referenced by labelFor
-				*findings = append(*findings, resourceFinding(path, child.Line, rule,
+				*findings = append(*findings, baseFinding(path, child.Line, rule,
 					fmt.Sprintf("`%s` has no `android:id`, so no label can reference it via `labelFor`. "+
 						"Add an id and a corresponding label for accessibility.", child.Type)))
 			}
@@ -236,7 +236,7 @@ func (r *ClickableViewAccessibilityResourceRule) check(ctx *api.Context) {
 				strings.Contains(v.Attributes["tools:ignore"], "ContentDescription") {
 				return
 			}
-			ctx.Emit(resourceFinding(layout.FilePath, v.Line, r.BaseRule,
+			ctx.Emit(baseFinding(layout.FilePath, v.Line, r.BaseRule,
 				fmt.Sprintf("`%s` is clickable but missing `android:contentDescription`. "+
 					"Add a description for accessibility.", v.Type)))
 		})
@@ -270,7 +270,7 @@ func (r *BackButtonResourceRule) check(ctx *api.Context) {
 			}
 			text := v.Text
 			if strings.EqualFold(text, "back") || text == "@string/back" {
-				ctx.Emit(resourceFinding(layout.FilePath, v.Line, r.BaseRule,
+				ctx.Emit(baseFinding(layout.FilePath, v.Line, r.BaseRule,
 					fmt.Sprintf("Button with text `%s` detected. Avoid explicit back buttons; use the system navigation bar instead.",
 						text)))
 			}
@@ -308,11 +308,11 @@ func (r *ButtonCaseResourceRule) check(ctx *api.Context) {
 			}
 			lower := strings.ToLower(text)
 			if lower == "ok" && text != "OK" {
-				ctx.Emit(resourceFinding(layout.FilePath, v.Line, r.BaseRule,
+				ctx.Emit(baseFinding(layout.FilePath, v.Line, r.BaseRule,
 					fmt.Sprintf("Button text `%s` should be `OK` (all caps).", text)))
 			}
 			if lower == "cancel" && text != "CANCEL" {
-				ctx.Emit(resourceFinding(layout.FilePath, v.Line, r.BaseRule,
+				ctx.Emit(baseFinding(layout.FilePath, v.Line, r.BaseRule,
 					fmt.Sprintf("Button text `%s` should be `CANCEL` (all caps on Android).", text)))
 			}
 		})
@@ -365,7 +365,7 @@ func (r *ButtonOrderResourceRule) check(ctx *api.Context) {
 				}
 			}
 			if okBtn != nil && cancelBtn != nil && cancelBtn.Line > okBtn.Line {
-				ctx.Emit(resourceFinding(layout.FilePath, cancelBtn.Line, r.BaseRule,
+				ctx.Emit(baseFinding(layout.FilePath, cancelBtn.Line, r.BaseRule,
 					fmt.Sprintf("Cancel button (line %d) appears after OK button (line %d). "+
 						"Android convention places Cancel before OK.", cancelBtn.Line, okBtn.Line)))
 			}
@@ -403,7 +403,7 @@ func (r *ButtonStyleResourceRule) check(ctx *api.Context) {
 			if style != "" && (strings.Contains(style, "Borderless") || strings.Contains(style, "borderless")) {
 				return
 			}
-			ctx.Emit(resourceFinding(layout.FilePath, v.Line, r.BaseRule,
+			ctx.Emit(baseFinding(layout.FilePath, v.Line, r.BaseRule,
 				fmt.Sprintf("Button in dialog layout `%s` should use a borderless style (e.g., `?android:attr/borderlessButtonStyle`).", name)))
 		})
 	}
@@ -430,7 +430,7 @@ func (r *LayoutClickableWithoutMinSizeRule) check(ctx *api.Context) {
 			w := parseLayoutDp(v.LayoutWidth)
 			h := parseLayoutDp(v.LayoutHeight)
 			if (w > 0 && w < 48) || (h > 0 && h < 48) {
-				ctx.Emit(resourceFinding(layout.FilePath, v.Line, r.BaseRule,
+				ctx.Emit(baseFinding(layout.FilePath, v.Line, r.BaseRule,
 					fmt.Sprintf("`%s` is clickable with a dimension below 48dp. "+
 						"Use at least 48dp for touch targets.", v.Type)))
 			}
@@ -474,7 +474,7 @@ func (r *LayoutEditTextMissingImportanceRule) check(ctx *api.Context) {
 			if v.Attributes["android:importantForAutofill"] != "" {
 				return
 			}
-			ctx.Emit(resourceFinding(layout.FilePath, v.Line, r.BaseRule,
+			ctx.Emit(baseFinding(layout.FilePath, v.Line, r.BaseRule,
 				fmt.Sprintf("`%s` missing `android:importantForAutofill`. "+
 					"Set `yes` or `no` explicitly for autofill accessibility (API 26+).", v.Type)))
 		})
@@ -501,7 +501,7 @@ func (r *LayoutImportantForAccessibilityNoRule) check(ctx *api.Context) {
 			}
 			if v.Attributes["android:clickable"] == "true" ||
 				v.Attributes["android:focusable"] == "true" {
-				ctx.Emit(resourceFinding(layout.FilePath, v.Line, r.BaseRule,
+				ctx.Emit(baseFinding(layout.FilePath, v.Line, r.BaseRule,
 					fmt.Sprintf("`%s` has `importantForAccessibility=\"no\"` but is clickable or focusable. "+
 						"This hides an interactive element from assistive technology.", v.Type)))
 			}
@@ -543,7 +543,7 @@ func (r *LayoutAutofillHintMismatchRule) check(ctx *api.Context) {
 			}
 			autofillHints := v.Attributes["android:autofillHints"]
 			if autofillHints == "" {
-				ctx.Emit(resourceFinding(layout.FilePath, v.Line, r.BaseRule,
+				ctx.Emit(baseFinding(layout.FilePath, v.Line, r.BaseRule,
 					fmt.Sprintf("`%s` has `inputType=\"%s\"` but no `android:autofillHints`. "+
 						"Add `autofillHints=\"%s\"` for autofill support.", v.Type, inputType, expectedHint)))
 			}
@@ -590,7 +590,7 @@ func (r *LayoutMinTouchTargetInButtonRowRule) check(ctx *api.Context) {
 				if h == "wrap_content" || h == "" {
 					minH := child.Attributes["android:minHeight"]
 					if minH == "" || parseLayoutDp(minH) < 48 {
-						ctx.Emit(resourceFinding(layout.FilePath, child.Line, r.BaseRule,
+						ctx.Emit(baseFinding(layout.FilePath, child.Line, r.BaseRule,
 							fmt.Sprintf("`%s` in `%s` with `wrap_content` height and no `minHeight >= 48dp`. "+
 								"Ensure a minimum 48dp touch target.", child.Type, v.Type)))
 					}
@@ -655,7 +655,7 @@ func (r *StringNotSelectableRule) check(ctx *api.Context) {
 				}
 			}
 			if containsURLOrPhone(stringValue) {
-				ctx.Emit(resourceFinding(layout.FilePath, v.Line, r.BaseRule,
+				ctx.Emit(baseFinding(layout.FilePath, v.Line, r.BaseRule,
 					fmt.Sprintf("`%s` with `textIsSelectable=\"false\"` contains URLs or phone numbers. "+
 						"Allow selection for assistive technology users to copy content.", v.Type)))
 			}
@@ -691,7 +691,7 @@ func (r *StringRepeatedInContentDescriptionRule) check(ctx *api.Context) {
 			for _, sibling := range v.Children {
 				sibText := resolveStringValue(idx, sibling.Text)
 				if sibText != "" && strings.EqualFold(cd, sibText) {
-					ctx.Emit(resourceFinding(layout.FilePath, v.Line, r.BaseRule,
+					ctx.Emit(baseFinding(layout.FilePath, v.Line, r.BaseRule,
 						fmt.Sprintf("`contentDescription` on `%s` duplicates visible text of child `%s`. "+
 							"TalkBack reads both, causing stutter.", v.Type, sibling.Type)))
 				}
@@ -708,7 +708,7 @@ func (r *StringRepeatedInContentDescriptionRule) check(ctx *api.Context) {
 				}
 				sibText := resolveStringValue(idx, sibling.Text)
 				if sibText != "" && strings.EqualFold(cd, sibText) {
-					ctx.Emit(resourceFinding(layout.FilePath, v.Line, r.BaseRule,
+					ctx.Emit(baseFinding(layout.FilePath, v.Line, r.BaseRule,
 						fmt.Sprintf("`contentDescription` on `%s` duplicates visible text of sibling `%s`. "+
 							"TalkBack reads both, causing stutter.", v.Type, sibling.Type)))
 				}
@@ -754,7 +754,7 @@ func (r *StringSpanInContentDescriptionRule) check(ctx *api.Context) {
 			if !locOk {
 				continue
 			}
-			ctx.Emit(resourceFinding(loc.FilePath, loc.Line, r.BaseRule,
+			ctx.Emit(baseFinding(loc.FilePath, loc.Line, r.BaseRule,
 				fmt.Sprintf("String `%s` used as `contentDescription` contains HTML markup. "+
 					"TalkBack reads raw tags aloud.", name)))
 		}

--- a/internal/rules/android_resource_ids.go
+++ b/internal/rules/android_resource_ids.go
@@ -38,7 +38,7 @@ func (r *DuplicateIDsResourceRule) check(ctx *api.Context) {
 			id = strings.TrimPrefix(id, "@+id/")
 			id = strings.TrimPrefix(id, "@id/")
 			if firstLine, ok := seen[id]; ok {
-				ctx.Emit(resourceFinding(layout.FilePath, v.Line, r.BaseRule,
+				ctx.Emit(baseFinding(layout.FilePath, v.Line, r.BaseRule,
 					fmt.Sprintf("Duplicate id `@+id/%s` in layout `%s` (first used at line %d).",
 						id, layout.Name, firstLine)))
 			} else {
@@ -101,7 +101,7 @@ func (r *InvalidIDResourceRule) check(ctx *api.Context) {
 				return
 			}
 			if !isValidAndroidID(id) {
-				ctx.Emit(resourceFinding(layout.FilePath, v.Line, r.BaseRule,
+				ctx.Emit(baseFinding(layout.FilePath, v.Line, r.BaseRule,
 					fmt.Sprintf("Invalid `android:id` value `%s`. IDs must be `@+id/name` or `@id/name` with alphanumeric/underscore names.",
 						id)))
 			}
@@ -140,7 +140,7 @@ func (r *MissingIDResourceRule) check(ctx *api.Context) {
 			if v.Attributes["android:tag"] != "" {
 				return
 			}
-			ctx.Emit(resourceFinding(layout.FilePath, v.Line, r.BaseRule,
+			ctx.Emit(baseFinding(layout.FilePath, v.Line, r.BaseRule,
 				fmt.Sprintf("<%s> should specify an `android:id` or `android:tag` to allow proper state saving.",
 					v.Type)))
 		})
@@ -257,7 +257,7 @@ func (r *CutPasteIDResourceRule) check(ctx *api.Context) {
 					}
 				}
 				if !matched {
-					ctx.Emit(resourceFinding(layout.FilePath, v.Line, r.BaseRule,
+					ctx.Emit(baseFinding(layout.FilePath, v.Line, r.BaseRule,
 						fmt.Sprintf("ID `%s` suggests a `%s` but the view is `%s`. Possible copy-paste mistake.",
 							v.ID, expectedTypes[0], v.Type)))
 				}
@@ -359,7 +359,7 @@ func (r *DuplicateIncludedIDsResourceRule) check(ctx *api.Context) {
 		if !foundConflict {
 			continue
 		}
-		ctx.Emit(resourceFinding(conflictPair[0].path, conflictPair[0].line, r.BaseRule,
+		ctx.Emit(baseFinding(conflictPair[0].path, conflictPair[0].line, r.BaseRule,
 			fmt.Sprintf("ID `%s` collides: layout `%s` includes `%s` which also defines `%s`. Runtime findViewById will return the wrong view.",
 				id, conflictPair[0].name, conflictPair[1].name, id)))
 	}
@@ -438,7 +438,7 @@ func (r *MissingPrefixResourceRule) check(ctx *api.Context) {
 				}
 				// Check if this is a known android attribute missing its prefix
 				if knownAndroidAttrs[attrName] {
-					ctx.Emit(resourceFinding(layout.FilePath, v.Line, r.BaseRule,
+					ctx.Emit(baseFinding(layout.FilePath, v.Line, r.BaseRule,
 						fmt.Sprintf("Attribute `%s` missing `android:` prefix. Use `android:%s` instead.",
 							attrName, attrName)))
 				}
@@ -511,7 +511,7 @@ func (r *NamespaceTypoResourceRule) check(ctx *api.Context) {
 				strings.Contains(attrVal, "shemas.android.com") {
 				dist := levenshtein(attrVal, correctAndroidNS)
 				if dist > 0 && dist <= 5 {
-					ctx.Emit(resourceFinding(layout.FilePath, layout.RootView.Line, r.BaseRule,
+					ctx.Emit(baseFinding(layout.FilePath, layout.RootView.Line, r.BaseRule,
 						fmt.Sprintf("Possible typo in namespace URI `%s`. Did you mean `%s`?",
 							attrVal, correctAndroidNS)))
 				}
@@ -548,7 +548,7 @@ func (r *ResAutoResourceRule) check(ctx *api.Context) {
 				if strings.HasPrefix(attr, "xmlns:") && strings.HasPrefix(val, resPackagePrefix) {
 					suffix := val[len(resPackagePrefix):]
 					if suffix != "" && suffix != "android" {
-						ctx.Emit(resourceFinding(layout.FilePath, v.Line, r.BaseRule,
+						ctx.Emit(baseFinding(layout.FilePath, v.Line, r.BaseRule,
 							fmt.Sprintf("Namespace declaration `%s=\"%s\"` uses a hardcoded package name. "+
 								"Use `http://schemas.android.com/apk/res-auto` instead.",
 								attr, val)))
@@ -615,7 +615,7 @@ func (r *UnusedNamespaceResourceRule) check(ctx *api.Context) {
 			}
 			prefix := strings.TrimPrefix(attr, "xmlns:")
 			if !used[prefix] {
-				ctx.Emit(resourceFinding(layout.FilePath, root.Line, r.BaseRule,
+				ctx.Emit(baseFinding(layout.FilePath, root.Line, r.BaseRule,
 					fmt.Sprintf("Unused namespace declaration `xmlns:%s`. "+
 						"No attributes in the layout use the `%s:` prefix.",
 						prefix, prefix)))
@@ -661,7 +661,7 @@ func (r *IllegalResourceRefResourceRule) check(ctx *api.Context) {
 				ref = strings.TrimPrefix(ref, "+")
 				// Must contain a / separating type from name
 				if !strings.Contains(ref, "/") {
-					ctx.Emit(resourceFinding(layout.FilePath, v.Line, r.BaseRule,
+					ctx.Emit(baseFinding(layout.FilePath, v.Line, r.BaseRule,
 						fmt.Sprintf("Malformed resource reference `%s` in attribute `%s`. "+
 							"Expected format `@[type]/name`.",
 							val, attr)))
@@ -673,14 +673,14 @@ func (r *IllegalResourceRefResourceRule) check(ctx *api.Context) {
 				// Type part (possibly prefixed with "android:")
 				resType = strings.TrimPrefix(resType, "android:")
 				if resType == "" {
-					ctx.Emit(resourceFinding(layout.FilePath, v.Line, r.BaseRule,
+					ctx.Emit(baseFinding(layout.FilePath, v.Line, r.BaseRule,
 						fmt.Sprintf("Malformed resource reference `%s` in attribute `%s`. "+
 							"Missing resource type before `/`.",
 							val, attr)))
 					continue
 				}
 				if resName == "" {
-					ctx.Emit(resourceFinding(layout.FilePath, v.Line, r.BaseRule,
+					ctx.Emit(baseFinding(layout.FilePath, v.Line, r.BaseRule,
 						fmt.Sprintf("Malformed resource reference `%s` in attribute `%s`. "+
 							"Missing resource name after `/`.",
 							val, attr)))
@@ -760,7 +760,7 @@ func (r *WrongCaseResourceRule) check(ctx *api.Context) {
 				return
 			}
 			if v.Type != correct {
-				ctx.Emit(resourceFinding(layout.FilePath, v.Line, r.BaseRule,
+				ctx.Emit(baseFinding(layout.FilePath, v.Line, r.BaseRule,
 					fmt.Sprintf("View tag `%s` has wrong capitalization. Use `%s` instead.",
 						v.Type, correct)))
 			}
@@ -804,7 +804,7 @@ func (r *WrongFolderResourceRule) check(ctx *api.Context) {
 					continue
 				}
 				if !drawableSet[name] {
-					ctx.Emit(resourceFinding(layout.FilePath, v.Line, r.BaseRule,
+					ctx.Emit(baseFinding(layout.FilePath, v.Line, r.BaseRule,
 						fmt.Sprintf("Resource reference `%s` in attribute `%s` not found in any drawable or mipmap directory.",
 							val, attr)))
 				}
@@ -864,7 +864,7 @@ func (r *InvalidResourceFolderResourceRule) check(ctx *api.Context) {
 		}
 		folder := afterRes[:slashIdx]
 		if !isValidResFolderName(folder) {
-			ctx.Emit(resourceFinding(layout.FilePath, 1, r.BaseRule,
+			ctx.Emit(baseFinding(layout.FilePath, 1, r.BaseRule,
 				fmt.Sprintf("Invalid resource folder name `%s`. "+
 					"Expected one of: layout, drawable, mipmap, values, raw, xml, anim, animator, color, menu, font, navigation, transition.",
 					folder)))
@@ -893,7 +893,7 @@ func (r *AppCompatResourceRule) check(ctx *api.Context) {
 	for _, layout := range idx.Layouts {
 		walkViews(layout.RootView, func(v *android.View) {
 			if v.Attributes["android:showAsAction"] != "" {
-				ctx.Emit(resourceFinding(layout.FilePath, v.Line, r.BaseRule,
+				ctx.Emit(baseFinding(layout.FilePath, v.Line, r.BaseRule,
 					fmt.Sprintf("`%s` uses `android:showAsAction` instead of `app:showAsAction`. Use `app:showAsAction` for AppCompat compatibility.", v.Type)))
 			}
 		})

--- a/internal/rules/android_resource_layout.go
+++ b/internal/rules/android_resource_layout.go
@@ -38,7 +38,7 @@ func (r *TooManyViewsResourceRule) check(ctx *api.Context) {
 	for _, layout := range idx.Layouts {
 		count := layout.ViewCount()
 		if count > maxViews {
-			ctx.Emit(resourceFinding(layout.FilePath, 1, r.BaseRule,
+			ctx.Emit(baseFinding(layout.FilePath, 1, r.BaseRule,
 				fmt.Sprintf("Layout `%s` has %d views (threshold: %d). "+
 					"Consider simplifying or using ViewStub/include.",
 					layout.Name, count, maxViews)))
@@ -72,7 +72,7 @@ func (r *TooDeepLayoutResourceRule) check(ctx *api.Context) {
 	for _, layout := range idx.Layouts {
 		depth := layout.MaxDepth()
 		if depth > maxDepth {
-			ctx.Emit(resourceFinding(layout.FilePath, 1, r.BaseRule,
+			ctx.Emit(baseFinding(layout.FilePath, 1, r.BaseRule,
 				fmt.Sprintf("Layout `%s` has nesting depth %d (threshold: %d). "+
 					"Flatten with ConstraintLayout or merge tags.",
 					layout.Name, depth, maxDepth)))
@@ -120,7 +120,7 @@ func (r *UselessParentResourceRule) check(ctx *api.Context) {
 			if hasAnyPadding(v) {
 				return
 			}
-			ctx.Emit(resourceFinding(layout.FilePath, v.Line, r.BaseRule,
+			ctx.Emit(baseFinding(layout.FilePath, v.Line, r.BaseRule,
 				fmt.Sprintf("Useless parent `%s` with single child. Remove wrapper and promote the child.",
 					v.Type)))
 		})
@@ -174,7 +174,7 @@ func (r *UselessLeafResourceRule) check(ctx *api.Context) {
 			if v.ID != "" {
 				return
 			}
-			ctx.Emit(resourceFinding(layout.FilePath, v.Line, r.BaseRule,
+			ctx.Emit(baseFinding(layout.FilePath, v.Line, r.BaseRule,
 				fmt.Sprintf("Useless leaf `%s` has no children, no background, and no id. Remove it.",
 					v.Type)))
 		})
@@ -210,7 +210,7 @@ func findNestedScrollViews(v *android.View, insideScroll bool, path string, rule
 	}
 	isScroll := android.IsScrollableView(v.Type)
 	if isScroll && insideScroll {
-		ctx.Emit(resourceFinding(path, v.Line, rule,
+		ctx.Emit(baseFinding(path, v.Line, rule,
 			fmt.Sprintf("Nested scrolling: `%s` inside another scrollable view. "+
 				"This causes broken or unpredictable scrolling behavior.", v.Type)))
 	}
@@ -243,7 +243,7 @@ func (r *ScrollViewCountResourceRule) check(ctx *api.Context) {
 				return
 			}
 			if len(v.Children) > 1 {
-				ctx.Emit(resourceFinding(layout.FilePath, v.Line, r.BaseRule,
+				ctx.Emit(baseFinding(layout.FilePath, v.Line, r.BaseRule,
 					fmt.Sprintf("`%s` should have exactly one direct child, but has %d.",
 						v.Type, len(v.Children))))
 			}
@@ -280,14 +280,14 @@ func (r *ScrollViewSizeResourceRule) check(ctx *api.Context) {
 			for _, child := range v.Children {
 				if isHorizontal {
 					if child.LayoutWidth == "match_parent" || child.LayoutWidth == "fill_parent" {
-						ctx.Emit(resourceFinding(layout.FilePath, child.Line, r.BaseRule,
+						ctx.Emit(baseFinding(layout.FilePath, child.Line, r.BaseRule,
 							fmt.Sprintf("`%s` child of `%s` should use `layout_width=\"wrap_content\"` instead of `%s`. "+
 								"The parent scrolls horizontally so the child does not need to fill it.",
 								child.Type, v.Type, child.LayoutWidth)))
 					}
 				} else {
 					if child.LayoutHeight == "match_parent" || child.LayoutHeight == "fill_parent" {
-						ctx.Emit(resourceFinding(layout.FilePath, child.Line, r.BaseRule,
+						ctx.Emit(baseFinding(layout.FilePath, child.Line, r.BaseRule,
 							fmt.Sprintf("`%s` child of `%s` should use `layout_height=\"wrap_content\"` instead of `%s`. "+
 								"The parent scrolls vertically so the child does not need to fill it.",
 								child.Type, v.Type, child.LayoutHeight)))
@@ -351,13 +351,13 @@ func (r *RequiredSizeResourceRule) check(ctx *api.Context) {
 			missingWidth := v.Attributes["android:layout_width"] == ""
 			missingHeight := v.Attributes["android:layout_height"] == ""
 			if missingWidth && missingHeight {
-				ctx.Emit(resourceFinding(layout.FilePath, v.Line, r.BaseRule,
+				ctx.Emit(baseFinding(layout.FilePath, v.Line, r.BaseRule,
 					fmt.Sprintf("`%s` is missing both `android:layout_width` and `android:layout_height`.", v.Type)))
 			} else if missingWidth {
-				ctx.Emit(resourceFinding(layout.FilePath, v.Line, r.BaseRule,
+				ctx.Emit(baseFinding(layout.FilePath, v.Line, r.BaseRule,
 					fmt.Sprintf("`%s` is missing `android:layout_width`.", v.Type)))
 			} else if missingHeight {
-				ctx.Emit(resourceFinding(layout.FilePath, v.Line, r.BaseRule,
+				ctx.Emit(baseFinding(layout.FilePath, v.Line, r.BaseRule,
 					fmt.Sprintf("`%s` is missing `android:layout_height`.", v.Type)))
 			}
 		})
@@ -428,7 +428,7 @@ func (r *OrientationResourceRule) check(ctx *api.Context) {
 					return
 				}
 			}
-			ctx.Emit(resourceFinding(layout.FilePath, v.Line, r.BaseRule,
+			ctx.Emit(baseFinding(layout.FilePath, v.Line, r.BaseRule,
 				"`LinearLayout` missing explicit `android:orientation`. The default is horizontal, which may not be intended."))
 		})
 	}
@@ -480,7 +480,7 @@ func (r *AdapterViewChildrenResourceRule) check(ctx *api.Context) {
 				return
 			}
 			if len(v.Children) > 0 {
-				ctx.Emit(resourceFinding(layout.FilePath, v.Line, r.BaseRule,
+				ctx.Emit(baseFinding(layout.FilePath, v.Line, r.BaseRule,
 					fmt.Sprintf("`%s` cannot have children in XML. Its content is populated from an adapter.",
 						v.Type)))
 			}
@@ -520,7 +520,7 @@ func (r *IncludeLayoutParamResourceRule) check(ctx *api.Context) {
 			if hasWidth == hasHeight {
 				return
 			}
-			ctx.Emit(resourceFinding(layout.FilePath, v.Line, r.BaseRule,
+			ctx.Emit(baseFinding(layout.FilePath, v.Line, r.BaseRule,
 				"`<include>` specifies only one of `layout_width`/`layout_height`. Partial overrides are silently ignored — specify both dimensions or neither."))
 		})
 	}
@@ -569,7 +569,7 @@ func (r *UseCompoundDrawablesResourceRule) check(ctx *api.Context) {
 				if imgView.Attributes["android:scaleType"] != "" {
 					return
 				}
-				ctx.Emit(resourceFinding(layout.FilePath, v.Line, r.BaseRule,
+				ctx.Emit(baseFinding(layout.FilePath, v.Line, r.BaseRule,
 					fmt.Sprintf("`LinearLayout` with `ImageView` + `TextView` can be replaced "+
 						"by a single `TextView` with a compound drawable (e.g., `drawableStart`).")))
 			}
@@ -639,7 +639,7 @@ func (r *InconsistentLayoutResourceRule) check(ctx *api.Context) {
 
 			// Check root type mismatch.
 			if first.rootType != other.rootType {
-				ctx.Emit(resourceFinding(
+				ctx.Emit(baseFinding(
 					other.filePath, other.rootLine, r.BaseRule,
 					fmt.Sprintf("Layout '%s' has inconsistent root view: '%s' in %s vs '%s' in %s",
 						name, first.rootType, first.qualifier, other.rootType, other.qualifier),
@@ -649,7 +649,7 @@ func (r *InconsistentLayoutResourceRule) check(ctx *api.Context) {
 
 			// Check root child count mismatch.
 			if first.childCount != other.childCount {
-				ctx.Emit(resourceFinding(
+				ctx.Emit(baseFinding(
 					other.filePath, other.rootLine, r.BaseRule,
 					fmt.Sprintf("Layout '%s' has inconsistent root child count: %d in %s vs %d in %s",
 						name, first.childCount, first.qualifier, other.childCount, other.qualifier),
@@ -667,7 +667,7 @@ func (r *InconsistentLayoutResourceRule) check(ctx *api.Context) {
 				diff := larger - smaller
 				avg := (larger + smaller) / 2
 				if avg > 0 && diff*100/avg > 50 {
-					ctx.Emit(resourceFinding(
+					ctx.Emit(baseFinding(
 						other.filePath, other.rootLine, r.BaseRule,
 						fmt.Sprintf("Layout '%s' has significantly different view counts: %d in %s vs %d in %s",
 							name, first.viewCount, first.qualifier, other.viewCount, other.qualifier),

--- a/internal/rules/android_resource_rtl.go
+++ b/internal/rules/android_resource_rtl.go
@@ -61,7 +61,7 @@ func (r *RtlHardcodedResourceRule) check(ctx *api.Context) {
 			// attribute at the same (file, line) collided on the finding
 			// key downstream.
 			if len(replacements) == 1 {
-				ctx.Emit(resourceFinding(layout.FilePath, v.Line, r.BaseRule,
+				ctx.Emit(baseFinding(layout.FilePath, v.Line, r.BaseRule,
 					fmt.Sprintf("Use `%s` instead of `%s` for RTL support in `%s`.",
 						replacements[0].new, replacements[0].old, v.Type)))
 				return
@@ -70,7 +70,7 @@ func (r *RtlHardcodedResourceRule) check(ctx *api.Context) {
 			for _, rep := range replacements {
 				parts = append(parts, fmt.Sprintf("`%s` -> `%s`", rep.old, rep.new))
 			}
-			ctx.Emit(resourceFinding(layout.FilePath, v.Line, r.BaseRule,
+			ctx.Emit(baseFinding(layout.FilePath, v.Line, r.BaseRule,
 				fmt.Sprintf("Use Start/End instead of Left/Right in `%s` for RTL support: %s.",
 					v.Type, strings.Join(parts, ", "))))
 		})
@@ -168,11 +168,11 @@ func (r *RtlSymmetryResourceRule) check(ctx *api.Context) {
 				hasLeft := v.Attributes[pair[0]] != ""
 				hasRight := v.Attributes[pair[1]] != ""
 				if hasLeft && !hasRight {
-					ctx.Emit(resourceFinding(layout.FilePath, v.Line, r.BaseRule,
+					ctx.Emit(baseFinding(layout.FilePath, v.Line, r.BaseRule,
 						fmt.Sprintf("`%s` has `%s` but not `%s`. Add the missing attribute for symmetric spacing.",
 							v.Type, pair[0], pair[1])))
 				} else if hasRight && !hasLeft {
-					ctx.Emit(resourceFinding(layout.FilePath, v.Line, r.BaseRule,
+					ctx.Emit(baseFinding(layout.FilePath, v.Line, r.BaseRule,
 						fmt.Sprintf("`%s` has `%s` but not `%s`. Add the missing attribute for symmetric spacing.",
 							v.Type, pair[1], pair[0])))
 				}
@@ -207,7 +207,7 @@ func (r *RtlSuperscriptResourceRule) check(ctx *api.Context) {
 			}
 			lower := strings.ToLower(textStyle)
 			if strings.Contains(lower, "superscript") || strings.Contains(lower, "subscript") {
-				ctx.Emit(resourceFinding(layout.FilePath, v.Line, r.BaseRule,
+				ctx.Emit(baseFinding(layout.FilePath, v.Line, r.BaseRule,
 					fmt.Sprintf("`%s` uses textStyle `%s` which may render incorrectly in RTL locales.", v.Type, textStyle)))
 			}
 		})
@@ -273,7 +273,7 @@ func (r *RelativeOverlapResourceRule) check(ctx *api.Context) {
 			for i := 0; i < len(leftAligned); i++ {
 				for j := i + 1; j < len(leftAligned); j++ {
 					if leftAligned[i].vertKey == leftAligned[j].vertKey {
-						ctx.Emit(resourceFinding(layout.FilePath, leftAligned[j].view.Line, r.BaseRule,
+						ctx.Emit(baseFinding(layout.FilePath, leftAligned[j].view.Line, r.BaseRule,
 							fmt.Sprintf("`%s` (line %d) and `%s` (line %d) in `RelativeLayout` both use left/start alignment "+
 								"without different vertical constraints and may overlap.",
 								leftAligned[i].view.Type, leftAligned[i].view.Line,
@@ -359,7 +359,7 @@ func checkNotSibling(v *android.View, filePath string, base BaseRule, findings *
 					continue
 				}
 				if !siblingIDs[refID] {
-					*findings = append(*findings, resourceFinding(filePath, child.Line, base,
+					*findings = append(*findings, baseFinding(filePath, child.Line, base,
 						fmt.Sprintf("`%s=\"%s\"` references `%s` which is not a sibling in this RelativeLayout.",
 							attr, ref, refID)))
 				}

--- a/internal/rules/android_resource_style.go
+++ b/internal/rules/android_resource_style.go
@@ -150,7 +150,7 @@ func (r *PxUsageResourceRule) check(ctx *api.Context) {
 			for _, attr := range pxDimensionAttrs {
 				val := v.Attributes[attr]
 				if isPxValue(val) && !pxValueExempt(val) {
-					ctx.Emit(resourceFinding(layout.FilePath, v.Line, r.BaseRule,
+					ctx.Emit(baseFinding(layout.FilePath, v.Line, r.BaseRule,
 						fmt.Sprintf("Avoid using `px` in `%s=\"%s\"`. Use `dp` or `sp` instead for density-independent sizing.",
 							attr, val)))
 				}
@@ -167,7 +167,7 @@ func (r *PxUsageResourceRule) check(ctx *api.Context) {
 		if path == "" {
 			path = "res/values/dimens.xml"
 		}
-		ctx.Emit(resourceFinding(path, loc.Line, r.BaseRule,
+		ctx.Emit(baseFinding(path, loc.Line, r.BaseRule,
 			fmt.Sprintf("Dimension `%s` uses `px` value `%s`. Use `dp` or `sp` instead.",
 				name, val)))
 	}
@@ -177,7 +177,7 @@ func (r *PxUsageResourceRule) check(ctx *api.Context) {
 			if !isPxValue(val) || pxValueExempt(val) {
 				continue
 			}
-			ctx.Emit(resourceFinding(style.FilePath, style.ItemLines[itemName], r.BaseRule,
+			ctx.Emit(baseFinding(style.FilePath, style.ItemLines[itemName], r.BaseRule,
 				fmt.Sprintf("Style `%s` item `%s` uses `px` value `%s`. Use `dp` or `sp` instead.",
 					style.Name, itemName, val)))
 		}
@@ -232,14 +232,14 @@ func (r *SpUsageResourceRule) check(ctx *api.Context) {
 				return
 			}
 			if isDpValue(val) {
-				ctx.Emit(resourceFinding(layout.FilePath, v.Line, r.BaseRule,
+				ctx.Emit(baseFinding(layout.FilePath, v.Line, r.BaseRule,
 					fmt.Sprintf("`android:textSize=\"%s\"` uses `dp`. Use `sp` instead so text respects the user's font size preference.",
 						val)))
 				return
 			}
 			if resolved, loc, ok := resolveDimenReference(idx, val); ok && isDpValue(resolved) {
 				origin := dimenOriginSuffix(loc, resolved)
-				ctx.Emit(resourceFinding(layout.FilePath, v.Line, r.BaseRule,
+				ctx.Emit(baseFinding(layout.FilePath, v.Line, r.BaseRule,
 					fmt.Sprintf("`android:textSize=\"%s\"` resolves to a `dp` value%s. Use `sp` instead so text respects the user's font size preference.",
 						val, origin)))
 			}
@@ -252,14 +252,14 @@ func (r *SpUsageResourceRule) check(ctx *api.Context) {
 				continue
 			}
 			if isDpValue(val) {
-				ctx.Emit(resourceFinding(style.FilePath, style.ItemLines[itemName], r.BaseRule,
+				ctx.Emit(baseFinding(style.FilePath, style.ItemLines[itemName], r.BaseRule,
 					fmt.Sprintf("Style `%s` item `%s=\"%s\"` uses `dp`. Use `sp` instead so text respects the user's font size preference.",
 						style.Name, itemName, val)))
 				continue
 			}
 			if resolved, loc, ok := resolveDimenReference(idx, val); ok && isDpValue(resolved) {
 				origin := dimenOriginSuffix(loc, resolved)
-				ctx.Emit(resourceFinding(style.FilePath, style.ItemLines[itemName], r.BaseRule,
+				ctx.Emit(baseFinding(style.FilePath, style.ItemLines[itemName], r.BaseRule,
 					fmt.Sprintf("Style `%s` item `%s=\"%s\"` resolves to a `dp` value%s. Use `sp` instead so text respects the user's font size preference.",
 						style.Name, itemName, val, origin)))
 			}
@@ -353,7 +353,7 @@ func handleSpLiteral(ctx *api.Context, rule BaseRule, path string, line int, val
 		return false
 	}
 	if sp < 12 {
-		ctx.Emit(resourceFinding(path, line, rule,
+		ctx.Emit(baseFinding(path, line, rule,
 			fmt.Sprintf("Text size `%s`%s is too small (below 12sp) for `%s`. Consider using at least 12sp for readability.",
 				val, origin, label)))
 	}
@@ -417,7 +417,7 @@ func (r *InOrMmUsageResourceRule) check(ctx *api.Context) {
 				if !ok || inOrMmValueExempt(val, unit) {
 					continue
 				}
-				ctx.Emit(resourceFinding(layout.FilePath, v.Line, r.BaseRule,
+				ctx.Emit(baseFinding(layout.FilePath, v.Line, r.BaseRule,
 					fmt.Sprintf("Avoid using `%s` units in `%s=\"%s\"`. Use `dp` or `sp` for density-independent sizing.",
 						unit, attr, val)))
 			}
@@ -433,7 +433,7 @@ func (r *InOrMmUsageResourceRule) check(ctx *api.Context) {
 		if path == "" {
 			path = "res/values/dimens.xml"
 		}
-		ctx.Emit(resourceFinding(path, loc.Line, r.BaseRule,
+		ctx.Emit(baseFinding(path, loc.Line, r.BaseRule,
 			fmt.Sprintf("Dimension `%s` uses `%s` value `%s`. Use `dp` or `sp` instead.",
 				name, unit, val)))
 	}
@@ -443,7 +443,7 @@ func (r *InOrMmUsageResourceRule) check(ctx *api.Context) {
 			if !ok || inOrMmValueExempt(val, unit) {
 				continue
 			}
-			ctx.Emit(resourceFinding(style.FilePath, style.ItemLines[itemName], r.BaseRule,
+			ctx.Emit(baseFinding(style.FilePath, style.ItemLines[itemName], r.BaseRule,
 				fmt.Sprintf("Style `%s` item `%s` uses `%s` value `%s`. Use `dp` or `sp` instead.",
 					style.Name, itemName, unit, val)))
 		}
@@ -501,12 +501,12 @@ func (r *NegativeMarginResourceRule) check(ctx *api.Context) {
 				return
 			}
 			if len(offenders) == 1 {
-				ctx.Emit(resourceFinding(layout.FilePath, v.Line, r.BaseRule,
+				ctx.Emit(baseFinding(layout.FilePath, v.Line, r.BaseRule,
 					fmt.Sprintf("Negative margin %s in `%s`. Negative margins can cause overlapping or clipping.",
 						offenders[0], v.Type)))
 				return
 			}
-			ctx.Emit(resourceFinding(layout.FilePath, v.Line, r.BaseRule,
+			ctx.Emit(baseFinding(layout.FilePath, v.Line, r.BaseRule,
 				fmt.Sprintf("Negative margins in `%s`: %s. Negative margins can cause overlapping or clipping.",
 					v.Type, strings.Join(offenders, ", "))))
 		})
@@ -570,13 +570,13 @@ func (r *Suspicious0dpResourceRule) check(ctx *api.Context) {
 			case "horizontal":
 				// In horizontal, 0dp height is suspicious
 				if h == "0dp" && w != "0dp" {
-					ctx.Emit(resourceFinding(layout.FilePath, v.Line, r.BaseRule,
+					ctx.Emit(baseFinding(layout.FilePath, v.Line, r.BaseRule,
 						"Suspicious `0dp` on `layout_height` in horizontal `LinearLayout`. Did you mean `layout_width=\"0dp\"` (for weight)?"))
 				}
 			case "vertical":
 				// In vertical, 0dp width is suspicious
 				if w == "0dp" && h != "0dp" {
-					ctx.Emit(resourceFinding(layout.FilePath, v.Line, r.BaseRule,
+					ctx.Emit(baseFinding(layout.FilePath, v.Line, r.BaseRule,
 						"Suspicious `0dp` on `layout_width` in vertical `LinearLayout`. Did you mean `layout_height=\"0dp\"` (for weight)?"))
 				}
 			}
@@ -636,7 +636,7 @@ func (r *DisableBaselineAlignmentResourceRule) check(ctx *api.Context) {
 			if requireText && !hasDirectTextChild(v) {
 				return
 			}
-			ctx.Emit(resourceFinding(layout.FilePath, v.Line, r.BaseRule,
+			ctx.Emit(baseFinding(layout.FilePath, v.Line, r.BaseRule,
 				fmt.Sprintf("`%s` with weighted children should set `android:baselineAligned=\"false\"` for better performance.", v.Type)))
 		})
 	}
@@ -715,7 +715,7 @@ func (r *InefficientWeightResourceRule) check(ctx *api.Context) {
 			}
 			// Check if orientation is missing
 			if v.Attributes["android:orientation"] == "" {
-				ctx.Emit(resourceFinding(layout.FilePath, v.Line, r.BaseRule,
+				ctx.Emit(baseFinding(layout.FilePath, v.Line, r.BaseRule,
 					fmt.Sprintf("`%s` uses `layout_weight` but is missing `android:orientation`. "+
 						"Declare orientation explicitly when using weights.", v.Type)))
 			}
@@ -775,7 +775,7 @@ func findNestedWeights(v *android.View, path string, rule BaseRule, findings *[]
 	if isLinearLayout(v.Type) &&
 		v.Attributes["android:layout_weight"] != "" &&
 		hasWeightedChildren(v) {
-		*findings = append(*findings, resourceFinding(path, v.Line, rule,
+		*findings = append(*findings, baseFinding(path, v.Line, rule,
 			fmt.Sprintf("Nested weights: `%s` has `layout_weight` set AND contains weighted children. "+
 				"This causes exponential measure passes — restructure to avoid nesting weights.", v.Type)))
 	}
@@ -820,7 +820,7 @@ func checkObsoleteParams(v *android.View, path string, rule BaseRule, findings *
 	for _, child := range v.Children {
 		if !isLinear {
 			if child.Attributes["android:layout_weight"] != "" {
-				*findings = append(*findings, resourceFinding(path, child.Line, rule,
+				*findings = append(*findings, baseFinding(path, child.Line, rule,
 					fmt.Sprintf("`android:layout_weight` on `%s` is only valid inside `LinearLayout`. "+
 						"Parent is `%s`.", child.Type, v.Type)))
 			}
@@ -864,7 +864,7 @@ func (r *MergeRootFrameResourceRule) check(ctx *api.Context) {
 		if hasAnyPadding(root) {
 			continue
 		}
-		ctx.Emit(resourceFinding(layout.FilePath, root.Line, r.BaseRule,
+		ctx.Emit(baseFinding(layout.FilePath, root.Line, r.BaseRule,
 			fmt.Sprintf("Root `FrameLayout` in `%s` can be replaced with `<merge>` tag to reduce nesting.",
 				layout.Name)))
 	}
@@ -920,7 +920,7 @@ func (r *OverdrawResourceRule) check(ctx *api.Context) {
 				continue
 			}
 			if android.IsLayoutView(child.Type) {
-				ctx.Emit(resourceFinding(layout.FilePath, child.Line, r.BaseRule,
+				ctx.Emit(baseFinding(layout.FilePath, child.Line, r.BaseRule,
 					fmt.Sprintf("Possible overdraw: child `%s` has background `%s` and root `%s` also has background `%s`. "+
 						"Remove one background to reduce overdraw.",
 						child.Type, child.Background, root.Type, root.Background)))
@@ -955,7 +955,7 @@ func (r *AlwaysShowActionResourceRule) check(ctx *api.Context) {
 				val = v.Attributes["android:showAsAction"]
 			}
 			if strings.Contains(val, "always") {
-				ctx.Emit(resourceFinding(layout.FilePath, v.Line, r.BaseRule,
+				ctx.Emit(baseFinding(layout.FilePath, v.Line, r.BaseRule,
 					fmt.Sprintf("`showAsAction=\"%s\"` in `%s`. Use `ifRoom` instead of `always` to avoid crowding the action bar on small screens.",
 						val, v.Type)))
 			}

--- a/internal/rules/android_resource_values.go
+++ b/internal/rules/android_resource_values.go
@@ -45,7 +45,7 @@ func findWebViewInScroll(v *android.View, insideScroll bool, path string, rule B
 	}
 	isScroll := android.IsScrollableView(v.Type)
 	if insideScroll && v.Type == "WebView" {
-		ctx.Emit(resourceFinding(path, v.Line, rule,
+		ctx.Emit(baseFinding(path, v.Line, rule,
 			"WebView inside a ScrollView causes broken scrolling. "+
 				"Remove the ScrollView or use a different container."))
 	}
@@ -74,7 +74,7 @@ func (r *OnClickResourceRule) check(ctx *api.Context) {
 	for _, layout := range idx.Layouts {
 		walkViews(layout.RootView, func(v *android.View) {
 			if handler := v.Attributes["android:onClick"]; handler != "" {
-				ctx.Emit(resourceFinding(layout.FilePath, v.Line, r.BaseRule,
+				ctx.Emit(baseFinding(layout.FilePath, v.Line, r.BaseRule,
 					fmt.Sprintf("`android:onClick=\"%s\"` in `%s`. Use `View.setOnClickListener` in code instead of XML onClick handlers.",
 						handler, v.Type)))
 			}
@@ -106,7 +106,7 @@ func (r *TextFieldsResourceRule) check(ctx *api.Context) {
 			hasInputType := v.Attributes["android:inputType"] != ""
 			hasHint := v.Attributes["android:hint"] != ""
 			if !hasInputType && !hasHint {
-				ctx.Emit(resourceFinding(layout.FilePath, v.Line, r.BaseRule,
+				ctx.Emit(baseFinding(layout.FilePath, v.Line, r.BaseRule,
 					fmt.Sprintf("`%s` is missing both `android:inputType` and `android:hint`. "+
 						"Specify `inputType` so the correct keyboard is shown.", v.Type)))
 			}
@@ -141,7 +141,7 @@ func (r *UnusedAttributeResourceRule) check(ctx *api.Context) {
 		walkViews(layout.RootView, func(v *android.View) {
 			for attr, minAPI := range apiLevelAttrs {
 				if v.Attributes[attr] != "" {
-					ctx.Emit(resourceFinding(layout.FilePath, v.Line, r.BaseRule,
+					ctx.Emit(baseFinding(layout.FilePath, v.Line, r.BaseRule,
 						fmt.Sprintf("Attribute `%s` is only used in API level %d and higher "+
 							"(current min is unspecified). It will be ignored on older platforms.",
 							attr, minAPI)))
@@ -252,7 +252,7 @@ func (r *WrongRegionResourceRule) check(ctx *api.Context) {
 			}
 		}
 		if !found {
-			ctx.Emit(resourceFinding(layout.FilePath, 1, r.BaseRule,
+			ctx.Emit(baseFinding(layout.FilePath, 1, r.BaseRule,
 				fmt.Sprintf("Suspicious language/region combination: language `%s` with region `%s` "+
 					"in folder `%s`. Expected regions for `%s`: %s.",
 					lang, region, folder, lang, strings.Join(expected, ", "))))
@@ -302,7 +302,7 @@ func (r *LocaleConfigStaleResourceRule) check(ctx *api.Context) {
 			parts = append(parts, fmt.Sprintf("config locales without matching values folders: %s", strings.Join(missing, ", ")))
 		}
 
-		ctx.Emit(resourceFinding(configPath, line, r.BaseRule,
+		ctx.Emit(baseFinding(configPath, line, r.BaseRule,
 			fmt.Sprintf("`locales_config.xml` does not match the explicit locale resource folders (%s).", strings.Join(parts, "; "))))
 	}
 }
@@ -523,7 +523,7 @@ func (r *MissingQuantityResourceRule) check(ctx *api.Context) {
 	idx := ctx.ResourceIndex
 	for name, quantities := range idx.Plurals {
 		if _, ok := quantities["other"]; !ok {
-			ctx.Emit(resourceFinding("res/values/plurals.xml", 0, r.BaseRule,
+			ctx.Emit(baseFinding("res/values/plurals.xml", 0, r.BaseRule,
 				fmt.Sprintf("Plural `%s` is missing the required `other` quantity.", name)))
 		}
 	}
@@ -557,7 +557,7 @@ func (r *UnusedQuantityResourceRule) check(ctx *api.Context) {
 	for name, quantities := range idx.Plurals {
 		for qty := range quantities {
 			if unusedEnglishQuantities[qty] {
-				ctx.Emit(resourceFinding("res/values/plurals.xml", 0, r.BaseRule,
+				ctx.Emit(baseFinding("res/values/plurals.xml", 0, r.BaseRule,
 					fmt.Sprintf("Plural `%s` defines unused quantity `%s` for English. "+
 						"Only `one` and `other` are used.", name, qty)))
 			}
@@ -586,7 +586,7 @@ func (r *ImpliedQuantityResourceRule) check(ctx *api.Context) {
 	for name, quantities := range idx.Plurals {
 		if oneVal, ok := quantities["one"]; ok {
 			if !strings.Contains(oneVal, "%d") {
-				ctx.Emit(resourceFinding("res/values/plurals.xml", 0, r.BaseRule,
+				ctx.Emit(baseFinding("res/values/plurals.xml", 0, r.BaseRule,
 					fmt.Sprintf("Plural `%s` quantity `one` value `%s` does not contain `%%d`. "+
 						"The actual number may not be 1; use `%%d` to display it correctly.",
 						name, truncate(oneVal, 40))))
@@ -647,7 +647,7 @@ func (r *StringFormatInvalidResourceRule) check(ctx *api.Context) {
 				line = loc.Line
 			}
 		}
-		ctx.Emit(resourceFinding(filePath, line, r.BaseRule,
+		ctx.Emit(baseFinding(filePath, line, r.BaseRule,
 			fmt.Sprintf("String `%s` has invalid format specifier: %s", name, msg)))
 	}
 }
@@ -722,7 +722,7 @@ func (r *StringFormatCountResourceRule) check(ctx *api.Context) {
 	idx := ctx.ResourceIndex
 	for name, val := range idx.Strings {
 		if msg := checkFormatArgCount(val); msg != "" {
-			ctx.Emit(resourceFinding("res/values/strings.xml", 0, r.BaseRule,
+			ctx.Emit(baseFinding("res/values/strings.xml", 0, r.BaseRule,
 				fmt.Sprintf("String `%s`: %s", name, msg)))
 		}
 	}
@@ -827,14 +827,14 @@ func (r *StringFormatMatchesResourceRule) check(ctx *api.Context) {
 				continue
 			}
 			if len(types) != len(refTypes) {
-				ctx.Emit(resourceFinding("res/values/strings.xml", 0, r.BaseRule,
+				ctx.Emit(baseFinding("res/values/strings.xml", 0, r.BaseRule,
 					fmt.Sprintf("Plural `%s`: quantity `%s` has %d format args but `%s` has %d",
 						name, qty, len(types), refQty, len(refTypes))))
 				continue
 			}
 			for i := range types {
 				if types[i] != refTypes[i] {
-					ctx.Emit(resourceFinding("res/values/strings.xml", 0, r.BaseRule,
+					ctx.Emit(baseFinding("res/values/strings.xml", 0, r.BaseRule,
 						fmt.Sprintf("Plural `%s`: format type mismatch at arg %d — `%s` uses `%%%c` but `%s` uses `%%%c`",
 							name, i+1, qty, types[i], refQty, refTypes[i])))
 					break
@@ -917,7 +917,7 @@ func (r *StringFormatTrivialResourceRule) check(ctx *api.Context) {
 					line = loc.Line
 				}
 			}
-			ctx.Emit(resourceFinding(filePath, line, r.BaseRule,
+			ctx.Emit(baseFinding(filePath, line, r.BaseRule,
 				fmt.Sprintf("String `%s` is only a string format placeholder. "+
 					"Use the source string directly instead of formatting this resource.", name)))
 		}
@@ -1049,21 +1049,21 @@ func (r *StringNotLocalizableResourceRule) check(ctx *api.Context) {
 		}
 		line := loc.Line
 		if isURL(val) {
-			ctx.Emit(resourceFinding(filePath, line, r.BaseRule,
+			ctx.Emit(baseFinding(filePath, line, r.BaseRule,
 				fmt.Sprintf("String `%s` contains a URL (`%s`). "+
 					"URLs should not be in localizable string resources; use a non-translatable resource.",
 					name, truncate(val, 60))))
 			continue
 		}
 		if isEmail(val) {
-			ctx.Emit(resourceFinding(filePath, line, r.BaseRule,
+			ctx.Emit(baseFinding(filePath, line, r.BaseRule,
 				fmt.Sprintf("String `%s` contains an email address (`%s`). "+
 					"Email addresses should not be in localizable string resources.",
 					name, truncate(val, 60))))
 			continue
 		}
 		if isTechnicalIdentifier(val) {
-			ctx.Emit(resourceFinding(filePath, line, r.BaseRule,
+			ctx.Emit(baseFinding(filePath, line, r.BaseRule,
 				fmt.Sprintf("String `%s` appears to be a technical identifier (`%s`). "+
 					"Consider marking as `translatable=\"false\"`.",
 					name, truncate(val, 60))))
@@ -1125,7 +1125,7 @@ func (r *GoogleAPIKeyInResourcesRule) check(ctx *api.Context) {
 		if strings.HasPrefix(strings.TrimSpace(val), "@string/") {
 			continue
 		}
-		ctx.Emit(resourceFinding(loc.FilePath, loc.Line, r.BaseRule,
+		ctx.Emit(baseFinding(loc.FilePath, loc.Line, r.BaseRule,
 			fmt.Sprintf("String resource `%s` appears to embed a Google API key directly. Reference a build-time injected `@string/...` value instead.", name)))
 	}
 }
@@ -1183,7 +1183,7 @@ func (r *InconsistentArraysResourceRule) check(ctx *api.Context) {
 	idx := ctx.ResourceIndex
 	for name, items := range idx.StringArrays {
 		if len(items) == 0 {
-			ctx.Emit(resourceFinding("res/values/arrays.xml", 0, r.BaseRule,
+			ctx.Emit(baseFinding("res/values/arrays.xml", 0, r.BaseRule,
 				fmt.Sprintf("String-array `%s` has zero items. This may indicate an incomplete array definition.",
 					name)))
 		}
@@ -1222,7 +1222,7 @@ func (r *StringTrailingWhitespaceResourceRule) check(ctx *api.Context) {
 				line = loc.Line
 			}
 		}
-		ctx.Emit(resourceFinding(filePath, line, r.BaseRule,
+		ctx.Emit(baseFinding(filePath, line, r.BaseRule,
 			fmt.Sprintf("String `%s` has trailing whitespace. Trailing whitespace is significant in concatenated strings and some locales; trim it or mark the resource `translatable=\"false\"`.", name)))
 	}
 }
@@ -1266,7 +1266,7 @@ func (r *StringResourceMissingPositionalRule) check(ctx *api.Context) {
 				line = loc.Line
 			}
 		}
-		ctx.Emit(resourceFinding(filePath, line, r.BaseRule,
+		ctx.Emit(baseFinding(filePath, line, r.BaseRule,
 			fmt.Sprintf("String `%s` has multiple non-positional format specifiers. "+
 				"Use positional syntax like `%%1$s %%2$s` so translators can reorder arguments.", name)))
 	}
@@ -1346,7 +1346,7 @@ func (r *ExtraTextResourceRule) Confidence() float64 { return api.ConfidenceMedi
 func (r *ExtraTextResourceRule) check(ctx *api.Context) {
 	idx := ctx.ResourceIndex
 	for _, et := range idx.ExtraTexts {
-		ctx.Emit(resourceFinding(et.FilePath, et.Line, r.BaseRule,
+		ctx.Emit(baseFinding(et.FilePath, et.Line, r.BaseRule,
 			fmt.Sprintf("Extraneous text `%s` found in resource file. "+
 				"Text outside elements is usually a mistake.",
 				truncate(et.Text, 40))))
@@ -1378,7 +1378,7 @@ func (r *LocaleFolderRule) check(ctx *api.Context) {
 		if m == nil {
 			return
 		}
-		ctx.Emit(resourceFinding(filepath.Join(resRoot, name), 1, r.BaseRule,
+		ctx.Emit(baseFinding(filepath.Join(resRoot, name), 1, r.BaseRule,
 			"Wrong locale folder naming `"+name+"`. Use `values-<lang>-r<REGION>` format (e.g., `values-"+m[1]+"-r"+m[2]+"`)."))
 	})
 }
@@ -1409,7 +1409,7 @@ func (r *UseAlpha2Rule) check(ctx *api.Context) {
 		if !ok {
 			return
 		}
-		ctx.Emit(resourceFinding(filepath.Join(resRoot, name), 1, r.BaseRule,
+		ctx.Emit(baseFinding(filepath.Join(resRoot, name), 1, r.BaseRule,
 			"Use 2-letter ISO 639-1 code `"+repl+"` instead of 3-letter code `"+m[1]+"` in locale folder."))
 	})
 }

--- a/internal/rules/i18n_markup.go
+++ b/internal/rules/i18n_markup.go
@@ -131,7 +131,7 @@ func (r *TranslatableMarkupMismatchRule) checkResourceRoot(ctx *api.Context, res
 			if def.style.eq(vs.style) {
 				continue
 			}
-			ctx.Emit(resourceFinding(vs.path, vs.line, r.BaseRule,
+			ctx.Emit(baseFinding(vs.path, vs.line, r.BaseRule,
 				fmt.Sprintf("String `%s` markup style differs from default: `values/` uses %s; `values-%s/` uses %s.",
 					name, def.style.describe(), v.locale, vs.style.describe())))
 		}

--- a/internal/rules/i18n_plurals.go
+++ b/internal/rules/i18n_plurals.go
@@ -197,7 +197,7 @@ func (r *PluralsMissingZeroRule) scanValuesDir(ctx *api.Context, dir, lang strin
 				continue
 			}
 			pluralName := p.Attr("name")
-			ctx.Emit(resourceFinding(path, p.Line, r.BaseRule,
+			ctx.Emit(baseFinding(path, p.Line, r.BaseRule,
 				fmt.Sprintf("Plural `%s` in `values-%s/` is missing `<item quantity=\"zero\">`. CLDR specifies a zero form for `%s`.",
 					pluralName, lang, lang)))
 		}

--- a/internal/rules/i18n_string_contains_html_without_cdata.go
+++ b/internal/rules/i18n_string_contains_html_without_cdata.go
@@ -102,7 +102,7 @@ func (r *StringContainsHTMLWithoutCDATARule) checkResourceRoot(ctx *api.Context,
 			if !hasUnescapedHTMLChild(s) {
 				return
 			}
-			ctx.Emit(resourceFinding(path, s.Line, r.BaseRule,
+			ctx.Emit(baseFinding(path, s.Line, r.BaseRule,
 				fmt.Sprintf("String `%s` contains literal HTML markup. Wrap the value in `<![CDATA[...]]>` or entity-escape `<` and `>` (`&lt;`, `&gt;`).",
 					name)))
 		})

--- a/internal/rules/i18n_string_resource_placeholder_order.go
+++ b/internal/rules/i18n_string_resource_placeholder_order.go
@@ -75,7 +75,7 @@ func (r *StringResourcePlaceholderOrderRule) check(ctx *api.Context) {
 				if info.total < 2 || info.hasPositional {
 					return
 				}
-				ctx.Emit(resourceFinding(path, s.Line, r.BaseRule,
+				ctx.Emit(baseFinding(path, s.Line, r.BaseRule,
 					fmt.Sprintf("String `%s` in `%s/` drops positional format syntax used by the default value. "+
 						"Use `%%1$s`, `%%2$s`, ... so translators can reorder arguments.",
 						name, variant)))

--- a/internal/rules/licensing.go
+++ b/internal/rules/licensing.go
@@ -69,7 +69,7 @@ func (r *OssLicensesNotIncludedInAndroidRule) check(ctx *api.Context) {
 	if line == 0 {
 		line = 1
 	}
-	ctx.Emit(gradleFinding(path, line, r.BaseRule,
+	ctx.Emit(baseFinding(path, line, r.BaseRule,
 		"Android application module declares implementation dependencies but neither applies `com.google.android.gms.oss-licenses-plugin` nor ships a LICENSE file. Add an attribution surface for third-party libraries."))
 }
 
@@ -1030,7 +1030,7 @@ func (r *DependencyLicenseUnknownRule) check(ctx *api.Context) {
 			line = 1
 		}
 
-		ctx.Emit(gradleFinding(path, line, r.BaseRule,
+		ctx.Emit(baseFinding(path, line, r.BaseRule,
 			fmt.Sprintf("Dependency %s is not present in the embedded license registry; add a registry entry or disable license verification for this project.", coord)))
 	}
 }
@@ -1078,7 +1078,7 @@ func (r *LgplStaticLinkingInApkRule) check(ctx *api.Context) {
 			line = 1
 		}
 
-		ctx.Emit(gradleFinding(path, line, r.BaseRule,
+		ctx.Emit(baseFinding(path, line, r.BaseRule,
 			fmt.Sprintf("Dependency %s is %s and is statically linked into the application APK via `%s`. Move it to a `com.android.dynamic-feature` delivered separately or replace it with a permissively licensed alternative.", coord, spdx, dep.Configuration)))
 	}
 }
@@ -1137,7 +1137,7 @@ func (r *DependencyLicenseIncompatibleRule) check(ctx *api.Context) {
 			line = 1
 		}
 
-		ctx.Emit(gradleFinding(path, line, r.BaseRule,
+		ctx.Emit(baseFinding(path, line, r.BaseRule,
 			fmt.Sprintf("Dependency %s is %s, which is incompatible with the project's %s license.",
 				coord, depLicense, r.ProjectLicense)))
 	}
@@ -1196,7 +1196,7 @@ func (r *NoticeFileOutOfDateRule) check(ctx *api.Context) {
 			line = 1
 		}
 
-		ctx.Emit(gradleFinding(path, line, r.BaseRule,
+		ctx.Emit(baseFinding(path, line, r.BaseRule,
 			fmt.Sprintf("NOTICE file is missing required attribution for %s; add the attribution text to NOTICE.", coord)))
 	}
 }

--- a/internal/rules/rule.go
+++ b/internal/rules/rule.go
@@ -5,7 +5,23 @@ import (
 	"strings"
 
 	"github.com/kaeawc/krit/internal/rules/base"
+	"github.com/kaeawc/krit/internal/scanner"
 )
+
+// baseFinding constructs a scanner.Finding from a BaseRule, file path,
+// 1-based line, and message. Column defaults to 1 — rules that need a
+// precise column construct scanner.Finding directly.
+func baseFinding(path string, line int, rule BaseRule, msg string) scanner.Finding {
+	return scanner.Finding{
+		File:     path,
+		Line:     line,
+		Col:      1,
+		RuleSet:  rule.RuleSetName,
+		Rule:     rule.RuleName,
+		Severity: rule.Sev,
+		Message:  msg,
+	}
+}
 
 // Rules that do not declare NeedsOracle are never fed to the oracle's
 // file-selection pass.


### PR DESCRIPTION
## Summary
- \`gradleFinding\`, \`manifestFinding\`, and \`resourceFinding\` were byte-identical \`scanner.Finding\` constructors over \`BaseRule\`.
- Collapse to a single \`baseFinding\` in \`internal/rules/rule.go\` and update ~190 call sites.
- Behavior unchanged — the new helper is the same body.

## Test plan
- [x] \`go build ./...\`
- [x] \`go vet ./...\`
- [x] \`golangci-lint run ./...\` (0 issues)
- [x] \`go test ./... -count=1\` (all pass)