### PR TITLE
fix(serve,pipeline): warm+ABI correctness — invalidate both path forms + gate preloaded short-circuit on bundle-source

### DIFF
--- a/internal/cli/serve/watcher.go
+++ b/internal/cli/serve/watcher.go
@@ -288,7 +288,7 @@ func (fw *fileWatcher) handle(ev backendEvent) {
 		// separate version counters so a Kotlin edit doesn't
 		// needlessly invalidate the Java source index (which is
 		// expensive to rebuild: ~100 ms of content hashing).
-		fw.state.Invalidate(ev.Path)
+		fw.invalidateBothForms(ev.Path)
 		fw.state.InvalidateCodeIndex()
 		fw.state.InvalidateDependents()
 		fw.state.InvalidateResolver()
@@ -303,7 +303,7 @@ func (fw *fileWatcher) handle(ev backendEvent) {
 		// XML version counter. Kotlin/Java edits don't move XML
 		// hashes so the counter stays independent — same shape
 		// as the .java case above.
-		fw.state.Invalidate(ev.Path)
+		fw.invalidateBothForms(ev.Path)
 		fw.state.InvalidateCodeIndex()
 		fw.state.InvalidateDependents()
 		fw.state.Touch(ev.Path)
@@ -351,7 +351,7 @@ func (fw *fileWatcher) scheduleKotlinInvalidate(path string) {
 		delete(fw.debounce, path)
 		delete(fw.debounceGen, path)
 		fw.debounceMu.Unlock()
-		fw.state.Invalidate(path)
+		fw.invalidateBothForms(path)
 		fw.state.InvalidateCodeIndex()
 		fw.state.InvalidateDependents()
 		fw.state.InvalidateResolver()
@@ -359,6 +359,37 @@ func (fw *fileWatcher) scheduleKotlinInvalidate(path string) {
 		fw.state.Touch(path)
 	})
 	fw.debounceMu.Unlock()
+}
+
+// invalidateBothForms drops the WorkspaceState parse-cache entry for
+// path under BOTH the absolute and the relative-to-root forms.
+// fsnotify hands us absolute paths, but the parse-phase resident
+// cache (WorkspaceState.parsed, queried by scanWithResident via
+// LookupParsedByPath) is keyed under whatever form callers used at
+// StoreParsed time — relative when the CLI invokes `krit .` (the
+// common daemon-driven case), absolute when paths come in
+// absolutized.
+//
+// Without the dual call, a file edited while the daemon is running
+// retains its stale *scanner.File in the resident cache: the
+// absolute-keyed entry is invalidated, the relative-keyed entry
+// isn't, and the next warm analyze's scanWithResident.LookupParsedByPath
+// returns the pre-edit FlatTree + bytes. Downstream
+// FileStructuralFingerprint hashes the OLD symbols, the cross-file
+// structural FP appears unchanged, the structural-replay gate
+// accepts, and the prior bundle's findings get served for content
+// they no longer reflect. Demonstrated against ~/github/kotlin: a
+// probe that adds 3 top-level declarations to libraries/stdlib/
+// src/kotlin/Unit.kt produces 84623 findings (== cold baseline)
+// instead of 84630 (cold + 7 probe-triggered findings).
+func (fw *fileWatcher) invalidateBothForms(absPath string) {
+	fw.state.Invalidate(absPath)
+	if fw.root == "" {
+		return
+	}
+	if rel, err := filepath.Rel(fw.root, absPath); err == nil && !strings.HasPrefix(rel, "..") {
+		fw.state.Invalidate(rel)
+	}
 }
 
 // addRecursive walks dir and adds every directory to the watcher.

--- a/internal/cli/serve/watcher_test.go
+++ b/internal/cli/serve/watcher_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -416,8 +417,15 @@ func TestFileWatcher_DebounceEditorSavePattern(t *testing.T) {
 	// window + margin to complete before asserting the final count.
 	time.Sleep(window * 2)
 
-	if got := state.invalidateCalls.Load(); got != 1 {
-		t.Errorf("Invalidate called %d times, want 1 (debounce should coalesce burst)", got)
+	// Post path-form-dual-invalidate (fix for warm+ABI parse-cache
+	// staleness): each debounced burst fires Invalidate twice — once
+	// under the absolute fsnotify path, once under the relative-to-
+	// root form — so the resident parse cache is dropped regardless
+	// of which form scanWithResident is keyed on. The debounce still
+	// coalesces the burst of 3 events into a single callback firing,
+	// just the callback now invokes Invalidate twice instead of once.
+	if got := state.invalidateCalls.Load(); got != 2 {
+		t.Errorf("Invalidate called %d times, want 2 (debounce should coalesce burst; the 2 calls are the absolute+relative forms)", got)
 	}
 }
 
@@ -753,4 +761,104 @@ func TestFileWatcher_BumpSourceMTimeIsEager(t *testing.T) {
 		t.Errorf("Invalidate fired before debounce window (bump=%d invalidate=%d); the eager bump must NOT also have eagerly invalidated downstream state",
 			state.bumpCalls.Load(), got)
 	}
+}
+
+// TestFileWatcher_InvalidatesBothPathForms is the regression guard
+// for the warm+ABI correctness bug: fsnotify delivers absolute paths
+// while the parse-phase resident cache (WorkspaceState.parsed,
+// queried by scanWithResident via LookupParsedByPath) is keyed under
+// whatever form scanWithResident sees in kotlinPaths — relative when
+// the CLI invokes `krit .` (the common daemon-driven case).
+//
+// Without the dual-form invalidate, a file edited while the daemon
+// is running retains its stale *scanner.File in the resident cache:
+// the absolute-keyed entry is invalidated, the relative-keyed entry
+// isn't, and the next warm analyze's scanWithResident.LookupParsedByPath
+// returns the pre-edit FlatTree + bytes. Empirically observed against
+// ~/github/kotlin: a probe adding 3 top-level declarations + 1 class
+// to libraries/stdlib/src/kotlin/Unit.kt produced 84623 findings
+// (== cold baseline) instead of 84630 (cold + 7 probe-triggered
+// findings).
+//
+// The fix wraps state.Invalidate with invalidateBothForms which
+// drops both the absolute and the relative-to-root form. This test
+// pins that both calls fire on every Kotlin write.
+func TestFileWatcher_InvalidatesBothPathForms(t *testing.T) {
+	root := t.TempDir()
+	subdir := filepath.Join(root, "src")
+	if err := os.MkdirAll(subdir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	ktPath := filepath.Join(subdir, "Foo.kt")
+	if err := os.WriteFile(ktPath, []byte("fun a() {}\n"), 0o644); err != nil {
+		t.Fatalf("seed kt: %v", err)
+	}
+
+	state := &pathRecordingState{}
+	w, err := startFileWatcherWithState(context.Background(), root, state, nil,
+		withDebounceWindow(20*time.Millisecond))
+	if err != nil {
+		t.Fatalf("startFileWatcher: %v", err)
+	}
+	defer w.Stop()
+	<-w.Ready()
+
+	if err := os.WriteFile(ktPath, []byte("fun a() { 42 }\n"), 0o644); err != nil {
+		t.Fatalf("rewrite: %v", err)
+	}
+
+	if !waitForCondition(func() bool { return len(state.snapshot()) >= 2 }) {
+		t.Fatalf("expected Invalidate to fire for both abs + rel; got %v", state.snapshot())
+	}
+
+	calls := state.snapshot()
+	wantAbs := ktPath
+	wantRel := filepath.Join("src", "Foo.kt")
+	haveAbs := false
+	haveRel := false
+	for _, p := range calls {
+		if p == wantAbs {
+			haveAbs = true
+		}
+		if p == wantRel {
+			haveRel = true
+		}
+	}
+	if !haveAbs {
+		t.Errorf("Invalidate must include the absolute form %q; got %v", wantAbs, calls)
+	}
+	if !haveRel {
+		t.Errorf("Invalidate must include the relative-to-root form %q; got %v", wantRel, calls)
+	}
+}
+
+// pathRecordingState is a watcherState fake that records each
+// Invalidate path so dual-form tests can assert both the absolute
+// and the relative-to-root form fire on every event.
+type pathRecordingState struct {
+	mu    sync.Mutex
+	paths []string
+}
+
+func (s *pathRecordingState) Invalidate(path string) {
+	s.mu.Lock()
+	s.paths = append(s.paths, path)
+	s.mu.Unlock()
+}
+func (s *pathRecordingState) InvalidateCodeIndex()    {}
+func (s *pathRecordingState) InvalidateDependents()   {}
+func (s *pathRecordingState) InvalidateLibraryFacts() {}
+func (s *pathRecordingState) InvalidateResolver()     {}
+func (s *pathRecordingState) InvalidateOracleFilter() {}
+func (s *pathRecordingState) Touch(string)            {}
+func (s *pathRecordingState) BumpSourceMTimeVersion() {}
+func (s *pathRecordingState) BumpJavaSourceVersion()  {}
+func (s *pathRecordingState) BumpXMLFilesVersion()    {}
+
+func (s *pathRecordingState) snapshot() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]string, len(s.paths))
+	copy(out, s.paths)
+	return out
 }

--- a/internal/pipeline/dispatch_preloaded_test.go
+++ b/internal/pipeline/dispatch_preloaded_test.go
@@ -41,7 +41,8 @@ func TestRunDispatchOrLoadBundle_PreloadedSkipsStoreLoad(t *testing.T) {
 		FindingsBundleCacheRoot: "/repo",
 	}
 	indexResult := IndexResult{
-		WarmCrossFindings: preloaded,
+		WarmCrossFindings:          preloaded,
+		WarmCrossFindingsAreBundle: true, // preview-bundle source
 	}
 
 	d, c, hit, _, err := runDispatchOrLoadBundle(
@@ -97,5 +98,51 @@ func TestRunDispatchOrLoadBundle_NoPreloadHitsStoreLoad(t *testing.T) {
 	)
 	if store.loadCalls < 1 {
 		t.Errorf("nil WarmCrossFindings must drive at least one Load; got loadCalls=%d", store.loadCalls)
+	}
+}
+
+// TestRunDispatchOrLoadBundle_AnalysisCacheCrossFindingsDoNotShortCircuit
+// is the regression guard for the warm+ABI = 0 findings bug
+// (#605's short-circuit treated WarmCrossFindings as the full
+// bundle, but the lexically-irrelevant analysis-cache fallback only
+// populates it with cross-file findings; short-circuiting there
+// drops every per-file finding).
+//
+// The fix gates the short-circuit on WarmCrossFindingsAreBundle.
+// Test wires a scenario where WarmCrossFindings is non-nil but the
+// flag is false (= analysis-cache source) and asserts the
+// short-circuit does NOT fire — the regular bundle layers run, and
+// since the store has no matching entry, the dispatch falls through
+// to the full-dispatch path that produces correct per-file findings.
+func TestRunDispatchOrLoadBundle_AnalysisCacheCrossFindingsDoNotShortCircuit(t *testing.T) {
+	crossOnly := &scanner.FindingColumns{}
+	store := &loadCountingBundleStore{}
+	host := ProjectHostState{
+		FindingsBundleStore:     store,
+		FindingsBundleCacheRoot: "/repo",
+	}
+	indexResult := IndexResult{
+		WarmCrossFindings: crossOnly,
+		// WarmCrossFindingsAreBundle intentionally false — this is
+		// the lexically-irrelevant analysis-cache fallback source,
+		// which holds only cross-file findings.
+		WarmCrossFindingsAreBundle: false,
+	}
+
+	_, _, hit, _, _ := runDispatchOrLoadBundle(
+		context.Background(),
+		ProjectArgs{},
+		host,
+		indexResult,
+		ParseResult{},
+		scanner.RunFingerprint{Version: "v1"},
+		true,
+		deltaManifestData{},
+	)
+	if hit {
+		t.Errorf("non-bundle WarmCrossFindings must NOT short-circuit; got hit=true (would emit cross-only findings and drop per-file)")
+	}
+	if store.loadCalls < 1 {
+		t.Errorf("non-bundle WarmCrossFindings must let the regular dispatchBundleLoad fire; got loadCalls=%d", store.loadCalls)
 	}
 }

--- a/internal/pipeline/project.go
+++ b/internal/pipeline/project.go
@@ -408,7 +408,25 @@ type warmAnalysisCachePlan struct {
 	filePaths   []string
 	kotlinPaths []string
 	javaPaths   []string
-	cross       *scanner.FindingColumns
+	// cross is the prior run's cross-file findings — either the full
+	// bundle (set by the preview when a bundle hit is confirmed) or
+	// just the cross-file subset (set by loadWarmCrossFindings when
+	// the analysis-cache path infers a body-only edit). The
+	// IndexPhase gates (codeIndexBuild, moduleIndex, buildBaseResolver)
+	// treat both the same — they short-circuit when cross is non-nil
+	// because rule execution is going to use the cached values.
+	cross *scanner.FindingColumns
+	// crossIsFullBundle distinguishes the two sources of cross. True
+	// when the preview confirmed a stored bundle exists for the
+	// current runFP — meaning warm.cross IS the complete findings the
+	// downstream OutputPhase / runDispatchOrLoadBundle short-circuit
+	// is allowed to serve verbatim. False (or zero-valued) when cross
+	// was loaded by canSkipRunProjectParse's lexically-irrelevant
+	// path: that path returns ONLY cross-file findings and needs the
+	// regular dispatch + cross-file pipeline to fill in per-file
+	// findings. Misreading this flag emits 0 findings on warm+ABI
+	// when the analysis-cache lexically-irrelevant fallback fires.
+	crossIsFullBundle bool
 }
 
 // ProjectInput is the value type that drives RunProject. The split
@@ -707,6 +725,13 @@ func RunProjectAnalysis(ctx context.Context, in ProjectInput) (ProjectAnalysisRe
 	earlyBundle := previewPostParseBundleHit(args, host, parseResult)
 	if earlyBundle != nil {
 		warmPlan.cross = earlyBundle
+		// Mark warm.cross as the FULL bundle so #605's
+		// runDispatchOrLoadBundle preloaded short-circuit fires
+		// (saving the redundant disk Load). The analysis-cache path
+		// in canSkipRunProjectParse leaves this false because it
+		// only populates cross with cross-file findings — the
+		// downstream still needs to run dispatch for per-file rules.
+		warmPlan.crossIsFullBundle = true
 	}
 
 	indexStart := time.Now()
@@ -938,6 +963,7 @@ func completeRunProjectIndexResult(args ProjectArgs, host ProjectHostState, warm
 	// in runDispatchOrLoadBundle's cacheHitFullBundle path.
 	if warm.cross != nil {
 		indexResult.WarmCrossFindings = warm.cross
+		indexResult.WarmCrossFindingsAreBundle = warm.crossIsFullBundle
 	}
 	if warm.result != nil {
 		indexResult.CacheResult = warm.result
@@ -1684,9 +1710,18 @@ func runDispatchOrLoadBundle(
 		// under runFP, indexResult.WarmCrossFindings carries the
 		// decoded FindingColumns. Skipping the redundant
 		// FindingsBundleStore.Load saves ~90 ms of zstd+gob decode on
-		// kotlin-corpus scale — one of three Loads warm+ABI used to
-		// pay (preview-full-miss + preview-prior-hit + this one).
-		if indexResult.WarmCrossFindings != nil {
+		// kotlin-corpus scale.
+		//
+		// CRITICAL: only short-circuit when WarmCrossFindingsAreBundle
+		// is true — i.e. the preview confirmed a stored bundle hit
+		// and these are the COMPLETE findings. When WarmCrossFindings
+		// came from canSkipRunProjectParse's lexically-irrelevant
+		// fallback (cold's cross-file findings only, not per-file),
+		// short-circuiting here drops every per-file finding and
+		// emits the cross-file subset alone — observed as 0 findings
+		// on warm+ABI on kotlin-corpus when the analysis-cache path
+		// fires for an irrelevant single-file edit.
+		if indexResult.WarmCrossFindings != nil && indexResult.WarmCrossFindingsAreBundle {
 			perf.AddEntryDetails(tracker, "dispatchBundleLoad", 0, nil, map[string]string{"outcome": "preloaded"})
 			d := DispatchResult{IndexResult: indexResult, Findings: *indexResult.WarmCrossFindings}
 			recordDispatchPath("cacheHitFullBundle")

--- a/internal/pipeline/types.go
+++ b/internal/pipeline/types.go
@@ -331,8 +331,22 @@ type IndexResult struct {
 	// JavaSourceIndex method satisfies this signature.
 	JavaSourceIndexCache func(build func() *javafacts.SourceIndex) *javafacts.SourceIndex
 	// WarmCrossFindings carries cross-rule findings loaded before
-	// parsing on an all-files analysis-cache hit.
+	// parsing on an all-files analysis-cache hit, OR the full bundle
+	// findings when the early bundle preview confirmed a hit. The
+	// WarmCrossFindingsAreBundle flag distinguishes the two sources:
+	// only the preview-bundle case is safe for
+	// runDispatchOrLoadBundle to short-circuit on.
 	WarmCrossFindings *scanner.FindingColumns
+	// WarmCrossFindingsAreBundle is true when WarmCrossFindings holds
+	// the COMPLETE FindingColumns from a confirmed bundle hit (set by
+	// previewPostParseBundleHit). False when WarmCrossFindings only
+	// holds cross-file findings (set by canSkipRunProjectParse's
+	// lexically-irrelevant fallback) — that case still requires the
+	// dispatch + CrossFilePhase work to produce per-file findings.
+	// Misreading this flag emits 0 findings on warm+ABI when the
+	// lexically-irrelevant fallback fires for an analysis-cache-miss
+	// edit.
+	WarmCrossFindingsAreBundle bool
 }
 
 // XFileCache memoizes a single value of type T across RunProject


### PR DESCRIPTION
## Summary

Two coupled correctness bugs surfaced when a real ABI-changing probe (class + 3 top-level fns adding 7 findings) was injected into \`~/github/kotlin/libraries/stdlib/src/kotlin/Unit.kt\` mid-daemon-session:

### Bug A: Watcher Invalidate doesn't drop the resident parse-cache entry

\`Watcher.Invalidate(absPath)\` didn't drop the parse-cache entry stored under the relative form. fsnotify reports absolute paths but \`scanWithResident\`'s \`LookupParsedByPath\` is keyed under whatever form callers used at \`StoreParsed\` time — relative when the CLI runs \`krit .\` (the common daemon-driven case). Result: the next analyze's \`scanWithResident\` returned the stale \`*scanner.File\` (pre-edit \`FlatTree\` + content), \`FileStructuralFingerprint\` hashed the OLD symbols, the structural-replay gate's \`bodyOnlyKotlinChange\` returned true on the unchanged FP, and the prior bundle's findings were served verbatim.

### Bug B: #605's preloaded short-circuit treats analysis-cache cross findings as a full bundle

#605's preloaded short-circuit treated \`indexResult.WarmCrossFindings\` as the full bundle. Once Bug A was fixed, the lexically-irrelevant analysis-cache fallback in \`loadWarmCrossFindings\` populated \`warm.cross\` with ONLY cross-file findings (\`LoadLastCrossFindings\`). The short-circuit then emitted those cross-only findings as the complete result, dropping every per-file finding. Empirically observed as 0 findings instead of 84630 on the warm+ABI run.

### Fixes

A. Wrap \`state.Invalidate\` in \`fileWatcher.invalidateBothForms\` that drops both the absolute fsnotify path AND the relative-to-root form. Applied to \`.kt\`, \`.java\`, \`.xml\` event paths.

B. Add \`warmAnalysisCachePlan.crossIsFullBundle\` + \`IndexResult.WarmCrossFindingsAreBundle\`. Preview sets the flag true; the analysis-cache lexically-irrelevant path leaves it false. The #605 short-circuit gates on the flag, so only preview-bundle sources fast-path the dispatch and the lexically-irrelevant fallback lets the regular bundle layers run.

## Empirical verification (~/github/kotlin daemon-FIR)

Probe adds \`class __KritABIVerify {}\`, \`fun __probe1() = 42\`, \`fun __probe2(x) { println(x!!) }\` to \`libraries/stdlib/src/kotlin/Unit.kt\` — 7 new findings (EmptyClassBlock, ClassNaming, FunctionNaming×2, FunctionOnlyReturningConstant, PrintlnInProduction, UnsafeCallOnNullableType).

| Run | Findings | dispatchPath | Status |
|-----|---------:|--------------|--------|
| cold | 84623 | (full dispatch) | baseline |
| warm+ABI | **84630** | cacheMissFullDispatch | ✅ correct (was 0 between fix A and B; was 84623 [stale] without fix A) |
| warm-revert | **84623** | cacheHitFullBundle | ✅ correct |
| warm-steady | **84623** | (pre-parse hit) | ✅ correct |

## Test plan

- [x] \`TestFileWatcher_InvalidatesBothPathForms\` (new) — pins (A): fsnotify abs-path event must fire Invalidate under both forms.
- [x] \`TestRunDispatchOrLoadBundle_AnalysisCacheCrossFindingsDoNotShortCircuit\` (new) — pins (B): \`WarmCrossFindings\` with \`AreBundle=false\` must NOT short-circuit.
- [x] \`TestRunDispatchOrLoadBundle_PreloadedSkipsStoreLoad\` updated to set \`AreBundle=true\` (preview source).
- [x] \`TestFileWatcher_DebounceEditorSavePattern\` updated to expect 2 Invalidate calls per coalesced burst (abs+rel forms).
- [x] Empirical kotlin-corpus \`verify-correctness.sh\` script confirms cold/warm+ABI/warm-revert/warm-steady all produce expected counts.
- [x] \`go vet\`, \`golangci-lint\`, full pipeline+serve test suites all green.