### PR TITLE
perf(pipeline): label affected-set replay bail reasons in perf output

### DIFF
--- a/internal/pipeline/affected_set_widen_test.go
+++ b/internal/pipeline/affected_set_widen_test.go
@@ -9,6 +9,33 @@ import (
 	"github.com/kaeawc/krit/internal/scanner"
 )
 
+// TestTryAffectedSetDispatch_BailReasons pins the observable bail labels the
+// early gates report, so the dispatchAffectedSetPath perf "reason" stays
+// meaningful.
+func TestTryAffectedSetDispatch_BailReasons(t *testing.T) {
+	ctx := context.Background()
+	args := ProjectArgs{Config: config.NewConfig()}
+	host := ProjectHostState{}
+
+	t.Setenv("KRIT_AFFECTED_SET_REPLAY", "")
+	if _, _, reason, err := tryAffectedSetDispatch(ctx, args, host, IndexResult{}, ParseResult{}, deltaManifestData{}); err != nil || reason != replayBailDisabled {
+		t.Fatalf("flag off -> reason %q err %v, want %q", reason, err, replayBailDisabled)
+	}
+
+	t.Setenv("KRIT_AFFECTED_SET_REPLAY", "on")
+	if _, _, reason, _ := tryAffectedSetDispatch(ctx, args, host, IndexResult{}, ParseResult{}, deltaManifestData{}); reason != replayBailNoManifest {
+		t.Errorf("manifest disabled -> %q, want %q", reason, replayBailNoManifest)
+	}
+	m := deltaManifestData{enabled: true, manifestKey: "k"}
+	if _, _, reason, _ := tryAffectedSetDispatch(ctx, args, host, IndexResult{}, ParseResult{}, m); reason != replayBailNoIndex {
+		t.Errorf("nil index -> %q, want %q", reason, replayBailNoIndex)
+	}
+	idx := IndexResult{CodeIndex: scanner.BuildIndexFromData(nil, nil)}
+	if _, _, reason, _ := tryAffectedSetDispatch(ctx, args, host, idx, ParseResult{}, m); reason != replayBailFullBuild {
+		t.Errorf("full build (no removed edges) -> %q, want %q", reason, replayBailFullBuild)
+	}
+}
+
 // TestMergeParsedFiles appends without mutating the original and de-dups
 // nothing (callers guarantee disjoint inputs).
 func TestMergeParsedFiles(t *testing.T) {
@@ -38,9 +65,9 @@ func TestMergeParsedFiles(t *testing.T) {
 func TestMaterializeAffectedFiles_AlreadyParsed(t *testing.T) {
 	p := ParseResult{KotlinFiles: []*scanner.File{{Path: "a.kt", Language: scanner.LangKotlin}}}
 	args := ProjectArgs{Config: config.NewConfig()}
-	got, ok := materializeAffectedFiles(context.Background(), args, ProjectHostState{}, p, []string{"a.kt"})
-	if !ok {
-		t.Fatalf("all-present affected set must succeed")
+	got, bail := materializeAffectedFiles(context.Background(), args, ProjectHostState{}, p, []string{"a.kt"})
+	if bail != "" {
+		t.Fatalf("all-present affected set must succeed; got bail %q", bail)
 	}
 	if len(got.KotlinFiles) != 1 {
 		t.Errorf("expected the input passed through; got %v", pathsOf(got.KotlinFiles))
@@ -60,9 +87,9 @@ func TestMaterializeAffectedFiles_ParsesMissingDependent(t *testing.T) {
 	p := ParseResult{KotlinFiles: []*scanner.File{{Path: dirty, Language: scanner.LangKotlin}}}
 	args := ProjectArgs{Config: config.NewConfig(), Paths: []string{dir}}
 
-	got, ok := materializeAffectedFiles(context.Background(), args, ProjectHostState{}, p, []string{dirty, dep})
-	if !ok {
-		t.Fatalf("missing source dependent must be materialized, not bailed")
+	got, bail := materializeAffectedFiles(context.Background(), args, ProjectHostState{}, p, []string{dirty, dep})
+	if bail != "" {
+		t.Fatalf("missing source dependent must be materialized, not bailed; got %q", bail)
 	}
 	parsed := parsedPathSet(got)
 	if !parsed[dirty] || !parsed[dep] {
@@ -75,8 +102,8 @@ func TestMaterializeAffectedFiles_ParsesMissingDependent(t *testing.T) {
 func TestMaterializeAffectedFiles_BailsOnXML(t *testing.T) {
 	p := ParseResult{KotlinFiles: []*scanner.File{{Path: "a.kt", Language: scanner.LangKotlin}}}
 	args := ProjectArgs{Config: config.NewConfig(), Paths: []string{t.TempDir()}}
-	if _, ok := materializeAffectedFiles(context.Background(), args, ProjectHostState{}, p, []string{"a.kt", "res/layout/main.xml"}); ok {
-		t.Errorf("an XML affected file must force a bail")
+	if _, bail := materializeAffectedFiles(context.Background(), args, ProjectHostState{}, p, []string{"a.kt", "res/layout/main.xml"}); bail != replayBailNonSource {
+		t.Errorf("an XML affected file must bail with %q; got %q", replayBailNonSource, bail)
 	}
 }
 
@@ -87,7 +114,7 @@ func TestMaterializeAffectedFiles_BailsOnDeletedSource(t *testing.T) {
 	p := ParseResult{KotlinFiles: []*scanner.File{{Path: filepath.Join(dir, "a.kt"), Language: scanner.LangKotlin}}}
 	args := ProjectArgs{Config: config.NewConfig(), Paths: []string{dir}}
 	gone := filepath.Join(dir, "Gone.kt") // never created on disk
-	if _, ok := materializeAffectedFiles(context.Background(), args, ProjectHostState{}, p, []string{filepath.Join(dir, "a.kt"), gone}); ok {
-		t.Errorf("a deleted/unparseable affected source file must force a bail")
+	if _, bail := materializeAffectedFiles(context.Background(), args, ProjectHostState{}, p, []string{filepath.Join(dir, "a.kt"), gone}); bail != replayBailParseIncomplete {
+		t.Errorf("a deleted/unparseable affected source file must bail with %q; got %q", replayBailParseIncomplete, bail)
 	}
 }

--- a/internal/pipeline/project.go
+++ b/internal/pipeline/project.go
@@ -1826,16 +1826,15 @@ func runDispatchOrLoadBundle(
 		// and ApplyDelta against the prior bundle. Opt-in
 		// (KRIT_AFFECTED_SET_REPLAY) and #608 gated inside.
 		asStart := time.Now()
-		asD, asC, asOK, asErr := tryAffectedSetDispatch(ctx, args, host, indexResult, parseResult, manifest)
-		asOutcome := "miss"
-		if asOK {
-			asOutcome = "hit"
-		}
-		perf.AddEntryDetails(tracker, "dispatchAffectedSetPath", time.Since(asStart), nil, map[string]string{"outcome": asOutcome})
+		asD, asC, asReason, asErr := tryAffectedSetDispatch(ctx, args, host, indexResult, parseResult, manifest)
+		// reason is "hit" when the path fired, else the bail label explaining
+		// why it fell back to full dispatch — self-explaining in the perf JSON
+		// (hit vs miss is derivable from reason == replayHit).
+		perf.AddEntryDetails(tracker, "dispatchAffectedSetPath", time.Since(asStart), nil, map[string]string{"reason": asReason})
 		if asErr != nil {
 			return DispatchResult{}, CrossFileResult{}, false, dispatchTimings{}, asErr
 		}
-		if asOK {
+		if asReason == replayHit {
 			recordDispatchPath("cacheHitAffectedSetBundle")
 			return asD, asC, false, dispatchTimings{}, nil
 		}
@@ -2836,11 +2835,12 @@ func mergeParsedFiles(p ParseResult, kotlin, java []*scanner.File) ParseResult {
 // reverse-dependency source files that were not edited are parsed on demand
 // and merged into a copy of parseResult.
 //
-// It returns ok=false (caller bails to full dispatch) when an affected file
-// cannot be re-dispatched: a non-source file (e.g. an XML referrer), a parse
-// failure, or a source file that is gone (e.g. deleted) and so never comes
-// back parsed. Full dispatch handles all of those correctly.
-func materializeAffectedFiles(ctx context.Context, args ProjectArgs, host ProjectHostState, parseResult ParseResult, affected []string) (ParseResult, bool) {
+// It returns a non-empty bail reason (caller falls back to full dispatch) when
+// an affected file cannot be re-dispatched: a non-source file (e.g. an XML
+// referrer), a parse failure, or a source file that is gone (e.g. deleted) and
+// so never comes back parsed. Full dispatch handles all of those correctly. An
+// empty reason means success.
+func materializeAffectedFiles(ctx context.Context, args ProjectArgs, host ProjectHostState, parseResult ParseResult, affected []string) (ParseResult, string) {
 	parsed := parsedPathSet(parseResult)
 	var missingKotlin, missingJava []string
 	for _, f := range affected {
@@ -2853,17 +2853,17 @@ func materializeAffectedFiles(ctx context.Context, args ProjectArgs, host Projec
 		case strings.HasSuffix(f, ".java"):
 			missingJava = append(missingJava, f)
 		default:
-			return ParseResult{}, false
+			return ParseResult{}, replayBailNonSource
 		}
 	}
 	if len(missingKotlin) == 0 && len(missingJava) == 0 {
 		// Every affected file was already parsed (the classification loop
 		// proved it); nothing to materialize.
-		return parseResult, true
+		return parseResult, ""
 	}
 	kt, jv, err := parseFilesByPath(ctx, args, host, missingKotlin, missingJava)
 	if err != nil {
-		return ParseResult{}, false
+		return ParseResult{}, replayBailParseFailed
 	}
 	// parseFilesByPath silently drops paths it cannot read (e.g. a deleted
 	// source file). Confirm every requested dependent actually came back, or
@@ -2881,16 +2881,35 @@ func materializeAffectedFiles(ctx context.Context, args ProjectArgs, host Projec
 	}
 	for _, f := range missingKotlin {
 		if !got[f] {
-			return ParseResult{}, false
+			return ParseResult{}, replayBailParseIncomplete
 		}
 	}
 	for _, f := range missingJava {
 		if !got[f] {
-			return ParseResult{}, false
+			return ParseResult{}, replayBailParseIncomplete
 		}
 	}
-	return mergeParsedFiles(parseResult, kt, jv), true
+	return mergeParsedFiles(parseResult, kt, jv), ""
 }
+
+// Affected-set replay outcome labels, emitted as the "reason" detail on the
+// dispatchAffectedSetPath perf entry. "hit" means the path fired; every other
+// value is a bail reason that explains why the run fell back to full dispatch,
+// so the perf JSON answers "why didn't replay fire?" without code-reading.
+const (
+	replayHit                 = "hit"
+	replayBailDisabled        = "disabled"         // flag off
+	replayBailNoManifest      = "no_manifest"      // manifest disabled / key empty / load miss
+	replayBailNoIndex         = "no_index"         // current CodeIndex nil
+	replayBailFullBuild       = "full_build"       // no removed-edge data (#608 nil gate)
+	replayBailNoChanges       = "no_changes"       // diffContentHashes empty
+	replayBailNoBundle        = "no_bundle"        // prior findings bundle missing
+	replayBailEmptyAffected   = "empty_affected"   // affected set empty
+	replayBailTooLarge        = "too_large"        // affected set fails the ratio gate
+	replayBailNonSource       = "non_source"       // affected file is not Kotlin/Java (e.g. XML)
+	replayBailParseFailed     = "parse_failed"     // parseFilesByPath errored
+	replayBailParseIncomplete = "parse_incomplete" // a dependent never came back parsed
+)
 
 // affectedSetReplayEnabled reports whether the opt-in affected-set replay
 // dispatch path is turned on. Default OFF: the path is conservative and #608
@@ -2940,47 +2959,47 @@ func tryAffectedSetDispatch(
 	indexResult IndexResult,
 	parseResult ParseResult,
 	manifest deltaManifestData,
-) (DispatchResult, CrossFileResult, bool, error) {
+) (DispatchResult, CrossFileResult, string, error) {
 	if !affectedSetReplayEnabled() {
-		return DispatchResult{}, CrossFileResult{}, false, nil
+		return DispatchResult{}, CrossFileResult{}, replayBailDisabled, nil
 	}
 	if !manifest.enabled || manifest.manifestKey == "" {
-		return DispatchResult{}, CrossFileResult{}, false, nil
+		return DispatchResult{}, CrossFileResult{}, replayBailNoManifest, nil
 	}
 	current := indexResult.CodeIndex
 	if current == nil {
-		return DispatchResult{}, CrossFileResult{}, false, nil
+		return DispatchResult{}, CrossFileResult{}, replayBailNoIndex, nil
 	}
 	// #608 gate: only safe when the current index carries the edges the edit
 	// removed. A nil here means a full build (no overlay), where a removed
 	// reference is unrecoverable and the affected set could miss a flip.
 	removed := current.LastRemovedContributions()
 	if removed == nil {
-		return DispatchResult{}, CrossFileResult{}, false, nil
+		return DispatchResult{}, CrossFileResult{}, replayBailFullBuild, nil
 	}
 	prior, ok := loadBundleManifest(host, manifest.manifestKey)
 	if !ok {
-		return DispatchResult{}, CrossFileResult{}, false, nil
+		return DispatchResult{}, CrossFileResult{}, replayBailNoManifest, nil
 	}
 	changedPaths := diffContentHashes(prior.ContentHashes, manifest.contentHashes)
 	if len(changedPaths) == 0 {
-		return DispatchResult{}, CrossFileResult{}, false, nil
+		return DispatchResult{}, CrossFileResult{}, replayBailNoChanges, nil
 	}
 	priorBundle, ok := host.FindingsBundleStore.Load(host.FindingsBundleCacheRoot, prior.Fingerprint)
 	if !ok || priorBundle == nil {
-		return DispatchResult{}, CrossFileResult{}, false, nil
+		return DispatchResult{}, CrossFileResult{}, replayBailNoBundle, nil
 	}
 
 	affected := scanner.AffectedSetIncremental(current, changedPaths, removed)
 	if len(affected) == 0 {
-		return DispatchResult{}, CrossFileResult{}, false, nil
+		return DispatchResult{}, CrossFileResult{}, replayBailEmptyAffected, nil
 	}
 	// Perf gate: if the affected set spans most of the project, full dispatch
 	// is about as cheap. Use the prior manifest's file set as the denominator
 	// (warm parseResult holds only dirty files).
 	total := len(prior.ContentHashes)
 	if total == 0 || len(affected)*2 > total {
-		return DispatchResult{}, CrossFileResult{}, false, nil
+		return DispatchResult{}, CrossFileResult{}, replayBailTooLarge, nil
 	}
 
 	affectedSet := make(map[string]bool, len(affected))
@@ -2990,20 +3009,20 @@ func tryAffectedSetDispatch(
 
 	// Invariant 2: materialize any affected files the warm parse skipped, or
 	// bail to full dispatch if the full affected set cannot be re-dispatched.
-	dispatchParse, ok := materializeAffectedFiles(ctx, args, host, parseResult, affected)
-	if !ok {
-		return DispatchResult{}, CrossFileResult{}, false, nil
+	dispatchParse, bail := materializeAffectedFiles(ctx, args, host, parseResult, affected)
+	if bail != "" {
+		return DispatchResult{}, CrossFileResult{}, bail, nil
 	}
 
 	scoped := indexResult
 	scoped.ParseResult = scopeParseResultMulti(dispatchParse, affectedSet)
 	d, err := DispatchPhase{}.Run(ctx, scoped)
 	if err != nil {
-		return DispatchResult{}, CrossFileResult{}, false, fmt.Errorf("dispatch (affected-set): %w", err)
+		return DispatchResult{}, CrossFileResult{}, "", fmt.Errorf("dispatch (affected-set): %w", err)
 	}
 	c, err := CrossFilePhase{Workers: args.Workers}.Run(ctx, d)
 	if err != nil {
-		return DispatchResult{}, CrossFileResult{}, false, fmt.Errorf("crossfile (affected-set): %w", err)
+		return DispatchResult{}, CrossFileResult{}, "", fmt.Errorf("crossfile (affected-set): %w", err)
 	}
 
 	replacement := scanner.FilterColumnsByFilePaths(&c.Findings, affectedSet)
@@ -3012,7 +3031,7 @@ func tryAffectedSetDispatch(
 	d.Findings = merged
 	c.DispatchResult = d
 	c.Findings = merged
-	return d, c, true, nil
+	return d, c, replayHit, nil
 }
 
 // computeRunFingerprint builds a scanner.RunFingerprint from the run's


### PR DESCRIPTION
## Summary

First of a four-PR sequence following up on the affected-set replay path (#617–#619). Adds bail-reason observability so we can validate the path's fire-rate on real repos before widening it (XML) or flipping the default.

Previously the ~ten early-return gates in `tryAffectedSetDispatch` all collapsed to `outcome: miss` on the `dispatchAffectedSetPath` perf entry — a run that fell back to full dispatch gave no signal as to *why*. Now `tryAffectedSetDispatch` and `materializeAffectedFiles` return a reason string (`hit` on success, a `replayBail*` label otherwise — `disabled`, `no_manifest`, `no_index`, `full_build`, `no_changes`, `no_bundle`, `empty_affected`, `too_large`, `non_source`, `parse_failed`, `parse_incomplete`) emitted as the `reason` detail.

The redundant `outcome` detail is dropped (hit vs miss is derivable from `reason == "hit"`; the sibling `dispatchDeltaPath` already only emits one label).

## Test plan

- [ ] `go build ./... && go vet ./... && golangci-lint run ./...` — clean
- [ ] `go test ./... -count=1` — green
- [ ] New `TestTryAffectedSetDispatch_BailReasons` pins the early-gate labels; existing materialize tests now assert the `non_source` / `parse_incomplete` reasons