### PR TITLE
feat(scanner): add declsByFile forward declaration map to CodeIndex

### DIFF
--- a/internal/scanner/index.go
+++ b/internal/scanner/index.go
@@ -75,6 +75,25 @@ type CodeIndex struct {
 	nonCommentRefFilesByName     map[string]map[string]bool // name -> set of files with non-comment references
 	nonCommentRefCountByNameFile map[string]map[string]int  // name -> file -> non-comment ref count
 
+	// declsByFile maps a file path to the multiset of symbol names and
+	// FQNs it declares (name -> declaration count). It is the forward
+	// declaration map that bridges a changed file to the reference-level
+	// reverse-dependency lookup (refFilesByName): changed file ->
+	// declsByFile -> referencing files. Where refFilesByName answers "who
+	// references name N", declsByFile answers "what does file F declare",
+	// and composing the two yields the set of files whose cross-file
+	// findings could change when F changes — a #608-safe affected-set for
+	// incremental cross-file replay.
+	//
+	// It is a count multiset (not a plain set) so overloads and repeated
+	// FQNs decrement exactly on removal: a name is only dropped from a
+	// file once its last declaration is removed. Maintained alongside
+	// symbolsByName in addSymbolToLookups / removeSymbolFromLookups and so
+	// shares their stability contract — mutated only under the daemon's
+	// per-project analyze mutex, read lock-free after publish (not under
+	// refMu).
+	declsByFile map[string]map[string]int
+
 	// Bloom filter for fast "is this name referenced?" checks.
 	// False positives are OK (we fall back to exact check), false negatives are not.
 	refBloom *bloom.BloomFilter
@@ -349,6 +368,7 @@ func buildCodeIndexWithBloom(symbols []Symbol, refs []Reference, prebuilt *bloom
 		References:    refs,
 		symbolsByName: make(map[string][]Symbol),
 		symbolsByFQN:  make(map[string]Symbol),
+		declsByFile:   make(map[string]map[string]int),
 	}
 
 	if prebuilt != nil {
@@ -382,6 +402,60 @@ func (idx *CodeIndex) addSymbolToLookups(sym Symbol) {
 			idx.symbolsByName[sym.FQN] = append(idx.symbolsByName[sym.FQN], sym)
 		}
 	}
+	idx.addDeclByFile(sym)
+}
+
+// addDeclByFile records that sym.File declares sym.Name (and sym.FQN, when
+// distinct) in the forward declaration multiset. Counts are incremented so
+// overloads and repeated FQNs decrement exactly on removal. A nil declsByFile
+// (older zero-value indexes that predate this field) is tolerated by skipping.
+func (idx *CodeIndex) addDeclByFile(sym Symbol) {
+	if idx.declsByFile == nil || sym.File == "" {
+		return
+	}
+	names := idx.declsByFile[sym.File]
+	if names == nil {
+		names = make(map[string]int)
+		idx.declsByFile[sym.File] = names
+	}
+	if sym.Name != "" {
+		names[sym.Name]++
+	}
+	if sym.FQN != "" && sym.FQN != sym.Name {
+		names[sym.FQN]++
+	}
+}
+
+// removeDeclByFile is the inverse of addDeclByFile: it decrements the counts
+// for sym.Name and sym.FQN, deleting a name at count 0 and the file entry once
+// it has no remaining names. Safe to call when the entry is absent.
+func (idx *CodeIndex) removeDeclByFile(sym Symbol) {
+	if idx.declsByFile == nil || sym.File == "" {
+		return
+	}
+	names := idx.declsByFile[sym.File]
+	if names == nil {
+		return
+	}
+	if sym.Name != "" {
+		decrementName(names, sym.Name)
+	}
+	if sym.FQN != "" && sym.FQN != sym.Name {
+		decrementName(names, sym.FQN)
+	}
+	if len(names) == 0 {
+		delete(idx.declsByFile, sym.File)
+	}
+}
+
+// decrementName drops one occurrence of name from the count multiset, removing
+// the key entirely when its count reaches zero.
+func decrementName(names map[string]int, name string) {
+	if names[name] <= 1 {
+		delete(names, name)
+		return
+	}
+	names[name]--
 }
 
 // removeSymbolFromLookups deletes sym's entries from symbolsByName +
@@ -398,6 +472,7 @@ func (idx *CodeIndex) removeSymbolFromLookups(sym Symbol) {
 			dropSymbolFromSlice(idx.symbolsByName, sym.FQN, sym)
 		}
 	}
+	idx.removeDeclByFile(sym)
 }
 
 // dropSymbolFromSlice removes target from m[key] (using struct
@@ -420,6 +495,38 @@ func dropSymbolFromSlice(m map[string][]Symbol, key string, target Symbol) {
 	} else {
 		m[key] = dst
 	}
+}
+
+// rebuildDeclsByFile reconstructs declsByFile from scratch over idx.Symbols.
+// It is used by cache-unpack paths (unpackFull) that populate the symbol
+// slice and lookup maps directly without routing each symbol through
+// addSymbolToLookups, so the forward declaration multiset would otherwise be
+// empty.
+func (idx *CodeIndex) rebuildDeclsByFile() {
+	idx.declsByFile = make(map[string]map[string]int, len(idx.declsByFile))
+	for _, sym := range idx.Symbols {
+		idx.addDeclByFile(sym)
+	}
+}
+
+// DeclaredNames returns the distinct symbol names and FQNs declared in file,
+// as a freshly allocated slice (safe for the caller to retain and mutate).
+// The forward direction of the reverse-dependency lookup: compose with
+// RefFilesByName to map a changed file to the files that reference what it
+// declares. Order is unspecified. Returns nil when the file declares nothing.
+func (idx *CodeIndex) DeclaredNames(file string) []string {
+	if idx == nil || idx.declsByFile == nil {
+		return nil
+	}
+	names := idx.declsByFile[file]
+	if len(names) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(names))
+	for name := range names {
+		out = append(out, name)
+	}
+	return out
 }
 
 func (idx *CodeIndex) removeFileContributions(paths map[string]bool) {

--- a/internal/scanner/index_cache.go
+++ b/internal/scanner/index_cache.go
@@ -768,6 +768,11 @@ func (p cachePayload) unpackFull() (*CodeIndex, bool) {
 	}
 	idx.refBloom = bf
 
+	// unpackSymsByName populated symbolsByName/symbolsByFQN directly, bypassing
+	// addSymbolToLookups, so the forward declaration multiset is still empty.
+	// Rebuild it from the symbol slice now that idx.Symbols is set.
+	idx.rebuildDeclsByFile()
+
 	return idx, true
 }
 

--- a/internal/scanner/index_decls_by_file_test.go
+++ b/internal/scanner/index_decls_by_file_test.go
@@ -1,0 +1,136 @@
+package scanner
+
+import (
+	"sort"
+	"testing"
+)
+
+// sortedDeclaredNames returns DeclaredNames(file) sorted for stable comparison.
+func sortedDeclaredNames(idx *CodeIndex, file string) []string {
+	got := idx.DeclaredNames(file)
+	sort.Strings(got)
+	return got
+}
+
+func eqStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// TestDeclaredNames_BuildFromData pins the forward declaration map produced by
+// the normal build path: each file maps to the distinct names and FQNs it
+// declares. The FQN is included alongside the bare name so a changed file can
+// be matched against references by either spelling.
+func TestDeclaredNames_BuildFromData(t *testing.T) {
+	symbols := []Symbol{
+		{Name: "helperFunc", File: "a.kt", FQN: "demo.helperFunc"},
+		{Name: "HelperClass", File: "b.kt", FQN: "demo.HelperClass"},
+		{Name: "topLevel", File: "b.kt", FQN: ""}, // no FQN: name only
+	}
+	idx := BuildIndexFromData(symbols, nil)
+
+	if got, want := sortedDeclaredNames(idx, "a.kt"), []string{"demo.helperFunc", "helperFunc"}; !eqStrings(got, want) {
+		t.Errorf("a.kt declared = %v, want %v", got, want)
+	}
+	if got, want := sortedDeclaredNames(idx, "b.kt"), []string{"HelperClass", "demo.HelperClass", "topLevel"}; !eqStrings(got, want) {
+		t.Errorf("b.kt declared = %v, want %v", got, want)
+	}
+	if got := idx.DeclaredNames("missing.kt"); got != nil {
+		t.Errorf("unknown file must return nil; got %v", got)
+	}
+}
+
+// TestDeclaredNames_NilSafety verifies the accessor tolerates a nil receiver
+// and a zero-value index without a declsByFile map.
+func TestDeclaredNames_NilSafety(t *testing.T) {
+	var idx *CodeIndex
+	if got := idx.DeclaredNames("a.kt"); got != nil {
+		t.Errorf("nil receiver must return nil; got %v", got)
+	}
+	if got := (&CodeIndex{}).DeclaredNames("a.kt"); got != nil {
+		t.Errorf("zero-value index must return nil; got %v", got)
+	}
+}
+
+// TestDeclaredNames_FreshCopy verifies the returned slice is owned by the
+// caller: mutating it must not corrupt the internal multiset.
+func TestDeclaredNames_FreshCopy(t *testing.T) {
+	idx := BuildIndexFromData([]Symbol{{Name: "f", File: "a.kt"}}, nil)
+	got := idx.DeclaredNames("a.kt")
+	if len(got) != 1 {
+		t.Fatalf("expected 1 name, got %v", got)
+	}
+	got[0] = "mutated"
+	if again := idx.DeclaredNames("a.kt"); len(again) != 1 || again[0] != "f" {
+		t.Errorf("mutating returned slice corrupted internal state: %v", again)
+	}
+}
+
+// TestDeclaredNames_IncrementalAddRemove pins the exact-count multiset
+// behavior across the incremental overlay path: overloads sharing a name must
+// require exactly as many removals as additions before the name disappears.
+func TestDeclaredNames_IncrementalAddRemove(t *testing.T) {
+	// Two overloads of overloaded() in a.kt — same Name, distinct FQN/Arity.
+	base := BuildIndexFromData([]Symbol{
+		{Name: "overloaded", File: "a.kt", FQN: "demo.overloaded", Arity: 0},
+		{Name: "overloaded", File: "a.kt", FQN: "demo.overloaded", Arity: 1},
+		{Name: "keep", File: "a.kt", FQN: "demo.keep"},
+	}, nil)
+
+	// Whole-file removal must drop every name for the file.
+	idx := BuildIndexIncremental(base, map[string]bool{"a.kt": true}, nil, nil)
+	if got := idx.DeclaredNames("a.kt"); got != nil {
+		t.Fatalf("whole-file removal must clear declarations; got %v", got)
+	}
+
+	// Re-add the same overload set, then verify the name survives one removal.
+	idx = BuildIndexIncremental(idx, nil, []Symbol{
+		{Name: "overloaded", File: "a.kt", FQN: "demo.overloaded", Arity: 0},
+		{Name: "overloaded", File: "a.kt", FQN: "demo.overloaded", Arity: 1},
+	}, nil)
+	// removeFileContributions is whole-file; exercise the per-symbol decrement
+	// directly to prove the count multiset, which the affected-set needs when a
+	// single overload is dropped from a still-present file.
+	idx.removeSymbolFromLookups(Symbol{Name: "overloaded", File: "a.kt", FQN: "demo.overloaded", Arity: 0})
+	if got, want := sortedDeclaredNames(idx, "a.kt"), []string{"demo.overloaded", "overloaded"}; !eqStrings(got, want) {
+		t.Errorf("after dropping one overload, name must remain; got %v want %v", got, want)
+	}
+	idx.removeSymbolFromLookups(Symbol{Name: "overloaded", File: "a.kt", FQN: "demo.overloaded", Arity: 1})
+	if got := idx.DeclaredNames("a.kt"); got != nil {
+		t.Errorf("after dropping both overloads, file must be empty; got %v", got)
+	}
+}
+
+// TestDeclaredNames_CacheRoundTrip verifies the forward map is reconstructed by
+// the warm cache-unpack path (unpackFull), which populates the lookup maps
+// directly and so relies on rebuildDeclsByFile.
+func TestDeclaredNames_CacheRoundTrip(t *testing.T) {
+	symbols := []Symbol{
+		{Name: "helperFunc", Kind: "function", Visibility: "public", File: "a.kt", Line: 10, StartByte: 3, EndByte: 18, Language: LangKotlin, Package: "demo", FQN: "demo.helperFunc", Signature: "<package>#helperFunc/0"},
+		{Name: "HelperClass", Kind: "class", Visibility: "internal", File: "b.kt", Line: 2, StartByte: 0, EndByte: 12, Language: LangJava, Package: "demo", FQN: "demo.HelperClass", Signature: "demo.HelperClass", IsFinal: true},
+	}
+	refs := []Reference{
+		{Name: "helperFunc", File: "a.kt", Line: 10},
+		{Name: "HelperClass", File: "c.kt", Line: 7},
+	}
+
+	src := BuildIndexFromData(symbols, refs)
+	payload := packPayloadWithIndex(src)
+	idx, ok := payload.unpackFull()
+	if !ok {
+		t.Fatalf("unpackFull failed")
+	}
+	if got, want := sortedDeclaredNames(idx, "a.kt"), []string{"demo.helperFunc", "helperFunc"}; !eqStrings(got, want) {
+		t.Errorf("a.kt declared after round-trip = %v, want %v", got, want)
+	}
+	if got, want := sortedDeclaredNames(idx, "b.kt"), []string{"HelperClass", "demo.HelperClass"}; !eqStrings(got, want) {
+		t.Errorf("b.kt declared after round-trip = %v, want %v", got, want)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `declsByFile`, a count-multiset `map[file]→map[name]→count` on `CodeIndex` recording the symbol names and FQNs each file declares.
- Maintained alongside `symbolsByName` in `addSymbolToLookups` / `removeSymbolFromLookups` (so the incremental overlay and whole-file-removal paths stay exact), initialized in `buildCodeIndexWithBloom`, and reconstructed via `rebuildDeclsByFile()` on the warm cache-unpack path (`unpackFull`), which populates the lookup maps directly.
- Exposes `DeclaredNames(file string) []string` returning a fresh-copy slice of the distinct names+FQNs a file declares.

## Why
This is the forward half of a reference-level reverse-dependency lookup. Composing `DeclaredNames(file)` with the existing `refFilesByName` ("who references name N") yields the set of files whose cross-file findings could change when a file changes — the foundation for a #608-safe affected-set used by incremental cross-file replay. First of a 3-PR sequence; this PR is purely additive with no behavior change.

## Correctness notes
- Count multiset (not a plain set) so overloads / repeated FQNs decrement exactly: a name is dropped from a file only when its last declaration is removed. This is #608-safe — a still-declared name is never lost.
- Shares `symbolsByName`'s publish-time stability contract: mutated only under the daemon's per-project analyze mutex, read lock-free after publish. No new mutex.
- All `CodeIndex` construction paths covered: fresh build, incremental overlay, whole-file removal, and cache round-trip.

## Test plan
- [x] `go build ./... && go vet ./... && golangci-lint run ./internal/scanner/` clean
- [x] New unit tests: build-from-data, nil safety, fresh-copy ownership, incremental add/remove with exact overload decrement, cache round-trip via `unpackFull`
- [x] `go test ./... -count=1` passes
- [x] `make integration` — only `cmd/krit` end-to-end exceeds the 60s harness cap under load (passes in isolation at 71s); not a regression (change is `internal/scanner`-only, additive)