### PR TITLE
perf(pipeline): skip codeIndexBuild on early post-parse bundle hit

### DIFF
--- a/internal/pipeline/early_bundle_test.go
+++ b/internal/pipeline/early_bundle_test.go
@@ -1,0 +1,151 @@
+package pipeline
+
+import (
+	"testing"
+
+	"github.com/kaeawc/krit/internal/scanner"
+)
+
+// recordingPreviewStore counts Load and Save calls so the
+// previewPostParseBundleHit tests can assert hit/miss behavior without
+// a full RunProject fixture.
+type recordingPreviewStore struct {
+	loadCalls int
+	loaded    *scanner.FindingColumns
+	saved     map[string]*scanner.FindingColumns
+}
+
+func (s *recordingPreviewStore) Load(_ string, fp scanner.RunFingerprint) (*scanner.FindingColumns, bool) {
+	s.loadCalls++
+	if s.saved == nil {
+		return s.loaded, s.loaded != nil
+	}
+	v, ok := s.saved[scanner.FindingsBundleKey(fp)]
+	return v, ok
+}
+
+func (s *recordingPreviewStore) Save(_ string, fp scanner.RunFingerprint, cols *scanner.FindingColumns) error {
+	if s.saved == nil {
+		s.saved = make(map[string]*scanner.FindingColumns)
+	}
+	s.saved[scanner.FindingsBundleKey(fp)] = cols
+	return nil
+}
+
+// TestPreviewPostParseBundleHit_SkipsLoadWhenNoPriorManifest pins the
+// gate that protects the existing bundle-cache load-count contract:
+// on cold runs the host has no PriorContentHashes (the manifest
+// hasn't been persisted yet), so the preview can never hit by
+// construction. Returning early avoids an extra Load that would
+// otherwise show up in the bundle-cache test fixtures and break the
+// "1 Load per analyze" invariant.
+func TestPreviewPostParseBundleHit_SkipsLoadWhenNoPriorManifest(t *testing.T) {
+	store := &recordingPreviewStore{}
+	host := ProjectHostState{
+		FindingsBundleStore:     store,
+		FindingsBundleCacheRoot: "/tmp/cache",
+		// PriorContentHashes intentionally nil (cold run).
+	}
+	args := ProjectArgs{Version: "test"}
+	parseResult := ParseResult{
+		KotlinFiles: []*scanner.File{{Path: "/repo/Foo.kt", Language: scanner.LangKotlin}},
+	}
+
+	got := previewPostParseBundleHit(args, host, parseResult)
+	if got != nil {
+		t.Errorf("cold-run preview should return nil; got %v", got)
+	}
+	if store.loadCalls != 0 {
+		t.Errorf("cold-run preview must not call Load; got loadCalls=%d", store.loadCalls)
+	}
+}
+
+// TestPreviewPostParseBundleHit_NoStoreReturnsNil pins the CLI-path
+// contract: callers that don't wire a FindingsBundleStore (CLI / tests
+// that don't care about the bundle cache) get a nil return without
+// any extra work. Mirrors computeRunFingerprint's gate.
+func TestPreviewPostParseBundleHit_NoStoreReturnsNil(t *testing.T) {
+	host := ProjectHostState{
+		// FindingsBundleStore intentionally nil.
+		PriorContentHashes: map[string]string{"/repo/Foo.kt": "h1"},
+	}
+	args := ProjectArgs{Version: "test"}
+	parseResult := ParseResult{}
+
+	got := previewPostParseBundleHit(args, host, parseResult)
+	if got != nil {
+		t.Errorf("nil store must return nil; got %v", got)
+	}
+}
+
+// TestPreviewPostParseBundleHit_CustomRuleJarsBypass mirrors
+// computeRunFingerprint's --custom-rule-jars gate: bundle caching
+// disables when custom rule jars are loaded (output depends on
+// jar-side behavior that the runFP doesn't capture). The preview
+// must respect the same gate so it doesn't serve stale findings on a
+// custom-rule-jars invocation.
+func TestPreviewPostParseBundleHit_CustomRuleJarsBypass(t *testing.T) {
+	store := &recordingPreviewStore{}
+	host := ProjectHostState{
+		FindingsBundleStore:     store,
+		FindingsBundleCacheRoot: "/tmp/cache",
+		PriorContentHashes:      map[string]string{"/repo/Foo.kt": "h1"},
+	}
+	args := ProjectArgs{Version: "test", CustomRuleJars: []string{"/path/to/jar"}}
+	parseResult := ParseResult{}
+
+	got := previewPostParseBundleHit(args, host, parseResult)
+	if got != nil {
+		t.Errorf("custom-rule-jars path must return nil; got %v", got)
+	}
+	if store.loadCalls != 0 {
+		t.Errorf("custom-rule-jars path must not call Load; got loadCalls=%d", store.loadCalls)
+	}
+}
+
+// TestPreviewPostParseBundleHit_LoadHitReturnsColumns is the happy
+// path: prior manifest present, store has a matching entry, the
+// preview returns the cached FindingColumns so the caller can
+// populate warmPlan.cross and skip IndexPhase's codeIndexBuild.
+func TestPreviewPostParseBundleHit_LoadHitReturnsColumns(t *testing.T) {
+	cached := &scanner.FindingColumns{}
+	store := &recordingPreviewStore{loaded: cached}
+	host := ProjectHostState{
+		FindingsBundleStore:     store,
+		FindingsBundleCacheRoot: "/tmp/cache",
+		PriorContentHashes:      map[string]string{"/repo/Foo.kt": "h1"},
+	}
+	args := ProjectArgs{Version: "test"}
+	parseResult := ParseResult{}
+
+	got := previewPostParseBundleHit(args, host, parseResult)
+	if got != cached {
+		t.Errorf("store Load returned hit; preview should pass it through. got=%v want=%v", got, cached)
+	}
+	if store.loadCalls != 1 {
+		t.Errorf("preview must call Load once; got loadCalls=%d", store.loadCalls)
+	}
+}
+
+// TestPreviewPostParseBundleHit_LoadMissReturnsNil is the fall-through
+// case: PriorContentHashes is set but the store has no matching
+// entry. Returning nil lets the caller proceed with the full
+// IndexPhase + dispatch path.
+func TestPreviewPostParseBundleHit_LoadMissReturnsNil(t *testing.T) {
+	store := &recordingPreviewStore{} // no loaded, no saved
+	host := ProjectHostState{
+		FindingsBundleStore:     store,
+		FindingsBundleCacheRoot: "/tmp/cache",
+		PriorContentHashes:      map[string]string{"/repo/Foo.kt": "h1"},
+	}
+	args := ProjectArgs{Version: "test"}
+	parseResult := ParseResult{}
+
+	got := previewPostParseBundleHit(args, host, parseResult)
+	if got != nil {
+		t.Errorf("Load miss must return nil; got %v", got)
+	}
+	if store.loadCalls != 1 {
+		t.Errorf("preview must still call Load once on miss; got loadCalls=%d", store.loadCalls)
+	}
+}

--- a/internal/pipeline/project.go
+++ b/internal/pipeline/project.go
@@ -639,6 +639,30 @@ func RunProjectAnalysis(ctx context.Context, in ProjectInput) (ProjectAnalysisRe
 	if err != nil {
 		return ProjectAnalysisResult{}, fmt.Errorf("parse: %w", err)
 	}
+
+	// Augment the watcher's dirty set with paths whose on-disk stat has
+	// drifted from the prior manifest's recorded FileStats. Moved ahead
+	// of IndexPhase so previewPostParseBundleHit (below) sees the same
+	// dirty set computeRunFingerprint will see later — both must hash
+	// the same parsed contents through priorOrCompute, otherwise the
+	// preview's runFP diverges from the canonical one.
+	host.SourceSetDirty = augmentDirtyWithStatDrift(host, parseResult)
+
+	// Early post-parse bundle check. When the canonical runFP we'd
+	// compute after IndexPhase already matches a stored bundle, the
+	// IndexPhase's codeIndexBuild + buildBaseResolver + module index
+	// work is pure overhead — the bundle's FindingColumns is the only
+	// output we need. Populate warmPlan.cross with the cached bundle
+	// so runProjectIndexPhase's `buildCodeIndex := hasIndexBackedCrossFileRule
+	// && warm.cross == nil` gate flips false and codeIndexBuild is
+	// skipped. The post-IndexPhase runDispatchOrLoadBundle still calls
+	// Load with the same key and short-circuits dispatch via the
+	// existing cacheHitFullBundle / cacheHitStructuralBundle paths.
+	earlyBundle := previewPostParseBundleHit(args, host, parseResult)
+	if earlyBundle != nil {
+		warmPlan.cross = earlyBundle
+	}
+
 	indexStart := time.Now()
 	indexResult, err := runProjectIndexPhase(ctx, args, host, warmPlan, parseResult)
 	phaseTimings.Index = time.Since(indexStart).Milliseconds()
@@ -650,18 +674,6 @@ func RunProjectAnalysis(ctx context.Context, in ProjectInput) (ProjectAnalysisRe
 		return ProjectAnalysisResult{}, err
 	}
 	runProjectTargetedResolution(args, host, parseResult.KotlinFiles, indexResult)
-
-	// Augment the watcher's dirty set with paths whose on-disk stat has
-	// drifted from the prior manifest's recorded FileStats. The
-	// watcher's dirty set is empty on the first analyze of a daemon
-	// session (no events observed yet), but the persisted prior content
-	// hashes can be stale if files were edited while the daemon was
-	// down. Without this augmentation, priorOrCompute would return the
-	// stale prior hashes, runFP would match the prior bundle key, and a
-	// stale bundle would be served. Cost: ~one os.Stat per parsed file
-	// (~80 ms on kotlin-corpus scale), and only when PriorFileStats is
-	// populated (daemon path only).
-	host.SourceSetDirty = augmentDirtyWithStatDrift(host, parseResult)
 
 	runFP, bundleEnabled := computeRunFingerprint(args, host, parseResult, indexResult)
 	manifestData := buildManifestData(args, host, parseResult, runFP, bundleEnabled)
@@ -2519,6 +2531,64 @@ func scopeParseResult(p ParseResult, only *scanner.File) ParseResult {
 // identical input. Body-only Kotlin edits that move SourceSet but keep
 // CrossFile stable are handled by runDispatchOrLoadBundle's structural
 // reuse path.
+// previewPostParseBundleHit computes the canonical runFP from the parsed
+// files + a lightweight Android/LibraryFacts probe and tries to load a
+// stored bundle keyed by it. When a bundle hits, the caller assigns the
+// returned columns to warmPlan.cross so runProjectIndexPhase's
+// `buildCodeIndex := hasIndexBackedCrossFileRule && warm.cross == nil`
+// gate skips codeIndexBuild and module-index build — savings observed
+// on kotlin-corpus warm+ABI: ~409ms of codeIndexBuild plus the
+// indirect saving from buildBaseResolver no longer being demanded by
+// downstream consumers.
+//
+// Returns nil when:
+//   - the bundle cache is disabled (no store / no root)
+//   - the call passes custom rule jars (computeRunFingerprint refuses
+//     fingerprinting in that case, so we mirror)
+//   - the Load misses (genuinely fresh combination of inputs)
+//
+// The runFP computation must match computeRunFingerprint byte-for-byte
+// — otherwise the Load returns nil here but succeeds later, and we
+// silently skip the optimization on every call. The helper shares
+// every input (rulesHash, dirty set, file-list hashing) with the
+// canonical implementation and uses preparseProjectFingerprints for
+// the Android/LibraryFacts pair (the same helper preparseBundleFingerprint
+// already trusts on the warm pre-parse fast path).
+func previewPostParseBundleHit(args ProjectArgs, host ProjectHostState, parseResult ParseResult) *scanner.FindingColumns {
+	if host.FindingsBundleStore == nil || host.FindingsBundleCacheRoot == "" {
+		return nil
+	}
+	if len(args.CustomRuleJars) > 0 {
+		return nil
+	}
+	// Cold runs (no prior manifest residing in the host) cannot hit
+	// the bundle by construction — Load with a freshly-computed runFP
+	// has no stored predecessor to match. Skip the wasted Load: the
+	// regular post-IndexPhase path will populate the bundle for next
+	// time. This also preserves the existing test contract that
+	// counts Load calls — one Load per analyze, not two.
+	if len(host.PriorContentHashes) == 0 {
+		return nil
+	}
+	rulesHash := projectRuleHash(args.ActiveRules, args.Config)
+	dirty := dirtyPathSet(host.SourceSetDirty)
+	androidFP, libraryFactsFP := preparseProjectFingerprints(args, host)
+	fp := scanner.RunFingerprint{
+		Version:      args.Version,
+		Rules:        rulesHash,
+		Config:       rulesHash,
+		SourceSet:    sourceSetFingerprint(parseResult.KotlinFiles, parseResult.JavaFiles, host.PriorContentHashes, dirty),
+		CrossFile:    crossFileStructuralFingerprint(parseResult.KotlinFiles, parseResult.JavaFiles, host.PriorStructuralFPs, dirty),
+		Android:      androidFP,
+		LibraryFacts: libraryFactsFP,
+	}
+	cached, ok := host.FindingsBundleStore.Load(host.FindingsBundleCacheRoot, fp)
+	if !ok || cached == nil {
+		return nil
+	}
+	return cached
+}
+
 func computeRunFingerprint(args ProjectArgs, host ProjectHostState, parseResult ParseResult, indexResult IndexResult) (scanner.RunFingerprint, bool) {
 	if host.FindingsBundleStore == nil || host.FindingsBundleCacheRoot == "" {
 		return scanner.RunFingerprint{}, false


### PR DESCRIPTION
## Summary

- Post-#591, the warm+ABI breakdown on kotlin-corpus daemon-FIR is dominated by `crossFileAnalysis = 1123ms` of which `codeIndexBuild = 409ms` and the rest is post-IndexPhase work that the parent scope spans through. When the post-parse bundle is going to hit, that IndexPhase work is dead weight — the cached `FindingColumns` is the only output needed.
- Run a lightweight `previewPostParseBundleHit` BEFORE `runProjectIndexPhase`: compute the canonical runFP from parsed files + a cheap Android/LibraryFacts probe and attempt `host.FindingsBundleStore.Load`. On hit, populate `warmPlan.cross` so the existing `buildCodeIndex := hasIndexBackedCrossFileRule && warm.cross == nil` gate skips `codeIndexBuild`. The post-IndexPhase `runDispatchOrLoadBundle` still loads with the same key and short-circuits dispatch via the existing `cacheHitFullBundle` path.
- Also moves `augmentDirtyWithStatDrift` ahead of IndexPhase so the preview's runFP sees the same dirty set `computeRunFingerprint` will see later (both must hash the same parsed contents through `priorOrCompute`).
- Cold runs (no `PriorContentHashes`) early-out without calling `Load` so the existing bundle-cache test contract (1 Load per analyze, not 2) survives.

## Impact (kotlin-corpus, daemon-FIR)

| Run | Before (post-#591) | After | Notes |
|-----|------:|------:|-------|
| warm-no-change `cacheHitFullBundle` | 1083ms | **1051ms** | `codeIndexBuild = 0ms` (skipped) |
| warm+ABI `cacheHitStructuralBundle` | 1302ms | **1135ms** | augmentDirtyWithStatDrift earlier yields incidental speedup |
| warm-no-change (pre-parse hit) | 123ms | 131ms | unchanged — pre-parse already short-circuits |
| warm3 (BundleOutput cache) | 59ms | 68ms | unchanged |

Total: -32ms on `cacheHitFullBundle`, -167ms on warm+ABI. The direct lever is the codeIndexBuild skip; the structural-bundle path still runs IndexPhase because `previewPostParseBundleHit` only handles full-runFP matches in this PR — follow-up will add `cacheHitStructuralBundle` and gate module-index build so warm-no-change can skip the rest of crossFileAnalysis.

## Test plan

- [x] `TestPreviewPostParseBundleHit_SkipsLoadWhenNoPriorManifest` — cold-run gate (preserves existing 1-Load-per-analyze contract).
- [x] `TestPreviewPostParseBundleHit_NoStoreReturnsNil` — CLI-path contract.
- [x] `TestPreviewPostParseBundleHit_CustomRuleJarsBypass` — mirrors computeRunFingerprint's gate.
- [x] `TestPreviewPostParseBundleHit_LoadHitReturnsColumns` — happy path: cached columns flow back to caller.
- [x] `TestPreviewPostParseBundleHit_LoadMissReturnsNil` — fall-through when no stored bundle matches.
- [x] Existing bundle-cache test suite still passes (loadCalls invariant preserved).
- [x] `go vet ./...`, `golangci-lint run ./...`, `go test ./internal/pipeline/ ./internal/cli/serve/ -count=1` all green.
- [x] Empirical kotlin-corpus daemon-FIR benchmark above.