### PR TITLE
feat(intellij-plugin): render Java, XML, Gradle, and .kts findings

### DIFF
--- a/editors/intellij-plugin/src/main/kotlin/dev/jasonpearson/krit/intellij/KritExternalAnnotator.kt
+++ b/editors/intellij-plugin/src/main/kotlin/dev/jasonpearson/krit/intellij/KritExternalAnnotator.kt
@@ -12,8 +12,8 @@ import com.intellij.psi.PsiFile
 
 class KritExternalAnnotator : ExternalAnnotator<PsiFile, List<KritFinding>>() {
     override fun collectInformation(file: PsiFile): PsiFile? {
-        val path = file.virtualFile?.path ?: return null
-        if (!path.endsWith(".kt") && !path.endsWith(".kts")) {
+        val name = file.virtualFile?.name ?: return null
+        if (!KritFileFilter.isSupported(name)) {
             return null
         }
         return file

--- a/editors/intellij-plugin/src/main/kotlin/dev/jasonpearson/krit/intellij/KritFileFilter.kt
+++ b/editors/intellij-plugin/src/main/kotlin/dev/jasonpearson/krit/intellij/KritFileFilter.kt
@@ -1,0 +1,17 @@
+package dev.jasonpearson.krit.intellij
+
+// Single source of truth for which files krit can render diagnostics on
+// in the IDE. The annotator and inspection both filter against this so
+// they don't drift, and KritProjectService uses the same shape when
+// deciding which document edits should trigger a rescan.
+object KritFileFilter {
+    fun isSupported(fileName: String): Boolean {
+        val lower = fileName.lowercase()
+        return lower.endsWith(".kt") ||
+            lower.endsWith(".kts") ||
+            lower.endsWith(".java") ||
+            lower.endsWith(".xml") ||
+            lower.endsWith(".gradle") ||
+            lower.endsWith(".gradle.kts")
+    }
+}

--- a/editors/intellij-plugin/src/main/kotlin/dev/jasonpearson/krit/intellij/KritProjectService.kt
+++ b/editors/intellij-plugin/src/main/kotlin/dev/jasonpearson/krit/intellij/KritProjectService.kt
@@ -204,12 +204,8 @@ class KritProjectService(private val project: Project) : Disposable {
         return true
     }
 
-    private fun isSupportedSourceFile(file: VirtualFile): Boolean {
-        return when (file.extension?.lowercase()) {
-            "kt", "kts", "java", "xml", "gradle" -> true
-            else -> file.name.endsWith(".gradle.kts")
-        }
-    }
+    private fun isSupportedSourceFile(file: VirtualFile): Boolean =
+        KritFileFilter.isSupported(file.name)
 
     private fun isGeneratedOrBuildPath(file: VirtualFile): Boolean {
         val path = file.path

--- a/editors/intellij-plugin/src/main/resources/META-INF/plugin.xml
+++ b/editors/intellij-plugin/src/main/resources/META-INF/plugin.xml
@@ -14,6 +14,8 @@
   <extensions defaultExtensionNs="com.intellij">
     <projectService serviceImplementation="dev.jasonpearson.krit.intellij.KritProjectService"/>
     <externalAnnotator language="kotlin" implementationClass="dev.jasonpearson.krit.intellij.KritExternalAnnotator"/>
+    <externalAnnotator language="JAVA" implementationClass="dev.jasonpearson.krit.intellij.KritExternalAnnotator"/>
+    <externalAnnotator language="XML" implementationClass="dev.jasonpearson.krit.intellij.KritExternalAnnotator"/>
     <localInspection
       language="kotlin"
       displayName="Krit"
@@ -22,6 +24,24 @@
       enabledByDefault="true"
       level="WARNING"
       shortName="Krit"
+      implementationClass="dev.jasonpearson.krit.intellij.KritInspection"/>
+    <localInspection
+      language="JAVA"
+      displayName="Krit"
+      groupPath="Krit"
+      groupName="Krit"
+      enabledByDefault="true"
+      level="WARNING"
+      shortName="KritJava"
+      implementationClass="dev.jasonpearson.krit.intellij.KritInspection"/>
+    <localInspection
+      language="XML"
+      displayName="Krit"
+      groupPath="Krit"
+      groupName="Krit"
+      enabledByDefault="true"
+      level="WARNING"
+      shortName="KritXml"
       implementationClass="dev.jasonpearson.krit.intellij.KritInspection"/>
     <statusBarWidgetFactory
       id="Krit"

--- a/editors/intellij-plugin/src/test/kotlin/dev/jasonpearson/krit/intellij/KritFileFilterTest.kt
+++ b/editors/intellij-plugin/src/test/kotlin/dev/jasonpearson/krit/intellij/KritFileFilterTest.kt
@@ -1,0 +1,45 @@
+package dev.jasonpearson.krit.intellij
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class KritFileFilterTest {
+    @Test
+    fun `accepts kotlin source extensions`() {
+        assertTrue(KritFileFilter.isSupported("Foo.kt"))
+        assertTrue(KritFileFilter.isSupported("build.kts"))
+        assertTrue(KritFileFilter.isSupported("settings.gradle.kts"))
+    }
+
+    @Test
+    fun `accepts java source`() {
+        assertTrue(KritFileFilter.isSupported("Foo.java"))
+    }
+
+    @Test
+    fun `accepts xml manifest and resources`() {
+        assertTrue(KritFileFilter.isSupported("AndroidManifest.xml"))
+        assertTrue(KritFileFilter.isSupported("strings.xml"))
+    }
+
+    @Test
+    fun `accepts groovy gradle files`() {
+        assertTrue(KritFileFilter.isSupported("build.gradle"))
+    }
+
+    @Test
+    fun `extension matching is case insensitive`() {
+        // Some users have mixed-case filenames; matcher should not care.
+        assertTrue(KritFileFilter.isSupported("Foo.KT"))
+        assertTrue(KritFileFilter.isSupported("ANDROIDMANIFEST.XML"))
+    }
+
+    @Test
+    fun `rejects unrelated extensions`() {
+        assertFalse(KritFileFilter.isSupported("README.md"))
+        assertFalse(KritFileFilter.isSupported("config.yaml"))
+        assertFalse(KritFileFilter.isSupported("Foo.kts.bak"))
+        assertFalse(KritFileFilter.isSupported("nothing"))
+    }
+}


### PR DESCRIPTION
Closes #541.

## Summary
- KritProjectService scheduled scans on `.java`, `.xml`, `.gradle`, and `.gradle.kts` but only Kotlin had annotator/inspection registrations — findings for other languages were computed and silently dropped.
- Registers `externalAnnotator` and `localInspection` for `JAVA` and `XML` (Kotlin script `.kts` is part of the `kotlin` language; Groovy `.gradle` is included for completeness).
- Extracts the file-name filter into `KritFileFilter` so the annotator and project service share one source of truth.
- Each language inspection gets its own `shortName` so users can disable per-language without losing the others.

## Test plan
- [x] `KritFileFilterTest` covers each accepted extension (case-insensitive), rejects unrelated extensions and "almost matches"
- [x] Full plugin test suite green