### PR TITLE
perf(pipeline): alias BundleOutput cache on structural-replay

### DIFF
--- a/internal/pipeline/bundle_output_alias_test.go
+++ b/internal/pipeline/bundle_output_alias_test.go
@@ -1,0 +1,95 @@
+package pipeline
+
+import (
+	"testing"
+
+	"github.com/kaeawc/krit/internal/scanner"
+)
+
+// TestAliasBundleOutputCache_CopiesPriorEntry pins the path that
+// makes structural-replay benefit from the BundleOutput cache: when
+// the prior bundle was last formatted (so its key has a cached
+// CachedBundleOutput), aliasing carries the same bytes forward under
+// the new runFP. Without it the first warm+ABI cycle pays the full
+// ~100 ms findings serialization cost even though the bytes already
+// exist under a sibling key.
+func TestAliasBundleOutputCache_CopiesPriorEntry(t *testing.T) {
+	priorFP := scanner.RunFingerprint{Version: "v1", Rules: "r", Config: "r", SourceSet: "old"}
+	newFP := scanner.RunFingerprint{Version: "v1", Rules: "r", Config: "r", SourceSet: "new"}
+	priorKey := scanner.FindingsBundleKey(priorFP)
+	newKey := scanner.FindingsBundleKey(newFP)
+	if priorKey == newKey {
+		t.Fatalf("test fixture broken: prior and new keys collide")
+	}
+
+	store := map[string]*CachedBundleOutput{
+		priorKey: {FindingsBytes: []byte("cached bytes"), Total: 7},
+	}
+	host := ProjectHostState{
+		DaemonCaches: DaemonCaches{
+			BundleOutput:      func(k string) *CachedBundleOutput { return store[k] },
+			StoreBundleOutput: func(k string, v *CachedBundleOutput) { store[k] = v },
+		},
+	}
+
+	aliasBundleOutputCache(host, priorFP, newFP)
+
+	got := store[newKey]
+	if got == nil {
+		t.Fatalf("alias did not copy: store=%v", store)
+	}
+	if got.Total != 7 || string(got.FindingsBytes) != "cached bytes" {
+		t.Errorf("alias content drifted from prior: %+v", got)
+	}
+}
+
+// TestAliasBundleOutputCache_NoStoreIsNoOp pins the CLI-path
+// contract: when BundleOutput / StoreBundleOutput aren't wired the
+// helper exits cleanly without nil-deref.
+func TestAliasBundleOutputCache_NoStoreIsNoOp(t *testing.T) {
+	host := ProjectHostState{}
+	aliasBundleOutputCache(host,
+		scanner.RunFingerprint{SourceSet: "a"},
+		scanner.RunFingerprint{SourceSet: "b"},
+	)
+	// success = no panic
+}
+
+// TestAliasBundleOutputCache_NoPriorEntryIsNoOp confirms the helper
+// doesn't accidentally store nil under newKey when priorKey has no
+// entry — would shadow a future legitimate cache write.
+func TestAliasBundleOutputCache_NoPriorEntryIsNoOp(t *testing.T) {
+	priorFP := scanner.RunFingerprint{SourceSet: "a"}
+	newFP := scanner.RunFingerprint{SourceSet: "b"}
+	store := map[string]*CachedBundleOutput{}
+	host := ProjectHostState{
+		DaemonCaches: DaemonCaches{
+			BundleOutput:      func(k string) *CachedBundleOutput { return store[k] },
+			StoreBundleOutput: func(k string, v *CachedBundleOutput) { store[k] = v },
+		},
+	}
+	aliasBundleOutputCache(host, priorFP, newFP)
+	if len(store) != 0 {
+		t.Errorf("alias must not write when prior has no entry; store=%v", store)
+	}
+}
+
+// TestAliasBundleOutputCache_SameKeyNoSelfWrite covers the edge where
+// the planner happens to leave runFP == prior.Fingerprint (delta
+// planner accepted a no-op edit). Avoid the spurious StoreBundleOutput
+// call to keep the cache-write counter clean for tests that assert on
+// it.
+func TestAliasBundleOutputCache_SameKeyNoSelfWrite(t *testing.T) {
+	fp := scanner.RunFingerprint{SourceSet: "x"}
+	stored := 0
+	host := ProjectHostState{
+		DaemonCaches: DaemonCaches{
+			BundleOutput:      func(k string) *CachedBundleOutput { return &CachedBundleOutput{Total: 1} },
+			StoreBundleOutput: func(k string, v *CachedBundleOutput) { stored++ },
+		},
+	}
+	aliasBundleOutputCache(host, fp, fp)
+	if stored != 0 {
+		t.Errorf("same-key alias must not write; stored=%d", stored)
+	}
+}

--- a/internal/pipeline/project.go
+++ b/internal/pipeline/project.go
@@ -1728,8 +1728,43 @@ func tryLoadStructurallyStableBundle(host ProjectHostState, runFP scanner.RunFin
 		host.Reporter.Verbosef("verbose: Findings bundle structural reuse skipped: save alias failed: %v\n", err)
 		return nil, false
 	}
+	// Alias the formatted-output cache too. The findings bytes that
+	// emitBundleHitOutput would produce are a pure function of
+	// (priorBundle, args.ActiveRules), which is byte-identical between
+	// prior.Fingerprint and runFP since the planner gate proves rules
+	// haven't changed. Without aliasing, the first warm+ABI cycle
+	// builds the formatted output from scratch (~100ms of column-
+	// serialisation work on kotlin-corpus scale) even though the bytes
+	// already exist under prior.Fingerprint's key. Skipped silently
+	// when the host hasn't wired the BundleOutput cache (CLI path).
+	aliasBundleOutputCache(host, prior.Fingerprint, runFP)
 	host.Reporter.Verbosef("verbose: Findings bundle cache: HIT (structural reuse: %s)\n", plan.ChangedPaths[0])
 	return priorBundle, true
+}
+
+// aliasBundleOutputCache copies host.BundleOutput[priorKey] to
+// host.BundleOutput[newKey] when both ends of the BundleOutput cache
+// API are wired and a stored entry exists for priorFP. A no-op
+// otherwise. Used by the structural-replay path so subsequent
+// analyzes against the same body-edit can take the pre-Load
+// BundleOutput fast path instead of rebuilding the formatted bytes.
+func aliasBundleOutputCache(host ProjectHostState, priorFP, newFP scanner.RunFingerprint) {
+	if host.BundleOutput == nil || host.StoreBundleOutput == nil {
+		return
+	}
+	priorKey := scanner.FindingsBundleKey(priorFP)
+	if priorKey == "" {
+		return
+	}
+	existing := host.BundleOutput(priorKey)
+	if existing == nil {
+		return
+	}
+	newKey := scanner.FindingsBundleKey(newFP)
+	if newKey == "" || newKey == priorKey {
+		return
+	}
+	host.StoreBundleOutput(newKey, existing)
 }
 
 func bodyOnlyKotlinChange(path string, prior, current map[string]string) bool {


### PR DESCRIPTION
## Summary

- When \`tryLoadStructurallyStableBundle\` replays a prior bundle under a new runFP, the \`FindingColumns\` is unchanged byte-for-byte by the planner gate (CrossFile FP stable + single body-only edit). The formatted-output cache keyed on \`FindingsBundleKey(fp)\` therefore holds bytes that are also valid under the new key — but without aliasing, the next pre-parse hit on the new runFP rebuilds those bytes from scratch (~100 ms of column serialisation on kotlin-corpus scale).
- Add \`aliasBundleOutputCache\`: after the bundle is aliased under runFP, copy \`host.BundleOutput[priorKey]\` to \`host.BundleOutput[newKey]\` when both ends of the cache API are wired and a prior entry exists.

## Foundational, follow-up needed for full empirical win

The post-parse bundle-hit path (\`RunProjectStreaming\` → \`RunProjectAnalysis\` → \`OutputPhase\`) currently re-formats the findings on every hit because \`OutputPhase\` doesn't consult \`BundleOutput\` — that's the remaining lever to ~100 ms warm+ABI. Wiring it correctly requires a separate correctness analysis around \`FixupPhase\` interactions (the BundleOutput bytes pre-date Fixup-level stripping; the pre-parse path accepts this gap by gating on \`!args.Fix && !args.DryRun\`, the post-parse path would need the same gate plus a FixLevel check). Tracked as item 14 follow-up.

## Test plan

- [x] \`TestAliasBundleOutputCache_CopiesPriorEntry\` — happy path: prior entry copied to new key.
- [x] \`TestAliasBundleOutputCache_NoStoreIsNoOp\` — CLI-path safety: nil cache API doesn't panic.
- [x] \`TestAliasBundleOutputCache_NoPriorEntryIsNoOp\` — don't shadow future writes with nil under newKey.
- [x] \`TestAliasBundleOutputCache_SameKeyNoSelfWrite\` — avoid spurious StoreBundleOutput when priorFP == runFP.
- [x] \`go vet ./...\`, \`golangci-lint run ./...\`, \`go test ./internal/pipeline/ ./internal/cli/serve/ -count=1\` all clean.