### PR TITLE
feat(gradle): migrate GradleGetter to the .kts flat AST

### DIFF
--- a/internal/rules/android_gradle.go
+++ b/internal/rules/android_gradle.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/kaeawc/krit/internal/android"
 	api "github.com/kaeawc/krit/internal/rules/api"
+	"github.com/kaeawc/krit/internal/scanner"
 )
 
 // GradleBase is an empty marker type embedded by Gradle rule
@@ -839,6 +840,15 @@ func (r *GradleGetterRule) check(ctx *api.Context) {
 	if !strings.HasSuffix(path, ".kts") {
 		return
 	}
+	if astFile := ctx.GradleAST(); astFile != nil {
+		for _, setter := range findGradleGroovySettersAST(astFile) {
+			ctx.Emit(baseFinding(path, setter.line, r.BaseRule,
+				fmt.Sprintf("Groovy-style '%s' should be replaced with '%s' in Kotlin DSL.", setter.name, setter.replacement)))
+		}
+		return
+	}
+	// Fallback: line/regex scan for the rare case where the .kts file did not
+	// produce a flat AST.
 	for i, line := range strings.Split(content, "\n") {
 		if isGradleCommentLine(line) {
 			continue
@@ -864,6 +874,44 @@ func (r *GradleGetterRule) check(ctx *api.Context) {
 			break
 		}
 	}
+}
+
+type gradleGroovySetter struct {
+	line        int
+	name        string
+	replacement string
+}
+
+// findGradleGroovySettersAST finds Groovy-style positional DSL setters in a
+// Kotlin DSL script via the flat AST. `compileSdkVersion 34` is invalid Kotlin,
+// so tree-sitter parses the bare name as a simple_identifier statement whose
+// immediate next sibling is an ERROR node (the un-parseable positional
+// argument). The valid Kotlin forms `compileSdkVersion(34)` (a call) and
+// `compileSdk = 34` (an assignment) parse cleanly and are not matched, and a
+// name appearing inside a string or comment never parses as a bare identifier
+// statement — so this is strictly more precise than substring scanning.
+func findGradleGroovySettersAST(file *scanner.File) []gradleGroovySetter {
+	var setters []gradleGroovySetter
+	file.FlatWalkNodes(0, "simple_identifier", func(idx uint32) {
+		name := file.FlatNodeString(idx, nil)
+		replacement, ok := groovyStyleDSL[name]
+		if !ok {
+			return
+		}
+		parent, ok := file.FlatParent(idx)
+		if !ok || file.FlatType(parent) != "statements" {
+			return
+		}
+		if next := file.FlatNextSib(idx); next == 0 || file.FlatType(next) != "ERROR" {
+			return
+		}
+		setters = append(setters, gradleGroovySetter{
+			line:        file.FlatRow(idx) + 1,
+			name:        name,
+			replacement: replacement,
+		})
+	})
+	return setters
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/rules/android_gradle_test.go
+++ b/internal/rules/android_gradle_test.go
@@ -861,6 +861,38 @@ func TestGradleGetter(t *testing.T) {
 			t.Fatalf("expected 0 findings for .gradle file, got %d", len(findings))
 		}
 	})
+
+	// Regression: the line scanner only skips whole-comment lines, so the
+	// deprecated name inside a string literal or an inline comment produced
+	// false positives. The .kts AST path matches only a bare identifier
+	// statement followed by the un-parseable positional argument, so neither
+	// lookalike fires.
+	t.Run("name inside string or inline comment is clean", func(t *testing.T) {
+		content := `val note = "compileSdkVersion 34 is the old way"
+android {
+    compileSdk = 34 // was compileSdkVersion 34
+}
+`
+		cfg, _ := android.ParseBuildGradleContent(content)
+		findings := runGradleRule(r, "build.gradle.kts", content, cfg)
+		if len(findings) != 0 {
+			t.Fatalf("expected 0 findings, got %d", len(findings))
+		}
+	})
+
+	// The valid Kotlin call form compileSdkVersion(34) is not the Groovy
+	// positional setter and must stay clean.
+	t.Run("kotlin call form is clean", func(t *testing.T) {
+		content := `android {
+    compileSdkVersion(34)
+}
+`
+		cfg, _ := android.ParseBuildGradleContent(content)
+		findings := runGradleRule(r, "build.gradle.kts", content, cfg)
+		if len(findings) != 0 {
+			t.Fatalf("expected 0 findings, got %d", len(findings))
+		}
+	})
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Final structural Gradle-rule migration onto the tree-sitter flat AST from #621. `GradleGetter` (Groovy-style positional DSL setters in Kotlin DSL files) now uses the AST instead of substring scanning.

A Groovy positional setter like `compileSdkVersion 34` is **invalid Kotlin**, so the grammar parses the bare name as a `simple_identifier` statement whose immediate next sibling is an `ERROR` node (the un-parseable positional argument). The detection keys on exactly that shape. The valid Kotlin forms `compileSdkVersion(34)` (a call) and `compileSdk = 34` (an assignment) parse cleanly and are not matched.

## Why

The line scanner only skipped whole-comment lines, so a deprecated name inside a **string literal** or an **inline comment** produced false positives (verified: the old path flags such a file twice; the AST path reports zero). Matching the parsed statement shape is strictly more precise.

## Scope

Depends on #621, #623, #629 (merged). This completes the four-rule migration; `ctx.GradleAST()` (#621) now backs `ApplyPluginTwice`, `ConfigurationsAllSideEffect`, `DependenciesInRootProject`, and `GradleGetter`.

## Test plan

- `go build`, `go vet`, `golangci-lint run ./...`, `go test ./...` — green
- `make integration` — running
- New regressions: deprecated name inside a string / inline comment is clean; `compileSdkVersion(34)` call form is clean. Existing cases (positional setter triggers, nested `defaultConfig`, assignment form clean, Groovy `.gradle` ignored) pass through the AST path. The line/regex scan is retained as a fallback for the rare non-parsing `.kts` file.