### PR TITLE
fix(rules): require proven non-null target for UselessElvisOnNonNull

### DIFF
--- a/internal/rules/potentialbugs_nullsafety_elvis_proven_internal_test.go
+++ b/internal/rules/potentialbugs_nullsafety_elvis_proven_internal_test.go
@@ -1,0 +1,104 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/kaeawc/krit/internal/scanner"
+	"github.com/kaeawc/krit/internal/typeinfer"
+)
+
+// resolveFirstElvisOperandType parses code with a source resolver, finds the
+// first elvis_expression the rule would consider, and returns the result of
+// uselessElvisResolvedOperandType for its left operand. `present` reports
+// whether a candidate elvis operand was found at all.
+func resolveFirstElvisOperandType(t *testing.T, code string) (rt *typeinfer.ResolvedType, ok, present bool) {
+	t.Helper()
+	file := parseInlineForInternalTest(t, code)
+	resolver := typeinfer.NewResolver()
+	resolver.IndexFilesParallel([]*scanner.File{file}, 1)
+
+	var operand uint32
+	file.FlatWalkNodes(0, "elvis_expression", func(idx uint32) {
+		if present {
+			return
+		}
+		if _, op, accepted := uselessElvisOperand(file, idx); accepted {
+			operand = op
+			present = true
+		}
+	})
+	if !present {
+		return nil, false, false
+	}
+	rt, ok = uselessElvisResolvedOperandType(file, resolver, operand)
+	return rt, ok, true
+}
+
+// TestUselessElvisResolvedOperandType_UnknownReceiverNavigation pins the
+// regression: a member-access elvis operand whose receiver type is not
+// declared in this file (`decl.source`) must NOT be treated as a proven
+// non-null type. Source inference defaults such an unresolved member access
+// to non-null, which previously made the rule flag the elvis fallback as dead
+// code even though the member may well be nullable.
+func TestUselessElvisResolvedOperandType_UnknownReceiverNavigation(t *testing.T) {
+	code := "fun f(decl: ExternalDecl): Any { val y = decl.source ?: return Unit; return y }\n"
+	_, ok, present := resolveFirstElvisOperandType(t, code)
+	if !present {
+		t.Fatal("expected to find an elvis operand for `decl.source ?: ...`")
+	}
+	if ok {
+		t.Fatal("member access on a receiver whose type is not declared in-file must not resolve to a proven type")
+	}
+}
+
+// TestUselessElvisResolvedOperandType_UnknownMemberOnKnownClass covers a
+// navigation to a member that does not exist on an in-file class. The
+// receiver type resolves, but the member does not, so its nullability is
+// unproven and the operand must not be accepted.
+func TestUselessElvisResolvedOperandType_UnknownMemberOnKnownClass(t *testing.T) {
+	code := "class Holder { val label: String = \"\" }\n" +
+		"fun f(): Any { val h = Holder(); val y = h.missing ?: \"fallback\"; return y }\n"
+	_, ok, present := resolveFirstElvisOperandType(t, code)
+	if !present {
+		t.Fatal("expected to find an elvis operand for `h.missing ?: ...`")
+	}
+	if ok {
+		t.Fatal("navigation to a member absent from a known in-file class must not resolve to a proven type")
+	}
+}
+
+// TestUselessElvisResolvedOperandType_ProvenInFileMember is the positive
+// guard: a member access whose receiver is a local val of an in-file class
+// and whose member is a non-null property must still resolve to a proven
+// non-null type so the rule keeps firing on genuinely dead fallbacks.
+func TestUselessElvisResolvedOperandType_ProvenInFileMember(t *testing.T) {
+	code := "class Holder { val label: String = \"\" }\n" +
+		"fun f(): Any { val h = Holder(); val y = h.label ?: \"fallback\"; return y }\n"
+	rt, ok, present := resolveFirstElvisOperandType(t, code)
+	if !present {
+		t.Fatal("expected to find an elvis operand for `h.label ?: ...`")
+	}
+	if !ok || rt == nil {
+		t.Fatal("member access on a proven in-file non-null property must resolve")
+	}
+	if rt.IsNullable() {
+		t.Fatal("a non-null in-file property must not resolve as nullable")
+	}
+}
+
+// TestUselessElvisResolvedOperandType_LiteralKeepsDirectPath ensures the
+// gating change does not disturb intrinsically non-null operand shapes:
+// a string literal still resolves via the direct resolver path.
+func TestUselessElvisResolvedOperandType_LiteralKeepsDirectPath(t *testing.T) {
+	code := "fun f(): String { val y = \"always\" ?: \"dead\"; return y }\n"
+	rt, ok, present := resolveFirstElvisOperandType(t, code)
+	if !present {
+		t.Fatal("expected to find an elvis operand for `\"always\" ?: ...`")
+	}
+	if !ok || rt == nil {
+		t.Fatal("a string literal operand must resolve via the direct path")
+	}
+	if rt.IsNullable() {
+		t.Fatal("a string literal must not resolve as nullable")
+	}
+}

--- a/internal/rules/potentialbugs_nullsafety_redundant.go
+++ b/internal/rules/potentialbugs_nullsafety_redundant.go
@@ -1922,8 +1922,8 @@ func (r *UselessElvisOnNonNullRule) check(ctx *api.Context) {
 	if !ok {
 		return
 	}
-	resolved := ctx.Resolver.ResolveFlatNode(operand, file)
-	if resolved == nil {
+	resolved, ok := uselessElvisResolvedOperandType(file, ctx.Resolver, operand)
+	if !ok || resolved == nil {
 		return
 	}
 	if resolved.Kind == typeinfer.TypeUnknown || resolved.Kind == typeinfer.TypeGeneric {
@@ -1944,6 +1944,35 @@ func (r *UselessElvisOnNonNullRule) check(ctx *api.Context) {
 		Replacement: "",
 	}
 	ctx.Emit(f)
+}
+
+// uselessElvisResolvedOperandType resolves the elvis left operand's type, but
+// only when the result is genuinely proven non-null rather than defaulted to
+// non-null by source inference.
+//
+// For qualified calls and member-access navigations it requires a resolved
+// same-file / stdlib target (mirroring UnnecessaryNotNullCheckRule's operand
+// gate): source inference defaults an unresolved member call or property
+// access to a non-null type, which would wrongly flag the elvis fallback as
+// dead code (e.g. `external.create(x) ?: continue`, `decl.source ?: return`,
+// `obj.missingMember ?: fallback`). Intrinsically non-null operand shapes
+// (literals, bare identifiers with a same-file declaration, `this`, `x!!`,
+// `x as T`) keep the direct resolver path, where the resolver's nullability
+// verdict is trustworthy.
+func uselessElvisResolvedOperandType(file *scanner.File, resolver typeinfer.TypeResolver, operand uint32) (*typeinfer.ResolvedType, bool) {
+	if file == nil || resolver == nil || operand == 0 {
+		return nil, false
+	}
+	switch file.FlatType(operand) {
+	case "call_expression", "navigation_expression":
+		return flatResolvedNullCheckOperandType(file, resolver, operand)
+	default:
+		resolved := resolver.ResolveFlatNode(operand, file)
+		if resolved == nil {
+			return nil, false
+		}
+		return resolved, true
+	}
 }
 
 // ExpressionPositions enumerates left operands the rule wants resolved by

--- a/tests/fixtures/negative/potential-bugs/UselessElvisOnNonNull.kt
+++ b/tests/fixtures/negative/potential-bugs/UselessElvisOnNonNull.kt
@@ -42,6 +42,32 @@ class UselessElvisOnNonNull {
     fun navigationAfterSafeCall(harness: TestHarness?) {
         val y = harness?.group?.length.toString() ?: "fallback"
     }
+
+    // Member access on a receiver whose type is not declared in this file.
+    // Source inference cannot see the member's declared nullability and must
+    // not default it to non-null: the member may well be nullable, so the
+    // elvis fallback is meaningful.
+    fun memberAccessOnUnknownReceiver(decl: ExternalDecl) {
+        val y = decl.source ?: return
+        use(y)
+    }
+
+    // Member access to a name that does not exist on a known in-file class.
+    // The receiver type resolves, but the member does not — its nullability
+    // is unproven, so the rule must not fire.
+    fun memberAccessUnknownMember(h: TestHarness) {
+        val y = h.missing ?: "fallback"
+        use(y)
+    }
+
+    // Qualified call whose target cannot be resolved in-file or in the stdlib.
+    // The return type's nullability is unproven; the elvis must be preserved.
+    fun qualifiedCallUnknownTarget(factory: ExternalFactory) {
+        val y = factory.create() ?: return
+        use(y)
+    }
+
+    fun use(x: Any?) {}
 }
 
 class TestHarness {

--- a/tests/fixtures/positive/potential-bugs/UselessElvisOnNonNull.kt
+++ b/tests/fixtures/positive/potential-bugs/UselessElvisOnNonNull.kt
@@ -14,4 +14,21 @@ class UselessElvisOnNonNull {
         val n: Int = 42
         val m = n ?: 0
     }
+
+    // Member access on a local val whose class is declared in this file and
+    // whose member is non-null — the target is proven, so the fallback is dead.
+    fun nonNullMemberOnLocal() {
+        val h = Holder()
+        val v = h.label ?: "dead"
+    }
+
+    // Member access via `this` on a non-null property — also proven non-null.
+    val title: String = "t"
+    fun nonNullMemberOnThis() {
+        val v = this.title ?: "dead"
+    }
+}
+
+class Holder {
+    val label: String = ""
 }


### PR DESCRIPTION
## Problem

`UselessElvisOnNonNull` flagged the elvis fallback as dead code whenever source
inference returned a non-null type for the left operand. But source-level
inference **defaults an unresolved member access or method call to non-null**,
so it produced false positives on idiomatic code where the member or return
type is actually nullable:

- `decl.source ?: return` — member access on a receiver whose type is not in this file
- `obj.missingMember ?: fallback` — navigation to a name absent from a known in-file class
- `factory.create() ?: continue` — qualified call whose target is not resolvable in-file or in the stdlib

In each case the operand is genuinely nullable, but source inference couldn't
see the declared nullability and widened it to non-null, so the rule wrongly
reported the fallback as unreachable.

## Fix

Route `call_expression` and `navigation_expression` operands through the same
proven-target resolution `UnnecessaryNotNullCheck` already uses
(`flatResolvedNullCheckOperandType`): a finding now requires a resolved
same-file / stdlib target rather than a non-null verdict defaulted by source
inference.

Intrinsically non-null operand shapes keep the direct resolver path, where the
nullability verdict is trustworthy:

- literals
- bare identifiers with a same-file declaration
- `this`
- `!!`
- `as`

Proven in-file member access still fires (local-val and `this` receivers).

## Tests

- **Positive fixtures**: proven in-file member access via a local val and via `this`.
- **Negative fixtures**: unknown-receiver navigation, absent member on a known class, and an unresolved qualified call. These reproduce the false positives on the pre-fix binary and are silent after.
- **Unit tests**: the operand-resolution gate — unknown-receiver navigation and absent-member navigation do not resolve; a proven non-null in-file member and a string literal do.

## Validation

`go build`, `go vet`, `golangci-lint run ./...`, `make lint-rules`, and the
`internal/rules` package tests (fixtures + unit) all pass.