### PR TITLE
feat(intellij-plugin): per-file scans on document change (daemon Phase 1)

### DIFF
--- a/editors/intellij-plugin/src/main/kotlin/dev/jasonpearson/krit/intellij/KritProjectService.kt
+++ b/editors/intellij-plugin/src/main/kotlin/dev/jasonpearson/krit/intellij/KritProjectService.kt
@@ -15,6 +15,7 @@ import com.intellij.openapi.roots.ProjectFileIndex
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.wm.WindowManager
 import java.io.File
+import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.Executors
 import java.util.concurrent.ScheduledFuture
 import java.util.concurrent.ScheduledExecutorService
@@ -31,10 +32,12 @@ class KritProjectService(private val project: Project) : Disposable {
             Thread(runnable, "krit-project-runner").apply { isDaemon = true }
         }
     private var pendingScan: ScheduledFuture<*>? = null
+    private val pendingFiles = ConcurrentHashMap.newKeySet<String>()
     private val documentListener = object : BulkAwareDocumentListener {
         override fun documentChanged(event: DocumentEvent) {
             val file = FileDocumentManager.getInstance().getFile(event.document) ?: return
             if (shouldTriggerScan(file)) {
+                pendingFiles.add(file.path)
                 scheduleScan(CHANGE_DEBOUNCE_MS)
             }
         }
@@ -106,13 +109,25 @@ class KritProjectService(private val project: Project) : Disposable {
             return
         }
         try {
-            refreshFindings()
+            val targets = drainPendingFiles()
+            if (targets.isEmpty()) {
+                refreshFindings()
+            } else {
+                refreshChangedFiles(targets)
+            }
         } catch (t: Throwable) {
             log.warn("krit project runner failed", t)
         } finally {
             running.set(false)
             scheduleRequestedRerun()
         }
+    }
+
+    private fun drainPendingFiles(): Set<String> {
+        if (pendingFiles.isEmpty()) return emptySet()
+        val snapshot = HashSet(pendingFiles)
+        pendingFiles.removeAll(snapshot)
+        return snapshot
     }
 
     private fun refreshFindings() {
@@ -135,6 +150,41 @@ class KritProjectService(private val project: Project) : Disposable {
                 transition(KritState.Error(outcome.message))
             }
         }
+        restartHighlighting()
+    }
+
+    private fun refreshChangedFiles(paths: Set<String>) {
+        // Per-file rescans replace findings for each changed file in the
+        // running map; other files' findings are untouched. Errors and
+        // missing-binary on any one file bubble up to the state surface
+        // the same way a project scan would so the user still sees the
+        // failure mode in the status bar.
+        transition(KritState.Scanning)
+        val updated = findingsByFile.toMutableMap()
+        for (path in paths) {
+            val canonical = canonicalPath(path, project.basePath)
+            when (val outcome = KritRunner.analyzeFile(project, path)) {
+                is KritRunner.AnalyzeOutcome.Success -> {
+                    val grouped = outcome.report.findings.groupBy {
+                        canonicalPath(it.file, project.basePath)
+                    }
+                    updated[canonical] = grouped[canonical] ?: emptyList()
+                }
+                is KritRunner.AnalyzeOutcome.MissingBinary -> {
+                    transition(KritState.MissingBinary)
+                    notifyMissingBinaryOnce()
+                    restartHighlighting()
+                    return
+                }
+                is KritRunner.AnalyzeOutcome.Failure -> {
+                    transition(KritState.Error(outcome.message))
+                    restartHighlighting()
+                    return
+                }
+            }
+        }
+        findingsByFile = updated
+        transition(KritState.Idle(updated.values.sumOf { it.size }))
         restartHighlighting()
     }
 

--- a/editors/intellij-plugin/src/main/kotlin/dev/jasonpearson/krit/intellij/KritRunner.kt
+++ b/editors/intellij-plugin/src/main/kotlin/dev/jasonpearson/krit/intellij/KritRunner.kt
@@ -14,9 +14,22 @@ object KritRunner {
         data class Failure(val message: String) : AnalyzeOutcome()
     }
 
-    fun analyzeProject(project: Project): AnalyzeOutcome {
+    fun analyzeProject(project: Project): AnalyzeOutcome =
+        runAnalyze(project, target = null, label = "project analysis")
+
+    // Single-file scan. krit accepts a positional path argument and, when
+    // a daemon is running for this repo, the CLI delegates to it instead
+    // of redoing the parse/index work — so per-document-change calls reuse
+    // resident state. This is the cheap incremental path; whole-project
+    // scans stay reserved for initial load, manual refresh, and config
+    // changes.
+    fun analyzeFile(project: Project, filePath: String): AnalyzeOutcome =
+        runAnalyze(project, target = filePath, label = "file analysis")
+
+    private fun runAnalyze(project: Project, target: String?, label: String): AnalyzeOutcome {
         val projectDir = project.baseDir() ?: return AnalyzeOutcome.Failure("project has no base path")
         val binary = KritBinaryResolver.find() ?: return AnalyzeOutcome.MissingBinary
+        val scanPath = target ?: projectDir.absolutePath
         val output = File.createTempFile("krit-intellij-", ".json")
         return try {
             val command = listOf(
@@ -25,11 +38,11 @@ object KritRunner {
                 "-o",
                 output.absolutePath,
                 "-q",
-                projectDir.absolutePath,
+                scanPath,
             )
             // krit exits non-zero when it reports findings; trust the output
             // file as long as it exists rather than the exit code.
-            val result = runKrit(projectDir, command, ANALYZE_TIMEOUT_SECONDS, "project analysis") { exit, _ ->
+            val result = runKrit(projectDir, command, ANALYZE_TIMEOUT_SECONDS, label) { exit, _ ->
                 exit == 0 || output.isFile
             }
             when (result) {
@@ -41,7 +54,7 @@ object KritRunner {
                 is RunOutcome.Failed -> AnalyzeOutcome.Failure(result.message)
             }
         } catch (t: Throwable) {
-            log.warn("krit project analysis failed for ${projectDir.path}", t)
+            log.warn("krit $label failed for ${projectDir.path}", t)
             AnalyzeOutcome.Failure(t.message ?: "unknown error")
         } finally {
             output.delete()


### PR DESCRIPTION
Refs #538. Phase 1 of the daemon-mode work; direct-socket follow-up tracked as #561.

## Summary
- Per-document-change scans previously triggered a full project rescan after a 1s debounce. The plugin now tracks the set of changed file paths and scans just those, falling back to a full project scan only on initial load, manual refresh, and apply-fix / apply-suggestion completion.
- \`KritRunner.analyzeFile(project, filePath)\` reuses the same flag set as \`analyzeProject\` but passes the single file as krit's positional arg. When the krit CLI's daemon delegation is active (auto-spawned on first call), per-file scans hit resident parse cache, cross-file index, and oracle state.
- Per-file results replace just that file's entry in \`findingsByFile\`; other files' findings are untouched.

## What this does NOT include (tracked in #561)
- Direct Unix-socket connection from the plugin to \`.krit/daemon.sock\` — eliminates \`ProcessBuilder.start()\` from the hot path entirely. Needs a Java 16+ UnixDomainSocket client and a Kotlin decoder for the daemon's columnar findings JSON shape.
- Batched \`analyze-buffers\` for multi-file change windows (currently serial per-file invocations).

## Test plan
- [x] Plugin test suite green
- [ ] Manual: edit one file in a multi-module project, observe only that file rescanned in CLI args