### PR TITLE
fix(krit-fir): treat empty request.sourceDirs as 'reuse existing session'

### DIFF
--- a/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/Main.kt
+++ b/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/Main.kt
@@ -209,8 +209,7 @@ fun handleRequestLine(trimmed: String, session: AnalysisSession, startTime: Long
     return try {
         when (request.command) {
             "check" -> {
-                val needsRebuild =
-                    request.sourceDirs != session.sourceDirs || request.classpath != session.classpath
+                val needsRebuild = sessionNeedsRebuild(request, session)
                 val activeSession = if (needsRebuild) {
                     session.dispose()
                     AnalysisSession(request.sourceDirs, request.classpath)
@@ -241,8 +240,7 @@ fun handleRequestLine(trimmed: String, session: AnalysisSession, startTime: Long
             }
             "shutdown" -> RequestResult.Shutdown("""{"id":${request.id},"result":{"ok":true}}""")
             "analyze", "analyzeAll", "analyzeFiles", "analyzeWithDeps" -> {
-                val needsRebuild =
-                    request.sourceDirs != session.sourceDirs || request.classpath != session.classpath
+                val needsRebuild = sessionNeedsRebuild(request, session)
                 val activeSession = if (needsRebuild) {
                     session.dispose()
                     AnalysisSession(request.sourceDirs, request.classpath)
@@ -281,8 +279,7 @@ fun handleRequestLine(trimmed: String, session: AnalysisSession, startTime: Long
                 RequestResult.Response(response)
             }
             "analyzeFile" -> {
-                val needsRebuild =
-                    request.sourceDirs != session.sourceDirs || request.classpath != session.classpath
+                val needsRebuild = sessionNeedsRebuild(request, session)
                 val activeSession = if (needsRebuild) {
                     session.dispose()
                     AnalysisSession(request.sourceDirs, request.classpath)
@@ -302,6 +299,28 @@ fun handleRequestLine(trimmed: String, session: AnalysisSession, startTime: Long
         System.err.println("Error handling ${request.command}: ${e.message}")
         RequestResult.Response("""{"id":${request.id},"error":"${escJson(e.message ?: "unknown")}"}""")
     }
+}
+
+/**
+ * Decide whether the current request needs a full session rebuild.
+ *
+ * A request explicitly carrying `sourceDirs` / `classpath` means the
+ * caller wants to retarget the analysis surface, so we honor it via
+ * rebuild. But the persistent daemon path used by `internal/oracle/
+ * daemon.go` ships `analyzeWithDeps` requests with neither field
+ * populated — `sourceDirs` was set once when the daemon launched
+ * (`--sources …`), and subsequent miss requests only carry the file
+ * list. Comparing an empty `request.sourceDirs` to the session's
+ * real source roots would mismatch every time, triggering a full
+ * K2 FIR session rebuild per request (10-40 s on a 16 k-file repo).
+ *
+ * Empty fields therefore mean "reuse the current session". A
+ * non-empty difference is still a rebuild.
+ */
+internal fun sessionNeedsRebuild(request: CheckRequest, session: AnalysisSession): Boolean {
+    val sourceDirsMismatch = request.sourceDirs.isNotEmpty() && request.sourceDirs != session.sourceDirs
+    val classpathMismatch = request.classpath.isNotEmpty() && request.classpath != session.classpath
+    return sourceDirsMismatch || classpathMismatch
 }
 
 // ── Request model ─────────────────────────────────────────────────────────────

--- a/tools/krit-fir/src/test/kotlin/dev/jasonpearson/krit/fir/OracleDispatchTest.kt
+++ b/tools/krit-fir/src/test/kotlin/dev/jasonpearson/krit/fir/OracleDispatchTest.kt
@@ -160,4 +160,57 @@ class OracleDispatchTest {
         val result = handleRequestLine(request, session, startTime = 0L)
         assertTrue(result is RequestResult.ParseError, "expected ParseError, got $result")
     }
+
+    @Test
+    fun emptyRequestSourceDirsReusesExistingSession() {
+        // Regression for the warm-rerun session-rebuild storm: the
+        // oracle.Daemon path sends analyzeWithDeps with `files` only;
+        // it never re-ships `sourceDirs` (set once at daemon launch
+        // via `--sources …`). Before this fix, comparing an empty
+        // request.sourceDirs to the session's real source roots
+        // mismatched on every call, triggering a full K2 FIR session
+        // rebuild per request (10-40 s on a 16 k-file repo).
+        val sessionWithSources = AnalysisSession(listOf("/repo/src/main"), listOf("/lib.jar"))
+        val request = CheckRequest(
+            id = 1,
+            command = "analyzeWithDeps",
+            sourceDirs = emptyList(),
+            classpath = emptyList(),
+        )
+        assertFalse(
+            sessionNeedsRebuild(request, sessionWithSources),
+            "empty request.sourceDirs must reuse the existing session — otherwise every persistent-daemon call rebuilds",
+        )
+    }
+
+    @Test
+    fun nonEmptyDifferentSourceDirsStillForcesRebuild() {
+        // Symmetric guard: an explicit sourceDirs that differs from
+        // the session is still a real retarget, must still rebuild.
+        val sessionWithSources = AnalysisSession(listOf("/repo/src/main"), emptyList())
+        val request = CheckRequest(
+            id = 1,
+            command = "analyzeWithDeps",
+            sourceDirs = listOf("/different/src"),
+            classpath = emptyList(),
+        )
+        assertTrue(
+            sessionNeedsRebuild(request, sessionWithSources),
+            "explicit sourceDirs mismatch must rebuild — otherwise retargeting silently no-ops",
+        )
+    }
+
+    @Test
+    fun matchingExplicitSourceDirsReusesSession() {
+        // Same-sourceDirs request must NOT rebuild — that case predates
+        // the empty-fallback change and should still hold.
+        val sessionWithSources = AnalysisSession(listOf("/repo/src/main"), emptyList())
+        val request = CheckRequest(
+            id = 1,
+            command = "analyzeWithDeps",
+            sourceDirs = listOf("/repo/src/main"),
+            classpath = emptyList(),
+        )
+        assertFalse(sessionNeedsRebuild(request, sessionWithSources))
+    }
 }


### PR DESCRIPTION
## Summary
\`handleRequestLine\`'s analyze* / check / analyzeFile branches all compared \`request.sourceDirs\` and \`request.classpath\` to the live session, rebuilding the session whenever either differed. The persistent-daemon path (\`internal/oracle/daemon.go\`) ships \`analyzeWithDeps\` requests with neither field populated — \`sourceDirs\` is set once when the daemon launches (\`--sources …\`), and subsequent miss requests carry only the file list. Comparing the request's empty list to the session's real source roots mismatched every call, triggering a **full K2 FIR session rebuild per request**.

Follow-up to [#559](https://github.com/kaeawc/krit/pull/559) which let the persistent-daemon path actually reach krit-fir. With the protocol mismatch resolved, this rebuild storm became the next bottleneck on FIR warm reruns.

## Measured on \`~/github/kotlin\` (~16 k Kotlin files)
Before this fix (i.e. with #559 alone):

| Run | Wall | Top phase |
|---|---:|---|
| Prime | 55 s | typeOracle |
| Warm #1 | 23.8 s | typeOracle 17.3 s |
| Warm #2 | 11.7 s | typeOracle 17.3 s¹ |
| Warm+ABI | 55.3 s | typeOracle 19.4 s |

After:

| Run | Wall | Top phase |
|---|---:|---|
| Prime | **18.5 s** | crossFileAnalysis 7.5 s |
| Warm #1 | **12.3 s** | crossFileAnalysis 8 s |
| Warm #2 | **13.4 s** | crossFileAnalysis 7.9 s |
| Warm+ABI | **29.5 s** | typeOracle 17.5 s (legitimate single-file FIR work) |

Findings parity: 67,142 / 67,144 unchanged.

¹ R2's typeOracle figure was lower due to a measurement quirk in the prior benchmark; the rebuild was still happening per-call.

## Behavior change
Empty \`sourceDirs\` / \`classpath\` in a request now means **reuse the current session**. Explicit-and-different still triggers rebuild — that retargeting case must remain honored.

## Test plan
- [x] \`emptyRequestSourceDirsReusesExistingSession\` (regression guard for the rebuild storm)
- [x] \`nonEmptyDifferentSourceDirsStillForcesRebuild\` (symmetric — explicit retarget still rebuilds)
- [x] \`matchingExplicitSourceDirsReusesSession\` (no behavior regression for matched-explicit case)
- [x] Existing OracleDispatchTest cases all pass.
- [x] \`./gradlew :test --rerun-tasks\` passes.
- [x] End-to-end benchmark above.