### PR TITLE
refactor(rules): extract RelaxedMockUsedForValueClassRule (paired with registry)

### DIFF
--- a/internal/rules/registry_testing_quality.go
+++ b/internal/rules/registry_testing_quality.go
@@ -599,33 +599,7 @@ func registerTestingQualityTestInheritanceDepth() {
 	})
 }
 
-func registerTestingQualityRelaxedMockUsedForValueClass() {
-	r := &RelaxedMockUsedForValueClassRule{
-		BaseRule: BaseRule{RuleName: "RelaxedMockUsedForValueClass", RuleSetName: testingQualityRuleSet, Sev: "info", Desc: "Detects relaxed mocks of primitive or value types where literal values should be used instead."},
-	}
-	api.Register(&api.Rule{
-		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
-		NodeTypes: []string{"call_expression"}, Confidence: api.ConfidenceMedium, Implementation: r,
-		Check: func(ctx *api.Context) {
-			idx, file := ctx.Idx, ctx.File
-			if flatCallNameAny(file, idx) != "mockk" {
-				return
-			}
-			relaxedArg := flatNamedValueArgument(file, flatCallKeyArguments(file, idx), "relaxed")
-			if relaxedArg == 0 || !callArgHasBoolean(file, relaxedArg, true) {
-				return
-			}
-			typeArg := testingQualityTypeArgument(file, idx)
-			if typeArg == "" {
-				return
-			}
-			if !primitiveTypes[typeArg] {
-				return
-			}
-			ctx.EmitAt(file.FlatRow(idx)+1, file.FlatCol(idx)+1, "Don't mock primitives/value types; use literal values.")
-		},
-	})
-}
+// registerTestingQualityRelaxedMockUsedForValueClass lives in testing_quality_relaxed_mock.go.
 
 func registerTestingQualitySpyOnDataClass() {
 	r := &SpyOnDataClassRule{

--- a/internal/rules/testing_quality.go
+++ b/internal/rules/testing_quality.go
@@ -233,21 +233,7 @@ type TestInheritanceDepthRule struct {
 
 func (r *TestInheritanceDepthRule) Confidence() float64 { return api.ConfidenceMediumLow }
 
-// ---------------------------------------------------------------------------
-// RelaxedMockUsedForValueClassRule
-// ---------------------------------------------------------------------------
-
-type RelaxedMockUsedForValueClassRule struct {
-	FlatDispatchBase
-	BaseRule
-}
-
-func (r *RelaxedMockUsedForValueClassRule) Confidence() float64 { return api.ConfidenceMedium }
-
-var primitiveTypes = map[string]bool{
-	"Int": true, "Long": true, "Float": true, "Double": true,
-	"Boolean": true, "String": true, "Byte": true, "Short": true, "Char": true,
-}
+// RelaxedMockUsedForValueClassRule lives in testing_quality_relaxed_mock.go.
 
 // ---------------------------------------------------------------------------
 // SpyOnDataClassRule
@@ -1910,27 +1896,6 @@ func testingQualityReturnType(file *scanner.File, idx uint32) string {
 		}
 	}
 	return ""
-}
-
-func testingQualityTypeArgument(file *scanner.File, idx uint32) string {
-	if file == nil || idx == 0 {
-		return ""
-	}
-	result := ""
-	file.FlatWalkAllNodes(idx, func(n uint32) {
-		if result != "" {
-			return
-		}
-		if file.FlatType(n) == "type_arguments" {
-			for gc := file.FlatFirstChild(n); gc != 0; gc = file.FlatNextSib(gc) {
-				if file.FlatType(gc) == "type_projection" || file.FlatType(gc) == "user_type" || file.FlatType(gc) == "type_identifier" {
-					result = strings.TrimSpace(file.FlatNodeText(gc))
-					return
-				}
-			}
-		}
-	})
-	return result
 }
 
 func testingQualitySupertypes(file *scanner.File, classDecl uint32) []string {

--- a/internal/rules/testing_quality_relaxed_mock.go
+++ b/internal/rules/testing_quality_relaxed_mock.go
@@ -1,0 +1,78 @@
+package rules
+
+// Testing-quality rule: RelaxedMockUsedForValueClass. Flags
+// mockk(relaxed = true) calls whose type argument is a primitive /
+// value-class type — those should use literal values instead.
+//
+// Extracted from testing_quality.go and registry_testing_quality.go as
+// part of the god-file split. Pairs the rule struct, its Confidence()
+// method, the primitiveTypes table, the testingQualityTypeArgument
+// helper, and the registration closure that drives the check.
+
+import (
+	"strings"
+
+	api "github.com/kaeawc/krit/internal/rules/api"
+	"github.com/kaeawc/krit/internal/scanner"
+)
+
+type RelaxedMockUsedForValueClassRule struct {
+	FlatDispatchBase
+	BaseRule
+}
+
+func (r *RelaxedMockUsedForValueClassRule) Confidence() float64 { return api.ConfidenceMedium }
+
+var primitiveTypes = map[string]bool{
+	"Int": true, "Long": true, "Float": true, "Double": true,
+	"Boolean": true, "String": true, "Byte": true, "Short": true, "Char": true,
+}
+
+func testingQualityTypeArgument(file *scanner.File, idx uint32) string {
+	if file == nil || idx == 0 {
+		return ""
+	}
+	result := ""
+	file.FlatWalkAllNodes(idx, func(n uint32) {
+		if result != "" {
+			return
+		}
+		if file.FlatType(n) == "type_arguments" {
+			for gc := file.FlatFirstChild(n); gc != 0; gc = file.FlatNextSib(gc) {
+				if file.FlatType(gc) == "type_projection" || file.FlatType(gc) == "user_type" || file.FlatType(gc) == "type_identifier" {
+					result = strings.TrimSpace(file.FlatNodeText(gc))
+					return
+				}
+			}
+		}
+	})
+	return result
+}
+
+func registerTestingQualityRelaxedMockUsedForValueClass() {
+	r := &RelaxedMockUsedForValueClassRule{
+		BaseRule: BaseRule{RuleName: "RelaxedMockUsedForValueClass", RuleSetName: testingQualityRuleSet, Sev: "info", Desc: "Detects relaxed mocks of primitive or value types where literal values should be used instead."},
+	}
+	api.Register(&api.Rule{
+		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
+		NodeTypes: []string{"call_expression"}, Confidence: api.ConfidenceMedium, Implementation: r,
+		Check: func(ctx *api.Context) {
+			idx, file := ctx.Idx, ctx.File
+			if flatCallNameAny(file, idx) != "mockk" {
+				return
+			}
+			relaxedArg := flatNamedValueArgument(file, flatCallKeyArguments(file, idx), "relaxed")
+			if relaxedArg == 0 || !callArgHasBoolean(file, relaxedArg, true) {
+				return
+			}
+			typeArg := testingQualityTypeArgument(file, idx)
+			if typeArg == "" {
+				return
+			}
+			if !primitiveTypes[typeArg] {
+				return
+			}
+			ctx.EmitAt(file.FlatRow(idx)+1, file.FlatCol(idx)+1, "Don't mock primitives/value types; use literal values.")
+		},
+	})
+}


### PR DESCRIPTION
## Summary
\`testing_quality.go\` and \`registry_testing_quality.go\` follow a paired split: rule struct + helpers live in the former, the \`Check\` closure lives in the latter. This PR demonstrates the paired-extraction shape by collecting everything for one rule into one new file.

Moved into \`internal/rules/testing_quality_relaxed_mock.go\`:
- \`RelaxedMockUsedForValueClassRule\` struct + \`Confidence()\` method (was \`testing_quality.go\`)
- \`primitiveTypes\` var (was \`testing_quality.go\`)
- \`testingQualityTypeArgument\` helper (was \`testing_quality.go\`)
- \`registerTestingQualityRelaxedMockUsedForValueClass()\` registry closure (was \`registry_testing_quality.go\`)

All four artifacts were only referenced by this rule. The registration call site in \`registerTestingQualityRules()\` fires the same function — same Go package, nothing else changes.

This is a template more than a payoff: 35 LOC out of testing_quality.go's 1983. Sets the pattern for further rule-by-rule paired extractions.

## Test plan
- [x] \`go build ./...\`
- [x] \`go vet ./...\`
- [x] \`golangci-lint run ./...\` (0 issues)
- [x] \`go test ./internal/rules/ -count=1\` (pass)