### PR TITLE
feat(intellij-plugin): wire IDE-resolved classpath into krit invocation

### DIFF
--- a/editors/intellij-plugin/src/main/kotlin/dev/jasonpearson/krit/intellij/KritClasspathResolver.kt
+++ b/editors/intellij-plugin/src/main/kotlin/dev/jasonpearson/krit/intellij/KritClasspathResolver.kt
@@ -1,0 +1,45 @@
+package dev.jasonpearson.krit.intellij
+
+import com.intellij.openapi.application.ReadAction
+import com.intellij.openapi.module.ModuleManager
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.roots.OrderEnumerator
+import java.io.File
+
+object KritClasspathResolver {
+    // Walks every module's resolved order entries (compile + runtime,
+    // recursively into module dependencies) and collects the unique
+    // class-output and library-jar paths. Krit's Go side reads CLASSPATH
+    // via splitEnvClasspath in oracle_classpath.go, so we pass this
+    // through as an env var rather than inventing a new CLI flag.
+    //
+    // Runs inside a ReadAction because Module / OrderEnumerator access
+    // requires it. The walk is in-memory only — no I/O — so it's cheap
+    // enough to call per scan without caching.
+    fun resolve(project: Project): List<File> {
+        return ReadAction.compute<List<File>, RuntimeException> {
+            val seen = LinkedHashSet<File>()
+            for (module in ModuleManager.getInstance(project).modules) {
+                val paths = OrderEnumerator.orderEntries(module)
+                    .recursively()
+                    .classes()
+                    .pathsList
+                    .pathList
+                for (path in paths) {
+                    if (path.isNullOrBlank()) continue
+                    val file = File(path)
+                    if (file.exists()) {
+                        seen.add(file)
+                    }
+                }
+            }
+            seen.toList()
+        }
+    }
+
+    // Joins to the platform classpath form (CLASSPATH env var convention:
+    // `:` on Unix, `;` on Windows). Empty list returns empty string, which
+    // splitEnvClasspath then treats as no classpath.
+    fun toClasspathString(entries: List<File>): String =
+        entries.joinToString(File.pathSeparator) { it.absolutePath }
+}

--- a/editors/intellij-plugin/src/main/kotlin/dev/jasonpearson/krit/intellij/KritRunner.kt
+++ b/editors/intellij-plugin/src/main/kotlin/dev/jasonpearson/krit/intellij/KritRunner.kt
@@ -67,6 +67,7 @@ object KritRunner {
         val projectDir = project.baseDir() ?: return AnalyzeOutcome.Failure("project has no base path")
         val binary = KritBinaryResolver.find() ?: return AnalyzeOutcome.MissingBinary
         val scanPath = target ?: projectDir.absolutePath
+        val classpath = KritClasspathResolver.resolve(project)
         val output = File.createTempFile("krit-intellij-", ".json")
         return try {
             val command = listOf(
@@ -79,7 +80,7 @@ object KritRunner {
             )
             // krit exits non-zero when it reports findings; trust the output
             // file as long as it exists rather than the exit code.
-            val result = runKrit(projectDir, command, ANALYZE_TIMEOUT_SECONDS, label) { exit, _ ->
+            val result = runKrit(projectDir, command, classpath, ANALYZE_TIMEOUT_SECONDS, label) { exit, _ ->
                 exit == 0 || output.isFile
             }
             when (result) {
@@ -102,6 +103,7 @@ object KritRunner {
         if (findingId.isBlank()) return false
         val projectDir = project.baseDir() ?: return false
         val binary = KritBinaryResolver.find() ?: return false
+        val classpath = KritClasspathResolver.resolve(project)
         val level = KritFixLabels.normalizeFixLevel(fixLevel)
         val command = listOf(
             binary.absolutePath,
@@ -113,7 +115,7 @@ object KritRunner {
             "-q",
             projectDir.absolutePath,
         )
-        return runKrit(projectDir, command, FIX_TIMEOUT_SECONDS, "fix") { exit, _ -> exit == 0 } is RunOutcome.Ok
+        return runKrit(projectDir, command, classpath, FIX_TIMEOUT_SECONDS, "fix") { exit, _ -> exit == 0 } is RunOutcome.Ok
     }
 
     fun applySuggestion(
@@ -124,6 +126,7 @@ object KritRunner {
     ): Boolean {
         val projectDir = project.baseDir() ?: return false
         val binary = KritBinaryResolver.find() ?: return false
+        val classpath = KritClasspathResolver.resolve(project)
         if (reportJson.isBlank()) {
             log.warn("krit apply-suggestion skipped: no cached report for ${projectDir.path}")
             return false
@@ -142,7 +145,7 @@ object KritRunner {
                 projectDir.absolutePath,
                 reportFile.absolutePath,
             )
-            runKrit(projectDir, command, APPLY_SUGGESTION_TIMEOUT_SECONDS, "apply-suggestion") { exit, _ ->
+            runKrit(projectDir, command, classpath, APPLY_SUGGESTION_TIMEOUT_SECONDS, "apply-suggestion") { exit, _ ->
                 exit == 0
             } is RunOutcome.Ok
         } finally {
@@ -159,16 +162,25 @@ object KritRunner {
     private fun runKrit(
         projectDir: File,
         command: List<String>,
+        classpath: List<File>,
         timeoutSeconds: Long,
         label: String,
         isSuccess: (exit: Int, stderr: String) -> Boolean,
     ): RunOutcome {
         return try {
-            val process = ProcessBuilder(command)
+            val builder = ProcessBuilder(command)
                 .directory(projectDir)
                 .redirectError(ProcessBuilder.Redirect.PIPE)
                 .redirectOutput(ProcessBuilder.Redirect.PIPE)
-                .start()
+            if (classpath.isNotEmpty()) {
+                // Krit's Go side reads CLASSPATH via splitEnvClasspath in
+                // internal/cli/scan/oracle_classpath.go and threads it into
+                // the FIR/KAA oracle. Setting it here is what makes
+                // type-aware rules in the IDE behave the same as
+                // krit-gradle-plugin runs.
+                builder.environment()["CLASSPATH"] = KritClasspathResolver.toClasspathString(classpath)
+            }
+            val process = builder.start()
 
             if (!process.waitFor(timeoutSeconds, TimeUnit.SECONDS)) {
                 process.destroyForcibly()

--- a/editors/intellij-plugin/src/test/kotlin/dev/jasonpearson/krit/intellij/KritClasspathResolverTest.kt
+++ b/editors/intellij-plugin/src/test/kotlin/dev/jasonpearson/krit/intellij/KritClasspathResolverTest.kt
@@ -1,0 +1,40 @@
+package dev.jasonpearson.krit.intellij
+
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class KritClasspathResolverTest {
+    @Test
+    fun `toClasspathString joins on platform separator`() {
+        val a = File("/path/to/a.jar")
+        val b = File("/path/to/b.jar")
+        assertEquals(
+            listOf(a.absolutePath, b.absolutePath).joinToString(File.pathSeparator),
+            KritClasspathResolver.toClasspathString(listOf(a, b)),
+        )
+    }
+
+    @Test
+    fun `toClasspathString returns empty for empty list`() {
+        // Empty CLASSPATH is what splitEnvClasspath treats as no
+        // classpath; matters so the runner can skip setting the env
+        // var entirely without ambiguity.
+        assertEquals("", KritClasspathResolver.toClasspathString(emptyList()))
+    }
+
+    @Test
+    fun `toClasspathString preserves order and duplicates`() {
+        // Dedup happens earlier in resolve(); toClasspathString is a
+        // pure join — keep it that way so unit tests can pin behaviour
+        // without bringing up an IntelliJ project model.
+        val a = File("/a.jar")
+        val b = File("/b.jar")
+        val result = KritClasspathResolver.toClasspathString(listOf(a, b, a))
+        val parts = result.split(File.pathSeparator)
+        assertEquals(3, parts.size)
+        assertEquals(a.absolutePath, parts[0])
+        assertEquals(b.absolutePath, parts[1])
+        assertEquals(a.absolutePath, parts[2])
+    }
+}


### PR DESCRIPTION
Closes #542.

## Summary
- \`KritClasspathResolver\` walks every module's resolved \`OrderEnumerator\` classes (recursively into module deps), filters to entries that exist on disk, dedupes preserving first-occurrence order.
- \`KritRunner\` sets \`CLASSPATH\` on the ProcessBuilder env when the result is non-empty. Krit's Go side already reads \`CLASSPATH\` via \`splitEnvClasspath\` in \`internal/cli/scan/oracle_classpath.go\` — same path \`krit-gradle-plugin\` uses, so type-aware (KAA/FIR) rules now have parity in the IDE and CI.
- Resolver runs in a \`ReadAction\` (required for project model access) but is in-memory only, so per-scan calls are cheap and pick up Gradle-sync changes automatically.

## Test plan
- [x] \`KritClasspathResolverTest\` covers join, empty list, duplicate preservation
- [x] Full plugin test suite green