### PR TITLE
feat(gradle): migrate ConfigurationsAllSideEffect to the .kts flat AST

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kaeawc/krit
 
-go 1.25.0
+go 1.25.8
 
 require (
 	github.com/bits-and-blooms/bloom/v3 v3.7.1

--- a/internal/rules/supply_chain_test.go
+++ b/internal/rules/supply_chain_test.go
@@ -1003,6 +1003,38 @@ configurations.all {
 			t.Fatalf("expected 1 finding when convention plugin allowance is disabled, got %d", len(findings))
 		}
 	})
+
+	// Regression: the line scanner cannot track multi-line raw-string state, so
+	// a configurations.all { } block written inside a """...""" literal looked
+	// like real code and produced a false positive. The .kts AST path sees the
+	// multi_line_string and emits nothing.
+	t.Run("configurations.all inside multi-line raw string is clean", func(t *testing.T) {
+		content := `val template = """
+configurations.all {
+    resolutionStrategy.force("x:y:1")
+}
+"""
+`
+		cfg, _ := android.ParseBuildGradleContent(content)
+		findings := runGradleRule(r, "build.gradle.kts", content, cfg)
+		if len(findings) != 0 {
+			t.Fatalf("expected 0 findings, got %d", len(findings))
+		}
+	})
+
+	// The configurations.matching { }.all { } form mutates only a filtered view
+	// and must stay clean — the AST path distinguishes it by receiver shape.
+	t.Run("configurations.matching.all with mutator is clean", func(t *testing.T) {
+		content := `configurations.matching { it.name == "runtimeClasspath" }.all {
+    resolutionStrategy.force("com.squareup.okhttp3:okhttp:4.12.0")
+}
+`
+		cfg, _ := android.ParseBuildGradleContent(content)
+		findings := runGradleRule(r, "build.gradle.kts", content, cfg)
+		if len(findings) != 0 {
+			t.Fatalf("expected 0 findings, got %d", len(findings))
+		}
+	})
 }
 
 func TestDependencyFromBintray(t *testing.T) {

--- a/internal/rules/supply_drift.go
+++ b/internal/rules/supply_drift.go
@@ -756,7 +756,13 @@ func (r *ConfigurationsAllSideEffectRule) check(ctx *api.Context) {
 	if r.AllowInConventionPlugins && isConventionPluginBuildPath(path) {
 		return
 	}
-	for _, block := range findConfigurationsAllSideEffects(content) {
+	var blocks []configurationsAllSideEffect
+	if astFile := ctx.GradleAST(); astFile != nil {
+		blocks = findConfigurationsAllSideEffectsAST(astFile)
+	} else {
+		blocks = findConfigurationsAllSideEffects(content)
+	}
+	for _, block := range blocks {
 		ctx.Emit(scanner.Finding{
 			File:       path,
 			Line:       block.line,
@@ -839,6 +845,68 @@ func configurationsAllSideEffectMutator(line string) string {
 	case strings.Contains(compact, ".exclude(") || strings.HasPrefix(compact, "exclude("):
 		return "exclude"
 	case strings.Contains(compact, ".force(") || strings.HasPrefix(compact, "force("):
+		return "force"
+	default:
+		return ""
+	}
+}
+
+// findConfigurationsAllSideEffectsAST is the tree-sitter equivalent of
+// findConfigurationsAllSideEffects for Kotlin DSL (.kts) scripts. It matches a
+// `configurations.all { }` call by parser structure — the callee is `all`
+// invoked directly on the bare `configurations` receiver — so the
+// `configurations.matching { }.all { }` form (whose receiver is a call, not the
+// identifier) is correctly excluded, and string/comment lookalikes never parse
+// as calls.
+func findConfigurationsAllSideEffectsAST(file *scanner.File) []configurationsAllSideEffect {
+	var findings []configurationsAllSideEffect
+	file.FlatWalkNodes(0, "call_expression", func(idx uint32) {
+		if flatCallExpressionName(file, idx) != "all" || flatReceiverNameFromCall(file, idx) != "configurations" {
+			return
+		}
+		lambda := flatCallTrailingLambda(file, idx)
+		if lambda == 0 {
+			return
+		}
+		if mutator := configurationsAllMutatorAST(file, lambda); mutator != "" {
+			findings = append(findings, configurationsAllSideEffect{
+				line:    file.FlatRow(idx) + 1,
+				mutator: mutator,
+			})
+		}
+	})
+	return findings
+}
+
+// configurationsAllMutatorAST reports the dependency-resolution mutator invoked
+// inside a configurations.all lambda, or "" when the block only reads state.
+// A bare reference such as `println(resolutionStrategy)` is not a call on the
+// mutator and is correctly ignored. Priority mirrors the line scanner:
+// resolutionStrategy > dependencies.add > exclude > force.
+func configurationsAllMutatorAST(file *scanner.File, lambda uint32) string {
+	var hasRS, hasDepAdd, hasExclude, hasForce bool
+	file.FlatWalkNodes(lambda, "call_expression", func(call uint32) {
+		name := flatCallExpressionName(file, call)
+		recv := flatReceiverNameFromCall(file, call)
+		switch {
+		case name == "resolutionStrategy" || recv == "resolutionStrategy":
+			hasRS = true
+		case name == "add" && recv == "dependencies":
+			hasDepAdd = true
+		case name == "exclude":
+			hasExclude = true
+		case name == "force":
+			hasForce = true
+		}
+	})
+	switch {
+	case hasRS:
+		return "resolutionStrategy"
+	case hasDepAdd:
+		return "dependencies.add"
+	case hasExclude:
+		return "exclude"
+	case hasForce:
 		return "force"
 	default:
 		return ""


### PR DESCRIPTION
## Summary

Second of the structural Gradle-rule migrations onto the tree-sitter flat AST introduced in #621. `ConfigurationsAllSideEffect` now walks the AST for Kotlin DSL (`.kts`) build scripts instead of brace-counting lines.

- A `configurations.all { }` block is matched **by structure** — the callee `all` invoked directly on the bare `configurations` receiver. The `configurations.matching { }.all { }` form (receiver is a call, not the identifier) is correctly excluded.
- The mutator (`resolutionStrategy` / `dependencies.add` / `exclude` / `force`) is read from call shape, so a bare reference like `println(resolutionStrategy)` is no longer mistaken for a mutation.
- Groovy `.gradle` scripts continue through the original regex path via the `ctx.GradleAST()` accessor from #621.

## Why

The line scanner cannot track multi-line raw-string state, so a `configurations.all { }` block inside a `"""..."""` literal produced a false positive. The AST path does not.

## Scope

Depends on #621 (merged). Remaining: `DependenciesInRootProject`, `GradleGetter`.

## Test plan

- `go build`, `go vet`, `golangci-lint run`, `go test ./...` — green
- `make integration` — green
- New regressions: `configurations.all { }` inside a multi-line raw string is clean; `configurations.matching { }.all { }` with a mutator stays clean. All existing cases (mutator trigger, read-only block, string/comment lookalikes, convention-plugin path gating) pass through the AST path.