### PR TITLE
refactor(rules): make NewDispatcher resolver an explicit parameter

### DIFF
--- a/internal/cli/scorecard/scorecard.go
+++ b/internal/cli/scorecard/scorecard.go
@@ -94,7 +94,7 @@ func Build(paths []string, configPath string) ([]Row, error) {
 }
 
 func runRules(files []*scanner.File, active []*api.Rule) []scanner.Finding {
-	dispatcher := rules.NewDispatcher(active)
+	dispatcher := rules.NewDispatcher(active, nil)
 	collector := scanner.NewFindingCollector(len(files) * 8)
 	for _, file := range files {
 		cols, _ := dispatcher.RunColumnsWithStats(file)

--- a/internal/harvest/harvest.go
+++ b/internal/harvest/harvest.go
@@ -68,7 +68,7 @@ func ExtractFixture(target Target, ruleName string) (Result, error) {
 		return Result{}, err
 	}
 
-	columns, _ := rules.NewDispatcher([]*api.Rule{rule}).RunColumnsWithStats(file)
+	columns, _ := rules.NewDispatcher([]*api.Rule{rule}, nil).RunColumnsWithStats(file)
 	findings := columns.Findings()
 	match, err := selectFinding(findings, target.Line, ruleName)
 	if err != nil {

--- a/internal/mcp/tool_analyze.go
+++ b/internal/mcp/tool_analyze.go
@@ -282,7 +282,7 @@ func (s *Server) analyzeAndroid(args analyzeArgs) ToolResult {
 	collector := scanner.NewFindingCollector(len(proj.ManifestPaths)*4 + len(proj.ResDirs)*8 + len(proj.GradlePaths)*4)
 
 	libraryFacts := librarymodel.FactsForProfile(librarymodel.ProfileFromGradlePaths(proj.GradlePaths))
-	dispatcher := rules.NewDispatcher(api.Registry)
+	dispatcher := rules.NewDispatcher(api.Registry, nil)
 	dispatcher.SetLibraryFacts(libraryFacts)
 
 	if scope == "manifest" || scope == "all" {

--- a/internal/pipeline/android_gradle_cache_test.go
+++ b/internal/pipeline/android_gradle_cache_test.go
@@ -35,7 +35,7 @@ func writeGradle(t *testing.T, dir, name, body string) string {
 func runGradlePhase(t *testing.T, gradlePath, cacheDir string, writer *scanner.AndroidCacheWriter) AndroidResult {
 	t.Helper()
 	rule := findV2RuleForTest(t, "GradleDynamicVersion")
-	dispatcher := rules.NewDispatcher([]*api.Rule{rule})
+	dispatcher := rules.NewDispatcher([]*api.Rule{rule}, nil)
 	res, err := (AndroidPhase{}).Run(context.Background(), AndroidInput{
 		Project:        &android.Project{GradlePaths: []string{gradlePath}},
 		ActiveRules:    []*api.Rule{rule},

--- a/internal/pipeline/android_manifest_cache_test.go
+++ b/internal/pipeline/android_manifest_cache_test.go
@@ -39,7 +39,7 @@ func writeManifest(t *testing.T, dir, body string) string {
 func runManifestPhase(t *testing.T, manifestPath, cacheDir string, writer *scanner.AndroidCacheWriter) AndroidResult {
 	t.Helper()
 	rule := findV2RuleForTest(t, "AllowBackupManifest")
-	dispatcher := rules.NewDispatcher([]*api.Rule{rule})
+	dispatcher := rules.NewDispatcher([]*api.Rule{rule}, nil)
 	res, err := (AndroidPhase{}).Run(context.Background(), AndroidInput{
 		Project:        &android.Project{ManifestPaths: []string{manifestPath}},
 		ActiveRules:    []*api.Rule{rule},
@@ -127,7 +127,7 @@ func TestAndroidManifestCache_RuleHashChangeInvalidates(t *testing.T) {
 	cacheDir := filepath.Join(root, ".krit", "android-findings-cache")
 
 	rule := findV2RuleForTest(t, "AllowBackupManifest")
-	dispatcher := rules.NewDispatcher([]*api.Rule{rule})
+	dispatcher := rules.NewDispatcher([]*api.Rule{rule}, nil)
 
 	// First run with rule-hash A.
 	writer := scanner.NewAndroidCacheWriter(2)

--- a/internal/pipeline/android_resource_cache_test.go
+++ b/internal/pipeline/android_resource_cache_test.go
@@ -57,7 +57,7 @@ func writeLayout(t *testing.T, resDir, name, body string) string {
 func runResourcePhase(t *testing.T, resDir, cacheDir string, writer *scanner.AndroidCacheWriter) AndroidResult {
 	t.Helper()
 	rule := findV2RuleForTest(t, "DuplicateIdsResource")
-	dispatcher := rules.NewDispatcher([]*api.Rule{rule})
+	dispatcher := rules.NewDispatcher([]*api.Rule{rule}, nil)
 	res, err := (AndroidPhase{}).Run(context.Background(), AndroidInput{
 		Project:        &android.Project{ResDirs: []string{resDir}},
 		ActiveRules:    []*api.Rule{rule},

--- a/internal/pipeline/android_resource_source_cache_test.go
+++ b/internal/pipeline/android_resource_source_cache_test.go
@@ -66,7 +66,7 @@ func parseKotlinForTest(t *testing.T, path, content string) *scanner.File {
 func runResourceSourcePhase(t *testing.T, resDir, cacheDir string, sourceFiles []*scanner.File, writer *scanner.AndroidCacheWriter) AndroidResult {
 	t.Helper()
 	rule := findV2RuleForTest(t, "LayoutInflation")
-	dispatcher := rules.NewDispatcher([]*api.Rule{rule})
+	dispatcher := rules.NewDispatcher([]*api.Rule{rule}, nil)
 	res, err := (AndroidPhase{}).Run(context.Background(), AndroidInput{
 		Project:        &android.Project{ResDirs: []string{resDir}},
 		ActiveRules:    []*api.Rule{rule},

--- a/internal/pipeline/android_test.go
+++ b/internal/pipeline/android_test.go
@@ -228,7 +228,7 @@ func TestRunIconsIncludesIconColors(t *testing.T) {
 		t.Fatal("IconColors not registered")
 	}
 
-	dispatcher := rules.NewDispatcher([]*api.Rule{iconColorsRule})
+	dispatcher := rules.NewDispatcher([]*api.Rule{iconColorsRule}, nil)
 	columns := dispatcher.RunIcons(&scanner.File{Path: resDir, Language: scanner.LangXML}, idx)
 	if got := columns.Findings(); len(got) != 1 || got[0].Rule != "IconColors" {
 		t.Fatalf("expected one IconColors finding, got %#v", got)
@@ -261,7 +261,7 @@ func TestAndroidPhaseRunsIconRulesThroughDispatcher(t *testing.T) {
 	}
 
 	iconColorsRule := findV2RuleForTest(t, "IconColors")
-	dispatcher := rules.NewDispatcher([]*api.Rule{iconColorsRule})
+	dispatcher := rules.NewDispatcher([]*api.Rule{iconColorsRule}, nil)
 	result, err := (AndroidPhase{}).Run(context.Background(), AndroidInput{
 		Project:     &android.Project{ResDirs: []string{resDir}},
 		ActiveRules: []*api.Rule{iconColorsRule},

--- a/internal/rules/android_correctness_new_test.go
+++ b/internal/rules/android_correctness_new_test.go
@@ -869,7 +869,7 @@ func TestRunIcons_IncludesNewChecks(t *testing.T) {
 		t.Fatalf("expected IconColors and IconLauncherShape to be registered, got %d", len(selected))
 	}
 
-	dispatcher := rules.NewDispatcher(selected)
+	dispatcher := rules.NewDispatcher(selected, nil)
 	cols := dispatcher.RunIcons(&scanner.File{Path: resDir, Language: scanner.LangXML}, idx)
 	findings := cols.Findings()
 	hasIconColors := false

--- a/internal/rules/android_dependency_test.go
+++ b/internal/rules/android_dependency_test.go
@@ -33,7 +33,7 @@ func TestAndroidDependencyMetadata(t *testing.T) {
 }
 
 func TestIconRulesAreClassifiedForV2Dispatch(t *testing.T) {
-	dispatcher := rules.NewDispatcher(api.Registry)
+	dispatcher := rules.NewDispatcher(api.Registry, nil)
 	got := make(map[string]bool)
 	for _, rule := range dispatcher.IconRules() {
 		if rule.Check == nil {

--- a/internal/rules/android_requires_api_test.go
+++ b/internal/rules/android_requires_api_test.go
@@ -42,7 +42,7 @@ func runRequiresApi(t *testing.T, source string, minSdk int) []scanner.Finding {
 		t.Fatalf("parse failed: %v", err)
 	}
 	rule := findRequiresAPIViolationRule(t)
-	dispatcher := NewDispatcher([]*api.Rule{rule})
+	dispatcher := NewDispatcher([]*api.Rule{rule}, nil)
 	dispatcher.SetLibraryFacts(librarymodel.FactsForProfile(librarymodel.ProjectProfile{
 		MinSdkVersion: minSdk,
 	}))

--- a/internal/rules/android_source_line_test.go
+++ b/internal/rules/android_source_line_test.go
@@ -306,7 +306,7 @@ func runLayoutInflationRule(t *testing.T, code string, idx *android.ResourceInde
 	file := parseInline(t, code)
 	for _, r := range api.Registry {
 		if r.ID == "LayoutInflation" {
-			dispatcher := rules.NewDispatcher([]*api.Rule{r})
+			dispatcher := rules.NewDispatcher([]*api.Rule{r}, nil)
 			cols := dispatcher.RunResourceSource(file, idx)
 			return cols.Findings()
 		}

--- a/internal/rules/assert_inline_test.go
+++ b/internal/rules/assert_inline_test.go
@@ -64,7 +64,7 @@ func findRuleByID(t *testing.T, ruleID string) *api.Rule {
 // can't pollute the result.
 func findingsFor(t *testing.T, rule *api.Rule, file *scanner.File) []scanner.Finding {
 	t.Helper()
-	d := rules.NewDispatcher([]*api.Rule{rule})
+	d := rules.NewDispatcher([]*api.Rule{rule}, nil)
 	if rule.Needs.Has(api.NeedsResolver) {
 		resolver := typeinfer.NewResolver()
 		resolver.IndexFilesParallel([]*scanner.File{file}, 1)

--- a/internal/rules/benchmark_test.go
+++ b/internal/rules/benchmark_test.go
@@ -29,7 +29,7 @@ func parseFixtureB(b *testing.B, relPath string) *scanner.File {
 
 func BenchmarkDispatcherRun_SmallFile(b *testing.B) {
 	file := parseFixtureB(b, "../../tests/fixtures/positive/style/WildcardImport.kt")
-	d := rules.NewDispatcher(api.Registry)
+	d := rules.NewDispatcher(api.Registry, nil)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		_ = d.Run(file)
@@ -38,7 +38,7 @@ func BenchmarkDispatcherRun_SmallFile(b *testing.B) {
 
 func BenchmarkDispatcherRun_LargeFile(b *testing.B) {
 	file := parseFixtureB(b, "../../tests/fixtures/positive/complexity/LargeClass.kt")
-	d := rules.NewDispatcher(api.Registry)
+	d := rules.NewDispatcher(api.Registry, nil)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		_ = d.Run(file)
@@ -58,7 +58,7 @@ func BenchmarkDispatcherRun_SingleRule(b *testing.B) {
 	if len(single) == 0 {
 		b.Skip("MagicNumber rule not found in registry")
 	}
-	d := rules.NewDispatcher(single)
+	d := rules.NewDispatcher(single, nil)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		_ = d.Run(file)
@@ -68,7 +68,7 @@ func BenchmarkDispatcherRun_SingleRule(b *testing.B) {
 func BenchmarkDispatcherRun_AllRules(b *testing.B) {
 	// Use ALL registered rules on the largest fixture
 	file := parseFixtureB(b, "../../tests/fixtures/positive/complexity/LargeClass.kt")
-	d := rules.NewDispatcher(api.Registry)
+	d := rules.NewDispatcher(api.Registry, nil)
 	dispatched, lineRules, crossFile, moduleAware := d.Stats()
 	b.Logf("rules: dispatched=%d line=%d cross-file=%d module-aware=%d",
 		dispatched, lineRules, crossFile, moduleAware)
@@ -81,13 +81,13 @@ func BenchmarkDispatcherRun_AllRules(b *testing.B) {
 func BenchmarkDispatcherConstruction(b *testing.B) {
 	// Measure the cost of building the dispatcher from all rules
 	for i := 0; i < b.N; i++ {
-		_ = rules.NewDispatcher(api.Registry)
+		_ = rules.NewDispatcher(api.Registry, nil)
 	}
 }
 
 func BenchmarkDispatcherRun_SampleFile(b *testing.B) {
 	file := parseFixtureB(b, "../../tests/fixtures/Sample.kt")
-	d := rules.NewDispatcher(api.Registry)
+	d := rules.NewDispatcher(api.Registry, nil)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		_ = d.Run(file)

--- a/internal/rules/complexity_test.go
+++ b/internal/rules/complexity_test.go
@@ -1512,7 +1512,7 @@ func complexityBenchmarkDispatcher() *rules.Dispatcher {
 			selected = append(selected, r)
 		}
 	}
-	return rules.NewDispatcher(selected)
+	return rules.NewDispatcher(selected, nil)
 }
 
 func BenchmarkComplexityRules_HeavyClassAndFunction(b *testing.B) {
@@ -1577,7 +1577,7 @@ func BenchmarkCyclomaticComplexMethod_EarlyExit(b *testing.B) {
 	if rule == nil {
 		b.Fatal("CyclomaticComplexMethod rule not found")
 	}
-	d := rules.NewDispatcher([]*api.Rule{rule})
+	d := rules.NewDispatcher([]*api.Rule{rule}, nil)
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -1613,7 +1613,7 @@ func BenchmarkNestedBlockDepth_EarlyExit(b *testing.B) {
 	if rule == nil {
 		b.Fatal("NestedBlockDepth rule not found")
 	}
-	d := rules.NewDispatcher([]*api.Rule{rule})
+	d := rules.NewDispatcher([]*api.Rule{rule}, nil)
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -1647,7 +1647,7 @@ func BenchmarkNestedBlockDepth_ElseIfChain(b *testing.B) {
 	if rule == nil {
 		b.Fatal("NestedBlockDepth rule not found")
 	}
-	d := rules.NewDispatcher([]*api.Rule{rule})
+	d := rules.NewDispatcher([]*api.Rule{rule}, nil)
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -1688,7 +1688,7 @@ func BenchmarkTooManyFunctions_HeavyFile(b *testing.B) {
 	if rule == nil {
 		b.Fatal("TooManyFunctions rule not found")
 	}
-	d := rules.NewDispatcher([]*api.Rule{rule})
+	d := rules.NewDispatcher([]*api.Rule{rule}, nil)
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {

--- a/internal/rules/dispatch_test.go
+++ b/internal/rules/dispatch_test.go
@@ -32,7 +32,7 @@ func TestDispatcher_DefersCrossFileAndModuleAwareRules(t *testing.T) {
 		api.WithNeeds(api.NeedsModuleIndex),
 		api.WithCheck(func(ctx *api.Context) { modInvoked++ }),
 	)
-	dispatcher := NewDispatcher([]*api.Rule{cross, mod})
+	dispatcher := NewDispatcher([]*api.Rule{cross, mod}, nil)
 
 	dispatcher.Run(file)
 
@@ -75,7 +75,7 @@ func TestDispatcher_RunWithStats_TracksRuleBuckets(t *testing.T) {
 		}),
 	)
 	rule.Category = "test"
-	dispatcher := NewDispatcher([]*api.Rule{rule})
+	dispatcher := NewDispatcher([]*api.Rule{rule}, nil)
 	columns, stats := dispatcher.RunWithStats(file)
 	if columns.Len() == 0 {
 		t.Fatal("expected findings from magic number rule")
@@ -112,7 +112,7 @@ func TestDispatcher_RunWithStats_TracksLineRuleInvocations(t *testing.T) {
 			ctx.EmitAt(1, 1, "line finding")
 		}),
 	)
-	dispatcher := NewDispatcher([]*api.Rule{rule})
+	dispatcher := NewDispatcher([]*api.Rule{rule}, nil)
 	columns, stats := dispatcher.RunWithStats(file)
 	if columns.Len() != 1 {
 		t.Fatalf("expected one line-rule finding, got %d", columns.Len())
@@ -161,7 +161,7 @@ func TestDispatcher_FlatDispatchRuleRunsOnFlatTree(t *testing.T) {
 		}),
 	)
 	rule.Category = "test"
-	dispatcher := NewDispatcher([]*api.Rule{rule})
+	dispatcher := NewDispatcher([]*api.Rule{rule}, nil)
 	columns, stats := dispatcher.RunWithStats(file)
 
 	if columns.Len() != 1 {
@@ -225,7 +225,7 @@ fun live() {
 		}),
 	)
 	rule.Category = "test"
-	dispatcher := NewDispatcher([]*api.Rule{rule})
+	dispatcher := NewDispatcher([]*api.Rule{rule}, nil)
 	columns, _ := dispatcher.RunWithStats(file)
 
 	if columns.Len() != 1 {
@@ -284,7 +284,7 @@ fun second() = 2
 		}),
 	)
 	rule.Category = "test"
-	dispatcher := NewDispatcher([]*api.Rule{rule})
+	dispatcher := NewDispatcher([]*api.Rule{rule}, nil)
 
 	columns, columnStats := dispatcher.RunColumnsWithStats(file)
 	columns2, sliceStats := dispatcher.RunWithStats(file)
@@ -330,7 +330,7 @@ func TestDispatcher_ConfidenceProviderOverridesDefault(t *testing.T) {
 		}),
 	)
 	rule.Category = "test"
-	dispatcher := NewDispatcher([]*api.Rule{rule})
+	dispatcher := NewDispatcher([]*api.Rule{rule}, nil)
 	columns, _ := dispatcher.RunWithStats(file)
 
 	if columns.Len() != 1 {
@@ -371,7 +371,7 @@ func TestDispatcher_ExplicitFindingConfidenceBeatsRuleDefault(t *testing.T) {
 		}),
 	)
 	rule.Category = "test"
-	dispatcher := NewDispatcher([]*api.Rule{rule})
+	dispatcher := NewDispatcher([]*api.Rule{rule}, nil)
 	columns, _ := dispatcher.RunWithStats(file)
 
 	if columns.Len() != 1 {

--- a/internal/rules/dispatcher.go
+++ b/internal/rules/dispatcher.go
@@ -116,13 +116,13 @@ type Dispatcher struct {
 }
 
 // NewDispatcher constructs a Dispatcher from the supplied v2 rules.
-// An optional TypeResolver is wired through to any rule declaring
-// NeedsResolver via that rule's SetResolverHook.
-func NewDispatcher(rules []*api.Rule, resolver ...typeinfer.TypeResolver) *Dispatcher {
+// resolver is wired through to any rule declaring NeedsResolver via
+// that rule's SetResolverHook. Callers that have no resolver pass nil.
+func NewDispatcher(rules []*api.Rule, resolver typeinfer.TypeResolver) *Dispatcher {
 	d := &Dispatcher{fileFacts: filefacts.NewCache()}
 	setSharedFileFacts(d.fileFacts)
-	if len(resolver) > 0 && resolver[0] != nil {
-		d.typeResolver = resolver[0]
+	if resolver != nil {
+		d.typeResolver = resolver
 	}
 
 	// Validate RelatedRules references against the full registry so

--- a/internal/rules/dispatcher_test.go
+++ b/internal/rules/dispatcher_test.go
@@ -99,7 +99,7 @@ func TestDispatcher_RoutesFamiliesIndependently(t *testing.T) {
 		},
 	}
 
-	d := NewDispatcher([]*api.Rule{nodeRule, lineRule, emptyNodeTypesRule})
+	d := NewDispatcher([]*api.Rule{nodeRule, lineRule, emptyNodeTypesRule}, nil)
 	columns := d.Run(file)
 
 	if nodeCalls == 0 {
@@ -164,7 +164,7 @@ fun main() {
 		}),
 	)
 
-	NewDispatcher([]*api.Rule{rule}).Run(file)
+	NewDispatcher([]*api.Rule{rule}, nil).Run(file)
 
 	if len(calls) != 2 {
 		t.Fatalf("filtered rule invoked %d times (%v), want 2 keep calls", len(calls), calls)
@@ -229,7 +229,7 @@ class Browser {
 	)
 	lineRule.Languages = []scanner.Language{scanner.LangJava}
 
-	dispatcher := NewDispatcher([]*api.Rule{nodeRule, lineRule})
+	dispatcher := NewDispatcher([]*api.Rule{nodeRule, lineRule}, nil)
 	dispatcher.Run(file)
 
 	if nodeCalls == 0 {
@@ -260,7 +260,7 @@ func TestDispatcher_PanicRecovery(t *testing.T) {
 		}),
 	)
 
-	d := NewDispatcher([]*api.Rule{goodRule, badRule})
+	d := NewDispatcher([]*api.Rule{goodRule, badRule}, nil)
 	columns, stats := d.RunWithStats(file)
 
 	if goodCalls == 0 {
@@ -303,7 +303,7 @@ func TestDispatcher_RespectsExclusions(t *testing.T) {
 	SetRuleExcludes("ExcludableRule", []string{"**/*Test.kt"})
 	t.Cleanup(func() { SetRuleExcludes("ExcludableRule", nil) })
 
-	d := NewDispatcher([]*api.Rule{rule})
+	d := NewDispatcher([]*api.Rule{rule}, nil)
 	_ = d.Run(file)
 
 	if nodeCalls != 0 {
@@ -356,7 +356,7 @@ func TestDispatcher_ResolverNilWithoutResolver(t *testing.T) {
 		}),
 	)
 
-	d := NewDispatcher([]*api.Rule{rule})
+	d := NewDispatcher([]*api.Rule{rule}, nil)
 	_ = d.Run(file)
 
 	if gotResolver != nil {
@@ -375,7 +375,7 @@ func TestDispatcher_CrossFileRulesAccessor(t *testing.T) {
 		api.WithCheck(func(ctx *api.Context) { invoked++ }),
 	)
 
-	d := NewDispatcher([]*api.Rule{cross})
+	d := NewDispatcher([]*api.Rule{cross}, nil)
 	_ = d.Run(file)
 
 	if invoked != 0 {
@@ -398,7 +398,7 @@ func TestDispatcher_ModuleAwareRulesAccessor(t *testing.T) {
 		api.WithCheck(func(ctx *api.Context) { invoked++ }),
 	)
 
-	d := NewDispatcher([]*api.Rule{mod})
+	d := NewDispatcher([]*api.Rule{mod}, nil)
 	_ = d.Run(file)
 
 	if invoked != 0 {
@@ -425,7 +425,7 @@ func TestDispatcher_ResourceSourceRulesRunWithResourceIndex(t *testing.T) {
 	)
 	rule.Languages = []scanner.Language{scanner.LangKotlin}
 
-	d := NewDispatcher([]*api.Rule{rule})
+	d := NewDispatcher([]*api.Rule{rule}, nil)
 	_ = d.Run(file)
 	if invoked != 0 {
 		t.Fatalf("resource-backed source rule ran during ordinary dispatch")
@@ -450,7 +450,7 @@ func TestDispatcher_Stats(t *testing.T) {
 		api.FakeRule("Cross1", api.WithNeeds(api.NeedsCrossFile)),
 		api.FakeRule("Mod1", api.WithNeeds(api.NeedsModuleIndex)),
 	}
-	d := NewDispatcher(rules)
+	d := NewDispatcher(rules, nil)
 
 	// Parse a file so the NodeTypeTable has known entries (node rules
 	// are only counted after buildFlatTypeIndex matches their types).
@@ -483,7 +483,7 @@ func TestDispatcher_Stats(t *testing.T) {
 func TestDispatcher_ReportMissingCapabilities_ResolverMissing(t *testing.T) {
 	needsResolver := api.FakeRule("V2MissingResolver", api.WithNeeds(api.NeedsResolver))
 	noNeeds := api.FakeRule("V2NoNeeds")
-	d := NewDispatcher([]*api.Rule{needsResolver, noNeeds})
+	d := NewDispatcher([]*api.Rule{needsResolver, noNeeds}, nil)
 
 	var buf strings.Builder
 	logger := func(format string, args ...any) {
@@ -548,7 +548,7 @@ func TestDispatcher_ReportMissingCapabilities_AllSatisfied(t *testing.T) {
 	}
 
 	// Nil logger is always a no-op.
-	d2 := NewDispatcher([]*api.Rule{needsBoth})
+	d2 := NewDispatcher([]*api.Rule{needsBoth}, nil)
 	d2.ReportMissingCapabilities(false, nil)
 }
 

--- a/internal/rules/edge_test.go
+++ b/internal/rules/edge_test.go
@@ -99,7 +99,7 @@ func runRuleByNameOnJavaWithSemanticCalls(t *testing.T, ruleName string, code st
 	}
 	for _, r := range api.Registry {
 		if r.ID == ruleName {
-			d := rules.NewDispatcher([]*api.Rule{r})
+			d := rules.NewDispatcher([]*api.Rule{r}, nil)
 			d.SetJavaSemanticFacts(facts)
 			cols := d.Run(file)
 			return cols.Findings()
@@ -138,7 +138,7 @@ func runRuleByNameOnFile(t *testing.T, ruleName string, file *scanner.File) []sc
 	t.Helper()
 	for _, r := range api.Registry {
 		if r.ID == ruleName {
-			d := rules.NewDispatcher([]*api.Rule{r})
+			d := rules.NewDispatcher([]*api.Rule{r}, nil)
 			cols := d.Run(file)
 			return cols.Findings()
 		}
@@ -741,7 +741,7 @@ class Foo {
 			allRules = append(allRules, r)
 		}
 	}
-	d := rules.NewDispatcher(allRules)
+	d := rules.NewDispatcher(allRules, nil)
 	findingCols := d.Run(file)
 	findings := findingCols.Findings()
 
@@ -920,7 +920,7 @@ func runMatchingDeclarationName(t *testing.T, filename string, code string) []sc
 	file := parseInlineWithName(t, filename, code)
 	for _, r := range api.Registry {
 		if r.ID == "MatchingDeclarationName" {
-			d := rules.NewDispatcher([]*api.Rule{r})
+			d := rules.NewDispatcher([]*api.Rule{r}, nil)
 			cols := d.Run(file)
 			return cols.Findings()
 		}

--- a/internal/rules/excludes_test.go
+++ b/internal/rules/excludes_test.go
@@ -82,7 +82,7 @@ fun check(x: Boolean) {
 	rules.SetRuleExcludes("EmptyElseBlock", nil)
 
 	// Without excludes: should produce findings
-	d := rules.NewDispatcher([]*api.Rule{rule})
+	d := rules.NewDispatcher([]*api.Rule{rule}, nil)
 	findings := d.Run(file)
 	if findings.Len() == 0 {
 		t.Fatal("expected EmptyElseBlock to fire without excludes")
@@ -93,7 +93,7 @@ fun check(x: Boolean) {
 	defer rules.SetRuleExcludes("EmptyElseBlock", nil) // cleanup
 
 	// With excludes: should skip the rule for this test file
-	d2 := rules.NewDispatcher([]*api.Rule{rule})
+	d2 := rules.NewDispatcher([]*api.Rule{rule}, nil)
 	findings2 := d2.Run(file)
 	if findings2.Len() != 0 {
 		t.Errorf("expected EmptyElseBlock to be excluded for test file, got %d findings", findings2.Len())
@@ -139,7 +139,7 @@ fun check(x: Boolean) {
 	rules.SetRuleExcludes("EmptyElseBlock", []string{"**/test/**", "**/*Test.kt"})
 	defer rules.SetRuleExcludes("EmptyElseBlock", nil)
 
-	d := rules.NewDispatcher([]*api.Rule{rule})
+	d := rules.NewDispatcher([]*api.Rule{rule}, nil)
 	findings := d.Run(file)
 	if findings.Len() == 0 {
 		t.Error("expected EmptyElseBlock to fire on non-excluded main file")
@@ -186,7 +186,7 @@ fun check(x: Boolean) {
 	rules.SetRuleExcludes("EmptyElseBlock", []string{"**/test/**", "**/*Spec.kt"})
 	defer rules.SetRuleExcludes("EmptyElseBlock", nil)
 
-	d := rules.NewDispatcher([]*api.Rule{rule})
+	d := rules.NewDispatcher([]*api.Rule{rule}, nil)
 	findings := d.Run(file)
 	if findings.Len() != 0 {
 		t.Errorf("expected EmptyElseBlock to be excluded for Spec file, got %d findings", findings.Len())

--- a/internal/rules/fix_idempotency_test.go
+++ b/internal/rules/fix_idempotency_test.go
@@ -146,7 +146,7 @@ func findFixableFindings(sourcePath string, ruleSet []*api.Rule, ruleFilter stri
 	if err != nil {
 		return nil, err
 	}
-	dispatcher := rules.NewDispatcher(ruleSet)
+	dispatcher := rules.NewDispatcher(ruleSet, nil)
 	if rulesNeedResolver(ruleSet) {
 		resolver := typeinfer.NewResolver()
 		resolver.IndexFilesParallel([]*scanner.File{file}, 1)

--- a/internal/rules/fix_test.go
+++ b/internal/rules/fix_test.go
@@ -81,7 +81,7 @@ func runBundledFixableFixtures(t *testing.T, dir string, activeRules []*api.Rule
 				t.Fatalf("failed to parse %s: %v", sourcePath, err)
 			}
 
-			dispatcher := rules.NewDispatcher(activeRules)
+			dispatcher := rules.NewDispatcher(activeRules, nil)
 			if rulesNeedResolver(activeRules) {
 				resolver := typeinfer.NewResolver()
 				resolver.IndexFilesParallel([]*scanner.File{file}, 1)
@@ -173,7 +173,7 @@ func runPerRuleFixableFixtures(t *testing.T, dir string) (int, error) {
 			// cross-file rule or module-aware rule; the
 			// dispatcher handles all of those when given a singleton
 			// registry.
-			soloDispatcher := rules.NewDispatcher([]*api.Rule{rule})
+			soloDispatcher := rules.NewDispatcher([]*api.Rule{rule}, nil)
 			if rule.Needs.Has(api.NeedsResolver) {
 				resolver := typeinfer.NewResolver()
 				resolver.IndexFilesParallel([]*scanner.File{file}, 1)

--- a/internal/rules/hardcoded_gcp_service_account_test.go
+++ b/internal/rules/hardcoded_gcp_service_account_test.go
@@ -29,7 +29,7 @@ func runRuleByNameOnPath(t *testing.T, ruleName, filename, code string) []scanne
 
 	for _, r := range api.Registry {
 		if r.ID == ruleName {
-			d := rules.NewDispatcher([]*api.Rule{r})
+			d := rules.NewDispatcher([]*api.Rule{r}, nil)
 			cols := d.Run(file)
 			return cols.Findings()
 		}

--- a/internal/rules/naming_test.go
+++ b/internal/rules/naming_test.go
@@ -1886,7 +1886,7 @@ func BenchmarkNoNameShadowing_LargeFile(b *testing.B) {
 		b.Fatal("NoNameShadowing rule not found")
 	}
 
-	dispatcher := rules.NewDispatcher([]*api.Rule{rule})
+	dispatcher := rules.NewDispatcher([]*api.Rule{rule}, nil)
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {

--- a/internal/rules/package_naming_convention_drift_test.go
+++ b/internal/rules/package_naming_convention_drift_test.go
@@ -31,7 +31,7 @@ func TestPackageNamingConventionDriftRule_FlagsPackageOutsideSourcePathPrefix(t 
 class PackageNamingConventionDrift
 `)
 
-	columns := NewDispatcher([]*api.Rule{packageNamingV2Rule(t)}).Run(file)
+	columns := NewDispatcher([]*api.Rule{packageNamingV2Rule(t)}, nil).Run(file)
 
 	if columns.Len() != 1 {
 		t.Fatalf("expected 1 finding, got %d", columns.Len())
@@ -51,7 +51,7 @@ func TestPackageNamingConventionDriftRule_AcceptsNestedPackageBelowSourcePathPre
 class PackageNamingConventionDrift
 `)
 
-	columns := NewDispatcher([]*api.Rule{packageNamingV2Rule(t)}).Run(file)
+	columns := NewDispatcher([]*api.Rule{packageNamingV2Rule(t)}, nil).Run(file)
 
 	if columns.Len() != 0 {
 		t.Fatalf("expected 0 findings, got %d", columns.Len())

--- a/internal/rules/performance_test.go
+++ b/internal/rules/performance_test.go
@@ -284,7 +284,7 @@ func BenchmarkUnnecessaryTemporaryInstantiation_NoMatch(b *testing.B) {
 		b.Fatal("rule not found")
 	}
 
-	dispatcher := rules.NewDispatcher([]*api.Rule{rule})
+	dispatcher := rules.NewDispatcher([]*api.Rule{rule}, nil)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		_ = dispatcher.Run(file)

--- a/internal/rules/potentialbugs_misc_test.go
+++ b/internal/rules/potentialbugs_misc_test.go
@@ -36,7 +36,7 @@ func benchmarkRuleByName(b *testing.B, ruleName string, code string) {
 	if rule == nil {
 		b.Fatalf("rule %q not found", ruleName)
 	}
-	d := rules.NewDispatcher([]*api.Rule{rule})
+	d := rules.NewDispatcher([]*api.Rule{rule}, nil)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		_ = d.Run(file)

--- a/internal/rules/potentialbugs_nullsafety_test.go
+++ b/internal/rules/potentialbugs_nullsafety_test.go
@@ -318,7 +318,7 @@ fun process(record: Any) {
 				if r.ID != "UnsafeCast" {
 					continue
 				}
-				findingCols := rules.NewDispatcher([]*api.Rule{r}).Run(file)
+				findingCols := rules.NewDispatcher([]*api.Rule{r}, nil).Run(file)
 				if findingCols.Len() != 0 {
 					t.Fatalf("expected no findings for %s source set, got %d", root, findingCols.Len())
 				}

--- a/internal/rules/public_to_internal_leaky_abstraction_test.go
+++ b/internal/rules/public_to_internal_leaky_abstraction_test.go
@@ -28,7 +28,7 @@ func runLeakyAbstractionRule(t *testing.T, src string) []scanner.Finding {
 		NodeTypes: []string{"class_declaration"},
 		Check:     rule.check,
 	}
-	cols := NewDispatcher([]*api.Rule{apiRule}).Run(file)
+	cols := NewDispatcher([]*api.Rule{apiRule}, nil).Run(file)
 	return cols.Findings()
 }
 

--- a/internal/rules/rules_test.go
+++ b/internal/rules/rules_test.go
@@ -92,7 +92,7 @@ func runRule(t *testing.T, rule *api.Rule, file *scanner.File) []scanner.Finding
 		cols := dispatcher.Run(file)
 		return cols.Findings()
 	}
-	dispatcher := rules.NewDispatcher([]*api.Rule{rule})
+	dispatcher := rules.NewDispatcher([]*api.Rule{rule}, nil)
 	cols := dispatcher.Run(file)
 	return cols.Findings()
 }

--- a/internal/rules/ruletest/ruletest.go
+++ b/internal/rules/ruletest/ruletest.go
@@ -229,7 +229,7 @@ func runDispatcher(t *testing.T, rule *api.Rule, file *scanner.File, resolver ty
 	if resolver != nil {
 		d = rules.NewDispatcher([]*api.Rule{rule}, resolver)
 	} else {
-		d = rules.NewDispatcher([]*api.Rule{rule})
+		d = rules.NewDispatcher([]*api.Rule{rule}, nil)
 	}
 	cols := d.Run(file)
 	return cols.Findings()

--- a/internal/rules/style_braces_test.go
+++ b/internal/rules/style_braces_test.go
@@ -82,7 +82,7 @@ func runBracesIfRule(t *testing.T, singleLine, multiLine, code string) scanner.F
 	}
 
 	file := parseBracesInline(t, code)
-	d := NewDispatcher([]*api.Rule{makeBracesIfV2Rule(rule)})
+	d := NewDispatcher([]*api.Rule{makeBracesIfV2Rule(rule)}, nil)
 	return d.Run(file)
 }
 
@@ -96,7 +96,7 @@ func runBracesWhenRule(t *testing.T, singleLine, multiLine, code string) scanner
 	}
 
 	file := parseBracesInline(t, code)
-	d := NewDispatcher([]*api.Rule{makeBracesWhenV2Rule(rule)})
+	d := NewDispatcher([]*api.Rule{makeBracesWhenV2Rule(rule)}, nil)
 	return d.Run(file)
 }
 
@@ -286,7 +286,7 @@ fun example(x: Int) {
     }
 }
 `)
-	d := NewDispatcher([]*api.Rule{makeBracesWhenV2Rule(rule)})
+	d := NewDispatcher([]*api.Rule{makeBracesWhenV2Rule(rule)}, nil)
 	findings := d.Run(file)
 	if findings.Len() != 0 {
 		t.Fatalf("expected no findings for test sources, got %d", findings.Len())
@@ -382,7 +382,7 @@ fun example(x: Boolean) {
     if (x) println("yes")
 }
 `)
-	d := NewDispatcher([]*api.Rule{makeBracesIfV2Rule(rule)})
+	d := NewDispatcher([]*api.Rule{makeBracesIfV2Rule(rule)}, nil)
 	findings := d.Run(file)
 	if findings.Len() != 0 {
 		t.Fatalf("expected no findings for test sources, got %d", findings.Len())

--- a/internal/rules/style_expressions_internal_test.go
+++ b/internal/rules/style_expressions_internal_test.go
@@ -42,7 +42,7 @@ func runStyleExpressionsRuleByName(t *testing.T, ruleName string, code string) [
 	file := parseStyleExpressionsInline(t, code)
 	for _, rule := range api.Registry {
 		if rule.ID == ruleName {
-			cols := NewDispatcher([]*api.Rule{rule}).Run(file)
+			cols := NewDispatcher([]*api.Rule{rule}, nil).Run(file)
 			return cols.Findings()
 		}
 	}

--- a/internal/rules/style_expressions_test.go
+++ b/internal/rules/style_expressions_test.go
@@ -587,7 +587,7 @@ func BenchmarkVarCouldBeValSharedScope(b *testing.B) {
 		b.Fatal("VarCouldBeVal rule not found")
 	}
 
-	dispatcher := rules.NewDispatcher([]*api.Rule{target})
+	dispatcher := rules.NewDispatcher([]*api.Rule{target}, nil)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		_ = dispatcher.Run(file)

--- a/internal/rules/style_format_internal_test.go
+++ b/internal/rules/style_format_internal_test.go
@@ -34,7 +34,7 @@ func TestNoTabs_FixHonorsConfiguredIndentSize(t *testing.T) {
 				Needs: api.NeedsLinePass, Fix: api.FixCosmetic, Implementation: rule,
 				Check: rule.check,
 			}
-			d := NewDispatcher([]*api.Rule{v2rule})
+			d := NewDispatcher([]*api.Rule{v2rule}, nil)
 			cols := d.Run(file)
 			findings := cols.Findings()
 			if len(findings) == 0 {

--- a/tests/parity/fir_parity_test.go
+++ b/tests/parity/fir_parity_test.go
@@ -342,7 +342,7 @@ func runGoRule(t *testing.T, root, ruleName, fixture string) []scanner.Finding {
 			cols := rules.NewDispatcher([]*api.Rule{rule}, resolver).Run(file)
 			return cols.Findings()
 		}
-		cols := rules.NewDispatcher([]*api.Rule{rule}).Run(file)
+		cols := rules.NewDispatcher([]*api.Rule{rule}, nil).Run(file)
 		return cols.Findings()
 	}
 	t.Fatalf("rule %q not found", ruleName)


### PR DESCRIPTION
## Summary
- \`NewDispatcher(rules, resolver ...typeinfer.TypeResolver)\` was variadic-as-optional (always 0 or 1). Replace with a plain \`typeinfer.TypeResolver\` parameter.
- ~30 call sites updated; those with no resolver now pass \`nil\` explicitly.
- Behavior unchanged.

### Audit follow-up: two cousin items intentionally skipped

The original audit listed \`ResidentFileCache\` (interface w/ "single impl") and \`FallbackDecompiler\` (wrapper) alongside this one. On inspection both earn their keep:

- \`ResidentFileCache\` has a real test fake (\`*fakeResidentCache\` in \`parse_test.go\`) and serves the daemon-vs-CLI nil-vs-impl seam. Not single-impl.
- \`FallbackDecompiler\` is a 12-line tested abstraction with one consumer — encapsulation, not noise.

## Test plan
- [x] \`go build ./...\`
- [x] \`go vet ./...\`
- [x] \`golangci-lint run ./...\` (0 issues)
- [x] \`go test ./... -count=1\` (all pass)