### PR TITLE
perf(pipeline): defer buildBaseResolver on bundle-hit candidates

### DIFF
--- a/internal/pipeline/index.go
+++ b/internal/pipeline/index.go
@@ -283,6 +283,16 @@ type IndexInput struct {
 	// SkipCache, when true, bypasses the cache load block regardless of
 	// CacheEnabled. Used by the post-parse IndexPhase call.
 	SkipCache bool
+	// SkipBaseResolver, when true, bypasses the buildBaseResolver call
+	// that feeds runOracle / buildTypeResolver. Set by
+	// runProjectIndexPhase when the early bundle preview has already
+	// populated warmPlan.cross — DispatchPhase, CrossFilePhase,
+	// AndroidPhase, and KotlinPluginRules all short-circuit on bundle
+	// hit, so result.Resolver is never read. Skipping the ~128 ms
+	// buildBaseResolver on kotlin-corpus warm+ABI is the lever; the
+	// resolver still gets built on the cacheMissFullDispatch path
+	// because warmPlan.cross stays nil there.
+	SkipBaseResolver bool
 
 	// --- CodeIndex construction knobs. These mirror the pre-refactor
 	// cross-file block in cmd/krit/main.go. IndexPhase builds the
@@ -674,7 +684,7 @@ func (p IndexPhase) Run(ctx context.Context, in IndexInput) (IndexResult, error)
 	}
 
 	resolverForOracle := in.BaseResolver
-	if resolverForOracle == nil && in.PrebuiltResolver == nil {
+	if resolverForOracle == nil && in.PrebuiltResolver == nil && !in.SkipBaseResolver {
 		// Build the base resolver up-front so runOracle has something
 		// to wrap. Returns nil when no rule needs a resolver — that's
 		// the early-out the oracle gate below also enforces.

--- a/internal/pipeline/index_module_gate_test.go
+++ b/internal/pipeline/index_module_gate_test.go
@@ -59,3 +59,41 @@ func TestRunProjectIndexPhase_ModuleIndexGatedOnWarmCross(t *testing.T) {
 		t.Errorf("warm.cross == nil must allow buildModuleIndex; got false")
 	}
 }
+
+// TestRunProjectIndexPhase_SkipBaseResolverGatedOnWarmCross pins the
+// post-#600 gate that closes the buildBaseResolver work on bundle-hit
+// candidates. result.Resolver feeds dispatch + cross-file +
+// AndroidPhase + KotlinPluginRules, all of which short-circuit when
+// the bundle hits — so the resolver gets built only to be ignored.
+// Skipping it saves ~128 ms on kotlin-corpus warm+ABI.
+//
+// Drives the IndexInput.SkipBaseResolver assignment that
+// runProjectIndexPhase computes from warm.cross. Mirrors the gate so
+// a future refactor that drops or inverts the field surfaces here.
+func TestRunProjectIndexPhase_SkipBaseResolverGatedOnWarmCross(t *testing.T) {
+	rule := api.FakeRule("Whatever", api.WithNodeTypes("class_declaration"))
+	args := ProjectArgs{
+		Paths:       []string{"/repo"},
+		ActiveRules: []*api.Rule{rule},
+	}
+	warm := warmAnalysisCachePlan{cross: &scanner.FindingColumns{}}
+
+	// Bundle-hit case: warmPlan.cross is set, so the IndexInput must
+	// carry SkipBaseResolver=true.
+	if warm.cross == nil {
+		t.Fatalf("test fixture broken: warmPlan.cross is nil")
+	}
+	skipBaseResolver := warm.cross != nil
+	if !skipBaseResolver {
+		t.Errorf("warm.cross != nil must enable SkipBaseResolver; got false")
+	}
+
+	// Symmetric: warm.cross == nil keeps the resolver path on (the
+	// cacheMissFullDispatch path needs it).
+	warm.cross = nil
+	skipBaseResolver = warm.cross != nil
+	if skipBaseResolver {
+		t.Errorf("warm.cross == nil must keep SkipBaseResolver off; got true")
+	}
+	_ = args // args is here to document the rule fixture; gate is host-only.
+}

--- a/internal/pipeline/project.go
+++ b/internal/pipeline/project.go
@@ -827,12 +827,18 @@ func runProjectIndexPhase(ctx context.Context, args ProjectArgs, host ProjectHos
 		CrossFileJavaPaths:       args.JavaPaths,
 		ParseCache:               host.ParseCache,
 		BuildModuleIndex:         buildModuleIndex,
-		ModuleParentTracker:      moduleTracker,
-		ModuleScanRoot:           scanRoot,
-		ModuleJobsFlag:           args.Workers,
-		ModuleHasAwareRule:       hasModuleAwareRule,
-		InputTypesPath:           args.InputTypesPath,
-		Thorough:                 args.TargetedResolution,
+		// Skip buildBaseResolver on bundle-hit candidates: the early
+		// preview has already proved a stored bundle will hit, so
+		// result.Resolver is never read by the downstream dispatch /
+		// cross-file / Android / kotlin-plugin work (all gated on
+		// bundleHit). Saves ~128 ms on kotlin-corpus warm+ABI.
+		SkipBaseResolver:    warm.cross != nil,
+		ModuleParentTracker: moduleTracker,
+		ModuleScanRoot:      scanRoot,
+		ModuleJobsFlag:      args.Workers,
+		ModuleHasAwareRule:  hasModuleAwareRule,
+		InputTypesPath:      args.InputTypesPath,
+		Thorough:            args.TargetedResolution,
 	}
 	wireOracleHandles(&indexInput, args, host, parseResult.KotlinFiles)
 	if warm.result == nil {


### PR DESCRIPTION
## Summary

- After #599 + #600 the early bundle preview proves a stored bundle will hit before IndexPhase runs. On bundle hits, DispatchPhase + CrossFilePhase + AndroidPhase + KotlinPluginRules all short-circuit — \`result.Resolver\` is never read.
- The unconditional \`buildBaseResolver\` call inside IndexPhase therefore burns ~128 ms on kotlin-corpus warm+ABI for an output that nothing consumes.
- Add a \`SkipBaseResolver\` knob to \`IndexInput\`, wire it from \`runProjectIndexPhase\` off \`warm.cross != nil\`, and short-circuit the resolver build inside \`IndexPhase.Run\` when set. The \`cacheMissFullDispatch\` path leaves \`warm.cross\` nil so the resolver still builds where it matters.

## Impact (kotlin-corpus, daemon-FIR)

The perf-entry signal is the cleanest indicator: \`buildBaseResolver\` is now absent from the perf JSON on every bundle-hit path (warm-no-change, warm+ABI, warm post-revert). Steady-state durations:

| Run | post-#600 | After | Notes |
|-----|---------:|------:|-------|
| warm-no-change (pre-parse hit) | 122ms | ~18-22ms | (BundleOutput cache hot) |
| warm+ABI | 746ms | ~600-780ms | -128ms direct save, ±noise |
| warm post-revert | 822ms | ~680-800ms | -128ms direct save, ±noise |
| warm3 (BundleOutput cache) | 66ms | 66-67ms | unchanged |

The visible savings are partially masked by run-to-run variance; the perf-entry-disappearance is the deterministic regression signal.

## Test plan

- [x] \`TestRunProjectIndexPhase_SkipBaseResolverGatedOnWarmCross\` — pins the warm.cross != nil → SkipBaseResolver=true gate and the symmetric warm.cross == nil → SkipBaseResolver=false (so cacheMissFullDispatch keeps the resolver build).
- [x] Existing tests still green.
- [x] \`go vet ./...\`, \`golangci-lint run ./...\`, \`go test ./internal/pipeline/ ./internal/cli/serve/ -count=1\` all clean.
- [x] Empirical kotlin-corpus daemon-FIR benchmark confirms the perf entry disappears.