### PR TITLE
fix(pipeline): catch across-session manifest staleness via stat drift

### DIFF
--- a/internal/cli/serve/analyze_project.go
+++ b/internal/cli/serve/analyze_project.go
@@ -555,6 +555,7 @@ func (s *daemonState) buildProjectInput(args daemon.AnalyzeProjectArgs, backend 
 			PriorContentHashes:           priorManifest.ContentHashes,
 			PriorStructuralFPs:           priorManifest.StructuralFPs,
 			PriorAbiHashes:               priorManifest.AbiHashes,
+			PriorFileStats:               priorManifest.FileStats,
 		},
 	}, nil
 }

--- a/internal/pipeline/manifest_drift_test.go
+++ b/internal/pipeline/manifest_drift_test.go
@@ -1,0 +1,236 @@
+package pipeline
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/kaeawc/krit/internal/scanner"
+)
+
+// TestAugmentDirtyWithStatDrift_DetectsAcrossSessionEdit is the
+// regression guard for the across-session manifest/bundle staleness
+// bug. Scenario the test reconstructs:
+//
+//  1. Session A analyzes a file with content X. Manifest persists
+//     ContentHashes[F]=Hx and FileStats[F]=(sizeX, mtimeX). Bundle saved
+//     keyed by RunFingerprint built from Hx.
+//  2. Session A dies. File F is edited externally to content Y while
+//     the daemon is down — new stat (sizeY, mtimeY).
+//  3. Session B starts. The watcher's dirty set is empty (it hasn't
+//     observed any events yet — the edit happened before startup).
+//     host.PriorContentHashes still contains Hx from the persisted
+//     manifest; host.PriorFileStats contains (sizeX, mtimeX).
+//
+// Without augmentDirtyWithStatDrift, computeRunFingerprint's
+// priorOrCompute returns Hx (because dirty is nil/empty), producing a
+// runFP that matches the stale bundle key. Stale findings get served.
+//
+// With the augmentation, F is added to the dirty set because its
+// current stat doesn't match host.PriorFileStats[F], priorOrCompute
+// recomputes the hash from the parsed content (Hy), runFP differs from
+// the prior key, and the stale bundle is correctly skipped.
+func TestAugmentDirtyWithStatDrift_DetectsAcrossSessionEdit(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "Drifted.kt")
+	if err := os.WriteFile(path, []byte("package demo\nclass DriftedY\n"), 0o644); err != nil {
+		t.Fatalf("write Drifted.kt: %v", err)
+	}
+	current, ok := statForPath(path)
+	if !ok {
+		t.Fatalf("stat current %s", path)
+	}
+	// Synthesize a prior stat that differs from the file's actual
+	// stat — the across-session bug shape.
+	priorStat := scanner.FileStat{
+		Size:            current.Size + 17,
+		ModTimeUnixNano: current.ModTimeUnixNano - int64(time.Second),
+	}
+	host := ProjectHostState{
+		SourceSetDirty: nil, // watcher has observed no events yet
+		PriorFileStats: map[string]scanner.FileStat{
+			path: priorStat,
+		},
+	}
+	parseResult := ParseResult{
+		KotlinFiles: []*scanner.File{{
+			Path:     path,
+			Language: scanner.LangKotlin,
+			Content:  []byte("package demo\nclass DriftedY\n"),
+		}},
+	}
+
+	out := augmentDirtyWithStatDrift(host, parseResult)
+	if len(out) != 1 || out[0] != path {
+		t.Fatalf("expected drifted path %q in dirty set; got %v", path, out)
+	}
+}
+
+// TestAugmentDirtyWithStatDrift_NoOpWhenStatMatches confirms the warm
+// fast path: when PriorFileStats[path] matches the current on-disk
+// stat, the path is NOT added to dirty. Without this, every analyze
+// would force-recompute every hash on the daemon path, defeating the
+// priorOrCompute optimization.
+func TestAugmentDirtyWithStatDrift_NoOpWhenStatMatches(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "Stable.kt")
+	if err := os.WriteFile(path, []byte("package demo\nclass Stable\n"), 0o644); err != nil {
+		t.Fatalf("write Stable.kt: %v", err)
+	}
+	stat, ok := statForPath(path)
+	if !ok {
+		t.Fatalf("stat %s", path)
+	}
+	host := ProjectHostState{
+		SourceSetDirty: nil,
+		PriorFileStats: map[string]scanner.FileStat{
+			path: stat,
+		},
+	}
+	parseResult := ParseResult{
+		KotlinFiles: []*scanner.File{{
+			Path:     path,
+			Language: scanner.LangKotlin,
+			Content:  []byte("package demo\nclass Stable\n"),
+		}},
+	}
+
+	out := augmentDirtyWithStatDrift(host, parseResult)
+	if out != nil {
+		t.Errorf("nil dirty + no drift should round-trip nil; got %v", out)
+	}
+}
+
+// TestAugmentDirtyWithStatDrift_PreservesWatcherDirty pins the union
+// behavior: a watcher-observed dirty path must still appear in the
+// returned slice even when the stat-drift sweep finds no additional
+// paths. Without this, switching to the augmented set would lose the
+// watcher's events on warm same-session runs.
+func TestAugmentDirtyWithStatDrift_PreservesWatcherDirty(t *testing.T) {
+	tmp := t.TempDir()
+	a := filepath.Join(tmp, "A.kt")
+	b := filepath.Join(tmp, "B.kt")
+	if err := os.WriteFile(a, []byte("package demo\nclass A\n"), 0o644); err != nil {
+		t.Fatalf("write A.kt: %v", err)
+	}
+	if err := os.WriteFile(b, []byte("package demo\nclass B\n"), 0o644); err != nil {
+		t.Fatalf("write B.kt: %v", err)
+	}
+	statB, ok := statForPath(b)
+	if !ok {
+		t.Fatalf("stat B.kt")
+	}
+	host := ProjectHostState{
+		SourceSetDirty: []string{a},
+		PriorFileStats: map[string]scanner.FileStat{
+			b: statB, // B's stat matches; only A is dirty per watcher
+		},
+	}
+	parseResult := ParseResult{
+		KotlinFiles: []*scanner.File{
+			{Path: a, Language: scanner.LangKotlin},
+			{Path: b, Language: scanner.LangKotlin},
+		},
+	}
+
+	out := augmentDirtyWithStatDrift(host, parseResult)
+	if len(out) != 1 || out[0] != a {
+		t.Errorf("expected watcher dirty preserved; got %v", out)
+	}
+}
+
+// TestAugmentDirtyWithStatDrift_NilPriorIsCLINoOp pins the CLI-path
+// contract: PriorFileStats=nil means "no prior session to compare
+// against, trust the watcher's dirty set verbatim." CLI callers never
+// populate PriorFileStats, so this case must short-circuit before
+// reading any stats.
+func TestAugmentDirtyWithStatDrift_NilPriorIsCLINoOp(t *testing.T) {
+	host := ProjectHostState{
+		SourceSetDirty: []string{"/some/path.kt"},
+		PriorFileStats: nil,
+	}
+	parseResult := ParseResult{}
+
+	out := augmentDirtyWithStatDrift(host, parseResult)
+	if len(out) != 1 || out[0] != "/some/path.kt" {
+		t.Errorf("nil PriorFileStats must pass SourceSetDirty through; got %v", out)
+	}
+}
+
+// TestSourceSetFingerprint_FlipsAfterAugmentedDirty closes the loop on
+// the across-session staleness fix: with stat-drifted paths added to
+// the dirty set by augmentDirtyWithStatDrift, sourceSetFingerprint
+// must produce a hash that reflects the file's CURRENT content rather
+// than the stale prior. Without this, runFP would still match the
+// prior bundle key and the daemon would serve stale findings.
+//
+// Drives sourceSetFingerprint directly: same call shape
+// computeRunFingerprint uses, so this is the smallest scope where
+// the priorOrCompute interaction is visible without spinning a full
+// pipeline run.
+func TestSourceSetFingerprint_FlipsAfterAugmentedDirty(t *testing.T) {
+	currentContent := []byte("package demo\nclass X { fun a() = 999 }\n")
+	path := "/virtual/X.kt"
+
+	priorHashes := map[string]string{path: "STALE-HASH"}
+
+	// Stale path: dirty empty → priorOrCompute returns prior[path].
+	staleFP := sourceSetFingerprint(
+		[]*scanner.File{{Path: path, Language: scanner.LangKotlin, Content: currentContent}},
+		nil,
+		priorHashes,
+		nil, // dirty=nil → uses prior
+	)
+
+	// Fixed path: dirty contains path → priorOrCompute recomputes from
+	// f.Content, returning a fresh hash that captures currentContent.
+	freshDirty := map[string]bool{path: true}
+	freshFP := sourceSetFingerprint(
+		[]*scanner.File{{Path: path, Language: scanner.LangKotlin, Content: currentContent}},
+		nil,
+		priorHashes,
+		freshDirty,
+	)
+	if staleFP == freshFP {
+		t.Fatalf("expected stale and fresh fingerprints to differ; both = %s", staleFP)
+	}
+	// And freshFP must equal the no-prior recompute (i.e., what the
+	// pipeline would produce on a cold run with the same currentContent).
+	coldFP := sourceSetFingerprint(
+		[]*scanner.File{{Path: path, Language: scanner.LangKotlin, Content: currentContent}},
+		nil,
+		nil,
+		nil,
+	)
+	if freshFP != coldFP {
+		t.Errorf("dirty=path should compute identical hash to no-prior cold run\nfresh=%s\n cold=%s", freshFP, coldFP)
+	}
+}
+
+// TestAugmentDirtyWithStatDrift_MissingFileMarkedDirty covers the
+// deletion case: a path that appears in PriorFileStats but whose
+// os.Stat now fails (file gone) is flagged dirty so the prior content
+// hash can't haunt the next manifest.
+func TestAugmentDirtyWithStatDrift_MissingFileMarkedDirty(t *testing.T) {
+	tmp := t.TempDir()
+	missing := filepath.Join(tmp, "Gone.kt") // never written
+
+	host := ProjectHostState{
+		SourceSetDirty: nil,
+		PriorFileStats: map[string]scanner.FileStat{
+			missing: {Size: 42, ModTimeUnixNano: 1},
+		},
+	}
+	parseResult := ParseResult{
+		KotlinFiles: []*scanner.File{{
+			Path:     missing,
+			Language: scanner.LangKotlin,
+		}},
+	}
+
+	out := augmentDirtyWithStatDrift(host, parseResult)
+	if len(out) != 1 || out[0] != missing {
+		t.Errorf("missing file should be flagged dirty; got %v", out)
+	}
+}

--- a/internal/pipeline/project.go
+++ b/internal/pipeline/project.go
@@ -357,6 +357,17 @@ type ProjectHostState struct {
 	// persists a complete manifest. nil means "no hint" — buildManifestData
 	// computes fresh for every parsed Kotlin file.
 	PriorAbiHashes map[string]string
+	// PriorFileStats is the manifest's per-path (size, mtime) snapshot at
+	// the time PriorContentHashes / PriorStructuralFPs were computed.
+	// Used by augmentDirtyWithStatDrift to catch the across-session
+	// staleness case where files were edited while the daemon was down,
+	// so the watcher's dirty set is empty on the first analyze but the
+	// stored prior hashes no longer reflect on-disk content.
+	//
+	// Daemon callers wire this from the prior manifest's FileStats;
+	// CLI callers leave nil. nil means "trust the watcher's dirty set
+	// verbatim" — no drift check is performed.
+	PriorFileStats map[string]scanner.FileStat
 	// FindingsBundleManifestLoader, when non-nil, overrides the disk
 	// load of the prior-run manifest. Daemon callers wire this to an
 	// in-memory cache so the 10.9 MB JSON file (kotlin-corpus scale)
@@ -639,6 +650,18 @@ func RunProjectAnalysis(ctx context.Context, in ProjectInput) (ProjectAnalysisRe
 		return ProjectAnalysisResult{}, err
 	}
 	runProjectTargetedResolution(args, host, parseResult.KotlinFiles, indexResult)
+
+	// Augment the watcher's dirty set with paths whose on-disk stat has
+	// drifted from the prior manifest's recorded FileStats. The
+	// watcher's dirty set is empty on the first analyze of a daemon
+	// session (no events observed yet), but the persisted prior content
+	// hashes can be stale if files were edited while the daemon was
+	// down. Without this augmentation, priorOrCompute would return the
+	// stale prior hashes, runFP would match the prior bundle key, and a
+	// stale bundle would be served. Cost: ~one os.Stat per parsed file
+	// (~80 ms on kotlin-corpus scale), and only when PriorFileStats is
+	// populated (daemon path only).
+	host.SourceSetDirty = augmentDirtyWithStatDrift(host, parseResult)
 
 	runFP, bundleEnabled := computeRunFingerprint(args, host, parseResult, indexResult)
 	manifestData := buildManifestData(args, host, parseResult, runFP, bundleEnabled)
@@ -2552,6 +2575,62 @@ func priorOrCompute(prior map[string]string, dirty map[string]bool, path string,
 		}
 	}
 	return compute()
+}
+
+// augmentDirtyWithStatDrift returns host.SourceSetDirty extended with
+// any parsed file whose current on-disk stat differs from the manifest's
+// recorded FileStats. Closes the across-session staleness gap where
+// files are edited while the daemon is down: the watcher's dirty set
+// is empty on the next analyze (no events observed), and
+// priorOrCompute would otherwise return the stored stale content
+// hashes, which makes runFP match a prior bundle key and serves stale
+// findings.
+//
+// Returns SourceSetDirty unchanged when host.PriorFileStats is nil
+// (CLI path, no prior session to compare against) or when no parsed
+// file's stat has drifted (steady-state warm path).
+//
+// The function preserves the host's nil-vs-empty-slice contract:
+//   - host.SourceSetDirty=nil + no drift → return nil (no opinion)
+//   - host.SourceSetDirty=[] + no drift → return [] (clean source set)
+//   - any drift → return a non-nil slice containing observed dirty +
+//     drifted paths so downstream priorOrCompute calls recompute.
+func augmentDirtyWithStatDrift(host ProjectHostState, parseResult ParseResult) []string {
+	if host.PriorFileStats == nil {
+		return host.SourceSetDirty
+	}
+	existing := make(map[string]bool, len(host.SourceSetDirty))
+	for _, p := range host.SourceSetDirty {
+		existing[p] = true
+	}
+	var drifted []string
+	check := func(f *scanner.File) {
+		if f == nil || existing[f.Path] {
+			return
+		}
+		prior, ok := host.PriorFileStats[f.Path]
+		if !ok {
+			return
+		}
+		current, statOK := statForPath(f.Path)
+		if !statOK || prior != current {
+			drifted = append(drifted, f.Path)
+			existing[f.Path] = true
+		}
+	}
+	for _, f := range parseResult.KotlinFiles {
+		check(f)
+	}
+	for _, f := range parseResult.JavaFiles {
+		check(f)
+	}
+	if len(drifted) == 0 {
+		return host.SourceSetDirty
+	}
+	out := make([]string, 0, len(host.SourceSetDirty)+len(drifted))
+	out = append(out, host.SourceSetDirty...)
+	out = append(out, drifted...)
+	return out
 }
 
 // dirtyPathSet materialises a host's SourceSetDirty slice into a


### PR DESCRIPTION
## Summary

- Daemon's persisted bundle manifest stored per-file ContentHashes + FileStats. On the first analyze of a fresh daemon session the watcher's dirty set was empty (no events observed yet), so `priorOrCompute` returned the stored stale hashes verbatim — runFP matched the prior bundle key and stale findings were served.
- Wire `PriorFileStats` from the manifest into `ProjectHostState`. In `RunProjectAnalysis`, augment the dirty set with parsed paths whose on-disk stat doesn't match the manifest's recorded stat. `priorOrCompute` then recomputes hash/structural-fp for drifted paths, runFP shifts, and the pipeline produces fresh findings.
- Cost: ~one os.Stat per parsed file on the daemon path; no-op on CLI (PriorFileStats=nil).

Observed bug shape: warm-no-change call on kotlin-corpus returned findings referencing a probe (`__kritItem3`) on line 90 of a file that no longer had that content, across daemon restarts. Pairs with #589, which fixed the in-session watcher-debounce race; this PR closes the across-session gap that survived #589.

## Test plan

- [x] `TestAugmentDirtyWithStatDrift_DetectsAcrossSessionEdit` — synthesizes the bug shape: priorStat mismatches current stat → path flagged dirty.
- [x] `TestAugmentDirtyWithStatDrift_NoOpWhenStatMatches` — steady-state warm path: matching stat → nil pass-through.
- [x] `TestAugmentDirtyWithStatDrift_PreservesWatcherDirty` — union behavior: watcher dirty preserved when stat sweep finds no extra paths.
- [x] `TestAugmentDirtyWithStatDrift_NilPriorIsCLINoOp` — CLI contract: nil PriorFileStats → passes SourceSetDirty through untouched.
- [x] `TestAugmentDirtyWithStatDrift_MissingFileMarkedDirty` — deletion case: missing file is flagged so stale prior hash can't haunt the next manifest.
- [x] `TestSourceSetFingerprint_FlipsAfterAugmentedDirty` — end-of-chain: with the augmented dirty set, sourceSetFingerprint matches a fresh cold-run hash (i.e. the stale prior is bypassed).
- [x] `go vet ./...`, `golangci-lint run ./...`, `go test ./... -count=1` all green.