### PR TITLE
feat(gradle): migrate DependenciesInRootProject to the .kts flat AST

### DIFF
--- a/internal/rules/supply_chain_test.go
+++ b/internal/rules/supply_chain_test.go
@@ -721,6 +721,55 @@ dependencies {
 			t.Fatalf("expected 0 findings for module build file, got %d", len(findings))
 		}
 	})
+
+	// Regression: the line scanner cannot track multi-line raw-string state, so
+	// a dependencies { } block written inside a """...""" literal looked like a
+	// real top-level block and produced a false positive. The .kts AST path
+	// sees the multi_line_string and emits nothing.
+	t.Run("dependencies inside multi-line raw string is clean", func(t *testing.T) {
+		root := t.TempDir()
+		writeFile(t, filepath.Join(root, "settings.gradle.kts"), ``)
+		buildPath := filepath.Join(root, "build.gradle.kts")
+		content := `val template = """
+dependencies {
+    implementation("com.example:lib:1.0")
+}
+"""
+`
+		cfg, _ := android.ParseBuildGradleContent(content)
+		findings := runGradleRule(r, buildPath, content, cfg)
+		if len(findings) != 0 {
+			t.Fatalf("expected 0 findings, got %d", len(findings))
+		}
+	})
+
+	// A nested-argument call such as implementation(platform(...)) must report
+	// only the configuration (implementation), never the inner platform call —
+	// the AST path keys on statement-level calls, not substring leading ids.
+	t.Run("nested argument calls are not treated as configurations", func(t *testing.T) {
+		root := t.TempDir()
+		writeFile(t, filepath.Join(root, "settings.gradle.kts"), ``)
+		buildPath := filepath.Join(root, "build.gradle.kts")
+		content := `dependencies {
+    implementation(platform("com.example:bom:1.0"))
+    implementation(project(":core"))
+}
+`
+		cfg, _ := android.ParseBuildGradleContent(content)
+		findings := runGradleRule(r, buildPath, content, cfg)
+		if len(findings) != 1 {
+			t.Fatalf("expected 1 finding, got %d", len(findings))
+		}
+		// The "declares <configs>." clause must list only the configuration,
+		// not the nested platform()/project() argument calls. ("project"
+		// appears elsewhere in the boilerplate, so assert on the clause.)
+		if !strings.Contains(findings[0].Message, "declares implementation.") {
+			t.Fatalf("declares clause should be exactly implementation, got %q", findings[0].Message)
+		}
+		if strings.Contains(findings[0].Message, "platform") {
+			t.Fatalf("message should not name nested argument call platform, got %q", findings[0].Message)
+		}
+	})
 }
 
 func TestDependencyWithoutGroup(t *testing.T) {

--- a/internal/rules/supply_dependencies.go
+++ b/internal/rules/supply_dependencies.go
@@ -128,7 +128,13 @@ func (r *DependenciesInRootProjectRule) check(ctx *api.Context) {
 		return
 	}
 	allowed := rootDependencyAllowedConfigurations(r.AllowedConfigurations)
-	for _, block := range findRootProjectDependencyBlocks(content, allowed) {
+	var rootBlocks []rootProjectDependencyBlock
+	if astFile := ctx.GradleAST(); astFile != nil {
+		rootBlocks = findRootProjectDependencyBlocksAST(astFile, allowed)
+	} else {
+		rootBlocks = findRootProjectDependencyBlocks(content, allowed)
+	}
+	for _, block := range rootBlocks {
 		finding := scanner.Finding{
 			File:       path,
 			Line:       block.line,
@@ -366,6 +372,73 @@ func findRootProjectDependencyBlocks(content string, allowed map[string]bool) []
 		}
 	}
 	return blocks
+}
+
+// findRootProjectDependencyBlocksAST is the tree-sitter equivalent of
+// findRootProjectDependencyBlocks for Kotlin DSL (.kts) scripts. It flags a
+// top-level `dependencies { }` call — one with no enclosing block — so the
+// configuration set is collected by parser structure. A `dependencies { }`
+// nested inside buildscript { }, subprojects { }, allprojects { }, etc. has a
+// lambda_literal ancestor and is correctly ignored, and string/comment
+// lookalikes never parse as calls.
+func findRootProjectDependencyBlocksAST(file *scanner.File, allowed map[string]bool) []rootProjectDependencyBlock {
+	var blocks []rootProjectDependencyBlock
+	file.FlatWalkNodes(0, "call_expression", func(idx uint32) {
+		if flatCallNameAny(file, idx) != "dependencies" || !isTopLevelCallAST(file, idx) {
+			return
+		}
+		lambda := flatCallTrailingLambda(file, idx)
+		if lambda == 0 {
+			return
+		}
+		if configs := collectRootDependencyConfigsAST(file, lambda, allowed); len(configs) > 0 {
+			blocks = append(blocks, rootProjectDependencyBlock{
+				line:           file.FlatRow(idx) + 1,
+				configurations: configs,
+			})
+		}
+	})
+	return blocks
+}
+
+// isTopLevelCallAST reports whether a call sits at file scope — reached from
+// source_file without crossing a lambda_literal (i.e. not inside any { } block).
+func isTopLevelCallAST(file *scanner.File, idx uint32) bool {
+	for node := idx; node != 0; {
+		parent, ok := file.FlatParent(node)
+		if !ok {
+			return true
+		}
+		switch file.FlatType(parent) {
+		case "lambda_literal":
+			return false
+		case "source_file":
+			return true
+		}
+		node = parent
+	}
+	return true
+}
+
+// collectRootDependencyConfigsAST returns the sorted set of configuration names
+// invoked as statements inside a dependencies lambda, excluding `dependencies`
+// itself and any allowed root-tooling configurations. Only statement-level
+// calls count, so a nested argument call such as platform(...) or project(...)
+// in implementation(platform(...)) is not mistaken for a configuration.
+func collectRootDependencyConfigsAST(file *scanner.File, lambda uint32, allowed map[string]bool) []string {
+	found := make(map[string]bool)
+	file.FlatWalkNodes(lambda, "call_expression", func(call uint32) {
+		parent, ok := file.FlatParent(call)
+		if !ok || file.FlatType(parent) != "statements" {
+			return
+		}
+		name := flatCallNameAny(file, call)
+		if name == "" || name == "dependencies" || allowed[name] {
+			return
+		}
+		found[name] = true
+	})
+	return sortedGradleConfigurations(found)
 }
 
 func gradleLineStartsBlockCall(line, name string) bool {


### PR DESCRIPTION
## Summary

Third of the structural Gradle-rule migrations onto the tree-sitter flat AST from #621. `DependenciesInRootProject` now walks the AST for Kotlin DSL (`.kts`) build scripts instead of brace-counting lines.

- A **top-level** `dependencies { }` block is identified by parser structure — a `dependencies` call reached from `source_file` without crossing a `lambda_literal`. A `dependencies { }` nested inside `buildscript { }`, `subprojects { }`, or `allprojects { }` is correctly ignored.
- Configuration names are collected from **statement-level** calls only, so a nested argument call such as `platform(...)` or `project(...)` in `implementation(platform(...))` is no longer mistaken for a configuration.
- Groovy `.gradle` scripts continue through the original regex path via `ctx.GradleAST()`.

## Why

The line scanner cannot track multi-line raw-string state, so a `dependencies { }` block inside a `"""..."""` literal produced a false positive. The AST path does not.

## Scope

Depends on #621 and #623 (merged). Remaining: `GradleGetter`.

## Test plan

- `go build`, `go vet`, `golangci-lint run ./...`, `go test ./...` — green
- `make integration` — green
- New regressions: `dependencies { }` inside a multi-line raw string is clean; `implementation(platform(...))` / `implementation(project(...))` report only `implementation`, never the nested call. All existing cases (suggested fixes, allowlist edit, header preservation, allowed tooling configs, subprojects/module exclusion) pass through the AST path.