### PR TITLE
feat(gradle): parse .gradle.kts into a flat AST and migrate ApplyPluginTwice

### DIFF
--- a/internal/pipeline/android.go
+++ b/internal/pipeline/android.go
@@ -933,12 +933,7 @@ func (AndroidPhase) runGradleOne(in AndroidInput, path string) (scanner.FindingC
 		return scanner.FindingColumns{}, readParseDur, 0
 	}
 	ruleStart := time.Now()
-	file := &scanner.File{
-		Path:     path,
-		Language: scanner.LangGradle,
-		Content:  content,
-		Metadata: cfg,
-	}
+	file := scanner.ParseGradleScript(context.Background(), path, content, cfg)
 	cols := in.Dispatcher.RunGradle(file, cfg)
 	return cols, readParseDur, time.Since(ruleStart)
 }

--- a/internal/rules/android_gradle_test.go
+++ b/internal/rules/android_gradle_test.go
@@ -1,6 +1,7 @@
 package rules_test
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -29,7 +30,9 @@ func findGradleRule(t *testing.T, name string) *api.Rule {
 
 func runGradleRule(r *api.Rule, path, content string, cfg *android.BuildConfig) []scanner.Finding {
 	collector := scanner.NewFindingCollector(0)
+	file := scanner.ParseGradleScript(context.Background(), path, []byte(content), cfg)
 	ctx := &api.Context{
+		File:          file,
 		GradlePath:    path,
 		GradleContent: content,
 		GradleConfig:  cfg,

--- a/internal/rules/api/rule.go
+++ b/internal/rules/api/rule.go
@@ -1185,6 +1185,20 @@ type Context struct {
 	AtThoroughDepth bool
 }
 
+// GradleAST returns the parsed Gradle build script when it carries a
+// tree-sitter flat AST — i.e. a Kotlin DSL (.kts) script parsed by
+// scanner.ParseGradleScript. It returns nil for Groovy (.gradle) scripts,
+// where rules must fall back to line/regex scanning over GradleContent.
+// Gradle rules migrating off regex should branch on this rather than reaching
+// into ctx.File.FlatTree directly, so the AST-vs-regex contract stays in one
+// place.
+func (c *Context) GradleAST() *scanner.File {
+	if c.File != nil && c.File.FlatTree != nil {
+		return c.File
+	}
+	return nil
+}
+
 // Emit reports a finding. The finding is stamped with rule metadata and
 // written to the Collector.
 func (c *Context) Emit(f scanner.Finding) {

--- a/internal/rules/flat_node.go
+++ b/internal/rules/flat_node.go
@@ -117,6 +117,20 @@ func isBooleanLiteralTrue(file *scanner.File, idx uint32) bool {
 	return false
 }
 
+// isBooleanLiteralFalse returns true if the node is a boolean_literal whose
+// token is `false`. Accepts 0 and returns false (caller convenience).
+func isBooleanLiteralFalse(file *scanner.File, idx uint32) bool {
+	if file == nil || idx == 0 || file.FlatType(idx) != "boolean_literal" {
+		return false
+	}
+	for child := file.FlatFirstChild(idx); child != 0; child = file.FlatNextSib(child) {
+		if file.FlatType(child) == "false" {
+			return true
+		}
+	}
+	return false
+}
+
 // ifExpressionHasElse returns true when an if_expression has an `else`
 // token child. An if_expression with only the then branch has children
 // (if, "(", condition, ")", control_structure_body); adding an else

--- a/internal/rules/flat_string.go
+++ b/internal/rules/flat_string.go
@@ -154,6 +154,17 @@ func stringLiteralContent(file *scanner.File, idx uint32) string {
 	return b.String()
 }
 
+// flatStringLiteralExprContent returns the literal content of a string_literal
+// expression node, or "" when expr is zero, not a string_literal, or contains
+// interpolation. Convenient for pulling a fixed string out of a call argument
+// without the caller repeating the type/interpolation guards.
+func flatStringLiteralExprContent(file *scanner.File, expr uint32) string {
+	if expr == 0 || file.FlatType(expr) != "string_literal" || flatContainsStringInterpolation(file, expr) {
+		return ""
+	}
+	return stringLiteralContent(file, expr)
+}
+
 // stringLiteralIsRaw returns true when the string_literal node is a
 // triple-quoted raw string (`"""..."""`). Raw strings don't process
 // backslash escapes, so rules that analyze escape sequences should

--- a/internal/rules/supply_chain_test.go
+++ b/internal/rules/supply_chain_test.go
@@ -899,6 +899,25 @@ apply(plugin = "com.android.application")
 			t.Fatalf("fix output mismatch:\n--- got ---\n%q\n--- want ---\n%q", got, want)
 		}
 	})
+
+	// Regression: the line-based scanner cannot track multi-line raw-string
+	// state, so an apply(plugin = ...) inside a """...""" literal looked like
+	// a real application and produced a false positive. The .kts AST path
+	// sees the multi_line_string and emits nothing.
+	t.Run("apply inside multi-line raw string is clean", func(t *testing.T) {
+		content := `plugins {
+    id("com.android.application")
+}
+val template = """
+apply(plugin = "com.android.application")
+"""
+`
+		cfg, _ := android.ParseBuildGradleContent(content)
+		findings := runGradleRule(r, "build.gradle.kts", content, cfg)
+		if len(findings) != 0 {
+			t.Fatalf("expected 0 findings, got %d", len(findings))
+		}
+	})
 }
 
 func TestConfigurationsAllSideEffect(t *testing.T) {

--- a/internal/rules/supply_drift.go
+++ b/internal/rules/supply_drift.go
@@ -456,7 +456,13 @@ func (r *ApplyPluginTwiceRule) check(ctx *api.Context) {
 	if !isGradleBuildScript(path) {
 		return
 	}
-	for _, duplicate := range findApplyPluginTwice(content) {
+	var duplicates []applyPluginTwiceFinding
+	if astFile := ctx.GradleAST(); astFile != nil {
+		duplicates = findApplyPluginTwiceAST(astFile)
+	} else {
+		duplicates = findApplyPluginTwice(content)
+	}
+	for _, duplicate := range duplicates {
 		finding := scanner.Finding{
 			File:       path,
 			Line:       duplicate.line,
@@ -564,6 +570,118 @@ func findApplyPluginTwice(content string) []applyPluginTwiceFinding {
 		}
 	}
 	return findings
+}
+
+// findApplyPluginTwiceAST is the tree-sitter equivalent of
+// findApplyPluginTwice for Kotlin DSL (.kts) scripts. It walks the flat AST
+// instead of brace-counting lines, so string-literal lookalikes, comments,
+// and chained `apply false` declarations are handled by parser structure
+// rather than lexical heuristics.
+func findApplyPluginTwiceAST(file *scanner.File) []applyPluginTwiceFinding {
+	declared := map[string]gradlePluginOccurrence{}
+	var applied []gradlePluginOccurrence
+
+	file.FlatWalkNodes(0, "call_expression", func(idx uint32) {
+		switch flatCallExpressionName(file, idx) {
+		case "plugins":
+			collectPluginsBlockIDsAST(file, idx, declared)
+		case "apply":
+			if id, ok := applyPluginIDAST(file, idx); ok {
+				applied = append(applied, gradlePluginOccurrence{id: id, line: file.FlatRow(idx) + 1})
+			}
+		}
+	})
+
+	seen := map[string]bool{}
+	var findings []applyPluginTwiceFinding
+	for _, occurrence := range applied {
+		if seen[occurrence.id] {
+			continue
+		}
+		if _, ok := declared[occurrence.id]; ok {
+			findings = append(findings, applyPluginTwiceFinding(occurrence))
+			seen[occurrence.id] = true
+		}
+	}
+	return findings
+}
+
+// collectPluginsBlockIDsAST records every plugin id declared inside the
+// trailing lambda of a `plugins { }` call. `id("x")` yields its literal id;
+// `kotlin("jvm")` is normalized through kotlinGradlePluginID. Declarations
+// marked `apply false` are skipped — they are not applied in this script.
+func collectPluginsBlockIDsAST(file *scanner.File, pluginsCall uint32, declared map[string]gradlePluginOccurrence) {
+	lambda := flatCallTrailingLambda(file, pluginsCall)
+	if lambda == 0 {
+		return
+	}
+	file.FlatWalkNodes(lambda, "call_expression", func(idx uint32) {
+		var id string
+		switch flatCallExpressionName(file, idx) {
+		case "id":
+			id = pluginCallStringArgAST(file, idx)
+		case "kotlin":
+			id = kotlinGradlePluginID(pluginCallStringArgAST(file, idx))
+		default:
+			return
+		}
+		if id == "" || pluginDeclarationIsApplyFalseAST(file, idx) {
+			return
+		}
+		if _, ok := declared[id]; !ok {
+			declared[id] = gradlePluginOccurrence{id: id, line: file.FlatRow(idx) + 1}
+		}
+	})
+}
+
+// pluginCallStringArgAST returns the first positional string-literal argument
+// of a plugin call (`id("x")`, `kotlin("jvm")`), or "" when the argument is
+// absent or interpolated.
+func pluginCallStringArgAST(file *scanner.File, call uint32) string {
+	arg := flatPositionalValueArgument(file, flatCallKeyArguments(file, call), 0)
+	return flatStringLiteralExprContent(file, flatValueArgumentExpression(file, arg))
+}
+
+// applyPluginIDAST returns the plugin id of an `apply(plugin = "x")` call, or
+// false when the call is not that form.
+func applyPluginIDAST(file *scanner.File, call uint32) (string, bool) {
+	arg := flatNamedValueArgument(file, flatCallKeyArguments(file, call), "plugin")
+	id := flatStringLiteralExprContent(file, flatValueArgumentExpression(file, arg))
+	return id, id != ""
+}
+
+// pluginDeclarationIsApplyFalseAST reports whether a plugin declaration call
+// is the left operand of an `... apply false` infix expression, which marks
+// the plugin as declared-but-not-applied in this script.
+func pluginDeclarationIsApplyFalseAST(file *scanner.File, call uint32) bool {
+	for node := call; node != 0; {
+		parent, ok := file.FlatParent(node)
+		if !ok {
+			return false
+		}
+		switch file.FlatType(parent) {
+		case "infix_expression":
+			if infixIsApplyFalse(file, parent) {
+				return true
+			}
+		case "statements", "lambda_literal":
+			return false
+		}
+		node = parent
+	}
+	return false
+}
+
+func infixIsApplyFalse(file *scanner.File, infix uint32) bool {
+	if !infixOperatorIs(file, infix, "apply") {
+		return false
+	}
+	for child := file.FlatFirstChild(infix); child != 0; child = file.FlatNextSib(child) {
+		if isBooleanLiteralFalse(file, child) {
+			return true
+		}
+	}
+	return false
 }
 
 func gradlePluginsBlockStarts(line string) bool {

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -268,6 +268,32 @@ func NewParsedFile(path string, content []byte, tree *sitter.Tree) *File {
 	}
 }
 
+// ParseGradleScript builds a File for a Gradle build script. For Kotlin DSL
+// scripts (.kts) the content is parsed with the Kotlin tree-sitter grammar so
+// Gradle rules can walk the flat AST; Groovy (.gradle) scripts return a File
+// with no FlatTree and rules fall back to line/regex scanning. The returned
+// File always carries Language == LangGradle and the given metadata (typically
+// the parsed *android.BuildConfig, kept as `any` to avoid an import cycle).
+// The ctx is forwarded to the tree-sitter parser so callers can cancel a
+// long-running parse.
+func ParseGradleScript(ctx context.Context, path string, content []byte, metadata any) *File {
+	file := &File{
+		Path:     internString(path),
+		Language: LangGradle,
+		Content:  content,
+		Lines:    strings.Split(string(content), "\n"),
+		Metadata: metadata,
+	}
+	if strings.HasSuffix(path, ".kts") {
+		parser := GetKotlinParser()
+		defer PutKotlinParser(parser)
+		if tree, err := parser.ParseCtx(ctx, nil, content); err == nil && tree != nil {
+			file.FlatTree = flattenTree(tree.RootNode())
+		}
+	}
+	return file
+}
+
 // CollectKotlinFiles finds all .kt and .kts files under the given paths.
 func CollectKotlinFiles(paths []string, excludes []string) ([]string, error) {
 	return collectSourceFiles(paths, excludes, isKotlinFile)


### PR DESCRIPTION
## Summary

Gradle rules previously saw only raw text plus the regex-parsed `BuildConfig`. This PR adds tree-sitter AST support for Kotlin DSL build scripts and migrates the first structural rule onto it.

- **`scanner.ParseGradleScript`** parses `.gradle.kts` with the existing Kotlin tree-sitter grammar and attaches the flat AST to the Gradle `scanner.File`. Groovy `.gradle` scripts keep regex/line scanning (no FlatTree).
- The parsed `File` is already handed to every Gradle rule via `ctx.File`, so rules branch on a new documented **`ctx.GradleAST()`** accessor instead of poking `ctx.File.FlatTree` — establishing the AST-vs-regex contract in one place for the rules that follow.
- **`ApplyPluginTwice`** now walks the AST for `.kts`: plugin ids from the `plugins { }` block (`id(...)` / `kotlin(...)`, honoring `apply false` via the infix shape) and `apply(plugin = "...")` calls, by parser structure rather than brace-counting. Groovy scripts continue through the original regex path.

## Why

The line scanner cannot track multi-line raw-string state, so an `apply(plugin = ...)` inside a `"""..."""` literal produced a false positive. The AST path does not. A regression test locks this in.

## Scope

First of four PRs migrating the structural Gradle rules. This one carries the shared infra; `ConfigurationsAllSideEffect`, `DependenciesInRootProject`, and `GradleGetter` follow and build on `ctx.GradleAST()`.

## Test plan

- `go build`, `go vet`, `golangci-lint run`, `go test ./...` — green
- `make integration` — green
- New regression: `apply(plugin = ...)` inside a multi-line raw string is clean; all existing `ApplyPluginTwice` cases (string-literal lookalike, `apply false`, comment, settings file, Groovy normalization) now run through the AST path