### PR TITLE
fix(intellij-plugin): translate UTF-8 byte columns to UTF-16 char offsets

### DIFF
--- a/editors/intellij-plugin/src/main/kotlin/dev/jasonpearson/krit/intellij/KritRanges.kt
+++ b/editors/intellij-plugin/src/main/kotlin/dev/jasonpearson/krit/intellij/KritRanges.kt
@@ -6,17 +6,61 @@ import com.intellij.psi.PsiFile
 object KritRanges {
     fun rangeFor(file: PsiFile, finding: KritFinding): TextRange {
         val document = file.viewProvider.document ?: return TextRange(0, 0)
+        val text = document.charsSequence
         val lineIndex = (finding.line - 1).coerceAtLeast(0)
         if (lineIndex >= document.lineCount) {
-            return endOfFileRange(document.charsSequence)
+            return endOfFileRange(text)
         }
 
         val lineStart = document.getLineStartOffset(lineIndex)
         val lineEnd = document.getLineEndOffset(lineIndex)
-        val columnIndex = (finding.column - 1).coerceAtLeast(0)
-        val start = (lineStart + columnIndex).coerceIn(lineStart, lineEnd)
-        val end = findTokenEnd(document.charsSequence, start, lineEnd)
+        val byteCol = (finding.column - 1).coerceAtLeast(0)
+        val start = byteColumnToCharOffset(text, lineStart, lineEnd, byteCol)
+        val end = findTokenEnd(text, start, lineEnd)
         return TextRange(start, end.coerceAtLeast(start))
+    }
+
+    // Krit emits `column` from tree-sitter's start.Column, which is a UTF-8
+    // byte offset within the line. IntelliJ documents are UTF-16. This
+    // translation walks the line one char at a time, summing the UTF-8
+    // byte width of each code point until the byte budget is exhausted.
+    internal fun byteColumnToCharOffset(
+        text: CharSequence,
+        lineStartChar: Int,
+        lineEndChar: Int,
+        byteCol: Int,
+    ): Int {
+        if (byteCol <= 0) return lineStartChar
+        var bytes = 0
+        var i = lineStartChar
+        while (i < lineEndChar) {
+            if (bytes >= byteCol) return i
+            val c = text[i]
+            val code = c.code
+            val width: Int
+            val advance: Int
+            when {
+                code < 0x80 -> {
+                    width = 1
+                    advance = 1
+                }
+                code < 0x800 -> {
+                    width = 2
+                    advance = 1
+                }
+                c.isHighSurrogate() && i + 1 < lineEndChar && text[i + 1].isLowSurrogate() -> {
+                    width = 4
+                    advance = 2
+                }
+                else -> {
+                    width = 3
+                    advance = 1
+                }
+            }
+            bytes += width
+            i += advance
+        }
+        return lineEndChar
     }
 
     private fun endOfFileRange(text: CharSequence): TextRange {

--- a/editors/intellij-plugin/src/test/kotlin/dev/jasonpearson/krit/intellij/KritRangesTest.kt
+++ b/editors/intellij-plugin/src/test/kotlin/dev/jasonpearson/krit/intellij/KritRangesTest.kt
@@ -1,0 +1,89 @@
+package dev.jasonpearson.krit.intellij
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class KritRangesTest {
+    private fun translate(text: String, byteCol: Int): Int {
+        return KritRanges.byteColumnToCharOffset(text, 0, text.length, byteCol)
+    }
+
+    @Test
+    fun `ascii line passes through unchanged`() {
+        val line = "val answer = 42"
+        assertEquals(0, translate(line, 0))
+        assertEquals(4, translate(line, 4))
+        assertEquals(line.length, translate(line, 999))
+    }
+
+    @Test
+    fun `byte column past emoji maps to correct char offset`() {
+        // 😀 is U+1F600, 4 UTF-8 bytes, 2 UTF-16 chars (surrogate pair).
+        // Layout: v(1) a(1) l(1)  (1) x(1)  (1) =(1)  (1) "(1) 😀(4) "(1)
+        // Byte offsets: 0 1 2 3 4 5 6 7 8 9..12 13
+        // Char offsets: 0 1 2 3 4 5 6 7 8 9,10 11
+        val line = "val x = \"😀\""
+        assertEquals(9, translate(line, 9))    // start of emoji
+        assertEquals(11, translate(line, 13))  // closing quote
+    }
+
+    @Test
+    fun `accented identifier comment maps correctly`() {
+        // é = U+00E9, 2 UTF-8 bytes, 1 UTF-16 char.
+        // "// café" — bytes:  / / SP c a f é
+        //            chars:   0 1 2  3 4 5 6
+        //            bytes:   0 1 2  3 4 5 6,7
+        val line = "// café x"
+        // Byte 8 sits just after é (which occupies bytes 6..7), so the
+        // expected char offset is 7 (the space before 'x').
+        assertEquals(7, translate(line, 8))
+    }
+
+    @Test
+    fun `cjk character maps correctly`() {
+        // 中 is U+4E2D, 3 UTF-8 bytes, 1 UTF-16 char.
+        // "val 中 = 1" — bytes: v a l SP 中(3) SP = SP 1
+        //                chars: 0 1 2 3  4    5  6 7  8
+        //                bytes: 0 1 2 3  4..6 7  8 9  10
+        val line = "val 中 = 1"
+        assertEquals(4, translate(line, 4))   // start of 中
+        assertEquals(5, translate(line, 7))   // space after 中
+        assertEquals(6, translate(line, 8))   // '='
+    }
+
+    @Test
+    fun `byte column zero or negative returns line start`() {
+        val line = "val x = 1"
+        assertEquals(0, translate(line, 0))
+        assertEquals(0, translate(line, -5))
+    }
+
+    @Test
+    fun `byte column beyond line returns line end`() {
+        val line = "val x = 1"
+        assertEquals(line.length, translate(line, 1000))
+    }
+
+    @Test
+    fun `empty line returns line start`() {
+        assertEquals(0, translate("", 0))
+        assertEquals(0, translate("", 5))
+    }
+
+    @Test
+    fun `translation honors line bounds when called mid-document`() {
+        // Simulate the second line of a document. byteColumnToCharOffset
+        // should never read past lineEndChar, even if byteCol is huge.
+        val text = "line one\nval 中 = 1\nline three"
+        val lineStart = "line one\n".length
+        val lineEnd = lineStart + "val 中 = 1".length
+        assertEquals(
+            lineStart + 4,
+            KritRanges.byteColumnToCharOffset(text, lineStart, lineEnd, 4),
+        )
+        assertEquals(
+            lineEnd,
+            KritRanges.byteColumnToCharOffset(text, lineStart, lineEnd, 9999),
+        )
+    }
+}


### PR DESCRIPTION
Closes #545.

## Summary
- Krit emits `column` from tree-sitter's `start.Column`, which is a UTF-8 byte offset within the line. `KritRanges` treated it as a UTF-16 char offset, producing highlights on the wrong span for files containing emoji, accented characters, or CJK text. ASCII content was correct by coincidence.
- Adds `KritRanges.byteColumnToCharOffset`, a per-character walk that sums UTF-8 byte widths (1/2/3/4 for ASCII, 2-byte BMP, 3-byte BMP, and surrogate-paired supplementary chars) until the byte budget is consumed.
- Covers emoji (4 bytes / 2 chars), accented Latin (2 bytes / 1 char), CJK (3 bytes / 1 char), and edge cases (zero/negative byte columns, out-of-range, empty lines, mid-document line bounds).

## Test plan
- [x] New unit tests in `KritRangesTest` pass: `../../tools/krit-fir/gradlew --project-dir editors/intellij-plugin test`
- [x] Existing `KritJsonParserTest` still passes
- [x] Pure-ASCII fixtures unchanged (regression baseline preserved)