### PR TITLE
perf(pipeline): background daemon analysis-cache disk write off warm path

### DIFF
--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -223,18 +223,44 @@ func LoadFromDir(dir string) *Cache {
 // writers cannot tear the map mid-iteration. The compressed byte buffer
 // is written to disk after the lock is released.
 func (c *Cache) Save(cacheFilePath string) error {
-	if c.backingStore != nil {
+	data, shouldWrite, err := c.EncodeSnapshot()
+	if err != nil {
+		return err
+	}
+	if !shouldWrite {
 		return nil
 	}
+	return WriteSnapshot(cacheFilePath, data)
+}
+
+// EncodeSnapshot serializes the cache to a compressed byte buffer under
+// Cache.filesMu read-locked, producing an immutable snapshot that is
+// safe to write to disk from another goroutine even while the cache
+// keeps being mutated by later analyzes. shouldWrite is false (with nil
+// data/err) when the cache is backed by an external store — entries are
+// persisted individually on UpdateEntry, so there is nothing to flush.
+// Pair with WriteSnapshot, which performs the actual atomic disk write.
+func (c *Cache) EncodeSnapshot() (data []byte, shouldWrite bool, err error) {
+	if c.backingStore != nil {
+		return nil, false, nil
+	}
+	c.filesMu.RLock()
+	data, err = encodeBinary(c)
+	c.filesMu.RUnlock()
+	if err != nil {
+		return nil, false, fmt.Errorf("encode cache: %w", err)
+	}
+	return data, true, nil
+}
+
+// WriteSnapshot atomically writes a buffer produced by EncodeSnapshot to
+// cacheFilePath (temp file + rename for crash safety). The buffer is
+// immutable, so this is safe to call from a background goroutine while
+// the originating Cache continues to be mutated.
+func WriteSnapshot(cacheFilePath string, data []byte) error {
 	dir := filepath.Dir(cacheFilePath)
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		return fmt.Errorf("create cache dir: %w", err)
-	}
-	c.filesMu.RLock()
-	data, err := encodeBinary(c)
-	c.filesMu.RUnlock()
-	if err != nil {
-		return fmt.Errorf("encode cache: %w", err)
 	}
 	if err := fsutil.WriteFileAtomic(cacheFilePath, data, 0644); err != nil {
 		return fmt.Errorf("write cache: %w", err)

--- a/internal/cache/snapshot_test.go
+++ b/internal/cache/snapshot_test.go
@@ -1,0 +1,96 @@
+package cache
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/kaeawc/krit/internal/scanner"
+)
+
+// TestEncodeSnapshot_WriteRoundTrip pins that EncodeSnapshot +
+// WriteSnapshot persist exactly what the monolithic Save would, so the
+// daemon's deferred (snapshot-then-async-write) path stays byte-faithful
+// to the synchronous one.
+func TestEncodeSnapshot_WriteRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	cachePath := filepath.Join(dir, CacheFileName)
+
+	c := &Cache{
+		Version:  "1.0.0",
+		RuleHash: "abc123",
+		Files: map[string]FileEntry{
+			"/src/a.kt": {Hash: "h1", ModTime: 1000, Size: 100},
+			"/src/b.kt": {Hash: "h2", ModTime: 2000, Size: 200, Columns: testFindingColumns([]scanner.Finding{
+				{File: "/src/b.kt", Line: 5, Col: 1, Severity: "warning", RuleSet: "style", Rule: "MaxLen", Message: "too long"},
+			})},
+		},
+	}
+
+	data, shouldWrite, err := c.EncodeSnapshot()
+	if err != nil {
+		t.Fatalf("EncodeSnapshot: %v", err)
+	}
+	if !shouldWrite {
+		t.Fatal("expected shouldWrite=true for a store-less cache")
+	}
+	if err := WriteSnapshot(cachePath, data); err != nil {
+		t.Fatalf("WriteSnapshot: %v", err)
+	}
+
+	loaded := Load(cachePath)
+	if loaded.Version != c.Version || loaded.RuleHash != c.RuleHash {
+		t.Fatalf("header mismatch: got version=%s ruleHash=%s", loaded.Version, loaded.RuleHash)
+	}
+	if len(loaded.Files) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(loaded.Files))
+	}
+	bEntry := loaded.Files["/src/b.kt"]
+	if got := bEntry.Columns.Len(); got != 1 {
+		t.Fatalf("expected 1 cached row for b.kt, got %d", got)
+	}
+}
+
+// TestEncodeSnapshot_ImmuneToLaterMutation is the core safety property of
+// the async-save split: the byte buffer captured by EncodeSnapshot must
+// reflect the cache state at encode time, even if the cache is mutated
+// before the (deferred) WriteSnapshot lands. This is what makes it safe
+// to write on a background worker while the next analyze keeps mutating
+// the resident Cache.
+func TestEncodeSnapshot_ImmuneToLaterMutation(t *testing.T) {
+	dir := t.TempDir()
+	cachePath := filepath.Join(dir, CacheFileName)
+
+	c := &Cache{
+		Version:  "1.0.0",
+		RuleHash: "rh1",
+		Files: map[string]FileEntry{
+			"/src/a.kt": {Hash: "h1", ModTime: 1000, Size: 100},
+		},
+	}
+
+	// Capture the snapshot, THEN mutate the live cache the way a
+	// subsequent analyze would (new entry + header change).
+	data, _, err := c.EncodeSnapshot()
+	if err != nil {
+		t.Fatalf("EncodeSnapshot: %v", err)
+	}
+	cols := testFindingColumns([]scanner.Finding{{File: "/src/z.kt", Line: 1, Col: 1, Severity: "error", RuleSet: "x", Rule: "Y", Message: "m"}})
+	c.UpdateEntryColumns("/src/z.kt", &cols)
+	c.SetHeader("9.9.9", "rh2", []string{"/src"})
+
+	// Writing the pre-mutation snapshot must persist the pre-mutation
+	// state, not the mutated live cache.
+	if err := WriteSnapshot(cachePath, data); err != nil {
+		t.Fatalf("WriteSnapshot: %v", err)
+	}
+	loaded := Load(cachePath)
+	if loaded.RuleHash != "rh1" {
+		t.Errorf("snapshot leaked later header mutation: ruleHash=%s want rh1", loaded.RuleHash)
+	}
+	if _, ok := loaded.Files["/src/z.kt"]; ok {
+		t.Errorf("snapshot leaked later-added entry /src/z.kt")
+	}
+	if len(loaded.Files) != 1 {
+		t.Errorf("expected 1 entry in snapshot, got %d", len(loaded.Files))
+	}
+}

--- a/internal/pipeline/dispatch.go
+++ b/internal/pipeline/dispatch.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/kaeawc/krit/internal/cache"
 	"github.com/kaeawc/krit/internal/oracle"
 	"github.com/kaeawc/krit/internal/perf"
 	"github.com/kaeawc/krit/internal/rules"
@@ -128,20 +129,42 @@ func (DispatchPhase) writeCacheBack(in IndexResult, findingsByFile map[string]sc
 		return
 	}
 
-	var saveStart time.Time
-	saveFn := func() {
-		saveStart = time.Now()
-		if err := in.Cache.Save(in.CacheFilePath); err != nil {
+	// Encode an immutable snapshot synchronously (under the cache's read
+	// lock) so the next analyze's UpdateEntryColumns can't tear it. In
+	// daemon mode only the atomic disk write is handed to the
+	// background-save worker, taking the ~90 ms write I/O off the warm
+	// critical path; the "cacheSave" tracker then measures just the
+	// encode. CLI callers leave CacheBackgroundSave nil, so the write
+	// runs inline and SaveDurMs still reflects the full encode+write.
+	var (
+		data        []byte
+		shouldWrite bool
+		encErr      error
+	)
+	encodeStart := time.Now()
+	encodeFn := func() { data, shouldWrite, encErr = in.Cache.EncodeSnapshot() }
+	if in.Tracker != nil {
+		in.Tracker.TrackVoid("cacheSave", encodeFn)
+	} else {
+		encodeFn()
+	}
+	if encErr != nil {
+		in.Reporter.Warnf("warning: Failed to encode cache: %v\n", encErr)
+	} else if shouldWrite {
+		path := in.CacheFilePath
+		if in.CacheBackgroundSave != nil {
+			// Daemon mode: the write runs after the analyze response is
+			// sent, so the per-request Reporter is no longer a safe sink
+			// and errors are swallowed. A lost write only costs a recompute.
+			in.CacheBackgroundSave(func() { _ = cache.WriteSnapshot(path, data) })
+		} else if err := cache.WriteSnapshot(path, data); err != nil {
+			// CLI mode: the write runs inline while the Reporter is still
+			// a valid sink, so surface failures the way Save used to.
 			in.Reporter.Warnf("warning: Failed to save cache: %v\n", err)
 		}
 	}
-	if in.Tracker != nil {
-		in.Tracker.TrackVoid("cacheSave", saveFn)
-	} else {
-		saveFn()
-	}
 	if in.CacheStats != nil {
-		in.CacheStats.SaveDurMs = time.Since(saveStart).Milliseconds()
+		in.CacheStats.SaveDurMs = time.Since(encodeStart).Milliseconds()
 	}
 }
 

--- a/internal/pipeline/project.go
+++ b/internal/pipeline/project.go
@@ -981,6 +981,7 @@ func completeRunProjectIndexResult(args ProjectArgs, host ProjectHostState, warm
 		indexResult.Daemon = host.OracleDaemon
 	}
 	indexResult.Cache = host.AnalysisCache
+	indexResult.CacheBackgroundSave = host.BackgroundSave
 	indexResult.Jobs = args.Workers
 	indexResult.ProfileDispatch = args.ProfileDispatch
 	indexResult.EmitPerFileStats = args.EmitPerFileStats

--- a/internal/pipeline/types.go
+++ b/internal/pipeline/types.go
@@ -270,6 +270,14 @@ type IndexResult struct {
 	// CacheStats holds hit-rate / load-duration counters populated by
 	// IndexPhase's cache load block. Nil when caching is disabled.
 	CacheStats *cache.Stats
+	// CacheBackgroundSave, when non-nil, runs the analysis-cache disk
+	// write on the daemon's background-save worker. writeCacheBack
+	// encodes an immutable snapshot synchronously (under the cache's
+	// read lock) and hands only the byte-write to this hook, taking the
+	// ~90 ms cacheSave disk I/O off the warm critical path. nil in CLI
+	// mode (the write runs inline). Wired from
+	// ProjectHostState.BackgroundSave.
+	CacheBackgroundSave func(fn func())
 
 	// Reporter routes verbose progress and warning lines from the
 	// Dispatch and CrossFile phases. Nil means silent.


### PR DESCRIPTION
## Summary
- Split `cache.Cache.Save` into `EncodeSnapshot` (serialize to an immutable byte buffer under the cache read lock) + `WriteSnapshot` (atomic disk write), so the encoded snapshot can be safely written from another goroutine while later analyzes keep mutating the resident cache.
- In daemon mode, `writeCacheBack` now encodes synchronously and hands only the byte-write to the shared background-save worker via a new `IndexResult.CacheBackgroundSave` hook — taking the ~90 ms `cacheSave` disk I/O off the warm critical path. The `cacheSave` perf leaf now measures just the encode (~67 ms observed on warm+ABI).
- CLI callers leave the hook nil: the write runs inline, surfaces failures via the `Reporter` (as `Save` did), and `SaveDurMs` still reflects the full encode+write.

## Correctness
This is the second half of the async disk-persistence win (PR #611 deferred bundle+manifest writes). The #608 warm+ABI correctness gate still passes against a large Kotlin corpus:
- cold = 84623
- warm+ABI = 84630 (cold+7, `cacheMissFullDispatch`)
- warm-revert = 84623 (`cacheHitFullBundle`)
- warm-steady = 84623

The encoded buffer is captured under `filesMu.RLock` before any later analyze can mutate the cache, so the background write is tear-free. Drain on clear-cache and flush on shutdown go through the same worker that already handles bundle/manifest writes.

## Test plan
- [x] `go build`, `go vet`, `golangci-lint run ./...` (0 issues)
- [x] `go test ./... -count=1`
- [x] New `internal/cache/snapshot_test.go`: round-trip equivalence with `Save` + immutability under later mutation
- [x] Warm+ABI correctness gate (above)