### PR TITLE
fix(rules): count unary-prefixed continuation operands as variable uses

### DIFF
--- a/internal/rules/style_unused.go
+++ b/internal/rules/style_unused.go
@@ -702,14 +702,53 @@ func unusedVariableUnaryContinuationUsesName(file *scanner.File, target unusedVa
 		if file.FlatRow(op) <= lhsEndRow {
 			return
 		}
-		if file.FlatType(rhs) != "simple_identifier" {
-			return
+		// The unary-prefixed continuation `+expr` was bound by tree-sitter into
+		// the declaration's initializer as `lhs <op> rhs`. The target name may be
+		// the entire operand (`+factoryCall`) or nested inside it as a call
+		// argument or a reference within a trailing lambda (`+render(typeKey)`,
+		// `+apply { instance.append(...) }`). Treat any genuine reference to the
+		// name anywhere in the operand subtree as a use.
+		if unusedVariableContinuationOperandUsesName(file, rhs, target.name) {
+			found = true
 		}
-		if unusedVariableIdentifierName(file, rhs) != target.name {
-			return
-		}
-		found = true
 	})
+	return found
+}
+
+// unusedVariableContinuationOperandUsesName reports whether `operand` — the
+// right-hand side of a unary-prefixed continuation that tree-sitter folded
+// into a preceding declaration's initializer — contains a genuine reference to
+// `name`. A bare-identifier operand is matched directly; otherwise the operand
+// subtree is walked for an identifier (or string-template reference) that names
+// the target in a real reference position (not a label, type, or declaration).
+func unusedVariableContinuationOperandUsesName(file *scanner.File, operand uint32, name string) bool {
+	if file == nil || operand == 0 || name == "" {
+		return false
+	}
+	if file.FlatType(operand) == "simple_identifier" {
+		return unusedVariableIdentifierName(file, operand) == name
+	}
+	found := false
+	for _, nodeType := range []string{"simple_identifier", "interpolated_identifier", "line_str_ref", "multi_line_str_ref"} {
+		file.FlatWalkNodes(operand, nodeType, func(candidate uint32) {
+			if found {
+				return
+			}
+			if unusedVariableReferenceName(file, candidate) != name {
+				return
+			}
+			if file.FlatType(candidate) == "simple_identifier" {
+				isReference, known := unusedVariableIsReferenceIdentifier(file, candidate)
+				if !known || !isReference {
+					return
+				}
+			}
+			found = true
+		})
+		if found {
+			break
+		}
+	}
 	return found
 }
 

--- a/internal/rules/style_unused_unary_continuation_internal_test.go
+++ b/internal/rules/style_unused_unary_continuation_internal_test.go
@@ -1,0 +1,103 @@
+package rules
+
+import (
+	"testing"
+)
+
+// unusedVariableUsageForName parses code, locates the local variable
+// declaration that binds `name`, and reports the usage verdict the
+// UnusedVariable rule would compute for it.
+func unusedVariableUsageForName(t *testing.T, code, name string) (used, unknown, found bool) {
+	t.Helper()
+	file := parseInlineForInternalTest(t, code)
+	var result struct{ used, unknown, found bool }
+	for _, nodeType := range []string{"property_declaration", "variable_declaration"} {
+		file.FlatWalkNodes(0, nodeType, func(idx uint32) {
+			if result.found {
+				return
+			}
+			target, ok := unusedVariableDeclaration(file, idx)
+			if !ok || target.name != name {
+				return
+			}
+			used, unknown := unusedVariableUsage(file, target)
+			result.used, result.unknown, result.found = used, unknown, true
+		})
+		if result.found {
+			break
+		}
+	}
+	return result.used, result.unknown, result.found
+}
+
+// TestUnusedVariableUnaryContinuation_BareName is the baseline already
+// supported before this change: `+factoryCall` on the line after the
+// declaration references the variable as the whole unary operand.
+func TestUnusedVariableUnaryContinuation_BareName(t *testing.T) {
+	code := "package test\n" +
+		"fun f(b: Builder) {\n" +
+		"    val factoryCall = b.create()\n" +
+		"    +factoryCall\n" +
+		"}\n"
+	used, _, found := unusedVariableUsageForName(t, code, "factoryCall")
+	if !found {
+		t.Fatal("expected to find declaration of factoryCall")
+	}
+	if !used {
+		t.Fatal("variable used as a bare unary continuation operand must count as used")
+	}
+}
+
+// TestUnusedVariableUnaryContinuation_CallArgument pins the regression: the
+// variable is nested as a call argument inside the unary operand
+// (`+b.add(typeKey)`), not the whole operand. Before the fix the walker only
+// matched a bare-identifier operand and reported a false positive.
+func TestUnusedVariableUnaryContinuation_CallArgument(t *testing.T) {
+	code := "package test\n" +
+		"fun f(b: Builder) {\n" +
+		"    val typeKey = b.key()\n" +
+		"    +b.add(typeKey)\n" +
+		"}\n"
+	used, _, found := unusedVariableUsageForName(t, code, "typeKey")
+	if !found {
+		t.Fatal("expected to find declaration of typeKey")
+	}
+	if !used {
+		t.Fatal("variable used as a call argument inside the unary operand must count as used")
+	}
+}
+
+// TestUnusedVariableUnaryContinuation_LambdaBody covers a reference inside a
+// trailing lambda of the unary operand (`+b.apply { instance.register() }`).
+func TestUnusedVariableUnaryContinuation_LambdaBody(t *testing.T) {
+	code := "package test\n" +
+		"fun f(b: Builder) {\n" +
+		"    val instance = b.create()\n" +
+		"    +b.apply { instance.register() }\n" +
+		"}\n"
+	used, _, found := unusedVariableUsageForName(t, code, "instance")
+	if !found {
+		t.Fatal("expected to find declaration of instance")
+	}
+	if !used {
+		t.Fatal("variable referenced inside the unary operand's trailing lambda must count as used")
+	}
+}
+
+// TestUnusedVariableUnaryContinuation_GenuinelyUnused guards against
+// over-suppression: a unary continuation that does NOT reference the variable
+// must leave it reported as unused.
+func TestUnusedVariableUnaryContinuation_GenuinelyUnused(t *testing.T) {
+	code := "package test\n" +
+		"fun f(b: Builder) {\n" +
+		"    val dead = b.create()\n" +
+		"    +b.add(0)\n" +
+		"}\n"
+	used, unknown, found := unusedVariableUsageForName(t, code, "dead")
+	if !found {
+		t.Fatal("expected to find declaration of dead")
+	}
+	if used || unknown {
+		t.Fatalf("a variable absent from the unary continuation must remain unused (used=%v unknown=%v)", used, unknown)
+	}
+}

--- a/tests/fixtures/negative/style/UnusedVariable.kt
+++ b/tests/fixtures/negative/style/UnusedVariable.kt
@@ -44,3 +44,29 @@ fun walkPairsIgnoringFirst(pairs: List<Pair<Int, Int>>) {
         println(b)
     }
 }
+
+// A unary-prefixed continuation (`+expr`) on the line after a declaration is
+// folded by tree-sitter into the declaration's initializer. The variable is
+// genuinely used inside that continuation, so it must NOT be reported.
+fun unaryContinuationBareName(builder: Builder) {
+    val factoryCall = builder.create()
+    +factoryCall
+}
+
+fun unaryContinuationCallArgument(builder: Builder) {
+    val typeKey = builder.key()
+    +builder.add(typeKey)
+}
+
+fun unaryContinuationLambdaBody(builder: Builder) {
+    val instance = builder.create()
+    +builder.apply { instance.register() }
+}
+
+class Builder {
+    fun create(): Builder = this
+    fun key(): Int = 0
+    fun add(k: Int): Builder = this
+    fun register() {}
+    operator fun Builder.unaryPlus() {}
+}


### PR DESCRIPTION
## Problem

A unary-prefixed expression statement (`+expr`) written on the line after a
declaration is folded by tree-sitter — following Kotlin's own grammar — into
the preceding declaration's initializer as an additive expression
(`val x = init()` + `+expr` parses as `val x = init() + expr`).

`UnusedVariable` already special-cased this continuation, but only when the
unary operand was a **bare identifier** (`+factoryCall`). When the variable was
used *inside* the operand it was missed and falsely reported as unused:

- `+builder.add(typeKey)` — variable nested as a call argument
- `+builder.apply { instance.register() }` — variable referenced inside a trailing lambda

## Fix

Walk the entire continuation-operand subtree for a genuine reference to the
variable name (an identifier or string-template reference in a real reference
position — not a label, type, or declaration), instead of matching only a
bare-identifier operand. A continuation that does not reference the variable
still leaves it reported, so genuinely-unused locals are unaffected.

## Tests

- **Negative fixtures**: call-argument and trailing-lambda continuation forms (plus the pre-existing bare-name form). These reproduce the false positives on the pre-fix binary and are silent after.
- **Unit tests**: bare-name, call-argument, lambda-body, and a genuinely-unused guard asserting the change does not over-suppress.

## Validation

`go build`, `go vet`, `golangci-lint run`, `make lint-rules`, and the full
`internal/rules` package tests pass.