### PR TITLE
fix(krit-fir): accept method field as command alias for oracle.Daemon protocol

### DIFF
--- a/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/Main.kt
+++ b/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/Main.kt
@@ -331,7 +331,17 @@ data class CheckRequest(
 
 fun parseRequest(json: String): CheckRequest {
     val id = extractLong(json, "id") ?: throw IllegalArgumentException("Missing 'id' field")
-    val command = extractString(json, "command") ?: throw IllegalArgumentException("Missing 'command' field")
+    // Accept either `command` (krit-fir's native shape) or `method` (the
+    // oracle.Daemon shape used by internal/oracle/daemon.go when it routes
+    // small miss requests through the persistent daemon). The two
+    // protocols are otherwise wire-compatible: regex-based field
+    // extraction is nest-blind, so fields like `files` / `sourceDirs`
+    // get picked up whether they live at the top level (krit-fir) or
+    // inside a `params` object (oracle.Daemon), and the response shape
+    // (id + result + optional errors/cacheDeps) is already shared.
+    val command = extractString(json, "command")
+        ?: extractString(json, "method")
+        ?: throw IllegalArgumentException("Missing 'command' / 'method' field")
     val sourceDirs = extractStringArray(json, "sourceDirs") ?: emptyList()
     val classpath = extractStringArray(json, "classpath") ?: emptyList()
     val rules = extractStringArray(json, "rules") ?: emptyList()

--- a/tools/krit-fir/src/test/kotlin/dev/jasonpearson/krit/fir/OracleDispatchTest.kt
+++ b/tools/krit-fir/src/test/kotlin/dev/jasonpearson/krit/fir/OracleDispatchTest.kt
@@ -123,4 +123,41 @@ class OracleDispatchTest {
         assertTrue(""""error":"Unknown command:""" in response, response)
         assertEquals(true, response.contains("analyzz"), response)
     }
+
+    @Test
+    fun methodFieldIsAcceptedAsCommandAlias() {
+        // Regression: internal/oracle/daemon.go sends requests as
+        // {"id":N,"method":"analyzeWithDeps","params":{...}} when it
+        // routes small miss requests through the persistent daemon.
+        // Before this fix, parseRequest threw on the missing "command"
+        // field, the daemon error-replied with id=null, and the Go side
+        // saw a response ID mismatch and fell back to a fresh one-shot
+        // JVM — defeating the daemon optimization entirely.
+        val request = """{"id":21,"method":"analyzeAll","params":{}}"""
+        val result = handleRequestLine(request, session, startTime = 0L)
+        val response = (result as RequestResult.Response).json
+        assertTrue(response.startsWith("""{"id":21,"result":{"""), response)
+        assertFalse(""""error":""" in response, response)
+    }
+
+    @Test
+    fun methodFieldRoutesAnalyzeWithDepsCorrectly() {
+        // Pin the exact path the oracle.Daemon takes most often: the
+        // analyzeWithDeps round-trip used by small-miss warm reruns.
+        val request = """{"id":22,"method":"analyzeWithDeps","params":{"files":[]}}"""
+        val result = handleRequestLine(request, session, startTime = 0L)
+        val response = (result as RequestResult.Response).json
+        assertTrue(response.startsWith("""{"id":22,"result":{"""), response)
+        assertTrue(""""cacheDeps":""" in response, response)
+    }
+
+    @Test
+    fun missingBothCommandAndMethodStillErrors() {
+        // Negative guard: if neither field is present, parseRequest
+        // must still raise so the daemon never silently processes a
+        // request with no routing.
+        val request = """{"id":23}"""
+        val result = handleRequestLine(request, session, startTime = 0L)
+        assertTrue(result is RequestResult.ParseError, "expected ParseError, got $result")
+    }
 }


### PR DESCRIPTION
## Summary
\`internal/oracle/daemon.go\` sends requests as \`{\"id\":N,\"method\":\"analyzeWithDeps\",\"params\":{...}}\` when it routes small miss requests through the persistent daemon (the warm-rerun fast path introduced by [#552](https://github.com/kaeawc/krit/pull/552)). \`krit-fir\`'s \`parseRequest\` rejected such requests with \"Missing 'command' field\", error-replied with \`id=null\`, and the Go side then saw a response ID mismatch and fell back to a fresh one-shot JVM — defeating the persistent-daemon optimization for the FIR backend entirely.

The two protocols are otherwise wire-compatible:
- Response shape is already shared (\`id\` + \`result\` + optional \`errors\` / \`cacheDeps\`).
- The regex-based field extractors are nest-blind, so top-level krit-fir fields and nested oracle.Daemon \`params.*\` fields both resolve correctly.
- The ready handshake (\`{\"ready\":true,\"port\":N}\`) matches what \`oracle.Daemon\`'s \`waitPortReady\` consumes.

\`parseRequest\` now accepts either \`command\` or \`method\` as the routing field; missing-both still raises so silent mis-dispatches stay impossible.

## Repro
Observed against \`~/github/kotlin\` on the warm rerun + ABI path:
\`\`\`
verbose: daemon cache path falling back to one-shot:
   AnalyzeWithDeps: response ID mismatch: expected 1, got 0
verbose: Running oracle JVM (cached) jar=krit-fir.jar: ...
\`\`\`
The fall-through to one-shot was paying a fresh JVM cold-start (~50–60s) per warm+ABI invocation even though the daemon was running and ready.

## Test plan
- [x] \`OracleDispatchTest\` new cases:
  - \`methodFieldIsAcceptedAsCommandAlias\` — analyzeAll routed via \`method\`.
  - \`methodFieldRoutesAnalyzeWithDepsCorrectly\` — the path oracle.Daemon takes most often.
  - \`missingBothCommandAndMethodStillErrors\` — negative guard so dispatch never silently absorbs a missing routing field.
- [x] \`./gradlew :test --tests \"dev.jasonpearson.krit.fir.OracleDispatchTest\" --rerun-tasks\` (passed).
- [ ] Follow-up benchmark on \`~/github/kotlin\` — expecting warm+ABI to drop from ~60–80s to a few seconds when the daemon is hot.