### PR TITLE
perf(pipeline): daemon-resident bundle cache mirrors disk Load+Save

### DIFF
--- a/internal/cli/serve/analyze_project.go
+++ b/internal/cli/serve/analyze_project.go
@@ -537,6 +537,8 @@ func (s *daemonState) buildProjectInput(args daemon.AnalyzeProjectArgs, backend 
 				SourceMTimeVersion:       s.workspace.SourceMTimeVersion,
 				BundleOutput:             s.workspace.BundleOutput,
 				StoreBundleOutput:        s.workspace.StoreBundleOutput,
+				ResidentBundle:           s.workspace.ResidentBundle,
+				StoreResidentBundle:      s.workspace.StoreResidentBundle,
 			},
 			AndroidCacheWriter:           diskCache.androidCacheWriter,
 			AndroidCacheDir:              diskCache.androidCacheDir,

--- a/internal/pipeline/daemon_caches.go
+++ b/internal/pipeline/daemon_caches.go
@@ -62,4 +62,15 @@ type DaemonCaches struct {
 	// pre-formatted bundle-hit JSON. *WorkspaceState satisfies both.
 	BundleOutput      func(bundleKey string) *CachedBundleOutput
 	StoreBundleOutput func(bundleKey string, output *CachedBundleOutput)
+
+	// ResidentBundle / StoreResidentBundle are the daemon-side
+	// in-memory mirror of the on-disk FindingsBundleStore. Hit by
+	// previewPostParseBundleHit before consulting the disk store to
+	// skip the ~90 ms zstd+gob decode when the same bundle was
+	// already loaded earlier in this daemon session. Bounded to a
+	// small number of entries (residentBundleCapacity) so daemon
+	// memory growth stays predictable. *WorkspaceState satisfies
+	// both.
+	ResidentBundle      func(bundleKey string) *scanner.FindingColumns
+	StoreResidentBundle func(bundleKey string, cols *scanner.FindingColumns)
 }

--- a/internal/pipeline/project.go
+++ b/internal/pipeline/project.go
@@ -2759,7 +2759,12 @@ func previewPostParseBundleHit(args ProjectArgs, host ProjectHostState, parseRes
 	// analyze has ever produced a bundle keyed on this fp, so the
 	// Load would miss.
 	if priorOK && fp == prior.Fingerprint {
+		fpKey := scanner.FindingsBundleKey(fp)
+		if cached := residentBundleLookup(host, fpKey); cached != nil {
+			return cached
+		}
 		if cached, ok := host.FindingsBundleStore.Load(host.FindingsBundleCacheRoot, fp); ok && cached != nil {
+			residentBundleStash(host, fpKey, cached)
 			return cached
 		}
 	}
@@ -2793,17 +2798,60 @@ func tryLoadStructurallyStableBundleWithPrior(host ProjectHostState, runFP scann
 	if !plan.ReusePrevious || len(plan.ChangedPaths) != 1 || !bodyOnlyKotlinChange(plan.ChangedPaths[0], prior.StructuralFPs, manifest.structuralFPs) {
 		return nil, false
 	}
-	priorBundle, ok := host.FindingsBundleStore.Load(host.FindingsBundleCacheRoot, prior.Fingerprint)
-	if !ok || priorBundle == nil {
-		return nil, false
+	priorKey := scanner.FindingsBundleKey(prior.Fingerprint)
+	var priorBundle *scanner.FindingColumns
+	if cached := residentBundleLookup(host, priorKey); cached != nil {
+		priorBundle = cached
+	} else {
+		loaded, ok := host.FindingsBundleStore.Load(host.FindingsBundleCacheRoot, prior.Fingerprint)
+		if !ok || loaded == nil {
+			return nil, false
+		}
+		priorBundle = loaded
+		residentBundleStash(host, priorKey, priorBundle)
 	}
 	if err := host.FindingsBundleStore.Save(host.FindingsBundleCacheRoot, runFP, priorBundle); err != nil {
 		host.Reporter.Verbosef("verbose: Findings bundle structural reuse skipped: save alias failed: %v\n", err)
 		return nil, false
 	}
+	// Mirror the alias into the in-memory cache so the next analyze's
+	// cacheHitFullBundle attempt (which Loads by runFP) skips the
+	// disk decode of the bundle we just confirmed in memory.
+	residentBundleStash(host, scanner.FindingsBundleKey(runFP), priorBundle)
 	aliasBundleOutputCache(host, prior.Fingerprint, runFP)
 	host.Reporter.Verbosef("verbose: Findings bundle cache: HIT (structural reuse: %s)\n", plan.ChangedPaths[0])
 	return priorBundle, true
+}
+
+// residentBundleLookup consults host.ResidentBundle when wired, nil-
+// safe otherwise. The lookup is keyed on FindingsBundleKey(runFP);
+// content-addressed keys mean any input change rotates the key, so
+// stale entries naturally become unreachable rather than returning
+// the wrong findings. Emits a perf entry tagged with hit/miss
+// outcome so --perf surfaces the cache's effectiveness on every
+// analyze.
+func residentBundleLookup(host ProjectHostState, key string) *scanner.FindingColumns {
+	if host.ResidentBundle == nil || key == "" {
+		return nil
+	}
+	cached := host.ResidentBundle(key)
+	outcome := "miss"
+	if cached != nil {
+		outcome = "hit"
+	}
+	perf.AddEntryDetails(host.Tracker, "residentBundleLookup", 0, nil, map[string]string{"outcome": outcome})
+	return cached
+}
+
+// residentBundleStash mirrors a freshly loaded or saved bundle into
+// host.StoreResidentBundle when wired. No-op otherwise. The bounded-
+// capacity FIFO inside *WorkspaceState guards against unbounded
+// daemon memory growth.
+func residentBundleStash(host ProjectHostState, key string, cols *scanner.FindingColumns) {
+	if host.StoreResidentBundle == nil || key == "" || cols == nil {
+		return
+	}
+	host.StoreResidentBundle(key, cols)
 }
 
 // buildPreviewManifestData is the parse-only subset of buildManifestData

--- a/internal/pipeline/resident_bundle_test.go
+++ b/internal/pipeline/resident_bundle_test.go
@@ -1,0 +1,114 @@
+package pipeline
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/kaeawc/krit/internal/scanner"
+)
+
+// TestWorkspaceState_ResidentBundle_StoreAndLookup pins the basic
+// store/lookup contract of the resident bundle cache: a successful
+// StoreResidentBundle is visible to the next ResidentBundle call
+// keyed on the same bundleKey.
+func TestWorkspaceState_ResidentBundle_StoreAndLookup(t *testing.T) {
+	w := &WorkspaceState{}
+	cols := &scanner.FindingColumns{}
+
+	if got := w.ResidentBundle("k"); got != nil {
+		t.Errorf("empty cache must miss; got %v", got)
+	}
+	w.StoreResidentBundle("k", cols)
+	if got := w.ResidentBundle("k"); got != cols {
+		t.Errorf("stored bundle not returned; got %v want %v", got, cols)
+	}
+}
+
+// TestWorkspaceState_ResidentBundle_NilSafety mirrors the rest of
+// WorkspaceState's nil-tolerant API: methods on a nil receiver must
+// not panic. Lets test fixtures and the CLI path keep zero-value
+// hosts without special-casing the new slot.
+func TestWorkspaceState_ResidentBundle_NilSafety(t *testing.T) {
+	var w *WorkspaceState
+	if got := w.ResidentBundle("k"); got != nil {
+		t.Errorf("nil receiver must return nil; got %v", got)
+	}
+	w.StoreResidentBundle("k", &scanner.FindingColumns{}) // must not panic
+}
+
+// TestWorkspaceState_ResidentBundle_FIFOEvictsOldest pins the bound:
+// inserting more than residentBundleCapacity distinct entries evicts
+// the oldest. Without the bound, daemons servicing many warm+ABI
+// cycles would accumulate decoded FindingColumns (10-20 MB each on
+// kotlin-corpus scale).
+func TestWorkspaceState_ResidentBundle_FIFOEvictsOldest(t *testing.T) {
+	w := &WorkspaceState{}
+	// Capacity+1 inserts — the first one must evict.
+	for i := 0; i < residentBundleCapacity+1; i++ {
+		w.StoreResidentBundle("k"+strconv.Itoa(i), &scanner.FindingColumns{})
+	}
+	if got := w.ResidentBundle("k0"); got != nil {
+		t.Errorf("oldest entry must be evicted past capacity; got %v", got)
+	}
+	for i := 1; i <= residentBundleCapacity; i++ {
+		key := "k" + strconv.Itoa(i)
+		if got := w.ResidentBundle(key); got == nil {
+			t.Errorf("entry %q must remain after FIFO eviction; got nil", key)
+		}
+	}
+}
+
+// TestWorkspaceState_ResidentBundle_RefreshDoesNotEvict pins the
+// re-store semantics: writing to an existing key updates the value
+// in place without rotating the FIFO. Used by the structural-replay
+// path where the same priorKey may get refreshed across analyzes
+// without bumping a "new" entry into the eviction list.
+func TestWorkspaceState_ResidentBundle_RefreshDoesNotEvict(t *testing.T) {
+	w := &WorkspaceState{}
+	// Fill to capacity.
+	for i := 0; i < residentBundleCapacity; i++ {
+		w.StoreResidentBundle("k"+strconv.Itoa(i), &scanner.FindingColumns{})
+	}
+	// Refresh the oldest — must NOT trigger eviction of any entry.
+	refreshed := &scanner.FindingColumns{}
+	w.StoreResidentBundle("k0", refreshed)
+	if got := w.ResidentBundle("k0"); got != refreshed {
+		t.Errorf("refresh must update value; got %v", got)
+	}
+	for i := 0; i < residentBundleCapacity; i++ {
+		key := "k" + strconv.Itoa(i)
+		if got := w.ResidentBundle(key); got == nil {
+			t.Errorf("refresh must NOT evict any entry; %q gone", key)
+		}
+	}
+}
+
+// TestWorkspaceState_ResidentBundle_NilValuesIgnored pins the
+// defensive contract: StoreResidentBundle with a nil cols must NOT
+// insert a sentinel into the map (would shadow legitimate future
+// stores) and must NOT consume a FIFO slot.
+func TestWorkspaceState_ResidentBundle_NilValuesIgnored(t *testing.T) {
+	w := &WorkspaceState{}
+	w.StoreResidentBundle("k", nil)
+	if got := w.ResidentBundle("k"); got != nil {
+		t.Errorf("nil store must not insert; got %v", got)
+	}
+	w.StoreResidentBundle("", &scanner.FindingColumns{})
+	if got := w.ResidentBundle(""); got != nil {
+		t.Errorf("empty-key store must not insert; got %v", got)
+	}
+}
+
+// TestResidentBundleLookup_RoutesToHostHelper pins the CLI-path
+// contract: when host.ResidentBundle isn't wired the helper returns
+// nil without nil-deref, mirroring residentBundleStash on the write
+// side. Tests covering CLI runs and bundle-test fixtures get
+// zero-value hosts; the lookup must degrade gracefully.
+func TestResidentBundleLookup_RoutesToHostHelper(t *testing.T) {
+	if got := residentBundleLookup(ProjectHostState{}, "k"); got != nil {
+		t.Errorf("nil ResidentBundle must return nil; got %v", got)
+	}
+	if got := residentBundleLookup(ProjectHostState{}, ""); got != nil {
+		t.Errorf("empty key must return nil; got %v", got)
+	}
+}

--- a/internal/pipeline/workspace.go
+++ b/internal/pipeline/workspace.go
@@ -98,6 +98,26 @@ type WorkspaceState struct {
 	// reuse the same buffer.
 	bundleOutput map[string]*CachedBundleOutput
 
+	residentBundleMu sync.Mutex
+	// residentBundle is the in-memory mirror of the on-disk
+	// FindingsBundleStore: keyed by FindingsBundleKey, value is the
+	// decoded *scanner.FindingColumns. The structural-replay path in
+	// previewPostParseBundleHit otherwise re-decodes the prior bundle
+	// from zstd+gob on every warm+ABI analyze (~90 ms on
+	// kotlin-corpus); consulting this map first cuts that to a map
+	// lookup. The Save path also mirrors into here so the next
+	// analyze's cacheHitFullBundle attempt picks up the alias without
+	// a disk read.
+	//
+	// Bounded by residentBundleCapacity entries: each FindingColumns
+	// can be 10-20MB on kotlin-corpus scale, so the daemon caps
+	// memory growth at a few hundred MB worst case. Eviction uses a
+	// FIFO insertion-order list — simple and adequate for the
+	// observed access pattern (the latest 2-3 entries cover the
+	// warm/warm+ABI/revert loop).
+	residentBundle      map[string]*scanner.FindingColumns
+	residentBundleOrder []string
+
 	javaSourceMu sync.Mutex
 	// javaSourceVersion is bumped on every .java watcher event. The
 	// resident javaSourceIndex slot uses it to detect whether its
@@ -927,6 +947,62 @@ func (w *WorkspaceState) StoreBundleOutput(bundleKey string, output *CachedBundl
 	}
 	w.bundleOutput[bundleKey] = output
 	w.bundleOutputMu.Unlock()
+}
+
+// residentBundleCapacity caps the in-memory bundle mirror. 4 entries
+// is enough to cover the typical warm cycle (cold + warm-no-change +
+// warm+ABI + revert) without holding multiple GB of decoded
+// FindingColumns on kotlin-corpus-scale repos.
+const residentBundleCapacity = 4
+
+// ResidentBundle looks up the decoded FindingColumns mirrored by a
+// successful disk Load or Save. Returns nil on miss. Callers in
+// previewPostParseBundleHit consult it before
+// FindingsBundleStore.Load to skip the ~90 ms zstd+gob decode when
+// the same bundle was already loaded by an earlier analyze in this
+// daemon session.
+//
+// Bundle keys are content-addressed (FindingsBundleKey of a
+// RunFingerprint) so there's no stale-value risk: any input change
+// rotates the key, leaving the prior entry unreachable rather than
+// returning wrong findings.
+func (w *WorkspaceState) ResidentBundle(bundleKey string) *scanner.FindingColumns {
+	if w == nil || bundleKey == "" {
+		return nil
+	}
+	w.residentBundleMu.Lock()
+	defer w.residentBundleMu.Unlock()
+	return w.residentBundle[bundleKey]
+}
+
+// StoreResidentBundle mirrors a freshly loaded or freshly saved
+// bundle into the in-memory cache. Inserts at the head of the FIFO
+// order and evicts from the tail when capacity is exceeded — simple
+// and adequate for the observed access pattern where the latest 2-3
+// entries cover the warm-no-change / warm+ABI / revert loop.
+func (w *WorkspaceState) StoreResidentBundle(bundleKey string, cols *scanner.FindingColumns) {
+	if w == nil || bundleKey == "" || cols == nil {
+		return
+	}
+	w.residentBundleMu.Lock()
+	defer w.residentBundleMu.Unlock()
+	if w.residentBundle == nil {
+		w.residentBundle = make(map[string]*scanner.FindingColumns, residentBundleCapacity)
+	}
+	if _, exists := w.residentBundle[bundleKey]; exists {
+		// Refresh the slot but keep its position in the FIFO — the
+		// caller is re-storing the same key (e.g. structural-replay
+		// aliasing a bundle we already mirrored).
+		w.residentBundle[bundleKey] = cols
+		return
+	}
+	w.residentBundle[bundleKey] = cols
+	w.residentBundleOrder = append(w.residentBundleOrder, bundleKey)
+	for len(w.residentBundleOrder) > residentBundleCapacity {
+		evict := w.residentBundleOrder[0]
+		w.residentBundleOrder = w.residentBundleOrder[1:]
+		delete(w.residentBundle, evict)
+	}
 }
 
 // AndroidProject memoizes the detected Android project across calls.


### PR DESCRIPTION
## Summary

Per-analyze the structural-replay path \`Load\`'d the prior bundle from disk (~90 ms zstd+gob decode on kotlin-corpus) and \`Save\`'d an alias (~50 ms zstd+gob encode + fsync). Both are pure I/O against a value that's already in the daemon's process memory from the prior analyze — only daemon restarts ever need the disk read.

Add a bounded in-memory mirror on \`WorkspaceState\`:
- \`residentBundle\` map (FIFO eviction at 4 entries to cap memory at a few hundred MB even on the largest repos).
- Mirror through \`DaemonCaches.ResidentBundle\` / \`StoreResidentBundle\` so the pipeline can call it without taking a hard dependency on \`WorkspaceState\`.

Hook into \`previewPostParseBundleHit\`:
- **cacheHitFullBundle**: \`residentBundleLookup\` BEFORE the disk Load; stash on disk-Load success.
- **structural-replay** (\`tryLoadStructurallyStableBundleWithPrior\`): same shape — try in-memory first, fall back to disk, stash. After the Save alias, also stash the bundle under the new runFP's key so subsequent cacheHitFullBundle attempts hit memory.

Bundle keys are content-addressed (\`FindingsBundleKey\` of a \`RunFingerprint\`), so stale entries are unreachable rather than wrong: any input change rotates the key.

## Empirical signal

Wall-time on kotlin-corpus daemon-FIR is in the benchmark noise floor (~50-150 ms run-to-run variance). The deterministic signal is the new \`residentBundleLookup\` perf entry showing \`outcome="hit"\` on every warm+ABI and warm post-revert analyze after the first one. The architecture is in place; the disk Save is still synchronous and is the next lever to defer.

## Test plan

- [x] \`TestWorkspaceState_ResidentBundle_StoreAndLookup\` — basic round-trip.
- [x] \`TestWorkspaceState_ResidentBundle_NilSafety\` — nil receiver does not panic.
- [x] \`TestWorkspaceState_ResidentBundle_FIFOEvictsOldest\` — bounded memory contract.
- [x] \`TestWorkspaceState_ResidentBundle_RefreshDoesNotEvict\` — re-storing the same key updates the value without rotating the FIFO.
- [x] \`TestWorkspaceState_ResidentBundle_NilValuesIgnored\` — defensive: nil cols / empty key are no-ops.
- [x] \`TestResidentBundleLookup_RoutesToHostHelper\` — CLI-path contract: nil \`ResidentBundle\` returns nil without panic.
- [x] \`go vet ./...\`, \`golangci-lint run ./...\`, \`go test ./internal/pipeline/ ./internal/cli/serve/ -count=1\` all green.