### PR TITLE
feat(intellij-plugin): Settings → Tools → Krit panel with persistent state

### DIFF
--- a/editors/intellij-plugin/src/main/kotlin/dev/jasonpearson/krit/intellij/KritBinaryResolver.kt
+++ b/editors/intellij-plugin/src/main/kotlin/dev/jasonpearson/krit/intellij/KritBinaryResolver.kt
@@ -4,11 +4,23 @@ import java.io.File
 
 object KritBinaryResolver {
     // Order of precedence:
-    //   1. -Dkrit.binary
-    //   2. KRIT_BINARY env var
-    //   3. `krit` on PATH
-    fun find(env: Map<String, String> = System.getenv(), props: () -> String? = { System.getProperty("krit.binary") }): File? {
-        val configured = props() ?: env["KRIT_BINARY"]
+    //   1. Settings → Tools → Krit "Krit binary" (when set and executable)
+    //   2. -Dkrit.binary
+    //   3. KRIT_BINARY env var
+    //   4. `krit` on PATH
+    //
+    // A configured override that doesn't resolve (path missing, not
+    // executable) returns null rather than falling through to PATH —
+    // honoring the explicit choice the user made. This keeps debugging
+    // legible: if you set a path, the resolver respects it exactly.
+    fun find(
+        env: Map<String, String> = System.getenv(),
+        props: () -> String? = { System.getProperty("krit.binary") },
+        settings: () -> String? = ::settingsBinaryPath,
+    ): File? {
+        val configured = settings()?.ifBlank { null }
+            ?: props()?.ifBlank { null }
+            ?: env["KRIT_BINARY"]?.ifBlank { null }
         if (configured != null) {
             val f = File(configured)
             return if (f.canExecute()) f else null
@@ -21,4 +33,7 @@ object KritBinaryResolver {
         }
         return null
     }
+
+    private fun settingsBinaryPath(): String? =
+        KritSettingsState.getSafely()?.state?.binaryPath?.takeIf { it.isNotBlank() }
 }

--- a/editors/intellij-plugin/src/main/kotlin/dev/jasonpearson/krit/intellij/KritSettingsConfigurable.kt
+++ b/editors/intellij-plugin/src/main/kotlin/dev/jasonpearson/krit/intellij/KritSettingsConfigurable.kt
@@ -1,0 +1,77 @@
+package dev.jasonpearson.krit.intellij
+
+import com.intellij.openapi.fileChooser.FileChooserDescriptorFactory
+import com.intellij.openapi.options.Configurable
+import com.intellij.openapi.ui.ComboBox
+import com.intellij.openapi.ui.TextFieldWithBrowseButton
+import com.intellij.util.ui.FormBuilder
+import javax.swing.JComponent
+import javax.swing.JPanel
+
+class KritSettingsConfigurable : Configurable {
+    private var form: Form? = null
+
+    override fun getDisplayName(): String = "Krit"
+
+    override fun createComponent(): JComponent {
+        val f = Form()
+        form = f
+        f.load(KritSettingsState.get().state)
+        return f.panel
+    }
+
+    override fun isModified(): Boolean = form?.isModified(KritSettingsState.get().state) ?: false
+
+    override fun apply() {
+        form?.let { KritSettingsState.get().update(it.save()) }
+    }
+
+    override fun reset() {
+        form?.load(KritSettingsState.get().state)
+    }
+
+    override fun disposeUIResources() {
+        form = null
+    }
+
+    private class Form {
+        private val binaryField = TextFieldWithBrowseButton().apply {
+            addBrowseFolderListener(
+                "Select Krit Binary",
+                "Path to the krit executable (leave blank to use KRIT_BINARY or PATH).",
+                null,
+                FileChooserDescriptorFactory.createSingleFileDescriptor(),
+            )
+        }
+        private val fixLevelCombo = ComboBox(arrayOf("cosmetic", "idiomatic", "semantic"))
+        private val configField = TextFieldWithBrowseButton().apply {
+            addBrowseFolderListener(
+                "Select Krit Config File",
+                "Path to a krit.yml override (leave blank to auto-detect).",
+                null,
+                FileChooserDescriptorFactory.createSingleFileDescriptor(),
+            )
+        }
+
+        val panel: JPanel = FormBuilder.createFormBuilder()
+            .addLabeledComponent("Krit binary:", binaryField)
+            .addLabeledComponent("Default fix level:", fixLevelCombo)
+            .addLabeledComponent("Config file:", configField)
+            .addComponentFillVertically(JPanel(), 0)
+            .panel
+
+        fun load(state: KritSettingsState.Snapshot) {
+            binaryField.text = state.binaryPath
+            fixLevelCombo.selectedItem = state.fixLevel.ifBlank { KritSettingsState.DEFAULT_FIX_LEVEL }
+            configField.text = state.configPath
+        }
+
+        fun save(): KritSettingsState.Snapshot = KritSettingsState.Snapshot(
+            binaryPath = binaryField.text.trim(),
+            fixLevel = (fixLevelCombo.selectedItem as? String) ?: KritSettingsState.DEFAULT_FIX_LEVEL,
+            configPath = configField.text.trim(),
+        )
+
+        fun isModified(state: KritSettingsState.Snapshot): Boolean = save() != state
+    }
+}

--- a/editors/intellij-plugin/src/main/kotlin/dev/jasonpearson/krit/intellij/KritSettingsState.kt
+++ b/editors/intellij-plugin/src/main/kotlin/dev/jasonpearson/krit/intellij/KritSettingsState.kt
@@ -1,0 +1,46 @@
+package dev.jasonpearson.krit.intellij
+
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.components.PersistentStateComponent
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.components.State
+import com.intellij.openapi.components.Storage
+import com.intellij.openapi.components.service
+
+@State(name = "KritSettings", storages = [Storage("krit.xml")])
+@Service(Service.Level.APP)
+class KritSettingsState : PersistentStateComponent<KritSettingsState.Snapshot> {
+    data class Snapshot(
+        var binaryPath: String = "",
+        var fixLevel: String = DEFAULT_FIX_LEVEL,
+        var configPath: String = "",
+    )
+
+    @Volatile
+    private var snapshot: Snapshot = Snapshot()
+
+    override fun getState(): Snapshot = snapshot
+
+    override fun loadState(state: Snapshot) {
+        this.snapshot = state
+    }
+
+    fun update(next: Snapshot) {
+        snapshot = next
+    }
+
+    companion object {
+        const val DEFAULT_FIX_LEVEL = "idiomatic"
+
+        fun get(): KritSettingsState = ApplicationManager.getApplication().service()
+
+        // Null when the IntelliJ Application isn't initialised — e.g. unit
+        // tests that don't bring up the platform. Lets KritBinaryResolver
+        // call this safely from its no-arg production default while leaving
+        // its unit tests platform-free.
+        fun getSafely(): KritSettingsState? {
+            val app = ApplicationManager.getApplication() ?: return null
+            return runCatching { app.service<KritSettingsState>() }.getOrNull()
+        }
+    }
+}

--- a/editors/intellij-plugin/src/main/resources/META-INF/plugin.xml
+++ b/editors/intellij-plugin/src/main/resources/META-INF/plugin.xml
@@ -48,6 +48,12 @@
       order="last"
       implementation="dev.jasonpearson.krit.intellij.KritStatusBarWidgetFactory"/>
     <notificationGroup id="Krit" displayType="BALLOON"/>
+    <applicationService serviceImplementation="dev.jasonpearson.krit.intellij.KritSettingsState"/>
+    <applicationConfigurable
+      parentId="tools"
+      id="dev.jasonpearson.krit.settings"
+      displayName="Krit"
+      instance="dev.jasonpearson.krit.intellij.KritSettingsConfigurable"/>
   </extensions>
 
   <extensions defaultExtensionNs="org.jetbrains.kotlin">

--- a/editors/intellij-plugin/src/test/kotlin/dev/jasonpearson/krit/intellij/KritBinaryResolverSettingsTest.kt
+++ b/editors/intellij-plugin/src/test/kotlin/dev/jasonpearson/krit/intellij/KritBinaryResolverSettingsTest.kt
@@ -1,0 +1,72 @@
+package dev.jasonpearson.krit.intellij
+
+import java.io.File
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class KritBinaryResolverSettingsTest {
+    @Test
+    fun `settings override wins over system property`() {
+        val settingsBinary = makeExecutable("from-settings")
+        val propBinary = makeExecutable("from-prop")
+        val found = KritBinaryResolver.find(
+            env = mapOf("PATH" to ""),
+            props = { propBinary.absolutePath },
+            settings = { settingsBinary.absolutePath },
+        )
+        assertEquals(settingsBinary.canonicalFile, found?.canonicalFile)
+    }
+
+    @Test
+    fun `settings override wins over env`() {
+        val settingsBinary = makeExecutable("from-settings")
+        val envBinary = makeExecutable("from-env")
+        val found = KritBinaryResolver.find(
+            env = mapOf("KRIT_BINARY" to envBinary.absolutePath, "PATH" to ""),
+            props = { null },
+            settings = { settingsBinary.absolutePath },
+        )
+        assertEquals(settingsBinary.canonicalFile, found?.canonicalFile)
+    }
+
+    @Test
+    fun `blank settings falls through to system property`() {
+        // Empty string in settings is the "unset" sentinel — don't treat
+        // it as an explicit override, fall through to the next source.
+        val propBinary = makeExecutable("from-prop")
+        val found = KritBinaryResolver.find(
+            env = mapOf("PATH" to ""),
+            props = { propBinary.absolutePath },
+            settings = { "" },
+        )
+        assertEquals(propBinary.canonicalFile, found?.canonicalFile)
+    }
+
+    @Test
+    fun `non-executable settings path returns null without falling through`() {
+        // Honors the explicit user choice: if the user pointed at a path
+        // through Settings, that's their answer. Silently fall-through to
+        // PATH would hide the misconfiguration.
+        val nonExec = Files.createTempFile("krit-settings-not-exec", ".txt").toFile()
+        nonExec.deleteOnExit()
+        val pathBinary = makeExecutable("krit")
+        val found = KritBinaryResolver.find(
+            env = mapOf("PATH" to pathBinary.parentFile.absolutePath),
+            props = { null },
+            settings = { nonExec.absolutePath },
+        )
+        assertNull(found)
+    }
+
+    private fun makeExecutable(name: String): File {
+        val dir = Files.createTempDirectory("krit-settings-$name").toFile()
+        dir.deleteOnExit()
+        val f = File(dir, name)
+        f.writeText("#!/bin/sh\nexit 0\n")
+        f.setExecutable(true)
+        f.deleteOnExit()
+        return f
+    }
+}

--- a/editors/intellij-plugin/src/test/kotlin/dev/jasonpearson/krit/intellij/KritSettingsStateTest.kt
+++ b/editors/intellij-plugin/src/test/kotlin/dev/jasonpearson/krit/intellij/KritSettingsStateTest.kt
@@ -1,0 +1,39 @@
+package dev.jasonpearson.krit.intellij
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class KritSettingsStateTest {
+    @Test
+    fun `default snapshot uses documented fix level`() {
+        val s = KritSettingsState.Snapshot()
+        assertEquals("idiomatic", s.fixLevel)
+        assertEquals("", s.binaryPath)
+        assertEquals("", s.configPath)
+    }
+
+    @Test
+    fun `update replaces the snapshot in place`() {
+        // The Configurable's apply() round-trips through update(), so this
+        // pins the contract that a subsequent state read returns the new
+        // value (no copy semantics that would silently lose edits).
+        val state = KritSettingsState()
+        val next = KritSettingsState.Snapshot(
+            binaryPath = "/opt/krit/krit",
+            fixLevel = "cosmetic",
+            configPath = "/repo/krit.yml",
+        )
+        state.update(next)
+        assertEquals(next, state.state)
+    }
+
+    @Test
+    fun `loadState replaces the snapshot — PersistentStateComponent contract`() {
+        // IntelliJ calls loadState during deserialisation; update() is the
+        // app-side path. They must agree on the resulting state.
+        val state = KritSettingsState()
+        val next = KritSettingsState.Snapshot(binaryPath = "/x/krit")
+        state.loadState(next)
+        assertEquals(next, state.state)
+    }
+}


### PR DESCRIPTION
Refs #543. Per-rule inspection node follow-up tracked as #566.

## Summary
- New \`Settings → Tools → Krit\` panel exposes krit binary path, default fix level, and config file override.
- \`KritSettingsState\` is an application-level \`PersistentStateComponent\` so values survive IDE restarts.
- \`KritBinaryResolver\` consults the settings path first, then the existing -Dkrit.binary / KRIT_BINARY / PATH cascade. Blank values uniformly fall through across all three sources; an explicit non-executable settings path returns null without falling through, so misconfiguration stays legible.

## Out of scope (tracked as #566)
- Per-rule inspection nodes driven by \`krit list-rules --json\`. That work needs a dynamic InspectionToolProvider, rule-id routing of findings to the right tool, and explicit precedence rules vs \`krit.yml\`.

## Test plan
- [x] \`KritBinaryResolverSettingsTest\`: precedence (settings > prop > env), blank-as-unset fallthrough, non-executable override returns null
- [x] \`KritSettingsStateTest\`: default values, update()/loadState() round-trip
- [x] Full plugin test suite green