### PR TITLE
feat(scan,intellij-plugin): per-finding --fix via --finding-id

### DIFF
--- a/editors/intellij-plugin/src/main/kotlin/dev/jasonpearson/krit/intellij/KritExternalAnnotator.kt
+++ b/editors/intellij-plugin/src/main/kotlin/dev/jasonpearson/krit/intellij/KritExternalAnnotator.kt
@@ -77,21 +77,24 @@ object KritIntentions {
             return applicable.map { KritApplySuggestionIntention(finding.findingId, it) } + suppress
         }
         if (finding.fixable) {
-            return listOf(KritApplyFixesIntention(finding.fixLevel), suppress)
+            return listOf(KritApplyFixesIntention(finding.fixLevel, finding.findingId), suppress)
         }
         return listOf(suppress)
     }
 }
 
-class KritApplyFixesIntention(private val fixLevel: String?) : IntentionAction {
-    override fun getText(): String = KritFixLabels.applyFixesTitle(fixLevel)
+class KritApplyFixesIntention(
+    private val fixLevel: String?,
+    private val findingId: String,
+) : IntentionAction {
+    override fun getText(): String = KritFixLabels.applyFixTitle(fixLevel)
 
     override fun getFamilyName(): String = text
 
     override fun isAvailable(project: Project, editor: Editor?, file: PsiFile?): Boolean = true
 
     override fun invoke(project: Project, editor: Editor?, file: PsiFile?) {
-        project.service<KritProjectService>().applyFixes(KritFixLabels.normalizeFixLevel(fixLevel))
+        project.service<KritProjectService>().applyFix(KritFixLabels.normalizeFixLevel(fixLevel), findingId)
     }
 
     override fun startInWriteAction(): Boolean = false

--- a/editors/intellij-plugin/src/main/kotlin/dev/jasonpearson/krit/intellij/KritFixLabels.kt
+++ b/editors/intellij-plugin/src/main/kotlin/dev/jasonpearson/krit/intellij/KritFixLabels.kt
@@ -6,8 +6,11 @@ object KritFixLabels {
     fun normalizeFixLevel(fixLevel: String?): String =
         fixLevel.orEmpty().ifBlank { DEFAULT_FIX_LEVEL }
 
-    fun applyFixesTitle(fixLevel: String?): String =
-        "Apply Krit ${normalizeFixLevel(fixLevel)} auto-fixes"
+    // Per-finding label — kept short because IntelliJ truncates intention
+    // text in the editor gutter. Avoids any "all" / "project" wording so
+    // the user doesn't expect a project-wide rewrite from a single click.
+    fun applyFixTitle(fixLevel: String?): String =
+        "Apply Krit ${normalizeFixLevel(fixLevel)} fix"
 
     fun suggestionTitle(suggestion: KritSuggestedFix): String {
         val title = suggestion.title.ifBlank { suggestion.id }

--- a/editors/intellij-plugin/src/main/kotlin/dev/jasonpearson/krit/intellij/KritInspection.kt
+++ b/editors/intellij-plugin/src/main/kotlin/dev/jasonpearson/krit/intellij/KritInspection.kt
@@ -56,15 +56,18 @@ class KritInspection : LocalInspectionTool() {
         if (!finding.fixable) {
             return arrayOf(suppress)
         }
-        return arrayOf(KritApplyFixesQuickFix(finding.fixLevel), suppress)
+        return arrayOf(KritApplyFixesQuickFix(finding.fixLevel, finding.findingId), suppress)
     }
 }
 
-class KritApplyFixesQuickFix(private val fixLevel: String?) : LocalQuickFix {
-    override fun getFamilyName(): String = KritFixLabels.applyFixesTitle(fixLevel)
+class KritApplyFixesQuickFix(
+    private val fixLevel: String?,
+    private val findingId: String,
+) : LocalQuickFix {
+    override fun getFamilyName(): String = KritFixLabels.applyFixTitle(fixLevel)
 
     override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
-        project.service<KritProjectService>().applyFixes(KritFixLabels.normalizeFixLevel(fixLevel))
+        project.service<KritProjectService>().applyFix(KritFixLabels.normalizeFixLevel(fixLevel), findingId)
     }
 }
 

--- a/editors/intellij-plugin/src/main/kotlin/dev/jasonpearson/krit/intellij/KritProjectService.kt
+++ b/editors/intellij-plugin/src/main/kotlin/dev/jasonpearson/krit/intellij/KritProjectService.kt
@@ -61,18 +61,18 @@ class KritProjectService(private val project: Project) : Disposable {
         return findingsByFile[canonicalPath(path)].orEmpty()
     }
 
-    fun applyFixes(fixLevel: String?) {
+    fun applyFix(fixLevel: String?, findingId: String) {
         executor.execute {
             if (project.isDisposed || !running.compareAndSet(false, true)) {
                 rerunAfterCurrent.set(true)
                 return@execute
             }
             try {
-                if (KritRunner.fixProject(project, fixLevel)) {
+                if (KritRunner.fixFinding(project, fixLevel, findingId)) {
                     refreshFindings()
                 }
             } catch (t: Throwable) {
-                log.warn("krit fix runner failed", t)
+                log.warn("krit per-finding fix runner failed", t)
             } finally {
                 running.set(false)
                 scheduleRequestedRerun()

--- a/editors/intellij-plugin/src/main/kotlin/dev/jasonpearson/krit/intellij/KritRunner.kt
+++ b/editors/intellij-plugin/src/main/kotlin/dev/jasonpearson/krit/intellij/KritRunner.kt
@@ -48,7 +48,8 @@ object KritRunner {
         }
     }
 
-    fun fixProject(project: Project, fixLevel: String?): Boolean {
+    fun fixFinding(project: Project, fixLevel: String?, findingId: String): Boolean {
+        if (findingId.isBlank()) return false
         val projectDir = project.baseDir() ?: return false
         val binary = KritBinaryResolver.find() ?: return false
         val level = KritFixLabels.normalizeFixLevel(fixLevel)
@@ -57,6 +58,8 @@ object KritRunner {
             "--fix",
             "--fix-level",
             level,
+            "--finding-id",
+            findingId,
             "-q",
             projectDir.absolutePath,
         )

--- a/editors/intellij-plugin/src/test/kotlin/dev/jasonpearson/krit/intellij/KritJsonParserTest.kt
+++ b/editors/intellij-plugin/src/test/kotlin/dev/jasonpearson/krit/intellij/KritJsonParserTest.kt
@@ -173,7 +173,7 @@ class KritJsonParserTest {
         assertEquals(2, actions.size)
         assertTrue(actions[0] is KritApplyFixesIntention)
         assertTrue(actions[1] is KritSuppressIntention)
-        assertEquals("Apply Krit cosmetic auto-fixes", actions[0].text)
+        assertEquals("Apply Krit cosmetic fix", actions[0].text)
     }
 
     @Test

--- a/internal/cli/scan/daemon_fix.go
+++ b/internal/cli/scan/daemon_fix.go
@@ -43,12 +43,13 @@ func runDaemonFix(f *scanFlags, paths []string, res daemon.AnalyzeProjectResult)
 				Findings: *cols,
 			},
 		},
-		Apply:        *f.Fix && !*f.DryRun,
-		ApplyBinary:  *f.FixBinary,
-		Suffix:       *f.FixSuffix,
-		MaxFixLevel:  maxFixLevel,
-		DryRunBinary: *f.DryRun,
-		CountOnly:    *f.DryRun,
+		Apply:         *f.Fix && !*f.DryRun,
+		ApplyBinary:   *f.FixBinary,
+		Suffix:        *f.FixSuffix,
+		MaxFixLevel:   maxFixLevel,
+		DryRunBinary:  *f.DryRun,
+		CountOnly:     *f.DryRun,
+		OnlyFindingID: *f.FixFindingID,
 	})
 
 	printFixupResult(f, fixRes, start)

--- a/internal/cli/scan/flags.go
+++ b/internal/cli/scan/flags.go
@@ -29,6 +29,7 @@ type scanFlags struct {
 	Fix                      *bool
 	FixSuffix                *string
 	FixLevel                 *string
+	FixFindingID             *string
 	DryRun                   *bool
 	AllRules                 *bool
 	Experimental             *bool
@@ -136,6 +137,7 @@ func registerScanFlags(fs *flag.FlagSet) *scanFlags {
 	f.Fix = fs.Bool("fix", false, "Apply auto-fixes to files")
 	f.FixSuffix = fs.String("fix-suffix", "", "Write fixed files with this suffix instead of editing in place (e.g., '.new')")
 	f.FixLevel = fs.String("fix-level", "idiomatic", "Maximum fix level: cosmetic, idiomatic, semantic")
+	f.FixFindingID = fs.String("finding-id", "", "With --fix: restrict fix application to a single finding id (<rule>:<file>:<line>:<col>)")
 	f.DryRun = fs.Bool("dry-run", false, "Show what --fix would change without modifying files")
 	f.AllRules = fs.Bool("all-rules", false, "Enable all rules including opt-in")
 	f.Experimental = fs.Bool("experimental", false, "Enable rules whose Maturity is experimental (does not enable deprecated rules)")

--- a/internal/cli/scan/runner_state.go
+++ b/internal/cli/scan/runner_state.go
@@ -784,12 +784,13 @@ func (r *runner) runFixup() (handled bool, code int) {
 					Findings: *r.allColumns,
 				},
 			},
-			Apply:        *r.f.Fix && !*r.f.DryRun,
-			ApplyBinary:  *r.f.FixBinary,
-			Suffix:       *r.f.FixSuffix,
-			MaxFixLevel:  r.maxFixLevel,
-			DryRunBinary: *r.f.DryRun,
-			CountOnly:    *r.f.DryRun,
+			Apply:         *r.f.Fix && !*r.f.DryRun,
+			ApplyBinary:   *r.f.FixBinary,
+			Suffix:        *r.f.FixSuffix,
+			MaxFixLevel:   r.maxFixLevel,
+			DryRunBinary:  *r.f.DryRun,
+			CountOnly:     *r.f.DryRun,
+			OnlyFindingID: *r.f.FixFindingID,
 		})
 		postColumns := fixRes.Findings
 		r.allColumns = &postColumns

--- a/internal/pipeline/fixup.go
+++ b/internal/pipeline/fixup.go
@@ -3,12 +3,23 @@ package pipeline
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sort"
 
 	"github.com/kaeawc/krit/internal/fixer"
 	"github.com/kaeawc/krit/internal/rules"
 	api "github.com/kaeawc/krit/internal/rules/api"
 )
+
+// FindingID computes the canonical id used to address a single finding
+// when --finding-id is set (e.g. from the IDE plugin's per-finding fix
+// intention). Format is "<rule>:<file>:<line>:<col>" — stable across
+// daemon/in-process paths so external callers can construct it from
+// the JSON `rule`/`file`/`line`/`column` fields without reading any
+// other state.
+func FindingID(file, rule string, line, col int) string {
+	return fmt.Sprintf("%s:%s:%d:%d", rule, file, line, col)
+}
 
 // FixupInput configures the Fixup phase. It wraps CrossFileResult rather
 // than stuffing options onto the shared result type so non-fix callers
@@ -36,6 +47,12 @@ type FixupInput struct {
 	// text fixes. Useful for --dry-run callers that want the counts but
 	// not the side effects. Has no effect on ApplyBinary.
 	CountOnly bool
+	// OnlyFindingID, when non-empty, restricts fix application to the
+	// single finding whose FindingID(file, rule, line, col) matches.
+	// All other text fixes are stripped before application. Lets per-
+	// finding IDE intentions invoke `krit --fix --finding-id ID` without
+	// rewriting unrelated files.
+	OnlyFindingID string
 }
 
 // FixupPhase applies auto-fixes (text and/or binary) that were attached
@@ -82,6 +99,12 @@ func (FixupPhase) Run(ctx context.Context, in FixupInput) (FixupResult, error) {
 				lvl = rules.FixSemantic
 			}
 			return lvl > in.MaxFixLevel
+		})
+	}
+	if in.OnlyFindingID != "" {
+		columns.StripTextFixes(func(row int) bool {
+			id := FindingID(columns.FileAt(row), columns.RuleAt(row), columns.LineAt(row), columns.ColumnAt(row))
+			return id != in.OnlyFindingID
 		})
 	}
 	fixableCount := columns.CountTextFixes()

--- a/internal/pipeline/fixup_test.go
+++ b/internal/pipeline/fixup_test.go
@@ -68,6 +68,138 @@ func TestFixupPhase_NoOp_WhenApplyFalse(t *testing.T) {
 	}
 }
 
+func TestFindingID_FormatIsStable(t *testing.T) {
+	// The IDE plugin constructs the same id from the JSON fields without
+	// reading any other state. If this format changes, the plugin's
+	// per-finding fix intention breaks silently. Pin it explicitly.
+	got := FindingID("/repo/src/A.kt", "TrailingWhitespace", 7, 12)
+	want := "TrailingWhitespace:/repo/src/A.kt:7:12"
+	if got != want {
+		t.Errorf("FindingID = %q, want %q", got, want)
+	}
+}
+
+func TestFixupPhase_OnlyFindingID_AppliesMatchingFix(t *testing.T) {
+	dir := t.TempDir()
+	targetPath := filepath.Join(dir, "Target.kt")
+	otherPath := filepath.Join(dir, "Other.kt")
+	original := "val x  =  1\n"
+	for _, p := range []string{targetPath, otherPath} {
+		if err := os.WriteFile(p, []byte(original), 0644); err != nil {
+			t.Fatalf("WriteFile %s: %v", p, err)
+		}
+	}
+
+	columns := scanner.CollectFindings([]scanner.Finding{
+		{
+			File:     targetPath,
+			Line:     1,
+			Col:      1,
+			RuleSet:  "style",
+			Rule:     "TrailingWhitespace",
+			Severity: "warning",
+			Message:  "target",
+			Fix: &scanner.Fix{
+				StartLine:   1,
+				EndLine:     1,
+				Replacement: "val x = 1",
+			},
+		},
+		{
+			File:     otherPath,
+			Line:     1,
+			Col:      1,
+			RuleSet:  "style",
+			Rule:     "TrailingWhitespace",
+			Severity: "warning",
+			Message:  "other",
+			Fix: &scanner.Fix{
+				StartLine:   1,
+				EndLine:     1,
+				Replacement: "val x = 1",
+			},
+		},
+	})
+
+	in := FixupInput{
+		CrossFileResult: CrossFileResult{
+			DispatchResult: DispatchResult{
+				Findings: columns,
+			},
+		},
+		Apply:         true,
+		OnlyFindingID: FindingID(targetPath, "TrailingWhitespace", 1, 1),
+	}
+
+	out, err := (FixupPhase{}).Run(context.Background(), in)
+	if err != nil {
+		t.Fatalf("Run: unexpected error: %v", err)
+	}
+	if out.AppliedFixes != 1 {
+		t.Errorf("AppliedFixes = %d, want 1 (target only)", out.AppliedFixes)
+	}
+	if !reflect.DeepEqual(out.ModifiedFiles, []string{targetPath}) {
+		t.Errorf("ModifiedFiles = %v, want [%s]", out.ModifiedFiles, targetPath)
+	}
+
+	got, _ := os.ReadFile(targetPath)
+	if string(got) != "val x = 1\n" {
+		t.Errorf("target file = %q, want %q", string(got), "val x = 1\n")
+	}
+	gotOther, _ := os.ReadFile(otherPath)
+	if string(gotOther) != original {
+		t.Errorf("other file should be unchanged, got %q", string(gotOther))
+	}
+}
+
+func TestFixupPhase_OnlyFindingID_NoMatchAppliesNothing(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "Sample.kt")
+	original := "val x  =  1\n"
+	if err := os.WriteFile(path, []byte(original), 0644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	columns := scanner.CollectFindings([]scanner.Finding{
+		{
+			File:     path,
+			Line:     1,
+			Col:      1,
+			RuleSet:  "style",
+			Rule:     "TrailingWhitespace",
+			Severity: "warning",
+			Message:  "m",
+			Fix: &scanner.Fix{
+				StartLine:   1,
+				EndLine:     1,
+				Replacement: "val x = 1",
+			},
+		},
+	})
+
+	in := FixupInput{
+		CrossFileResult: CrossFileResult{
+			DispatchResult: DispatchResult{
+				Findings: columns,
+			},
+		},
+		Apply:         true,
+		OnlyFindingID: "TrailingWhitespace:/nope.kt:99:99",
+	}
+
+	out, err := (FixupPhase{}).Run(context.Background(), in)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if out.AppliedFixes != 0 {
+		t.Errorf("AppliedFixes = %d, want 0", out.AppliedFixes)
+	}
+	got, _ := os.ReadFile(path)
+	if string(got) != original {
+		t.Errorf("file should be unchanged, got %q", string(got))
+	}
+}
+
 func TestFixupPhase_AppliesCosmeticFix(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "Sample.kt")


### PR DESCRIPTION
Closes #540.

## Summary
- New Go flag \`--finding-id <id>\` restricts \`krit --fix\` to a single finding (\`<rule>:<file>:<line>:<col>\`). Both in-process and daemon-routed fix paths honor it; the daemon never writes user files so application stays CLI-side.
- New \`pipeline.FindingID\` exported helper pins the canonical id format so the plugin and Go side cannot drift.
- IntelliJ plugin's per-finding fix intention now calls \`fixFinding\`/\`applyFix\` instead of the project-wide \`applyFixes\` — clicking the intention on a single finding modifies only the affected file. Action label is short ("Apply Krit cosmetic fix") to make the scope obvious.

## Test plan
- [x] \`TestFindingID_FormatIsStable\` pins the format
- [x] \`TestFixupPhase_OnlyFindingID_AppliesMatchingFix\` — two fixable findings in different files, only the targeted file is modified
- [x] \`TestFixupPhase_OnlyFindingID_NoMatchAppliesNothing\` — stale id is a no-op
- [x] \`KritJsonParserTest\` intention-label assertion updated
- [x] \`go vet\`, \`golangci-lint run\`, package tests for \`internal/pipeline\` and \`internal/cli/scan\` green