### PR TITLE
perf(pipeline): add parseFilesByPath helper for on-demand source parsing

### DIFF
--- a/internal/pipeline/parse_files_by_path.go
+++ b/internal/pipeline/parse_files_by_path.go
@@ -1,0 +1,46 @@
+package pipeline
+
+import (
+	"context"
+
+	"github.com/kaeawc/krit/internal/scanner"
+)
+
+// parseFilesByPath parses exactly the supplied Kotlin and Java source paths
+// into *scanner.File, reusing the daemon's resident-file cache and disk parse
+// cache (and the normal generated-file filtering + suppression-index install)
+// via ParsePhase.Run.
+//
+// It exists for the affected-set replay path: a warm run parses only the dirty
+// (cache-miss) files, so an affected reverse-dependency file that was not
+// edited has no parsed *scanner.File available. This materializes those files
+// on demand so they can be re-dispatched, instead of falling back to a full
+// project dispatch.
+//
+// Both path lists reach ParseInput as non-nil slices. That is load-bearing:
+// ParsePhase.Run treats a nil KotlinPaths/JavaPaths as "collect the whole
+// project", whereas a non-nil empty slice parses nothing for that language.
+// (Java is additionally gated on the active rules driving Java collection, the
+// same as every other ParsePhase.Run caller.)
+func parseFilesByPath(ctx context.Context, args ProjectArgs, host ProjectHostState, kotlinPaths, javaPaths []string) ([]*scanner.File, []*scanner.File, error) {
+	if len(kotlinPaths) == 0 && len(javaPaths) == 0 {
+		return nil, nil, nil
+	}
+	res, err := ParsePhase{Workers: args.Workers}.Run(ctx, ParseInput{
+		Config:           args.Config,
+		Paths:            args.Paths,
+		ActiveRules:      args.ActiveRules,
+		IncludeGenerated: args.IncludeGenerated,
+		KotlinPaths:      append([]string{}, kotlinPaths...),
+		JavaPaths:        append([]string{}, javaPaths...),
+		Workers:          args.Workers,
+		Reporter:         host.Reporter,
+		Tracker:          host.Tracker,
+		ParseCache:       host.ParseCache,
+		ResidentFiles:    host.ResidentFiles,
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	return res.KotlinFiles, res.JavaFiles, nil
+}

--- a/internal/pipeline/parse_files_by_path_test.go
+++ b/internal/pipeline/parse_files_by_path_test.go
@@ -1,0 +1,75 @@
+package pipeline
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/kaeawc/krit/internal/config"
+	api "github.com/kaeawc/krit/internal/rules/api"
+)
+
+// TestParseFilesByPath_ParsesRequestedSubset verifies the helper parses only
+// the requested Kotlin paths and returns them as *scanner.File — crucially NOT
+// the whole project (the daemon footgun the non-nil slice guards against).
+func TestParseFilesByPath_ParsesRequestedSubset(t *testing.T) {
+	dir := t.TempDir()
+	a := filepath.Join(dir, "A.kt")
+	b := filepath.Join(dir, "B.kt")
+	c := filepath.Join(dir, "C.kt")
+	writeKt(t, a, "package test\nclass A\n")
+	writeKt(t, b, "package test\nclass B\n")
+	writeKt(t, c, "package test\nclass C\n")
+
+	args := ProjectArgs{Config: config.NewConfig(), Paths: []string{dir}}
+	kt, jv, err := parseFilesByPath(context.Background(), args, ProjectHostState{}, []string{a}, nil)
+	if err != nil {
+		t.Fatalf("parseFilesByPath: %v", err)
+	}
+	if len(jv) != 0 {
+		t.Errorf("no Java requested, want 0 Java files; got %d", len(jv))
+	}
+	if len(kt) != 1 {
+		t.Fatalf("requested one Kotlin file, got %d (whole-project collection?)", len(kt))
+	}
+	if kt[0].Path != a {
+		t.Errorf("parsed path = %q, want %q", kt[0].Path, a)
+	}
+}
+
+// TestParseFilesByPath_EmptyInput returns nil without touching the parser.
+func TestParseFilesByPath_EmptyInput(t *testing.T) {
+	args := ProjectArgs{Config: config.NewConfig(), Paths: []string{t.TempDir()}}
+	kt, jv, err := parseFilesByPath(context.Background(), args, ProjectHostState{}, nil, nil)
+	if err != nil {
+		t.Fatalf("parseFilesByPath: %v", err)
+	}
+	if kt != nil || jv != nil {
+		t.Errorf("empty input must return nil,nil; got kt=%v jv=%v", kt, jv)
+	}
+}
+
+// TestParseFilesByPath_JavaWithCrossFileRule confirms Java paths are parsed
+// when the active rule set drives Java collection (NeedsCrossFile).
+func TestParseFilesByPath_JavaWithCrossFileRule(t *testing.T) {
+	dir := t.TempDir()
+	j := filepath.Join(dir, "Widget.java")
+	writeJavaSource(t, j, "package test;\nclass Widget {}\n")
+
+	rule := api.FakeRule("CrossRule", api.WithNeeds(api.NeedsCrossFile))
+	args := ProjectArgs{
+		Config:      config.NewConfig(),
+		Paths:       []string{dir},
+		ActiveRules: []*api.Rule{rule},
+	}
+	kt, jv, err := parseFilesByPath(context.Background(), args, ProjectHostState{}, nil, []string{j})
+	if err != nil {
+		t.Fatalf("parseFilesByPath: %v", err)
+	}
+	if len(kt) != 0 {
+		t.Errorf("no Kotlin requested, want 0; got %d", len(kt))
+	}
+	if len(jv) != 1 || jv[0].Path != j {
+		t.Fatalf("requested one Java file %q; got %v", j, pathsOf(jv))
+	}
+}


### PR DESCRIPTION
## Summary

First of a two-PR sequence widening the affected-set replay dispatch path (added in #617). Adds `parseFilesByPath`, a helper that parses an explicit subset of Kotlin/Java source paths into `*scanner.File` on demand via `ParsePhase.Run`, reusing the daemon's resident-file cache and disk parse cache (and the normal generated-file filtering + suppression-index install).

### Why

A warm daemon run parses only the dirty (cache-miss) files, so a file that was not edited has no parsed `*scanner.File` available mid-run. Today `tryAffectedSetDispatch` bails to full dispatch whenever the affected set includes such a file. This helper lets a follow-up PR materialize those affected reverse-dependency files and re-dispatch them instead — extending the replay win to edits that have external cross-file dependents.

### Notes

- Both path lists reach `ParseInput` as **non-nil** slices. That's load-bearing: `ParsePhase.Run` treats a nil `KotlinPaths`/`JavaPaths` as "collect the whole project", whereas a non-nil empty slice parses nothing for that language.
- No production caller yet — the wiring lands in PR2. The helper is exercised by unit tests (subset isolation, empty input, Java-under-cross-file-rule).

## Test plan

- [ ] `go build ./... && go vet ./... && golangci-lint run ./...` — clean
- [ ] `go test ./... -count=1` — green
- [ ] New unit tests: `TestParseFilesByPath_ParsesRequestedSubset` (proves no whole-project collection), `_EmptyInput`, `_JavaWithCrossFileRule`