### PR TITLE
perf(pipeline): reuse host.PriorFileStats in manifest carry-forward

### DIFF
--- a/internal/pipeline/build_manifest_data_test.go
+++ b/internal/pipeline/build_manifest_data_test.go
@@ -105,6 +105,91 @@ func TestBuildManifestData_DropsDirtyUnparsedPaths(t *testing.T) {
 	}
 }
 
+// TestBuildManifestData_CarryForwardReusesPriorFileStats pins the
+// perf win that closes 18k stat syscalls on kotlin-corpus warm runs:
+// when host.PriorFileStats has an entry for a carry-forward path
+// (non-parsed, non-dirty), the manifest builder must copy it
+// verbatim rather than call statForPath. The non-dirty + non-parsed
+// invariant means the on-disk stat hasn't changed since the prior
+// manifest was written, so the prior value is correct by
+// construction.
+//
+// Drives buildManifestData directly with a synthesized prior stat
+// that DIFFERS from any plausible current stat (size=0xDEAD,
+// mtime=0xBEEF) so we can tell whether the code took the
+// reuse-prior branch or fell through to statForPath. statForPath
+// would return the real (small, fresh) file stat, never the
+// synthesized one — so observing the synthesized values in the
+// output proves the carry-forward used the prior map.
+func TestBuildManifestData_CarryForwardReusesPriorFileStats(t *testing.T) {
+	tmp := t.TempDir()
+	carried := writeManifestTestFile(t, tmp, "Carried.kt", "package demo\nclass Carried\n")
+
+	args := ProjectArgs{
+		Paths:       []string{tmp},
+		KotlinPaths: []string{carried},
+	}
+	syntheticStat := scanner.FileStat{Size: 0xDEAD, ModTimeUnixNano: 0xBEEF}
+	host := ProjectHostState{
+		FindingsBundleCacheRoot: tmp,
+		PriorContentHashes: map[string]string{
+			carried: "prior-hash",
+		},
+		PriorStructuralFPs: map[string]string{
+			carried: "prior-fp",
+		},
+		PriorFileStats: map[string]scanner.FileStat{
+			carried: syntheticStat,
+		},
+		// SourceSetDirty intentionally nil so the carried file is
+		// non-dirty + non-parsed.
+	}
+	parseResult := ParseResult{} // nothing parsed; everything carries forward
+
+	m := buildManifestData(args, host, parseResult, scanner.RunFingerprint{}, true)
+	if !m.enabled {
+		t.Fatalf("manifest disabled: %+v", m)
+	}
+	got, ok := m.fileStats[carried]
+	if !ok {
+		t.Fatalf("carried path missing from fileStats")
+	}
+	if got != syntheticStat {
+		t.Errorf("carry-forward must reuse PriorFileStats verbatim; got %+v want %+v", got, syntheticStat)
+	}
+}
+
+// TestBuildManifestData_CarryForwardFallsBackToStatWhenPriorMissing
+// covers the CLI-path contract: when host.PriorFileStats is nil (no
+// prior manifest), the helper must fall back to statForPath rather
+// than dropping the carry-forward entry. Otherwise the persisted
+// manifest would be missing fileStats for every carried path, which
+// breaks fileStatsMatch on the next analyze.
+func TestBuildManifestData_CarryForwardFallsBackToStatWhenPriorMissing(t *testing.T) {
+	tmp := t.TempDir()
+	carried := writeManifestTestFile(t, tmp, "Carried.kt", "package demo\nclass Carried\n")
+
+	args := ProjectArgs{
+		Paths:       []string{tmp},
+		KotlinPaths: []string{carried},
+	}
+	host := ProjectHostState{
+		FindingsBundleCacheRoot: tmp,
+		PriorContentHashes:      map[string]string{carried: "prior-hash"},
+		// PriorFileStats intentionally nil — CLI path.
+	}
+	parseResult := ParseResult{}
+
+	m := buildManifestData(args, host, parseResult, scanner.RunFingerprint{}, true)
+	got, ok := m.fileStats[carried]
+	if !ok {
+		t.Fatalf("nil PriorFileStats must still populate fileStats via statForPath; got missing entry")
+	}
+	if got.Size == 0 || got.ModTimeUnixNano == 0 {
+		t.Errorf("statForPath fallback produced empty stat: %+v", got)
+	}
+}
+
 func writeManifestTestFile(t *testing.T, dir, name, content string) string {
 	t.Helper()
 	path := filepath.Join(dir, name)

--- a/internal/pipeline/project.go
+++ b/internal/pipeline/project.go
@@ -1461,7 +1461,20 @@ func buildManifestData(args ProjectArgs, host ProjectHostState, parseResult Pars
 		if fp, ok := host.PriorStructuralFPs[path]; ok {
 			structuralFPs[path] = fp
 		}
-		if stat, ok := statForPath(path); ok {
+		// Reuse host.PriorFileStats for carry-forward when populated
+		// (daemon path post-#590). By construction these files are
+		// NOT in the dirty set — neither the watcher saw an event
+		// nor augmentDirtyWithStatDrift detected a stat change — so
+		// the on-disk stat is unchanged from the prior manifest.
+		// Calling os.Stat here would re-confirm the same stat at
+		// ~one syscall per file × 18 k files = 80-200 ms of pure
+		// overhead on kotlin-corpus warm runs. Fall back to
+		// statForPath when PriorFileStats is nil (CLI path / cold
+		// daemon session — no prior manifest, so no carry-forward
+		// either).
+		if priorStat, ok := host.PriorFileStats[path]; ok {
+			fileStats[path] = priorStat
+		} else if stat, ok := statForPath(path); ok {
 			fileStats[path] = stat
 		}
 		if priorAbi != nil {


### PR DESCRIPTION
## Summary

\`buildManifestData\`'s carry-forward loop iterates every entry in \`host.PriorContentHashes\` that wasn't parsed this run and isn't dirty, calling \`statForPath\` on each to populate the new manifest's \`fileStats\`. On kotlin-corpus that's ~18k \`os.Stat\` syscalls per analyze — 80-200 ms of pure overhead because the file is demonstrably unchanged (not in the watcher's dirty set, not in \`augmentDirtyWithStatDrift\`'s drifted set), so its on-disk stat is necessarily equal to the prior stat.

Reuse \`host.PriorFileStats[path]\` when populated (daemon path post-#590) instead of calling \`statForPath\`. Fall back to \`statForPath\` when \`PriorFileStats\` is nil (CLI path / cold daemon session — no prior manifest, so the fallback path doesn't add overhead).

## Correctness

For a path in the carry-forward branch:
- It's NOT in \`parsedByPath\` (parse cache fast-pathed it, meaning content hash unchanged), AND
- It's NOT in the dirty set (watcher didn't see an event AND #590's \`augmentDirtyWithStatDrift\` didn't detect drift).

Both conditions together imply the file's on-disk content is byte-identical to the prior run. The \`(size, mtime)\` pair stored in \`host.PriorFileStats[path]\` is therefore the same value \`statForPath\` would return now.

The next analyze's \`fileStatsMatch\` compares the file's then-current OS stat against this stored value; if nothing has touched the file in between they match and the warm fast path fires — same outcome as today, fewer syscalls.

## Test plan

- [x] \`TestBuildManifestData_CarryForwardReusesPriorFileStats\` — synthesizes a prior stat that no real \`os.Stat\` would return (size=0xDEAD, mtime=0xBEEF). Observing those synthesized values in the output manifest proves the reuse-prior branch fired.
- [x] \`TestBuildManifestData_CarryForwardFallsBackToStatWhenPriorMissing\` — CLI-path contract: nil \`PriorFileStats\` still populates \`fileStats\` via \`statForPath\`.
- [x] Existing \`TestBuildManifestData_*\` suite (CarriesForwardCachedPaths, DropsDirtyUnparsedPaths) still green.
- [x] \`go vet ./...\`, \`golangci-lint run ./...\`, \`go test ./internal/pipeline/ ./internal/cli/serve/ -count=1\` clean.