### PR TITLE
fix(serve): bump source-mtime version eagerly to close BundleStatsClean race

### DIFF
--- a/internal/cli/serve/watcher.go
+++ b/internal/cli/serve/watcher.go
@@ -315,7 +315,27 @@ func (fw *fileWatcher) handle(ev backendEvent) {
 // scheduleKotlinInvalidate coalesces rapid fsnotify events for path into a
 // single Invalidate+Touch call fired after fw.debounceWindow of silence.
 // Each new event within the window restarts the timer (sliding debounce).
+//
+// The source-mtime version bump is intentionally NOT part of the debounced
+// body: it fires eagerly on every event so the daemon's
+// BundleStatsClean memo invalidates within microseconds of the first
+// write rather than waiting for the 50 ms quiescence window. Without the
+// eager bump, an analyze-project call within the debounce window of a
+// file write would see BundleStatsClean=true (no event has fired yet —
+// the watcher's timer is still ticking) and serve STALE findings from
+// the pre-parse bundle. Demonstrated against ~/github/kotlin: a probe
+// appended to iterators.kt immediately before analyze-project produced
+// byte-identical findings to the no-probe call, both serving findings
+// for a `__kritItem3` function from a prior session's probe. Bumping
+// eagerly is safe because (a) the bump is just an atomic counter
+// increment, and (b) all downstream invalidations remain debounced —
+// resident workspace state stays consistent, and the next analyze
+// rebuilds from disk anyway via the post-parse path.
 func (fw *fileWatcher) scheduleKotlinInvalidate(path string) {
+	// Eager bump: invalidate BundleStatsClean on the very first event
+	// so the pre-parse bundle layer cannot serve stale findings within
+	// the debounce window.
+	fw.state.BumpSourceMTimeVersion()
 	fw.debounceMu.Lock()
 	if t, ok := fw.debounce[path]; ok {
 		t.Stop()
@@ -337,12 +357,6 @@ func (fw *fileWatcher) scheduleKotlinInvalidate(path string) {
 		fw.state.InvalidateResolver()
 		fw.state.InvalidateOracleFilter()
 		fw.state.Touch(path)
-		// Bumping the version invalidates every daemon-resident
-		// bundle-stats-clean memo, so the next analyze re-runs
-		// fileStatsMatch against the manifest. Without this the
-		// memo could survive a real edit that the watcher saw —
-		// correctness-critical, not just a perf hook.
-		fw.state.BumpSourceMTimeVersion()
 	})
 	fw.debounceMu.Unlock()
 }

--- a/internal/cli/serve/watcher_test.go
+++ b/internal/cli/serve/watcher_test.go
@@ -705,3 +705,52 @@ func TestFileWatcher_BumpsXMLFilesVersionOnXMLEdit(t *testing.T) {
 		}
 	})
 }
+
+// TestFileWatcher_BumpSourceMTimeIsEager pins the BundleStatsClean race
+// fix: BumpSourceMTimeVersion must fire on the FIRST fsnotify event, not
+// after the debounce window. The pre-parse bundle layer's
+// BundleStatsClean fast path returns true when sourceMTimeVersion hasn't
+// changed since the prior sweep. If the bump waited for the debounce
+// timer (50 ms by default), an analyze-project call within the debounce
+// window of a write would still see the stale "no events" state and
+// serve cached findings that don't reflect the change.
+//
+// Setup: install a watcher with a long debounce window (300 ms) so the
+// downstream Invalidate* calls demonstrably haven't fired yet, write a
+// .kt file, and assert that BumpSourceMTimeVersion was called before the
+// debounce body. invalidateCalls must still be 0 (debounced); bumpCalls
+// must already be >= 1 (eager).
+func TestFileWatcher_BumpSourceMTimeIsEager(t *testing.T) {
+	root := t.TempDir()
+	ktPath := filepath.Join(root, "Foo.kt")
+	if err := os.WriteFile(ktPath, []byte("fun a() {}\n"), 0o644); err != nil {
+		t.Fatalf("seed kt: %v", err)
+	}
+
+	state := &countingState{}
+	const debounce = 300 * time.Millisecond
+	w, err := startFileWatcherWithState(context.Background(), root, state, nil,
+		withDebounceWindow(debounce))
+	if err != nil {
+		t.Fatalf("startFileWatcher: %v", err)
+	}
+	defer w.Stop()
+	<-w.Ready()
+
+	// Trigger a write. The fsnotify event delivery is async but should
+	// complete well within 100 ms on every supported platform.
+	if err := os.WriteFile(ktPath, []byte("fun a() { 42 }\n"), 0o644); err != nil {
+		t.Fatalf("rewrite kt: %v", err)
+	}
+
+	// Wait long enough for the event to be delivered (~10-30 ms typical)
+	// but well under the 300 ms debounce window. The bump must already
+	// have fired; the Invalidate must not.
+	if !waitForCondition(func() bool { return state.bumpCalls.Load() >= 1 }) {
+		t.Fatalf("BumpSourceMTimeVersion did not fire within timeout; bump=%d", state.bumpCalls.Load())
+	}
+	if got := state.invalidateCalls.Load(); got != 0 {
+		t.Errorf("Invalidate fired before debounce window (bump=%d invalidate=%d); the eager bump must NOT also have eagerly invalidated downstream state",
+			state.bumpCalls.Load(), got)
+	}
+}


### PR DESCRIPTION
## Summary
The watcher's \`BumpSourceMTimeVersion()\` call sat inside the debounce timer body, so for the default 50 ms debounce window the daemon's \`BundleStatsClean\` memo still reported \"no events\" after a file write. An analyze-project call landing inside that window saw \`BundleStatsClean=true\`, the pre-parse bundle layer's \`fileStatsMatch\` sweep was skipped, and **STALE findings** were served from the bundle output cache.

Discovered during item 2 of the warm+ABI architectural follow-up enumeration. The bump itself is an atomic counter increment; there's no reason to debounce it. Downstream invalidations stay debounced.

## Repro
Demonstrated against \`~/github/kotlin\`:
\`\`\`bash
# Daemon already warm with iterators.kt cached (87 lines, no probe)
printf '\\n\\nfun __kritProbe(): Int = 42\\n' >> iterators.kt
krit --oracle-backend fir -f json ~/github/kotlin  # <50 ms after the write
\`\`\`
Result before this fix: 67,128 findings, byte-identical to the prior no-probe call. Findings reference \`__kritItem3\` (from a prior session) and line 90 (the file is only 87 lines). Pre-parse bundle hit served stale bytes.

Result after this fix: the eager bump invalidates BundleStatsClean within microseconds of the fsnotify event. The pre-parse \`fileStatsMatch\` sweep runs, sees mismatched stats for iterators.kt, falls through to the post-parse path, and rebuilds correctly from disk.

## Test plan
- [x] \`TestFileWatcher_BumpSourceMTimeIsEager\` — writes a .kt file with a 300 ms debounce window, asserts \`BumpSourceMTimeVersion\` has fired while \`Invalidate\` has NOT (debounce-of-downstream is preserved, only the counter bump is eager).
- [x] Existing \`TestFileWatcher_DebounceEditorSavePattern\` still passes — confirms the debounce of downstream invalidation still coalesces a burst of writes into one \`Invalidate\`.
- [x] Existing \`TestFileWatcher_DebounceGenerationGuard\` still passes — generation-guard race still covered.
- [x] \`go test ./internal/cli/serve/\` full package green.
- [x] \`go vet ./...\`, \`golangci-lint run ./internal/cli/serve/\` — 0 issues.