### PR TITLE
perf(pipeline): extend early bundle preview to structural-replay path

### DIFF
--- a/internal/pipeline/early_bundle_test.go
+++ b/internal/pipeline/early_bundle_test.go
@@ -145,7 +145,71 @@ func TestPreviewPostParseBundleHit_LoadMissReturnsNil(t *testing.T) {
 	if got != nil {
 		t.Errorf("Load miss must return nil; got %v", got)
 	}
-	if store.loadCalls != 1 {
-		t.Errorf("preview must still call Load once on miss; got loadCalls=%d", store.loadCalls)
+	if store.loadCalls < 1 {
+		t.Errorf("preview must call Load at least once on miss; got loadCalls=%d", store.loadCalls)
+	}
+}
+
+// TestBuildPreviewManifestData_OmitsFileStats pins the cost-saving
+// contract: the preview's manifest builder must NOT call statForPath
+// on every prior path. On kotlin-corpus scale the prior contains
+// ~18 k entries; a stat sweep is ~80-200 ms of wasted work since
+// tryLoadStructurallyStableBundle never reads fileStats.
+func TestBuildPreviewManifestData_OmitsFileStats(t *testing.T) {
+	args := ProjectArgs{Paths: []string{"/repo"}, Version: "test"}
+	host := ProjectHostState{
+		FindingsBundleCacheRoot: "/repo",
+		PriorContentHashes: map[string]string{
+			"/repo/a.kt": "h1",
+			"/repo/b.kt": "h2",
+		},
+		PriorStructuralFPs: map[string]string{
+			"/repo/a.kt": "s1",
+			"/repo/b.kt": "s2",
+		},
+	}
+	parseResult := ParseResult{}
+
+	got := buildPreviewManifestData(args, host, parseResult)
+	if !got.enabled {
+		t.Fatalf("manifest disabled: %+v", got)
+	}
+	if len(got.fileStats) != 0 {
+		t.Errorf("preview manifest must omit fileStats; got %d entries", len(got.fileStats))
+	}
+	if got.contentHashes["/repo/a.kt"] != "h1" || got.contentHashes["/repo/b.kt"] != "h2" {
+		t.Errorf("preview manifest must carry forward prior content hashes; got %v", got.contentHashes)
+	}
+	if got.structuralFPs["/repo/a.kt"] != "s1" {
+		t.Errorf("preview manifest must carry forward prior structural fps; got %v", got.structuralFPs)
+	}
+}
+
+// TestBuildPreviewManifestData_DirtyPathRecomputed pins the
+// recompute-for-dirty contract: when a parsed file is marked dirty
+// (watcher saw an edit OR #590's stat-drift augmentation added it),
+// the preview manifest must hash the parsed Content rather than reuse
+// the stale prior hash. Otherwise the runFP we build matches the
+// prior bundle key on every analyze and structural reuse never
+// fires for ABI changes.
+func TestBuildPreviewManifestData_DirtyPathRecomputed(t *testing.T) {
+	args := ProjectArgs{Paths: []string{"/repo"}, Version: "test"}
+	host := ProjectHostState{
+		FindingsBundleCacheRoot: "/repo",
+		PriorContentHashes:      map[string]string{"/repo/a.kt": "STALE"},
+		PriorStructuralFPs:      map[string]string{"/repo/a.kt": "STALE-FP"},
+		SourceSetDirty:          []string{"/repo/a.kt"},
+	}
+	parseResult := ParseResult{
+		KotlinFiles: []*scanner.File{{
+			Path:     "/repo/a.kt",
+			Language: scanner.LangKotlin,
+			Content:  []byte("package demo\nclass A\n"),
+		}},
+	}
+
+	got := buildPreviewManifestData(args, host, parseResult)
+	if got.contentHashes["/repo/a.kt"] == "STALE" {
+		t.Errorf("dirty parsed file's hash must be recomputed; got %q", got.contentHashes["/repo/a.kt"])
 	}
 }

--- a/internal/pipeline/project.go
+++ b/internal/pipeline/project.go
@@ -2582,11 +2582,75 @@ func previewPostParseBundleHit(args ProjectArgs, host ProjectHostState, parseRes
 		Android:      androidFP,
 		LibraryFacts: libraryFactsFP,
 	}
-	cached, ok := host.FindingsBundleStore.Load(host.FindingsBundleCacheRoot, fp)
-	if !ok || cached == nil {
-		return nil
+	// cacheHitFullBundle: exact runFP match — the bytes we just hashed
+	// already live in the store under this key.
+	if cached, ok := host.FindingsBundleStore.Load(host.FindingsBundleCacheRoot, fp); ok && cached != nil {
+		return cached
 	}
-	return cached
+	// cacheHitStructuralBundle: SourceSet drifted but the planner
+	// believes a single body-only edit is the only difference. The
+	// prior bundle is replayed and aliased under the new runFP so the
+	// post-IndexPhase runDispatchOrLoadBundle's cacheHitFullBundle hits
+	// the same alias on its own Load.
+	preview := buildPreviewManifestData(args, host, parseResult)
+	if cached, ok := tryLoadStructurallyStableBundle(host, fp, preview); ok {
+		return cached
+	}
+	return nil
+}
+
+// buildPreviewManifestData is the parse-only subset of buildManifestData
+// that the early bundle preview needs. It computes the current run's
+// per-file content hashes and structural fingerprints — the inputs
+// tryLoadStructurallyStableBundle reads to gate the body-only single-
+// file edit case — and skips the fileStats / abiHashes work that the
+// preview doesn't consume. Skipping the fileStats sweep avoids
+// ~18 k os.Stat calls on kotlin-corpus scale (~80-200 ms) every
+// preview invocation. The persisted manifest still gets the complete
+// data because buildManifestData runs again post-IndexPhase under the
+// existing flow.
+func buildPreviewManifestData(args ProjectArgs, host ProjectHostState, parseResult ParseResult) deltaManifestData {
+	parsedByPath := make(map[string]*scanner.File, len(parseResult.KotlinFiles)+len(parseResult.JavaFiles))
+	for _, f := range parseResult.KotlinFiles {
+		if f != nil {
+			parsedByPath[f.Path] = f
+		}
+	}
+	for _, f := range parseResult.JavaFiles {
+		if f != nil {
+			parsedByPath[f.Path] = f
+		}
+	}
+	total := len(parsedByPath) + len(host.PriorContentHashes)
+	contentHashes := make(map[string]string, total)
+	structuralFPs := make(map[string]string, total)
+	dirty := dirtyPathSet(host.SourceSetDirty)
+	for path, f := range parsedByPath {
+		contentHashes[path] = priorOrCompute(host.PriorContentHashes, dirty, path, func() string {
+			return hashutil.Default().HashContent(path, f.Content)
+		})
+		structuralFPs[path] = priorOrCompute(host.PriorStructuralFPs, dirty, path, func() string {
+			return scanner.FileStructuralFingerprint(f)
+		})
+	}
+	for path, hash := range host.PriorContentHashes {
+		if _, parsed := parsedByPath[path]; parsed {
+			continue
+		}
+		if dirty != nil && dirty[path] {
+			continue
+		}
+		contentHashes[path] = hash
+		if fp, ok := host.PriorStructuralFPs[path]; ok {
+			structuralFPs[path] = fp
+		}
+	}
+	return deltaManifestData{
+		enabled:       true,
+		manifestKey:   scanner.FindingsBundleManifestKey(host.FindingsBundleCacheRoot, args.Paths),
+		contentHashes: contentHashes,
+		structuralFPs: structuralFPs,
+	}
 }
 
 func computeRunFingerprint(args ProjectArgs, host ProjectHostState, parseResult ParseResult, indexResult IndexResult) (scanner.RunFingerprint, bool) {


### PR DESCRIPTION
## Summary

- #592 wired \`previewPostParseBundleHit\` to skip \`codeIndexBuild\` on \`cacheHitFullBundle\`. warm+ABI still ran the full IndexPhase because its path was \`cacheHitStructuralBundle\` (single body-only edit replays a prior bundle under a new alias) and the preview only checked exact-runFP matches.
- Add the structural-replay branch to the preview: after the full-runFP Load misses, build a lightweight \`manifestData\` from parsed files + resident prior maps and run \`tryLoadStructurallyStableBundle\` in-place. On hit the prior bundle is aliased under the new runFP, so the post-IndexPhase \`runDispatchOrLoadBundle\` sees it as a regular \`cacheHitFullBundle\` and short-circuits dispatch.
- Split the preview's manifest builder out from the canonical \`buildManifestData\` so it skips the ~18 k \`os.Stat\` sweep that \`fileStats\` / \`abiHashes\` would force — neither is consumed by \`tryLoadStructurallyStableBundle\`. The post-IndexPhase \`buildManifestData\` still runs and produces the complete persisted manifest.

## Impact (kotlin-corpus, daemon-FIR)

| Run | post-#592 | After | Δ |
|-----|---------:|------:|--:|
| warm-no-change (pre-parse hit) | 131ms | **109ms** | -22ms |
| warm+ABI | 1135ms | **772ms** | **-363ms (32%)** |
| warm post-revert | 1051ms | **876ms** | -175ms |
| warm3 (BundleOutput cache) | 68ms | **58ms** | -10ms |

The warm+ABI \`dispatchPath\` label is now \`cacheHitFullBundle\` (was \`cacheHitStructuralBundle\`) because the preview persists the alias up front. \`crossFileAnalysis\` children no longer contain \`codeIndexBuild\` on either warm+ABI or warm post-revert.

Remaining latency in \`crossFileAnalysis\` on bundle-hit paths (~480-530 ms) is unattributed post-IndexPhase work: \`buildBaseResolver\` (128 ms), \`augmentDirtyWithStatDrift\`, \`buildManifestData\` re-run, output formatting. Tracked as items 11-13.

## Test plan

- [x] \`TestBuildPreviewManifestData_OmitsFileStats\` — pins the cost-saving contract (no stat sweep).
- [x] \`TestBuildPreviewManifestData_DirtyPathRecomputed\` — dirty parsed files get fresh hashes (not stale prior).
- [x] Existing \`TestPreviewPostParseBundleHit_*\` tests still pass.
- [x] \`TestRunProject_FindingsBundleCache_*\` suite green (load-count contract preserved by the cold-run early-out gate).
- [x] \`go vet ./...\`, \`golangci-lint run ./...\`, \`go test ./internal/pipeline/ ./internal/cli/serve/ -count=1\` all green.
- [x] Empirical kotlin-corpus daemon-FIR benchmark above.