### PR TITLE
feat(serve): spawn krit-fir under the resident oracle-daemon lifecycle

### DIFF
--- a/internal/cli/serve/analyze_project.go
+++ b/internal/cli/serve/analyze_project.go
@@ -52,20 +52,15 @@ func handleAnalyzeProject(_ context.Context, state *daemonState, raw json.RawMes
 		return nil, fmt.Errorf("%s (daemon=%s client=%s)", daemon.ErrBinaryHashMismatchPrefix, daemonHash, args.ClientBinaryHash)
 	}
 
-	// Validate the requested oracle backend. The daemon's resident
-	// OracleDaemon is currently spawned via oracle.FindJar (krit-types
-	// only); a later PR will plumb krit-fir into the same lifecycle.
-	// Until that lands, accept the empty / kaa values and return a
-	// typed error for anything else so the CLI falls back to
-	// in-process via runDaemonAnalyze's existing error-fallback path
-	// — preserving the historical `--oracle-backend fir` behavior
-	// from before the wire was carrying this field.
+	// Validate the requested oracle backend up front so the
+	// daemon-resident OracleDaemon spawn picks the right jar.
+	// ensureOracleDaemon routes BackendKAA to krit-types and
+	// BackendFIR to krit-fir; unrecognised spellings surface as a
+	// typed ErrUnsupportedOracleBackendPrefix so the CLI falls back
+	// to in-process via runDaemonAnalyze.
 	backend, err := oracle.ParseBackend(args.OracleBackend)
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", daemon.ErrUnsupportedOracleBackendPrefix, err)
-	}
-	if backend != oracle.BackendKAA {
-		return nil, fmt.Errorf("%s: %s not yet supported by serve daemon (pass --no-daemon for in-process %s)", daemon.ErrUnsupportedOracleBackendPrefix, backend, backend)
 	}
 
 	state.analyzeMu.Lock()
@@ -82,7 +77,7 @@ func handleAnalyzeProject(_ context.Context, state *daemonState, raw json.RawMes
 	start := time.Now()
 	dirty := state.workspace.DrainDirty()
 
-	in, err := state.buildProjectInput(args)
+	in, err := state.buildProjectInput(args, backend)
 	if err != nil {
 		state.analyzeMu.Unlock()
 		return nil, err
@@ -386,8 +381,10 @@ func (w *analyzeRespWriter) Write(p []byte) (int, error) {
 // buildProjectInput translates wire args into a pipeline.ProjectInput
 // against daemon-resident state. The function is the single seam
 // where CLI-flag-style knobs (rule lists, format) are wired into the
-// pipeline's typed value inputs.
-func (s *daemonState) buildProjectInput(args daemon.AnalyzeProjectArgs) (pipeline.ProjectInput, error) {
+// pipeline's typed value inputs. backend selects which JVM jar the
+// resident OracleDaemon spawns (krit-types vs krit-fir); the value
+// is parsed/validated upstream in handleAnalyzeProject.
+func (s *daemonState) buildProjectInput(args daemon.AnalyzeProjectArgs, backend oracle.Backend) (pipeline.ProjectInput, error) {
 	cfg, err := s.ensureConfig()
 	if err != nil {
 		return pipeline.ProjectInput{}, fmt.Errorf("load config: %w", err)
@@ -446,10 +443,11 @@ func (s *daemonState) buildProjectInput(args daemon.AnalyzeProjectArgs) (pipelin
 	}
 
 	// OracleDaemon is daemon-resident: lazy-started on first request
-	// when krit-types.jar is found. nil daemon means oracle stays
-	// disabled (no JVM, no behavior change vs. pre-#125). Per-verb
-	// ping happens at the call boundary in handleAnalyzeProject.
-	oracleDaemon, err := s.ensureOracleDaemon(paths)
+	// when the matching jar (krit-types for BackendKAA, krit-fir for
+	// BackendFIR) is found. nil daemon means oracle stays disabled
+	// (no JVM, no behavior change). Per-verb ping happens at the
+	// call boundary in handleAnalyzeProject.
+	oracleDaemon, err := s.ensureOracleDaemon(paths, backend)
 	if err != nil {
 		// Best-effort degrade: a failed daemon start shouldn't fail
 		// the whole verb. Log via stderr; the verb continues with

--- a/internal/cli/serve/analyze_project_oracle_backend_test.go
+++ b/internal/cli/serve/analyze_project_oracle_backend_test.go
@@ -3,13 +3,16 @@ package serve
 import (
 	"context"
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/kaeawc/krit/internal/daemon"
+	"github.com/kaeawc/krit/internal/oracle"
 )
 
-// TestHandleAnalyzeProject_RejectsUnknownOracleBackend pins the new
+// TestHandleAnalyzeProject_RejectsUnknownOracleBackend pins the
 // validation gate. An AnalyzeProjectArgs.OracleBackend value that
 // oracle.ParseBackend can't classify must come back with the typed
 // ErrUnsupportedOracleBackendPrefix so the CLI's runDaemonAnalyze
@@ -31,28 +34,97 @@ func TestHandleAnalyzeProject_RejectsUnknownOracleBackend(t *testing.T) {
 	}
 }
 
-// TestHandleAnalyzeProject_RejectsFIRBackendForNow holds the
-// transitional contract: the daemon's resident OracleDaemon is still
-// spawned via oracle.FindJar (krit-types). Until a later PR plumbs
-// krit-fir into the same lifecycle, the FIR backend must return the
-// typed ErrUnsupportedOracleBackendPrefix so the CLI falls back to
-// in-process — preserving the historical `--oracle-backend fir`
-// behavior end users had before the wire carried this field.
-func TestHandleAnalyzeProject_RejectsFIRBackendForNow(t *testing.T) {
-	state := newDaemonState(t.TempDir())
-	args := daemon.AnalyzeProjectArgs{OracleBackend: "fir"}
-	raw, err := json.Marshal(args)
+// TestOracleJarForBackend_PicksMatchingJar pins the backend → jar
+// routing. BackendKAA must consult oracle.FindJar (krit-types);
+// BackendFIR must consult firchecks.FindFirJar. Empty/unknown
+// backends fall through to KAA so callers can pass the result of
+// oracle.ParseBackend without re-checking. We exercise the routing
+// against a tmpdir with neither jar installed so both branches
+// return "" and the call is observable purely through whether it
+// took the FIR or KAA discovery path; that's captured by the t
+// helper sub-tests below which seed a jar in the matching layout
+// for each backend.
+func TestOracleJarForBackend_PicksMatchingJar(t *testing.T) {
+	t.Run("kaa-finds-krit-types", func(t *testing.T) {
+		tmp := t.TempDir()
+		seedJar(t, tmp, ".krit/krit-types.jar")
+		if got := oracleJarForBackend([]string{tmp}, oracle.BackendKAA); got == "" {
+			t.Error("BackendKAA must return non-empty when krit-types.jar is in place")
+		}
+	})
+	t.Run("fir-finds-krit-fir", func(t *testing.T) {
+		tmp := t.TempDir()
+		seedJar(t, tmp, ".krit/krit-fir.jar")
+		if got := oracleJarForBackend([]string{tmp}, oracle.BackendFIR); got == "" {
+			t.Error("BackendFIR must return non-empty when krit-fir.jar is in place")
+		}
+	})
+	t.Run("fir-ignores-krit-types", func(t *testing.T) {
+		// Only krit-types.jar present; FIR lookup must not return it.
+		tmp := t.TempDir()
+		seedJar(t, tmp, ".krit/krit-types.jar")
+		if got := oracleJarForBackend([]string{tmp}, oracle.BackendFIR); got != "" {
+			t.Errorf("BackendFIR returned %q but only krit-types.jar exists; routing leaked the wrong jar", got)
+		}
+	})
+	t.Run("kaa-ignores-krit-fir", func(t *testing.T) {
+		tmp := t.TempDir()
+		seedJar(t, tmp, ".krit/krit-fir.jar")
+		if got := oracleJarForBackend([]string{tmp}, oracle.BackendKAA); got != "" {
+			t.Errorf("BackendKAA returned %q but only krit-fir.jar exists; routing leaked the wrong jar", got)
+		}
+	})
+}
+
+// TestEnsureOracleDaemon_BackendKeyIsolation verifies that the two
+// backends populate independent cache slots; a KAA call must not
+// reuse the FIR entry and vice versa. Uses the fake starter so we
+// can prove the routing without spinning real JVMs. Each starter
+// call gets a distinct *oracle.Daemon pointer so the test can
+// detect any cache-key collision.
+func TestEnsureOracleDaemon_BackendKeyIsolation(t *testing.T) {
+	tmp := t.TempDir()
+	seedJar(t, tmp, ".krit/krit-types.jar")
+	seedJar(t, tmp, ".krit/krit-fir.jar")
+
+	state := newDaemonState(tmp)
+	t.Cleanup(state.closeOracleDaemons)
+	kaa := &oracle.Daemon{}
+	fir := &oracle.Daemon{}
+	state.oracleDaemonStarter = &fakeOracleDaemonStarter{returns: []*oracle.Daemon{kaa, fir}}
+
+	dk, err := state.ensureOracleDaemon([]string{tmp}, oracle.BackendKAA)
 	if err != nil {
-		t.Fatalf("marshal: %v", err)
+		t.Fatalf("KAA ensure: %v", err)
 	}
-	_, err = handleAnalyzeProject(context.Background(), state, raw)
-	if err == nil {
-		t.Fatal("expected typed error for FIR backend (not yet supported daemon-side)")
+	df, err := state.ensureOracleDaemon([]string{tmp}, oracle.BackendFIR)
+	if err != nil {
+		t.Fatalf("FIR ensure: %v", err)
 	}
-	if !strings.Contains(err.Error(), daemon.ErrUnsupportedOracleBackendPrefix) {
-		t.Errorf("error missing typed prefix %q: %v", daemon.ErrUnsupportedOracleBackendPrefix, err)
+	if dk == df {
+		t.Errorf("KAA and FIR daemons share a cache slot: dk=%p df=%p (key isolation broken)", dk, df)
 	}
-	if !strings.Contains(err.Error(), "fir") {
-		t.Errorf("error message should mention the offending backend; got %v", err)
+	// Second KAA call must reuse the cached pointer.
+	dk2, err := state.ensureOracleDaemon([]string{tmp}, oracle.BackendKAA)
+	if err != nil {
+		t.Fatalf("KAA second ensure: %v", err)
+	}
+	if dk2 != dk {
+		t.Errorf("KAA cache miss on second call: dk=%p dk2=%p", dk, dk2)
+	}
+}
+
+// seedJar writes a zero-byte file at root/rel so the jar-discovery
+// path returns a non-empty match. Useful for asserting the routing
+// without actually spawning a JVM. Cleaned up automatically by
+// t.TempDir's lifecycle.
+func seedJar(t *testing.T, root, rel string) {
+	t.Helper()
+	full := filepath.Join(root, rel)
+	if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+		t.Fatalf("mkdir for %s: %v", rel, err)
+	}
+	if err := os.WriteFile(full, nil, 0o644); err != nil {
+		t.Fatalf("write %s: %v", rel, err)
 	}
 }

--- a/internal/cli/serve/oracle_daemon_test.go
+++ b/internal/cli/serve/oracle_daemon_test.go
@@ -45,7 +45,7 @@ func TestEnsureOracleDaemon_GracefulDisableWhenJarMissing(t *testing.T) {
 	fake := &fakeOracleDaemonStarter{}
 	state.oracleDaemonStarter = fake
 
-	d, err := state.ensureOracleDaemon([]string{state.root})
+	d, err := state.ensureOracleDaemon([]string{state.root}, oracle.BackendKAA)
 	if err != nil {
 		t.Fatalf("ensureOracleDaemon: %v", err)
 	}

--- a/internal/cli/serve/serve.go
+++ b/internal/cli/serve/serve.go
@@ -25,6 +25,7 @@ import (
 	"github.com/kaeawc/krit/internal/cli/clishared"
 	"github.com/kaeawc/krit/internal/config"
 	"github.com/kaeawc/krit/internal/daemon"
+	"github.com/kaeawc/krit/internal/firchecks"
 	"github.com/kaeawc/krit/internal/module"
 	"github.com/kaeawc/krit/internal/oracle"
 	"github.com/kaeawc/krit/internal/pipeline"
@@ -477,19 +478,40 @@ func (e *oracleDaemonEntry) close() error {
 	return e.daemon.Close()
 }
 
-// ensureOracleDaemon lazy-starts (or reuses) a krit-types JVM daemon
-// for the given scan paths. Returns (nil, nil) when the krit-types JAR
-// cannot be located — callers treat that as "oracle disabled" and the
-// verb proceeds without type resolution. Subsequent calls with the
-// same scan-path key reuse the cached *oracle.Daemon.
+// oracleJarForBackend picks the JVM jar the resident oracle daemon
+// runs. Empty / unknown backends route to KAA (the historical
+// default) so the caller can treat "" as "use the default" without
+// reproducing the routing logic. Returns "" when neither jar is
+// installed; callers degrade to "oracle disabled".
+func oracleJarForBackend(scanPaths []string, backend oracle.Backend) string {
+	switch backend {
+	case oracle.BackendFIR:
+		return firchecks.FindFirJar(scanPaths)
+	default:
+		return oracle.FindJar(scanPaths)
+	}
+}
+
+// ensureOracleDaemon lazy-starts (or reuses) the JVM daemon backing
+// the requested backend for the given scan paths. BackendKAA spawns
+// krit-types via oracle.FindJar; BackendFIR spawns krit-fir via
+// firchecks.FindFirJar. Returns (nil, nil) when the matching JAR
+// cannot be located — callers treat that as "oracle disabled" and
+// the verb proceeds without type resolution.
+//
+// Each (jarPath, sourceDirs) pair gets its own cache entry, so a
+// project that flips between FIR and KAA reaches each backend
+// without trampling the other's resident state. The on-the-wire
+// protocol is the same for both jars (see #559), so the
+// defaultOracleDaemonStarter implementation is reused verbatim.
 //
 // Wired into the analyze-project verb path: buildProjectInput threads
 // the returned handle into ProjectHostState.OracleDaemon and flips
 // ProjectArgs.OracleEnabled when the daemon is non-nil, so type-aware
 // rules in the daemon get oracle precision without paying JVM startup
 // on every call.
-func (s *daemonState) ensureOracleDaemon(scanPaths []string) (*oracle.Daemon, error) {
-	jarPath := oracle.FindJar(scanPaths)
+func (s *daemonState) ensureOracleDaemon(scanPaths []string, backend oracle.Backend) (*oracle.Daemon, error) {
+	jarPath := oracleJarForBackend(scanPaths, backend)
 	if jarPath == "" {
 		// Graceful disable: no jar means oracle isn't installed in
 		// this environment. Cache the negative result so we don't


### PR DESCRIPTION
## Summary
The serve daemon's resident \`OracleDaemon\` was hardcoded to krit-types via \`oracle.FindJar\`. \`AnalyzeProjectArgs.OracleBackend\` ([#585](https://github.com/kaeawc/krit/pull/585)) carried the user's selection over the wire but the serve handler rejected anything other than KAA with a typed \`ErrUnsupportedOracleBackendPrefix\` so the CLI fell back to in-process. This PR completes the FIR-via-daemon plumbing:

- \`ensureOracleDaemon\` takes the parsed \`oracle.Backend\` and routes jar lookup through \`oracleJarForBackend\` — krit-types for \`BackendKAA\`, krit-fir for \`BackendFIR\` via \`firchecks.FindFirJar\`.
- The cache key encodes the jar path, so each backend gets an independent \`oracle.Daemon\` slot — flipping \`--oracle-backend\` between calls warms both jars without trampling either's resident state.
- \`handleAnalyzeProject\` parses the backend and threads it through \`buildProjectInput\` → \`ensureOracleDaemon\`. The transitional \"FIR not yet supported\" guard is removed.

Item 2 of the FIR + daemon plumbing enumeration (item 1 was [#585](https://github.com/kaeawc/krit/pull/585)).

## Protocol compatibility
The on-the-wire protocol \`oracle.Daemon\` speaks is identical between krit-types and krit-fir (#559 added the \`method\` alias on the FIR side; #565 made empty \`sourceDirs\` reuse the existing session). The existing \`defaultOracleDaemonStarter\` drives either jar unchanged.

## Test plan
- [x] \`TestOracleJarForBackend_PicksMatchingJar\` (4 sub-tests) — backend → jar routing including negative cases (KAA must NOT pick krit-fir and vice versa).
- [x] \`TestEnsureOracleDaemon_BackendKeyIsolation\` — two backends populate independent cache slots; same-backend reuses the slot.
- [x] \`TestHandleAnalyzeProject_RejectsUnknownOracleBackend\` — typed error still surfaces for unparseable values.
- [x] Pre-existing \`TestEnsureOracleDaemon_GracefulDisableWhenJarMissing\` updated to new signature.
- [x] \`go test ./internal/cli/serve/ -count=1\`
- [x] \`golangci-lint run ./internal/cli/serve/... ./internal/cli/scan/...\` — 0 issues.
- [ ] Follow-up benchmark vs \`~/github/kotlin\` — items 3 (parity via \`--strict-verify\`) and 4 (warm-rerun floor measurement) in the enumeration.