### PR TITLE
feat(intellij-plugin): direct Unix-socket daemon client for per-file scans

### DIFF
--- a/editors/intellij-plugin/src/main/kotlin/dev/jasonpearson/krit/intellij/KritDaemonClient.kt
+++ b/editors/intellij-plugin/src/main/kotlin/dev/jasonpearson/krit/intellij/KritDaemonClient.kt
@@ -1,0 +1,103 @@
+package dev.jasonpearson.krit.intellij
+
+import com.google.gson.Gson
+import com.google.gson.JsonObject
+import com.intellij.openapi.diagnostic.Logger
+import java.io.BufferedReader
+import java.io.IOException
+import java.io.InputStreamReader
+import java.net.StandardProtocolFamily
+import java.net.UnixDomainSocketAddress
+import java.nio.ByteBuffer
+import java.nio.channels.Channels
+import java.nio.channels.SocketChannel
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
+
+// Direct Unix-socket client for the krit daemon. Per-call dial — the
+// Go-side client (internal/daemon/client.go) uses the same pattern and
+// it's plenty fast on Unix sockets. Reusing a long-lived connection is
+// a future optimisation if profiling shows the dial cost matters.
+//
+// Resilience model: any IOException becomes a null return so callers
+// can fall back to the CLI invocation path. We do NOT crash the IDE on
+// a daemon hiccup.
+class KritDaemonClient(private val socketPath: Path) {
+    private val log = Logger.getInstance(KritDaemonClient::class.java)
+    private val gson = Gson()
+
+    fun available(): Boolean {
+        if (!Files.exists(socketPath)) return false
+        return try {
+            openChannel().use { /* dial only */ }
+            true
+        } catch (_: IOException) {
+            false
+        }
+    }
+
+    fun analyzeBuffer(filePath: String, content: String): List<KritFinding>? {
+        val args = gson.toJsonTree(KritDaemonProtocol.AnalyzeBufferArgs(filePath, content)).asJsonObject
+        val data = call(KritDaemonProtocol.VERB_ANALYZE_BUFFER, args) ?: return null
+        val payload = gson.fromJson(data, KritDaemonProtocol.AnalyzeBufferData::class.java)
+            ?: return emptyList()
+        return KritColumnarFindingsDecoder.decode(payload.findings)
+    }
+
+    private fun call(verb: String, args: JsonObject?): JsonObject? {
+        return try {
+            openChannel().use { channel ->
+                writeRequest(channel, verb, args)
+                readResponse(channel)
+            }
+        } catch (t: IOException) {
+            log.debug("krit daemon call failed for $verb: ${t.message}")
+            null
+        }
+    }
+
+    private fun openChannel(): SocketChannel {
+        val channel = SocketChannel.open(StandardProtocolFamily.UNIX)
+        try {
+            channel.connect(UnixDomainSocketAddress.of(socketPath))
+        } catch (t: IOException) {
+            channel.close()
+            throw t
+        }
+        return channel
+    }
+
+    private fun writeRequest(channel: SocketChannel, verb: String, args: JsonObject?) {
+        val request = JsonObject().apply {
+            addProperty("verb", verb)
+            if (args != null) {
+                add("args", args)
+            }
+        }
+        val body = (gson.toJson(request) + "\n").toByteArray(StandardCharsets.UTF_8)
+        var buf = ByteBuffer.wrap(body)
+        while (buf.hasRemaining()) {
+            channel.write(buf)
+        }
+    }
+
+    private fun readResponse(channel: SocketChannel): JsonObject? {
+        // The daemon writes one JSON object per response terminated by \n,
+        // but a single analyze-buffer reply can run to tens of KB on a
+        // chatty file — read a full line, not a fixed-size buffer.
+        val reader = BufferedReader(InputStreamReader(Channels.newInputStream(channel), StandardCharsets.UTF_8))
+        val line = reader.readLine() ?: return null
+        val response = gson.fromJson(line, KritDaemonProtocol.Response::class.java) ?: return null
+        if (!response.ok) {
+            log.debug("krit daemon error: ${response.error}")
+            return null
+        }
+        return response.data
+    }
+
+    companion object {
+        fun socketPathFor(projectDir: java.io.File): Path =
+            projectDir.toPath().resolve(".krit").resolve("daemon.sock")
+    }
+}

--- a/editors/intellij-plugin/src/main/kotlin/dev/jasonpearson/krit/intellij/KritDaemonProtocol.kt
+++ b/editors/intellij-plugin/src/main/kotlin/dev/jasonpearson/krit/intellij/KritDaemonProtocol.kt
@@ -1,0 +1,99 @@
+package dev.jasonpearson.krit.intellij
+
+import com.google.gson.Gson
+import com.google.gson.JsonObject
+import com.google.gson.annotations.SerializedName
+
+// Wire types for krit's line-delimited JSON daemon protocol. See
+// `internal/daemon/protocol.go` on the Go side — verb names and
+// envelope shape must stay in lockstep with that file.
+object KritDaemonProtocol {
+    const val VERB_ANALYZE_BUFFER = "analyze-buffer"
+    const val VERB_ANALYZE_BUFFERS = "analyze-buffers"
+
+    data class Request(
+        val verb: String,
+        val args: JsonObject?,
+    )
+
+    data class Response(
+        val ok: Boolean = false,
+        val error: String = "",
+        val data: JsonObject? = null,
+    )
+
+    data class AnalyzeBufferArgs(
+        val path: String,
+        val content: String,
+    )
+
+    data class AnalyzeBufferData(
+        @SerializedName("findings") val findings: JsonObject? = null,
+        @SerializedName("cache_hit") val cacheHit: Boolean = false,
+    )
+}
+
+// Decodes the columnar FindingColumns JSON the daemon emits into the
+// flat KritFinding list the rest of the plugin already speaks. Mirrors
+// `scanner.FindingColumns.MarshalJSON` (internal/scanner/findings_json.go)
+// and `severityFromID` / `confidenceToByte` on the Go side. Keep this
+// in sync with those when fields move.
+object KritColumnarFindingsDecoder {
+    private val gson = Gson()
+
+    private const val SEVERITY_INFO: Int = 0
+    private const val SEVERITY_WARNING: Int = 1
+    private const val SEVERITY_ERROR: Int = 2
+
+    fun decode(json: JsonObject?): List<KritFinding> {
+        if (json == null) return emptyList()
+        val columns = gson.fromJson(json, ColumnarPayload::class.java) ?: return emptyList()
+        return columns.toFindings()
+    }
+
+    private data class ColumnarPayload(
+        val files: List<String> = emptyList(),
+        val ruleSets: List<String> = emptyList(),
+        val rules: List<String> = emptyList(),
+        val messages: List<String> = emptyList(),
+        val fileIdx: List<Int> = emptyList(),
+        val line: List<Int> = emptyList(),
+        val col: List<Int> = emptyList(),
+        val ruleSetIdx: List<Int> = emptyList(),
+        val ruleIdx: List<Int> = emptyList(),
+        val severityID: List<Int> = emptyList(),
+        val messageIdx: List<Int> = emptyList(),
+        val confidence: List<Int> = emptyList(),
+        val n: Int = 0,
+    ) {
+        fun toFindings(): List<KritFinding> {
+            val rowCount = rowCount()
+            if (rowCount == 0) return emptyList()
+            return (0 until rowCount).map { row ->
+                KritFinding(
+                    file = lookup(files, fileIdx, row).orEmpty(),
+                    line = line.getOrElse(row) { 0 },
+                    column = col.getOrElse(row) { 0 },
+                    ruleSet = lookup(ruleSets, ruleSetIdx, row).orEmpty(),
+                    rule = lookup(rules, ruleIdx, row).orEmpty(),
+                    severity = decodeSeverity(severityID.getOrElse(row) { SEVERITY_INFO }),
+                    message = lookup(messages, messageIdx, row).orEmpty(),
+                    confidence = (confidence.getOrElse(row) { 0 }) / 100.0,
+                )
+            }
+        }
+
+        private fun rowCount(): Int = if (n > 0) n else fileIdx.size
+
+        private fun lookup(pool: List<String>, indexes: List<Int>, row: Int): String? {
+            val idx = indexes.getOrNull(row) ?: return null
+            return pool.getOrNull(idx)
+        }
+
+        private fun decodeSeverity(id: Int): String = when (id) {
+            SEVERITY_ERROR -> "error"
+            SEVERITY_WARNING -> "warning"
+            else -> "info"
+        }
+    }
+}

--- a/editors/intellij-plugin/src/main/kotlin/dev/jasonpearson/krit/intellij/KritProjectService.kt
+++ b/editors/intellij-plugin/src/main/kotlin/dev/jasonpearson/krit/intellij/KritProjectService.kt
@@ -9,9 +9,11 @@ import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.editor.EditorFactory
 import com.intellij.openapi.editor.event.BulkAwareDocumentListener
 import com.intellij.openapi.editor.event.DocumentEvent
+import com.intellij.openapi.application.ReadAction
 import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.ProjectFileIndex
+import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.wm.WindowManager
 import java.io.File
@@ -163,7 +165,8 @@ class KritProjectService(private val project: Project) : Disposable {
         val updated = findingsByFile.toMutableMap()
         for (path in paths) {
             val canonical = canonicalPath(path, project.basePath)
-            when (val outcome = KritRunner.analyzeFile(project, path)) {
+            val liveContent = readLiveDocument(path)
+            when (val outcome = KritRunner.analyzeFile(project, path, liveContent)) {
                 is KritRunner.AnalyzeOutcome.Success -> {
                     val grouped = outcome.report.findings.groupBy {
                         canonicalPath(it.file, project.basePath)
@@ -186,6 +189,18 @@ class KritProjectService(private val project: Project) : Disposable {
         findingsByFile = updated
         transition(KritState.Idle(updated.values.sumOf { it.size }))
         restartHighlighting()
+    }
+
+    // Returns the in-editor buffer text for path when one is open in the
+    // IDE, or null when no document is loaded for this file. The daemon
+    // analyse-buffer path consumes this so the user sees diagnostics for
+    // what's on screen rather than the on-disk snapshot; the CLI
+    // fallback ignores it and reads from disk via krit's path arg.
+    private fun readLiveDocument(path: String): String? {
+        return ReadAction.compute<String?, RuntimeException> {
+            val file = LocalFileSystem.getInstance().findFileByPath(path) ?: return@compute null
+            FileDocumentManager.getInstance().getDocument(file)?.text
+        }
     }
 
     private fun transition(next: KritState) {

--- a/editors/intellij-plugin/src/main/kotlin/dev/jasonpearson/krit/intellij/KritRunner.kt
+++ b/editors/intellij-plugin/src/main/kotlin/dev/jasonpearson/krit/intellij/KritRunner.kt
@@ -3,6 +3,7 @@ package dev.jasonpearson.krit.intellij
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.Project
 import java.io.File
+import java.nio.file.Files
 import java.util.concurrent.TimeUnit
 
 object KritRunner {
@@ -17,14 +18,50 @@ object KritRunner {
     fun analyzeProject(project: Project): AnalyzeOutcome =
         runAnalyze(project, target = null, label = "project analysis")
 
-    // Single-file scan. krit accepts a positional path argument and, when
-    // a daemon is running for this repo, the CLI delegates to it instead
-    // of redoing the parse/index work — so per-document-change calls reuse
-    // resident state. This is the cheap incremental path; whole-project
-    // scans stay reserved for initial load, manual refresh, and config
-    // changes.
-    fun analyzeFile(project: Project, filePath: String): AnalyzeOutcome =
-        runAnalyze(project, target = filePath, label = "file analysis")
+    // Single-file scan. When a daemon socket is reachable at
+    // <repo>/.krit/daemon.sock, sends an analyze-buffer request directly
+    // over the Unix socket — no ProcessBuilder.start() on the hot path.
+    // Falls back to the CLI invocation if the socket is absent or the
+    // RPC fails for any reason, so the plugin behaves identically when
+    // no daemon is running.
+    //
+    // liveContent, when non-null, is the in-editor buffer text — the
+    // daemon analyses exactly what the user sees rather than the
+    // on-disk snapshot. CLI fallback reads from disk because krit's
+    // positional-path argument expects a real file.
+    fun analyzeFile(project: Project, filePath: String, liveContent: String? = null): AnalyzeOutcome {
+        val projectDir = project.baseDir() ?: return AnalyzeOutcome.Failure("project has no base path")
+        val daemonOutcome = tryDaemonAnalyzeBuffer(projectDir, filePath, liveContent)
+        if (daemonOutcome != null) {
+            return daemonOutcome
+        }
+        return runAnalyze(project, target = filePath, label = "file analysis")
+    }
+
+    private fun tryDaemonAnalyzeBuffer(
+        projectDir: File,
+        filePath: String,
+        liveContent: String?,
+    ): AnalyzeOutcome? {
+        val socketPath = KritDaemonClient.socketPathFor(projectDir)
+        if (!Files.exists(socketPath)) return null
+        val content = liveContent ?: try {
+            File(filePath).readText()
+        } catch (_: java.io.IOException) {
+            return null
+        }
+        val findings = try {
+            KritDaemonClient(socketPath).analyzeBuffer(filePath, content)
+        } catch (t: Throwable) {
+            log.debug("krit daemon analyze-buffer threw, falling back to CLI", t)
+            return null
+        } ?: return null
+        // rawJson is intentionally empty: the daemon path doesn't carry
+        // suggested-fix metadata for apply-suggestion. Per-file scans
+        // refresh after each apply-fix anyway, so lastReportJson is
+        // never consumed for daemon-served updates.
+        return AnalyzeOutcome.Success(KritReport(findings), "")
+    }
 
     private fun runAnalyze(project: Project, target: String?, label: String): AnalyzeOutcome {
         val projectDir = project.baseDir() ?: return AnalyzeOutcome.Failure("project has no base path")

--- a/editors/intellij-plugin/src/test/kotlin/dev/jasonpearson/krit/intellij/KritColumnarFindingsDecoderTest.kt
+++ b/editors/intellij-plugin/src/test/kotlin/dev/jasonpearson/krit/intellij/KritColumnarFindingsDecoderTest.kt
@@ -1,0 +1,93 @@
+package dev.jasonpearson.krit.intellij
+
+import com.google.gson.JsonParser
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class KritColumnarFindingsDecoderTest {
+    @Test
+    fun `null payload decodes to empty list`() {
+        assertTrue(KritColumnarFindingsDecoder.decode(null).isEmpty())
+    }
+
+    @Test
+    fun `empty columns decode to empty list`() {
+        val json = JsonParser.parseString("{}").asJsonObject
+        assertTrue(KritColumnarFindingsDecoder.decode(json).isEmpty())
+    }
+
+    @Test
+    fun `single-finding columnar payload decodes to flat finding`() {
+        // Mirrors the wire shape internal/scanner/findings_json.go writes.
+        // Two index columns dereference into the file/rule/message pools;
+        // severity is the uint8 id (1 = warning); confidence is 0..100
+        // scaled back to 0.0..1.0.
+        val json = JsonParser.parseString(
+            """
+            {
+                "files": ["/repo/Foo.kt"],
+                "ruleSets": ["release-engineering"],
+                "rules": ["PrintlnInProduction"],
+                "messages": ["println/print in production code"],
+                "fileIdx": [0],
+                "line": [7],
+                "col": [12],
+                "ruleSetIdx": [0],
+                "ruleIdx": [0],
+                "severityID": [1],
+                "messageIdx": [0],
+                "confidence": [85],
+                "n": 1
+            }
+            """.trimIndent(),
+        ).asJsonObject
+        val findings = KritColumnarFindingsDecoder.decode(json)
+        assertEquals(1, findings.size)
+        val f = findings.single()
+        assertEquals("/repo/Foo.kt", f.file)
+        assertEquals(7, f.line)
+        assertEquals(12, f.column)
+        assertEquals("release-engineering", f.ruleSet)
+        assertEquals("PrintlnInProduction", f.rule)
+        assertEquals("warning", f.severity)
+        assertEquals("println/print in production code", f.message)
+        assertEquals(0.85, f.confidence)
+    }
+
+    @Test
+    fun `severity id 0 decodes to info, 2 decodes to error`() {
+        // Pin the severity ID mapping. If the Go side renumbers the
+        // severity enum, this test catches the wire-format drift.
+        val payload = """
+            {
+                "files":["/x.kt"],"ruleSets":["rs"],"rules":["r"],
+                "messages":["a","b"],
+                "fileIdx":[0,0],"line":[1,2],"col":[1,1],
+                "ruleSetIdx":[0,0],"ruleIdx":[0,0],
+                "severityID":[0,2],"messageIdx":[0,1],"confidence":[0,0],
+                "n":2
+            }
+        """.trimIndent()
+        val findings = KritColumnarFindingsDecoder.decode(JsonParser.parseString(payload).asJsonObject)
+        assertEquals(listOf("info", "error"), findings.map { it.severity })
+    }
+
+    @Test
+    fun `decoder infers row count from fileIdx when n is absent`() {
+        // The Go side omits 'n' when zero, so the decoder must fall back
+        // to fileIdx length to find the row count.
+        val payload = """
+            {
+                "files":["/x.kt"],"ruleSets":["rs"],"rules":["r"],
+                "messages":["m"],
+                "fileIdx":[0,0,0],"line":[1,2,3],"col":[1,1,1],
+                "ruleSetIdx":[0,0,0],"ruleIdx":[0,0,0],
+                "severityID":[1,1,1],"messageIdx":[0,0,0],"confidence":[50,50,50]
+            }
+        """.trimIndent()
+        val findings = KritColumnarFindingsDecoder.decode(JsonParser.parseString(payload).asJsonObject)
+        assertEquals(3, findings.size)
+        assertEquals(listOf(1, 2, 3), findings.map { it.line })
+    }
+}

--- a/editors/intellij-plugin/src/test/kotlin/dev/jasonpearson/krit/intellij/KritDaemonClientTest.kt
+++ b/editors/intellij-plugin/src/test/kotlin/dev/jasonpearson/krit/intellij/KritDaemonClientTest.kt
@@ -1,0 +1,159 @@
+package dev.jasonpearson.krit.intellij
+
+import java.io.BufferedReader
+import java.io.IOException
+import java.io.InputStreamReader
+import java.net.StandardProtocolFamily
+import java.net.UnixDomainSocketAddress
+import java.nio.ByteBuffer
+import java.nio.channels.Channels
+import java.nio.channels.ServerSocketChannel
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class KritDaemonClientTest {
+    private lateinit var socketDir: Path
+    private lateinit var socketPath: Path
+    private var server: MockDaemonServer? = null
+
+    @BeforeTest
+    fun setUp() {
+        socketDir = Files.createTempDirectory("krit-daemon-test")
+        socketPath = socketDir.resolve("daemon.sock")
+    }
+
+    @AfterTest
+    fun tearDown() {
+        server?.close()
+        runCatching { Files.deleteIfExists(socketPath) }
+        runCatching { Files.deleteIfExists(socketDir) }
+    }
+
+    @Test
+    fun `available returns false when socket file is missing`() {
+        // No server running, no socket file: caller should fall back.
+        assertFalse(KritDaemonClient(socketPath).available())
+    }
+
+    @Test
+    fun `available returns true when daemon accepts connections`() {
+        server = MockDaemonServer.start(socketPath) { _, _ -> okResponse(emptyColumnsPayload()) }
+        assertTrue(KritDaemonClient(socketPath).available())
+    }
+
+    @Test
+    fun `analyzeBuffer decodes a single-finding response from the wire`() {
+        // Captures the verb the client actually sent so a mistake in
+        // KritDaemonClient (wrong verb, missing newline, etc.) would
+        // surface as a verb mismatch here rather than a silent fall-back.
+        val seenVerb = AtomicReference<String>()
+        server = MockDaemonServer.start(socketPath) { verb, _ ->
+            seenVerb.set(verb)
+            okResponse(singleFindingColumnsPayload())
+        }
+        val findings = KritDaemonClient(socketPath).analyzeBuffer("/repo/X.kt", "fun a() {}\n")
+        assertEquals(KritDaemonProtocol.VERB_ANALYZE_BUFFER, seenVerb.get())
+        assertEquals(1, findings?.size)
+        val f = findings!!.single()
+        assertEquals("/repo/X.kt", f.file)
+        assertEquals("warning", f.severity)
+        assertEquals("rule.id", f.rule)
+    }
+
+    @Test
+    fun `analyzeBuffer returns null when daemon reports error`() {
+        // ok=false is the daemon's "I tried and failed" signal; client
+        // returns null so the caller falls back to the CLI without
+        // surfacing a false-positive empty-findings result.
+        server = MockDaemonServer.start(socketPath) { _, _ ->
+            """{"ok":false,"error":"oracle init failed"}""" + "\n"
+        }
+        assertNull(KritDaemonClient(socketPath).analyzeBuffer("/x.kt", ""))
+    }
+
+    @Test
+    fun `analyzeBuffer returns null when socket is absent`() {
+        // Confirms the IOException-to-null translation: no daemon running,
+        // dial fails, caller falls back gracefully.
+        assertNull(KritDaemonClient(socketPath).analyzeBuffer("/x.kt", ""))
+    }
+
+    private fun emptyColumnsPayload(): String =
+        """{"findings":{},"cache_hit":false}"""
+
+    private fun singleFindingColumnsPayload(): String =
+        """{"findings":{"files":["/repo/X.kt"],"ruleSets":["rs"],"rules":["rule.id"],"messages":["m"],""" +
+            """"fileIdx":[0],"line":[1],"col":[1],"ruleSetIdx":[0],"ruleIdx":[0],"severityID":[1],""" +
+            """"messageIdx":[0],"confidence":[80],"n":1},"cache_hit":false}"""
+
+    // Daemon writes one JSON object per response terminated by \n. Strip
+    // any embedded newlines so tests can author pretty-printed JSON in
+    // helpers without breaking the line-delimited contract.
+    private fun okResponse(dataJson: String): String =
+        """{"ok":true,"data":${dataJson.replace("\n", "").replace(Regex("\\s+"), " ")}}""" + "\n"
+}
+
+private class MockDaemonServer private constructor(
+    private val server: ServerSocketChannel,
+    private val thread: Thread,
+) : AutoCloseable {
+    @Volatile
+    private var running = true
+
+    override fun close() {
+        running = false
+        runCatching { server.close() }
+        thread.interrupt()
+        thread.join(2_000)
+    }
+
+    companion object {
+        fun start(
+            socketPath: Path,
+            respond: (verb: String, requestLine: String) -> String,
+        ): MockDaemonServer {
+            val server = ServerSocketChannel.open(StandardProtocolFamily.UNIX)
+            server.bind(UnixDomainSocketAddress.of(socketPath))
+            val thread = Thread {
+                while (true) {
+                    val conn = try {
+                        server.accept() ?: continue
+                    } catch (_: IOException) {
+                        return@Thread
+                    }
+                    try {
+                        val reader = BufferedReader(
+                            InputStreamReader(Channels.newInputStream(conn), StandardCharsets.UTF_8),
+                        )
+                        val requestLine = reader.readLine() ?: continue
+                        // Cheap verb extraction — doesn't need a JSON parser
+                        // for the test fixture. Pattern: {"verb":"…"}.
+                        val verb = Regex("\"verb\"\\s*:\\s*\"([^\"]+)\"")
+                            .find(requestLine)?.groupValues?.getOrNull(1)
+                            .orEmpty()
+                        val response = respond(verb, requestLine)
+                        val bytes = response.toByteArray(StandardCharsets.UTF_8)
+                        var buf = ByteBuffer.wrap(bytes)
+                        while (buf.hasRemaining()) {
+                            conn.write(buf)
+                        }
+                    } finally {
+                        runCatching { conn.close() }
+                    }
+                }
+            }
+            thread.isDaemon = true
+            thread.start()
+            return MockDaemonServer(server, thread)
+        }
+    }
+}


### PR DESCRIPTION
Closes #561. Phase 2 of the daemon-mode work (#538 follow-up).

## Summary
- Per-document-change scans now talk to the krit daemon directly over its Unix socket at \`<repo>/.krit/daemon.sock\`. \`ProcessBuilder.start()\` is off the hot path entirely when the daemon is reachable.
- Falls back to the existing CLI invocation when the socket is absent or any RPC step fails — behaviour is identical with no daemon running.
- Daemon analyzes the **in-editor buffer text**, not the on-disk snapshot, so diagnostics match what the user sees even before autosave fires.

## Pieces
- \`KritDaemonProtocol\` mirrors \`internal/daemon/protocol.go\`'s line-delimited \`Request\`/\`Response\` envelope. Verb names pinned in constants so Go-side renames surface here at compile time.
- \`KritColumnarFindingsDecoder\` decodes the daemon's \`FindingColumns\` JSON (\`internal/scanner/findings_json.go\`) into the flat \`KritFinding\` list the plugin already speaks. Mirrors \`severityFromID\` and the uint8 confidence → float64 round-trip.
- \`KritDaemonClient\` does per-call dial (same as Go-side \`internal/daemon/client.go\`). \`IOException\` → null so the caller falls back gracefully.
- \`KritRunner.analyzeFile\` gains an optional \`liveContent\` parameter; \`KritProjectService.refreshChangedFiles\` reads the editor document via \`ReadAction\` and threads it through.

## Test plan
- [x] \`KritColumnarFindingsDecoderTest\` — single-finding decode, severity-id mapping (info/warning/error), \`n\`-absent row count inference, empty input
- [x] \`KritDaemonClientTest\` spins up a real in-process Unix-socket mock daemon and verifies:
  - \`available()\` semantics (no socket vs reachable)
  - round-trip decoding of a single-finding response
  - the wire verb matches \`VERB_ANALYZE_BUFFER\`
  - \`ok=false\` daemon response returns null (graceful fallback)
  - missing socket returns null without surfacing the IOException
- [x] Full plugin test suite green