### PR TITLE
perf(pipeline): defer daemon bundle+manifest disk writes off warm path

### DIFF
--- a/internal/cli/serve/analyze_project.go
+++ b/internal/cli/serve/analyze_project.go
@@ -539,6 +539,7 @@ func (s *daemonState) buildProjectInput(args daemon.AnalyzeProjectArgs, backend 
 				StoreBundleOutput:        s.workspace.StoreBundleOutput,
 				ResidentBundle:           s.workspace.ResidentBundle,
 				StoreResidentBundle:      s.workspace.StoreResidentBundle,
+				BackgroundSave:           s.workspace.EnqueueBackgroundSave,
 			},
 			AndroidCacheWriter:           diskCache.androidCacheWriter,
 			AndroidCacheDir:              diskCache.androidCacheDir,

--- a/internal/cli/serve/clear_cache.go
+++ b/internal/cli/serve/clear_cache.go
@@ -45,6 +45,11 @@ func handleClearCache(_ context.Context, state *daemonState, raw json.RawMessage
 	state.analyzeMu.Lock()
 	defer state.analyzeMu.Unlock()
 
+	// Drain any background bundle/manifest save still in flight from a
+	// prior analyze before we wipe disk; otherwise a deferred save can
+	// re-create a file under the cache dir we're about to clear.
+	state.workspace.DrainBackgroundSaves()
+
 	var allErrs []error
 	if err := cacheutil.ClearAll(cacheutil.ClearContext{RepoDir: state.repoDir}); err != nil {
 		allErrs = append(allErrs, fmt.Errorf("cacheutil.ClearAll: %w", err))

--- a/internal/cli/serve/serve.go
+++ b/internal/cli/serve/serve.go
@@ -150,6 +150,10 @@ func Run(args []string) int {
 	// cancellation — SIGKILL still orphans the children, but that's
 	// the expected ceiling for unrecoverable parent death.
 	defer state.closeOracleDaemons()
+	// Drain any pending background bundle/manifest disk writes before the
+	// process exits so a save deferred off the warm critical path still
+	// lands on disk. Runs (LIFO) before the oracle shutdown above.
+	defer state.workspace.FlushBackgroundSaves()
 	state.strictVerify = *strictVerifyFlag
 	state.workspace.SetMaxParsedBytes(*maxParseBytesFlag)
 	warmStart := time.Now()

--- a/internal/cli/serve/server_testhelper_test.go
+++ b/internal/cli/serve/server_testhelper_test.go
@@ -33,6 +33,11 @@ func startServerWith(tb testing.TB, root string, readyTimeout time.Duration) (st
 	socket := filepath.Join(socketDir, "d.sock")
 
 	state := newDaemonState(root)
+	// Drain any background bundle/manifest disk writes before the test's
+	// TempDir cleanup removes the cache dir; otherwise an async save can
+	// race the cleanup and fail with "directory not empty". Registered
+	// after the t.TempDir() cleanup so it runs first (Cleanup is LIFO).
+	tb.Cleanup(state.workspace.FlushBackgroundSaves)
 	srv := daemon.NewServer(socket)
 	registerVerbs(srv, state)
 	if err := srv.Start(context.Background()); err != nil {

--- a/internal/pipeline/daemon_caches.go
+++ b/internal/pipeline/daemon_caches.go
@@ -73,4 +73,13 @@ type DaemonCaches struct {
 	// both.
 	ResidentBundle      func(bundleKey string) *scanner.FindingColumns
 	StoreResidentBundle func(bundleKey string, cols *scanner.FindingColumns)
+
+	// BackgroundSave runs fn on the daemon's single background-save
+	// worker, taking the ~300 ms findings-bundle + delta-manifest disk
+	// writes off the warm analyze critical path. The resident/in-memory
+	// mirrors are updated synchronously before this is called, so a
+	// not-yet-flushed disk write only costs a recompute, never a stale
+	// read. nil in CLI mode (callers run fn inline instead). Flushed on
+	// daemon shutdown. *WorkspaceState.EnqueueBackgroundSave satisfies it.
+	BackgroundSave func(fn func())
 }

--- a/internal/pipeline/project.go
+++ b/internal/pipeline/project.go
@@ -782,10 +782,26 @@ func RunProjectAnalysis(ctx context.Context, in ProjectInput) (ProjectAnalysisRe
 
 	if bundleEnabled {
 		bundleSaveStart := time.Now()
+		bundleKey := scanner.FindingsBundleKey(runFP)
+		manifest := buildDeltaManifest(manifestData, runFP)
+		// Update the in-memory mirrors synchronously so the next analyze
+		// reuses them no matter when the disk write lands. The disk write
+		// itself is the slow part (~300 ms on kotlin-corpus), so defer it
+		// to the daemon's background-save worker; correctness holds because
+		// a not-yet-flushed disk write only costs a recompute on a daemon
+		// restart, never a stale read (the resident bundle is keyed by the
+		// content-addressed FindingsBundleKey).
 		if !bundleHit {
-			_ = host.FindingsBundleStore.Save(host.FindingsBundleCacheRoot, runFP, &crossFileResult.Findings)
+			residentBundleStash(host, bundleKey, &crossFileResult.Findings)
 		}
-		_ = saveDeltaManifest(host, manifestData, runFP, &crossFileResult.Findings)
+		storeDeltaManifestResident(host, manifestData, manifest)
+		findings := &crossFileResult.Findings
+		runBackgroundSave(host, func() {
+			if !bundleHit {
+				_ = host.FindingsBundleStore.Save(host.FindingsBundleCacheRoot, runFP, findings)
+			}
+			_ = saveDeltaManifestDisk(host, manifestData, manifest)
+		})
 		perf.AddEntry(host.Tracker, "bundleSave", time.Since(bundleSaveStart))
 	}
 
@@ -1548,17 +1564,12 @@ func buildManifestData(args ProjectArgs, host ProjectHostState, parseResult Pars
 	}
 }
 
-// saveDeltaManifest persists the current run's manifest entry so a
-// future run can detect single-file changes for the delta path.
-// Best-effort — manifest write failures don't fail the verb. When
-// the host wired FindingsBundleManifestSaver, the in-memory cache is
-// updated after a successful disk save so the next analyze-project
-// call doesn't pay the multi-MB JSON re-parse.
-func saveDeltaManifest(host ProjectHostState, m deltaManifestData, runFP scanner.RunFingerprint, _ *scanner.FindingColumns) error {
-	if !m.enabled || m.manifestKey == "" {
-		return nil
-	}
-	manifest := scanner.FindingsBundleManifest{
+// buildDeltaManifest assembles the manifest struct for the current run
+// from the per-request immutable delta data. The result is safe to hand
+// to a background save closure — none of its fields alias daemon-shared
+// mutable state.
+func buildDeltaManifest(m deltaManifestData, runFP scanner.RunFingerprint) scanner.FindingsBundleManifest {
+	return scanner.FindingsBundleManifest{
 		BundleKey:     scanner.FindingsBundleKey(runFP),
 		Fingerprint:   runFP,
 		ContentHashes: m.contentHashes,
@@ -1566,13 +1577,29 @@ func saveDeltaManifest(host ProjectHostState, m deltaManifestData, runFP scanner
 		FileStats:     m.fileStats,
 		AbiHashes:     m.abiHashes,
 	}
-	if err := scanner.SaveFindingsBundleManifest(host.FindingsBundleCacheRoot, m.manifestKey, manifest); err != nil {
-		return err
+}
+
+// storeDeltaManifestResident updates the daemon's in-memory manifest
+// cache synchronously so the next analyze-project call doesn't pay the
+// multi-MB JSON re-parse, regardless of when the disk write lands.
+// No-op when manifests are disabled or the host left the saver nil.
+func storeDeltaManifestResident(host ProjectHostState, m deltaManifestData, manifest scanner.FindingsBundleManifest) {
+	if !m.enabled || m.manifestKey == "" || host.FindingsBundleManifestSaver == nil {
+		return
 	}
-	if host.FindingsBundleManifestSaver != nil {
-		host.FindingsBundleManifestSaver(scanner.FindingsBundleManifestPath(host.FindingsBundleCacheRoot, m.manifestKey), manifest)
+	host.FindingsBundleManifestSaver(scanner.FindingsBundleManifestPath(host.FindingsBundleCacheRoot, m.manifestKey), manifest)
+}
+
+// saveDeltaManifestDisk persists the current run's manifest entry so a
+// future run (or a restarted daemon) can detect single-file changes for
+// the delta path. Best-effort — manifest write failures don't fail the
+// verb. The in-memory mirror is updated separately and synchronously by
+// storeDeltaManifestResident, so this disk write is safe to background.
+func saveDeltaManifestDisk(host ProjectHostState, m deltaManifestData, manifest scanner.FindingsBundleManifest) error {
+	if !m.enabled || m.manifestKey == "" {
+		return nil
 	}
-	return nil
+	return scanner.SaveFindingsBundleManifest(host.FindingsBundleCacheRoot, m.manifestKey, manifest)
 }
 
 // loadBundleManifest reads the prior-run manifest, preferring the
@@ -2905,6 +2932,18 @@ func residentBundleStash(host ProjectHostState, key string, cols *scanner.Findin
 		return
 	}
 	host.StoreResidentBundle(key, cols)
+}
+
+// runBackgroundSave hands fn to the daemon's background-save worker when
+// the host wired one (daemon mode), taking the disk write off the warm
+// analyze critical path. CLI callers leave BackgroundSave nil, so fn
+// runs inline and keeps the previous synchronous behavior.
+func runBackgroundSave(host ProjectHostState, fn func()) {
+	if host.BackgroundSave != nil {
+		host.BackgroundSave(fn)
+		return
+	}
+	fn()
 }
 
 // buildPreviewManifestData is the parse-only subset of buildManifestData

--- a/internal/pipeline/workspace.go
+++ b/internal/pipeline/workspace.go
@@ -181,7 +181,28 @@ type WorkspaceState struct {
 	// hits into 18 k map lookups: ~185 ms → ~5 ms in
 	// typeIndex.perFileExtraction.
 	typeInfo map[string]*typeinfer.FileTypeInfo
+
+	// saveQueue is the single-worker background-save channel. Enqueued
+	// closures run the ~300 ms findings-bundle + delta-manifest disk
+	// writes off the warm analyze critical path. A single worker (not a
+	// pool) matches the serialized per-project analyze model and keeps
+	// disk-write concurrency bounded; the underlying writes are atomic
+	// (temp file + rename) and content-addressed, so even the rare
+	// inline-fallback overlap below is safe (distinct temp paths,
+	// last-writer-wins on identical content). Lazily started on the
+	// first enqueue (saveOnce). When the buffer is full the producer
+	// runs the closure inline, applying natural back-pressure without
+	// dropping a write. nil until the first enqueue.
+	saveQueue chan func()
+	saveOnce  sync.Once
+	saveWG    sync.WaitGroup
 }
+
+// backgroundSaveQueueDepth bounds the buffered save channel. The
+// serialized analyze model emits at most one bundle+manifest save per
+// analyze, so a small buffer absorbs bursts while keeping memory
+// bounded; a full buffer makes the producer run the save inline.
+const backgroundSaveQueueDepth = 8
 
 // CachedBundleOutput holds everything OutputPhase needs to assemble
 // the JSON envelope on a warm bundle hit without re-formatting 87 k
@@ -225,6 +246,69 @@ func NewWorkspaceState(repoRoot string) *WorkspaceState {
 		parsed:    make(map[string]parsedEntry),
 		parsedLRU: list.New(),
 	}
+}
+
+// EnqueueBackgroundSave runs fn on the daemon's single background-save
+// worker, taking disk writes off the warm analyze critical path. The
+// worker is started lazily on the first call. If the buffered queue is
+// full the closure runs inline (back-pressure), so a save is never
+// dropped. A nil receiver runs fn inline (CLI mode never constructs a
+// WorkspaceState via the daemon path, but the guard keeps callers
+// simple). Satisfies DaemonCaches.BackgroundSave.
+func (w *WorkspaceState) EnqueueBackgroundSave(fn func()) {
+	if w == nil || fn == nil {
+		if fn != nil {
+			fn()
+		}
+		return
+	}
+	w.saveOnce.Do(func() {
+		w.saveQueue = make(chan func(), backgroundSaveQueueDepth)
+		w.saveWG.Add(1)
+		go func() {
+			defer w.saveWG.Done()
+			for job := range w.saveQueue {
+				job()
+			}
+		}()
+	})
+	select {
+	case w.saveQueue <- fn:
+	default:
+		// Queue full: run inline so the write still happens and the
+		// producer is naturally throttled.
+		fn()
+	}
+}
+
+// DrainBackgroundSaves blocks until every currently-queued background
+// save has completed, leaving the worker running so later analyzes can
+// keep enqueueing. Callers that wipe the on-disk cache (clear-cache)
+// drain first so a still-in-flight save can't resurrect a file under
+// the directory being cleared. Relies on the FIFO worker: a barrier
+// closure enqueued with a blocking send runs only after all prior
+// queued jobs, so observing the barrier complete proves the queue
+// drained. Must be called with no concurrent EnqueueBackgroundSave
+// (clear-cache holds analyzeMu). No-op when no worker was started.
+func (w *WorkspaceState) DrainBackgroundSaves() {
+	if w == nil || w.saveQueue == nil {
+		return
+	}
+	done := make(chan struct{})
+	w.saveQueue <- func() { close(done) }
+	<-done
+}
+
+// FlushBackgroundSaves drains any pending background saves and stops the
+// worker. Call once on daemon shutdown so in-flight bundle/manifest
+// disk writes complete before the process exits. Safe to call when no
+// worker was ever started (no-op). Not safe to enqueue after Flush.
+func (w *WorkspaceState) FlushBackgroundSaves() {
+	if w == nil || w.saveQueue == nil {
+		return
+	}
+	close(w.saveQueue)
+	w.saveWG.Wait()
 }
 
 // SetMaxParsedBytes sets the resident byte cap for the parsed cache.

--- a/internal/pipeline/workspace_background_save_test.go
+++ b/internal/pipeline/workspace_background_save_test.go
@@ -1,0 +1,80 @@
+package pipeline
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+// TestWorkspaceState_BackgroundSave_RunsAndFlushes pins the core
+// contract: enqueued closures run on the background worker, and
+// FlushBackgroundSaves blocks until every pending save has completed.
+// This is the daemon-shutdown guarantee — a save deferred off the warm
+// critical path must still land before the process exits.
+func TestWorkspaceState_BackgroundSave_RunsAndFlushes(t *testing.T) {
+	w := NewWorkspaceState("")
+
+	var ran atomic.Int64
+	const n = 5
+	for i := 0; i < n; i++ {
+		w.EnqueueBackgroundSave(func() { ran.Add(1) })
+	}
+
+	w.FlushBackgroundSaves()
+
+	if got := ran.Load(); got != n {
+		t.Fatalf("expected %d background saves to complete after flush, got %d", n, got)
+	}
+}
+
+// TestWorkspaceState_BackgroundSave_NilSafe verifies the nil-receiver
+// and nil-closure guards: a nil receiver runs a non-nil closure inline
+// (so callers needn't branch), and FlushBackgroundSaves on a workspace
+// that never enqueued anything is a no-op.
+func TestWorkspaceState_BackgroundSave_NilSafe(t *testing.T) {
+	var ran bool
+	var w *WorkspaceState
+	w.EnqueueBackgroundSave(func() { ran = true })
+	if !ran {
+		t.Fatal("nil receiver should run the closure inline")
+	}
+
+	fresh := NewWorkspaceState("")
+	fresh.FlushBackgroundSaves() // worker never started — must not block or panic
+}
+
+// TestWorkspaceState_BackgroundSave_BackPressureRunsInline drives more
+// saves than the buffer holds while the worker is blocked, proving the
+// producer falls back to running inline rather than dropping a write.
+// Every enqueued save must still complete.
+func TestWorkspaceState_BackgroundSave_BackPressureRunsInline(t *testing.T) {
+	w := NewWorkspaceState("")
+
+	// Block the worker on the first job until we release it, so the
+	// buffer fills and later enqueues take the inline back-pressure path.
+	release := make(chan struct{})
+	var started sync.WaitGroup
+	started.Add(1)
+	var once sync.Once
+	var ran atomic.Int64
+
+	total := backgroundSaveQueueDepth * 3
+	for i := 0; i < total; i++ {
+		first := i == 0
+		w.EnqueueBackgroundSave(func() {
+			if first {
+				once.Do(started.Done)
+				<-release
+			}
+			ran.Add(1)
+		})
+	}
+	// Ensure the worker has picked up the blocking job before releasing.
+	started.Wait()
+	close(release)
+	w.FlushBackgroundSaves()
+
+	if got := ran.Load(); int(got) != total {
+		t.Fatalf("expected all %d saves to run under back-pressure, got %d", total, got)
+	}
+}


### PR DESCRIPTION
## Summary
- The findings-bundle + delta-manifest disk writes (~300 ms on the kotlin corpus) ran synchronously at the tail of every warm+ABI analyze. This moves them to a single-worker background save queue on `WorkspaceState`, stashing the resident bundle and in-memory manifest mirrors synchronously so the next analyze reuses them no matter when the disk write lands.
- `bundleSave` drops from ~298 ms to ~0 ms on the warm+ABI critical path.
- CLI callers leave `BackgroundSave` nil and keep the prior synchronous behavior.

## Correctness
- Resident caches are updated before the analyze returns; on-disk writes are atomic (temp + rename) and content-addressed, so a not-yet-flushed write only costs a recompute on a daemon restart — never a stale read.
- `clear-cache` drains pending saves before wiping disk; daemon shutdown flushes the queue so deferred writes still land.
- The single worker is started lazily; a full buffer makes the producer run the save inline (back-pressure, never dropped). `srv.Wait()` drains all in-flight handlers before the deferred flush, so no enqueue can race the channel close.

## Test plan
- [x] `go build ./cmd/krit/ && go vet ./... && golangci-lint run ./...` (0 issues)
- [x] `go test ./... -count=1` (full suite green; new `workspace_background_save_test.go` passes under `-race`)
- [x] Warm+ABI correctness gate on the kotlin corpus: cold=84623, warm+ABI=84630, warm-revert=84623, warm-steady=84623 (#608 invariant preserved)
- [x] Perf attribution confirms `bundleSave` ~0 ms on the warm+ABI critical path