### PR TITLE
perf(pipeline): background resource-source manifest write + resident mirror

### DIFF
--- a/internal/cli/serve/analyze_project.go
+++ b/internal/cli/serve/analyze_project.go
@@ -539,7 +539,10 @@ func (s *daemonState) buildProjectInput(args daemon.AnalyzeProjectArgs, backend 
 				StoreBundleOutput:        s.workspace.StoreBundleOutput,
 				ResidentBundle:           s.workspace.ResidentBundle,
 				StoreResidentBundle:      s.workspace.StoreResidentBundle,
-				BackgroundSave:           s.workspace.EnqueueBackgroundSave,
+
+				ResidentResourceSourceManifest:      s.workspace.ResidentResourceSourceManifest,
+				StoreResidentResourceSourceManifest: s.workspace.StoreResidentResourceSourceManifest,
+				BackgroundSave:                      s.workspace.EnqueueBackgroundSave,
 			},
 			AndroidCacheWriter:           diskCache.androidCacheWriter,
 			AndroidCacheDir:              diskCache.androidCacheDir,

--- a/internal/pipeline/android.go
+++ b/internal/pipeline/android.go
@@ -78,6 +78,22 @@ type AndroidInput struct {
 	// WorkspaceState-resident map; cache keys include the content
 	// hash + rule hash so config changes invalidate. CLI passes nil.
 	GradleFindingsCache func(key string, build func() scanner.FindingColumns) scanner.FindingColumns
+
+	// BackgroundSave, when non-nil, runs the resource-source bundle
+	// manifest disk write on the daemon's background-save worker instead
+	// of inline on the warm analyze critical path. The resident manifest
+	// mirror is updated synchronously first, so a not-yet-flushed write
+	// only costs a recompute on daemon restart, never a stale read. CLI
+	// callers leave it nil and the write runs inline.
+	// Wired from ProjectHostState.BackgroundSave.
+	BackgroundSave func(fn func())
+	// ResidentResourceSourceManifest / StoreResidentResourceSourceManifest
+	// mirror the on-disk resource-source bundle manifest in daemon memory,
+	// keyed by manifestKey. The delta path reads the mirror before the
+	// on-disk JSON load and writes it on every save. Both nil in CLI mode.
+	// Wired from ProjectHostState.{,Store}ResidentResourceSourceManifest.
+	ResidentResourceSourceManifest      func(key string) (resourceSourceBundleManifest, bool)
+	StoreResidentResourceSourceManifest func(key string, manifest resourceSourceBundleManifest)
 }
 
 // AndroidResult is the output of the Android phase.
@@ -594,7 +610,7 @@ func saveResourceSourceBundles(in AndroidInput, mergedFP string, bundleCollector
 		}
 		if paths := sourcePathsForManifest(in); len(manifestHashes) == len(paths) {
 			if manifestKey, ok := in.resourceSourceBundleManifestKey(paths, mergedFP); ok {
-				_ = saveResourceSourceBundleManifest(in.CacheDir, manifestKey, bundleKey, manifestHashes)
+				in.persistResourceSourceBundleManifest(manifestKey, bundleKey, manifestHashes)
 			}
 		}
 	}
@@ -653,7 +669,7 @@ func tryResourceSourceBundleDelta(in AndroidInput, mergedSourceIdx *android.Reso
 	if !ok {
 		return false, stats
 	}
-	manifest, ok := loadResourceSourceBundleManifest(in.CacheDir, manifestKey)
+	manifest, ok := in.lookupResourceSourceBundleManifest(manifestKey)
 	if !ok {
 		return false, stats
 	}
@@ -699,7 +715,7 @@ func tryResourceSourceBundleDelta(in AndroidInput, mergedSourceIdx *android.Reso
 	if sourceSetFP, ok := resourceSourceEntriesFingerprint(resourceSourceEntriesFromHashes(currentHashes)); ok {
 		bundleKey := in.resourceSourceBundleKey(sourceSetFP, mergedFP)
 		in.CacheWriter.Save(in.CacheDir, bundleKey, merged)
-		_ = saveResourceSourceBundleManifest(in.CacheDir, manifestKey, bundleKey, currentHashes)
+		in.persistResourceSourceBundleManifest(manifestKey, bundleKey, currentHashes)
 	}
 	stats.hits = len(paths) - len(changed)
 	stats.misses = len(changed)

--- a/internal/pipeline/android_bundle.go
+++ b/internal/pipeline/android_bundle.go
@@ -84,6 +84,56 @@ func saveResourceSourceBundleManifest(cacheDir, key, bundleKey string, hashes ma
 	return fsutil.WriteFileAtomic(path, raw, 0o644)
 }
 
+// lookupResourceSourceBundleManifest returns the resource-source bundle
+// manifest for key, consulting the daemon-resident mirror first (a map
+// lookup) before falling back to the on-disk JSON read. A disk hit
+// populates the mirror so subsequent warm analyzes skip the read.
+func (in AndroidInput) lookupResourceSourceBundleManifest(key string) (resourceSourceBundleManifest, bool) {
+	if in.ResidentResourceSourceManifest != nil {
+		if manifest, ok := in.ResidentResourceSourceManifest(key); ok {
+			return manifest, true
+		}
+	}
+	manifest, ok := loadResourceSourceBundleManifest(in.CacheDir, key)
+	if ok && in.StoreResidentResourceSourceManifest != nil {
+		in.StoreResidentResourceSourceManifest(key, manifest)
+	}
+	return manifest, ok
+}
+
+// persistResourceSourceBundleManifest mirrors the manifest into the
+// daemon-resident cache synchronously, then writes it to disk — off the
+// warm critical path via BackgroundSave when wired, inline otherwise.
+// Because the resident mirror is updated before this returns, a deferred
+// (not-yet-flushed) disk write never costs the next analyze a re-sweep;
+// only a daemon restart before the flush falls back to a recompute.
+func (in AndroidInput) persistResourceSourceBundleManifest(key, bundleKey string, hashes map[string]string) {
+	if key == "" || bundleKey == "" || len(hashes) == 0 {
+		return
+	}
+	if in.StoreResidentResourceSourceManifest != nil {
+		// Store canonical-width hashes so the resident value is
+		// byte-identical to what loadResourceSourceBundleManifest would
+		// return after the disk write lands.
+		canon := make(map[string]string, len(hashes))
+		for path, hash := range hashes {
+			canon[path] = canonResourceSourceHash(hash)
+		}
+		in.StoreResidentResourceSourceManifest(key, resourceSourceBundleManifest{
+			Version:   resourceSourceBundleManifestVersion,
+			Key:       key,
+			BundleKey: bundleKey,
+			Hashes:    canon,
+		})
+	}
+	write := func() { _ = saveResourceSourceBundleManifest(in.CacheDir, key, bundleKey, hashes) }
+	if in.BackgroundSave != nil {
+		in.BackgroundSave(write)
+	} else {
+		write()
+	}
+}
+
 const mergedResourceIndexBundleVersion = 1
 
 type mergedResourceIndexBundlePayload struct {

--- a/internal/pipeline/android_resource_source_manifest_test.go
+++ b/internal/pipeline/android_resource_source_manifest_test.go
@@ -1,0 +1,192 @@
+package pipeline
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// residentManifestStore is a tiny in-memory stand-in for the daemon's resident
+// manifest mirror (WorkspaceState.ResidentResourceSourceManifest /
+// StoreResidentResourceSourceManifest). The pipeline-level tests only need the
+// map semantics, not the FIFO eviction, so this stays minimal.
+type residentManifestStore struct {
+	m map[string]resourceSourceBundleManifest
+}
+
+func newResidentManifestStore() *residentManifestStore {
+	return &residentManifestStore{m: map[string]resourceSourceBundleManifest{}}
+}
+
+func (s *residentManifestStore) get(key string) (resourceSourceBundleManifest, bool) {
+	manifest, ok := s.m[key]
+	return manifest, ok
+}
+
+func (s *residentManifestStore) put(key string, manifest resourceSourceBundleManifest) {
+	s.m[key] = manifest
+}
+
+// TestPersistResourceSourceBundleManifest_DeferredWriteServedFromResident pins
+// the load-bearing safety property of deferring the manifest disk write: when
+// BackgroundSave holds the write (does not run it inline), the very next
+// lookup must still see the manifest via the resident mirror. Were that not
+// true, every warm analyze between the persist and the eventual flush would
+// width-mismatch the on-disk (absent) manifest and force a full O(N) re-sweep.
+func TestPersistResourceSourceBundleManifest_DeferredWriteServedFromResident(t *testing.T) {
+	root := t.TempDir()
+	cacheDir := filepath.Join(root, ".krit", "android-findings-cache")
+
+	resident := newResidentManifestStore()
+	var deferred []func() // BackgroundSave parks writes here; never run inline.
+
+	in := AndroidInput{
+		CacheDir:                            cacheDir,
+		ResidentResourceSourceManifest:      resident.get,
+		StoreResidentResourceSourceManifest: resident.put,
+		BackgroundSave:                      func(fn func()) { deferred = append(deferred, fn) },
+	}
+
+	const key = "manifest-key"
+	const bundleKey = "bundle-key"
+	hashes := map[string]string{"/src/A.kt": "aaaa", "/src/B.kt": "bbbb"}
+
+	in.persistResourceSourceBundleManifest(key, bundleKey, hashes)
+
+	// The disk write is parked, not run: nothing on disk yet.
+	if _, ok := loadResourceSourceBundleManifest(cacheDir, key); ok {
+		t.Fatal("expected no on-disk manifest before the deferred write runs")
+	}
+	if len(deferred) != 1 {
+		t.Fatalf("expected exactly one parked write, got %d", len(deferred))
+	}
+
+	// The resident mirror serves the lookup immediately, with canonical-width
+	// hashes byte-identical to what a later disk read would return.
+	got, ok := in.lookupResourceSourceBundleManifest(key)
+	if !ok {
+		t.Fatal("expected resident mirror to serve the manifest before flush")
+	}
+	if got.BundleKey != bundleKey {
+		t.Fatalf("BundleKey = %q, want %q", got.BundleKey, bundleKey)
+	}
+	for path, raw := range hashes {
+		if want := canonResourceSourceHash(raw); got.Hashes[path] != want {
+			t.Fatalf("resident hash[%s] = %q, want canonical %q", path, got.Hashes[path], want)
+		}
+	}
+
+	// Draining the parked write lands the manifest on disk, byte-identical to
+	// the resident value.
+	for _, fn := range deferred {
+		fn()
+	}
+	disk, ok := loadResourceSourceBundleManifest(cacheDir, key)
+	if !ok {
+		t.Fatal("expected on-disk manifest after flushing the deferred write")
+	}
+	if disk.BundleKey != got.BundleKey {
+		t.Fatalf("disk BundleKey = %q, want %q", disk.BundleKey, got.BundleKey)
+	}
+	for path, h := range got.Hashes {
+		if disk.Hashes[path] != h {
+			t.Fatalf("disk hash[%s] = %q, want %q", path, disk.Hashes[path], h)
+		}
+	}
+}
+
+// TestLookupResourceSourceBundleManifest_DiskHitPopulatesResident verifies the
+// loader populates the resident mirror on a disk hit, so a second daemon
+// session that started cold reads disk once and serves from memory thereafter.
+func TestLookupResourceSourceBundleManifest_DiskHitPopulatesResident(t *testing.T) {
+	root := t.TempDir()
+	cacheDir := filepath.Join(root, ".krit", "android-findings-cache")
+
+	const key = "manifest-key"
+	const bundleKey = "bundle-key"
+	hashes := map[string]string{"/src/A.kt": "aaaa"}
+	if err := saveResourceSourceBundleManifest(cacheDir, key, bundleKey, hashes); err != nil {
+		t.Fatalf("saveResourceSourceBundleManifest: %v", err)
+	}
+
+	resident := newResidentManifestStore()
+	in := AndroidInput{
+		CacheDir:                            cacheDir,
+		ResidentResourceSourceManifest:      resident.get,
+		StoreResidentResourceSourceManifest: resident.put,
+	}
+
+	if _, ok := resident.get(key); ok {
+		t.Fatal("resident mirror should start empty")
+	}
+	if _, ok := in.lookupResourceSourceBundleManifest(key); !ok {
+		t.Fatal("expected disk hit")
+	}
+	if _, ok := resident.get(key); !ok {
+		t.Fatal("expected disk hit to populate the resident mirror")
+	}
+}
+
+// TestPersistResourceSourceBundleManifest_NilHooksWriteInline verifies CLI mode
+// (no BackgroundSave, no resident hooks): the write happens inline so the
+// manifest is on disk immediately, and lookup falls through to the disk read.
+func TestPersistResourceSourceBundleManifest_NilHooksWriteInline(t *testing.T) {
+	root := t.TempDir()
+	cacheDir := filepath.Join(root, ".krit", "android-findings-cache")
+
+	in := AndroidInput{CacheDir: cacheDir} // all daemon hooks nil
+
+	const key = "manifest-key"
+	const bundleKey = "bundle-key"
+	hashes := map[string]string{"/src/A.kt": "aaaa"}
+
+	in.persistResourceSourceBundleManifest(key, bundleKey, hashes)
+
+	// Inline write: on disk immediately.
+	if _, ok := loadResourceSourceBundleManifest(cacheDir, key); !ok {
+		t.Fatal("expected inline write to land on disk for CLI mode")
+	}
+	// Lookup falls through to disk with no resident mirror.
+	got, ok := in.lookupResourceSourceBundleManifest(key)
+	if !ok {
+		t.Fatal("expected lookup to read the inline-written manifest from disk")
+	}
+	if got.BundleKey != bundleKey {
+		t.Fatalf("BundleKey = %q, want %q", got.BundleKey, bundleKey)
+	}
+}
+
+// TestPersistResourceSourceBundleManifest_RejectsEmptyInputs verifies the guard
+// rails: empty key / bundleKey / hashes are no-ops that neither touch the
+// resident mirror nor enqueue a write.
+func TestPersistResourceSourceBundleManifest_RejectsEmptyInputs(t *testing.T) {
+	resident := newResidentManifestStore()
+	var enqueued int
+	in := AndroidInput{
+		CacheDir:                            t.TempDir(),
+		ResidentResourceSourceManifest:      resident.get,
+		StoreResidentResourceSourceManifest: resident.put,
+		BackgroundSave:                      func(func()) { enqueued++ },
+	}
+
+	cases := []struct {
+		name      string
+		key       string
+		bundleKey string
+		hashes    map[string]string
+	}{
+		{"empty key", "", "bundle", map[string]string{"/a": "h"}},
+		{"empty bundleKey", "key", "", map[string]string{"/a": "h"}},
+		{"empty hashes", "key", "bundle", nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			in.persistResourceSourceBundleManifest(tc.key, tc.bundleKey, tc.hashes)
+		})
+	}
+	if len(resident.m) != 0 {
+		t.Fatalf("expected no resident entries, got %d", len(resident.m))
+	}
+	if enqueued != 0 {
+		t.Fatalf("expected no enqueued writes, got %d", enqueued)
+	}
+}

--- a/internal/pipeline/daemon_caches.go
+++ b/internal/pipeline/daemon_caches.go
@@ -74,6 +74,16 @@ type DaemonCaches struct {
 	ResidentBundle      func(bundleKey string) *scanner.FindingColumns
 	StoreResidentBundle func(bundleKey string, cols *scanner.FindingColumns)
 
+	// ResidentResourceSourceManifest / StoreResidentResourceSourceManifest
+	// are the daemon-side in-memory mirror of the on-disk resource-source
+	// bundle manifest (android_bundle.go). The Android delta path consults
+	// the loader before the ~30 ms JSON disk read and mirrors every saved
+	// manifest here so a deferred (BackgroundSave) disk write never costs
+	// the next analyze a full re-sweep. Both nil in CLI mode (the delta
+	// path reads/writes disk inline). *WorkspaceState satisfies both.
+	ResidentResourceSourceManifest      func(key string) (resourceSourceBundleManifest, bool)
+	StoreResidentResourceSourceManifest func(key string, manifest resourceSourceBundleManifest)
+
 	// BackgroundSave runs fn on the daemon's single background-save
 	// worker, taking the ~300 ms findings-bundle + delta-manifest disk
 	// writes off the warm analyze critical path. The resident/in-memory

--- a/internal/pipeline/project.go
+++ b/internal/pipeline/project.go
@@ -1659,7 +1659,11 @@ func runAndroidPhaseAndMerge(ctx context.Context, args ProjectArgs, host Project
 		CacheDir:            host.AndroidCacheDir,
 		CacheWriter:         host.AndroidCacheWriter,
 		GradleFindingsCache: host.GradleFindingsCache,
-		Tracker:             androidTracker,
+		BackgroundSave:      host.BackgroundSave,
+
+		ResidentResourceSourceManifest:      host.ResidentResourceSourceManifest,
+		StoreResidentResourceSourceManifest: host.StoreResidentResourceSourceManifest,
+		Tracker:                             androidTracker,
 	})
 	if androidTracker != nil {
 		androidTracker.End()

--- a/internal/pipeline/resident_resource_manifest_test.go
+++ b/internal/pipeline/resident_resource_manifest_test.go
@@ -1,0 +1,108 @@
+package pipeline
+
+import (
+	"strconv"
+	"testing"
+)
+
+func manifestForTest(bundleKey string) resourceSourceBundleManifest {
+	return resourceSourceBundleManifest{
+		Version:   resourceSourceBundleManifestVersion,
+		Key:       "ignored", // ResidentResourceSourceManifest keys on the arg, not this
+		BundleKey: bundleKey,
+		Hashes:    map[string]string{"/src/A.kt": "aaaa"},
+	}
+}
+
+// TestWorkspaceState_ResidentResourceManifest_StoreAndLookup pins the basic
+// store/lookup contract: a stored manifest is visible to the next lookup keyed
+// on the same key.
+func TestWorkspaceState_ResidentResourceManifest_StoreAndLookup(t *testing.T) {
+	w := &WorkspaceState{}
+	if _, ok := w.ResidentResourceSourceManifest("k"); ok {
+		t.Error("empty cache must miss")
+	}
+	w.StoreResidentResourceSourceManifest("k", manifestForTest("b"))
+	got, ok := w.ResidentResourceSourceManifest("k")
+	if !ok {
+		t.Fatal("stored manifest not returned")
+	}
+	if got.BundleKey != "b" {
+		t.Errorf("BundleKey = %q, want b", got.BundleKey)
+	}
+}
+
+// TestWorkspaceState_ResidentResourceManifest_NilSafety mirrors the rest of
+// WorkspaceState's nil-tolerant API: methods on a nil receiver must not panic.
+func TestWorkspaceState_ResidentResourceManifest_NilSafety(t *testing.T) {
+	var w *WorkspaceState
+	if _, ok := w.ResidentResourceSourceManifest("k"); ok {
+		t.Error("nil receiver must miss")
+	}
+	w.StoreResidentResourceSourceManifest("k", manifestForTest("b")) // must not panic
+}
+
+// TestWorkspaceState_ResidentResourceManifest_EmptyKeyIgnored pins the guard:
+// an empty key neither stores nor looks up.
+func TestWorkspaceState_ResidentResourceManifest_EmptyKeyIgnored(t *testing.T) {
+	w := &WorkspaceState{}
+	w.StoreResidentResourceSourceManifest("", manifestForTest("b"))
+	if _, ok := w.ResidentResourceSourceManifest(""); ok {
+		t.Error("empty-key store must not insert")
+	}
+}
+
+// TestWorkspaceState_ResidentResourceManifest_FIFOEvictsOldest pins the bound:
+// inserting past residentResourceManifestCapacity evicts the oldest entry.
+func TestWorkspaceState_ResidentResourceManifest_FIFOEvictsOldest(t *testing.T) {
+	w := &WorkspaceState{}
+	for i := 0; i < residentResourceManifestCapacity+1; i++ {
+		w.StoreResidentResourceSourceManifest("k"+strconv.Itoa(i), manifestForTest("b"))
+	}
+	if _, ok := w.ResidentResourceSourceManifest("k0"); ok {
+		t.Error("oldest entry must be evicted past capacity")
+	}
+	for i := 1; i <= residentResourceManifestCapacity; i++ {
+		key := "k" + strconv.Itoa(i)
+		if _, ok := w.ResidentResourceSourceManifest(key); !ok {
+			t.Errorf("entry %q must remain after FIFO eviction", key)
+		}
+	}
+}
+
+// TestWorkspaceState_ResidentResourceManifest_RefreshDoesNotEvict pins the
+// re-store semantics: writing an existing key updates the value in place
+// without rotating the FIFO. This is the warm-cycle case where the same
+// path-set-addressed key is re-saved every analyze.
+func TestWorkspaceState_ResidentResourceManifest_RefreshDoesNotEvict(t *testing.T) {
+	w := &WorkspaceState{}
+	for i := 0; i < residentResourceManifestCapacity; i++ {
+		w.StoreResidentResourceSourceManifest("k"+strconv.Itoa(i), manifestForTest("orig"))
+	}
+	w.StoreResidentResourceSourceManifest("k0", manifestForTest("refreshed"))
+	got, ok := w.ResidentResourceSourceManifest("k0")
+	if !ok || got.BundleKey != "refreshed" {
+		t.Fatalf("refresh must update value in place; got ok=%v bundleKey=%q", ok, got.BundleKey)
+	}
+	for i := 0; i < residentResourceManifestCapacity; i++ {
+		key := "k" + strconv.Itoa(i)
+		if _, ok := w.ResidentResourceSourceManifest(key); !ok {
+			t.Errorf("refresh must NOT evict any entry; %q gone", key)
+		}
+	}
+}
+
+// TestWorkspaceState_ResidentResourceManifest_InvalidateAllClears verifies the
+// resident manifest mirror is dropped on InvalidateAll, so a config/rule change
+// that resets the workspace cannot serve a stale manifest into the delta path.
+func TestWorkspaceState_ResidentResourceManifest_InvalidateAllClears(t *testing.T) {
+	w := NewWorkspaceState("") // InvalidateAll touches the parsedLRU list
+	w.StoreResidentResourceSourceManifest("k", manifestForTest("b"))
+	if _, ok := w.ResidentResourceSourceManifest("k"); !ok {
+		t.Fatal("precondition: manifest should be present before InvalidateAll")
+	}
+	w.InvalidateAll()
+	if _, ok := w.ResidentResourceSourceManifest("k"); ok {
+		t.Error("InvalidateAll must clear the resident manifest mirror")
+	}
+}

--- a/internal/pipeline/workspace.go
+++ b/internal/pipeline/workspace.go
@@ -118,6 +118,27 @@ type WorkspaceState struct {
 	residentBundle      map[string]*scanner.FindingColumns
 	residentBundleOrder []string
 
+	residentResourceManifestMu sync.Mutex
+	// residentResourceManifest mirrors the on-disk resource-source bundle
+	// manifest (internal/pipeline/android_bundle.go) in daemon memory,
+	// keyed by the path-set+resource-fingerprint manifestKey. The Android
+	// delta path otherwise re-reads + JSON-decodes the full manifest
+	// (~30 ms) on every warm+ABI analyze and re-writes it synchronously
+	// (~80-125 ms on kotlin-corpus scale). Mirroring the latest saved
+	// manifest here lets the next analyze diff against it with a map
+	// lookup while the disk write happens off the warm path via
+	// EnqueueBackgroundSave.
+	//
+	// Unlike residentBundle (content-addressed, never stale), the manifest
+	// key is path-set-addressed, so the value mutates across content edits.
+	// Holding the latest saved value matches the on-disk overwrite
+	// semantics exactly — the delta path always diffs the stored hashes
+	// against this run's hashes and re-sweeps the difference, so a stale
+	// (older) entry only widens the changed set, never serves wrong
+	// findings. Bounded by residentResourceManifestCapacity.
+	residentResourceManifest      map[string]resourceSourceBundleManifest
+	residentResourceManifestOrder []string
+
 	javaSourceMu sync.Mutex
 	// javaSourceVersion is bumped on every .java watcher event. The
 	// resident javaSourceIndex slot uses it to detect whether its
@@ -762,6 +783,10 @@ func (w *WorkspaceState) InvalidateAll() {
 	w.codeIndexSnapshot = nil
 	w.codeIndexSnapshotMeta = scanner.CrossFileCacheMeta{}
 	w.codeIndexSnapshotMu.Unlock()
+	w.residentResourceManifestMu.Lock()
+	w.residentResourceManifest = nil
+	w.residentResourceManifestOrder = nil
+	w.residentResourceManifestMu.Unlock()
 }
 
 // LibraryFacts returns the cached *librarymodel.Facts when its
@@ -1086,6 +1111,57 @@ func (w *WorkspaceState) StoreResidentBundle(bundleKey string, cols *scanner.Fin
 		evict := w.residentBundleOrder[0]
 		w.residentBundleOrder = w.residentBundleOrder[1:]
 		delete(w.residentBundle, evict)
+	}
+}
+
+// residentResourceManifestCapacity caps the in-memory resource-source
+// manifest mirror. A handful of entries covers the typical warm cycle
+// across a small number of Android source sets; each entry is a path→hash
+// map that is cheap relative to a decoded FindingColumns bundle.
+const residentResourceManifestCapacity = 4
+
+// ResidentResourceSourceManifest returns the daemon-resident mirror of the
+// resource-source bundle manifest for key, or ok=false on miss. Consulted
+// by the Android delta path before the on-disk JSON read.
+// Satisfies DaemonCaches.ResidentResourceSourceManifest.
+//
+// The return type is package-private by design — callers in other packages
+// only assign this method value to the DaemonCaches hook, never name the type.
+//
+//nolint:revive // unexported-return: the manifest type is intentionally internal; this accessor is exported solely to wire the daemon hook.
+func (w *WorkspaceState) ResidentResourceSourceManifest(key string) (resourceSourceBundleManifest, bool) {
+	if w == nil || key == "" {
+		return resourceSourceBundleManifest{}, false
+	}
+	w.residentResourceManifestMu.Lock()
+	defer w.residentResourceManifestMu.Unlock()
+	m, ok := w.residentResourceManifest[key]
+	return m, ok
+}
+
+// StoreResidentResourceSourceManifest mirrors a freshly loaded or saved
+// manifest into the in-memory cache, evicting the oldest entry past
+// capacity. Re-storing an existing key refreshes the value in place.
+// Satisfies DaemonCaches.StoreResidentResourceSourceManifest.
+func (w *WorkspaceState) StoreResidentResourceSourceManifest(key string, manifest resourceSourceBundleManifest) {
+	if w == nil || key == "" {
+		return
+	}
+	w.residentResourceManifestMu.Lock()
+	defer w.residentResourceManifestMu.Unlock()
+	if w.residentResourceManifest == nil {
+		w.residentResourceManifest = make(map[string]resourceSourceBundleManifest, residentResourceManifestCapacity)
+	}
+	if _, exists := w.residentResourceManifest[key]; exists {
+		w.residentResourceManifest[key] = manifest
+		return
+	}
+	w.residentResourceManifest[key] = manifest
+	w.residentResourceManifestOrder = append(w.residentResourceManifestOrder, key)
+	for len(w.residentResourceManifestOrder) > residentResourceManifestCapacity {
+		evict := w.residentResourceManifestOrder[0]
+		w.residentResourceManifestOrder = w.residentResourceManifestOrder[1:]
+		delete(w.residentResourceManifest, evict)
 	}
 }
 


### PR DESCRIPTION
## Summary
- The Android resource-source delta path re-read (~30 ms JSON) and re-wrote (~80-125 ms, full path→hash map) the bundle manifest **synchronously on every warm+ABI analyze**, regardless of how few source files changed.
- Adds a daemon-resident manifest mirror (keyed by the path-set+resource-fingerprint `manifestKey`) and moves the disk write onto the background-save worker via `host.BackgroundSave`. The resident mirror is updated synchronously before the deferred write is enqueued, so a not-yet-flushed write never costs the next analyze a full re-sweep — only a daemon restart before the flush falls back to a recompute.
- CLI callers leave the hooks nil; the write runs inline exactly as before.

This mirrors the resident-cache + `BackgroundSave` pattern established in #607 / #611 / #612, applied to the Android-specific manifest path that those PRs did not cover.

## Correctness (#608-safe)
- The resident value holds the latest saved manifest (path-set-addressed, overwrite semantics); the delta path always diffs stored hashes against this run's hashes and re-sweeps the difference — a stale (older) entry only *widens* the changed set, never serves wrong findings.
- `manifestKey` encodes the rule hash, so a rule change shifts the key (no stale-rule serving).
- `InvalidateAll` drops the mirror.
- Every crash / async-ordering path degrades to a cache miss → full re-sweep, never stale findings.

## Test plan
- [x] `go build ./cmd/krit/`, `go vet ./...`, `golangci-lint run ./...` (0 issues)
- [x] `go test ./... -count=1` (full suite green)
- [x] New regression tests: deferred-write served from resident mirror; disk hit populates resident; nil hooks write inline; empty-input guards; WorkspaceState FIFO eviction / refresh-in-place / `InvalidateAll` reset
- [x] `make integration` — all steps green except `cmd/krit` which exceeds the harness's 60s timeout on this dev machine (passes in isolation at ~94s; unmodified package, environmental)