### PR TITLE
perf(pipeline): parse affected dependents in affected-set replay instead of bailing

### DIFF
--- a/internal/pipeline/affected_set_dispatch_test.go
+++ b/internal/pipeline/affected_set_dispatch_test.go
@@ -70,11 +70,10 @@ func TestScopeParseResultMulti_EmptyPaths(t *testing.T) {
 }
 
 // TestAllAffectedFilesParsed is the #608 gate: the affected-set replay path
-// must bail unless every affected file is present in the (warm, dirty-only)
-// parse result. An affected reverse-dependency that was not re-parsed cannot
-// be re-dispatched, so ApplyDelta would drop its prior rows with no
-// replacement — losing findings.
-func TestAllAffectedFilesParsed(t *testing.T) {
+// collects the paths of a parse result's Kotlin and Java files, skipping nils.
+// It backs invariant 2 of tryAffectedSetDispatch (deciding which affected
+// files still need to be materialized for re-dispatch).
+func TestParsedPathSet(t *testing.T) {
 	p := ParseResult{
 		KotlinFiles: []*scanner.File{
 			{Path: "a.kt", Language: scanner.LangKotlin},
@@ -83,19 +82,15 @@ func TestAllAffectedFilesParsed(t *testing.T) {
 		JavaFiles: []*scanner.File{{Path: "C.java", Language: scanner.LangJava}},
 	}
 
-	if !allAffectedFilesParsed(p, []string{"a.kt", "C.java"}) {
-		t.Errorf("all affected files present must report true")
+	got := parsedPathSet(p)
+	if !got["a.kt"] || !got["C.java"] {
+		t.Errorf("parsed path set must contain a.kt and C.java; got %v", got)
 	}
-	if !allAffectedFilesParsed(p, nil) {
-		t.Errorf("empty affected set must report true (nothing to dispatch)")
+	if got["b.kt"] {
+		t.Errorf("parsed path set must not contain unparsed b.kt; got %v", got)
 	}
-	// A non-dirty dependent (b.kt) that was not re-parsed must fail the gate.
-	if allAffectedFilesParsed(p, []string{"a.kt", "b.kt"}) {
-		t.Errorf("affected file missing from parse result must report false")
-	}
-	// An XML referrer is never in Kotlin/Java parse files -> must fail.
-	if allAffectedFilesParsed(p, []string{"layout.xml"}) {
-		t.Errorf("XML referrer not in parse result must report false")
+	if len(got) != 2 {
+		t.Errorf("nil entries must be skipped; got %d paths %v", len(got), got)
 	}
 }
 

--- a/internal/pipeline/affected_set_widen_test.go
+++ b/internal/pipeline/affected_set_widen_test.go
@@ -1,0 +1,93 @@
+package pipeline
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/kaeawc/krit/internal/config"
+	"github.com/kaeawc/krit/internal/scanner"
+)
+
+// TestMergeParsedFiles appends without mutating the original and de-dups
+// nothing (callers guarantee disjoint inputs).
+func TestMergeParsedFiles(t *testing.T) {
+	orig := ParseResult{
+		KotlinFiles: []*scanner.File{{Path: "a.kt", Language: scanner.LangKotlin}},
+		JavaFiles:   []*scanner.File{{Path: "C.java", Language: scanner.LangJava}},
+	}
+	merged := mergeParsedFiles(orig,
+		[]*scanner.File{{Path: "b.kt", Language: scanner.LangKotlin}},
+		[]*scanner.File{{Path: "D.java", Language: scanner.LangJava}},
+	)
+	if got := pathsOf(merged.KotlinFiles); len(got) != 2 {
+		t.Errorf("merged kotlin = %v, want 2", got)
+	}
+	if got := pathsOf(merged.JavaFiles); len(got) != 2 {
+		t.Errorf("merged java = %v, want 2", got)
+	}
+	// Original slices must be untouched.
+	if len(orig.KotlinFiles) != 1 || len(orig.JavaFiles) != 1 {
+		t.Errorf("mergeParsedFiles mutated the original: kt=%d java=%d",
+			len(orig.KotlinFiles), len(orig.JavaFiles))
+	}
+}
+
+// TestMaterializeAffectedFiles_AlreadyParsed returns the input unchanged when
+// every affected file is already present.
+func TestMaterializeAffectedFiles_AlreadyParsed(t *testing.T) {
+	p := ParseResult{KotlinFiles: []*scanner.File{{Path: "a.kt", Language: scanner.LangKotlin}}}
+	args := ProjectArgs{Config: config.NewConfig()}
+	got, ok := materializeAffectedFiles(context.Background(), args, ProjectHostState{}, p, []string{"a.kt"})
+	if !ok {
+		t.Fatalf("all-present affected set must succeed")
+	}
+	if len(got.KotlinFiles) != 1 {
+		t.Errorf("expected the input passed through; got %v", pathsOf(got.KotlinFiles))
+	}
+}
+
+// TestMaterializeAffectedFiles_ParsesMissingDependent parses an affected
+// reverse-dependency source file that the warm parse skipped.
+func TestMaterializeAffectedFiles_ParsesMissingDependent(t *testing.T) {
+	dir := t.TempDir()
+	dirty := filepath.Join(dir, "Dirty.kt")
+	dep := filepath.Join(dir, "Dep.kt")
+	writeKt(t, dirty, "package test\nclass Dirty\n")
+	writeKt(t, dep, "package test\nclass Dep\n")
+
+	// parseResult holds only the dirty file (warm regime).
+	p := ParseResult{KotlinFiles: []*scanner.File{{Path: dirty, Language: scanner.LangKotlin}}}
+	args := ProjectArgs{Config: config.NewConfig(), Paths: []string{dir}}
+
+	got, ok := materializeAffectedFiles(context.Background(), args, ProjectHostState{}, p, []string{dirty, dep})
+	if !ok {
+		t.Fatalf("missing source dependent must be materialized, not bailed")
+	}
+	parsed := parsedPathSet(got)
+	if !parsed[dirty] || !parsed[dep] {
+		t.Errorf("dispatch parse must contain both files; got %v", pathsOf(got.KotlinFiles))
+	}
+}
+
+// TestMaterializeAffectedFiles_BailsOnXML bails when an affected file is not
+// Kotlin/Java source (XML referrers cannot be re-dispatched this way).
+func TestMaterializeAffectedFiles_BailsOnXML(t *testing.T) {
+	p := ParseResult{KotlinFiles: []*scanner.File{{Path: "a.kt", Language: scanner.LangKotlin}}}
+	args := ProjectArgs{Config: config.NewConfig(), Paths: []string{t.TempDir()}}
+	if _, ok := materializeAffectedFiles(context.Background(), args, ProjectHostState{}, p, []string{"a.kt", "res/layout/main.xml"}); ok {
+		t.Errorf("an XML affected file must force a bail")
+	}
+}
+
+// TestMaterializeAffectedFiles_BailsOnDeletedSource bails when an affected
+// source file is gone — it never comes back parsed, so the set is incomplete.
+func TestMaterializeAffectedFiles_BailsOnDeletedSource(t *testing.T) {
+	dir := t.TempDir()
+	p := ParseResult{KotlinFiles: []*scanner.File{{Path: filepath.Join(dir, "a.kt"), Language: scanner.LangKotlin}}}
+	args := ProjectArgs{Config: config.NewConfig(), Paths: []string{dir}}
+	gone := filepath.Join(dir, "Gone.kt") // never created on disk
+	if _, ok := materializeAffectedFiles(context.Background(), args, ProjectHostState{}, p, []string{filepath.Join(dir, "a.kt"), gone}); ok {
+		t.Errorf("a deleted/unparseable affected source file must force a bail")
+	}
+}

--- a/internal/pipeline/project.go
+++ b/internal/pipeline/project.go
@@ -2797,11 +2797,9 @@ func scopeParseResultMulti(p ParseResult, paths map[string]bool) ParseResult {
 	return scoped
 }
 
-// allAffectedFilesParsed reports whether every path in affected is present in
-// p's Kotlin or Java files. It backs invariant 2 of tryAffectedSetDispatch: an
-// affected file that was not re-parsed cannot be re-dispatched, so its prior
-// findings would be dropped without replacement.
-func allAffectedFilesParsed(p ParseResult, affected []string) bool {
+// parsedPathSet returns the set of file paths present in p's Kotlin or Java
+// files (skipping nils).
+func parsedPathSet(p ParseResult) map[string]bool {
 	parsed := make(map[string]bool, len(p.KotlinFiles)+len(p.JavaFiles))
 	for _, f := range p.KotlinFiles {
 		if f != nil {
@@ -2813,12 +2811,85 @@ func allAffectedFilesParsed(p ParseResult, affected []string) bool {
 			parsed[f.Path] = true
 		}
 	}
+	return parsed
+}
+
+// mergeParsedFiles returns a copy of p with the supplied Kotlin and Java files
+// appended. Callers pass files that were not already in p (the missing
+// affected dependents), so no de-duplication is needed.
+func mergeParsedFiles(p ParseResult, kotlin, java []*scanner.File) ParseResult {
+	merged := p
+	if len(kotlin) > 0 {
+		merged.KotlinFiles = make([]*scanner.File, 0, len(p.KotlinFiles)+len(kotlin))
+		merged.KotlinFiles = append(append(merged.KotlinFiles, p.KotlinFiles...), kotlin...)
+	}
+	if len(java) > 0 {
+		merged.JavaFiles = make([]*scanner.File, 0, len(p.JavaFiles)+len(java))
+		merged.JavaFiles = append(append(merged.JavaFiles, p.JavaFiles...), java...)
+	}
+	return merged
+}
+
+// materializeAffectedFiles ensures every affected file has a parsed
+// *scanner.File available for re-dispatch (invariant 2 of
+// tryAffectedSetDispatch). The warm parse holds only dirty files, so affected
+// reverse-dependency source files that were not edited are parsed on demand
+// and merged into a copy of parseResult.
+//
+// It returns ok=false (caller bails to full dispatch) when an affected file
+// cannot be re-dispatched: a non-source file (e.g. an XML referrer), a parse
+// failure, or a source file that is gone (e.g. deleted) and so never comes
+// back parsed. Full dispatch handles all of those correctly.
+func materializeAffectedFiles(ctx context.Context, args ProjectArgs, host ProjectHostState, parseResult ParseResult, affected []string) (ParseResult, bool) {
+	parsed := parsedPathSet(parseResult)
+	var missingKotlin, missingJava []string
 	for _, f := range affected {
-		if !parsed[f] {
-			return false
+		if parsed[f] {
+			continue
+		}
+		switch {
+		case strings.HasSuffix(f, ".kt") || strings.HasSuffix(f, ".kts"):
+			missingKotlin = append(missingKotlin, f)
+		case strings.HasSuffix(f, ".java"):
+			missingJava = append(missingJava, f)
+		default:
+			return ParseResult{}, false
 		}
 	}
-	return true
+	if len(missingKotlin) == 0 && len(missingJava) == 0 {
+		// Every affected file was already parsed (the classification loop
+		// proved it); nothing to materialize.
+		return parseResult, true
+	}
+	kt, jv, err := parseFilesByPath(ctx, args, host, missingKotlin, missingJava)
+	if err != nil {
+		return ParseResult{}, false
+	}
+	// parseFilesByPath silently drops paths it cannot read (e.g. a deleted
+	// source file). Confirm every requested dependent actually came back, or
+	// bail so full dispatch handles the gap.
+	got := make(map[string]bool, len(kt)+len(jv))
+	for _, f := range kt {
+		if f != nil {
+			got[f.Path] = true
+		}
+	}
+	for _, f := range jv {
+		if f != nil {
+			got[f.Path] = true
+		}
+	}
+	for _, f := range missingKotlin {
+		if !got[f] {
+			return ParseResult{}, false
+		}
+	}
+	for _, f := range missingJava {
+		if !got[f] {
+			return ParseResult{}, false
+		}
+	}
+	return mergeParsedFiles(parseResult, kt, jv), true
 }
 
 // affectedSetReplayEnabled reports whether the opt-in affected-set replay
@@ -2855,13 +2926,13 @@ func affectedSetReplayEnabled() bool {
 //  2. Every affected file is re-dispatched, so its regenerated findings fully
 //     replace the prior rows ApplyDelta drops. On the warm daemon path
 //     parseResult holds only the dirty (cache-miss) files, so an affected
-//     reverse-dependency declarer/referrer (or an XML referrer) that was not
-//     re-parsed cannot be re-dispatched — yet ApplyDelta would still drop its
-//     prior rows, silently losing findings (#608). The parsed-availability
-//     gate below bails to full dispatch unless every affected file is present
-//     in parseResult. In practice this restricts the path to edits whose
-//     affected set is contained in the changed (dirty) set — still a win over
-//     full dispatch, and unconditionally safe.
+//     reverse-dependency declarer/referrer that was not edited has no parsed
+//     file — yet ApplyDelta would still drop its prior rows, silently losing
+//     findings (#608). Those missing Kotlin/Java dependents are parsed on
+//     demand (parseFilesByPath) and merged into the dispatch input. Anything
+//     that still cannot be re-dispatched — a non-source affected file (XML
+//     referrer) or a source file that failed to parse (e.g. it was deleted) —
+//     forces a bail to full dispatch, which handles those cases correctly.
 func tryAffectedSetDispatch(
 	ctx context.Context,
 	args ProjectArgs,
@@ -2917,17 +2988,15 @@ func tryAffectedSetDispatch(
 		affectedSet[f] = true
 	}
 
-	// Parsed-availability gate (invariant 2): every affected file must be in
-	// the warm parseResult so it is re-dispatched and its findings regenerated.
-	// If any affected file (a non-dirty dependent, or an XML referrer) was not
-	// re-parsed, bail — ApplyDelta would otherwise drop its prior rows with no
-	// replacement.
-	if !allAffectedFilesParsed(parseResult, affected) {
+	// Invariant 2: materialize any affected files the warm parse skipped, or
+	// bail to full dispatch if the full affected set cannot be re-dispatched.
+	dispatchParse, ok := materializeAffectedFiles(ctx, args, host, parseResult, affected)
+	if !ok {
 		return DispatchResult{}, CrossFileResult{}, false, nil
 	}
 
 	scoped := indexResult
-	scoped.ParseResult = scopeParseResultMulti(parseResult, affectedSet)
+	scoped.ParseResult = scopeParseResultMulti(dispatchParse, affectedSet)
 	d, err := DispatchPhase{}.Run(ctx, scoped)
 	if err != nil {
 		return DispatchResult{}, CrossFileResult{}, false, fmt.Errorf("dispatch (affected-set): %w", err)


### PR DESCRIPTION
## Summary

Second of the two-PR sequence widening the affected-set replay dispatch path (#617), building on the `parseFilesByPath` helper from #618.

Previously `tryAffectedSetDispatch` bailed to full dispatch whenever the affected set contained a file the warm parse skipped — which is every reverse-dependency that wasn't itself edited (the warm parse only parses dirty files). That's exactly the cross-file case the reverse-dependency index was built to handle, so the path almost never fired on real ABI edits.

Now it materializes those dependents: `materializeAffectedFiles` classifies each affected file not already parsed, parses the missing Kotlin/Java sources on demand via `parseFilesByPath` (reusing the resident + disk parse cache), and merges them into the dispatch input so the full affected set is re-dispatched and `ApplyDelta`'s row replacement stays complete.

### Safety (unchanged #608 posture)

It bails to full dispatch — unconditionally safe — when a file cannot be re-dispatched:
- a **non-source** affected file (an XML referrer) — per the agreed scope, XML stays a future item;
- a **parse failure**;
- a source file that is **gone** (e.g. deleted) and never comes back parsed (caught by a targeted completeness check over the requested dependents).

The removed-edge nil-gate and perf ratio gate from #617 are untouched. Still behind `KRIT_AFFECTED_SET_REPLAY` (default OFF).

### Notes

- `/simplify` pass: replaced a redundant full path-set rebuild with a targeted completeness check over just the materialized files, single-allocation merge, and removed the now-superseded `allAffectedFilesParsed` gate.
- Follow-up: a dedicated daemon integration test that drives the full warm+ABI overlay regime end-to-end (the unit tests cover `materializeAffectedFiles`, `parseFilesByPath`, and the scanner-level affected-set/ApplyDelta composition individually).

## Test plan

- [ ] `go build ./... && go vet ./... && golangci-lint run ./...` — clean
- [ ] `go test ./... -count=1` — green (the `initcmd` TempDir-cleanup race and `cmd/krit` 62s load-timeout are known environmental flakes; both pass in isolation; this change is flag-gated OFF)
- [ ] New unit tests: `TestMaterializeAffectedFiles_*` (already-parsed / parses-missing-dependent / bail-on-XML / bail-on-deleted-source), `TestMergeParsedFiles`, `TestParsedPathSet`