### PR TITLE
perf(pipeline): opt-in affected-set replay dispatch for warm+ABI

### DIFF
--- a/internal/pipeline/affected_set_dispatch_test.go
+++ b/internal/pipeline/affected_set_dispatch_test.go
@@ -1,0 +1,111 @@
+package pipeline
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/kaeawc/krit/internal/scanner"
+)
+
+// TestAffectedSetReplayEnabled_DefaultOff pins the opt-in contract: the
+// affected-set replay path is OFF unless KRIT_AFFECTED_SET_REPLAY is set to a
+// recognized truthy value.
+func TestAffectedSetReplayEnabled_DefaultOff(t *testing.T) {
+	t.Setenv("KRIT_AFFECTED_SET_REPLAY", "")
+	if affectedSetReplayEnabled() {
+		t.Errorf("replay must be OFF when the env var is empty")
+	}
+
+	for _, v := range []string{"0", "off", "false", "no", "nope", " "} {
+		t.Setenv("KRIT_AFFECTED_SET_REPLAY", v)
+		if affectedSetReplayEnabled() {
+			t.Errorf("replay must be OFF for %q", v)
+		}
+	}
+
+	for _, v := range []string{"1", "true", "on", "yes", "TRUE", "On", " yes "} {
+		t.Setenv("KRIT_AFFECTED_SET_REPLAY", v)
+		if !affectedSetReplayEnabled() {
+			t.Errorf("replay must be ON for %q", v)
+		}
+	}
+}
+
+// TestScopeParseResultMulti narrows the parse result to the requested paths,
+// preserving language routing and dropping everything else.
+func TestScopeParseResultMulti(t *testing.T) {
+	kt1 := &scanner.File{Path: "a.kt", Language: scanner.LangKotlin}
+	kt2 := &scanner.File{Path: "b.kt", Language: scanner.LangKotlin}
+	jv1 := &scanner.File{Path: "C.java", Language: scanner.LangJava}
+	jv2 := &scanner.File{Path: "D.java", Language: scanner.LangJava}
+	p := ParseResult{
+		KotlinFiles: []*scanner.File{kt1, kt2, nil},
+		JavaFiles:   []*scanner.File{jv1, jv2},
+	}
+
+	scoped := scopeParseResultMulti(p, map[string]bool{"a.kt": true, "D.java": true})
+
+	gotKt := pathsOf(scoped.KotlinFiles)
+	if len(gotKt) != 1 || gotKt[0] != "a.kt" {
+		t.Errorf("kotlin scoped = %v, want [a.kt]", gotKt)
+	}
+	gotJv := pathsOf(scoped.JavaFiles)
+	if len(gotJv) != 1 || gotJv[0] != "D.java" {
+		t.Errorf("java scoped = %v, want [D.java]", gotJv)
+	}
+}
+
+// TestScopeParseResultMulti_EmptyPaths returns an empty parse result when no
+// paths are requested.
+func TestScopeParseResultMulti_EmptyPaths(t *testing.T) {
+	p := ParseResult{
+		KotlinFiles: []*scanner.File{{Path: "a.kt", Language: scanner.LangKotlin}},
+		JavaFiles:   []*scanner.File{{Path: "C.java", Language: scanner.LangJava}},
+	}
+	scoped := scopeParseResultMulti(p, nil)
+	if len(scoped.KotlinFiles) != 0 || len(scoped.JavaFiles) != 0 {
+		t.Errorf("empty paths must yield no files; got kt=%v java=%v",
+			pathsOf(scoped.KotlinFiles), pathsOf(scoped.JavaFiles))
+	}
+}
+
+// TestAllAffectedFilesParsed is the #608 gate: the affected-set replay path
+// must bail unless every affected file is present in the (warm, dirty-only)
+// parse result. An affected reverse-dependency that was not re-parsed cannot
+// be re-dispatched, so ApplyDelta would drop its prior rows with no
+// replacement — losing findings.
+func TestAllAffectedFilesParsed(t *testing.T) {
+	p := ParseResult{
+		KotlinFiles: []*scanner.File{
+			{Path: "a.kt", Language: scanner.LangKotlin},
+			nil,
+		},
+		JavaFiles: []*scanner.File{{Path: "C.java", Language: scanner.LangJava}},
+	}
+
+	if !allAffectedFilesParsed(p, []string{"a.kt", "C.java"}) {
+		t.Errorf("all affected files present must report true")
+	}
+	if !allAffectedFilesParsed(p, nil) {
+		t.Errorf("empty affected set must report true (nothing to dispatch)")
+	}
+	// A non-dirty dependent (b.kt) that was not re-parsed must fail the gate.
+	if allAffectedFilesParsed(p, []string{"a.kt", "b.kt"}) {
+		t.Errorf("affected file missing from parse result must report false")
+	}
+	// An XML referrer is never in Kotlin/Java parse files -> must fail.
+	if allAffectedFilesParsed(p, []string{"layout.xml"}) {
+		t.Errorf("XML referrer not in parse result must report false")
+	}
+}
+
+func pathsOf(files []*scanner.File) []string {
+	out := make([]string, 0, len(files))
+	for _, f := range files {
+		if f != nil {
+			out = append(out, f.Path)
+		}
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/pipeline/project.go
+++ b/internal/pipeline/project.go
@@ -1819,6 +1819,26 @@ func runDispatchOrLoadBundle(
 			recordDispatchPath("cacheHitDeltaBundle")
 			return deltaD, deltaC, false, dispatchTimings{}, nil
 		}
+		// cacheHitAffectedSetBundle: the single-file delta planner declined
+		// (multi-file edit, or an ABI change that drifts the CrossFile
+		// fingerprint), but the reference-level reverse-dependency index can
+		// still bound the work. Re-dispatch only the #608-safe affected set
+		// and ApplyDelta against the prior bundle. Opt-in
+		// (KRIT_AFFECTED_SET_REPLAY) and #608 gated inside.
+		asStart := time.Now()
+		asD, asC, asOK, asErr := tryAffectedSetDispatch(ctx, args, host, indexResult, parseResult, manifest)
+		asOutcome := "miss"
+		if asOK {
+			asOutcome = "hit"
+		}
+		perf.AddEntryDetails(tracker, "dispatchAffectedSetPath", time.Since(asStart), nil, map[string]string{"outcome": asOutcome})
+		if asErr != nil {
+			return DispatchResult{}, CrossFileResult{}, false, dispatchTimings{}, asErr
+		}
+		if asOK {
+			recordDispatchPath("cacheHitAffectedSetBundle")
+			return asD, asC, false, dispatchTimings{}, nil
+		}
 	}
 	dispatchStart := time.Now()
 	d, err := DispatchPhase{}.Run(ctx, indexResult)
@@ -2749,6 +2769,181 @@ func scopeParseResult(p ParseResult, only *scanner.File) ParseResult {
 		scoped.KotlinFiles = []*scanner.File{only}
 	}
 	return scoped
+}
+
+// scopeParseResultMulti returns a copy of p with KotlinFiles + JavaFiles
+// narrowed to those present in paths. It is the multi-file companion of
+// scopeParseResult, used by the affected-set replay path: per-file rules
+// re-run for every affected file (changed files plus their reverse-dependency
+// declarers/referrers) so the regenerated findings are complete for the set
+// ApplyDelta replaces. IndexResult.CodeIndex retains the full project index.
+func scopeParseResultMulti(p ParseResult, paths map[string]bool) ParseResult {
+	scoped := p
+	scoped.KotlinFiles = nil
+	scoped.JavaFiles = nil
+	if len(paths) == 0 {
+		return scoped
+	}
+	for _, f := range p.KotlinFiles {
+		if f != nil && paths[f.Path] {
+			scoped.KotlinFiles = append(scoped.KotlinFiles, f)
+		}
+	}
+	for _, f := range p.JavaFiles {
+		if f != nil && paths[f.Path] {
+			scoped.JavaFiles = append(scoped.JavaFiles, f)
+		}
+	}
+	return scoped
+}
+
+// allAffectedFilesParsed reports whether every path in affected is present in
+// p's Kotlin or Java files. It backs invariant 2 of tryAffectedSetDispatch: an
+// affected file that was not re-parsed cannot be re-dispatched, so its prior
+// findings would be dropped without replacement.
+func allAffectedFilesParsed(p ParseResult, affected []string) bool {
+	parsed := make(map[string]bool, len(p.KotlinFiles)+len(p.JavaFiles))
+	for _, f := range p.KotlinFiles {
+		if f != nil {
+			parsed[f.Path] = true
+		}
+	}
+	for _, f := range p.JavaFiles {
+		if f != nil {
+			parsed[f.Path] = true
+		}
+	}
+	for _, f := range affected {
+		if !parsed[f] {
+			return false
+		}
+	}
+	return true
+}
+
+// affectedSetReplayEnabled reports whether the opt-in affected-set replay
+// dispatch path is turned on. Default OFF: the path is conservative and #608
+// gated, but it is new, so it ships behind KRIT_AFFECTED_SET_REPLAY until it
+// has soaked. Any of 1/true/on/yes (case-insensitive) enables it.
+func affectedSetReplayEnabled() bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("KRIT_AFFECTED_SET_REPLAY"))) {
+	case "1", "true", "on", "yes":
+		return true
+	default:
+		return false
+	}
+}
+
+// tryAffectedSetDispatch generalizes tryDeltaDispatch from a single changed
+// file to the multi-file warm+ABI regime. The conservative delta planner only
+// fires for exactly one changed file with every fingerprint stable; an ABI
+// edit drifts the CrossFile fingerprint, so delta misses and we would
+// otherwise pay a full DispatchPhase. Instead we compute a #608-safe affected
+// set from the reference-level reverse-dependency index and re-dispatch only
+// those files, merging against the prior findings bundle with ApplyDelta.
+//
+// Correctness rests on two invariants:
+//
+//  1. AffectedSetIncremental returns a true superset of every file whose
+//     findings can change. That requires the prior edges the edit removed,
+//     captured on the current index by the incremental overlay build
+//     (LastRemovedContributions). When the index did not go through that path
+//     (full build) LastRemovedContributions is nil and we must not run — a
+//     removed reference would be invisible and we could drop a declaring
+//     file's flipped finding. The nil gate below enforces this.
+//
+//  2. Every affected file is re-dispatched, so its regenerated findings fully
+//     replace the prior rows ApplyDelta drops. On the warm daemon path
+//     parseResult holds only the dirty (cache-miss) files, so an affected
+//     reverse-dependency declarer/referrer (or an XML referrer) that was not
+//     re-parsed cannot be re-dispatched — yet ApplyDelta would still drop its
+//     prior rows, silently losing findings (#608). The parsed-availability
+//     gate below bails to full dispatch unless every affected file is present
+//     in parseResult. In practice this restricts the path to edits whose
+//     affected set is contained in the changed (dirty) set — still a win over
+//     full dispatch, and unconditionally safe.
+func tryAffectedSetDispatch(
+	ctx context.Context,
+	args ProjectArgs,
+	host ProjectHostState,
+	indexResult IndexResult,
+	parseResult ParseResult,
+	manifest deltaManifestData,
+) (DispatchResult, CrossFileResult, bool, error) {
+	if !affectedSetReplayEnabled() {
+		return DispatchResult{}, CrossFileResult{}, false, nil
+	}
+	if !manifest.enabled || manifest.manifestKey == "" {
+		return DispatchResult{}, CrossFileResult{}, false, nil
+	}
+	current := indexResult.CodeIndex
+	if current == nil {
+		return DispatchResult{}, CrossFileResult{}, false, nil
+	}
+	// #608 gate: only safe when the current index carries the edges the edit
+	// removed. A nil here means a full build (no overlay), where a removed
+	// reference is unrecoverable and the affected set could miss a flip.
+	removed := current.LastRemovedContributions()
+	if removed == nil {
+		return DispatchResult{}, CrossFileResult{}, false, nil
+	}
+	prior, ok := loadBundleManifest(host, manifest.manifestKey)
+	if !ok {
+		return DispatchResult{}, CrossFileResult{}, false, nil
+	}
+	changedPaths := diffContentHashes(prior.ContentHashes, manifest.contentHashes)
+	if len(changedPaths) == 0 {
+		return DispatchResult{}, CrossFileResult{}, false, nil
+	}
+	priorBundle, ok := host.FindingsBundleStore.Load(host.FindingsBundleCacheRoot, prior.Fingerprint)
+	if !ok || priorBundle == nil {
+		return DispatchResult{}, CrossFileResult{}, false, nil
+	}
+
+	affected := scanner.AffectedSetIncremental(current, changedPaths, removed)
+	if len(affected) == 0 {
+		return DispatchResult{}, CrossFileResult{}, false, nil
+	}
+	// Perf gate: if the affected set spans most of the project, full dispatch
+	// is about as cheap. Use the prior manifest's file set as the denominator
+	// (warm parseResult holds only dirty files).
+	total := len(prior.ContentHashes)
+	if total == 0 || len(affected)*2 > total {
+		return DispatchResult{}, CrossFileResult{}, false, nil
+	}
+
+	affectedSet := make(map[string]bool, len(affected))
+	for _, f := range affected {
+		affectedSet[f] = true
+	}
+
+	// Parsed-availability gate (invariant 2): every affected file must be in
+	// the warm parseResult so it is re-dispatched and its findings regenerated.
+	// If any affected file (a non-dirty dependent, or an XML referrer) was not
+	// re-parsed, bail — ApplyDelta would otherwise drop its prior rows with no
+	// replacement.
+	if !allAffectedFilesParsed(parseResult, affected) {
+		return DispatchResult{}, CrossFileResult{}, false, nil
+	}
+
+	scoped := indexResult
+	scoped.ParseResult = scopeParseResultMulti(parseResult, affectedSet)
+	d, err := DispatchPhase{}.Run(ctx, scoped)
+	if err != nil {
+		return DispatchResult{}, CrossFileResult{}, false, fmt.Errorf("dispatch (affected-set): %w", err)
+	}
+	c, err := CrossFilePhase{Workers: args.Workers}.Run(ctx, d)
+	if err != nil {
+		return DispatchResult{}, CrossFileResult{}, false, fmt.Errorf("crossfile (affected-set): %w", err)
+	}
+
+	replacement := scanner.FilterColumnsByFilePaths(&c.Findings, affectedSet)
+	merged := scanner.ApplyDelta(priorBundle, &replacement, affected)
+
+	d.Findings = merged
+	c.DispatchResult = d
+	c.Findings = merged
+	return d, c, true, nil
 }
 
 // computeRunFingerprint builds a scanner.RunFingerprint from the run's

--- a/internal/scanner/affected_set_incremental.go
+++ b/internal/scanner/affected_set_incremental.go
@@ -1,0 +1,175 @@
+package scanner
+
+// PriorRemovedContributions records, per file, the symbol names/FQNs a file
+// declared and the names it referenced in the prior index, captured just
+// before an incremental rebuild removed those contributions.
+//
+// It exists because the daemon mutates the prior CodeIndex in place
+// (BuildIndexIncremental adopts and rewrites the resident snapshot), so by the
+// time dispatch runs, the edges an edit DELETED are gone from the index. Those
+// removed edges are exactly what AffectedSetIncremental needs to stay
+// #608-safe: an edit that deletes file B's only reference to symbol S must
+// still re-analyze the file that declares S (its "S is unused" finding can
+// flip), and that link is only discoverable from B's prior references.
+type PriorRemovedContributions struct {
+	// Declared maps a file path to the distinct names/FQNs it declared in
+	// the prior index.
+	Declared map[string][]string
+	// Referenced maps a file path to the distinct names it referenced in
+	// the prior index.
+	Referenced map[string][]string
+}
+
+// SnapshotRemovedContributions records the declared and referenced names that
+// the given files contribute to idx. Call it on the PRIOR index immediately
+// before BuildIndexIncremental removes those files' contributions. The cost is
+// bounded by the changed files' symbol/reference counts (a handful of files
+// per edit), so it is cheap enough to capture unconditionally.
+func (idx *CodeIndex) SnapshotRemovedContributions(files map[string]bool) PriorRemovedContributions {
+	out := PriorRemovedContributions{
+		Declared:   make(map[string][]string),
+		Referenced: make(map[string][]string),
+	}
+	if idx == nil || len(files) == 0 {
+		return out
+	}
+	for f := range files {
+		if names := idx.DeclaredNames(f); len(names) > 0 {
+			out.Declared[f] = names
+		}
+	}
+	// Referenced names per file: single pass over the reference slice,
+	// bucketed by the changed-file set.
+	perFile := make(map[string]map[string]bool)
+	for _, ref := range idx.References {
+		if !files[ref.File] {
+			continue
+		}
+		set := perFile[ref.File]
+		if set == nil {
+			set = make(map[string]bool)
+			perFile[ref.File] = set
+		}
+		set[ref.Name] = true
+	}
+	for f, set := range perFile {
+		names := make([]string, 0, len(set))
+		for n := range set {
+			names = append(names, n)
+		}
+		out.Referenced[f] = names
+	}
+	return out
+}
+
+// setLastRemoved stashes the prior removed contributions on the index. Called
+// by the incremental overlay build after BuildIndexIncremental mutates the
+// prior in place.
+func (idx *CodeIndex) setLastRemoved(removed PriorRemovedContributions) {
+	if idx == nil {
+		return
+	}
+	r := removed
+	idx.lastRemoved = &r
+}
+
+// LastRemovedContributions returns the contributions dropped by the most
+// recent incremental rebuild that produced this index, or nil when the index
+// came from a full build (nothing removed) or never went through the overlay
+// path. The pipeline reads it to compute a #608-safe affected set.
+func (idx *CodeIndex) LastRemovedContributions() *PriorRemovedContributions {
+	if idx == nil {
+		return nil
+	}
+	return idx.lastRemoved
+}
+
+// AffectedSetIncremental computes a conservative, #608-safe superset of the
+// files whose cross-file findings could change when changedFiles change, given
+// the post-edit (current) index and the prior contributions the edit removed.
+//
+// It is the daemon-path companion to AffectedSet, which needs a full prior
+// index. Because the surviving endpoint of every removed edge still lives in
+// current (e.g. an edit that removes B's reference to S leaves S's declaring
+// file present), the removed-edge dependents are found by looking the removed
+// names up in current — no synthetic prior index is required.
+//
+// For each changed file B it unions four dependency directions, all resolved
+// against current's lookup tables:
+//
+//   - B's current declarations -> their referrers
+//   - B's removed declarations -> their referrers (edit deleted the decl)
+//   - B's current references -> their declarers
+//   - B's removed references -> their declarers (edit deleted the reference)
+//
+// changedFiles are always present in the result. removed may be nil (no prior
+// removals, e.g. a purely additive edit). current may be nil (degenerate).
+func AffectedSetIncremental(current *CodeIndex, changedFiles []string, removed *PriorRemovedContributions) []string {
+	if len(changedFiles) == 0 {
+		return nil
+	}
+	changed := make(map[string]bool, len(changedFiles))
+	affected := make(map[string]bool, len(changedFiles))
+	for _, f := range changedFiles {
+		if f == "" {
+			continue
+		}
+		changed[f] = true
+		affected[f] = true
+	}
+	if len(changed) == 0 {
+		return nil
+	}
+	if current == nil {
+		out := make([]string, 0, len(affected))
+		for f := range affected {
+			out = append(out, f)
+		}
+		return out
+	}
+
+	addReferrers := func(name string) {
+		for ref := range current.ReferenceFiles(name) {
+			affected[ref] = true
+		}
+	}
+	addDeclarers := func(name string) {
+		for _, sym := range current.SymbolsNamed(name) {
+			if sym.File != "" {
+				affected[sym.File] = true
+			}
+		}
+	}
+
+	for file := range changed {
+		// Current declarations -> referrers.
+		for _, name := range current.DeclaredNames(file) {
+			addReferrers(name)
+		}
+		// Removed declarations -> referrers.
+		if removed != nil {
+			for _, name := range removed.Declared[file] {
+				addReferrers(name)
+			}
+		}
+	}
+
+	// Current references -> declarers.
+	for name := range current.referencedNamesInFiles(changed) {
+		addDeclarers(name)
+	}
+	// Removed references -> declarers.
+	if removed != nil {
+		for file := range changed {
+			for _, name := range removed.Referenced[file] {
+				addDeclarers(name)
+			}
+		}
+	}
+
+	out := make([]string, 0, len(affected))
+	for f := range affected {
+		out = append(out, f)
+	}
+	return out
+}

--- a/internal/scanner/affected_set_incremental_test.go
+++ b/internal/scanner/affected_set_incremental_test.go
@@ -1,0 +1,247 @@
+package scanner
+
+import (
+	"sort"
+	"testing"
+)
+
+func affectedSetIncrementalSorted(current *CodeIndex, changed []string, removed *PriorRemovedContributions) []string {
+	got := AffectedSetIncremental(current, changed, removed)
+	sort.Strings(got)
+	return got
+}
+
+func containsName(names []string, want string) bool {
+	for _, n := range names {
+		if n == want {
+			return true
+		}
+	}
+	return false
+}
+
+// TestAffectedSetIncremental_CurrentDeclarationToReferrers pins direction 1
+// against the current index: a changed file's declaration affects every file
+// that references it.
+func TestAffectedSetIncremental_CurrentDeclarationToReferrers(t *testing.T) {
+	syms := []Symbol{{Name: "S", File: "b.kt", FQN: "demo.S"}}
+	refs := []Reference{
+		{Name: "S", File: "a.kt"},
+		{Name: "S", File: "c.kt"},
+		{Name: "Unrelated", File: "d.kt"},
+	}
+	current := BuildIndexFromData(syms, refs)
+
+	got := affectedSetIncrementalSorted(current, []string{"b.kt"}, nil)
+	for _, want := range []string{"a.kt", "b.kt", "c.kt"} {
+		if !hasFile(got, want) {
+			t.Errorf("affected must include %q (current declaration->referrers); got %v", want, got)
+		}
+	}
+	if hasFile(got, "d.kt") {
+		t.Errorf("unrelated file d.kt must not be affected; got %v", got)
+	}
+}
+
+// TestAffectedSetIncremental_CurrentReferenceToDeclarers pins direction 2: a
+// changed file's reference affects the file that declares the name.
+func TestAffectedSetIncremental_CurrentReferenceToDeclarers(t *testing.T) {
+	syms := []Symbol{{Name: "S", File: "a.kt", FQN: "demo.S"}}
+	refs := []Reference{{Name: "S", File: "b.kt"}}
+	current := BuildIndexFromData(syms, refs)
+
+	got := affectedSetIncrementalSorted(current, []string{"b.kt"}, nil)
+	if !hasFile(got, "a.kt") {
+		t.Errorf("affected must include declaring file a.kt (current reference->declarers); got %v", got)
+	}
+}
+
+// TestAffectedSetIncremental_RemovedReferenceUsesRemoved is the critical #608
+// case on the daemon path: the edit deleted B's only reference to S (declared
+// in A). Current no longer links B to S — only the captured removed
+// contributions reveal that A's "S is unused" finding could flip. The removed
+// name is resolved against current, whose declaring endpoint (A) survives.
+func TestAffectedSetIncremental_RemovedReferenceUsesRemoved(t *testing.T) {
+	// current: a.kt still declares S; b.kt no longer references it.
+	current := BuildIndexFromData(
+		[]Symbol{{Name: "S", File: "a.kt", FQN: "demo.S"}},
+		nil,
+	)
+	removed := &PriorRemovedContributions{
+		Referenced: map[string][]string{"b.kt": {"S"}},
+	}
+
+	got := affectedSetIncrementalSorted(current, []string{"b.kt"}, removed)
+	if !hasFile(got, "a.kt") {
+		t.Errorf("removed reference must still affect the declaring file via removed; got %v", got)
+	}
+
+	// Precondition: without the removed contributions, current-only misses a.kt.
+	currentOnly := AffectedSetIncremental(current, []string{"b.kt"}, nil)
+	if hasFile(currentOnly, "a.kt") {
+		t.Errorf("precondition: current-only should not reach a.kt; got %v", currentOnly)
+	}
+}
+
+// TestAffectedSetIncremental_RemovedDeclarationUsesRemoved is the mirror case:
+// the edit deleted B's declaration of S that A referenced. The removed
+// declaration name resolves against current's surviving referrer (A).
+func TestAffectedSetIncremental_RemovedDeclarationUsesRemoved(t *testing.T) {
+	// current: b.kt no longer declares S; a.kt's now-dangling reference remains.
+	current := BuildIndexFromData(
+		nil,
+		[]Reference{{Name: "S", File: "a.kt"}},
+	)
+	removed := &PriorRemovedContributions{
+		Declared: map[string][]string{"b.kt": {"S"}},
+	}
+
+	got := affectedSetIncrementalSorted(current, []string{"b.kt"}, removed)
+	if !hasFile(got, "a.kt") {
+		t.Errorf("removed declaration must still affect the referencing file via removed; got %v", got)
+	}
+}
+
+// TestAffectedSetIncremental_DeletedFile covers a fully deleted changed file:
+// it has no current declarations or references, so every dependent is reached
+// only through the captured removed contributions. A deleted file that both
+// declared P (referenced by p.kt) and referenced Q (declared in q.kt) must
+// affect both p.kt and q.kt.
+func TestAffectedSetIncremental_DeletedFile(t *testing.T) {
+	// current: gone.kt is deleted; p.kt's dangling reference to P and q.kt's
+	// declaration of Q survive.
+	current := BuildIndexFromData(
+		[]Symbol{{Name: "Q", File: "q.kt", FQN: "demo.Q"}},
+		[]Reference{{Name: "P", File: "p.kt"}},
+	)
+	removed := &PriorRemovedContributions{
+		Declared:   map[string][]string{"gone.kt": {"P"}},
+		Referenced: map[string][]string{"gone.kt": {"Q"}},
+	}
+
+	got := affectedSetIncrementalSorted(current, []string{"gone.kt"}, removed)
+	if !hasFile(got, "p.kt") {
+		t.Errorf("deleted file's removed declaration must affect referrer p.kt; got %v", got)
+	}
+	if !hasFile(got, "q.kt") {
+		t.Errorf("deleted file's removed reference must affect declarer q.kt; got %v", got)
+	}
+}
+
+// TestAffectedSetIncremental_FQNMatch verifies an FQN-spelled reference still
+// links to the declaring file.
+func TestAffectedSetIncremental_FQNMatch(t *testing.T) {
+	syms := []Symbol{{Name: "S", File: "b.kt", FQN: "demo.S"}}
+	refs := []Reference{{Name: "demo.S", File: "a.kt"}}
+	current := BuildIndexFromData(syms, refs)
+
+	got := affectedSetIncrementalSorted(current, []string{"b.kt"}, nil)
+	if !hasFile(got, "a.kt") {
+		t.Errorf("FQN-spelled reference must be linked to declaration; got %v", got)
+	}
+}
+
+// TestAffectedSetIncremental_EdgeCases pins the degenerate inputs.
+func TestAffectedSetIncremental_EdgeCases(t *testing.T) {
+	idx := BuildIndexFromData([]Symbol{{Name: "S", File: "a.kt"}}, nil)
+
+	if got := AffectedSetIncremental(idx, nil, nil); got != nil {
+		t.Errorf("nil changedFiles must return nil; got %v", got)
+	}
+	if got := AffectedSetIncremental(idx, []string{""}, nil); got != nil {
+		t.Errorf("empty-string-only changedFiles must return nil; got %v", got)
+	}
+	if got := AffectedSetIncremental(nil, []string{"x.kt"}, nil); !hasFile(got, "x.kt") || len(got) != 1 {
+		t.Errorf("nil current must still echo the changed file; got %v", got)
+	}
+}
+
+// TestAffectedSetIncremental_AlwaysIncludesChanged guarantees the changed files
+// are always present even when they neither declare nor reference anything.
+func TestAffectedSetIncremental_AlwaysIncludesChanged(t *testing.T) {
+	idx := BuildIndexFromData([]Symbol{{Name: "Other", File: "z.kt"}}, nil)
+	got := affectedSetIncrementalSorted(idx, []string{"new.kt", "new2.kt"}, nil)
+	for _, want := range []string{"new.kt", "new2.kt"} {
+		if !hasFile(got, want) {
+			t.Errorf("changed file %q must always be present; got %v", want, got)
+		}
+	}
+}
+
+// TestSnapshotRemovedContributions_CapturesDeclaredAndReferenced verifies the
+// snapshot records both declared names (bare + FQN) and referenced names for
+// exactly the requested files, and ignores files outside the set.
+func TestSnapshotRemovedContributions_CapturesDeclaredAndReferenced(t *testing.T) {
+	idx := BuildIndexFromData(
+		[]Symbol{
+			{Name: "S", File: "b.kt", FQN: "demo.S"},
+			{Name: "T", File: "other.kt", FQN: "demo.T"},
+		},
+		[]Reference{
+			{Name: "X", File: "b.kt"},
+			{Name: "Y", File: "b.kt"},
+			{Name: "Z", File: "other.kt"},
+		},
+	)
+
+	got := idx.SnapshotRemovedContributions(map[string]bool{"b.kt": true})
+
+	if !containsName(got.Declared["b.kt"], "S") {
+		t.Errorf("declared must include bare name S; got %v", got.Declared["b.kt"])
+	}
+	if !containsName(got.Declared["b.kt"], "demo.S") {
+		t.Errorf("declared must include FQN demo.S; got %v", got.Declared["b.kt"])
+	}
+	if _, ok := got.Declared["other.kt"]; ok {
+		t.Errorf("declared must not include files outside the set; got %v", got.Declared)
+	}
+	refs := got.Referenced["b.kt"]
+	if !containsName(refs, "X") || !containsName(refs, "Y") {
+		t.Errorf("referenced must include X and Y; got %v", refs)
+	}
+	if containsName(refs, "Z") {
+		t.Errorf("referenced must not include other.kt's Z; got %v", refs)
+	}
+	if _, ok := got.Referenced["other.kt"]; ok {
+		t.Errorf("referenced must not include files outside the set; got %v", got.Referenced)
+	}
+}
+
+// TestSnapshotRemovedContributions_NilSafety covers the degenerate receivers.
+func TestSnapshotRemovedContributions_NilSafety(t *testing.T) {
+	var nilIdx *CodeIndex
+	got := nilIdx.SnapshotRemovedContributions(map[string]bool{"b.kt": true})
+	if len(got.Declared) != 0 || len(got.Referenced) != 0 {
+		t.Errorf("nil index must produce empty contributions; got %+v", got)
+	}
+
+	idx := BuildIndexFromData([]Symbol{{Name: "S", File: "b.kt"}}, nil)
+	empty := idx.SnapshotRemovedContributions(nil)
+	if len(empty.Declared) != 0 || len(empty.Referenced) != 0 {
+		t.Errorf("empty file set must produce empty contributions; got %+v", empty)
+	}
+}
+
+// TestLastRemovedContributions_RoundTrip verifies setLastRemoved stores a copy
+// that LastRemovedContributions returns, and that a fresh index reports nil.
+func TestLastRemovedContributions_RoundTrip(t *testing.T) {
+	idx := BuildIndexFromData([]Symbol{{Name: "S", File: "a.kt"}}, nil)
+	if idx.LastRemovedContributions() != nil {
+		t.Errorf("fresh index must report nil removed contributions")
+	}
+
+	snap := idx.SnapshotRemovedContributions(map[string]bool{"a.kt": true})
+	idx.setLastRemoved(snap)
+	got := idx.LastRemovedContributions()
+	if got == nil {
+		t.Fatalf("LastRemovedContributions must return the stored snapshot")
+	}
+	if !containsName(got.Declared["a.kt"], "S") {
+		t.Errorf("stored snapshot must include declared S; got %v", got.Declared["a.kt"])
+	}
+
+	var nilIdx *CodeIndex
+	if nilIdx.LastRemovedContributions() != nil {
+		t.Errorf("nil index must report nil removed contributions")
+	}
+}

--- a/internal/scanner/index.go
+++ b/internal/scanner/index.go
@@ -94,6 +94,16 @@ type CodeIndex struct {
 	// refMu).
 	declsByFile map[string]map[string]int
 
+	// lastRemoved captures the declared/referenced names that the most
+	// recent incremental rebuild dropped from this index (the prior
+	// contributions of the changed/deleted files). The prior index is
+	// mutated in place by BuildIndexIncremental, so these removed edges
+	// are otherwise unrecoverable at dispatch time — they are what keeps
+	// AffectedSetIncremental #608-safe for edits that delete a declaration
+	// or reference. nil after a full build (nothing was removed) and on
+	// indexes that never went through the incremental overlay path.
+	lastRemoved *PriorRemovedContributions
+
 	// Bloom filter for fast "is this name referenced?" checks.
 	// False positives are OK (we fall back to exact check), false negatives are not.
 	refBloom *bloom.BloomFilter

--- a/internal/scanner/index_overlay.go
+++ b/internal/scanner/index_overlay.go
@@ -127,7 +127,14 @@ func buildIndexFromPriorOverlay(cacheDir string, entries []fingerprintEntry, fil
 	changedJava := selectFilesByPath(javaFiles, addPaths)
 	changedXML := selectFilesByPath(xmlFiles, addPaths)
 	symbols, refs, _ := collectIndexDataSharded(cacheDir, changedKotlin, changedJava, changedXML, workers, tracker)
+	// Capture the changed files' prior declared/referenced names BEFORE
+	// BuildIndexIncremental removes those contributions in place. Dispatch
+	// reads these to compute a #608-safe affected set: an edit that deletes
+	// the last reference to a symbol must still re-analyze that symbol's
+	// declaring file, and that link is only discoverable from the prior edge.
+	removed := priorIdx.SnapshotRemovedContributions(removePaths)
 	idx := BuildIndexIncremental(priorIdx, removePaths, symbols, refs)
+	idx.setLastRemoved(removed)
 
 	meta := overlayMetaForEntries(priorMeta, entries)
 	meta.KotlinFiles = len(files)


### PR DESCRIPTION
## Summary

Third and final PR of the reference-level reverse-dependency series (after #615 `declsByFile` and #616 `AffectedSet`). Adds a new, opt-in dispatch layer that bounds warm+ABI work using the affected set instead of paying a full `DispatchPhase` over every file.

The conservative delta planner only replays the prior findings bundle for a single body-only edit; any ABI change drifts the CrossFile fingerprint and falls through to full dispatch. This layer fires in that regime when it can prove the work is bounded and safe.

## How it stays #608-safe

- The daemon rebuilds the cross-file index incrementally, **mutating the prior index in place**, so the edges an edit deletes are gone by dispatch time. The overlay build now snapshots the changed files' prior declared/referenced names *before* that mutation (`SnapshotRemovedContributions`) and stashes them on the index (`LastRemovedContributions`).
- `AffectedSetIncremental` unions four dependency directions (current/removed declarations → referrers, current/removed references → declarers) against the current index plus those removed edges, yielding a true superset of every file whose findings can change.
- `tryAffectedSetDispatch` re-dispatches only the affected set and merges against the prior bundle with `ApplyDelta`. Two gates keep it correct:
  1. **removed-edge gate** — runs only when the index carries removed-edge data (`LastRemovedContributions != nil`); a full build leaves it nil and the path bails.
  2. **parsed-availability gate** — runs only when every affected file is present in the warm (dirty-only) parse result, so each file whose prior rows `ApplyDelta` drops is actually re-dispatched and its findings regenerated. Otherwise it falls back to full dispatch.
- Default OFF behind `KRIT_AFFECTED_SET_REPLAY` while it soaks.

## Test plan

- [ ] `go build ./... && go vet ./... && golangci-lint run ./...` — clean
- [ ] `go test ./... -count=1` — green
- [ ] Scanner unit tests: removed-reference, removed-declaration, deleted-file, FQN, edge cases, snapshot capture, round-trip
- [ ] Pipeline unit tests: flag parsing, `scopeParseResultMulti`, parsed-availability gate
- [ ] `make integration` — only the known environmental `cmd/krit` 62s timeout (`TestKritInitPlaygroundEndToEnd`); passes in isolation at ~67s