### PR TITLE
feat(intellij-plugin): confidence-aware severity + Suppress quick-fix

### DIFF
--- a/editors/intellij-plugin/src/main/kotlin/dev/jasonpearson/krit/intellij/KritExternalAnnotator.kt
+++ b/editors/intellij-plugin/src/main/kotlin/dev/jasonpearson/krit/intellij/KritExternalAnnotator.kt
@@ -1,6 +1,7 @@
 package dev.jasonpearson.krit.intellij
 
 import com.intellij.codeInsight.intention.IntentionAction
+import com.intellij.codeInspection.ProblemHighlightType
 import com.intellij.lang.annotation.AnnotationHolder
 import com.intellij.lang.annotation.ExternalAnnotator
 import com.intellij.lang.annotation.HighlightSeverity
@@ -36,28 +37,49 @@ class KritExternalAnnotator : ExternalAnnotator<PsiFile, List<KritFinding>>() {
         }
     }
 
-    private fun highlightSeverity(finding: KritFinding): HighlightSeverity {
-        return when (finding.severity.lowercase()) {
-            "error" -> HighlightSeverity.ERROR
-            "info" -> HighlightSeverity.INFORMATION
-            else -> HighlightSeverity.WARNING
-        }
+    private fun highlightSeverity(finding: KritFinding): HighlightSeverity =
+        KritSeverity.highlightSeverity(finding)
+}
+
+internal object KritSeverity {
+    // Confidence in (0, 0.5) is a "soft" finding — render at weak warning so
+    // it doesn't compete with high-confidence diagnostics. Confidence == 0
+    // means the rule didn't set it; treat as a normal warning.
+    private const val WEAK_THRESHOLD = 0.5
+
+    fun highlightSeverity(finding: KritFinding): HighlightSeverity = when {
+        finding.severity.equals("error", ignoreCase = true) -> HighlightSeverity.ERROR
+        finding.severity.equals("info", ignoreCase = true) -> HighlightSeverity.INFORMATION
+        finding.confidence > 0.0 && finding.confidence < WEAK_THRESHOLD -> HighlightSeverity.WEAK_WARNING
+        else -> HighlightSeverity.WARNING
+    }
+
+    fun problemHighlightType(finding: KritFinding): ProblemHighlightType = when {
+        finding.severity.equals("error", ignoreCase = true) ->
+            ProblemHighlightType.ERROR
+        finding.severity.equals("info", ignoreCase = true) ->
+            ProblemHighlightType.INFORMATION
+        finding.confidence > 0.0 && finding.confidence < WEAK_THRESHOLD ->
+            ProblemHighlightType.WEAK_WARNING
+        else -> ProblemHighlightType.WARNING
     }
 }
 
 object KritIntentions {
     // Suggestions and the autofix slot are mutually exclusive per finding:
     // when a rule emits suggestions the user picks one explicitly, so the
-    // catch-all "apply auto-fixes" entry would conflict.
+    // catch-all "apply auto-fixes" entry would conflict. Suppress is
+    // orthogonal and always offered.
     fun forFinding(finding: KritFinding): List<IntentionAction> {
+        val suppress = KritSuppressIntention(finding.rule)
         val applicable = finding.suggestedFixes.filter { it.edits.isNotEmpty() }
         if (applicable.isNotEmpty()) {
-            return applicable.map { KritApplySuggestionIntention(finding.findingId, it) }
+            return applicable.map { KritApplySuggestionIntention(finding.findingId, it) } + suppress
         }
         if (finding.fixable) {
-            return listOf(KritApplyFixesIntention(finding.fixLevel))
+            return listOf(KritApplyFixesIntention(finding.fixLevel), suppress)
         }
-        return emptyList()
+        return listOf(suppress)
     }
 }
 

--- a/editors/intellij-plugin/src/main/kotlin/dev/jasonpearson/krit/intellij/KritFinding.kt
+++ b/editors/intellij-plugin/src/main/kotlin/dev/jasonpearson/krit/intellij/KritFinding.kt
@@ -10,6 +10,7 @@ data class KritFinding(
     val message: String,
     val fixable: Boolean = false,
     val fixLevel: String? = null,
+    val confidence: Double = 0.0,
     val suggestedFixes: List<KritSuggestedFix> = emptyList(),
 ) {
     val displayMessage: String

--- a/editors/intellij-plugin/src/main/kotlin/dev/jasonpearson/krit/intellij/KritInspection.kt
+++ b/editors/intellij-plugin/src/main/kotlin/dev/jasonpearson/krit/intellij/KritInspection.kt
@@ -42,25 +42,21 @@ class KritInspection : LocalInspectionTool() {
 
     override fun isEnabledByDefault(): Boolean = true
 
-    private fun problemHighlightType(finding: KritFinding): ProblemHighlightType {
-        return when (finding.severity.lowercase()) {
-            "error" -> ProblemHighlightType.ERROR
-            "info" -> ProblemHighlightType.INFORMATION
-            else -> ProblemHighlightType.WARNING
-        }
-    }
+    private fun problemHighlightType(finding: KritFinding): ProblemHighlightType =
+        KritSeverity.problemHighlightType(finding)
 
     private fun quickFixes(finding: KritFinding): Array<LocalQuickFix> {
+        val suppress = KritSuppressQuickFix(finding.rule)
         val applicable = finding.suggestedFixes.filter { it.edits.isNotEmpty() }
         if (applicable.isNotEmpty()) {
-            return applicable
-                .map { KritApplySuggestionQuickFix(finding.findingId, it) }
-                .toTypedArray()
+            return (
+                applicable.map { KritApplySuggestionQuickFix(finding.findingId, it) } + suppress
+            ).toTypedArray()
         }
         if (!finding.fixable) {
-            return emptyArray()
+            return arrayOf(suppress)
         }
-        return arrayOf(KritApplyFixesQuickFix(finding.fixLevel))
+        return arrayOf(KritApplyFixesQuickFix(finding.fixLevel), suppress)
     }
 }
 

--- a/editors/intellij-plugin/src/main/kotlin/dev/jasonpearson/krit/intellij/KritSuppress.kt
+++ b/editors/intellij-plugin/src/main/kotlin/dev/jasonpearson/krit/intellij/KritSuppress.kt
@@ -1,0 +1,144 @@
+package dev.jasonpearson.krit.intellij
+
+import com.intellij.codeInsight.intention.IntentionAction
+import com.intellij.codeInspection.LocalQuickFix
+import com.intellij.codeInspection.ProblemDescriptor
+import com.intellij.openapi.command.WriteCommandAction
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.psi.JavaPsiFacade
+import com.intellij.psi.PsiAnnotation
+import com.intellij.psi.PsiArrayInitializerMemberValue
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import com.intellij.psi.PsiLiteralExpression
+import com.intellij.psi.PsiModifierListOwner
+import com.intellij.psi.util.PsiTreeUtil
+import org.jetbrains.kotlin.psi.KtAnnotationEntry
+import org.jetbrains.kotlin.psi.KtModifierListOwner
+import org.jetbrains.kotlin.psi.KtPsiFactory
+
+internal object KritSuppress {
+    const val SUPPRESS_FAMILY = "Krit suppress"
+
+    fun titleFor(ruleId: String): String = "Suppress Krit '$ruleId' on this declaration"
+
+    // Pure helper for merging args: dedupes the rule id into an existing
+    // argument list. Returns null if the rule id is already present
+    // (caller skips the edit so it remains a no-op).
+    fun mergeArguments(existing: List<String>, ruleId: String): List<String>? {
+        if (existing.contains(ruleId)) return null
+        return existing + ruleId
+    }
+
+    fun formatJavaSuppressValue(args: List<String>): String {
+        if (args.size == 1) return "\"${args.single()}\""
+        return "{${args.joinToString(", ") { "\"$it\"" }}}"
+    }
+
+    fun applyToElement(element: PsiElement, ruleId: String) {
+        val owner = enclosingOwner(element) ?: return
+        when (owner) {
+            is KtModifierListOwner -> applyKotlin(owner, ruleId)
+            is PsiModifierListOwner -> applyJava(owner, ruleId)
+        }
+    }
+
+    fun enclosingOwner(element: PsiElement): PsiElement? {
+        return PsiTreeUtil.getParentOfType(element, KtModifierListOwner::class.java)
+            ?: PsiTreeUtil.getParentOfType(element, PsiModifierListOwner::class.java)
+    }
+
+    private fun applyKotlin(owner: KtModifierListOwner, ruleId: String) {
+        val factory = KtPsiFactory(owner.project)
+        val existing = owner.annotationEntries.firstOrNull {
+            it.shortName?.asString() == "Suppress"
+        }
+        if (existing == null) {
+            owner.addAnnotationEntry(factory.createAnnotationEntry("@Suppress(\"$ruleId\")"))
+            return
+        }
+        val merged = mergeArguments(extractKotlinSuppressArgs(existing), ruleId) ?: return
+        val replacement = factory.createAnnotationEntry(
+            "@Suppress(${merged.joinToString(", ") { "\"$it\"" }})",
+        )
+        existing.replace(replacement)
+    }
+
+    private fun applyJava(owner: PsiModifierListOwner, ruleId: String) {
+        val modifierList = owner.modifierList ?: return
+        val existing = modifierList.findAnnotation("java.lang.SuppressWarnings")
+            ?: modifierList.findAnnotation("SuppressWarnings")
+        val current = if (existing != null) extractJavaSuppressArgs(existing) else emptyList()
+        val merged = mergeArguments(current, ruleId) ?: return
+        val factory = JavaPsiFacade.getElementFactory(owner.project)
+        val annotation = factory.createAnnotationFromText(
+            "@SuppressWarnings(${formatJavaSuppressValue(merged)})",
+            owner,
+        )
+        if (existing != null) {
+            existing.replace(annotation)
+        } else {
+            modifierList.addBefore(annotation, modifierList.firstChild)
+        }
+    }
+
+    internal fun extractKotlinSuppressArgs(entry: KtAnnotationEntry): List<String> {
+        return entry.valueArguments.mapNotNull { arg ->
+            val text = arg.getArgumentExpression()?.text ?: return@mapNotNull null
+            stripQuotes(text)
+        }
+    }
+
+    internal fun extractJavaSuppressArgs(annotation: PsiAnnotation): List<String> {
+        val value = annotation.findAttributeValue("value") ?: return emptyList()
+        return when (value) {
+            is PsiLiteralExpression -> listOfNotNull(value.value as? String)
+            is PsiArrayInitializerMemberValue -> value.initializers.mapNotNull {
+                (it as? PsiLiteralExpression)?.value as? String
+            }
+            else -> emptyList()
+        }
+    }
+
+    internal fun stripQuotes(text: String): String {
+        val trimmed = text.trim()
+        return if (trimmed.length >= 2 && trimmed.first() == '"' && trimmed.last() == '"') {
+            trimmed.substring(1, trimmed.length - 1)
+        } else {
+            trimmed
+        }
+    }
+}
+
+class KritSuppressIntention(private val ruleId: String) : IntentionAction {
+    override fun getText(): String = KritSuppress.titleFor(ruleId)
+
+    override fun getFamilyName(): String = KritSuppress.SUPPRESS_FAMILY
+
+    override fun isAvailable(project: Project, editor: Editor?, file: PsiFile?): Boolean {
+        if (file == null || editor == null) return false
+        val element = file.findElementAt(editor.caretModel.offset) ?: return false
+        return KritSuppress.enclosingOwner(element) != null
+    }
+
+    override fun invoke(project: Project, editor: Editor?, file: PsiFile?) {
+        val ed = editor ?: return
+        val f = file ?: return
+        val element = f.findElementAt(ed.caretModel.offset) ?: return
+        WriteCommandAction.runWriteCommandAction(project) {
+            KritSuppress.applyToElement(element, ruleId)
+        }
+    }
+
+    override fun startInWriteAction(): Boolean = false
+}
+
+class KritSuppressQuickFix(private val ruleId: String) : LocalQuickFix {
+    override fun getFamilyName(): String = KritSuppress.titleFor(ruleId)
+
+    override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
+        val element = descriptor.psiElement ?: return
+        KritSuppress.applyToElement(element, ruleId)
+    }
+}

--- a/editors/intellij-plugin/src/test/kotlin/dev/jasonpearson/krit/intellij/KritJsonParserConfidenceTest.kt
+++ b/editors/intellij-plugin/src/test/kotlin/dev/jasonpearson/krit/intellij/KritJsonParserConfidenceTest.kt
@@ -1,0 +1,34 @@
+package dev.jasonpearson.krit.intellij
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class KritJsonParserConfidenceTest {
+    @Test
+    fun `parser populates confidence from JSON`() {
+        val json = """
+            {"findings":[{
+                "file":"X.kt","line":1,"column":1,
+                "ruleSet":"rs","rule":"r","severity":"warning","message":"m",
+                "confidence":0.3
+            }]}
+        """.trimIndent()
+        val report = KritJsonParser.parse(json)
+        assertEquals(1, report.findings.size)
+        assertEquals(0.3, report.findings.single().confidence)
+    }
+
+    @Test
+    fun `parser defaults confidence to zero when absent`() {
+        // Krit omits confidence when unset (omitempty on the Go side).
+        // The default must be 0.0 so severity mapping doesn't treat
+        // missing confidence as "very low confidence".
+        val json = """
+            {"findings":[{
+                "file":"X.kt","line":1,"column":1,
+                "ruleSet":"rs","rule":"r","severity":"warning","message":"m"
+            }]}
+        """.trimIndent()
+        assertEquals(0.0, KritJsonParser.parse(json).findings.single().confidence)
+    }
+}

--- a/editors/intellij-plugin/src/test/kotlin/dev/jasonpearson/krit/intellij/KritJsonParserTest.kt
+++ b/editors/intellij-plugin/src/test/kotlin/dev/jasonpearson/krit/intellij/KritJsonParserTest.kt
@@ -147,8 +147,10 @@ class KritJsonParserTest {
         )
 
         val actions = KritIntentions.forFinding(finding)
-        assertEquals(2, actions.size)
-        actions.forEach { assertTrue(it is KritApplySuggestionIntention) }
+        assertEquals(3, actions.size)
+        assertTrue(actions[0] is KritApplySuggestionIntention)
+        assertTrue(actions[1] is KritApplySuggestionIntention)
+        assertTrue(actions[2] is KritSuppressIntention)
         assertEquals("Krit suggestion: Apply A", actions[0].text)
         assertEquals("Krit suggestion: Apply B", actions[1].text)
     }
@@ -168,9 +170,10 @@ class KritJsonParserTest {
         )
 
         val actions = KritIntentions.forFinding(finding)
-        assertEquals(1, actions.size)
-        assertTrue(actions.single() is KritApplyFixesIntention)
-        assertEquals("Apply Krit cosmetic auto-fixes", actions.single().text)
+        assertEquals(2, actions.size)
+        assertTrue(actions[0] is KritApplyFixesIntention)
+        assertTrue(actions[1] is KritSuppressIntention)
+        assertEquals("Apply Krit cosmetic auto-fixes", actions[0].text)
     }
 
     @Test
@@ -194,8 +197,10 @@ class KritJsonParserTest {
         )
 
         val actions = KritIntentions.forFinding(finding)
-        assertEquals(1, actions.size)
-        assertEquals("Krit suggestion: Convert to val", actions.single().text)
+        assertEquals(2, actions.size)
+        assertTrue(actions[0] is KritApplySuggestionIntention)
+        assertTrue(actions[1] is KritSuppressIntention)
+        assertEquals("Krit suggestion: Convert to val", actions[0].text)
     }
 
     @Test
@@ -216,8 +221,9 @@ class KritJsonParserTest {
         )
 
         val actions = KritIntentions.forFinding(finding)
-        assertEquals(1, actions.size)
-        assertTrue(actions.single() is KritApplyFixesIntention)
+        assertEquals(2, actions.size)
+        assertTrue(actions[0] is KritApplyFixesIntention)
+        assertTrue(actions[1] is KritSuppressIntention)
     }
 
     @Test
@@ -232,7 +238,9 @@ class KritJsonParserTest {
             message = "m",
         )
 
-        assertTrue(KritIntentions.forFinding(finding).isEmpty())
+        val actions = KritIntentions.forFinding(finding)
+        assertEquals(1, actions.size)
+        assertTrue(actions.single() is KritSuppressIntention)
     }
 
     @Test

--- a/editors/intellij-plugin/src/test/kotlin/dev/jasonpearson/krit/intellij/KritSeverityTest.kt
+++ b/editors/intellij-plugin/src/test/kotlin/dev/jasonpearson/krit/intellij/KritSeverityTest.kt
@@ -1,0 +1,60 @@
+package dev.jasonpearson.krit.intellij
+
+import com.intellij.codeInspection.ProblemHighlightType
+import com.intellij.lang.annotation.HighlightSeverity
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class KritSeverityTest {
+    private fun finding(severity: String, confidence: Double = 0.0): KritFinding =
+        KritFinding(
+            file = "X.kt",
+            line = 1,
+            column = 1,
+            ruleSet = "rs",
+            rule = "r",
+            severity = severity,
+            message = "m",
+            confidence = confidence,
+        )
+
+    @Test
+    fun `error severity wins over confidence`() {
+        assertEquals(HighlightSeverity.ERROR, KritSeverity.highlightSeverity(finding("error", 0.1)))
+        assertEquals(ProblemHighlightType.ERROR, KritSeverity.problemHighlightType(finding("error", 0.1)))
+    }
+
+    @Test
+    fun `info severity wins over confidence`() {
+        assertEquals(HighlightSeverity.INFORMATION, KritSeverity.highlightSeverity(finding("info", 0.1)))
+    }
+
+    @Test
+    fun `low confidence maps to weak warning`() {
+        assertEquals(HighlightSeverity.WEAK_WARNING, KritSeverity.highlightSeverity(finding("warning", 0.3)))
+        assertEquals(
+            ProblemHighlightType.WEAK_WARNING,
+            KritSeverity.problemHighlightType(finding("warning", 0.3)),
+        )
+    }
+
+    @Test
+    fun `confidence at threshold renders as warning`() {
+        // 0.5 is the boundary — equal-and-above gets normal warning weight.
+        assertEquals(HighlightSeverity.WARNING, KritSeverity.highlightSeverity(finding("warning", 0.5)))
+        assertEquals(HighlightSeverity.WARNING, KritSeverity.highlightSeverity(finding("warning", 0.9)))
+    }
+
+    @Test
+    fun `confidence zero means unset and renders as warning`() {
+        // Krit's JSON omits confidence when unset; default 0.0 should NOT be
+        // treated as "very low confidence" or every finding without a
+        // confidence score would be weakened.
+        assertEquals(HighlightSeverity.WARNING, KritSeverity.highlightSeverity(finding("warning", 0.0)))
+    }
+
+    @Test
+    fun `unknown severity strings default to warning`() {
+        assertEquals(HighlightSeverity.WARNING, KritSeverity.highlightSeverity(finding("style")))
+    }
+}

--- a/editors/intellij-plugin/src/test/kotlin/dev/jasonpearson/krit/intellij/KritSuppressTest.kt
+++ b/editors/intellij-plugin/src/test/kotlin/dev/jasonpearson/krit/intellij/KritSuppressTest.kt
@@ -1,0 +1,57 @@
+package dev.jasonpearson.krit.intellij
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class KritSuppressTest {
+    @Test
+    fun `mergeArguments appends to empty list`() {
+        assertEquals(listOf("HardcodedColor"), KritSuppress.mergeArguments(emptyList(), "HardcodedColor"))
+    }
+
+    @Test
+    fun `mergeArguments preserves existing args and appends new one`() {
+        assertEquals(
+            listOf("UNCHECKED_CAST", "HardcodedColor"),
+            KritSuppress.mergeArguments(listOf("UNCHECKED_CAST"), "HardcodedColor"),
+        )
+    }
+
+    @Test
+    fun `mergeArguments returns null when rule id already present`() {
+        // Caller skips the edit so the file is not touched. Avoids
+        // duplicate args and unnecessary undo entries.
+        assertNull(KritSuppress.mergeArguments(listOf("HardcodedColor"), "HardcodedColor"))
+        assertNull(
+            KritSuppress.mergeArguments(listOf("UNCHECKED_CAST", "HardcodedColor"), "HardcodedColor"),
+        )
+    }
+
+    @Test
+    fun `titleFor uses the rule id`() {
+        assertEquals("Suppress Krit 'HardcodedColor' on this declaration", KritSuppress.titleFor("HardcodedColor"))
+    }
+
+    @Test
+    fun `formatJavaSuppressValue emits bare string for single arg`() {
+        assertEquals("\"HardcodedColor\"", KritSuppress.formatJavaSuppressValue(listOf("HardcodedColor")))
+    }
+
+    @Test
+    fun `formatJavaSuppressValue emits brace array for multiple args`() {
+        // Matches javac's expected SuppressWarnings literal form so the
+        // file remains compilable after the rewrite.
+        assertEquals(
+            "{\"unchecked\", \"HardcodedColor\"}",
+            KritSuppress.formatJavaSuppressValue(listOf("unchecked", "HardcodedColor")),
+        )
+    }
+
+    @Test
+    fun `stripQuotes strips matching double quotes only`() {
+        assertEquals("HardcodedColor", KritSuppress.stripQuotes("\"HardcodedColor\""))
+        assertEquals("HardcodedColor", KritSuppress.stripQuotes("HardcodedColor"))
+        assertEquals("\"unbalanced", KritSuppress.stripQuotes("\"unbalanced"))
+    }
+}


### PR DESCRIPTION
Closes #544.

## Summary
- Findings with `confidence` in `(0, 0.5)` render at `WEAK_WARNING` / `ProblemHighlightType.WEAK_WARNING` so low-confidence diagnostics don't compete with high-confidence ones. `confidence == 0.0` (the JSON default when unset) stays at normal `WARNING`.
- Every finding gets a `Suppress Krit 'rule-id' on this declaration` intention/quick-fix that inserts `@Suppress("rule-id")` (Kotlin) or `@SuppressWarnings("rule-id")` (Java) on the enclosing modifier-list owner, merging with any existing annotation arguments.
- Severity mapping is factored into a shared `KritSeverity` object so the annotator and inspection don't drift.

## Test plan
- [x] `KritSeverityTest` covers error/info/threshold/zero-confidence cases (`../../tools/krit-fir/gradlew --project-dir editors/intellij-plugin test`)
- [x] `KritSuppressTest` covers pure `mergeArguments` dedup, Java single-vs-multi-arg formatting, quote stripping
- [x] `KritJsonParserConfidenceTest` round-trips `confidence` and verifies the omitted-field default
- [x] Existing `KritJsonParserTest` intention-count tests updated for the trailing Suppress entry

## Notes
- PSI-level integration tests (actually rewriting Kotlin/Java files) require an IntelliJ `BasePlatformTestCase` fixture that the plugin doesn't yet wire up. The PSI code paths are thin wrappers around the tested pure helpers; bringing up a fixture is reasonable follow-up work for a separate PR.