### PR TITLE
perf(pipeline): reuse validated source hashes for warm+ABI resource-source fingerprint

### DIFF
--- a/internal/pipeline/android.go
+++ b/internal/pipeline/android.go
@@ -758,7 +758,7 @@ func resourceSourceHashes(in AndroidInput) (map[string]string, bool) {
 			return nil, false
 		}
 		if hash := in.SourceHashes[path]; hash != "" {
-			hashes[path] = hash
+			hashes[path] = canonResourceSourceHash(hash)
 			continue
 		}
 		file := sourceByPath[path]
@@ -774,7 +774,7 @@ func resourceSourceHashes(in AndroidInput) (map[string]string, bool) {
 		if err != nil {
 			return nil, false
 		}
-		hashes[path] = hash
+		hashes[path] = canonResourceSourceHash(hash)
 	}
 	return hashes, true
 }
@@ -1085,7 +1085,7 @@ func (in AndroidInput) loadWarmResourceFindings(resourceDeps rules.AndroidDataDe
 
 func (in AndroidInput) warmResourceSourceBundleFingerprint() (string, int, bool) {
 	if len(in.SourceFiles) > 0 {
-		if sourceSetFP, ok := resourceSourceSetFingerprint(in.SourceFiles); ok {
+		if sourceSetFP, ok := in.resourceSourceSetFingerprintReusingHashes(); ok {
 			return sourceSetFP, len(in.SourceFiles), true
 		}
 	}

--- a/internal/pipeline/android_bundle.go
+++ b/internal/pipeline/android_bundle.go
@@ -22,7 +22,12 @@ type resourceSourceBundleManifest struct {
 	Hashes    map[string]string `json:"hashes"`
 }
 
-const resourceSourceBundleManifestVersion = 1
+// resourceSourceBundleManifestVersion is bumped to 2 alongside the canonical
+// 16-char hash-width migration: a v1 manifest stores full-width (64-char)
+// hashes, which would width-mismatch every path against the new 16-char
+// currentHashes and force a needless full re-sweep. Bumping invalidates stale
+// manifests cleanly so the first warm run after upgrade rebuilds once.
+const resourceSourceBundleManifestVersion = 2
 
 func resourceSourceBundleManifestPath(cacheDir, key string) string {
 	if cacheDir == "" || key == "" {
@@ -61,9 +66,11 @@ func saveResourceSourceBundleManifest(cacheDir, key, bundleKey string, hashes ma
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return err
 	}
+	// Store canonical-width hashes so a cold (64-char memo) save and a warm
+	// (16-char cache) delta compare against byte-identical values.
 	copyHashes := make(map[string]string, len(hashes))
 	for path, hash := range hashes {
-		copyHashes[path] = hash
+		copyHashes[path] = canonResourceSourceHash(hash)
 	}
 	raw, err := json.Marshal(resourceSourceBundleManifest{
 		Version:   resourceSourceBundleManifestVersion,

--- a/internal/pipeline/android_keys.go
+++ b/internal/pipeline/android_keys.go
@@ -86,8 +86,10 @@ func (in AndroidInput) resourceSourceKey(srcPath, srcContentHash, mergedIdxFP st
 		RuleHash:            in.RuleHash,
 		LibraryFactsFP:      in.LibraryFactsFP,
 		JavaSemanticFactsFP: in.JavaSemanticFactsFP,
-		InputFP:             srcContentHash,
-		Extra:               srcPath + "\x00" + mergedIdxFP,
+		// Canonicalize so a warm run's 16-char cache hash and a cold run's
+		// 64-char memo hash for the same file resolve to the same key.
+		InputFP: canonResourceSourceHash(srcContentHash),
+		Extra:   srcPath + "\x00" + mergedIdxFP,
 	})
 }
 
@@ -259,7 +261,7 @@ func writeResDirFingerprints(h interface {
 
 func (in AndroidInput) resourceSourceFingerprintForBundle() (string, bool) {
 	if len(in.SourceFiles) > 0 {
-		return resourceSourceSetFingerprint(in.SourceFiles)
+		return in.resourceSourceSetFingerprintReusingHashes()
 	}
 	if len(in.SourcePaths) > 0 && len(in.SourceHashes) > 0 {
 		entries := make([]resourceSourceEntry, 0, len(in.SourcePaths))

--- a/internal/pipeline/android_resource_source_cache_test.go
+++ b/internal/pipeline/android_resource_source_cache_test.go
@@ -354,3 +354,104 @@ func TestResourceSourceCacheKey_PathInvalidates(t *testing.T) {
 		t.Fatal("identical-content files at different paths must not share a resource-source cache key")
 	}
 }
+
+// canon16 mirrors cache.ComputeFileHash: the 16-char truncation the analysis
+// cache's JSON backend records as a file's content hash and hands the Android
+// phase via AndroidInput.SourceHashes.
+func canon16(t *testing.T, path string) string {
+	t.Helper()
+	h, err := hashutil.Default().HashFile(path, nil)
+	if err != nil {
+		t.Fatalf("hash %s: %v", path, err)
+	}
+	return h[:resourceSourceHashWidth]
+}
+
+// TestResourceSourceSetFingerprintReusingHashes_MatchesFullRehash pins the
+// load-bearing safety property of the warm-probe optimization: reusing the
+// analysis cache's per-file hashes (AndroidInput.SourceHashes) must yield a
+// fingerprint byte-identical to hashing every source file from scratch.
+//
+// Critically, the SourceHashes seeded here are 16-char (cache.ComputeFileHash
+// form, what the JSON backend actually produces) while the from-scratch
+// baseline hashes at 64-char (memo.HashFile). Without the canonical-width
+// migration these diverge and the warm bundle key silently shifts; with it they
+// match. The partial-coverage case mirrors warm+ABI: the changed file is absent
+// from SourceHashes (the cache only carries hashes for unchanged hits) and must
+// fall back to a real hash without changing the result.
+func TestResourceSourceSetFingerprintReusingHashes_MatchesFullRehash(t *testing.T) {
+	root := t.TempDir()
+	ktA := parseKotlinForTest(t, filepath.Join(root, "A.kt"), inflateNullKotlin)
+	ktB := parseKotlinForTest(t, filepath.Join(root, "B.kt"), inflateCleanKotlin)
+	ktC := parseKotlinForTest(t, filepath.Join(root, "C.kt"), inflateNullKotlin)
+	files := []*scanner.File{ktA, ktB, ktC}
+
+	want, ok := resourceSourceSetFingerprint(files)
+	if !ok {
+		t.Fatal("baseline resourceSourceSetFingerprint failed")
+	}
+
+	cases := []struct {
+		name   string
+		hashes map[string]string
+	}{
+		{"full coverage (16-char cache hashes)", map[string]string{
+			ktA.Path: canon16(t, ktA.Path), ktB.Path: canon16(t, ktB.Path), ktC.Path: canon16(t, ktC.Path),
+		}},
+		{"changed file absent (warm+ABI)", map[string]string{
+			ktA.Path: canon16(t, ktA.Path), ktB.Path: canon16(t, ktB.Path),
+		}},
+		{"no coverage", nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			in := AndroidInput{SourceFiles: files, SourceHashes: tc.hashes}
+			got, ok := in.resourceSourceSetFingerprintReusingHashes()
+			if !ok {
+				t.Fatal("resourceSourceSetFingerprintReusingHashes failed")
+			}
+			if got != want {
+				t.Fatalf("fingerprint diverged from full rehash:\n got %s\nwant %s", got, want)
+			}
+		})
+	}
+}
+
+// TestResourceSourceKey_CanonicalWidthStable verifies that a file's per-file
+// resource-source cache key is identical whether the content hash arrives as the
+// cold 64-char memo hash or the warm 16-char cache hash. This is what lets a
+// delta re-dispatch (which carries 16-char hashes) hit findings a cold run wrote
+// under the 64-char hash.
+func TestResourceSourceKey_CanonicalWidthStable(t *testing.T) {
+	in := AndroidInput{RuleHash: "rh", LibraryFactsFP: "lf"}
+	full := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	short := full[:resourceSourceHashWidth]
+	if in.resourceSourceKey("/src/A.kt", full, "merged-fp") != in.resourceSourceKey("/src/A.kt", short, "merged-fp") {
+		t.Fatal("64-char and 16-char hashes for the same file must yield the same resource-source key")
+	}
+}
+
+// TestResourceSourceHashes_CanonicalWidth verifies the manifest body / delta
+// compare hashes are normalized to the canonical width regardless of the width
+// the analysis cache supplied, so a cold (64-char) save and a warm (16-char)
+// delta compare against byte-identical values.
+func TestResourceSourceHashes_CanonicalWidth(t *testing.T) {
+	root := t.TempDir()
+	kt := parseKotlinForTest(t, filepath.Join(root, "A.kt"), inflateNullKotlin)
+	full, err := hashutil.Default().HashFile(kt.Path, nil)
+	if err != nil {
+		t.Fatalf("hash: %v", err)
+	}
+	in := AndroidInput{
+		SourceFiles:  []*scanner.File{kt},
+		SourcePaths:  []string{kt.Path},
+		SourceHashes: map[string]string{kt.Path: full}, // 64-char, as the unified store supplies
+	}
+	hashes, ok := resourceSourceHashes(in)
+	if !ok {
+		t.Fatal("resourceSourceHashes failed")
+	}
+	if got := hashes[kt.Path]; len(got) != resourceSourceHashWidth {
+		t.Fatalf("resourceSourceHashes returned width %d (%q), want %d", len(got), got, resourceSourceHashWidth)
+	}
+}

--- a/internal/pipeline/android_warmcache.go
+++ b/internal/pipeline/android_warmcache.go
@@ -208,8 +208,79 @@ func resourceSourceEntriesFingerprint(entries []resourceSourceEntry) (string, bo
 	for _, e := range entries {
 		h.Write([]byte(e.path))
 		h.Write([]byte{0})
-		h.Write([]byte(e.hash))
+		h.Write([]byte(canonResourceSourceHash(e.hash)))
 		h.Write([]byte{0})
 	}
 	return hex.EncodeToString(h.Sum(nil)), true
+}
+
+// resourceSourceHashWidth is the canonical width, in hex characters, of every
+// content hash that participates in a resource-source cache key, bundle
+// fingerprint, or bundle manifest. The analysis cache's JSON backend records
+// 16-char truncated hashes (cache.ComputeFileHash), while memo.HashFile and the
+// unified store produce full 64-char hashes. Canonicalizing every hash to a
+// single width before it enters a key lets a warm run reuse the per-file hashes
+// the analysis cache already validated this run — without re-stat'ing every
+// source file — and still land on the exact key a cold (full-hash) run wrote.
+// 16 hex chars (64 bits) matches the truncation cache.ComputeFileHash already
+// uses for the primary per-file analysis cache, so this adds no collision risk
+// beyond what the cache subsystem already accepts.
+const resourceSourceHashWidth = 16
+
+// canonResourceSourceHash truncates a content hash to resourceSourceHashWidth so
+// 16- and 64-char hashes for the same file produce identical resource-source
+// keys. Shorter inputs are returned unchanged.
+func canonResourceSourceHash(hash string) string {
+	if len(hash) > resourceSourceHashWidth {
+		return hash[:resourceSourceHashWidth]
+	}
+	return hash
+}
+
+// resourceSourceSetFingerprintReusingHashes computes the same fingerprint as
+// resourceSourceSetFingerprint(in.SourceFiles), but pulls each file's content
+// hash from in.SourceHashes when present, hashing only the files the analysis
+// cache didn't cover — on a warm+ABI run that's just the changed file.
+//
+// By design this reuses the analysis cache's per-file hashes, so it inherits
+// the cache's staleness model rather than the always-rehash-from-content
+// behavior of resourceSourceSetFingerprint: under the git-dirty / watcher
+// incremental shortcuts (see cache.CheckFiles / CheckFilesIncremental), a
+// SourceHashes entry can be a prior run's hash that wasn't re-validated this
+// run. That is intentional — it makes the resource-source bundle hit/miss share
+// the same freshness guarantee as the main analysis cache that produced those
+// hashes, instead of being spuriously fresher. Genuinely changed files are
+// absent from SourceHashes (the cache only carries hashes for hits) and fall
+// through to the rehash below, which is what preserves warm+ABI correctness.
+//
+// Because every fingerprint hash is canonicalized to resourceSourceHashWidth
+// (see resourceSourceEntriesFingerprint / canonResourceSourceHash), the cache's
+// 16-char hashes and a from-scratch 64-char rehash produce a byte-identical
+// fingerprint, so reuse never shifts the key; only the per-file os.Stat +
+// content-hash storm over thousands of unchanged files is avoided. Returns
+// false (matching resourceSourceSetFingerprint) if any file is nil/path-less or
+// an uncached file can't be hashed.
+func (in AndroidInput) resourceSourceSetFingerprintReusingHashes() (string, bool) {
+	memo := hashutil.Default()
+	entries := make([]resourceSourceEntry, 0, len(in.SourceFiles))
+	for _, file := range in.SourceFiles {
+		if file == nil || file.Path == "" {
+			return "", false
+		}
+		hash := in.SourceHashes[file.Path]
+		if hash == "" {
+			var provider func() ([]byte, error)
+			if len(file.Content) > 0 {
+				content := file.Content
+				provider = func() ([]byte, error) { return content, nil }
+			}
+			h, err := memo.HashFile(file.Path, provider)
+			if err != nil {
+				return "", false
+			}
+			hash = h
+		}
+		entries = append(entries, resourceSourceEntry{path: file.Path, hash: hash})
+	}
+	return resourceSourceEntriesFingerprint(entries)
 }


### PR DESCRIPTION
## Summary
- On warm+ABI, the Android resource-source phase re-stat'd and re-hashed every source file just to compute the bundle fingerprint (~150ms of androidPhase). This reuses the per-file content hashes the analysis cache already produced this run (`AndroidInput.SourceHashes`), hashing only files the cache didn't cover — on warm+ABI that's just the changed file.
- To make reuse safe, every resource-source content hash is canonicalized to a single 16-char width at the three sinks that feed a cache key / bundle fingerprint / bundle manifest (`resourceSourceEntriesFingerprint`, `resourceSourceKey`, `resourceSourceHashes`, `saveResourceSourceBundleManifest`). The JSON cache backend stores 16-char hashes while `memo.HashFile`/the unified store produce 64-char hashes of the *same* xxh3 digest, so canonicalizing makes a warm 16-char reuse and a cold 64-char rehash land on a byte-identical key. The warm bundle hit/miss outcome is unchanged; only the per-file stat + hash storm is avoided.
- Bundle reuse now shares the same freshness guarantee as the analysis cache that produced the hashes (instead of being spuriously fresher). Genuinely changed files are absent from `SourceHashes` and fall through to a real rehash, which preserves warm+ABI correctness.
- Bumped the resource-source bundle manifest version so pre-migration full-width manifests invalidate cleanly (one rebuild) rather than width-mismatching every path.

## Result
- `androidPhase` 150ms → 15ms on the warm+ABI (`cacheMissFullDispatch`) path.
- PR #608 correctness gate holds: cold=84623, warm+ABI=84630 (cold + 7 probe findings), warm-revert=84623, warm-steady=84623.

## Test plan
- [x] `go build ./cmd/krit/`, `go vet ./...`, `golangci-lint run ./...` (0 issues), `go test ./... -count=1` all green
- [x] New regression tests pin byte-identity of the reusing fingerprint vs full rehash using 16-char-seeded `SourceHashes` (the real JSON form), incl. the partial-coverage warm+ABI case, plus canonical-width stability of the per-file key and `resourceSourceHashes`
- [x] #608 correctness gate re-verified (cold / warm+ABI / warm-revert / warm-steady)