### PR TITLE
feat(serve): strict-verify honors AnalyzeProjectArgs.OracleBackend

### DIFF
--- a/internal/cli/serve/strict_verify.go
+++ b/internal/cli/serve/strict_verify.go
@@ -12,6 +12,7 @@ import (
 	"github.com/kaeawc/krit/internal/cli/clishared"
 	"github.com/kaeawc/krit/internal/config"
 	"github.com/kaeawc/krit/internal/daemon"
+	"github.com/kaeawc/krit/internal/oracle"
 	"github.com/kaeawc/krit/internal/pipeline"
 	"github.com/kaeawc/krit/internal/rules"
 	"github.com/kaeawc/krit/internal/scanner"
@@ -154,12 +155,23 @@ func (r *strictVerifyAnalyzeResponse) WriteRawResponse(ctx context.Context, w io
 // finding sets via daemon.Compare, and persists a structured log under
 // `${repoDir}/.krit/daemon-divergence-NNNN.log` on divergence.
 //
-// The baseline runs with an empty ProjectHostState so no resident cache
-// contaminates the comparison: a fresh parse cache, no resident
-// CodeIndex / Resolver / OracleFilter / AnalysisCache, no resident
-// oracle daemon. The intent is to reproduce what `krit --no-daemon`
-// would emit and surface any drift the daemon's resident state
-// introduced.
+// The baseline runs with a fresh ProjectHostState so resident CodeIndex
+// / Resolver / OracleFilter / AnalysisCache state can't contaminate the
+// comparison. Two exceptions are intentional:
+//
+//   - The parse cache is freshly constructed for the baseline only, so
+//     stale memoised parses can't mask a daemon-side bug.
+//   - The oracle daemon (krit-types or krit-fir, picked from
+//     args.OracleBackend) is shared with the daemon call. The
+//     out-of-process JVM is itself a daemon-resident piece whose
+//     correctness is independent of krit's resident state, and
+//     spawning a second JVM per strict-verify would balloon the
+//     cost without exercising any new code path. Sharing it keeps
+//     the comparison apples-to-apples for oracle-dependent rules.
+//
+// The intent is to reproduce what `krit --no-daemon` would emit (with
+// the same backend) and surface any drift the daemon's resident
+// non-oracle state introduced.
 //
 // On divergence the returned log path is non-empty and the error
 // describes the diff shape; callers should fail the analyze response
@@ -190,6 +202,27 @@ func (s *daemonState) runStrictVerify(ctx context.Context, args daemon.AnalyzePr
 		paths = []string{s.root}
 	}
 
+	// Honor the daemon call's oracle backend so the baseline is a
+	// true apples-to-apples comparison. Without this the baseline
+	// would always disable oracle and any oracle-dependent rule
+	// (CommitPrefEdits, ShowToast, the FIR-only rules, …) would
+	// diverge regardless of daemon correctness. Validation already
+	// happened upstream in handleAnalyzeProject; here we just need
+	// to spawn (or reuse) the matching jar.
+	backend, parseErr := oracle.ParseBackend(args.OracleBackend)
+	if parseErr != nil {
+		return "", fmt.Errorf("baseline oracle backend: %w", parseErr)
+	}
+	oracleDaemon, oracleErr := s.ensureOracleDaemon(paths, backend)
+	if oracleErr != nil {
+		// Mirror buildProjectInput's "best-effort degrade": a failed
+		// oracle daemon start shouldn't fail strict-verify. The
+		// resulting comparison may surface oracle-driven divergence,
+		// which is the same shape we'd get on a fresh CLI run with
+		// no oracle available — still useful as a diff signal.
+		oracleDaemon = nil
+	}
+
 	pc, err := scanner.NewParseCacheWithCap(s.repoDir, cacheutil.DefaultParseCacheCapBytes)
 	if err != nil {
 		return "", fmt.Errorf("baseline parse cache: %w", err)
@@ -208,8 +241,15 @@ func (s *daemonState) runStrictVerify(ctx context.Context, args daemon.AnalyzePr
 			WarningsAsErrors: args.WarningsAsErrors,
 			IncludeGenerated: args.IncludeGenerated,
 			Version:          kritVersion(),
+			// Enabling oracle keys the baseline to the same backend the
+			// daemon call used; wireOracleHandles consumes host.OracleDaemon
+			// from the matching ensureOracleDaemon slot.
+			OracleEnabled: oracleDaemon != nil,
 		},
-		Host: pipeline.ProjectHostState{ParseCache: pc},
+		Host: pipeline.ProjectHostState{
+			ParseCache:   pc,
+			OracleDaemon: oracleDaemon,
+		},
 	})
 	if err != nil {
 		return "", fmt.Errorf("baseline analyze: %w", err)

--- a/internal/cli/serve/strict_verify_test.go
+++ b/internal/cli/serve/strict_verify_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/kaeawc/krit/internal/daemon"
+	"github.com/kaeawc/krit/internal/oracle"
 	"github.com/kaeawc/krit/internal/scanner"
 )
 
@@ -88,5 +89,105 @@ func TestRunStrictVerify_DetectsAddedRow(t *testing.T) {
 	}
 	if _, statErr := os.Stat(logPath); statErr != nil {
 		t.Fatalf("divergence log not written at %s: %v", logPath, statErr)
+	}
+}
+
+// TestRunStrictVerify_RejectsBogusBackend pins the validation gate.
+// runStrictVerify must surface oracle.ParseBackend's error rather
+// than silently substituting the default, otherwise a typo'd
+// AnalyzeProjectArgs.OracleBackend slips through as "matched
+// KAA on both sides" and masks any FIR-only daemon bug.
+func TestRunStrictVerify_RejectsBogusBackend(t *testing.T) {
+	root := t.TempDir()
+	writeKotlinFile(t, root, "X.kt", "package demo\n\nclass X\n")
+
+	state := newDaemonState(root)
+	state.strictVerify = true
+
+	daemonCols := scanner.FindingColumns{}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	args := daemon.AnalyzeProjectArgs{OracleBackend: "not-a-backend"}
+	_, err := state.runStrictVerify(ctx, args, &daemonCols)
+	if err == nil {
+		t.Fatal("expected error for bogus baseline oracle backend")
+	}
+	if !strings.Contains(err.Error(), "baseline oracle backend") {
+		t.Errorf("expected error to mention baseline oracle backend; got %q", err.Error())
+	}
+}
+
+// TestRunStrictVerify_KAABaselineSharesOracleDaemon pins the
+// apples-to-apples contract for KAA: the baseline must reuse the
+// daemon's resident oracle handle (same JVM, same session) so a
+// no-source-change comparison only exercises non-oracle resident
+// state. Two ensureOracleDaemon calls with the same backend return
+// the cached entry, so we can assert pointer equality after a
+// strict-verify run.
+//
+// Drives the helper directly: a fake starter records pointer
+// identities, and we cross-check that the slot used by the daemon
+// call is the same one runStrictVerify wires into ProjectHostState.
+func TestRunStrictVerify_KAABaselineSharesOracleDaemon(t *testing.T) {
+	root := t.TempDir()
+	seedJar(t, root, ".krit/krit-types.jar")
+	writeKotlinFile(t, root, "X.kt", "package demo\n\nclass X\n")
+
+	state := newDaemonState(root)
+	state.strictVerify = true
+	resident := &oracle.Daemon{}
+	state.oracleDaemonStarter = &fakeOracleDaemonStarter{returns: []*oracle.Daemon{resident}}
+
+	// First call seeds the cache as the daemon analyze path would.
+	if _, err := state.ensureOracleDaemon([]string{root}, oracle.BackendKAA); err != nil {
+		t.Fatalf("ensure KAA: %v", err)
+	}
+
+	// The strict-verify baseline must reuse the same slot. We can't
+	// easily peek at ProjectHostState the helper builds, but the
+	// public observable is: a second ensureOracleDaemon call from
+	// runStrictVerify must return resident without incrementing the
+	// starter call count.
+	prevCalls := state.oracleDaemonStarter.(*fakeOracleDaemonStarter).calls.Load()
+	daemonCols := scanner.FindingColumns{}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	// Use OracleBackend="" which parses to DefaultBackend (KAA).
+	_, _ = state.runStrictVerify(ctx, daemon.AnalyzeProjectArgs{}, &daemonCols)
+	newCalls := state.oracleDaemonStarter.(*fakeOracleDaemonStarter).calls.Load()
+	if newCalls != prevCalls {
+		t.Errorf("baseline spawned a fresh starter call (%d → %d); expected to reuse the daemon's resident KAA slot", prevCalls, newCalls)
+	}
+}
+
+// TestRunStrictVerify_FIRBaselineSharesOracleDaemon mirrors the KAA
+// case for BackendFIR — the post-#586 daemon spawns krit-fir under
+// the same ensureOracleDaemon contract. Without this guard a
+// strict-verify run with --oracle-backend=fir would silently spawn
+// a second JVM for the baseline, defeating the apples-to-apples
+// intent.
+func TestRunStrictVerify_FIRBaselineSharesOracleDaemon(t *testing.T) {
+	root := t.TempDir()
+	seedJar(t, root, ".krit/krit-fir.jar")
+	writeKotlinFile(t, root, "X.kt", "package demo\n\nclass X\n")
+
+	state := newDaemonState(root)
+	state.strictVerify = true
+	resident := &oracle.Daemon{}
+	state.oracleDaemonStarter = &fakeOracleDaemonStarter{returns: []*oracle.Daemon{resident}}
+
+	if _, err := state.ensureOracleDaemon([]string{root}, oracle.BackendFIR); err != nil {
+		t.Fatalf("ensure FIR: %v", err)
+	}
+
+	prevCalls := state.oracleDaemonStarter.(*fakeOracleDaemonStarter).calls.Load()
+	daemonCols := scanner.FindingColumns{}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	_, _ = state.runStrictVerify(ctx, daemon.AnalyzeProjectArgs{OracleBackend: "fir"}, &daemonCols)
+	newCalls := state.oracleDaemonStarter.(*fakeOracleDaemonStarter).calls.Load()
+	if newCalls != prevCalls {
+		t.Errorf("FIR baseline spawned a fresh starter call (%d → %d); expected to reuse the daemon's resident FIR slot", prevCalls, newCalls)
 	}
 }


### PR DESCRIPTION
## Summary
\`runStrictVerify\` baseline ran with no oracle daemon, so any oracle-dependent rule diverged from the daemon's call regardless of correctness. After [#586](https://github.com/kaeawc/krit/pull/586) the daemon honors \`--oracle-backend\` (KAA or FIR); this PR teaches the strict-verify baseline to share the same backend so the comparison is apples-to-apples.

Item 3 of the FIR + daemon plumbing enumeration.

## Implementation
The baseline parses \`args.OracleBackend\` via \`oracle.ParseBackend\`, calls \`state.ensureOracleDaemon(paths, backend)\`, and threads the resulting handle into the baseline \`ProjectInput\`. The resident oracle daemon is **intentionally shared** with the daemon call: the out-of-process JVM is itself a daemon-resident piece whose correctness is independent of krit's resident Go-side state. Spawning a second JVM per strict-verify would balloon the cost without exercising any new code path, so sharing keeps the comparison apples-to-apples for oracle-dependent rules.

## Test plan
- [x] \`TestRunStrictVerify_RejectsBogusBackend\` — typed validation gate so a typo'd \`OracleBackend\` doesn't silently substitute \`DefaultBackend\`.
- [x] \`TestRunStrictVerify_KAABaselineSharesOracleDaemon\` — baseline reuses the cached KAA slot (no fresh starter call).
- [x] \`TestRunStrictVerify_FIRBaselineSharesOracleDaemon\` — same guarantee for the FIR slot (post-#586).
- [x] Pre-existing \`TestRunStrictVerify_DetectsAddedRow\` + \`TestAnalyzeProject_StrictVerifyHappyPath\` still green.
- [x] \`go test ./internal/cli/serve/ -count=1\`, \`golangci-lint run ./internal/cli/serve/...\` — 0 issues.