### PR TITLE
feat(intellij-plugin): JetBrains Marketplace publish workflow

### DIFF
--- a/.github/workflows/publish-intellij-plugin.yml
+++ b/.github/workflows/publish-intellij-plugin.yml
@@ -1,0 +1,69 @@
+name: publish-intellij-plugin
+
+# Tag-driven publish to JetBrains Marketplace. Tags must look like
+# `intellij-plugin-vX.Y.Z` to avoid colliding with other repository tags.
+# `workflow_dispatch` lets a maintainer ship an unscheduled build from any
+# branch — handy when a tagged release needs an emergency re-publish or
+# when validating the workflow itself.
+on:
+  push:
+    tags:
+      - 'intellij-plugin-v*'
+  workflow_dispatch:
+    inputs:
+      channel:
+        description: 'JetBrains Marketplace channel'
+        type: choice
+        default: default
+        options:
+          - default
+          - beta
+          - eap
+      version:
+        description: 'Plugin version (omit to use the build.gradle.kts default)'
+        type: string
+        required: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - uses: gradle/actions/setup-gradle@v4
+
+      - name: Resolve plugin version
+        id: version
+        run: |
+          if [ -n "${{ inputs.version }}" ]; then
+            echo "value=${{ inputs.version }}" >> "$GITHUB_OUTPUT"
+          elif [[ "$GITHUB_REF" == refs/tags/intellij-plugin-v* ]]; then
+            echo "value=${GITHUB_REF#refs/tags/intellij-plugin-v}" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Verify plugin builds before publishing
+        working-directory: editors/intellij-plugin
+        run: ../../tools/krit-fir/gradlew --project-dir . buildPlugin
+
+      - name: Publish to JetBrains Marketplace
+        working-directory: editors/intellij-plugin
+        env:
+          JETBRAINS_MARKETPLACE_TOKEN: ${{ secrets.JETBRAINS_MARKETPLACE_TOKEN }}
+        run: |
+          ARGS=(publishPlugin -PpluginChannel=${{ inputs.channel || 'default' }})
+          if [ -n "${{ steps.version.outputs.value }}" ]; then
+            ARGS+=(-Pversion=${{ steps.version.outputs.value }})
+          fi
+          ../../tools/krit-fir/gradlew --project-dir . "${ARGS[@]}"

--- a/editors/intellij-plugin/README.md
+++ b/editors/intellij-plugin/README.md
@@ -40,9 +40,24 @@ reload.
 
 The plugin resolves the Krit binary in this order:
 
-1. `-Dkrit.binary=/absolute/path/to/krit`
-2. `KRIT_BINARY=/absolute/path/to/krit`
-3. `krit` on `PATH`
+1. `Settings → Tools → Krit → Krit binary` (when set and executable)
+2. `-Dkrit.binary=/absolute/path/to/krit`
+3. `KRIT_BINARY=/absolute/path/to/krit`
+4. `krit` on `PATH`
+
+## Publishing to JetBrains Marketplace
+
+A tag matching `intellij-plugin-vX.Y.Z` triggers
+`.github/workflows/publish-intellij-plugin.yml`, which builds the plugin
+zip and uploads it to the Marketplace under the `dev.jasonpearson.krit`
+id. The workflow needs a `JETBRAINS_MARKETPLACE_TOKEN` repository secret
+(generated from the publisher account at
+<https://plugins.jetbrains.com/author/me/tokens>).
+
+The same workflow has a `workflow_dispatch` entry that takes a
+`channel` argument (`default`, `beta`, or `eap`) and an optional
+`version` override, so a maintainer can ship an unscheduled build
+without cutting a tag.
 
 ## Intentional Limits
 

--- a/editors/intellij-plugin/build.gradle.kts
+++ b/editors/intellij-plugin/build.gradle.kts
@@ -38,7 +38,20 @@ intellijPlatform {
         id.set("dev.jasonpearson.krit")
         name.set("Krit")
         version.set(project.version.toString())
-        description.set("Native IntelliJ integration for Krit diagnostics.")
+        description.set(
+            """
+            Live IntelliJ and Android Studio integration for the Krit static analyzer.
+
+            Krit is a Go-first analyzer for Kotlin, Java, and Android projects.
+            This plugin renders Krit findings as editor annotations and
+            inspections, offers a per-finding fix and a Suppress quick-fix,
+            tracks scan state in the status bar, and reads the IDE's resolved
+            classpath so type-aware (KAA / FIR) rules match CI behaviour.
+
+            Configure the Krit binary, default fix level, and config file
+            override under Settings → Tools → Krit.
+            """.trimIndent(),
+        )
 
         ideaVersion {
             sinceBuild.set("253")
@@ -49,6 +62,14 @@ intellijPlatform {
             name.set("Krit")
             url.set("https://github.com/kaeawc/krit")
         }
+    }
+
+    publishing {
+        token.set(providers.environmentVariable("JETBRAINS_MARKETPLACE_TOKEN"))
+        // "default" is the public stable channel; CI passes "beta" / "eap"
+        // via -PpluginChannel for pre-release builds.
+        val channel = (findProperty("pluginChannel") as String?) ?: "default"
+        channels.set(listOf(channel))
     }
 
     pluginVerification { ides { recommended() } }


### PR DESCRIPTION
Closes #546 (modulo the secret + first listing — see Prerequisites).

## Summary
- Tag-triggered \`.github/workflows/publish-intellij-plugin.yml\` builds the plugin zip and uploads it to JetBrains Marketplace under the \`dev.jasonpearson.krit\` id.
- \`build.gradle.kts\` gains the \`publishing\` block (\`token\` from env, \`channel\` parameterised via \`-PpluginChannel\`) and a real marketplace-worthy \`description\` (was a single-line placeholder).
- README documents the secret prerequisite and \`workflow_dispatch\` parameters.

## Prerequisites the workflow needs
- **Repository secret:** \`JETBRAINS_MARKETPLACE_TOKEN\` (generated at <https://plugins.jetbrains.com/author/me/tokens>). Without it the workflow runs but \`publishPlugin\` errors at upload time.
- **First-time listing:** the initial release also needs a Marketplace listing created with description, screenshots, and category. Subsequent tagged releases just update it.

## Tag scheme
\`intellij-plugin-vX.Y.Z\` — scoped prefix so the workflow doesn't fire on unrelated repository tags.

## Test plan
- [x] \`actionlint\` clean: \`scripts/lint-actions.sh\`
- [x] \`buildPlugin\` succeeds with the new \`publishing\` config (verifies the gradle script is valid)
- [x] Full plugin test suite green
- [ ] Manual: cut \`intellij-plugin-v0.1.0\` tag once secret is provisioned to validate the upload path