### PR TITLE
perf(pipeline): skip redundant bundle Load when preview already loaded it

### DIFF
--- a/internal/pipeline/dispatch_preloaded_test.go
+++ b/internal/pipeline/dispatch_preloaded_test.go
@@ -1,0 +1,101 @@
+package pipeline
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kaeawc/krit/internal/scanner"
+)
+
+// loadCountingStore is a FindingsBundleStore that counts how many
+// times Load fires. Used by the preload-bundle test to assert the
+// short-circuit fired (loadCalls=0 when WarmCrossFindings is set).
+type loadCountingBundleStore struct {
+	loadCalls int
+	saveCalls int
+}
+
+func (s *loadCountingBundleStore) Load(string, scanner.RunFingerprint) (*scanner.FindingColumns, bool) {
+	s.loadCalls++
+	return nil, false
+}
+
+func (s *loadCountingBundleStore) Save(string, scanner.RunFingerprint, *scanner.FindingColumns) error {
+	s.saveCalls++
+	return nil
+}
+
+// TestRunDispatchOrLoadBundle_PreloadedSkipsStoreLoad pins the
+// short-circuit added on top of #603: when previewPostParseBundleHit
+// already loaded the bundle and stashed it on indexResult.WarmCrossFindings,
+// runDispatchOrLoadBundle must return it directly without calling
+// FindingsBundleStore.Load again. Each Load is ~90ms of zstd+gob
+// decode on kotlin-corpus scale; warm+ABI used to pay three of them
+// (preview-full-miss + preview-prior-hit + dispatch-Load). The
+// short-circuit eliminates the third.
+func TestRunDispatchOrLoadBundle_PreloadedSkipsStoreLoad(t *testing.T) {
+	preloaded := &scanner.FindingColumns{}
+	store := &loadCountingBundleStore{}
+	host := ProjectHostState{
+		FindingsBundleStore:     store,
+		FindingsBundleCacheRoot: "/repo",
+	}
+	indexResult := IndexResult{
+		WarmCrossFindings: preloaded,
+	}
+
+	d, c, hit, _, err := runDispatchOrLoadBundle(
+		context.Background(),
+		ProjectArgs{},
+		host,
+		indexResult,
+		ParseResult{},
+		scanner.RunFingerprint{Version: "v1"},
+		true, // bundleEnabled
+		deltaManifestData{},
+	)
+	if err != nil {
+		t.Fatalf("runDispatchOrLoadBundle: %v", err)
+	}
+	if !hit {
+		t.Fatalf("expected bundle hit; got hit=false")
+	}
+	if store.loadCalls != 0 {
+		t.Errorf("preloaded bundle must skip Load; got loadCalls=%d", store.loadCalls)
+	}
+	if d.Findings.Len() != preloaded.Len() {
+		t.Errorf("DispatchResult.Findings did not carry the preloaded columns")
+	}
+	if c.Findings.Len() != preloaded.Len() {
+		t.Errorf("CrossFileResult.Findings did not carry the preloaded columns")
+	}
+}
+
+// TestRunDispatchOrLoadBundle_NoPreloadHitsStoreLoad confirms the
+// fallback path is unchanged when WarmCrossFindings is nil — the
+// usual cacheHitFullBundle / cacheHitStructuralBundle / dispatch
+// flow must still drive FindingsBundleStore.Load.
+func TestRunDispatchOrLoadBundle_NoPreloadHitsStoreLoad(t *testing.T) {
+	store := &loadCountingBundleStore{}
+	host := ProjectHostState{
+		FindingsBundleStore:     store,
+		FindingsBundleCacheRoot: "/repo",
+	}
+	indexResult := IndexResult{
+		// WarmCrossFindings intentionally nil.
+	}
+
+	_, _, _, _, _ = runDispatchOrLoadBundle(
+		context.Background(),
+		ProjectArgs{},
+		host,
+		indexResult,
+		ParseResult{},
+		scanner.RunFingerprint{Version: "v1"},
+		true,
+		deltaManifestData{},
+	)
+	if store.loadCalls < 1 {
+		t.Errorf("nil WarmCrossFindings must drive at least one Load; got loadCalls=%d", store.loadCalls)
+	}
+}

--- a/internal/pipeline/project.go
+++ b/internal/pipeline/project.go
@@ -927,12 +927,23 @@ func completeRunProjectIndexResult(args ProjectArgs, host ProjectHostState, warm
 	indexResult.EmitPerFileStats = args.EmitPerFileStats
 	indexResult.Reporter = host.Reporter
 	indexResult.Tracker = host.Tracker
+	// WarmCrossFindings carries the pre-loaded findings forward to
+	// runDispatchOrLoadBundle so it can short-circuit the disk Load
+	// when previewPostParseBundleHit already produced the bundle.
+	// Lifted out of the warm.result branch (which gates on the
+	// analysis-cache hit) because the early bundle preview runs
+	// independently and may populate warm.cross even when warm.result
+	// is nil. Without this lift, warm+ABI on a cold-analysis-cache
+	// daemon would Load the bundle twice — once in the preview, once
+	// in runDispatchOrLoadBundle's cacheHitFullBundle path.
+	if warm.cross != nil {
+		indexResult.WarmCrossFindings = warm.cross
+	}
 	if warm.result != nil {
 		indexResult.CacheResult = warm.result
 		indexResult.RuleHash = warm.ruleHash
 		indexResult.CacheFilePath = host.AnalysisCacheFilePath
 		indexResult.CacheStats = warm.stats
-		indexResult.WarmCrossFindings = warm.cross
 	}
 	if host.AnalysisCache == nil {
 		return
@@ -1668,6 +1679,19 @@ func runDispatchOrLoadBundle(
 		perf.AddEntryDetails(tracker, "dispatchPath", 0, nil, map[string]string{"path": path})
 	}
 	if bundleEnabled {
+		// Pre-loaded bundle from previewPostParseBundleHit: when the
+		// preview already Loaded (and possibly aliased) the bundle
+		// under runFP, indexResult.WarmCrossFindings carries the
+		// decoded FindingColumns. Skipping the redundant
+		// FindingsBundleStore.Load saves ~90 ms of zstd+gob decode on
+		// kotlin-corpus scale — one of three Loads warm+ABI used to
+		// pay (preview-full-miss + preview-prior-hit + this one).
+		if indexResult.WarmCrossFindings != nil {
+			perf.AddEntryDetails(tracker, "dispatchBundleLoad", 0, nil, map[string]string{"outcome": "preloaded"})
+			d := DispatchResult{IndexResult: indexResult, Findings: *indexResult.WarmCrossFindings}
+			recordDispatchPath("cacheHitFullBundle")
+			return d, CrossFileResult{DispatchResult: d}, true, dispatchTimings{}, nil
+		}
 		// cacheHitFullBundle: RunFingerprint matches a prior run
 		// exactly; the prior bytes are guaranteed correct for this
 		// request.


### PR DESCRIPTION
## Summary

On warm+ABI the bundle was being \`Load\`'d three times per analyze:

1. \`previewPostParseBundleHit\`: \`Load\` with runFP for cacheHitFullBundle (misses on warm+ABI because the runFP is new)
2. \`previewPostParseBundleHit\` → \`tryLoadStructurallyStableBundle\`: \`Load\` with \`prior.Fingerprint\` to fetch the bundle to alias (HIT)
3. \`runDispatchOrLoadBundle.cacheHitFullBundle\`: \`Load\` with runFP (HITS the alias the preview just saved)

Loads (2) and (3) both return the same bytes. Each Load is ~90 ms of zstd+gob decode on kotlin-corpus scale; the third one is redundant because the preview already has the decoded \`FindingColumns\` in hand.

Carry the loaded bundle forward through \`IndexResult.WarmCrossFindings\` (a field the preview already populates via \`warmPlan.cross\`) and short-circuit \`runDispatchOrLoadBundle\` on it before calling \`Load\`. Emit \`dispatchBundleLoad\` with \`outcome="preloaded"\` so \`--perf\` shows the short-circuit fired.

The \`completeRunProjectIndexResult\` assignment of \`WarmCrossFindings\` was gated on \`warm.result != nil\` (the analysis-cache hit). Lifted out of that branch so it fires whenever the preview populated \`warm.cross\`, independently of the analysis cache — without the lift, daemons with a cold analysis cache would still pay the third Load.

## Impact (kotlin-corpus, daemon-FIR)

| Run | post-#604 | After | Δ |
|-----|---------:|------:|--:|
| warm-no-change (pre-parse hit) | ~20ms | ~18ms | (noise) |
| warm+ABI | 575-632ms | **512-523ms** | -50-110ms |
| warm post-revert | 582-661ms | **552-577ms** | -30-110ms |
| warm3 (BundleOutput cache) | ~60ms | ~57ms | (noise) |

The perf entry change is the deterministic signal: \`dispatchBundleLoad\` now shows \`outcome="preloaded"\` on every warm+ABI / warm-post-revert analyze.

## Test plan

- [x] \`TestRunDispatchOrLoadBundle_PreloadedSkipsStoreLoad\` — drives \`runDispatchOrLoadBundle\` with \`WarmCrossFindings\` set; asserts \`FindingsBundleStore.Load\` is never called and the preloaded columns flow into \`DispatchResult\` + \`CrossFileResult\`.
- [x] \`TestRunDispatchOrLoadBundle_NoPreloadHitsStoreLoad\` — symmetric: nil \`WarmCrossFindings\` falls through to the regular Load.
- [x] Existing bundle-cache test suite still green (load-count invariants preserved).
- [x] \`go vet ./...\`, \`golangci-lint run ./...\`, \`go test ./internal/pipeline/ ./internal/cli/serve/ -count=1\` clean.