### PR TITLE
fix(scan): content-hash fallback in oracle freshness gate

### DIFF
--- a/internal/cli/scan/stale_oracle_paths.go
+++ b/internal/cli/scan/stale_oracle_paths.go
@@ -65,7 +65,7 @@ func computeStaleOraclePaths(scanPaths []string, kotlinFilePaths []string, inclu
 		perf.AddEntryDetails(tracker, "freshnessGateNoManifest", 0, nil, nil)
 		return nil
 	}
-	stale := scanner.StaleOracleCandidates(kotlinFilePaths, prior, scanner.StatFile)
+	stale := scanner.StaleOracleCandidates(kotlinFilePaths, prior, scanner.StatFile, oracleContentHashProvider)
 	if len(stale) == 0 {
 		if verbose {
 			fmt.Fprintln(os.Stderr, "verbose: oracle freshness gate: manifest is in sync with current file stats")
@@ -86,4 +86,18 @@ func computeStaleOraclePaths(scanPaths []string, kotlinFilePaths []string, inclu
 		"priorSize": int64(len(prior.FileStats)),
 	}, nil)
 	return stale
+}
+
+// oracleContentHashProvider adapts oracle.ContentHash to the
+// scanner.ContentHashProvider signature so the freshness gate can
+// fall back to content-hash comparison when a path's stat differs
+// from the prior manifest entry. Routed through hashutil's
+// process-scoped memo so the same file hashed elsewhere in the run
+// (parse phase, cache classifier) only pays the hash cost once.
+func oracleContentHashProvider(path string) (string, bool) {
+	hash, err := oracle.ContentHash(path)
+	if err != nil || hash == "" {
+		return "", false
+	}
+	return hash, true
 }

--- a/internal/scanner/findings_bundle_manifest.go
+++ b/internal/scanner/findings_bundle_manifest.go
@@ -162,6 +162,14 @@ func LoadFindingsBundleManifestFromPath(path string) (FindingsBundleManifest, bo
 // stub for deterministic input.
 type FileStatProvider func(path string) (FileStat, bool)
 
+// ContentHashProvider returns the current content hash of a path. Used
+// by StaleOracleCandidates to disambiguate stat-drift caused by mtime
+// bumps (gradle regen, git checkout, IDE touch) from real content
+// changes. Returning (_, false) leaves the path on the stale list —
+// the caller already saw stat drift, so the hash fallback should be
+// strictly additive.
+type ContentHashProvider func(path string) (string, bool)
+
 // StaleOracleCandidates returns the subset of paths whose file stat
 // differs from the prior manifest entry. Used by the oracle
 // freshness gate to identify .kt files that need a partial KAA
@@ -175,7 +183,14 @@ type FileStatProvider func(path string) (FileStat, bool)
 //
 // stat is required and must be non-nil. Files whose stat is
 // unavailable (deleted, unreadable) are treated as stale.
-func StaleOracleCandidates(paths []string, prior FindingsBundleManifest, stat FileStatProvider) []string {
+//
+// hash is optional. When non-nil and a path's stat differs from prior
+// but its content hash matches prior.ContentHashes[path], the path
+// is treated as fresh — covering the common mtime-only drift case
+// (git checkout, gradle re-emit with identical bytes, IDE touch).
+// Hashing is only paid for paths that already failed the stat check,
+// so the cost is bounded by the size of the stat-drifted subset.
+func StaleOracleCandidates(paths []string, prior FindingsBundleManifest, stat FileStatProvider, hash ContentHashProvider) []string {
 	if stat == nil {
 		return paths
 	}
@@ -183,7 +198,22 @@ func StaleOracleCandidates(paths []string, prior FindingsBundleManifest, stat Fi
 		return paths
 	}
 	priorStats := prior.FileStats
+	priorHashes := prior.ContentHashes
 	stale := make([]string, 0)
+	contentMatches := func(path string) bool {
+		if hash == nil || len(priorHashes) == 0 {
+			return false
+		}
+		priorHash, hadHash := priorHashes[path]
+		if !hadHash || priorHash == "" {
+			return false
+		}
+		current, ok := hash(path)
+		if !ok || current == "" {
+			return false
+		}
+		return current == priorHash
+	}
 	for _, path := range paths {
 		current, ok := stat(path)
 		if !ok {
@@ -196,19 +226,25 @@ func StaleOracleCandidates(paths []string, prior FindingsBundleManifest, stat Fi
 			// keeps freshly-upgraded daemons from re-running every
 			// file when the on-disk manifest format is one version
 			// behind.
-			if _, hadHash := prior.ContentHashes[path]; !hadHash {
+			if _, hadHash := priorHashes[path]; !hadHash {
 				stale = append(stale, path)
 			}
 			continue
 		}
 		priorStat, hadStat := priorStats[path]
 		if !hadStat {
+			// New path not in prior manifest — content-hash fallback
+			// can't help (no prior hash to compare against).
 			stale = append(stale, path)
 			continue
 		}
-		if priorStat != current {
-			stale = append(stale, path)
+		if priorStat == current {
+			continue
 		}
+		if contentMatches(path) {
+			continue
+		}
+		stale = append(stale, path)
 	}
 	return stale
 }

--- a/internal/scanner/stale_oracle_candidates_test.go
+++ b/internal/scanner/stale_oracle_candidates_test.go
@@ -9,7 +9,7 @@ import (
 func TestStaleOracleCandidates_NilStat_TreatsAllAsStale(t *testing.T) {
 	t.Parallel()
 	paths := []string{"/a.kt", "/b.kt"}
-	stale := StaleOracleCandidates(paths, FindingsBundleManifest{}, nil)
+	stale := StaleOracleCandidates(paths, FindingsBundleManifest{}, nil, nil)
 	if !reflect.DeepEqual(stale, paths) {
 		t.Errorf("stale = %v, want %v", stale, paths)
 	}
@@ -21,7 +21,7 @@ func TestStaleOracleCandidates_NoPriorManifest_AllStale(t *testing.T) {
 	stat := func(string) (FileStat, bool) {
 		return FileStat{Size: 1, ModTimeUnixNano: 1}, true
 	}
-	stale := StaleOracleCandidates(paths, FindingsBundleManifest{}, stat)
+	stale := StaleOracleCandidates(paths, FindingsBundleManifest{}, stat, nil)
 	// With no manifest evidence, every path must be reported stale so
 	// the caller doesn't reuse an oracle JSON we cannot verify.
 	if !reflect.DeepEqual(stale, paths) {
@@ -42,7 +42,7 @@ func TestStaleOracleCandidates_AllMatching_Empty(t *testing.T) {
 	stat := func(p string) (FileStat, bool) {
 		return prior.FileStats[p], true
 	}
-	stale := StaleOracleCandidates(paths, prior, stat)
+	stale := StaleOracleCandidates(paths, prior, stat, nil)
 	if len(stale) != 0 {
 		t.Errorf("stale = %v, want empty when stats match", stale)
 	}
@@ -64,7 +64,7 @@ func TestStaleOracleCandidates_StatMismatch_FlaggedStale(t *testing.T) {
 		}
 		return prior.FileStats[p], true
 	}
-	stale := StaleOracleCandidates(paths, prior, stat)
+	stale := StaleOracleCandidates(paths, prior, stat, nil)
 	want := []string{"/b.kt"}
 	if !reflect.DeepEqual(stale, want) {
 		t.Errorf("stale = %v, want %v", stale, want)
@@ -87,7 +87,7 @@ func TestStaleOracleCandidates_StatUnavailable_FlaggedStale(t *testing.T) {
 		}
 		return prior.FileStats[p], true
 	}
-	stale := StaleOracleCandidates(paths, prior, stat)
+	stale := StaleOracleCandidates(paths, prior, stat, nil)
 	want := []string{"/missing.kt"}
 	if !reflect.DeepEqual(stale, want) {
 		t.Errorf("stale = %v, want %v", stale, want)
@@ -113,7 +113,7 @@ func TestStaleOracleCandidates_PriorMissingPath_FlaggedStale(t *testing.T) {
 		}
 		return FileStat{}, false
 	}
-	stale := StaleOracleCandidates(paths, prior, stat)
+	stale := StaleOracleCandidates(paths, prior, stat, nil)
 	want := []string{"/b.kt"}
 	if !reflect.DeepEqual(stale, want) {
 		t.Errorf("stale = %v, want %v", stale, want)
@@ -132,7 +132,7 @@ func TestStaleOracleCandidates_LegacyManifestNoFileStats(t *testing.T) {
 	stat := func(string) (FileStat, bool) {
 		return FileStat{Size: 1, ModTimeUnixNano: 1}, true
 	}
-	stale := StaleOracleCandidates(paths, prior, stat)
+	stale := StaleOracleCandidates(paths, prior, stat, nil)
 	want := []string{"/new.kt"}
 	if !reflect.DeepEqual(stale, want) {
 		t.Errorf("stale = %v, want %v", stale, want)
@@ -151,7 +151,7 @@ func TestStaleOracleCandidates_OrderPreserved(t *testing.T) {
 	stat := func(string) (FileStat, bool) {
 		return FileStat{Size: 1, ModTimeUnixNano: 1}, true
 	}
-	stale := StaleOracleCandidates(paths, prior, stat)
+	stale := StaleOracleCandidates(paths, prior, stat, nil)
 	sorted := append([]string(nil), stale...)
 	sort.Strings(sorted)
 	if reflect.DeepEqual(stale, sorted) {
@@ -160,5 +160,108 @@ func TestStaleOracleCandidates_OrderPreserved(t *testing.T) {
 		if !reflect.DeepEqual(stale, paths) {
 			t.Errorf("stale = %v, want input order %v", stale, paths)
 		}
+	}
+}
+
+func TestStaleOracleCandidates_HashFallback_StatDriftSameContent(t *testing.T) {
+	t.Parallel()
+	// Common case the hash fallback targets: git checkout / gradle
+	// regen / IDE touch bumps the file's mtime without changing bytes.
+	// Stat differs, content hash matches prior → must be treated as
+	// fresh so we don't pay krit-fir's JVM startup on every warm rerun.
+	paths := []string{"/a.kt", "/b.kt"}
+	prior := FindingsBundleManifest{
+		FileStats: map[string]FileStat{
+			"/a.kt": {Size: 10, ModTimeUnixNano: 100},
+			"/b.kt": {Size: 20, ModTimeUnixNano: 200},
+		},
+		ContentHashes: map[string]string{
+			"/a.kt": "hashA",
+			"/b.kt": "hashB",
+		},
+	}
+	stat := func(p string) (FileStat, bool) {
+		if p == "/b.kt" {
+			return FileStat{Size: 20, ModTimeUnixNano: 999}, true // mtime bump, same size
+		}
+		return prior.FileStats[p], true
+	}
+	hash := func(p string) (string, bool) {
+		return prior.ContentHashes[p], true // current matches prior
+	}
+	stale := StaleOracleCandidates(paths, prior, stat, hash)
+	if len(stale) != 0 {
+		t.Errorf("stale = %v, want empty (content hash matches prior despite mtime drift)", stale)
+	}
+}
+
+func TestStaleOracleCandidates_HashFallback_StatDriftRealChange(t *testing.T) {
+	t.Parallel()
+	// Symmetric guard: content hash differs from prior → must still
+	// be flagged stale. The hash fallback only suppresses false
+	// positives; real changes must still propagate.
+	paths := []string{"/a.kt"}
+	prior := FindingsBundleManifest{
+		FileStats:     map[string]FileStat{"/a.kt": {Size: 10, ModTimeUnixNano: 100}},
+		ContentHashes: map[string]string{"/a.kt": "hashOriginal"},
+	}
+	stat := func(string) (FileStat, bool) {
+		return FileStat{Size: 11, ModTimeUnixNano: 200}, true // both size and mtime changed
+	}
+	hash := func(string) (string, bool) {
+		return "hashChanged", true
+	}
+	stale := StaleOracleCandidates(paths, prior, stat, hash)
+	want := []string{"/a.kt"}
+	if !reflect.DeepEqual(stale, want) {
+		t.Errorf("stale = %v, want %v (content hash differs — must mark stale)", stale, want)
+	}
+}
+
+func TestStaleOracleCandidates_HashFallback_PriorHashMissing(t *testing.T) {
+	t.Parallel()
+	// Prior manifest has FileStats but no ContentHashes entry for the
+	// path (legacy data). Hash fallback must NOT trust the missing
+	// entry — fall through to the stat-only verdict (stale).
+	paths := []string{"/a.kt"}
+	prior := FindingsBundleManifest{
+		FileStats:     map[string]FileStat{"/a.kt": {Size: 10, ModTimeUnixNano: 100}},
+		ContentHashes: map[string]string{}, // empty
+	}
+	stat := func(string) (FileStat, bool) {
+		return FileStat{Size: 10, ModTimeUnixNano: 999}, true
+	}
+	hash := func(string) (string, bool) {
+		return "anything", true
+	}
+	stale := StaleOracleCandidates(paths, prior, stat, hash)
+	want := []string{"/a.kt"}
+	if !reflect.DeepEqual(stale, want) {
+		t.Errorf("stale = %v, want %v (no prior hash to compare against)", stale, want)
+	}
+}
+
+func TestStaleOracleCandidates_HashFallback_NotPaidWhenStatMatches(t *testing.T) {
+	t.Parallel()
+	// Performance guarantee: if stat already matches, the hash
+	// provider must not be invoked at all. Confirmed via a stub that
+	// fails the test if called.
+	paths := []string{"/a.kt"}
+	prior := FindingsBundleManifest{
+		FileStats:     map[string]FileStat{"/a.kt": {Size: 10, ModTimeUnixNano: 100}},
+		ContentHashes: map[string]string{"/a.kt": "hashA"},
+	}
+	stat := func(string) (FileStat, bool) {
+		return prior.FileStats["/a.kt"], true
+	}
+	hashCalls := 0
+	hash := func(string) (string, bool) {
+		hashCalls++
+		t.Errorf("hash provider was called %d time(s) when stat matched; the hash fallback should only run on stat drift", hashCalls)
+		return "", true
+	}
+	stale := StaleOracleCandidates(paths, prior, stat, hash)
+	if len(stale) != 0 {
+		t.Errorf("stale = %v, want empty", stale)
 	}
 }


### PR DESCRIPTION
## Summary
\`StaleOracleCandidates\` flagged any path whose \`(size, mtime)\` tuple drifted from the prior manifest entry as stale, which routed it through the oracle layer as a \`ForcedMiss\` and triggered a krit-fir / krit-types one-shot JVM. That's correct when content actually changed, but wrong for the dominant warm-rerun case where mtime drifts without content changes — \`git checkout\`, gradle re-emit with identical bytes, IDE touch, etc.

Follow-up to [#548](https://github.com/kaeawc/krit/pull/548), which removed the structural \`/generated/\` phantom-miss source. This addresses the runtime-touch phantom-miss source.

## Behavior change
\`StaleOracleCandidates\` now accepts an optional \`ContentHashProvider\`. When stat drifts but the prior manifest has a \`ContentHashes\` entry for the path AND the current hash matches, the path is treated as fresh. Real content changes still hit the stale list (hash mismatch).

The hash provider is only invoked when stat already failed, so the cost is bounded by the stat-drifted subset — typically a handful of files. Production uses \`oracle.ContentHash\`, which routes through \`hashutil.Default()\`'s process-wide memo, so the same file hashed elsewhere in the run pays the hash cost once.

## Repro
Observed against \`~/github/kotlin\`: a \`git checkout -- one-file.kt\` between warm reruns previously triggered krit-fir one-shot JVM relaunch (~80s of warm overhead). With the hash fallback the reverted file's content hash matches the prior manifest → 0 stale paths → krit-fir not launched.

## Test plan
- [x] Existing scanner tests updated to 4-arg shape, still pass.
- [x] New tests: hash-fallback success (stat drift + same content → fresh), real change (stat drift + different content → stale), missing prior hash (no entry → fall through to stale), not-paid-when-stat-matches (provider must not be called).
- [x] \`go vet ./...\` / \`golangci-lint run ./...\`
- [ ] Warm benchmark on \`~/github/kotlin\` end-to-end (in progress separately) — expecting warm rerun to drop further when this lands on top of #548.