### PR TITLE
perf(pipeline): gate module-index build on warm.cross

### DIFF
--- a/internal/pipeline/index_module_gate_test.go
+++ b/internal/pipeline/index_module_gate_test.go
@@ -1,0 +1,61 @@
+package pipeline
+
+import (
+	"testing"
+
+	"github.com/kaeawc/krit/internal/rules/api"
+	"github.com/kaeawc/krit/internal/scanner"
+)
+
+// TestRunProjectIndexPhase_ModuleIndexGatedOnWarmCross pins the
+// post-#599 gate that closes the module-index build when the early
+// bundle preview already populated warmPlan.cross. On a bundle hit
+// runAndroidPhaseAndMerge / runDispatchOrLoadBundle short-circuit
+// dispatch + cross-file rule execution, and the same is true for
+// module-aware rules — they fan in through the same crossfile path.
+// Building the module index would produce a Graph nothing reads.
+//
+// Drives the IndexInput construction directly: a module-aware rule
+// is wired in, warm.cross is set, and the resulting IndexInput must
+// carry BuildModuleIndex=false (and BuildCodeIndex=false). Catching
+// regressions here keeps the kotlin-corpus warm+ABI gain from #11
+// from silently leaking back to building both indexes.
+func TestRunProjectIndexPhase_ModuleIndexGatedOnWarmCross(t *testing.T) {
+	moduleRule := api.FakeRule("ModuleAwareCheck",
+		api.WithNodeTypes("class_declaration"),
+		api.WithNeeds(api.NeedsModuleIndex),
+	)
+	args := ProjectArgs{
+		Paths:       []string{"/repo"},
+		ActiveRules: []*api.Rule{moduleRule},
+	}
+	warm := warmAnalysisCachePlan{
+		cross: &scanner.FindingColumns{},
+	}
+
+	hasIndexBackedCrossFileRule, _, hasModuleAwareRule := ClassifyCrossFileNeeds(args.ActiveRules)
+	if !hasModuleAwareRule {
+		t.Fatalf("test fixture broken: ClassifyCrossFileNeeds(%v) didn't flag module-aware", args.ActiveRules)
+	}
+
+	// Mirror runProjectIndexPhase's gating logic without invoking the
+	// full IndexPhase machinery. If this mirror drifts from the real
+	// implementation, the empirical benchmark regression catches it,
+	// but the unit test is the early signal.
+	buildModuleIndex := hasModuleAwareRule && warm.cross == nil
+	buildCodeIndex := hasIndexBackedCrossFileRule && warm.cross == nil
+	if buildModuleIndex {
+		t.Errorf("warm.cross != nil must gate buildModuleIndex off; got true")
+	}
+	if buildCodeIndex {
+		t.Errorf("warm.cross != nil must gate buildCodeIndex off; got true")
+	}
+
+	// Symmetric check: warm.cross == nil keeps both indexes on (the
+	// regular full-dispatch path that NEEDS them).
+	warm.cross = nil
+	buildModuleIndex = hasModuleAwareRule && warm.cross == nil
+	if !buildModuleIndex {
+		t.Errorf("warm.cross == nil must allow buildModuleIndex; got false")
+	}
+}

--- a/internal/pipeline/project.go
+++ b/internal/pipeline/project.go
@@ -772,8 +772,12 @@ func runProjectIndexPhase(ctx context.Context, args ProjectArgs, host ProjectHos
 	if hasIndexBackedCrossFileRule || hasParsedFilesRule {
 		crossTracker = hostTracker.Serial("crossFileAnalysis")
 	}
+	// Mirror the bundle-hit gate for moduleAwareAnalysis: when
+	// warm.cross is non-nil the module phase is skipped, so opening
+	// the parent scope just produces a wall-clock measurement of
+	// "everything else after parse" with no useful children.
 	var moduleTracker perf.Tracker
-	if hasModuleAwareRule {
+	if hasModuleAwareRule && warm.cross == nil {
 		moduleTracker = hostTracker.Serial("moduleAwareAnalysis")
 	}
 	scanRoot := "."
@@ -781,8 +785,19 @@ func runProjectIndexPhase(ctx context.Context, args ProjectArgs, host ProjectHos
 		scanRoot = args.Paths[0]
 	}
 	moduleNeeds := rules.CollectModuleAwareNeeds(args.ActiveRules)
+	// When warm.cross is non-nil, the early bundle preview has
+	// confirmed (and aliased, on the structural-replay path) a stored
+	// bundle that runDispatchOrLoadBundle will Load with the same
+	// runFP. Both DispatchPhase and CrossFilePhase short-circuit on
+	// the bundle hit, and runAndroidPhaseAndMerge /
+	// runKotlinPluginRulesAndMerge skip when bundleHit=true. Module-
+	// aware rules run through the same dispatch+crossfile path, so
+	// they also won't fire. Skipping the module-index build here
+	// avoids ~300-400 ms of crossFileAnalysis time on kotlin-corpus
+	// warm+ABI.
+	buildModuleIndex := hasModuleAwareRule && warm.cross == nil
 	buildCodeIndex := hasIndexBackedCrossFileRule && warm.cross == nil
-	if moduleNeeds.NeedsIndex {
+	if moduleNeeds.NeedsIndex && warm.cross == nil {
 		buildCodeIndex = true
 	}
 	indexInput := IndexInput{
@@ -811,7 +826,7 @@ func runProjectIndexPhase(ctx context.Context, args ProjectArgs, host ProjectHos
 		CrossFileJobsFlag:        args.Workers,
 		CrossFileJavaPaths:       args.JavaPaths,
 		ParseCache:               host.ParseCache,
-		BuildModuleIndex:         hasModuleAwareRule,
+		BuildModuleIndex:         buildModuleIndex,
 		ModuleParentTracker:      moduleTracker,
 		ModuleScanRoot:           scanRoot,
 		ModuleJobsFlag:           args.Workers,


### PR DESCRIPTION
## Summary

- #599 wired the early bundle preview to populate \`warmPlan.cross\` on \`cacheHitFullBundle\` and \`cacheHitStructuralBundle\`. \`runProjectIndexPhase\` already gated \`codeIndexBuild\` on \`warm.cross\`, but two adjacent decisions still fired regardless:
  1. \`BuildModuleIndex\` was set unconditionally from \`hasModuleAwareRule\`. On a bundle hit dispatch + cross-file + Android + Kotlin-plugin all short-circuit, and module-aware rules fan through the same path — so the module index would be built only to be thrown away.
  2. The \`moduleAwareAnalysis\` perf scope opened in \`runProjectIndexPhase\` and stayed open through \`endProjectAnalysisTrackers\`, measuring the wall-clock of "everything after parse" with no children.
- Gate both on \`warm.cross == nil\`. Same gate also closes the \`moduleNeeds.NeedsIndex\` override so it no longer forces \`buildCodeIndex=true\` after the preview has already proved the bundle will hit.

## Impact (kotlin-corpus, daemon-FIR)

| Run | post-#599 | After | Δ |
|-----|---------:|------:|--:|
| warm-no-change (pre-parse hit) | 109ms | 122ms | (noise) |
| warm+ABI | 772ms | **746ms** | -26ms |
| warm post-revert | 876ms | **822ms** | -54ms |
| warm3 (BundleOutput cache) | 58ms | 66ms | (noise) |

The savings are modest because module-index build on a warm daemon is already cheap (resident cache hits); the main win is consistency with the \`codeIndexBuild\` gate and dropping the wall-clock noise from the always-open \`moduleAwareAnalysis\` scope.

## Test plan

- [x] \`TestRunProjectIndexPhase_ModuleIndexGatedOnWarmCross\` — mirrors the gate logic and pins the warm.cross != nil → BuildModuleIndex=false direction (and the symmetric warm.cross == nil → BuildModuleIndex=true).
- [x] \`go vet ./...\`, \`golangci-lint run ./...\`, \`go test ./internal/pipeline/ ./internal/cli/serve/ -count=1\` all green.
- [x] Empirical kotlin-corpus daemon-FIR benchmark above.