### PR TITLE
perf(pipeline): attribute post-index glue under named perf leaves

### DIFF
--- a/internal/pipeline/project.go
+++ b/internal/pipeline/project.go
@@ -744,10 +744,24 @@ func RunProjectAnalysis(ctx context.Context, in ProjectInput) (ProjectAnalysisRe
 	if err := loadJavaSemanticFacts(ctx, args, host, parseResult.JavaFiles, &indexResult); err != nil {
 		return ProjectAnalysisResult{}, err
 	}
+	// The post-index glue below runs while the "crossFileAnalysis" scope
+	// is open but is not cross-file work, so without these leaves the
+	// time lands in crossFileAnalysis's untracked self-gap. Record each
+	// as a top-level sibling on host.Tracker so warm+ABI attribution is
+	// legible. (loadJavaSemanticFacts already emits "javaSemanticFacts"
+	// from the loader; dispatch/android emit their own spans.)
+	targetedStart := time.Now()
 	runProjectTargetedResolution(args, host, parseResult.KotlinFiles, indexResult)
+	perf.AddEntry(host.Tracker, "targetedResolution", time.Since(targetedStart))
 
+	fpStart := time.Now()
 	runFP, bundleEnabled := computeRunFingerprint(args, host, parseResult, indexResult)
+	perf.AddEntry(host.Tracker, "computeRunFingerprint", time.Since(fpStart))
+
+	manifestStart := time.Now()
 	manifestData := buildManifestData(args, host, parseResult, runFP, bundleEnabled)
+	perf.AddEntry(host.Tracker, "buildManifestData", time.Since(manifestStart))
+
 	dispatchResult, crossFileResult, bundleHit, dispatchTimes, err := runDispatchOrLoadBundle(ctx, args, host, indexResult, parseResult, runFP, bundleEnabled, manifestData)
 	if err != nil {
 		return ProjectAnalysisResult{}, err
@@ -759,16 +773,20 @@ func RunProjectAnalysis(ctx context.Context, in ProjectInput) (ProjectAnalysisRe
 	if err := runAndroidPhaseAndMerge(ctx, args, host, indexResult, &crossFileResult, bundleHit); err != nil {
 		return ProjectAnalysisResult{}, err
 	}
+	kotlinPluginStart := time.Now()
 	if err := runKotlinPluginRulesAndMerge(ctx, args, host, indexResult, &crossFileResult, bundleHit); err != nil {
 		return ProjectAnalysisResult{}, err
 	}
+	perf.AddEntry(host.Tracker, "kotlinPluginRules", time.Since(kotlinPluginStart))
 	phaseTimings.Android = time.Since(androidStart).Milliseconds()
 
 	if bundleEnabled {
+		bundleSaveStart := time.Now()
 		if !bundleHit {
 			_ = host.FindingsBundleStore.Save(host.FindingsBundleCacheRoot, runFP, &crossFileResult.Findings)
 		}
 		_ = saveDeltaManifest(host, manifestData, runFP, &crossFileResult.Findings)
+		perf.AddEntry(host.Tracker, "bundleSave", time.Since(bundleSaveStart))
 	}
 
 	hits1, misses1 := parseCacheCounters(host.ParseCache)


### PR DESCRIPTION
## Summary
- The `crossFileAnalysis` perf scope opens mid-IndexPhase and ends via `defer` at function return, so its wall-clock wraps the **entire** post-index pipeline. Several post-index steps emitted no span of their own, leaving ~300-400ms of warm+ABI time in `crossFileAnalysis`'s untracked self-gap.
- Add top-level perf leaves on `host.Tracker` for the previously-invisible glue: `targetedResolution`, `computeRunFingerprint`, `buildManifestData`, `kotlinPluginRules`, and `bundleSave` (findings-bundle `Save` + delta-manifest save). `loadJavaSemanticFacts` already emits `javaSemanticFacts`; dispatch/android emit their own spans.
- `perf.AddEntry` is nil-safe, so the daemon no-perf path is unaffected. Pure instrumentation — no behavior change.

## Result
On a kotlin-corpus warm+ABI `cacheMissFullDispatch` run, this surfaces **`bundleSave` (~298ms)** next to the existing **`cacheSave` (~222ms)** — together ~40% of the warm+ABI wall clock and the clear next optimization target (disk persistence on the response critical path), previously hidden inside the catch-all scope.

## Test plan
- [x] `go build ./cmd/krit/`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...` (0 issues)
- [x] `go test ./... -count=1` (all packages ok)
- [x] Corpus warm+ABI correctness gate holds (cold=84623, warm+ABI=84630, warm-revert=84623, warm-steady=84623)
- [x] Confirmed new leaves appear in `--perf --format=json` output