### PR TITLE
feat(intellij-plugin): status bar widget + missing-binary notification

### DIFF
--- a/editors/intellij-plugin/src/main/kotlin/dev/jasonpearson/krit/intellij/KritBinaryResolver.kt
+++ b/editors/intellij-plugin/src/main/kotlin/dev/jasonpearson/krit/intellij/KritBinaryResolver.kt
@@ -1,0 +1,24 @@
+package dev.jasonpearson.krit.intellij
+
+import java.io.File
+
+object KritBinaryResolver {
+    // Order of precedence:
+    //   1. -Dkrit.binary
+    //   2. KRIT_BINARY env var
+    //   3. `krit` on PATH
+    fun find(env: Map<String, String> = System.getenv(), props: () -> String? = { System.getProperty("krit.binary") }): File? {
+        val configured = props() ?: env["KRIT_BINARY"]
+        if (configured != null) {
+            val f = File(configured)
+            return if (f.canExecute()) f else null
+        }
+        val pathEntry = env["PATH"] ?: return null
+        for (dir in pathEntry.split(File.pathSeparator)) {
+            if (dir.isBlank()) continue
+            val f = File(dir, "krit")
+            if (f.canExecute()) return f
+        }
+        return null
+    }
+}

--- a/editors/intellij-plugin/src/main/kotlin/dev/jasonpearson/krit/intellij/KritProjectService.kt
+++ b/editors/intellij-plugin/src/main/kotlin/dev/jasonpearson/krit/intellij/KritProjectService.kt
@@ -1,6 +1,8 @@
 package dev.jasonpearson.krit.intellij
 
 import com.intellij.codeInsight.daemon.DaemonCodeAnalyzer
+import com.intellij.notification.NotificationGroupManager
+import com.intellij.notification.NotificationType
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.diagnostic.Logger
@@ -11,6 +13,7 @@ import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.ProjectFileIndex
 import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.openapi.wm.WindowManager
 import java.io.File
 import java.util.concurrent.Executors
 import java.util.concurrent.ScheduledFuture
@@ -42,6 +45,12 @@ class KritProjectService(private val project: Project) : Disposable {
 
     @Volatile
     private var lastReportJson: String = ""
+
+    @Volatile
+    var state: KritState = KritState.Initializing
+        private set
+
+    private val missingBinaryNotified = AtomicBoolean(false)
 
     init {
         EditorFactory.getInstance().eventMulticaster.addDocumentListener(documentListener, this)
@@ -107,10 +116,49 @@ class KritProjectService(private val project: Project) : Disposable {
     }
 
     private fun refreshFindings() {
-        val result = KritRunner.analyzeProject(project)
-        findingsByFile = result.report.findings.groupBy { canonicalPath(it.file, project.basePath) }
-        lastReportJson = result.rawJson
+        transition(KritState.Scanning)
+        when (val outcome = KritRunner.analyzeProject(project)) {
+            is KritRunner.AnalyzeOutcome.Success -> {
+                findingsByFile = outcome.report.findings.groupBy {
+                    canonicalPath(it.file, project.basePath)
+                }
+                lastReportJson = outcome.rawJson
+                transition(KritState.Idle(outcome.report.findings.size))
+            }
+            is KritRunner.AnalyzeOutcome.MissingBinary -> {
+                findingsByFile = emptyMap()
+                lastReportJson = ""
+                transition(KritState.MissingBinary)
+                notifyMissingBinaryOnce()
+            }
+            is KritRunner.AnalyzeOutcome.Failure -> {
+                transition(KritState.Error(outcome.message))
+            }
+        }
         restartHighlighting()
+    }
+
+    private fun transition(next: KritState) {
+        state = next
+        ApplicationManager.getApplication().invokeLater {
+            if (project.isDisposed) return@invokeLater
+            WindowManager.getInstance().getStatusBar(project)?.updateWidget(KritStatusBarWidget.ID)
+        }
+    }
+
+    private fun notifyMissingBinaryOnce() {
+        if (!missingBinaryNotified.compareAndSet(false, true)) return
+        ApplicationManager.getApplication().invokeLater {
+            if (project.isDisposed) return@invokeLater
+            NotificationGroupManager.getInstance()
+                .getNotificationGroup("Krit")
+                .createNotification(
+                    "Krit binary not found",
+                    "Set -Dkrit.binary or KRIT_BINARY, or install krit on PATH.",
+                    NotificationType.WARNING,
+                )
+                .notify(project)
+        }
     }
 
     private fun scheduleScan(delayMs: Long) {

--- a/editors/intellij-plugin/src/main/kotlin/dev/jasonpearson/krit/intellij/KritRunner.kt
+++ b/editors/intellij-plugin/src/main/kotlin/dev/jasonpearson/krit/intellij/KritRunner.kt
@@ -8,18 +8,19 @@ import java.util.concurrent.TimeUnit
 object KritRunner {
     private val log = Logger.getInstance(KritRunner::class.java)
 
-    data class AnalyzeResult(val report: KritReport, val rawJson: String) {
-        companion object {
-            val EMPTY = AnalyzeResult(KritReport(), "")
-        }
+    sealed class AnalyzeOutcome {
+        data class Success(val report: KritReport, val rawJson: String) : AnalyzeOutcome()
+        object MissingBinary : AnalyzeOutcome()
+        data class Failure(val message: String) : AnalyzeOutcome()
     }
 
-    fun analyzeProject(project: Project): AnalyzeResult {
-        val projectDir = project.baseDir() ?: return AnalyzeResult.EMPTY
+    fun analyzeProject(project: Project): AnalyzeOutcome {
+        val projectDir = project.baseDir() ?: return AnalyzeOutcome.Failure("project has no base path")
+        val binary = KritBinaryResolver.find() ?: return AnalyzeOutcome.MissingBinary
         val output = File.createTempFile("krit-intellij-", ".json")
         return try {
             val command = listOf(
-                kritBinary(),
+                binary.absolutePath,
                 "--format=json",
                 "-o",
                 output.absolutePath,
@@ -28,15 +29,20 @@ object KritRunner {
             )
             // krit exits non-zero when it reports findings; trust the output
             // file as long as it exists rather than the exit code.
-            val ok = runKrit(projectDir, command, ANALYZE_TIMEOUT_SECONDS, "project analysis") { exit, _ ->
+            val result = runKrit(projectDir, command, ANALYZE_TIMEOUT_SECONDS, "project analysis") { exit, _ ->
                 exit == 0 || output.isFile
             }
-            if (!ok) return AnalyzeResult.EMPTY
-            val raw = output.readText()
-            AnalyzeResult(KritJsonParser.parse(raw), raw)
+            when (result) {
+                is RunOutcome.Ok -> {
+                    val raw = output.readText()
+                    AnalyzeOutcome.Success(KritJsonParser.parse(raw), raw)
+                }
+                is RunOutcome.MissingBinary -> AnalyzeOutcome.MissingBinary
+                is RunOutcome.Failed -> AnalyzeOutcome.Failure(result.message)
+            }
         } catch (t: Throwable) {
             log.warn("krit project analysis failed for ${projectDir.path}", t)
-            AnalyzeResult.EMPTY
+            AnalyzeOutcome.Failure(t.message ?: "unknown error")
         } finally {
             output.delete()
         }
@@ -44,16 +50,17 @@ object KritRunner {
 
     fun fixProject(project: Project, fixLevel: String?): Boolean {
         val projectDir = project.baseDir() ?: return false
+        val binary = KritBinaryResolver.find() ?: return false
         val level = KritFixLabels.normalizeFixLevel(fixLevel)
         val command = listOf(
-            kritBinary(),
+            binary.absolutePath,
             "--fix",
             "--fix-level",
             level,
             "-q",
             projectDir.absolutePath,
         )
-        return runKrit(projectDir, command, FIX_TIMEOUT_SECONDS, "fix") { exit, _ -> exit == 0 }
+        return runKrit(projectDir, command, FIX_TIMEOUT_SECONDS, "fix") { exit, _ -> exit == 0 } is RunOutcome.Ok
     }
 
     fun applySuggestion(
@@ -63,6 +70,7 @@ object KritRunner {
         reportJson: String,
     ): Boolean {
         val projectDir = project.baseDir() ?: return false
+        val binary = KritBinaryResolver.find() ?: return false
         if (reportJson.isBlank()) {
             log.warn("krit apply-suggestion skipped: no cached report for ${projectDir.path}")
             return false
@@ -71,7 +79,7 @@ object KritRunner {
         return try {
             reportFile.writeText(reportJson)
             val command = listOf(
-                kritBinary(),
+                binary.absolutePath,
                 "apply-suggestion",
                 "--finding",
                 findingId,
@@ -83,10 +91,16 @@ object KritRunner {
             )
             runKrit(projectDir, command, APPLY_SUGGESTION_TIMEOUT_SECONDS, "apply-suggestion") { exit, _ ->
                 exit == 0
-            }
+            } is RunOutcome.Ok
         } finally {
             reportFile.delete()
         }
+    }
+
+    private sealed class RunOutcome {
+        object Ok : RunOutcome()
+        object MissingBinary : RunOutcome()
+        data class Failed(val message: String) : RunOutcome()
     }
 
     private fun runKrit(
@@ -95,7 +109,7 @@ object KritRunner {
         timeoutSeconds: Long,
         label: String,
         isSuccess: (exit: Int, stderr: String) -> Boolean,
-    ): Boolean {
+    ): RunOutcome {
         return try {
             val process = ProcessBuilder(command)
                 .directory(projectDir)
@@ -105,27 +119,29 @@ object KritRunner {
 
             if (!process.waitFor(timeoutSeconds, TimeUnit.SECONDS)) {
                 process.destroyForcibly()
-                log.warn("krit $label timed out for ${projectDir.path}")
-                return false
+                val msg = "krit $label timed out after ${timeoutSeconds}s"
+                log.warn("$msg for ${projectDir.path}")
+                return RunOutcome.Failed(msg)
             }
 
             val stderr = process.errorStream.bufferedReader().readText()
             val exit = process.exitValue()
             if (!isSuccess(exit, stderr)) {
-                log.warn("krit $label failed for ${projectDir.path} with exit $exit: $stderr")
-                return false
+                val msg = "krit $label exited $exit: ${stderr.lineSequence().firstOrNull().orEmpty()}"
+                log.warn("$msg for ${projectDir.path}")
+                return RunOutcome.Failed(msg)
             }
-            true
+            RunOutcome.Ok
+        } catch (t: java.io.IOException) {
+            // IOException at start() typically means the binary disappeared
+            // between resolver lookup and exec. Treat it as MissingBinary
+            // so the status surface stays consistent.
+            log.warn("krit $label process start failed for ${projectDir.path}", t)
+            RunOutcome.MissingBinary
         } catch (t: Throwable) {
             log.warn("krit $label failed for ${projectDir.path}", t)
-            false
+            RunOutcome.Failed(t.message ?: "unknown error")
         }
-    }
-
-    private fun kritBinary(): String {
-        return System.getProperty("krit.binary")
-            ?: System.getenv("KRIT_BINARY")
-            ?: "krit"
     }
 
     private fun Project.baseDir(): File? {

--- a/editors/intellij-plugin/src/main/kotlin/dev/jasonpearson/krit/intellij/KritState.kt
+++ b/editors/intellij-plugin/src/main/kotlin/dev/jasonpearson/krit/intellij/KritState.kt
@@ -1,0 +1,30 @@
+package dev.jasonpearson.krit.intellij
+
+sealed class KritState {
+    object Initializing : KritState()
+    object Scanning : KritState()
+    data class Idle(val findingCount: Int) : KritState()
+    object MissingBinary : KritState()
+    data class Error(val message: String) : KritState()
+}
+
+object KritStatusText {
+    fun render(state: KritState): String = when (state) {
+        is KritState.Initializing -> "Krit: starting…"
+        is KritState.Scanning -> "Krit: scanning…"
+        is KritState.Idle -> "Krit: ${state.findingCount}"
+        is KritState.MissingBinary -> "Krit: binary not found"
+        is KritState.Error -> "Krit: error"
+    }
+
+    fun tooltip(state: KritState): String = when (state) {
+        is KritState.Initializing -> "Krit is starting up; click to configure"
+        is KritState.Scanning -> "Krit is analyzing the project; click to configure"
+        is KritState.Idle ->
+            if (state.findingCount == 0) "Krit: no findings; click to configure"
+            else "Krit: ${state.findingCount} finding${if (state.findingCount == 1) "" else "s"}; click to configure"
+        is KritState.MissingBinary ->
+            "Krit binary not found on PATH. Set KRIT_BINARY or -Dkrit.binary; click to configure."
+        is KritState.Error -> "Krit error: ${state.message}; click for the IDE log"
+    }
+}

--- a/editors/intellij-plugin/src/main/kotlin/dev/jasonpearson/krit/intellij/KritStatusBarWidget.kt
+++ b/editors/intellij-plugin/src/main/kotlin/dev/jasonpearson/krit/intellij/KritStatusBarWidget.kt
@@ -1,0 +1,66 @@
+package dev.jasonpearson.krit.intellij
+
+import com.intellij.openapi.components.service
+import com.intellij.openapi.project.DumbAware
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.MessageType
+import com.intellij.openapi.ui.popup.Balloon
+import com.intellij.openapi.ui.popup.JBPopupFactory
+import com.intellij.openapi.wm.StatusBar
+import com.intellij.openapi.wm.StatusBarWidget
+import com.intellij.openapi.wm.StatusBarWidgetFactory
+import com.intellij.ui.awt.RelativePoint
+import com.intellij.util.Consumer
+import java.awt.event.MouseEvent
+
+class KritStatusBarWidgetFactory : StatusBarWidgetFactory {
+    override fun getId(): String = KritStatusBarWidget.ID
+
+    override fun getDisplayName(): String = "Krit"
+
+    override fun isAvailable(project: Project): Boolean = true
+
+    override fun createWidget(project: Project): StatusBarWidget = KritStatusBarWidget(project)
+
+    override fun disposeWidget(widget: StatusBarWidget) {
+        widget.dispose()
+    }
+
+    override fun canBeEnabledOn(statusBar: StatusBar): Boolean = true
+}
+
+class KritStatusBarWidget(private val project: Project) :
+    StatusBarWidget, StatusBarWidget.TextPresentation, DumbAware {
+
+    override fun ID(): String = ID
+
+    override fun getPresentation(): StatusBarWidget.WidgetPresentation = this
+
+    override fun install(statusBar: StatusBar) = Unit
+
+    override fun dispose() = Unit
+
+    override fun getText(): String = KritStatusText.render(project.service<KritProjectService>().state)
+
+    override fun getTooltipText(): String =
+        KritStatusText.tooltip(project.service<KritProjectService>().state)
+
+    override fun getAlignment(): Float = 0.5f
+
+    override fun getClickConsumer(): Consumer<MouseEvent> = Consumer { event ->
+        val state = project.service<KritProjectService>().state
+        val type = when (state) {
+            is KritState.MissingBinary, is KritState.Error -> MessageType.WARNING
+            else -> MessageType.INFO
+        }
+        JBPopupFactory.getInstance()
+            .createHtmlTextBalloonBuilder(KritStatusText.tooltip(state), type, null)
+            .setFadeoutTime(5_000)
+            .createBalloon()
+            .show(RelativePoint(event.component, event.point), Balloon.Position.above)
+    }
+
+    companion object {
+        const val ID: String = "Krit"
+    }
+}

--- a/editors/intellij-plugin/src/main/resources/META-INF/plugin.xml
+++ b/editors/intellij-plugin/src/main/resources/META-INF/plugin.xml
@@ -23,6 +23,11 @@
       level="WARNING"
       shortName="Krit"
       implementationClass="dev.jasonpearson.krit.intellij.KritInspection"/>
+    <statusBarWidgetFactory
+      id="Krit"
+      order="last"
+      implementation="dev.jasonpearson.krit.intellij.KritStatusBarWidgetFactory"/>
+    <notificationGroup id="Krit" displayType="BALLOON"/>
   </extensions>
 
   <extensions defaultExtensionNs="org.jetbrains.kotlin">

--- a/editors/intellij-plugin/src/test/kotlin/dev/jasonpearson/krit/intellij/KritBinaryResolverTest.kt
+++ b/editors/intellij-plugin/src/test/kotlin/dev/jasonpearson/krit/intellij/KritBinaryResolverTest.kt
@@ -1,0 +1,78 @@
+package dev.jasonpearson.krit.intellij
+
+import java.io.File
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class KritBinaryResolverTest {
+    @Test
+    fun `system property overrides environment when both point to executable`() {
+        val systemProp = makeExecutable("from-prop")
+        val envOverride = makeExecutable("from-env")
+        val found = KritBinaryResolver.find(
+            env = mapOf("KRIT_BINARY" to envOverride.absolutePath, "PATH" to ""),
+            props = { systemProp.absolutePath },
+        )
+        assertEquals(systemProp.canonicalFile, found?.canonicalFile)
+    }
+
+    @Test
+    fun `env override is honored when no system property`() {
+        val configured = makeExecutable("from-env")
+        val found = KritBinaryResolver.find(
+            env = mapOf("KRIT_BINARY" to configured.absolutePath, "PATH" to ""),
+            props = { null },
+        )
+        assertEquals(configured.canonicalFile, found?.canonicalFile)
+    }
+
+    @Test
+    fun `configured path that is not executable returns null even when PATH has one`() {
+        // Honor the explicit override exactly: if the user pointed at a
+        // path, that's the binary, not whatever happens to live on PATH.
+        val notExecutable = Files.createTempFile("krit-not-exec", ".txt").toFile()
+        notExecutable.deleteOnExit()
+        val pathBinary = makeExecutable("krit")
+        val found = KritBinaryResolver.find(
+            env = mapOf("KRIT_BINARY" to notExecutable.absolutePath, "PATH" to pathBinary.parentFile.absolutePath),
+            props = { null },
+        )
+        assertNull(found)
+    }
+
+    @Test
+    fun `PATH lookup finds krit in first matching directory`() {
+        val first = makeExecutable("krit", dirNameHint = "first")
+        val second = makeExecutable("krit", dirNameHint = "second")
+        val pathEntry = listOf(first.parentFile.absolutePath, second.parentFile.absolutePath)
+            .joinToString(File.pathSeparator)
+        val found = KritBinaryResolver.find(env = mapOf("PATH" to pathEntry), props = { null })
+        assertEquals(first.canonicalFile, found?.canonicalFile)
+    }
+
+    @Test
+    fun `returns null when no PATH and no override`() {
+        assertNull(KritBinaryResolver.find(env = emptyMap(), props = { null }))
+    }
+
+    @Test
+    fun `skips blank PATH entries`() {
+        val executable = makeExecutable("krit")
+        val pathEntry = listOf("", executable.parentFile.absolutePath, "")
+            .joinToString(File.pathSeparator)
+        val found = KritBinaryResolver.find(env = mapOf("PATH" to pathEntry), props = { null })
+        assertEquals(executable.canonicalFile, found?.canonicalFile)
+    }
+
+    private fun makeExecutable(name: String, dirNameHint: String = "bin"): File {
+        val dir = Files.createTempDirectory("krit-test-$dirNameHint").toFile()
+        dir.deleteOnExit()
+        val f = File(dir, name)
+        f.writeText("#!/bin/sh\nexit 0\n")
+        f.setExecutable(true)
+        f.deleteOnExit()
+        return f
+    }
+}

--- a/editors/intellij-plugin/src/test/kotlin/dev/jasonpearson/krit/intellij/KritStatusTextTest.kt
+++ b/editors/intellij-plugin/src/test/kotlin/dev/jasonpearson/krit/intellij/KritStatusTextTest.kt
@@ -1,0 +1,53 @@
+package dev.jasonpearson.krit.intellij
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class KritStatusTextTest {
+    @Test
+    fun `initializing state renders starting label`() {
+        assertEquals("Krit: starting…", KritStatusText.render(KritState.Initializing))
+    }
+
+    @Test
+    fun `scanning state renders scanning label`() {
+        assertEquals("Krit: scanning…", KritStatusText.render(KritState.Scanning))
+    }
+
+    @Test
+    fun `idle state renders finding count`() {
+        assertEquals("Krit: 0", KritStatusText.render(KritState.Idle(0)))
+        assertEquals("Krit: 42", KritStatusText.render(KritState.Idle(42)))
+    }
+
+    @Test
+    fun `missing binary state renders not-found label`() {
+        assertEquals("Krit: binary not found", KritStatusText.render(KritState.MissingBinary))
+    }
+
+    @Test
+    fun `error state renders generic error label`() {
+        // The detail goes in the tooltip; the status bar text stays short.
+        assertEquals("Krit: error", KritStatusText.render(KritState.Error("boom")))
+    }
+
+    @Test
+    fun `tooltip pluralizes findings correctly`() {
+        assertEquals("Krit: no findings; click to configure", KritStatusText.tooltip(KritState.Idle(0)))
+        assertEquals("Krit: 1 finding; click to configure", KritStatusText.tooltip(KritState.Idle(1)))
+        assertEquals("Krit: 5 findings; click to configure", KritStatusText.tooltip(KritState.Idle(5)))
+    }
+
+    @Test
+    fun `tooltip for error state includes the error message`() {
+        assertTrue("scan timed out" in KritStatusText.tooltip(KritState.Error("scan timed out")))
+    }
+
+    @Test
+    fun `tooltip for missing binary mentions both override mechanisms`() {
+        val msg = KritStatusText.tooltip(KritState.MissingBinary)
+        assertTrue("KRIT_BINARY" in msg)
+        assertTrue("krit.binary" in msg)
+    }
+}


### PR DESCRIPTION
Closes #539.

## Summary
- New status bar widget reflects a sealed `KritState` (Initializing / Scanning / Idle(count) / MissingBinary / Error(message)) — clicking it shows a tooltip balloon with the longer explanation.
- `KritBinaryResolver` is a pure helper for the documented precedence (`-Dkrit.binary`, `KRIT_BINARY`, `krit` on PATH) and is testable without spawning processes.
- `KritRunner.AnalyzeOutcome` replaces the "empty AnalyzeResult on any failure" pattern with a sealed Success / MissingBinary / Failure type, so the status surface stays consistent and missing-binary fires a one-time `Krit` notification balloon.

## Test plan
- [x] `KritStatusTextTest` covers labels for each state, plural-aware tooltip, error-message inclusion, missing-binary tooltip mentions both override mechanisms
- [x] `KritBinaryResolverTest` covers precedence (prop > env > PATH), explicit override does not fall through to PATH when not executable, blank PATH entries skipped, no-PATH case
- [x] Full plugin test suite green: `../../tools/krit-fir/gradlew --project-dir editors/intellij-plugin test`