### PR TITLE
fix(init): disable daemon auto-start for krit init subprocesses

### DIFF
--- a/internal/cli/initcmd/init.go
+++ b/internal/cli/initcmd/init.go
@@ -148,9 +148,18 @@ func runHeadlessInit(opts onboarding.ScanOptions, reg *onboarding.Registry, prof
 	fmt.Printf("wrote %s (profile=%s, findings=%d, overrides=%d)\n",
 		configPath, profile, res.Total, len(overrides))
 
+	// Both krit invocations below run with daemon auto-start disabled
+	// (see onboarding.NoDaemonAutostartEnv): a daemon-routed verb such
+	// as --create-baseline would otherwise fork a detached daemon that
+	// outlives the command and keeps background writers alive in the
+	// target's .krit/ directory after init returns.
+	noDaemonEnv := onboarding.NoDaemonAutostartEnv()
+
 	// Autofix pass: run krit --fix for its side effect, no output.
 	// Non-zero exit from krit when unfixable findings remain is expected.
-	_ = exec.CommandContext(ctx, opts.KritBin, "--config", configPath, "--fix", opts.Target).Run()
+	fixCmd := exec.CommandContext(ctx, opts.KritBin, "--config", configPath, "--fix", opts.Target)
+	fixCmd.Env = noDaemonEnv
+	_ = fixCmd.Run()
 
 	// Baseline: suppress the remaining findings.
 	baselineDir := filepath.Join(opts.Target, ".krit")
@@ -159,8 +168,10 @@ func runHeadlessInit(opts onboarding.ScanOptions, reg *onboarding.Registry, prof
 		return 1
 	}
 	baselinePath := filepath.Join(baselineDir, "baseline.xml")
-	_ = exec.CommandContext(ctx, opts.KritBin,
-		"--config", configPath, "--create-baseline", baselinePath, opts.Target).Run()
+	baselineCmd := exec.CommandContext(ctx, opts.KritBin,
+		"--config", configPath, "--create-baseline", baselinePath, opts.Target)
+	baselineCmd.Env = noDaemonEnv
+	_ = baselineCmd.Run()
 	if _, err := os.Stat(baselinePath); err != nil {
 		fmt.Fprintf(os.Stderr, "error: baseline not written: %v\n", err)
 		return 1

--- a/internal/onboarding/profiles.go
+++ b/internal/onboarding/profiles.go
@@ -13,6 +13,19 @@ import (
 	"strings"
 )
 
+// NoDaemonAutostartEnv returns the current environment with daemon
+// auto-start disabled. Every krit subprocess the onboarding flow
+// spawns runs one-shot and in-process: a scan, an autofix pass, a
+// baseline write. Letting any of them fork a detached daemon would
+// leave a watcher and background bundle/manifest writers alive in the
+// target's .krit/ directory after `krit init` returns — an unexpected
+// lingering process for real users, and a cleanup race for callers
+// that init into a throwaway directory (tests). Pinning these to the
+// in-process path makes each subprocess fully drain before it exits.
+func NoDaemonAutostartEnv() []string {
+	return append(os.Environ(), "KRIT_NO_DAEMON_AUTOSTART=1")
+}
+
 // StrictStages lists the ordered sub-stages emitted by `krit -v` to
 // stderr during a scan. The TUI uses this to render a live progress
 // bar for the strict profile scan (the slowest, cold-cache one).
@@ -155,6 +168,7 @@ func ScanProfile(ctx context.Context, opts ScanOptions, profile string) (*ScanRe
 		"-f", "json",
 		opts.Target,
 	)
+	cmd.Env = NoDaemonAutostartEnv()
 	out, runErr := cmd.Output()
 	// A non-zero exit from krit on findings is expected; only fail if
 	// we got no stdout at all (indicates a harder failure like an
@@ -210,6 +224,7 @@ func ScanProfileWithProgress(
 		"-f", "json",
 		opts.Target,
 	)
+	cmd.Env = NoDaemonAutostartEnv()
 	stdoutPipe, err := cmd.StdoutPipe()
 	if err != nil {
 		return nil, fmt.Errorf("stdout pipe: %w", err)

--- a/internal/onboarding/tui/init_model.go
+++ b/internal/onboarding/tui/init_model.go
@@ -215,7 +215,9 @@ func (m Model) autofixCmd() tea.Cmd {
 		prefixTotal := pre.Summary.Total
 		preByRule := pre.Summary.ByRule
 		// krit --fix returns non-zero when unfixed findings remain; expected.
-		_ = exec.CommandContext(ctx, kritBin, "--config", configPath, "--fix", target).Run()
+		fixCmd := exec.CommandContext(ctx, kritBin, "--config", configPath, "--fix", target)
+		fixCmd.Env = onboarding.NoDaemonAutostartEnv()
+		_ = fixCmd.Run()
 		post, err := runKritJSON(ctx, kritBin, "--config", configPath, "-f", "json", target)
 		if err != nil {
 			return autofixDoneMsg{err: fmt.Errorf("post-fix scan: %w", err)}
@@ -262,6 +264,7 @@ func (m Model) baselineCmd() tea.Cmd {
 		baselinePath := filepath.Join(baselineDir, "baseline.xml")
 		cmd := exec.CommandContext(context.Background(), kritBin,
 			"--config", configPath, "--create-baseline", baselinePath, target)
+		cmd.Env = onboarding.NoDaemonAutostartEnv()
 		if err := cmd.Run(); err != nil {
 			if _, statErr := os.Stat(baselinePath); statErr != nil {
 				return baselineDoneMsg{err: fmt.Errorf("baseline not written: %w (run err: %w)", statErr, err)}
@@ -283,6 +286,7 @@ type kritJSONOutput struct {
 
 func runKritJSON(ctx context.Context, bin string, args ...string) (*kritJSONOutput, error) {
 	cmd := exec.CommandContext(ctx, bin, args...)
+	cmd.Env = onboarding.NoDaemonAutostartEnv()
 	out, runErr := cmd.Output()
 	if len(out) == 0 {
 		return nil, fmt.Errorf("krit produced no output: %w", runErr)


### PR DESCRIPTION
## Summary

Fixes a pre-existing flake in `TestRunHeadlessInitInProcess` (`internal/cli/initcmd`), which failed ~2/3 of isolated runs in the `integration` job's unit-test step and intermittently reds CI for unrelated PRs.

## Root cause

`krit init` shells out to the `krit` binary several times — the initial scan, `--fix`, and `--create-baseline`. The scan and `--create-baseline` verbs are daemon-compatible, so each routed through `ensureDaemonForScan` and **forked a detached background daemon**. `cmd.Run()` waits only for the foreground process, not the daemon it spawned, so the daemon kept an fsnotify watcher and background bundle/manifest writers alive in the target's `.krit/` directory after the foreground command (and the test function) returned.

The test inits into a `t.TempDir()`. Its deferred `RemoveAll` then raced the live daemon's writes:

```
TempDir RemoveAll cleanup: unlinkat /tmp/.../001/.krit/...: directory not empty
```

This is also a real-world wart: a one-shot `krit init` left a background daemon running in the user's project.

## Fix

Pin every `krit` subprocess the onboarding flow spawns to the in-process path via `KRIT_NO_DAEMON_AUTOSTART=1`, exposed as `onboarding.NoDaemonAutostartEnv()`. Each subprocess now fully drains before it exits, so nothing outlives the command.

Applied to:
- Headless path: `internal/onboarding/profiles.go` (`ScanProfile`, `ScanProfileWithProgress`), `internal/cli/initcmd/init.go` (`--fix`, `--create-baseline`).
- Interactive TUI path: `internal/onboarding/tui/init_model.go` (same lingering-daemon behavior for real users).

## Verification

- `TestRunHeadlessInitInProcess` passes 60/60 across three `-count=20` stress runs (was failing reliably before).
- `go build`, `go vet ./...`, `golangci-lint run ./...` clean.
- `./internal/onboarding/...` and `./internal/cli/initcmd/` package tests pass; no daemons linger after runs.