### PR TITLE
fix(rules): honor @Suppress("UNUSED_PARAMETER") on parameters

### DIFF
--- a/internal/rules/registry_style_unused.go
+++ b/internal/rules/registry_style_unused.go
@@ -118,10 +118,7 @@ func registerStyleUnusedRules() {
 					if r.AllowedNames != nil && r.AllowedNames.MatchString(paramName) {
 						continue
 					}
-					paramText := file.FlatNodeText(param.idx)
-					if strings.Contains(paramText, "@Suppress") &&
-						(strings.Contains(paramText, "\"unused\"") ||
-							strings.Contains(paramText, "\"UNUSED_PARAMETER\"")) {
+					if parameterHasUnusedSuppression(file, param.idx) {
 						continue
 					}
 					used := false

--- a/internal/rules/style_unused.go
+++ b/internal/rules/style_unused.go
@@ -72,6 +72,36 @@ const (
 	unusedParameterUnknownMatch
 )
 
+// parameterHasUnusedSuppression reports whether the parameter at paramIdx
+// carries a `@Suppress("unused")` / `@Suppress("UNUSED_PARAMETER")` annotation.
+//
+// In the Kotlin grammar a parameter's annotations parse as a
+// `parameter_modifiers` node that precedes the `parameter` node inside
+// `function_value_parameters`, so the annotation is a *sibling* of the
+// parameter rather than part of its node text. Inspecting only the parameter
+// node text therefore misses the suppression and produces a false positive.
+// Check both the parameter node and its preceding `parameter_modifiers`
+// sibling.
+func parameterHasUnusedSuppression(file *scanner.File, paramIdx uint32) bool {
+	if file == nil || paramIdx == 0 {
+		return false
+	}
+	if parameterTextSuppressesUnused(file.FlatNodeText(paramIdx)) {
+		return true
+	}
+	if prev, ok := file.FlatPrevSibling(paramIdx); ok && file.FlatType(prev) == "parameter_modifiers" {
+		if parameterTextSuppressesUnused(file.FlatNodeText(prev)) {
+			return true
+		}
+	}
+	return false
+}
+
+func parameterTextSuppressesUnused(text string) bool {
+	return strings.Contains(text, "@Suppress") &&
+		(strings.Contains(text, `"unused"`) || strings.Contains(text, `"UNUSED_PARAMETER"`))
+}
+
 func unusedParameterUsageFlat(file *scanner.File, scope uint32, paramIdx uint32, paramName string, paramIsFunctionType bool) (used bool, unknown bool) {
 	if file == nil || scope == 0 || paramIdx == 0 || paramName == "" {
 		return false, false

--- a/internal/rules/style_unused_param_suppress_internal_test.go
+++ b/internal/rules/style_unused_param_suppress_internal_test.go
@@ -1,0 +1,76 @@
+package rules
+
+import (
+	"testing"
+)
+
+// TestParameterHasUnusedSuppression_UpperCaseDiagnostic pins the regression: a
+// `@Suppress("UNUSED_PARAMETER")` annotation parses as a `parameter_modifiers`
+// sibling of the `parameter` node, so the suppression must be detected even
+// though the annotation is not part of the parameter node's own text.
+func TestParameterHasUnusedSuppression_UpperCaseDiagnostic(t *testing.T) {
+	code := "package test\n" +
+		"class R {\n" +
+		"    private fun s(@Suppress(\"UNUSED_PARAMETER\") targetInfo: TargetInfo): Int = 0\n" +
+		"}\n"
+	f := parseInlineForInternalTest(t, code)
+	var param uint32
+	f.FlatWalkNodes(0, "parameter", func(p uint32) {
+		if param == 0 && extractIdentifierFlat(f, p) == "targetInfo" {
+			param = p
+		}
+	})
+	if param == 0 {
+		t.Fatal("expected to find the targetInfo parameter")
+	}
+	if !parameterHasUnusedSuppression(f, param) {
+		t.Fatal("@Suppress(\"UNUSED_PARAMETER\") on a parameter must be honored")
+	}
+}
+
+// TestParameterHasUnusedSuppression_LowerCaseDiagnostic covers the alternate
+// `@Suppress("unused")` spelling.
+func TestParameterHasUnusedSuppression_LowerCaseDiagnostic(t *testing.T) {
+	code := "package test\n" +
+		"class R {\n" +
+		"    private fun s(@Suppress(\"unused\") leftover: TargetInfo): Int = 0\n" +
+		"}\n"
+	f := parseInlineForInternalTest(t, code)
+	var param uint32
+	f.FlatWalkNodes(0, "parameter", func(p uint32) {
+		if param == 0 && extractIdentifierFlat(f, p) == "leftover" {
+			param = p
+		}
+	})
+	if param == 0 {
+		t.Fatal("expected to find the leftover parameter")
+	}
+	if !parameterHasUnusedSuppression(f, param) {
+		t.Fatal("@Suppress(\"unused\") on a parameter must be honored")
+	}
+}
+
+// TestParameterHasUnusedSuppression_Unannotated is the negative guard: a plain
+// parameter (no annotation, or an unrelated @Suppress) must not be treated as
+// suppressed, so genuinely-unused parameters are still reported.
+func TestParameterHasUnusedSuppression_Unannotated(t *testing.T) {
+	code := "package test\n" +
+		"class R {\n" +
+		"    private fun s(plain: TargetInfo, @Suppress(\"NOTHING\") other: TargetInfo): Int = 0\n" +
+		"}\n"
+	f := parseInlineForInternalTest(t, code)
+	for _, name := range []string{"plain", "other"} {
+		var param uint32
+		f.FlatWalkNodes(0, "parameter", func(p uint32) {
+			if param == 0 && extractIdentifierFlat(f, p) == name {
+				param = p
+			}
+		})
+		if param == 0 {
+			t.Fatalf("expected to find the %s parameter", name)
+		}
+		if parameterHasUnusedSuppression(f, param) {
+			t.Fatalf("parameter %s must not be treated as unused-suppressed", name)
+		}
+	}
+}

--- a/tests/fixtures/negative/style/UnusedParameter.kt
+++ b/tests/fixtures/negative/style/UnusedParameter.kt
@@ -96,3 +96,22 @@ class KSAnnotation {
 fun receivesSoftKeywordParam(annotation: KSAnnotation) {
     annotation.process()
 }
+
+// Parameter annotations parse as a `parameter_modifiers` sibling of the
+// `parameter` node, so a `@Suppress` on the parameter must still be honored
+// even though the annotation is not part of the parameter node's own text.
+fun explicitlySuppressedUpper(@Suppress("UNUSED_PARAMETER") targetInfo: KSAnnotation): Int {
+    return 0
+}
+
+fun explicitlySuppressedLower(@Suppress("unused") leftover: KSAnnotation): Int {
+    return 0
+}
+
+fun suppressedAmongUsedParams(
+    @Suppress("UNUSED_PARAMETER") unusedFirst: KSAnnotation,
+    second: KSAnnotation
+): Int {
+    second.process()
+    return 0
+}


### PR DESCRIPTION
## Problem

A parameter's annotations parse as a `parameter_modifiers` node that is a
**sibling** of the `parameter` node inside `function_value_parameters` — the
annotation is not part of the parameter node's own text. `UnusedParameter`
checked for `@Suppress` only in the parameter node's text, so a parameter
annotated `@Suppress("UNUSED_PARAMETER")` (or `@Suppress("unused")`) was still
reported as unused.

## Fix

Replace the parameter-node-only text check with a structural helper
(`parameterHasUnusedSuppression`) that inspects both the parameter node and its
preceding `parameter_modifiers` sibling for the suppression annotation.

## Tests

- **Negative fixtures**: `@Suppress("UNUSED_PARAMETER")`, `@Suppress("unused")`, and a suppressed parameter among used ones. These reproduce the false positive on the pre-fix binary and are silent after.
- **Unit tests**: upper- and lower-case diagnostics, plus an unannotated guard (a plain parameter and an unrelated `@Suppress` must not be treated as suppressed).

## Validation

`go build`, `go vet`, `golangci-lint run`, `make lint-rules`, and the full
`internal/rules` package tests pass.