### PR TITLE
fix(oracle): default small miss sets to persistent daemon

### DIFF
--- a/internal/oracle/invoke_cached.go
+++ b/internal/oracle/invoke_cached.go
@@ -687,7 +687,23 @@ func configuredDaemonCacheMode() string {
 	}
 }
 
-func shouldUseOneShotMissAnalysis(poolSize int) (bool, string) {
+// daemonPreferredMissThreshold is the upper bound on miss count below
+// which the persistent single-daemon path beats parallel one-shot by
+// a wide margin. Reasoning: parallel one-shot's win comes from running
+// `defaultKritTypesParallelFiles` analyses concurrently inside a fresh
+// JVM, paying JVM cold-start (~30-60s on first run, ~JIT-warm time
+// subsequently) once per invocation. For a small miss set the
+// parallelism can't accelerate the work — a 1-file or 2-file analysis
+// finishes in milliseconds — so the cold-start cost dominates.
+// A reused daemon serves those same misses without paying startup at
+// all on warm reruns. Threshold of 8 leaves enough headroom that the
+// occasional handful of ABI-driven changes still hit the fast path
+// while keeping large cache-miss waves on the parallel one-shot path.
+//
+// KRIT_DAEMON_CACHE=on / =off still wins.
+const daemonPreferredMissThreshold = 8
+
+func shouldUseOneShotMissAnalysis(poolSize, misses int) (bool, string) {
 	switch configuredDaemonCacheMode() {
 	case "off":
 		return true, "KRIT_DAEMON_CACHE=off"
@@ -695,6 +711,12 @@ func shouldUseOneShotMissAnalysis(poolSize int) (bool, string) {
 		return false, ""
 	}
 	if poolSize > 1 {
+		return false, ""
+	}
+	// Small miss sets: the persistent daemon amortizes JVM cold-start
+	// across reruns, which dominates the per-file analysis cost for
+	// ABI-sized changes (typically 1-few files).
+	if misses > 0 && misses <= daemonPreferredMissThreshold {
 		return false, ""
 	}
 	if workers := configuredKritTypesParallelFiles(); workers > 1 {
@@ -1047,7 +1069,7 @@ func runMissAnalysis(
 	}
 
 	poolSize := configuredDaemonPoolSize(len(misses))
-	if useOneShot, reason := shouldUseOneShotMissAnalysis(poolSize); useOneShot {
+	if useOneShot, reason := shouldUseOneShotMissAnalysis(poolSize, len(misses)); useOneShot {
 		return fallback(reason)
 	}
 

--- a/internal/oracle/invoke_cached_sharded_test.go
+++ b/internal/oracle/invoke_cached_sharded_test.go
@@ -36,15 +36,33 @@ func TestConfiguredKritTypesShards(t *testing.T) {
 	}
 }
 
-func TestShouldUseOneShotMissAnalysisDefaultsToParallelOneShot(t *testing.T) {
+func TestShouldUseOneShotMissAnalysisSmallMissDefaultsToDaemon(t *testing.T) {
 	t.Setenv("KRIT_DAEMON_CACHE", "")
 	t.Setenv("KRIT_DAEMON_POOL", "")
 	t.Setenv("KRIT_TYPES_PARALLEL_FILES", "")
 	t.Setenv("KRIT_TYPES_SHARDS", "")
 
-	got, reason := shouldUseOneShotMissAnalysis(1)
+	// 1-file warm-rerun miss (the dominant warm-cache workload):
+	// must route to the persistent daemon. Parallel one-shot can't
+	// parallelize a 1-file analysis and the JVM cold-start dominates.
+	got, reason := shouldUseOneShotMissAnalysis(1, 1)
+	if got {
+		t.Fatalf("1 miss should use the persistent daemon, got one-shot (reason=%q)", reason)
+	}
+}
+
+func TestShouldUseOneShotMissAnalysisLargeMissDefaultsToParallelOneShot(t *testing.T) {
+	t.Setenv("KRIT_DAEMON_CACHE", "")
+	t.Setenv("KRIT_DAEMON_POOL", "")
+	t.Setenv("KRIT_TYPES_PARALLEL_FILES", "")
+	t.Setenv("KRIT_TYPES_SHARDS", "")
+
+	// Above the threshold parallel one-shot's in-JVM file-worker
+	// parallelism wins; preserve the historical default for this
+	// regime.
+	got, reason := shouldUseOneShotMissAnalysis(1, daemonPreferredMissThreshold+1)
 	if !got {
-		t.Fatalf("default miss analysis should use one-shot")
+		t.Fatalf("large miss set should use parallel one-shot, got daemon (reason=%q)", reason)
 	}
 	if !strings.Contains(reason, "default parallel one-shot") {
 		t.Fatalf("reason = %q, want default parallel one-shot", reason)
@@ -56,7 +74,7 @@ func TestShouldUseOneShotMissAnalysisHonorsDaemonOptIn(t *testing.T) {
 	t.Setenv("KRIT_TYPES_PARALLEL_FILES", "")
 	t.Setenv("KRIT_TYPES_SHARDS", "")
 
-	got, reason := shouldUseOneShotMissAnalysis(1)
+	got, reason := shouldUseOneShotMissAnalysis(1, 100)
 	if got {
 		t.Fatalf("KRIT_DAEMON_CACHE=on should use daemon path, reason=%q", reason)
 	}
@@ -67,7 +85,7 @@ func TestShouldUseOneShotMissAnalysisHonorsDaemonPoolOptIn(t *testing.T) {
 	t.Setenv("KRIT_TYPES_PARALLEL_FILES", "")
 	t.Setenv("KRIT_TYPES_SHARDS", "")
 
-	got, reason := shouldUseOneShotMissAnalysis(2)
+	got, reason := shouldUseOneShotMissAnalysis(2, 100)
 	if got {
 		t.Fatalf("daemon pool should use daemon path, reason=%q", reason)
 	}
@@ -78,7 +96,7 @@ func TestShouldUseOneShotMissAnalysisHonorsExplicitOff(t *testing.T) {
 	t.Setenv("KRIT_TYPES_PARALLEL_FILES", "0")
 	t.Setenv("KRIT_TYPES_SHARDS", "")
 
-	got, reason := shouldUseOneShotMissAnalysis(1)
+	got, reason := shouldUseOneShotMissAnalysis(1, 1)
 	if !got {
 		t.Fatal("KRIT_DAEMON_CACHE=off should force one-shot")
 	}


### PR DESCRIPTION
## Summary
\`shouldUseOneShotMissAnalysis\` sent every default-config miss request through parallel one-shot whenever \`KRIT_TYPES_PARALLEL_FILES\` (default 4) was set — paying a full JVM cold-start (~30–60s on macOS with AppCDS) per invocation. That's right for large miss lists, where the in-JVM file-worker parallelism amortizes startup. For ABI-driven warm reruns (typically 1 to a handful of misses) the parallelism can't accelerate the analysis at all and the JVM cold-start dominates wall time.

Stacks on top of [#548](https://github.com/kaeawc/krit/pull/548) and [#549](https://github.com/kaeawc/krit/pull/549) — together those eliminate phantom misses, this PR cuts the cost of *real* misses on warm reruns.

## Behavior
Routes miss counts up to \`daemonPreferredMissThreshold\` (= 8) through the existing \`ConnectOrStartDaemon\` path. The single persistent daemon amortizes startup across reruns via the per-repo PID file — second and later invocations skip JVM cold-start entirely. Large miss sets (cold first run, mass ABI changes, etc.) still take the parallel one-shot path.

Opt-ins still win: \`KRIT_DAEMON_CACHE=on\` / \`=off\` and the daemon-pool path (\`KRIT_DAEMON_POOL\` + misses ≥ 50) supersede the new threshold.

## Observed
Against \`~/github/kotlin\` warm rerun with 1 real miss (an ABI probe in \`generators/builtins/iterators.kt\`):
- Before: ~57–76s (the entire scan was dominated by one-shot krit-fir JVM launch).
- After (when daemon warm): sub-second analysis path.

## Test plan
- [x] \`TestShouldUseOneShotMissAnalysisSmallMissDefaultsToDaemon\` (new) — asserts 1-miss request uses daemon.
- [x] \`TestShouldUseOneShotMissAnalysisLargeMissDefaultsToParallelOneShot\` (new) — asserts >threshold still picks parallel one-shot.
- [x] Existing daemon opt-in / pool opt-in / explicit-off tests updated to new signature, still pass.
- [x] \`go test ./internal/oracle/\` (full package).
- [x] \`go vet ./...\`.