### PR TITLE
feat(daemon): wire OracleBackend through AnalyzeProjectArgs + drop CLI bypass

### DIFF
--- a/internal/cli/daemonclient/client.go
+++ b/internal/cli/daemonclient/client.go
@@ -80,6 +80,18 @@ func IsBinaryHashMismatch(err error) bool {
 	return err != nil && strings.Contains(err.Error(), daemon.ErrBinaryHashMismatchPrefix)
 }
 
+// IsUnsupportedOracleBackend reports whether err is the daemon's
+// "unsupported oracle backend" rejection. Used by the CLI to fall
+// back to in-process execution when the user picked a backend the
+// daemon doesn't spawn yet (currently anything other than
+// AnalyzeProjectArgs.OracleBackend == "" / "kaa"). Mirrors
+// IsBinaryHashMismatch's contract so daemon_delegate's
+// runDaemonAnalyze can route both rejections through the same
+// "warn + fall through" branch.
+func IsUnsupportedOracleBackend(err error) bool {
+	return err != nil && strings.Contains(err.Error(), daemon.ErrUnsupportedOracleBackendPrefix)
+}
+
 // EnsureCompatible discovers a running daemon, compares its
 // reported binary hash against the running CLI's, and shuts the
 // daemon down + (when opts.AutoRestart is true) spawns a fresh one

--- a/internal/cli/daemonclient/tryconnect_test.go
+++ b/internal/cli/daemonclient/tryconnect_test.go
@@ -96,6 +96,30 @@ func TestIsBinaryHashMismatch_MatchesDaemonError(t *testing.T) {
 	}
 }
 
+// TestIsUnsupportedOracleBackend_MatchesDaemonError mirrors
+// TestIsBinaryHashMismatch_MatchesDaemonError for the
+// ErrUnsupportedOracleBackendPrefix sentinel. The CLI uses this
+// classifier to fall back silently to in-process when the user picks
+// a backend the serve daemon doesn't spawn yet — preserving the
+// historical `--oracle-backend fir` behavior from before the wire
+// carried the field.
+func TestIsUnsupportedOracleBackend_MatchesDaemonError(t *testing.T) {
+	err := errors.New("unsupported oracle backend: fir not yet supported by serve daemon")
+	if !IsUnsupportedOracleBackend(err) {
+		t.Fatal("expected true")
+	}
+	if IsUnsupportedOracleBackend(nil) {
+		t.Fatal("nil should be false")
+	}
+	if IsUnsupportedOracleBackend(errors.New("unrelated")) {
+		t.Fatal("unrelated error should be false")
+	}
+	// The binary-hash sentinel must not collide with the new sentinel.
+	if IsUnsupportedOracleBackend(errors.New("binary hash mismatch (daemon=aaaa client=bbbb)")) {
+		t.Fatal("binary-hash error misclassified as unsupported-backend")
+	}
+}
+
 // TestAnalyzeProject_MismatchSurfacesError exercises the end-to-end
 // handshake: a daemon configured to enforce a different hash refuses
 // the AnalyzeProject call, and IsBinaryHashMismatch classifies the

--- a/internal/cli/scan/daemon_delegate.go
+++ b/internal/cli/scan/daemon_delegate.go
@@ -75,6 +75,16 @@ func runDaemonAnalyze(client *daemonclient.Client, f *scanFlags, paths []string)
 			fmt.Fprintf(os.Stderr, "warning: krit daemon rejected request (%v); falling back to in-process. Restart it with: krit daemon restart\n", err)
 			return false, 0
 		}
+		if daemonclient.IsUnsupportedOracleBackend(err) {
+			// Silent fallback: the daemon doesn't spawn the requested
+			// backend yet (e.g. --oracle-backend=fir before the FIR
+			// jar lifecycle landed). The in-process path handles the
+			// flag correctly via runOracleIndex, so we just let it
+			// run without a noisy warning — preserves the historical
+			// `--oracle-backend fir` behavior from before the wire
+			// carried this field.
+			return false, 0
+		}
 		fmt.Fprintf(os.Stderr, "warning: krit daemon call failed (%v); falling back to in-process\n", err)
 		return false, 0
 	}
@@ -579,15 +589,13 @@ func daemonCompatibleFlags(f *scanFlags) bool {
 			return false
 		}
 	}
-	// `--oracle-backend` selects the JVM jar the oracle pass uses
-	// (krit-types vs krit-fir). The serve daemon's resident oracle
-	// always ties itself to krit-types via oracle.FindJar, and the
-	// daemon wire doesn't carry the backend flag — delegating would
-	// silently ignore the user's choice. Bypass delegation so the
-	// in-process path picks the right jar.
-	if *f.OracleBackend != "" {
-		return false
-	}
+	// `--oracle-backend` historically bypassed daemon delegation
+	// because the wire didn't carry the backend selection — the
+	// daemon always used krit-types via oracle.FindJar, so delegating
+	// would silently drop the user's choice. AnalyzeProjectArgs.OracleBackend
+	// now ships the value over the wire and the serve handler honors
+	// it, so the bypass is gone. buildDaemonAnalyzeArgs forwards
+	// *f.OracleBackend verbatim; the daemon picks the jar per call.
 	return true
 }
 
@@ -685,6 +693,7 @@ func buildDaemonAnalyzeArgs(f *scanFlags, paths []string) daemon.AnalyzeProjectA
 		DryRun:           *f.DryRun,
 		FixLevel:         *f.FixLevel,
 		IncludeColumns:   includeColumns,
+		OracleBackend:    *f.OracleBackend,
 		ClientBinaryHash: daemonclient.CurrentBinaryHash(),
 	}
 }

--- a/internal/cli/scan/daemon_delegate_oracle_args_test.go
+++ b/internal/cli/scan/daemon_delegate_oracle_args_test.go
@@ -39,26 +39,38 @@ func TestDaemonCompatibleFlags_OracleArgsAllowed(t *testing.T) {
 	}
 }
 
-// TestDaemonCompatibleFlags_OracleBackendBypassesDaemon pins the
-// short-circuit added when an explicit `--oracle-backend` arrives:
-// the serve daemon's resident oracle is tied to krit-types via
-// oracle.FindJar, and the wire doesn't carry the backend flag.
-// Delegating would silently ignore the user's choice — so the
-// gate refuses delegation and the in-process path handles it.
-func TestDaemonCompatibleFlags_OracleBackendBypassesDaemon(t *testing.T) {
-	for _, backend := range []string{"kaa", "fir"} {
-		t.Run(backend, func(t *testing.T) {
+// TestDaemonCompatibleFlags_OracleBackendForwardedNotBypassed pins
+// the post-wire behavior: AnalyzeProjectArgs.OracleBackend now carries
+// the user's choice to the daemon, so daemonCompatibleFlags admits
+// every spelling. The serve handler validates and returns a typed
+// ErrUnsupportedOracleBackendPrefix when it can't honor the request —
+// runDaemonAnalyze catches that and falls back to in-process.
+// Bypassing here would prevent the daemon from ever serving a backend
+// that's wired but not-yet-implemented end-to-end.
+func TestDaemonCompatibleFlags_OracleBackendForwardedNotBypassed(t *testing.T) {
+	for _, backend := range []string{"", "kaa", "fir"} {
+		t.Run("backend="+backend, func(t *testing.T) {
 			f := freshScanFlags(t)
 			*f.OracleBackend = backend
-			if got := daemonCompatibleFlags(f); got {
-				t.Errorf("daemonCompatibleFlags(--oracle-backend=%s) = true, want false", backend)
+			if got := daemonCompatibleFlags(f); !got {
+				t.Errorf("daemonCompatibleFlags(--oracle-backend=%q) = false, want true (backend now travels over the wire)", backend)
 			}
 		})
 	}
-	// Empty (default) value keeps delegation enabled.
-	f := freshScanFlags(t)
-	if got := daemonCompatibleFlags(f); !got {
-		t.Errorf("daemonCompatibleFlags(default) = false, want true")
+}
+
+// TestBuildDaemonAnalyzeArgs_ForwardsOracleBackend confirms the
+// user's --oracle-backend value reaches the wire verbatim.
+func TestBuildDaemonAnalyzeArgs_ForwardsOracleBackend(t *testing.T) {
+	for _, backend := range []string{"", "kaa", "fir"} {
+		t.Run("backend="+backend, func(t *testing.T) {
+			f := freshScanFlags(t)
+			*f.OracleBackend = backend
+			args := buildDaemonAnalyzeArgs(f, []string{"/tmp"})
+			if args.OracleBackend != backend {
+				t.Errorf("OracleBackend = %q, want %q", args.OracleBackend, backend)
+			}
+		})
 	}
 }
 

--- a/internal/cli/serve/analyze_project.go
+++ b/internal/cli/serve/analyze_project.go
@@ -16,6 +16,7 @@ import (
 	"github.com/kaeawc/krit/internal/cli/clishared"
 	"github.com/kaeawc/krit/internal/config"
 	"github.com/kaeawc/krit/internal/daemon"
+	"github.com/kaeawc/krit/internal/oracle"
 	"github.com/kaeawc/krit/internal/perf"
 	"github.com/kaeawc/krit/internal/pipeline"
 	"github.com/kaeawc/krit/internal/rules"
@@ -49,6 +50,22 @@ func handleAnalyzeProject(_ context.Context, state *daemonState, raw json.RawMes
 
 	if daemonHash := daemonBinaryHash(); args.ClientBinaryHash != "" && daemonHash != "" && args.ClientBinaryHash != daemonHash {
 		return nil, fmt.Errorf("%s (daemon=%s client=%s)", daemon.ErrBinaryHashMismatchPrefix, daemonHash, args.ClientBinaryHash)
+	}
+
+	// Validate the requested oracle backend. The daemon's resident
+	// OracleDaemon is currently spawned via oracle.FindJar (krit-types
+	// only); a later PR will plumb krit-fir into the same lifecycle.
+	// Until that lands, accept the empty / kaa values and return a
+	// typed error for anything else so the CLI falls back to
+	// in-process via runDaemonAnalyze's existing error-fallback path
+	// — preserving the historical `--oracle-backend fir` behavior
+	// from before the wire was carrying this field.
+	backend, err := oracle.ParseBackend(args.OracleBackend)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", daemon.ErrUnsupportedOracleBackendPrefix, err)
+	}
+	if backend != oracle.BackendKAA {
+		return nil, fmt.Errorf("%s: %s not yet supported by serve daemon (pass --no-daemon for in-process %s)", daemon.ErrUnsupportedOracleBackendPrefix, backend, backend)
 	}
 
 	state.analyzeMu.Lock()

--- a/internal/cli/serve/analyze_project_oracle_backend_test.go
+++ b/internal/cli/serve/analyze_project_oracle_backend_test.go
@@ -1,0 +1,58 @@
+package serve
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/kaeawc/krit/internal/daemon"
+)
+
+// TestHandleAnalyzeProject_RejectsUnknownOracleBackend pins the new
+// validation gate. An AnalyzeProjectArgs.OracleBackend value that
+// oracle.ParseBackend can't classify must come back with the typed
+// ErrUnsupportedOracleBackendPrefix so the CLI's runDaemonAnalyze
+// can route to the silent in-process fallback instead of failing
+// the scan.
+func TestHandleAnalyzeProject_RejectsUnknownOracleBackend(t *testing.T) {
+	state := newDaemonState(t.TempDir())
+	args := daemon.AnalyzeProjectArgs{OracleBackend: "totally-not-a-backend"}
+	raw, err := json.Marshal(args)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	_, err = handleAnalyzeProject(context.Background(), state, raw)
+	if err == nil {
+		t.Fatal("expected error for unknown backend")
+	}
+	if !strings.Contains(err.Error(), daemon.ErrUnsupportedOracleBackendPrefix) {
+		t.Errorf("error missing typed prefix %q: %v", daemon.ErrUnsupportedOracleBackendPrefix, err)
+	}
+}
+
+// TestHandleAnalyzeProject_RejectsFIRBackendForNow holds the
+// transitional contract: the daemon's resident OracleDaemon is still
+// spawned via oracle.FindJar (krit-types). Until a later PR plumbs
+// krit-fir into the same lifecycle, the FIR backend must return the
+// typed ErrUnsupportedOracleBackendPrefix so the CLI falls back to
+// in-process — preserving the historical `--oracle-backend fir`
+// behavior end users had before the wire carried this field.
+func TestHandleAnalyzeProject_RejectsFIRBackendForNow(t *testing.T) {
+	state := newDaemonState(t.TempDir())
+	args := daemon.AnalyzeProjectArgs{OracleBackend: "fir"}
+	raw, err := json.Marshal(args)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	_, err = handleAnalyzeProject(context.Background(), state, raw)
+	if err == nil {
+		t.Fatal("expected typed error for FIR backend (not yet supported daemon-side)")
+	}
+	if !strings.Contains(err.Error(), daemon.ErrUnsupportedOracleBackendPrefix) {
+		t.Errorf("error missing typed prefix %q: %v", daemon.ErrUnsupportedOracleBackendPrefix, err)
+	}
+	if !strings.Contains(err.Error(), "fir") {
+		t.Errorf("error message should mention the offending backend; got %v", err)
+	}
+}

--- a/internal/daemon/protocol.go
+++ b/internal/daemon/protocol.go
@@ -53,6 +53,15 @@ const (
 // `{ok:false,error:...}` envelope instead of a code field.
 const ErrBinaryHashMismatchPrefix = "binary hash mismatch"
 
+// ErrUnsupportedOracleBackendPrefix is emitted when the daemon
+// receives an AnalyzeProjectArgs.OracleBackend value it can't honor
+// (unknown spelling, or a backend the resident daemon doesn't spawn
+// yet). CLI callers detect this prefix and fall back to in-process
+// execution instead of failing the scan — preserving the historical
+// `--oracle-backend fir` behavior from before the wire field
+// existed.
+const ErrUnsupportedOracleBackendPrefix = "unsupported oracle backend"
+
 // ClearCacheArgs is the argument shape for the clear-cache verb.
 // ClientBinaryHash mirrors AnalyzeProjectArgs: empty disables the
 // handshake; non-empty values must match the daemon's hash or the
@@ -298,6 +307,16 @@ type AnalyzeProjectArgs struct {
 	// existing {findings,stats[,dispatch_profile]} shape so common
 	// scans stay byte-identical.
 	IncludeColumns bool `json:"include_columns,omitempty"`
+	// OracleBackend mirrors --oracle-backend: empty or "kaa" picks
+	// the krit-types JVM jar for the type oracle; "fir" picks
+	// krit-fir.jar instead. The daemon was historically pinned to
+	// krit-types via oracle.FindJar, and CLI invocations with
+	// --oracle-backend set bypassed daemon delegation entirely to
+	// avoid silently ignoring the user's choice. Forwarding the
+	// value lifts that bypass; an unrecognized value triggers a
+	// typed error response so silent-fallthrough cannot drop the
+	// caller's selection.
+	OracleBackend string `json:"oracle_backend,omitempty"`
 }
 
 // AnalyzeProjectResult is the response payload. Findings is the raw


### PR DESCRIPTION
## Summary
\`AnalyzeProjectArgs\` now carries the user's \`--oracle-backend\` choice over the wire, and \`daemonCompatibleFlags\` no longer short-circuits delegation on a non-empty \`--oracle-backend\`. The serve handler parses + validates the requested backend via \`oracle.ParseBackend\` and returns a typed \`ErrUnsupportedOracleBackendPrefix\` when it can't honor the value (currently anything other than empty / \"kaa\", since the resident \`OracleDaemon\` is still spawned via \`oracle.FindJar\` — a later PR adds krit-fir lifecycle). \`daemonclient.IsUnsupportedOracleBackend\` classifies that sentinel so \`runDaemonAnalyze\` falls back silently to in-process, preserving the historical \`--oracle-backend fir\` behavior end users had before the wire carried the field.

This is the **protocol-layer half** of the FIR-via-daemon work. The behavior-layer half (spawn krit-fir, route requests to it) lands separately so the rollout is reversible if the protocol shape needs to change in response to integration testing. Item 1 of the FIR + daemon plumbing enumeration.

## Context
Today \`--oracle-backend fir\` is a paywall: the CLI bypasses delegation entirely because the daemon was hardcoded to krit-types, so FIR scans never benefit from the daemon's resident workspace / parse cache / dirty-watcher. To get sub-second daemon-resident FIR scans, the daemon must accept the backend selection on each request. This PR makes that handshake possible without changing observable behavior — non-KAA backends still take the in-process path via the typed-error fallback.

## Test plan
- [x] \`TestDaemonCompatibleFlags_OracleBackendForwardedNotBypassed\` — post-wire admission (replaces the old bypass-asserting test).
- [x] \`TestBuildDaemonAnalyzeArgs_ForwardsOracleBackend\` — CLI→wire round-trip.
- [x] \`TestIsUnsupportedOracleBackend_MatchesDaemonError\` — sentinel classifier + collision guard vs binary-hash sentinel.
- [x] \`TestHandleAnalyzeProject_RejectsUnknownOracleBackend\` / \`RejectsFIRBackendForNow\` — serve handler transitional guard.
- [x] \`go test ./internal/cli/scan/ ./internal/cli/daemonclient/ ./internal/cli/serve/ -count=1\`.
- [x] \`go vet ./...\`, \`golangci-lint run ./internal/cli/... ./internal/daemon/...\` — 0 issues.