### PR TITLE
perf(pipeline): allow affected XML referrers in warm+ABI replay instead of bailing

### DIFF
--- a/internal/pipeline/affected_set_widen_test.go
+++ b/internal/pipeline/affected_set_widen_test.go
@@ -97,13 +97,25 @@ func TestMaterializeAffectedFiles_ParsesMissingDependent(t *testing.T) {
 	}
 }
 
-// TestMaterializeAffectedFiles_BailsOnXML bails when an affected file is not
-// Kotlin/Java source (XML referrers cannot be re-dispatched this way).
-func TestMaterializeAffectedFiles_BailsOnXML(t *testing.T) {
+// TestMaterializeAffectedFiles_AllowsXML lets an affected XML referrer through
+// unparsed: the Android phase regenerates its findings, so it needs no parse or
+// dispatch and must not force a fallback to full dispatch.
+func TestMaterializeAffectedFiles_AllowsXML(t *testing.T) {
 	p := ParseResult{KotlinFiles: []*scanner.File{{Path: "a.kt", Language: scanner.LangKotlin}}}
 	args := ProjectArgs{Config: config.NewConfig(), Paths: []string{t.TempDir()}}
-	if _, bail := materializeAffectedFiles(context.Background(), args, ProjectHostState{}, p, []string{"a.kt", "res/layout/main.xml"}); bail != replayBailNonSource {
-		t.Errorf("an XML affected file must bail with %q; got %q", replayBailNonSource, bail)
+	if _, bail := materializeAffectedFiles(context.Background(), args, ProjectHostState{}, p, []string{"a.kt", "res/layout/main.xml"}); bail != "" {
+		t.Errorf("an affected XML file must pass through (no bail); got %q", bail)
+	}
+}
+
+// TestMaterializeAffectedFiles_BailsOnNonSource bails when an affected file is
+// neither Kotlin/Java source nor XML — its findings can't be guaranteed to
+// regenerate, so full dispatch must handle it.
+func TestMaterializeAffectedFiles_BailsOnNonSource(t *testing.T) {
+	p := ParseResult{KotlinFiles: []*scanner.File{{Path: "a.kt", Language: scanner.LangKotlin}}}
+	args := ProjectArgs{Config: config.NewConfig(), Paths: []string{t.TempDir()}}
+	if _, bail := materializeAffectedFiles(context.Background(), args, ProjectHostState{}, p, []string{"a.kt", "app/proguard-rules.pro"}); bail != replayBailNonSource {
+		t.Errorf("a non-source affected file must bail with %q; got %q", replayBailNonSource, bail)
 	}
 }
 

--- a/internal/pipeline/project.go
+++ b/internal/pipeline/project.go
@@ -2840,10 +2840,11 @@ func mergeParsedFiles(p ParseResult, kotlin, java []*scanner.File) ParseResult {
 // and merged into a copy of parseResult.
 //
 // It returns a non-empty bail reason (caller falls back to full dispatch) when
-// an affected file cannot be re-dispatched: a non-source file (e.g. an XML
-// referrer), a parse failure, or a source file that is gone (e.g. deleted) and
-// so never comes back parsed. Full dispatch handles all of those correctly. An
-// empty reason means success.
+// an affected file cannot be re-dispatched: a non-source, non-XML file, a
+// parse failure, or a source file that is gone (e.g. deleted) and so never
+// comes back parsed. Full dispatch handles all of those correctly. Affected
+// XML referrers are allowed through unparsed — the Android phase regenerates
+// their findings. An empty reason means success.
 func materializeAffectedFiles(ctx context.Context, args ProjectArgs, host ProjectHostState, parseResult ParseResult, affected []string) (ParseResult, string) {
 	parsed := parsedPathSet(parseResult)
 	var missingKotlin, missingJava []string
@@ -2856,6 +2857,15 @@ func materializeAffectedFiles(ctx context.Context, args ProjectArgs, host Projec
 			missingKotlin = append(missingKotlin, f)
 		case strings.HasSuffix(f, ".java"):
 			missingJava = append(missingJava, f)
+		case strings.HasSuffix(f, ".xml"):
+			// XML findings are produced solely by the Android phase, which
+			// re-runs and replaces its own rows on every bundleHit=false run
+			// (replace-not-append). So an affected XML referrer needs no parse
+			// or dispatch here: leave it in the affected set — ApplyDelta drops
+			// its prior rows and the Android phase re-adds the fresh ones. No
+			// dispatch/cross-file rule ever attributes a finding to an .xml
+			// path, so nothing is lost.
+			continue
 		default:
 			return ParseResult{}, replayBailNonSource
 		}
@@ -2910,7 +2920,7 @@ const (
 	replayBailNoBundle        = "no_bundle"        // prior findings bundle missing
 	replayBailEmptyAffected   = "empty_affected"   // affected set empty
 	replayBailTooLarge        = "too_large"        // affected set fails the ratio gate
-	replayBailNonSource       = "non_source"       // affected file is not Kotlin/Java (e.g. XML)
+	replayBailNonSource       = "non_source"       // affected file is not Kotlin/Java/XML
 	replayBailParseFailed     = "parse_failed"     // parseFilesByPath errored
 	replayBailParseIncomplete = "parse_incomplete" // a dependent never came back parsed
 )


### PR DESCRIPTION
## Summary

Capstone of the affected-set replay follow-ups. The replay path bailed to full dispatch whenever the affected set contained a non-Kotlin/Java file — which on Android projects is every XML layout/manifest referencing a changed symbol (a common case, the dominant replay-bail cause on Android). This removes that limitation safely.

### Why it's now safe

That bail was required *before* the double-count fix (#634). It no longer is:
- XML findings are produced **solely by the Android phase**, which re-runs and **replaces** its own rows on every `bundleHit=false` run (the replace-not-append fix in #634). So an affected XML file's findings are regenerated regardless of whether it is re-dispatched.
- Verified that **no dispatch or cross-file rule attributes a finding to an `.xml` path** — all 7 XML-attributed emits live in the Android resource rules (`android_resource_values.go`), inside the Android phase. Cross-file/dispatch rules only touch Kotlin/Java. So leaving an XML file in the affected set unparsed loses nothing: `ApplyDelta` drops its prior rows and the Android phase re-adds the fresh ones.

### Change

`materializeAffectedFiles` passes affected `.xml` files through (no parse/dispatch) and continues to bail (`non_source`) on any *other* non-source type, whose regeneration isn't guaranteed.

## Test plan

- [ ] `go build ./... && go vet ./... && golangci-lint run ./...` — clean
- [ ] `go test ./... -count=1` — green
- [ ] `TestMaterializeAffectedFiles_AllowsXML` (XML passes through) + `_BailsOnNonSource` (.pro bails) replace the old XML-bails test