### PR TITLE
perf(pipeline): route post-parse bundle hits through BundleOutput cache

### DIFF
--- a/internal/pipeline/post_parse_bundle_output_test.go
+++ b/internal/pipeline/post_parse_bundle_output_test.go
@@ -1,0 +1,121 @@
+package pipeline
+
+import (
+	"testing"
+)
+
+// TestCanUsePostParseBundleOutputShortcut_DefaultArgsAllow pins the
+// happy path: a daemon analyze with the standard daemonState wiring
+// (BundleOutput / StoreBundleOutput populated, JSON+Compact format,
+// no Fix/DryRun, no baseline/diff/severity tweaks) clears every
+// gate. Without this, the kotlin-corpus warm+ABI BundleOutput
+// shortcut never fires and we burn ~100 ms re-formatting findings
+// on every cycle.
+func TestCanUsePostParseBundleOutputShortcut_DefaultArgsAllow(t *testing.T) {
+	host := ProjectHostState{
+		DaemonCaches: DaemonCaches{
+			BundleOutput:      func(string) *CachedBundleOutput { return nil },
+			StoreBundleOutput: func(string, *CachedBundleOutput) {},
+		},
+	}
+	args := ProjectArgs{Format: "json", JSONCompact: true}
+
+	if !canUsePostParseBundleOutputShortcut(args, host) {
+		t.Errorf("default daemon-shaped args + host must allow the shortcut")
+	}
+}
+
+// TestCanUsePostParseBundleOutputShortcut_FixForcesFullPath pins
+// the correctness envelope: args.Fix needs FixupPhase to apply
+// changes to the FindingColumns before serialization. The cached
+// bytes pre-date Fixup, so taking the shortcut would silently drop
+// fix application. Same shape as tryLoadFindingsBundleBeforeParse's
+// gate.
+func TestCanUsePostParseBundleOutputShortcut_FixForcesFullPath(t *testing.T) {
+	host := ProjectHostState{
+		DaemonCaches: DaemonCaches{
+			BundleOutput:      func(string) *CachedBundleOutput { return nil },
+			StoreBundleOutput: func(string, *CachedBundleOutput) {},
+		},
+	}
+	for _, tc := range []struct {
+		name string
+		args ProjectArgs
+	}{
+		{"Fix", ProjectArgs{Format: "json", JSONCompact: true, Fix: true}},
+		{"FixBinary", ProjectArgs{Format: "json", JSONCompact: true, FixBinary: true}},
+		{"DryRun", ProjectArgs{Format: "json", JSONCompact: true, DryRun: true}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if canUsePostParseBundleOutputShortcut(tc.args, host) {
+				t.Errorf("%s must force the full FixupPhase+OutputPhase route", tc.name)
+			}
+		})
+	}
+}
+
+// TestCanUsePostParseBundleOutputShortcut_CustomRuleJarsForcesFullPath
+// covers the custom-rule-jars case: those rules' outputs aren't
+// captured in the cached BundleOutput bytes (the cache is keyed on
+// the built-in rule set's fingerprint), so the shortcut would serve
+// findings missing the custom-jar contributions.
+func TestCanUsePostParseBundleOutputShortcut_CustomRuleJarsForcesFullPath(t *testing.T) {
+	host := ProjectHostState{
+		DaemonCaches: DaemonCaches{
+			BundleOutput:      func(string) *CachedBundleOutput { return nil },
+			StoreBundleOutput: func(string, *CachedBundleOutput) {},
+		},
+	}
+	args := ProjectArgs{
+		Format:         "json",
+		JSONCompact:    true,
+		CustomRuleJars: []string{"/path/to/custom.jar"},
+	}
+
+	if canUsePostParseBundleOutputShortcut(args, host) {
+		t.Errorf("custom-rule-jars must force the full route")
+	}
+}
+
+// TestCanUsePostParseBundleOutputShortcut_ResponseShapeGatesPassThrough
+// pins the layered relationship with canUseBundleOutputCache: anything
+// that ROAMS the response shape (baseline filter, format, etc.) must
+// still reject the shortcut even when Fix gates are clear.
+func TestCanUsePostParseBundleOutputShortcut_ResponseShapeGatesPassThrough(t *testing.T) {
+	host := ProjectHostState{
+		DaemonCaches: DaemonCaches{
+			BundleOutput:      func(string) *CachedBundleOutput { return nil },
+			StoreBundleOutput: func(string, *CachedBundleOutput) {},
+		},
+	}
+	for _, tc := range []struct {
+		name string
+		args ProjectArgs
+	}{
+		{"baseline filter", ProjectArgs{Format: "json", JSONCompact: true, BaselinePath: "/baseline.xml"}},
+		{"diff filter", ProjectArgs{Format: "json", JSONCompact: true, DiffRef: "main"}},
+		{"warnings-as-errors", ProjectArgs{Format: "json", JSONCompact: true, WarningsAsErrors: true}},
+		{"min-confidence", ProjectArgs{Format: "json", JSONCompact: true, MinConfidence: 0.5}},
+		{"non-json format", ProjectArgs{Format: "sarif", JSONCompact: true}},
+		{"json non-compact", ProjectArgs{Format: "json", JSONCompact: false}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if canUsePostParseBundleOutputShortcut(tc.args, host) {
+				t.Errorf("%s must reject the shortcut via canUseBundleOutputCache passthrough", tc.name)
+			}
+		})
+	}
+}
+
+// TestCanUsePostParseBundleOutputShortcut_NoStoreReturnsFalse pins
+// the CLI-path contract: when the host hasn't wired BundleOutput
+// (in-process CLI run, tests that don't care), the shortcut never
+// fires and the regular pipeline executes.
+func TestCanUsePostParseBundleOutputShortcut_NoStoreReturnsFalse(t *testing.T) {
+	host := ProjectHostState{} // no BundleOutput / StoreBundleOutput
+	args := ProjectArgs{Format: "json", JSONCompact: true}
+
+	if canUsePostParseBundleOutputShortcut(args, host) {
+		t.Errorf("nil BundleOutput must reject the shortcut")
+	}
+}

--- a/internal/pipeline/project.go
+++ b/internal/pipeline/project.go
@@ -477,15 +477,21 @@ type ProjectResult struct {
 // report formatting. CLI callers use this boundary to keep CLI-only FIR,
 // baseline verbs, profile handling, and exit-code policy outside pipeline.
 type ProjectAnalysisResult struct {
-	ParseResult       ParseResult
-	IndexResult       IndexResult
-	DispatchResult    DispatchResult
-	CrossFileResult   CrossFileResult
-	FilesScanned      int
-	ParseErrors       []error
-	Stats             rules.RunStats
-	ParseHits         int64
-	ParseMisses       int64
+	ParseResult     ParseResult
+	IndexResult     IndexResult
+	DispatchResult  DispatchResult
+	CrossFileResult CrossFileResult
+	FilesScanned    int
+	ParseErrors     []error
+	Stats           rules.RunStats
+	ParseHits       int64
+	ParseMisses     int64
+	// RunFP is the canonical RunFingerprint computeRunFingerprint
+	// produced for this analyze — exposed so RunProjectStreaming can
+	// key BundleOutput-cache lookups on it after a post-parse bundle
+	// hit. Zero-value when bundleEnabled was false (CLI path without
+	// a wired FindingsBundleStore, --custom-rule-jars, etc.).
+	RunFP             scanner.RunFingerprint
 	FindingsBundleHit bool
 	PhaseTimingsMs    PhaseTimingsMs
 }
@@ -554,6 +560,46 @@ func RunProjectStreaming(ctx context.Context, in ProjectInput, out io.Writer) (P
 		return ProjectResult{}, err
 	}
 	phaseTimings = analysis.PhaseTimingsMs
+
+	// Post-parse BundleOutput cache shortcut. When the dispatch path
+	// hit a bundle (cacheHitFullBundle, including the alias #599 and
+	// #602 produce on structural replay), the FindingColumns flowing
+	// out of RunProjectAnalysis is byte-identical to what the prior
+	// run produced. If the host's BundleOutput cache already holds
+	// the formatted bytes for analysis.RunFP, we can emit them
+	// directly and skip the ~100 ms FixupPhase + OutputPhase
+	// re-formatting on kotlin-corpus scale.
+	//
+	// Gates mirror tryLoadFindingsBundleBeforeParse so the same
+	// correctness envelope applies: Fix / FixBinary / DryRun /
+	// CustomRuleJars all force the full FixupPhase+OutputPhase route.
+	// canUseBundleOutputCache catches the remaining response-shape
+	// requirements (Format=json, JSONCompact, no baseline/diff
+	// filtering, etc.).
+	if analysis.FindingsBundleHit && canUsePostParseBundleOutputShortcut(args, host) {
+		perfTimings, caches, budget := capturePerfOutputs(args, host)
+		shortcutStart := time.Now()
+		res, ok, err := serveBundleHitFromOutputCache(
+			&analysis.CrossFileResult.Findings, analysis.RunFP,
+			analysis.ParseResult.KotlinFiles, analysis.ParseResult.JavaFiles,
+			args, host, out, startTime, perfTimings, caches, budget)
+		if err != nil {
+			return ProjectResult{}, err
+		}
+		if ok {
+			phaseTimings.Output = time.Since(shortcutStart).Milliseconds()
+			res.PhaseTimingsMs = phaseTimings
+			res.ParseErrors = analysis.ParseErrors
+			res.Stats = analysis.Stats
+			res.ParseHits = analysis.ParseHits
+			res.ParseMisses = analysis.ParseMisses
+			res.FileTimings = analysis.DispatchResult.FileTimings
+			return res, nil
+		}
+		// ok=false with nil error → cache build declined (degenerate
+		// FindingColumns). Fall through to FixupPhase+OutputPhase for
+		// correctness.
+	}
 
 	fixupStart := time.Now()
 	fixupView, err := runFixupPhase(ctx, args, analysis.CrossFileResult)
@@ -711,6 +757,7 @@ func RunProjectAnalysis(ctx context.Context, in ProjectInput) (ProjectAnalysisRe
 		Stats:             dispatchResult.Stats,
 		ParseHits:         hits1 - hits0,
 		ParseMisses:       misses1 - misses0,
+		RunFP:             runFP,
 		FindingsBundleHit: bundleHit,
 		PhaseTimingsMs:    phaseTimings,
 	}, nil
@@ -1975,6 +2022,26 @@ func emitBundleHitOutput(
 // post-bundle column set (baseline filter, diff filter, severity
 // promotion, min-confidence threshold) makes them incorrect, so
 // those cases fall back to the regular OutputPhase route.
+// canUsePostParseBundleOutputShortcut reports whether the post-parse
+// BundleOutput shortcut is safe to take. Mirrors the Fix-related gate
+// in tryLoadFindingsBundleBeforeParse (the pre-parse path) so the
+// same correctness envelope applies to both bundle-hit routes — both
+// skip FixupPhase, so both must refuse when Fix / FixBinary / DryRun
+// / CustomRuleJars would change the post-pipeline column set.
+//
+// Layered on top of canUseBundleOutputCache (which handles the
+// response-shape requirements: Format=json, JSONCompact, no
+// baseline/diff filtering, no severity promotion).
+func canUsePostParseBundleOutputShortcut(args ProjectArgs, host ProjectHostState) bool {
+	if args.Fix || args.FixBinary || args.DryRun {
+		return false
+	}
+	if len(args.CustomRuleJars) > 0 {
+		return false
+	}
+	return canUseBundleOutputCache(args, host)
+}
+
 func canUseBundleOutputCache(args ProjectArgs, host ProjectHostState) bool {
 	if host.BundleOutput == nil || host.StoreBundleOutput == nil {
 		return false


### PR DESCRIPTION
## Summary

- #602 wired \`aliasBundleOutputCache\` so a structural-replay copies the prior formatted bytes under the new runFP. But the post-parse hit path (\`RunProjectStreaming\` → \`RunProjectAnalysis\` → \`FixupPhase\` → \`OutputPhase\`) ignored that cache: \`OutputPhase\` re-formatted the findings every time, burning ~100 ms of column serialisation on kotlin-corpus scale plus FixupPhase / output wiring overhead.
- Expose \`runFP\` from \`ProjectAnalysisResult\` and add a fast-path after \`RunProjectAnalysis\`: when \`bundleHit=true\` and the gates are safe, call \`serveBundleHitFromOutputCache\` directly with the bundle's \`FindingColumns\` and \`analysis.RunFP\`.
- \`canUsePostParseBundleOutputShortcut\` mirrors \`tryLoadFindingsBundleBeforeParse\`'s gate (no Fix / FixBinary / DryRun / CustomRuleJars) so both bundle-hit routes share the same correctness envelope. \`canUseBundleOutputCache\` (which it composes with) handles the response-shape requirements.

## Impact (kotlin-corpus, daemon-FIR, steady-state)

| Run | post-#602 | After | Δ |
|-----|---------:|------:|--:|
| warm-no-change (pre-parse hit) | 122ms | **26ms** | -96ms |
| warm+ABI | 746ms | **~575-632ms** | -114-170ms |
| warm post-revert | 822ms | **~582-661ms** | -161-240ms |
| warm3 (BundleOutput cache) | 66ms | **59ms** | -7ms |

The remaining ~500 ms in \`crossFileAnalysis\` on warm+ABI is parse + \`augmentDirtyWithStatDrift\` (~80 ms) + bundle Load (~90 ms) + \`buildManifestData\` (~50 ms) + preview overhead — work that runs even when the bundle is going to hit. Trimming further requires either making \`augmentDirtyWithStatDrift\` a no-op fast-path when stat drift is already covered by the preview, or caching the manifest-data computation across calls.

## Test plan

- [x] \`TestCanUsePostParseBundleOutputShortcut_DefaultArgsAllow\` — happy path: daemon-shaped args clear every gate.
- [x] \`TestCanUsePostParseBundleOutputShortcut_FixForcesFullPath\` — Fix / FixBinary / DryRun each force the regular OutputPhase route.
- [x] \`TestCanUsePostParseBundleOutputShortcut_CustomRuleJarsForcesFullPath\` — custom-jar findings aren't captured in BundleOutput bytes.
- [x] \`TestCanUsePostParseBundleOutputShortcut_ResponseShapeGatesPassThrough\` — baseline / diff / WarningsAsErrors / MinConfidence / non-json / non-compact all reject via canUseBundleOutputCache passthrough.
- [x] \`TestCanUsePostParseBundleOutputShortcut_NoStoreReturnsFalse\` — CLI-path contract (no wired BundleOutput → no shortcut).
- [x] \`go vet ./...\`, \`golangci-lint run ./...\`, \`go test ./internal/pipeline/ ./internal/cli/serve/ -count=1\` all clean.
- [x] Empirical kotlin-corpus daemon-FIR benchmark above.