### PR TITLE
fix(pipeline): stop double-counting re-merged findings on warm reuse; default-on affected-set replay

### DIFF
--- a/internal/pipeline/affected_set_dispatch_test.go
+++ b/internal/pipeline/affected_set_dispatch_test.go
@@ -7,26 +7,26 @@ import (
 	"github.com/kaeawc/krit/internal/scanner"
 )
 
-// TestAffectedSetReplayEnabled_DefaultOff pins the opt-in contract: the
-// affected-set replay path is OFF unless KRIT_AFFECTED_SET_REPLAY is set to a
-// recognized truthy value.
-func TestAffectedSetReplayEnabled_DefaultOff(t *testing.T) {
+// TestAffectedSetReplayEnabled_DefaultOn pins the opt-out contract: the
+// affected-set replay path is ON by default; KRIT_AFFECTED_SET_REPLAY is a
+// kill switch that only disables on a recognized falsy value.
+func TestAffectedSetReplayEnabled_DefaultOn(t *testing.T) {
 	t.Setenv("KRIT_AFFECTED_SET_REPLAY", "")
-	if affectedSetReplayEnabled() {
-		t.Errorf("replay must be OFF when the env var is empty")
+	if !affectedSetReplayEnabled() {
+		t.Errorf("replay must be ON when the env var is empty (default on)")
 	}
 
-	for _, v := range []string{"0", "off", "false", "no", "nope", " "} {
+	for _, v := range []string{"0", "off", "false", "no", "OFF", "False", " off "} {
 		t.Setenv("KRIT_AFFECTED_SET_REPLAY", v)
 		if affectedSetReplayEnabled() {
-			t.Errorf("replay must be OFF for %q", v)
+			t.Errorf("replay must be OFF for kill-switch value %q", v)
 		}
 	}
 
-	for _, v := range []string{"1", "true", "on", "yes", "TRUE", "On", " yes "} {
+	for _, v := range []string{"1", "true", "on", "yes", "maybe", " "} {
 		t.Setenv("KRIT_AFFECTED_SET_REPLAY", v)
 		if !affectedSetReplayEnabled() {
-			t.Errorf("replay must be ON for %q", v)
+			t.Errorf("replay must be ON for %q (only explicit falsy disables)", v)
 		}
 	}
 }

--- a/internal/pipeline/affected_set_widen_test.go
+++ b/internal/pipeline/affected_set_widen_test.go
@@ -17,9 +17,9 @@ func TestTryAffectedSetDispatch_BailReasons(t *testing.T) {
 	args := ProjectArgs{Config: config.NewConfig()}
 	host := ProjectHostState{}
 
-	t.Setenv("KRIT_AFFECTED_SET_REPLAY", "")
+	t.Setenv("KRIT_AFFECTED_SET_REPLAY", "off")
 	if _, _, reason, err := tryAffectedSetDispatch(ctx, args, host, IndexResult{}, ParseResult{}, deltaManifestData{}); err != nil || reason != replayBailDisabled {
-		t.Fatalf("flag off -> reason %q err %v, want %q", reason, err, replayBailDisabled)
+		t.Fatalf("kill switch -> reason %q err %v, want %q", reason, err, replayBailDisabled)
 	}
 
 	t.Setenv("KRIT_AFFECTED_SET_REPLAY", "on")

--- a/internal/pipeline/custom_kotlin_rules.go
+++ b/internal/pipeline/custom_kotlin_rules.go
@@ -73,8 +73,18 @@ func runKotlinPluginRulesAndMerge(ctx context.Context, args ProjectArgs, host Pr
 		crossFilePayload = buildCrossFilePayload(indexResult.CodeIndex)
 	}
 
-	collector := scanner.NewFindingCollector(crossFileResult.Findings.Len())
-	collector.AppendColumns(&crossFileResult.Findings)
+	// Replace, don't append: on the delta / affected-set replay paths the prior
+	// findings bundle is carried forward (ApplyDelta) and already holds the last
+	// run's plugin findings. Drop these rules' prior rows before adding the
+	// freshly regenerated set so the two copies don't double-count. A no-op on
+	// the cold path, where no plugin findings are present yet.
+	pluginRuleSet := make(map[string]bool, len(ruleIDs))
+	for _, id := range ruleIDs {
+		pluginRuleSet[id] = true
+	}
+	base := dropFindingsByRule(crossFileResult.Findings, pluginRuleSet)
+	collector := scanner.NewFindingCollector(base.Len())
+	collector.AppendColumns(&base)
 	for _, file := range indexResult.KotlinFiles {
 		if file == nil {
 			continue

--- a/internal/pipeline/project.go
+++ b/internal/pipeline/project.go
@@ -1671,11 +1671,15 @@ func runAndroidPhaseAndMerge(ctx context.Context, args ProjectArgs, host Project
 	if err != nil {
 		return fmt.Errorf("android: %w", err)
 	}
-	if res.Findings.Len() == 0 {
-		return nil
-	}
-	merged := scanner.NewFindingCollector(crossFileResult.Findings.Len() + res.Findings.Len())
-	merged.AppendColumns(&crossFileResult.Findings)
+	// Replace, don't append: on the delta / affected-set replay paths the prior
+	// findings bundle is carried forward (ApplyDelta) and already holds the last
+	// run's Android findings. Drop this phase's own rules' prior rows before
+	// adding the freshly regenerated set so the two copies don't double-count.
+	// A no-op on the cold path (no Android rows present yet) and when res is
+	// empty but a stale prior copy must still be cleared.
+	base := dropFindingsByRule(crossFileResult.Findings, androidPhaseRuleIDs(args.ActiveRules))
+	merged := scanner.NewFindingCollector(base.Len() + res.Findings.Len())
+	merged.AppendColumns(&base)
 	merged.AppendColumns(&res.Findings)
 	crossFileResult.Findings = *merged.Columns()
 	return nil
@@ -2911,17 +2915,51 @@ const (
 	replayBailParseIncomplete = "parse_incomplete" // a dependent never came back parsed
 )
 
-// affectedSetReplayEnabled reports whether the opt-in affected-set replay
-// dispatch path is turned on. Default OFF: the path is conservative and #608
-// gated, but it is new, so it ships behind KRIT_AFFECTED_SET_REPLAY until it
-// has soaked. Any of 1/true/on/yes (case-insensitive) enables it.
+// affectedSetReplayEnabled reports whether the affected-set replay dispatch
+// path is turned on. Default ON: the path is #608-gated and has soaked behind
+// the flag, so it now runs by default and KRIT_AFFECTED_SET_REPLAY is an
+// opt-out kill switch. Any of 0/false/off/no (case-insensitive) disables it.
 func affectedSetReplayEnabled() bool {
 	switch strings.ToLower(strings.TrimSpace(os.Getenv("KRIT_AFFECTED_SET_REPLAY"))) {
-	case "1", "true", "on", "yes":
-		return true
-	default:
+	case "0", "false", "off", "no":
 		return false
+	default:
+		return true
 	}
+}
+
+// androidPhaseRuleIDs returns the IDs of rules whose findings are produced by
+// the Android phase (manifest / resources / icons / gradle), identified by an
+// Android capability or any AndroidDeps bit.
+func androidPhaseRuleIDs(activeRules []*api.Rule) map[string]bool {
+	ids := make(map[string]bool)
+	for _, r := range activeRules {
+		if r == nil {
+			continue
+		}
+		if r.Needs.Has(api.NeedsManifest) || r.Needs.Has(api.NeedsResources) ||
+			r.Needs.Has(api.NeedsGradle) || rules.AndroidDataDependency(r.AndroidDeps) != 0 {
+			ids[r.ID] = true
+		}
+	}
+	return ids
+}
+
+// dropFindingsByRule returns fc with every row whose rule is in ruleIDs
+// removed. It backs the replace-not-append behavior of the post-dispatch merge
+// phases (Android, Kotlin plugin): on the delta and affected-set replay paths a
+// prior findings bundle is carried forward via ApplyDelta, so it already
+// contains the previous run's copies of those rules' findings. Each merge phase
+// drops its own rules' prior rows before appending the freshly regenerated set,
+// so the carry-forward plus the re-run don't double-count. A no-op on the cold
+// full-dispatch path, where those rules' findings aren't present yet.
+func dropFindingsByRule(fc scanner.FindingColumns, ruleIDs map[string]bool) scanner.FindingColumns {
+	if len(ruleIDs) == 0 {
+		return fc
+	}
+	return fc.FilterRows(func(row int) bool {
+		return !ruleIDs[fc.RuleAt(row)]
+	})
 }
 
 // tryAffectedSetDispatch generalizes tryDeltaDispatch from a single changed

--- a/internal/pipeline/replay_double_count_test.go
+++ b/internal/pipeline/replay_double_count_test.go
@@ -1,0 +1,107 @@
+package pipeline
+
+import (
+	"context"
+	"image"
+	"image/color"
+	"image/png"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kaeawc/krit/internal/android"
+	"github.com/kaeawc/krit/internal/config"
+	api "github.com/kaeawc/krit/internal/rules/api"
+	"github.com/kaeawc/krit/internal/scanner"
+)
+
+func countRuleFindings(fc scanner.FindingColumns, ruleID string) int {
+	n := 0
+	for _, f := range fc.Findings() {
+		if f.Rule == ruleID {
+			n++
+		}
+	}
+	return n
+}
+
+// TestRunProject_AffectedSetReplay_NoAndroidDoubleCount is the regression for
+// the Android-findings double-count on the warm+ABI replay path. The findings
+// bundle includes Android-phase findings, and the replay path returns
+// bundleHit=false — so ApplyDelta carries the prior Android rows forward (their
+// files are never in the affected set) while runAndroidPhaseAndMerge re-runs.
+// The fix makes that phase replace its own rules' rows instead of appending;
+// without it the IconColors finding is emitted twice on the second replay run.
+func TestRunProject_AffectedSetReplay_NoAndroidDoubleCount(t *testing.T) {
+	dir := t.TempDir()
+	bundleRoot := t.TempDir()
+
+	write := func(name, content string) {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	a := filepath.Join(dir, "A.kt")
+	write("A.kt", "package p\n\nclass Helper\n")
+	write("B.kt", "package p\n\nclass Client {\n  fun make(): Helper = Helper()\n}\n")
+	write("C.kt", "package p\n\nclass U1\n")
+	write("D.kt", "package p\n\nclass U2\n")
+	write("E.kt", "package p\n\nclass U3\n")
+	write("AndroidManifest.xml", `<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.example"/>`)
+
+	// A red 48x48 icon makes the IconColors rule emit exactly one finding.
+	resDir := filepath.Join(dir, "res", "drawable-mdpi")
+	if err := os.MkdirAll(resDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	img := image.NewRGBA(image.Rect(0, 0, 48, 48))
+	for y := 0; y < 48; y++ {
+		for x := 0; x < 48; x++ {
+			img.Set(x, y, color.RGBA{R: 255, A: 255})
+		}
+	}
+	pf, err := os.Create(filepath.Join(resDir, "ic_action_share.png"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = png.Encode(pf, img)
+	pf.Close()
+
+	icon := findV2RuleForTest(t, "IconColors")
+	activeRules := []*api.Rule{crossFileHelperRule(), icon}
+	proj := &android.Project{
+		ManifestPaths: []string{filepath.Join(dir, "AndroidManifest.xml")},
+		ResDirs:       []string{filepath.Join(dir, "res")},
+	}
+
+	run := func() ProjectResult {
+		res, err := RunProject(context.Background(), ProjectInput{
+			Args: ProjectArgs{Config: config.NewConfig(), Paths: []string{dir}, ActiveRules: activeRules, Format: "json", Version: "test"},
+			Host: ProjectHostState{
+				PrebuiltAndroidProject:  proj,
+				CrossFileCacheDir:       scanner.CrossFileCacheDir(dir),
+				FindingsBundleStore:     scanner.DiskFindingsBundleStore{},
+				FindingsBundleCacheRoot: bundleRoot,
+			},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return res
+	}
+
+	r1 := run()
+	if got := countRuleFindings(r1.FinalFindings, "IconColors"); got != 1 {
+		t.Fatalf("cold run IconColors = %d, want 1", got)
+	}
+
+	// ABI edit on A.kt only; the icon is untouched.
+	if err := os.WriteFile(a, []byte("package p\n\nclass Helper2\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	r2 := run()
+	if got := countRuleFindings(r2.FinalFindings, "IconColors"); got != 1 {
+		t.Errorf("warm replay IconColors = %d, want 1 (no double-count of Android findings)", got)
+	}
+}


### PR DESCRIPTION
## Summary

Bundles a correctness fix with the affected-set replay default-ON flip (the flip is unsafe without the fix).

### The bug (found while scoping XML widening, repro-confirmed)

The delta and affected-set replay paths carry a prior findings bundle forward via `scanner.ApplyDelta` while returning `bundleHit=false`. That bundle already contains the previous run's **Android-phase** and **custom Kotlin-plugin** findings — their files are never in the affected set, so `ApplyDelta` keeps them. The post-dispatch merge phases (`runAndroidPhaseAndMerge`, `runKotlinPluginRulesAndMerge`) then re-run on `bundleHit=false` and **append** a fresh copy, double-counting.

Repro: a warm+ABI replay run reported an `IconColors` finding **twice** (cold=1 → replay=2).

### The fix — replace, don't append

Both merge phases now drop their own rules' prior rows (`dropFindingsByRule`) before appending the regenerated set. This:
- fixes the double-count on **both** the replay path and the **pre-existing default delta path**;
- covers **both** Android and Kotlin-plugin findings (same bug class — the second surfaced in review);
- clears stale rows when a re-run now produces fewer findings;
- is a no-op on the cold full-dispatch path (those rules' findings aren't present yet);
- lives at the right altitude — each phase owns its rule set, so no duplicated `AndroidProject` gate.

### The flip

`KRIT_AFFECTED_SET_REPLAY` now defaults **ON** (opt-out kill switch). The path is #608-gated, has soaked behind the flag (#617–#624), and with the double-count fixed is safe to enable for Android and custom-rule projects.

## Test plan

- [ ] `go build ./... && go vet ./... && golangci-lint run ./...` — clean
- [ ] `go test ./... -count=1` — green
- [ ] New `TestRunProject_AffectedSetReplay_NoAndroidDoubleCount` (cold=1, replay=1); updated `TestAffectedSetReplayEnabled_DefaultOn` + bail-reason tests
- [ ] `make integration` — only the known environmental flakes (`cmd/krit` ~62s timeout, `initcmd` TempDir-cleanup race under load); both pass in isolation