### PR TITLE
feat(scanner): add AffectedSet for #608-safe incremental cross-file replay

### DIFF
--- a/internal/scanner/affected_set.go
+++ b/internal/scanner/affected_set.go
@@ -1,0 +1,98 @@
+package scanner
+
+// AffectedSet computes a conservative, #608-safe superset of the files whose
+// cross-file findings could change when changedFiles change, given the prior
+// (pre-edit) and current (post-edit) code indexes.
+//
+// The returned set always includes changedFiles themselves, plus — computed
+// against BOTH the prior and current index — for every changed file B:
+//
+//   - declaration -> referrers: every file that references a name B declares.
+//     If B's declaration changed or was removed, those referrers may resolve
+//     differently or flip a finding.
+//   - reference -> declarers: every file that declares a name B references.
+//     If B added or removed a reference, a declaring file's finding may flip
+//     (e.g. an unused-declaration rule whose only use was in B).
+//
+// Unioning over both indexes is essential for correctness. An edit that
+// REMOVES a declaration or reference leaves no trace in the current index, so
+// the dependents that must be re-analyzed are only discoverable through the
+// prior index. Conversely an edit that ADDS one is only in the current index.
+// Including both never drops a real dependent; it only over-approximates,
+// which is safe (the affected files are re-dispatched, never served stale).
+//
+// Either index may be nil — a cold start has no prior, and a degenerate call
+// may have no current. Nil indexes contribute nothing. Empty changedFiles
+// yields nil. The result order is unspecified.
+func AffectedSet(prior, current *CodeIndex, changedFiles []string) []string {
+	if len(changedFiles) == 0 {
+		return nil
+	}
+	changed := make(map[string]bool, len(changedFiles))
+	affected := make(map[string]bool, len(changedFiles))
+	for _, f := range changedFiles {
+		if f == "" {
+			continue
+		}
+		changed[f] = true
+		affected[f] = true
+	}
+	if len(changed) == 0 {
+		return nil
+	}
+
+	for _, idx := range []*CodeIndex{prior, current} {
+		if idx == nil {
+			continue
+		}
+		idx.collectAffected(changed, affected)
+	}
+
+	out := make([]string, 0, len(affected))
+	for f := range affected {
+		out = append(out, f)
+	}
+	return out
+}
+
+// collectAffected adds, into affected, every file related to one of the
+// changed files through this index's declaration/reference tables, in both
+// dependency directions. See AffectedSet for the directionality and the
+// #608-safety argument.
+func (idx *CodeIndex) collectAffected(changed, affected map[string]bool) {
+	// Direction 1: declaration -> referrers.
+	for file := range changed {
+		for _, name := range idx.DeclaredNames(file) {
+			for ref := range idx.ReferenceFiles(name) {
+				affected[ref] = true
+			}
+		}
+	}
+
+	// Direction 2: reference -> declarers.
+	for name := range idx.referencedNamesInFiles(changed) {
+		for _, sym := range idx.SymbolsNamed(name) {
+			if sym.File != "" {
+				affected[sym.File] = true
+			}
+		}
+	}
+}
+
+// referencedNamesInFiles returns the set of names referenced by any file in
+// the given set, scanning the reference table once. The reference slice is
+// read lock-free: like the symbol lookup maps it is stable for the lifetime of
+// a published index, and AffectedSet's current-index argument is owned by the
+// analyzing goroutine until publish.
+func (idx *CodeIndex) referencedNamesInFiles(files map[string]bool) map[string]bool {
+	if idx == nil || len(files) == 0 {
+		return nil
+	}
+	names := make(map[string]bool)
+	for _, ref := range idx.References {
+		if files[ref.File] {
+			names[ref.Name] = true
+		}
+	}
+	return names
+}

--- a/internal/scanner/affected_set_test.go
+++ b/internal/scanner/affected_set_test.go
@@ -1,0 +1,166 @@
+package scanner
+
+import (
+	"sort"
+	"testing"
+)
+
+func affectedSetSorted(prior, current *CodeIndex, changed []string) []string {
+	got := AffectedSet(prior, current, changed)
+	sort.Strings(got)
+	return got
+}
+
+func hasFile(set []string, f string) bool {
+	for _, s := range set {
+		if s == f {
+			return true
+		}
+	}
+	return false
+}
+
+// TestAffectedSet_DeclarationToReferrers pins direction 1: when a changed file
+// declares a name, every file that references that name is affected.
+func TestAffectedSet_DeclarationToReferrers(t *testing.T) {
+	// b.kt declares S; a.kt and c.kt reference S; d.kt is unrelated.
+	syms := []Symbol{{Name: "S", File: "b.kt", FQN: "demo.S"}}
+	refs := []Reference{
+		{Name: "S", File: "a.kt"},
+		{Name: "S", File: "c.kt"},
+		{Name: "Unrelated", File: "d.kt"},
+	}
+	idx := BuildIndexFromData(syms, refs)
+
+	got := affectedSetSorted(idx, idx, []string{"b.kt"})
+	for _, want := range []string{"a.kt", "b.kt", "c.kt"} {
+		if !hasFile(got, want) {
+			t.Errorf("affected must include %q (declaration->referrers); got %v", want, got)
+		}
+	}
+	if hasFile(got, "d.kt") {
+		t.Errorf("unrelated file d.kt must not be affected; got %v", got)
+	}
+}
+
+// TestAffectedSet_ReferenceToDeclarers pins direction 2: when a changed file
+// references a name, every file that declares that name is affected. This is
+// the unused-declaration-flip case — the declaring file's finding can change
+// even though it was not itself edited.
+func TestAffectedSet_ReferenceToDeclarers(t *testing.T) {
+	// a.kt declares S; b.kt (changed) references S.
+	syms := []Symbol{{Name: "S", File: "a.kt", FQN: "demo.S"}}
+	refs := []Reference{{Name: "S", File: "b.kt"}}
+	idx := BuildIndexFromData(syms, refs)
+
+	got := affectedSetSorted(idx, idx, []string{"b.kt"})
+	if !hasFile(got, "a.kt") {
+		t.Errorf("affected must include declaring file a.kt (reference->declarers); got %v", got)
+	}
+}
+
+// TestAffectedSet_RemovedReferenceUsesPrior is the critical #608 case: the
+// changed file B *removed* its only reference to S (declared in A). The current
+// index no longer links B to S, so only the PRIOR index reveals that A's
+// finding (e.g. "S is unused") could flip. AffectedSet must consult prior.
+func TestAffectedSet_RemovedReferenceUsesPrior(t *testing.T) {
+	// prior: a.kt declares S, b.kt references S.
+	prior := BuildIndexFromData(
+		[]Symbol{{Name: "S", File: "a.kt", FQN: "demo.S"}},
+		[]Reference{{Name: "S", File: "b.kt"}},
+	)
+	// current: a.kt still declares S, b.kt no longer references it.
+	current := BuildIndexFromData(
+		[]Symbol{{Name: "S", File: "a.kt", FQN: "demo.S"}},
+		nil,
+	)
+
+	got := affectedSetSorted(prior, current, []string{"b.kt"})
+	if !hasFile(got, "a.kt") {
+		t.Errorf("removed reference must still affect the declaring file via prior; got %v", got)
+	}
+
+	// Sanity: current-only would MISS a.kt, demonstrating why prior is required.
+	currentOnly := AffectedSet(nil, current, []string{"b.kt"})
+	if hasFile(currentOnly, "a.kt") {
+		t.Errorf("precondition: current-only should not reach a.kt; got %v", currentOnly)
+	}
+}
+
+// TestAffectedSet_RemovedDeclarationUsesPrior covers the mirror case: the
+// changed file B *removed* a declaration of S that A referenced. Only prior
+// links B's declaration to A, so prior must be consulted.
+func TestAffectedSet_RemovedDeclarationUsesPrior(t *testing.T) {
+	// prior: b.kt declares S, a.kt references S.
+	prior := BuildIndexFromData(
+		[]Symbol{{Name: "S", File: "b.kt", FQN: "demo.S"}},
+		[]Reference{{Name: "S", File: "a.kt"}},
+	)
+	// current: b.kt no longer declares S; a.kt's (now dangling) reference remains.
+	current := BuildIndexFromData(
+		nil,
+		[]Reference{{Name: "S", File: "a.kt"}},
+	)
+
+	got := affectedSetSorted(prior, current, []string{"b.kt"})
+	if !hasFile(got, "a.kt") {
+		t.Errorf("removed declaration must still affect the referencing file via prior; got %v", got)
+	}
+}
+
+// TestAffectedSet_AddedReferenceUsesCurrent confirms the current index covers
+// the add case symmetrically: B added a reference to S declared in A.
+func TestAffectedSet_AddedReferenceUsesCurrent(t *testing.T) {
+	prior := BuildIndexFromData(
+		[]Symbol{{Name: "S", File: "a.kt", FQN: "demo.S"}},
+		nil,
+	)
+	current := BuildIndexFromData(
+		[]Symbol{{Name: "S", File: "a.kt", FQN: "demo.S"}},
+		[]Reference{{Name: "S", File: "b.kt"}},
+	)
+	got := affectedSetSorted(prior, current, []string{"b.kt"})
+	if !hasFile(got, "a.kt") {
+		t.Errorf("added reference must affect the declaring file via current; got %v", got)
+	}
+}
+
+// TestAffectedSet_FQNMatch verifies a reference written as the FQN still links
+// to the declaring file, since declsByFile records both the bare name and FQN.
+func TestAffectedSet_FQNMatch(t *testing.T) {
+	syms := []Symbol{{Name: "S", File: "b.kt", FQN: "demo.S"}}
+	refs := []Reference{{Name: "demo.S", File: "a.kt"}}
+	idx := BuildIndexFromData(syms, refs)
+
+	got := affectedSetSorted(idx, idx, []string{"b.kt"})
+	if !hasFile(got, "a.kt") {
+		t.Errorf("FQN-spelled reference must be linked to declaration; got %v", got)
+	}
+}
+
+// TestAffectedSet_EdgeCases pins the degenerate inputs.
+func TestAffectedSet_EdgeCases(t *testing.T) {
+	idx := BuildIndexFromData([]Symbol{{Name: "S", File: "a.kt"}}, nil)
+
+	if got := AffectedSet(idx, idx, nil); got != nil {
+		t.Errorf("nil changedFiles must return nil; got %v", got)
+	}
+	if got := AffectedSet(idx, idx, []string{""}); got != nil {
+		t.Errorf("empty-string-only changedFiles must return nil; got %v", got)
+	}
+	if got := AffectedSet(nil, nil, []string{"x.kt"}); !hasFile(got, "x.kt") || len(got) != 1 {
+		t.Errorf("nil indexes must still echo the changed file; got %v", got)
+	}
+}
+
+// TestAffectedSet_AlwaysIncludesChanged guarantees the changed files are always
+// in the result, even when they neither declare nor reference anything indexed.
+func TestAffectedSet_AlwaysIncludesChanged(t *testing.T) {
+	idx := BuildIndexFromData([]Symbol{{Name: "Other", File: "z.kt"}}, nil)
+	got := affectedSetSorted(idx, idx, []string{"new.kt", "new2.kt"})
+	for _, want := range []string{"new.kt", "new2.kt"} {
+		if !hasFile(got, want) {
+			t.Errorf("changed file %q must always be present; got %v", want, got)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `scanner.AffectedSet(prior, current *CodeIndex, changedFiles []string) []string` — a pure function computing a conservative superset of files whose cross-file findings could change when `changedFiles` change.
- For each changed file it follows two dependency directions against **both** the prior (pre-edit) and current (post-edit) index:
  - **declaration → referrers**: `DeclaredNames(file)` (PR #615) composed with `ReferenceFiles(name)`
  - **reference → declarers**: referenced names composed with `SymbolsNamed(name)`
- No pipeline wiring — this is the building block; PR3 wires it into warm+ABI behind a default-OFF flag.

## Why both indexes
Unioning over prior and current is what makes it #608-safe. An edit that **removes** a declaration or reference leaves no trace in the current index, so the dependents that must be re-analyzed (e.g. a file whose "unused declaration" finding flips because the changed file dropped its only reference) are only discoverable through the prior index. Including both never drops a real dependent; it only over-approximates, and over-approximation is safe — extra files are re-dispatched, never served stale.

## Test plan
- [x] `go build ./... && go vet ./... && golangci-lint run ./internal/scanner/` clean
- [x] Adversarial unit tests: declaration→referrers, reference→declarers, **removed reference uses prior**, **removed declaration uses prior**, added reference uses current, FQN-spelled reference, degenerate inputs (nil/empty), changed files always present
- [x] `go test ./... -count=1` passes
- [x] `make integration` — only `cmd/krit` end-to-end exceeds the 60s harness cap under load (passes in isolation at ~71s); not a regression (change is `internal/scanner`-only, additive, no pipeline wiring)