### PR TITLE
perf(pipeline): match dirty paths to manifest across path conventions

### DIFF
--- a/internal/pipeline/dirty_path_match_test.go
+++ b/internal/pipeline/dirty_path_match_test.go
@@ -1,0 +1,137 @@
+package pipeline
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// TestDirtyPathsAllInManifest_AbsoluteDirtyVsRelativeManifest is the
+// regression guard for the warm+ABI 40s tax observed on kotlin-corpus
+// post-#590. The watcher Touches with absolute fsnotify paths (its
+// registered root is absolute) while the manifest stores paths exactly
+// as scanner.CollectKotlinFiles emits them — relative when the CLI
+// passes "." (the common `krit .` invocation). Without
+// scanRoots-aware relativization, the watcher's absolute dirty path
+// misses every manifest key, dirtyPathsAllInManifest returns false,
+// and preparseSourcePaths falls back to a 30-40s CollectKotlinFiles
+// walk every warm+ABI cycle.
+//
+// With scanRoots threaded through, the fast path fires whenever the
+// dirty entries resolve to any manifest key under a reasonable path
+// reading.
+func TestDirtyPathsAllInManifest_AbsoluteDirtyVsRelativeManifest(t *testing.T) {
+	repoRoot, err := filepath.Abs(t.TempDir())
+	if err != nil {
+		t.Fatalf("abs: %v", err)
+	}
+	// Manifest mirrors CollectKotlinFiles output when args.Paths=["."].
+	manifest := map[string]string{
+		"libraries/stdlib/samples/test/iterators.kt": "hash1",
+		"other/file.kt": "hash2",
+	}
+	dirty := []string{
+		filepath.Join(repoRoot, "libraries/stdlib/samples/test/iterators.kt"),
+	}
+
+	// Without scanRoots, the lookup misses and forces the slow walk.
+	if dirtyPathsAllInManifest(dirty, manifest, nil) {
+		t.Fatal("dirtyPathsAllInManifest must miss without scanRoots — the test fixture is wrong if this passes")
+	}
+	// With scanRoots, the absolute dirty path is relativized to the
+	// manifest's "libraries/.../iterators.kt" key and matches.
+	if !dirtyPathsAllInManifest(dirty, manifest, []string{repoRoot}) {
+		t.Errorf("dirtyPathsAllInManifest(abs-dirty, rel-manifest, scanRoots) = false; want true")
+	}
+}
+
+// TestDirtyPathsAllInManifest_RelativeDirtyVsAbsoluteManifest covers
+// the symmetric case: CLI passes an absolute scan path so the
+// manifest's keys are absolute, but the dirty set somehow contains a
+// relative form (e.g. test harness, future watcher refactor). The
+// join-under-root branch catches it.
+func TestDirtyPathsAllInManifest_RelativeDirtyVsAbsoluteManifest(t *testing.T) {
+	repoRoot, err := filepath.Abs(t.TempDir())
+	if err != nil {
+		t.Fatalf("abs: %v", err)
+	}
+	abs := filepath.Join(repoRoot, "src/Foo.kt")
+	manifest := map[string]string{abs: "hash1"}
+	dirty := []string{"src/Foo.kt"}
+
+	if !dirtyPathsAllInManifest(dirty, manifest, []string{repoRoot}) {
+		t.Errorf("relative dirty + absolute manifest under same root must match via scanRoots join")
+	}
+}
+
+// TestDirtyPathsAllInManifest_DirtyOutsideManifest pins the failure
+// case: a dirty path that genuinely isn't in the manifest (e.g., a
+// newly-added .kt file) must still force the slow walk so the new
+// path is picked up.
+func TestDirtyPathsAllInManifest_DirtyOutsideManifest(t *testing.T) {
+	repoRoot, err := filepath.Abs(t.TempDir())
+	if err != nil {
+		t.Fatalf("abs: %v", err)
+	}
+	manifest := map[string]string{"src/Existing.kt": "hash1"}
+	dirty := []string{filepath.Join(repoRoot, "src/Brandnew.kt")}
+
+	if dirtyPathsAllInManifest(dirty, manifest, []string{repoRoot}) {
+		t.Errorf("dirty path not in manifest must fall through to full walk")
+	}
+}
+
+// TestDirtyPathsAllInManifest_MultipleScanRootsTryEach covers the
+// multi-root invocation (`krit src1 src2`): a dirty entry under either
+// root resolves correctly.
+func TestDirtyPathsAllInManifest_MultipleScanRootsTryEach(t *testing.T) {
+	a, err := filepath.Abs(t.TempDir())
+	if err != nil {
+		t.Fatalf("abs a: %v", err)
+	}
+	b, err := filepath.Abs(t.TempDir())
+	if err != nil {
+		t.Fatalf("abs b: %v", err)
+	}
+	manifest := map[string]string{
+		"Foo.kt":          "h1",
+		"deep/dir/Bar.kt": "h2",
+	}
+	dirty := []string{
+		filepath.Join(b, "deep/dir/Bar.kt"),
+	}
+
+	if !dirtyPathsAllInManifest(dirty, manifest, []string{a, b}) {
+		t.Errorf("dirty under second scan root must still match")
+	}
+}
+
+// TestDirtyPathsAllInManifest_LegacyDirectMatchStillWorks pins the
+// pre-fix path: when both dirty and manifest are in the same form
+// (both relative or both absolute), the direct lookup wins without
+// touching scanRoots. Preserves the fast common case.
+func TestDirtyPathsAllInManifest_LegacyDirectMatchStillWorks(t *testing.T) {
+	manifest := map[string]string{"src/Foo.kt": "h1"}
+
+	// Direct hit with empty scanRoots — the no-roots branch must still
+	// succeed when the path conventions match.
+	if !dirtyPathsAllInManifest([]string{"src/Foo.kt"}, manifest, nil) {
+		t.Errorf("direct-match (rel-rel) must succeed without scanRoots")
+	}
+}
+
+// TestDirtyPathsAllInManifest_NilDirtyMeansNoOpinion preserves the
+// existing contract: nil dirty (host has no opinion / watcher
+// uninitialised) forces the walk.
+func TestDirtyPathsAllInManifest_NilDirtyMeansNoOpinion(t *testing.T) {
+	if dirtyPathsAllInManifest(nil, map[string]string{"x.kt": "h"}, []string{"/repo"}) {
+		t.Errorf("nil dirty must not be treated as clean")
+	}
+}
+
+// TestDirtyPathsAllInManifest_EmptyDirtyOnEmptyManifestMatches is the
+// degenerate "no files" edge — both empty, no work to do, fast path.
+func TestDirtyPathsAllInManifest_EmptyDirtyOnEmptyManifestMatches(t *testing.T) {
+	if !dirtyPathsAllInManifest([]string{}, map[string]string{}, nil) {
+		t.Errorf("empty dirty + empty manifest is the clean case")
+	}
+}

--- a/internal/pipeline/project.go
+++ b/internal/pipeline/project.go
@@ -2155,7 +2155,7 @@ func preparseBundleFingerprintTracked(args ProjectArgs, host ProjectHostState, t
 }
 
 func preparseSourcePaths(args ProjectArgs, host ProjectHostState, prior scanner.FindingsBundleManifest) ([]string, []string, bool) {
-	if host.SourceSetClean || dirtyPathsAllInManifest(host.SourceSetDirty, prior.ContentHashes) {
+	if host.SourceSetClean || dirtyPathsAllInManifest(host.SourceSetDirty, prior.ContentHashes, args.Paths) {
 		kotlinPaths, javaPaths := pathsFromManifest(prior.ContentHashes)
 		return kotlinPaths, javaPaths, true
 	}
@@ -2180,22 +2180,73 @@ func preparseSourcePaths(args ProjectArgs, host ProjectHostState, prior scanner.
 // filesystem walk, which costs 30-40s on kotlin-corpus scale when the
 // OS dentry cache is cold.
 //
+// scanRoots threads through the analyze call's args.Paths so the
+// comparison is robust to a path-convention mismatch between dirty and
+// manifest. The watcher always Touches with absolute paths (fsnotify
+// reports them as registered, and the daemon registers an absolute
+// root), but the manifest stores paths exactly as scanner.CollectKotlinFiles
+// emits them — relative when the CLI passes "." (the common case), or
+// absolute when the CLI passes an absolute path. Without a fallback,
+// a one-file ABI edit on kotlin-corpus drops the warm path into a
+// 30-40s CollectKotlinFiles walk every time.
+//
 // nil dirty means "host has no opinion" and we return false so the
 // caller falls back to walking. Empty dirty is a clean source set,
 // also acceptable.
-func dirtyPathsAllInManifest(dirty []string, manifest map[string]string) bool {
+func dirtyPathsAllInManifest(dirty []string, manifest map[string]string, scanRoots []string) bool {
 	if dirty == nil {
 		return false
 	}
 	if len(manifest) == 0 {
 		return len(dirty) == 0
 	}
-	for _, p := range dirty {
-		if _, ok := manifest[p]; !ok {
-			return false
+	absRoots := make([]string, 0, len(scanRoots))
+	for _, r := range scanRoots {
+		if r == "" {
+			continue
+		}
+		if abs, err := filepath.Abs(r); err == nil {
+			absRoots = append(absRoots, abs)
 		}
 	}
+	for _, p := range dirty {
+		if pathInManifest(p, manifest, absRoots) {
+			continue
+		}
+		return false
+	}
 	return true
+}
+
+// pathInManifest reports whether p resolves to a manifest key under any
+// reasonable path-convention reading of p:
+//
+//   - Direct hit on the raw path (covers manifest and dirty both using
+//     the same convention — relative-relative or absolute-absolute).
+//   - Relativized against each scan root (covers absolute dirty path
+//     against relative manifest).
+//   - Joined under each scan root (covers relative dirty against
+//     absolute manifest).
+//
+// The double-check is cheap (a couple of filepath.Rel calls per dirty
+// entry, dirty is typically O(1) per analyze) and lets the fast path
+// fire regardless of which side normalized.
+func pathInManifest(p string, manifest map[string]string, absRoots []string) bool {
+	if _, ok := manifest[p]; ok {
+		return true
+	}
+	for _, root := range absRoots {
+		if rel, err := filepath.Rel(root, p); err == nil && !strings.HasPrefix(rel, "..") {
+			if _, ok := manifest[rel]; ok {
+				return true
+			}
+		}
+		joined := filepath.Join(root, p)
+		if _, ok := manifest[joined]; ok {
+			return true
+		}
+	}
+	return false
 }
 
 func pathsFromManifest(hashes map[string]string) ([]string, []string) {


### PR DESCRIPTION
## Summary

- `dirtyPathsAllInManifest` did a direct string lookup between the watcher's dirty set and the prior manifest's content-hash keys. The watcher Touches with absolute fsnotify paths; the manifest stores paths exactly as `scanner.CollectKotlinFiles` emits them — relative when the CLI passes `.` (the common `krit .` invocation).
- Result: a one-file ABI edit on kotlin-corpus missed every manifest key, the fast path refused, and `preparseSourcePaths` fell back to a 30-40s `CollectKotlinFiles` walk every warm+ABI cycle.
- Thread `args.Paths` through so the comparison can also try `filepath.Rel(scanRoot, dirtyPath)` and `filepath.Join(scanRoot, dirtyPath)` against each scan root. Direct match still wins when both sides already agree.

## Impact (kotlin-corpus, daemon-FIR, post-#590)

| Run | Before | After | dispatchPath | sourcePaths |
|-----|-------:|------:|--------------|------------:|
| warm-no-change | 124ms | 123ms | (pre-parse hit) | 3ms |
| warm+ABI       | **40,690ms** | **1,053ms** (38×) | cacheHitStructuralBundle | 39,568 → 3ms |
| warm-post-revert | **41,022ms** | **1,153ms** (35×) | cacheHitFullBundle | 39,749 → 3ms |

Findings are byte-identical for the no-probe runs and semantically equivalent for the probe run (the probe is an innocuous top-level fun that no rule fires on). `dispatchPath` labels prove the correct layer fires post-fix.

## Test plan

- [x] `TestDirtyPathsAllInManifest_AbsoluteDirtyVsRelativeManifest` — the exact bug shape (abs watcher / rel manifest).
- [x] `TestDirtyPathsAllInManifest_RelativeDirtyVsAbsoluteManifest` — symmetric case via join-under-root.
- [x] `TestDirtyPathsAllInManifest_DirtyOutsideManifest` — a genuinely-new file still forces the walk.
- [x] `TestDirtyPathsAllInManifest_MultipleScanRootsTryEach` — multi-root invocation.
- [x] `TestDirtyPathsAllInManifest_LegacyDirectMatchStillWorks` — preserves the no-scanRoots common case.
- [x] `TestDirtyPathsAllInManifest_NilDirtyMeansNoOpinion`, `TestDirtyPathsAllInManifest_EmptyDirtyOnEmptyManifestMatches` — edge contracts.
- [x] `go vet ./...`, `golangci-lint run ./...`, `go test ./internal/pipeline/ ./internal/cli/serve/ -count=1` all green.
- [x] Empirical kotlin-corpus warm+ABI benchmark confirms 38× speedup.