### PR TITLE
perf(pipeline): tag dispatch bundle outcomes + emit dispatchPath label

### DIFF
--- a/internal/pipeline/dispatch_path_perf_test.go
+++ b/internal/pipeline/dispatch_path_perf_test.go
@@ -1,0 +1,96 @@
+package pipeline
+
+import (
+	"testing"
+
+	"github.com/kaeawc/krit/internal/perf"
+	"github.com/kaeawc/krit/internal/scanner"
+)
+
+// TestTryBundleLayer_HitEmitsOutcomeAttr is the regression guard for the
+// diagnostic plumbing: a hit on any bundle layer must produce a perf
+// entry tagged with outcome=hit. Before the diagnostic patch, hit/miss
+// was implicit ("did the next layer's scope also show up?"), which the
+// daemon path doesn't surface clearly because tracker.IsEnabled() and
+// the per-layer scope creation interact in ways that obscured the
+// answer. With explicit attribute tagging, perf JSON always answers
+// the question on every call.
+func TestTryBundleLayer_HitEmitsOutcomeAttr(t *testing.T) {
+	tracker := perf.New(true)
+	cached := &scanner.FindingColumns{}
+	_, _, ok := tryBundleLayer(tracker, "dispatchBundleLoad", IndexResult{},
+		func() (*scanner.FindingColumns, bool) { return cached, true })
+	if !ok {
+		t.Fatal("expected hit")
+	}
+	entries := tracker.GetTimings()
+	found := false
+	for _, e := range entries {
+		if e.Name != "dispatchBundleLoad" {
+			continue
+		}
+		found = true
+		if got := e.Attributes["outcome"]; got != "hit" {
+			t.Errorf("dispatchBundleLoad outcome = %q, want %q", got, "hit")
+		}
+	}
+	if !found {
+		t.Errorf("dispatchBundleLoad entry missing; got %v", entryNames(entries))
+	}
+}
+
+// TestTryBundleLayer_MissEmitsOutcomeAttr is the symmetric guard: a
+// missed bundle layer must still emit a perf entry so the next layer's
+// presence isn't the only signal that this one was attempted.
+func TestTryBundleLayer_MissEmitsOutcomeAttr(t *testing.T) {
+	tracker := perf.New(true)
+	_, _, ok := tryBundleLayer(tracker, "dispatchStableBundleLoad", IndexResult{},
+		func() (*scanner.FindingColumns, bool) { return nil, false })
+	if ok {
+		t.Fatal("expected miss")
+	}
+	entries := tracker.GetTimings()
+	found := false
+	for _, e := range entries {
+		if e.Name != "dispatchStableBundleLoad" {
+			continue
+		}
+		found = true
+		if got := e.Attributes["outcome"]; got != "miss" {
+			t.Errorf("dispatchStableBundleLoad outcome = %q, want %q", got, "miss")
+		}
+	}
+	if !found {
+		t.Errorf("dispatchStableBundleLoad entry missing on miss; got %v", entryNames(entries))
+	}
+}
+
+// TestTryBundleLayer_NilCachedTreatedAsMiss pins the edge case where
+// the loader returns (nil, true) — historically this counts as a miss
+// even though `ok` is true, because there's nothing to replay. The
+// outcome attribute must reflect that.
+func TestTryBundleLayer_NilCachedTreatedAsMiss(t *testing.T) {
+	tracker := perf.New(true)
+	_, _, ok := tryBundleLayer(tracker, "dispatchBundleLoad", IndexResult{},
+		func() (*scanner.FindingColumns, bool) { return nil, true })
+	if ok {
+		t.Fatal("expected miss (nil cached treated as miss)")
+	}
+	entries := tracker.GetTimings()
+	for _, e := range entries {
+		if e.Name != "dispatchBundleLoad" {
+			continue
+		}
+		if got := e.Attributes["outcome"]; got != "miss" {
+			t.Errorf("nil-cached should record miss; got outcome=%q", got)
+		}
+	}
+}
+
+func entryNames(entries []perf.TimingEntry) []string {
+	out := make([]string, 0, len(entries))
+	for _, e := range entries {
+		out = append(out, e.Name)
+	}
+	return out
+}

--- a/internal/pipeline/project.go
+++ b/internal/pipeline/project.go
@@ -1543,6 +1543,14 @@ func runDispatchOrLoadBundle(
 	// dispatch flow, so a bundle hit halfway through leaves a "gap"
 	// with no children for the user to investigate).
 	tracker := host.Tracker
+	// recordDispatchPath emits a single "dispatchPath" perf entry with the
+	// outcome label so a one-glance read of the perf JSON answers
+	// "which layer fired" without cross-referencing the presence /
+	// absence of the per-layer scopes. Mirrors the per-layer hit/miss
+	// attribute pattern from tryBundleLayer.
+	recordDispatchPath := func(path string) {
+		perf.AddEntryDetails(tracker, "dispatchPath", 0, nil, map[string]string{"path": path})
+	}
 	if bundleEnabled {
 		// cacheHitFullBundle: RunFingerprint matches a prior run
 		// exactly; the prior bytes are guaranteed correct for this
@@ -1551,6 +1559,7 @@ func runDispatchOrLoadBundle(
 			cached, found := host.FindingsBundleStore.Load(host.FindingsBundleCacheRoot, runFP)
 			return cached, found
 		}); ok {
+			recordDispatchPath("cacheHitFullBundle")
 			return d, c, true, dispatchTimings{}, nil
 		}
 		// cacheHitStructuralBundle: SourceSet hash drifted but every
@@ -1560,6 +1569,7 @@ func runDispatchOrLoadBundle(
 		if d, c, ok := tryBundleLayer(tracker, "dispatchStableBundleLoad", indexResult, func() (*scanner.FindingColumns, bool) {
 			return tryLoadStructurallyStableBundle(host, runFP, manifest)
 		}); ok {
+			recordDispatchPath("cacheHitStructuralBundle")
 			return d, c, true, dispatchTimings{}, nil
 		}
 		reportFindingsBundleMiss(host, manifest, runFP)
@@ -1570,33 +1580,36 @@ func runDispatchOrLoadBundle(
 		var deltaC CrossFileResult
 		var deltaOK bool
 		var deltaErr error
-		deltaFn := func() {
-			deltaD, deltaC, deltaOK, deltaErr = tryDeltaDispatch(ctx, args, host, indexResult, parseResult, runFP, manifest)
+		deltaStart := time.Now()
+		deltaD, deltaC, deltaOK, deltaErr = tryDeltaDispatch(ctx, args, host, indexResult, parseResult, runFP, manifest)
+		deltaOutcome := "miss"
+		if deltaOK {
+			deltaOutcome = "hit"
 		}
-		if tracker != nil && tracker.IsEnabled() {
-			tracker.TrackVoid("dispatchDeltaPath", deltaFn)
-		} else {
-			deltaFn()
-		}
+		perf.AddEntryDetails(tracker, "dispatchDeltaPath", time.Since(deltaStart), nil, map[string]string{"outcome": deltaOutcome})
 		if deltaErr != nil {
 			return DispatchResult{}, CrossFileResult{}, false, dispatchTimings{}, deltaErr
 		}
 		if deltaOK {
+			recordDispatchPath("cacheHitDeltaBundle")
 			return deltaD, deltaC, false, dispatchTimings{}, nil
 		}
 	}
 	dispatchStart := time.Now()
 	d, err := DispatchPhase{}.Run(ctx, indexResult)
 	dispatchMs := time.Since(dispatchStart).Milliseconds()
+	perf.AddEntry(tracker, "dispatchPhaseRun", time.Since(dispatchStart))
 	if err != nil {
 		return DispatchResult{}, CrossFileResult{}, false, dispatchTimings{}, fmt.Errorf("dispatch: %w", err)
 	}
 	crossStart := time.Now()
 	c, err := CrossFilePhase{Workers: args.Workers}.Run(ctx, d)
 	crossMs := time.Since(crossStart).Milliseconds()
+	perf.AddEntry(tracker, "crossFilePhaseRun", time.Since(crossStart))
 	if err != nil {
 		return DispatchResult{}, CrossFileResult{}, false, dispatchTimings{}, fmt.Errorf("crossfile: %w", err)
 	}
+	recordDispatchPath("cacheMissFullDispatch")
 	return d, c, false, dispatchTimings{dispatchMs: dispatchMs, crossFileMs: crossMs}, nil
 }
 
@@ -1615,12 +1628,22 @@ func tryBundleLayer(
 ) (DispatchResult, CrossFileResult, bool) {
 	var cached *scanner.FindingColumns
 	var ok bool
-	fn := func() { cached, ok = load() }
-	if tracker != nil && tracker.IsEnabled() {
-		tracker.TrackVoid(scope, fn)
-	} else {
-		fn()
+	// Time the load manually so we can emit a perf entry tagged with
+	// hit/miss outcome. The historical tracker.TrackVoid path only
+	// timed the scope, leaving the hit/miss distinction implicit in
+	// "was the next layer's scope also emitted" — which is fragile
+	// for the daemon path where we genuinely want to know which
+	// bundle layer fired (cacheHitFullBundle / cacheHitStructuralBundle
+	// / cacheHitDeltaBundle / cacheMissFullDispatch). With explicit
+	// hit attrs the perf JSON answers that question on every call.
+	start := time.Now()
+	cached, ok = load()
+	dur := time.Since(start)
+	outcome := "miss"
+	if ok && cached != nil {
+		outcome = "hit"
 	}
+	perf.AddEntryDetails(tracker, scope, dur, nil, map[string]string{"outcome": outcome})
 	if !ok || cached == nil {
 		return DispatchResult{}, CrossFileResult{}, false
 	}


### PR DESCRIPTION
## Summary
\`runDispatchOrLoadBundle\` / \`tryBundleLayer\` previously emitted each bundle layer's perf scope only when \`tracker.IsEnabled()\`, and even then the scope's *duration alone* couldn't tell hit from miss — the distinction was implicit in whether the next layer's scope also showed up in the JSON. That broke down for the daemon path on warm+ABI where a 8 ms \`dispatchBundleLoad\` entry sat alone in the perf tree, ambiguous between \"layer 1 hit, layers 2-3 skipped\" and \"layer 1 missed, perf scope not emitted for the rest\".

The downstream architectural work (incremental code-index, incremental dispatch) can't pick the right target without knowing which dispatch path actually fired. This PR makes the answer visible at a glance.

Item 1 of the warm+ABI architectural follow-up enumeration.

## Behavior
- Each bundle-layer attempt records a perf entry tagged \`outcome=hit|miss\`.
- A final \`dispatchPath\` entry labels the chosen path: \`cacheHitFullBundle\` / \`cacheHitStructuralBundle\` / \`cacheHitDeltaBundle\` / \`cacheMissFullDispatch\`.
- The full-dispatch fall-through emits explicit \`dispatchPhaseRun\` + \`crossFilePhaseRun\` entries so the IndexPhase-vs-CrossFilePhase split is visible.

## Test plan
- [x] \`TestTryBundleLayer_HitEmitsOutcomeAttr\` — hit path tags outcome=hit.
- [x] \`TestTryBundleLayer_MissEmitsOutcomeAttr\` — miss path tags outcome=miss.
- [x] \`TestTryBundleLayer_NilCachedTreatedAsMiss\` — \`(nil, true)\` loader response counted as miss.
- [x] \`go test ./internal/pipeline/\` (full package green).
- [x] \`go vet ./...\`, \`golangci-lint run ./internal/pipeline/\` — 0 issues.