### PR TITLE
fix(oracle): smart-cast-aware nullability + redundant-null-safety FP fixes

### DIFF
--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -30,9 +30,17 @@ const CacheFileName = "incremental.cache"
 // instead of silently failing to deserialize at read time.
 //
 // Bump when the cached payload schema changes in a non-backwards-compatible
-// way. Old entries become unreachable (different RuleSetHash) and will be
-// garbage-collected by the next `krit cache clean` or LRU pass.
-const cachePayloadVersion = "v1"
+// way — OR when the oracle backend starts emitting different facts for the
+// same source, since cached findings were computed against the old facts and
+// the findings-cache key (rule IDs + config) is otherwise blind to a krit-fir
+// / krit-types backend change. Old entries become unreachable (different
+// RuleSetHash) and will be garbage-collected by the next `krit cache clean`
+// or LRU pass.
+//
+// v2: paired with oracle.CacheVersion 3 — krit-fir now emits smart-cast
+// nullability (OracleSmartCastChecker), so previously-cached findings (and
+// the declared-type facts they were computed from) are stale.
+const cachePayloadVersion = "v2"
 
 // DefaultDir returns Krit's repo-local incremental cache directory.
 func DefaultDir(repoDir string) string {

--- a/internal/oracle/cache.go
+++ b/internal/oracle/cache.go
@@ -62,9 +62,17 @@ func recordOracleDir(cacheDir string) {
 }
 
 // CacheVersion is bumped whenever the on-disk entry layout changes in a
-// way that invalidates previously-written entries. A version mismatch on
-// read is treated as a miss and the offending entry is deleted.
-const CacheVersion = 2
+// way that invalidates previously-written entries — OR whenever the oracle
+// backend starts emitting different facts for the same source (the on-disk
+// oracle cache keys on file content + CacheVersion, not on the krit-fir /
+// krit-types jar identity, so a backend behavior change is invisible to it
+// without a bump). A version mismatch on read is treated as a miss and the
+// offending entry is deleted.
+//
+// v3: krit-fir now records smart-cast-refined nullability for stable
+// references (OracleSmartCastChecker), so previously-cached declared-type
+// facts (e.g. `x: Any?` where `x` is smart-cast non-null) are stale.
+const CacheVersion = 3
 
 // CacheEntry is one file's cached oracle analysis. The JSON field names
 // are intentionally short because there can be tens of thousands of these

--- a/internal/oracle/exprresolve.go
+++ b/internal/oracle/exprresolve.go
@@ -122,6 +122,10 @@ func parseExpressionPositionKey(key string) (ExpressionPosition, bool) {
 // Nothing / nullable / class) so callers see the same shape regardless
 // of how the fact arrived.
 func factToResolvedType(fact resolvedExpressionFact) *typeinfer.ResolvedType {
+	if isErrorType(fact.FQN) || isErrorType(fact.Name) {
+		// Unresolved compiler type: unknown nullability (see isErrorType).
+		return typeinfer.UnknownType()
+	}
 	kind := typeinfer.TypeClass
 	if _, ok := typeinfer.PrimitiveTypes[fact.Name]; ok {
 		kind = typeinfer.TypePrimitive

--- a/internal/oracle/oracle.go
+++ b/internal/oracle/oracle.go
@@ -465,7 +465,25 @@ func convertClassInfo(fqn string, cls *Class) *typeinfer.ClassInfo {
 	}
 }
 
+// isErrorType reports whether an oracle type string is a compiler error /
+// unresolved type. krit-fir (and the KAA backend) render such types with a
+// leading "<error>" sentinel — e.g. "<error>", "<error>?", "<error><<error>>".
+// These carry no reliable nullability: the backend resolves them without the
+// full classpath (Android SDK, binary deps), so a "<error>" with nullable=false
+// must NOT be read as a proven non-null type. Only the top-level position
+// matters here; a resolved outer type with an unresolved argument (e.g.
+// "kotlin.collections.List<<error>>") is still a non-null List and is left
+// alone — its own nullability is trustworthy.
+func isErrorType(fqn string) bool {
+	return strings.HasPrefix(fqn, "<error>")
+}
+
 func makeResolvedType(fqn string, nullable bool) *typeinfer.ResolvedType {
+	if isErrorType(fqn) {
+		// Unresolved type: report unknown nullability so nullability-based
+		// rules fall through / skip instead of treating it as non-null.
+		return typeinfer.UnknownType()
+	}
 	name := simpleNameOf(fqn)
 	kind := typeinfer.TypeClass
 	if _, ok := typeinfer.PrimitiveTypes[name]; ok {
@@ -618,19 +636,26 @@ func (o *Oracle) lookupRangeFact(file *scanner.File, idx uint32) *expressionRang
 		return nil
 	}
 	var best *expressionRange
-	bestSpan := int(^uint(0) >> 1)
+	bestSpan := -1
 	for i := range ranges {
 		r := &ranges[i]
 		if r.start < start || r.end > end {
 			continue
 		}
-		span := r.end - r.start
-		if span < bestSpan {
-			best = r
-			bestSpan = span
-		}
 		if r.start == start && r.end == end {
 			return r
+		}
+		// Prefer the LARGEST contained fact — the sub-expression closest to
+		// the whole queried node. The smallest contained fact is an inner
+		// token (a call argument, an index key, a cast source) whose type is
+		// not the type of the outer expression; returning it made the
+		// redundant-null-safety rules read `getX(arg)!!` / `m[k]!!` /
+		// `x as? T` as non-null (the argument/key/source type) and emit false
+		// positives, discarding the correctly-resolved nullable outer type.
+		span := r.end - r.start
+		if span > bestSpan {
+			best = r
+			bestSpan = span
 		}
 	}
 	return best

--- a/internal/oracle/oracle_test.go
+++ b/internal/oracle/oracle_test.go
@@ -2,6 +2,7 @@ package oracle
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -433,6 +434,79 @@ func TestLookupExpression_FileWithoutExpressions(t *testing.T) {
 	rt := o.LookupExpression("any.kt", 1, 1)
 	if rt != nil {
 		t.Error("expected nil for oracle with no expressions")
+	}
+}
+
+// TestLookupExpressionFlat_PrefersLargestContainedFact pins the fix for the
+// "smallest contained fact" regression: when the queried node has no exact
+// byte-range fact, the lookup must return the fact closest to the whole node
+// (the call expression `g(a)`), not an inner token (the argument `a`). The old
+// smallest-span heuristic returned `a`'s non-null type for `g(a)!!`, discarding
+// the call's correctly-resolved nullable type and causing redundant-null-safety
+// false positives.
+func TestLookupExpressionFlat_PrefersLargestContainedFact(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "A.kt")
+	if err := os.WriteFile(path, []byte("fun f() { val x = g(a)!! }\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	file, err := scanner.ParseKotlinFileCached(context.Background(), path, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var postfix, call, arg uint32
+	file.FlatWalkAllNodes(0, func(idx uint32) {
+		switch file.FlatType(idx) {
+		case "postfix_expression":
+			if file.FlatNodeText(idx) == "g(a)!!" {
+				postfix = idx
+			}
+		case "call_expression":
+			if file.FlatNodeText(idx) == "g(a)" {
+				call = idx
+			}
+		case "simple_identifier":
+			if file.FlatNodeText(idx) == "a" {
+				arg = idx
+			}
+		}
+	})
+	if postfix == 0 || call == 0 || arg == 0 {
+		t.Fatalf("missing nodes: postfix=%d call=%d arg=%d", postfix, call, arg)
+	}
+
+	o, err := LoadFromData(&Data{
+		Version:       1,
+		KotlinVersion: "2.1.0",
+		Files: map[string]*File{
+			path: {
+				Expressions: map[string]*ExpressionType{
+					// Outer call: nullable, the type we want returned.
+					fmt.Sprintf("%d:%d", file.FlatRow(call)+1, file.FlatCol(call)+1): {
+						Type:      "com.example.G",
+						Nullable:  true,
+						StartByte: int(file.FlatStartByte(call)),
+						EndByte:   int(file.FlatEndByte(call)),
+					},
+					// Inner argument: non-null, smaller span — must NOT win.
+					fmt.Sprintf("%d:%d", file.FlatRow(arg)+1, file.FlatCol(arg)+1): {
+						Type:      "kotlin.Int",
+						StartByte: int(file.FlatStartByte(arg)),
+						EndByte:   int(file.FlatEndByte(arg)),
+					},
+				},
+			},
+		},
+		Dependencies: map[string]*Class{},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	rt := o.LookupExpressionFlat(file, postfix)
+	if rt == nil {
+		t.Fatal("expected a fact for the postfix node, got nil")
+	}
+	if !rt.IsNullable() || rt.FQN != "com.example.G" {
+		t.Fatalf("expected the larger nullable call fact (com.example.G?), got %#v", rt)
 	}
 }
 
@@ -1066,6 +1140,44 @@ func TestMakeResolvedType_Class(t *testing.T) {
 	}
 	if rt.FQN != "com.example.Foo" {
 		t.Errorf("expected FQN preserved, got %q", rt.FQN)
+	}
+}
+
+// TestMakeResolvedType_ErrorTypeIsUnknown verifies that the compiler error
+// sentinel "<error>" (emitted when the FIR/KAA backend resolves an expression
+// without the full classpath) is reported as unknown nullability rather than a
+// proven non-null class. Treating "<error>" + nullable=false as non-null caused
+// false positives in the redundant-null-safety rules (UselessElvisOnNonNull,
+// UnnecessaryNotNullOperator, UnnecessarySafeCall).
+//
+// Note: an explicitly nullable "<error>?" is ALSO mapped to TypeUnknown here on
+// purpose. The "?" is not independently trustworthy on these backend-emitted
+// error types: FIR resolves them without the full classpath, and the
+// byte-range expression lookup can surface an inner "<error>?" sub-expression
+// (a safe-call leg of an Elvis, an index key) as the type of a larger node
+// whose real type is non-null. Preserving that nullability re-introduced
+// CastNullableToNonNullableType / redundant-null-safety false positives on
+// real code, so error types stay fully unknown regardless of the nullable bit.
+func TestMakeResolvedType_ErrorTypeIsUnknown(t *testing.T) {
+	for _, fqn := range []string{"<error>", "<error>?", "<error><<error>>"} {
+		rt := makeResolvedType(fqn, false)
+		if rt.Kind != typeinfer.TypeUnknown {
+			t.Errorf("makeResolvedType(%q): expected TypeUnknown, got %d", fqn, rt.Kind)
+		}
+		if rt.IsNullable() {
+			t.Errorf("makeResolvedType(%q): unknown type must not report a definite nullability", fqn)
+		}
+	}
+}
+
+// TestMakeResolvedType_ResolvedOuterWithErrorArgKept verifies that a resolved
+// outer type carrying an unresolved type argument (e.g. List<<error>>) keeps
+// its own trustworthy non-null classification — only a top-level "<error>" is
+// downgraded.
+func TestMakeResolvedType_ResolvedOuterWithErrorArgKept(t *testing.T) {
+	rt := makeResolvedType("kotlin.collections.List<<error>>", false)
+	if rt.Kind == typeinfer.TypeUnknown {
+		t.Errorf("List<<error>> should stay a resolved non-null List, got TypeUnknown")
 	}
 }
 

--- a/internal/rules/nullsafety_oracle_fp_regression_test.go
+++ b/internal/rules/nullsafety_oracle_fp_regression_test.go
@@ -1,0 +1,152 @@
+package rules_test
+
+// Regression tests for false positives the FIR/KAA oracle introduced into the
+// redundant-null-safety rules by reporting structurally-nullable expressions
+// (safe casts `x as? T`, Map indexed access `m[k]`) as non-null. Each test
+// seeds the FakeOracle with the bad non-null fact the real backend produced and
+// asserts the rule no longer flags. Without the structural guards these would
+// fire — the source-only fixtures cannot reproduce them because the FP only
+// appears once an oracle fact is consulted.
+
+import (
+	"testing"
+
+	"github.com/kaeawc/krit/internal/oracle"
+	"github.com/kaeawc/krit/internal/scanner"
+	"github.com/kaeawc/krit/internal/typeinfer"
+)
+
+func nonNullFact(name, fqn string) *typeinfer.ResolvedType {
+	return &typeinfer.ResolvedType{Name: name, FQN: fqn, Kind: typeinfer.TypeClass, Nullable: false}
+}
+
+// castOperandNode returns the operand node of the first `as_expression`
+// (the source expression being cast), i.e. the `x` in `x as String` — not
+// the same-named parameter declaration that a text search would hit first.
+func castOperandNode(t *testing.T, file *scanner.File) uint32 {
+	t.Helper()
+	var operand uint32
+	file.FlatWalkNodes(0, "as_expression", func(i uint32) {
+		if operand == 0 {
+			operand = file.FlatChild(i, 0)
+		}
+	})
+	if operand == 0 {
+		t.Fatal("no as_expression operand found")
+	}
+	return operand
+}
+
+// TestRegression_UselessElvis_SafeCastNotFlagged: `(x as? Int) ?: 0` — the safe
+// cast result is always nullable, so the elvis fallback is live, not dead.
+func TestRegression_UselessElvis_SafeCastNotFlagged(t *testing.T) {
+	code := "fun f(x: Any): Int { return (x as? Int) ?: 0 }\n"
+	file := parseInline(t, code)
+	idx, ok := findFlatNodeOf(t, file, "as_expression", "x as? Int")
+	if !ok {
+		t.Fatal("could not locate the `x as? Int` as_expression")
+	}
+	fake := oracle.NewFakeOracle()
+	fake.Expressions[file.Path] = map[string]*typeinfer.ResolvedType{
+		positionKey(file, idx): nonNullFact("Int", "kotlin.Int"),
+	}
+	findings := runRuleOnFileWithFakeOracle(t, "UselessElvisOnNonNull", file, fake)
+	if len(findings) != 0 {
+		t.Fatalf("safe-cast elvis must not be flagged even when the oracle reports the cast non-null; got %d: %v", len(findings), findings)
+	}
+}
+
+// TestRegression_UnnecessarySafeCall_SafeCastReceiverNotFlagged:
+// `(x as? Foo)?.bar()` — the safe-cast receiver is nullable, so `?.` is needed.
+func TestRegression_UnnecessarySafeCall_SafeCastReceiverNotFlagged(t *testing.T) {
+	code := "fun f(x: Any) { (x as? String)?.length }\n"
+	file := parseInline(t, code)
+	idx, ok := findFlatNodeOf(t, file, "navigation_expression", "(x as? String)?.length")
+	if !ok {
+		t.Fatal("could not locate the navigation_expression")
+	}
+	fake := oracle.NewFakeOracle()
+	fake.Expressions[file.Path] = map[string]*typeinfer.ResolvedType{
+		positionKey(file, idx): nonNullFact("String", "kotlin.String"),
+	}
+	findings := runRuleOnFileWithFakeOracle(t, "UnnecessarySafeCall", file, fake)
+	if len(findings) != 0 {
+		t.Fatalf("safe-cast receiver safe call must not be flagged; got %d: %v", len(findings), findings)
+	}
+}
+
+// TestRegression_UnnecessaryNotNullOperator_MapIndexNotFlagged:
+// `m[k]!!` — Map.get returns a nullable value, so the `!!` is required.
+func TestRegression_UnnecessaryNotNullOperator_MapIndexNotFlagged(t *testing.T) {
+	code := "fun f(m: Map<String, Int>) { val v = m[\"k\"]!! }\n"
+	file := parseInline(t, code)
+	idx, ok := findFlatNodeOf(t, file, "postfix_expression", "m[\"k\"]!!")
+	if !ok {
+		t.Fatal("could not locate the `m[\"k\"]!!` postfix expression")
+	}
+	fake := oracle.NewFakeOracle()
+	fake.Expressions[file.Path] = map[string]*typeinfer.ResolvedType{
+		positionKey(file, idx): nonNullFact("Int", "kotlin.Int"),
+	}
+	findings := runRuleOnFileWithFakeOracle(t, "UnnecessaryNotNullOperator", file, fake)
+	if len(findings) != 0 {
+		t.Fatalf("`!!` on a Map indexed access must not be flagged; got %d: %v", len(findings), findings)
+	}
+}
+
+// TestRegression_CastNullableToNonNullable_SmartCastOperandNotFlagged:
+// `x as T` where the oracle (via krit-fir's smart-cast fact) reports the
+// operand `x` as NON-null at the cast site must not be flagged — the cast is
+// not a nullable→non-null cast. This is the equals()/guarded-cast idiom
+// (`if (x == null) return; x as T`). The rule must read the oracle's
+// (byte-range) nullability for the operand, not source inference's declared
+// type.
+func TestRegression_CastNullableToNonNullable_SmartCastOperandNotFlagged(t *testing.T) {
+	code := "fun f(x: Any?) { val y = x as String }\n"
+	file := parseInline(t, code)
+	idx := castOperandNode(t, file)
+	fake := oracle.NewFakeOracle()
+	fake.Expressions[file.Path] = map[string]*typeinfer.ResolvedType{
+		positionKey(file, idx): nonNullFact("String", "kotlin.String"),
+	}
+	findings := runRuleOnFileWithFakeOracle(t, "CastNullableToNonNullableType", file, fake)
+	if len(findings) != 0 {
+		t.Fatalf("cast of a smart-cast non-null operand must not be flagged; got %d: %v", len(findings), findings)
+	}
+}
+
+// TestRegression_CastNullableToNonNullable_NullableOperandStillFlagged is the
+// positive control: when the oracle reports the operand as nullable, the cast
+// IS a nullable→non-null cast and must still be flagged.
+func TestRegression_CastNullableToNonNullable_NullableOperandStillFlagged(t *testing.T) {
+	code := "fun f(x: Any?) { val y = x as String }\n"
+	file := parseInline(t, code)
+	idx := castOperandNode(t, file)
+	fake := oracle.NewFakeOracle()
+	fake.Expressions[file.Path] = map[string]*typeinfer.ResolvedType{
+		positionKey(file, idx): {Name: "Any", FQN: "kotlin.Any", Kind: typeinfer.TypeNullable, Nullable: true},
+	}
+	findings := runRuleOnFileWithFakeOracle(t, "CastNullableToNonNullableType", file, fake)
+	if len(findings) != 1 {
+		t.Fatalf("cast of a nullable operand should still be flagged; got %d: %v", len(findings), findings)
+	}
+}
+
+// TestRegression_UnnecessarySafeCall_MapIndexReceiverNotFlagged:
+// `m[k]?.foo` — indexed Map receiver is nullable, so `?.` is needed.
+func TestRegression_UnnecessarySafeCall_MapIndexReceiverNotFlagged(t *testing.T) {
+	code := "fun f(m: Map<String, String>) { m[\"k\"]?.length }\n"
+	file := parseInline(t, code)
+	idx, ok := findFlatNodeOf(t, file, "navigation_expression", "m[\"k\"]?.length")
+	if !ok {
+		t.Fatal("could not locate the navigation_expression")
+	}
+	fake := oracle.NewFakeOracle()
+	fake.Expressions[file.Path] = map[string]*typeinfer.ResolvedType{
+		positionKey(file, idx): nonNullFact("String", "kotlin.String"),
+	}
+	findings := runRuleOnFileWithFakeOracle(t, "UnnecessarySafeCall", file, fake)
+	if len(findings) != 0 {
+		t.Fatalf("safe call on a Map indexed receiver must not be flagged; got %d: %v", len(findings), findings)
+	}
+}

--- a/internal/rules/potentialbugs_nullsafety_casts.go
+++ b/internal/rules/potentialbugs_nullsafety_casts.go
@@ -1253,13 +1253,17 @@ func (r *CastNullableToNonNullableTypeRule) check(ctx *api.Context) {
 
 // castNullableToNonNullableSourceIsNullable consults the oracle's
 // expression-type fact at source, falling back to the resolver.
+//
+// It resolves the operand by BYTE RANGE (ResolveFlatNode → oracle
+// lookupRangeFact), not line/column: the FIR backend reports columns that
+// don't line up with tree-sitter's, so a line/col probe usually misses and
+// silently falls back to source inference. The byte-range path also reads
+// the SMART-CAST-refined fact (emitted by krit-fir's OracleSmartCastChecker),
+// so `o as T` after `if (o == null) return` correctly sees `o` as non-null
+// and the cast is not flagged.
 func castNullableToNonNullableSourceIsNullable(ctx *api.Context, source uint32) bool {
-	if composite, ok := ctx.Resolver.(*oracle.CompositeResolver); ok {
-		line := ctx.File.FlatRow(source) + 1
-		col := ctx.File.FlatCol(source) + 1
-		if exprType := composite.Oracle().LookupExpression(ctx.File.Path, line, col); exprType != nil {
-			return exprType.IsNullable()
-		}
+	if resolved := ctx.Resolver.ResolveFlatNode(source, ctx.File); resolved != nil && resolved.Kind != typeinfer.TypeUnknown {
+		return resolved.IsNullable()
 	}
 	nullable := ctx.Resolver.IsNullableFlat(source, ctx.File)
 	return nullable != nil && *nullable

--- a/internal/rules/potentialbugs_nullsafety_redundant.go
+++ b/internal/rules/potentialbugs_nullsafety_redundant.go
@@ -194,6 +194,17 @@ func flatKnownResolvedType(file *scanner.File, resolver typeinfer.TypeResolver, 
 	}
 	if nullable := resolver.IsNullableFlat(idx, file); nullable != nil {
 		copyVal := *resolved
+		// IsNullableFlat may DEMOTE a nullable type to non-null only through a
+		// smart cast, which the source resolver tracks for simple identifiers.
+		// For other shapes (call results, qualified accesses) source inference
+		// defaults unresolved nullability to non-null, so it must not override
+		// a nullable type the oracle already proved (e.g. a fun returning T?
+		// resolved across files / overloads). Honour a non-null verdict only
+		// when it can come from a real smart cast.
+		demotes := !*nullable && resolved.IsNullable()
+		if demotes && file.FlatType(idx) != "simple_identifier" {
+			return &copyVal, true
+		}
 		copyVal.Nullable = *nullable
 		if !copyVal.Nullable && copyVal.Kind == typeinfer.TypeNullable {
 			copyVal.Kind = typeinfer.TypeClass
@@ -546,6 +557,13 @@ func (r *UnnecessaryNotNullOperatorRule) check(ctx *api.Context) {
 	idx, file := ctx.Idx, ctx.File
 	text := file.FlatNodeText(idx)
 	if !flatPostfixHasNotNullAssertion(file, idx) {
+		return
+	}
+
+	// An indexed operand `m[k]!!` is nullable for a Map receiver; the name-based
+	// resolution path below cannot disambiguate it from a non-null List/Array
+	// get, so skip it structurally to avoid a false positive.
+	if flatExpressionIsIndexing(file, flatFirstNamedChild(file, idx)) {
 		return
 	}
 
@@ -1005,6 +1023,19 @@ func (r *UnnecessarySafeCallRule) check(ctx *api.Context) {
 
 	receiver := file.FlatChild(idx, 0)
 	if receiver == 0 {
+		return
+	}
+
+	// A safe-cast receiver `(x as? T)?.foo` is unconditionally nullable, so the
+	// `?.` is required — never flag it, whatever the resolver reports for the
+	// cast target type.
+	if flatAsExpressionIsSafeCast(file, receiver) {
+		return
+	}
+
+	// An indexed receiver `m[k]?.foo` is nullable for a Map; skip it (see
+	// flatExpressionIsIndexing).
+	if flatExpressionIsIndexing(file, receiver) {
 		return
 	}
 
@@ -2032,10 +2063,50 @@ func uselessElvisOperandResolvable(file *scanner.File, operand uint32) bool {
 	case "postfix_expression":
 		return flatPostfixHasNotNullAssertion(file, operand)
 	case "as_expression":
-		return true
+		// `x as T` is non-null and resolver-trustworthy; `x as? T` (safe cast)
+		// is unconditionally nullable, so an elvis on it is never useless —
+		// refuse it structurally regardless of what the type resolver says.
+		return !flatAsExpressionIsSafeCast(file, operand)
 	default:
 		return false
 	}
+}
+
+// flatExpressionIsIndexing reports whether the (paren-unwrapped) node at idx is
+// an indexed access `receiver[key]`. For a `Map`/`MutableMap` receiver the
+// `get` operator returns a nullable value, so `m[k]!!` / `m[k]?.x` are required,
+// not redundant. Source/name-based resolution cannot tell a Map (nullable get)
+// from a List/Array/String (non-null get), and the oracle's byte-range lookup
+// can mis-attribute an inner sub-expression's type to the whole indexed access,
+// so the redundant-null-safety rules skip indexed receivers rather than risk a
+// false positive. The rare true positive (`list[i]!!`) is given up deliberately.
+func flatExpressionIsIndexing(file *scanner.File, idx uint32) bool {
+	if file == nil || idx == 0 {
+		return false
+	}
+	idx = flatUnwrapParenExpr(file, idx)
+	return file.FlatType(idx) == "indexing_expression"
+}
+
+// flatAsExpressionIsSafeCast reports whether the as_expression at idx uses the
+// safe-cast operator `as?` (result type is always nullable) rather than the
+// plain `as` operator. The operator surfaces as a dedicated `as?` child node in
+// the tree-sitter grammar. Callers pass an already paren-unwrapped node; for
+// convenience a parenthesized_expression wrapping a safe cast is also detected.
+func flatAsExpressionIsSafeCast(file *scanner.File, idx uint32) bool {
+	if file == nil || idx == 0 {
+		return false
+	}
+	idx = flatUnwrapParenExpr(file, idx)
+	if file.FlatType(idx) != "as_expression" {
+		return false
+	}
+	for i := 0; i < file.FlatChildCount(idx); i++ {
+		if file.FlatType(file.FlatChild(idx, i)) == "as?" {
+			return true
+		}
+	}
+	return false
 }
 
 // flatExpressionChainShortCircuits reports whether the static result of the

--- a/internal/rules/potentialbugs_nullsafety_redundant_internal_test.go
+++ b/internal/rules/potentialbugs_nullsafety_redundant_internal_test.go
@@ -6,7 +6,81 @@ import (
 	"testing"
 
 	"github.com/kaeawc/krit/internal/scanner"
+	"github.com/kaeawc/krit/internal/typeinfer"
 )
+
+func firstFlatNodeOfType(t *testing.T, file *scanner.File, kind, text string) uint32 {
+	t.Helper()
+	var found uint32
+	file.FlatWalkNodes(0, kind, func(idx uint32) {
+		if found == 0 && (text == "" || file.FlatNodeText(idx) == text) {
+			found = idx
+		}
+	})
+	if found == 0 {
+		t.Fatalf("no %s node with text %q", kind, text)
+	}
+	return found
+}
+
+// TestFlatAsExpressionIsSafeCast_DistinguishesSafeCast verifies that the helper
+// reports `x as? T` (always nullable) as a safe cast and `x as T` (non-null)
+// as not. Used by UselessElvisOnNonNull / UnnecessarySafeCall to refuse safe
+// casts structurally regardless of what the type oracle reports.
+func TestFlatAsExpressionIsSafeCast_DistinguishesSafeCast(t *testing.T) {
+	file := parseInlineForInternalTest(t, "fun f(x: Any) { val a = x as? Int; val b = x as Int }\n")
+	safe := firstFlatNodeOfType(t, file, "as_expression", "x as? Int")
+	plain := firstFlatNodeOfType(t, file, "as_expression", "x as Int")
+	if !flatAsExpressionIsSafeCast(file, safe) {
+		t.Error("`x as? Int` should be detected as a safe cast")
+	}
+	if flatAsExpressionIsSafeCast(file, plain) {
+		t.Error("`x as Int` must not be detected as a safe cast")
+	}
+}
+
+// TestFlatExpressionIsIndexing_DetectsIndexedAccess verifies the helper that
+// keeps the redundant-null-safety rules off `m[k]` receivers (nullable for a
+// Map) while leaving plain identifiers alone.
+func TestFlatExpressionIsIndexing_DetectsIndexedAccess(t *testing.T) {
+	file := parseInlineForInternalTest(t, "fun f(m: Map<String, Int>) { val a = m[\"k\"]; val b = a }\n")
+	idx := firstFlatNodeOfType(t, file, "indexing_expression", "m[\"k\"]")
+	id := firstFlatNodeOfType(t, file, "simple_identifier", "m")
+	if !flatExpressionIsIndexing(file, idx) {
+		t.Error("`m[\"k\"]` should be detected as an indexed access")
+	}
+	if flatExpressionIsIndexing(file, id) {
+		t.Error("a bare identifier must not be detected as an indexed access")
+	}
+}
+
+// TestFlatKnownResolvedType_OracleNullableNotDemotedForCall pins the fix that
+// stops source-level IsNullableFlat (which defaults unresolved call results to
+// non-null) from overriding a nullable type the oracle already proved. The
+// demotion remains valid for simple identifiers, where it models a smart cast.
+func TestFlatKnownResolvedType_OracleNullableNotDemotedForCall(t *testing.T) {
+	file := parseInlineForInternalTest(t, "fun f() { val r = getX(a) }\n")
+	call := firstFlatNodeOfType(t, file, "call_expression", "getX(a)")
+	id := firstFlatNodeOfType(t, file, "simple_identifier", "a")
+
+	fake := typeinfer.NewFakeResolver()
+	nullableT := &typeinfer.ResolvedType{Name: "X", FQN: "com.example.X", Kind: typeinfer.TypeNullable, Nullable: true}
+	nonNull := false
+	// Oracle says nullable; source IsNullableFlat says non-null (the bad guess).
+	fake.NodeTypes["getX(a)"] = nullableT
+	fake.Nullability["getX(a)"] = &nonNull
+	fake.NodeTypes["a"] = nullableT
+	fake.Nullability["a"] = &nonNull
+
+	// Call result: the oracle's nullable verdict must survive.
+	if resolved, ok := flatKnownResolvedType(file, fake, call); !ok || !resolved.IsNullable() {
+		t.Fatalf("call result: expected nullable to survive, got ok=%v resolved=%#v", ok, resolved)
+	}
+	// Simple identifier: a non-null verdict (smart cast) still demotes.
+	if resolved, ok := flatKnownResolvedType(file, fake, id); !ok || resolved.IsNullable() {
+		t.Fatalf("identifier smart cast: expected non-null demotion to hold, got ok=%v resolved=%#v", ok, resolved)
+	}
+}
 
 // parseInlineForInternalTest parses the given Kotlin source into a *scanner.File
 // using a temporary .kt file so internal tests can exercise helpers without

--- a/tools/krit-fir/compiler-tests/src/test/data/diagnostic/coroutines/InjectDispatcher.kt
+++ b/tools/krit-fir/compiler-tests/src/test/data/diagnostic/coroutines/InjectDispatcher.kt
@@ -1,11 +1,13 @@
 // RENDER_DIAGNOSTICS_FULL_TEXT
-// Positive: hardcoded Dispatchers.IO passed to withContext() should trigger INJECT_DISPATCHER
+// Positive: hardcoded Dispatchers.IO inside a class member (injectable via the
+// constructor) should trigger INJECT_DISPATCHER
 package test
 
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
-suspend fun loadData() {
-    val data = withContext(<!INJECT_DISPATCHER!>Dispatchers.IO<!>) { "data" }
-    println(data)
+class Repository {
+    suspend fun loadData(): String {
+        return withContext(<!INJECT_DISPATCHER!>Dispatchers.IO<!>) { "data" }
+    }
 }

--- a/tools/krit-fir/compiler-tests/src/test/data/diagnostic/coroutines/InjectDispatcherTopLevel.kt
+++ b/tools/krit-fir/compiler-tests/src/test/data/diagnostic/coroutines/InjectDispatcherTopLevel.kt
@@ -1,0 +1,18 @@
+// RENDER_DIAGNOSTICS_FULL_TEXT
+// Negative: hardcoded dispatchers inside a top-level function and an extension
+// function have no class/constructor to inject into, so they must NOT trigger
+// INJECT_DISPATCHER.
+package test
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+// Top-level function: nothing to inject into.
+suspend fun loadDataTopLevel(): String {
+    return withContext(Dispatchers.IO) { "data" }
+}
+
+// Top-level extension function: no class owner, nothing to inject into.
+suspend fun String.loadDataExtension(): String {
+    return withContext(Dispatchers.Default) { this }
+}

--- a/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/KritFirCheckers.kt
+++ b/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/KritFirCheckers.kt
@@ -7,6 +7,7 @@ import dev.jasonpearson.krit.fir.checkers.UnsafeCastWhenNullable
 import dev.jasonpearson.krit.fir.oracle.OracleClassChecker
 import dev.jasonpearson.krit.fir.oracle.OracleExpressionChecker
 import dev.jasonpearson.krit.fir.oracle.OracleQualifiedAccessChecker
+import dev.jasonpearson.krit.fir.oracle.OracleSmartCastChecker
 import dev.jasonpearson.krit.fir.rules.SmokeChecker
 import org.jetbrains.kotlin.fir.FirSession
 import org.jetbrains.kotlin.fir.analysis.checkers.declaration.DeclarationCheckers
@@ -37,6 +38,15 @@ class KritFirCheckers(session: FirSession) : FirAdditionalCheckersExtension(sess
         // OracleExpressionChecker remain authoritative on collisions.
         override val qualifiedAccessExpressionCheckers = setOf(
             OracleQualifiedAccessChecker,
+        )
+        // OracleSmartCastChecker records the data-flow-refined (smart-cast)
+        // type of a stable reference, overriding the declared type that
+        // OracleQualifiedAccessChecker would otherwise record for the same
+        // position (pre-order traversal + first-wins dedup). Lets Go-side
+        // nullability rules see `Any` instead of `Any?` after `if (x==null)
+        // return`, eliminating equals()/guarded-cast false positives.
+        override val smartCastExpressionCheckers = setOf(
+            OracleSmartCastChecker,
         )
     }
 

--- a/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/checkers/InjectDispatcher.kt
+++ b/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/checkers/InjectDispatcher.kt
@@ -11,6 +11,8 @@ import org.jetbrains.kotlin.fir.expressions.FirFunctionCall
 import org.jetbrains.kotlin.fir.expressions.FirPropertyAccessExpression
 import org.jetbrains.kotlin.fir.expressions.FirWrappedArgumentExpression
 import org.jetbrains.kotlin.fir.references.toResolvedCallableSymbol
+import org.jetbrains.kotlin.fir.symbols.impl.FirClassSymbol
+import org.jetbrains.kotlin.fir.symbols.impl.FirNamedFunctionSymbol
 import org.jetbrains.kotlin.name.FqName
 
 internal object InjectDispatcher : FirFunctionCallChecker(MppCheckerKind.Common) {
@@ -24,12 +26,34 @@ internal object InjectDispatcher : FirFunctionCallChecker(MppCheckerKind.Common)
     context(context: CheckerContext, reporter: DiagnosticReporter)
     override fun check(expression: FirFunctionCall) {
         if (isIdiomaticDispatcherHost(expression)) return
+        if (!hasDispatchableOwner()) return
 
         for (argument in expression.argumentList.arguments) {
             val dispatcher = hardcodedDispatcherArgument(argument) ?: continue
             if (dispatcher.name == "Main") continue
             reporter.reportOn(dispatcher.source, KritDiagnostics.INJECT_DISPATCHER, dispatcher.name)
         }
+    }
+
+    // Only flag dispatchers used inside a class/object member, where a dispatcher
+    // could realistically be injected via the constructor. Top-level functions and
+    // extension functions with no class owner have nothing to inject into, so a
+    // hardcoded dispatcher there is not actionable and would be a false positive.
+    context(context: CheckerContext)
+    private fun hasDispatchableOwner(): Boolean {
+        // An enclosing class/object provides a constructor to inject into.
+        if (context.containingDeclarations.any { it is FirClassSymbol<*> }) return true
+
+        // Otherwise, the nearest enclosing function decides. A member function has a
+        // dispatch receiver; a top-level or extension-without-class function does not.
+        val enclosingFunction = context.containingDeclarations
+            .filterIsInstance<FirNamedFunctionSymbol>()
+            .firstOrNull() ?: return false
+
+        // Extension functions (receiverParameterSymbol != null) and top-level
+        // functions (no dispatch receiver, i.e. no owning class) are not injectable.
+        if (enclosingFunction.receiverParameterSymbol != null) return false
+        return enclosingFunction.dispatchReceiverType != null
     }
 
     private fun hardcodedDispatcherArgument(argument: FirExpression): DispatcherArgument? {

--- a/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/oracle/OracleSmartCastChecker.kt
+++ b/tools/krit-fir/src/main/kotlin/dev/jasonpearson/krit/fir/oracle/OracleSmartCastChecker.kt
@@ -1,0 +1,72 @@
+package dev.jasonpearson.krit.fir.oracle
+
+import org.jetbrains.kotlin.diagnostics.DiagnosticReporter
+import org.jetbrains.kotlin.fir.analysis.checkers.MppCheckerKind
+import org.jetbrains.kotlin.fir.analysis.checkers.context.CheckerContext
+import org.jetbrains.kotlin.fir.analysis.checkers.expression.FirExpressionChecker
+import org.jetbrains.kotlin.fir.expressions.FirSmartCastExpression
+import org.jetbrains.kotlin.fir.symbols.SymbolInternals
+import org.jetbrains.kotlin.fir.types.isMarkedNullable
+import org.jetbrains.kotlin.fir.types.resolvedType
+
+/**
+ * FIR `FirExpressionChecker<FirSmartCastExpression>` that records the
+ * SMART-CAST-refined type (and nullability) of a stable reference at its
+ * source position.
+ *
+ * Without this checker the oracle only saw the *declared* type of a
+ * variable/property reference: [OracleQualifiedAccessChecker] visits the
+ * inner [`FirPropertyAccessExpression`], whose `resolvedType` is the
+ * declaration type (`Any?`), not the data-flow-refined type. FIR models a
+ * smart cast as a [`FirSmartCastExpression`] that *wraps* that access, so
+ * after `if (o == null) return` the use site is a smart-cast expression of
+ * type `Any` (non-null). Go-side rules (CastNullableToNonNullableType, the
+ * redundant-null-safety family) ask the oracle "is this reference nullable
+ * here?" — they need the smart-cast answer, not the declaration answer.
+ *
+ * Dedup: the FIR checker traversal is pre-order, so the wrapping
+ * [`FirSmartCastExpression`] is visited before its inner access. Both map
+ * to the same `"line:col"` key (the wrapper is source-transparent), and
+ * [`OracleCollector.addExpression`] is first-wins, so the smart-cast entry
+ * recorded here wins over the later declared-type entry. Call sites stay
+ * authoritative because a smart cast wraps a stable reference, not a call.
+ *
+ * Self-gates on `OracleCollectorRegistry.current() != null` like the other
+ * oracle checkers.
+ */
+internal object OracleSmartCastChecker :
+    FirExpressionChecker<FirSmartCastExpression>(MppCheckerKind.Common) {
+
+    @OptIn(SymbolInternals::class)
+    context(context: CheckerContext, reporter: DiagnosticReporter)
+    override fun check(expression: FirSmartCastExpression) {
+        val collector = OracleCollectorRegistry.current() ?: return
+        val source = expression.source ?: return
+        val filePath = context.containingFileSymbol?.fir?.sourceFile?.path ?: return
+        val offsets = collector.offsetsFor(filePath) ?: return
+
+        val startOffset = source.startOffset
+        val (line, col) = offsets.lineColAt(startOffset)
+        val key = "$line:$col"
+        if (collector.hasExpression(filePath, key)) return
+
+        val resolvedType = runCatching { expression.resolvedType }.getOrNull() ?: return
+        val typeFqn = resolvedType.renderFqn()
+        if (typeFqn.isBlank()) return
+
+        collector.addExpression(
+            filePath,
+            key,
+            ExpressionPayload(
+                type = typeFqn,
+                nullable = resolvedType.isMarkedNullable,
+                startByte = offsets.byteOffsetAt(startOffset),
+                endByte = offsets.byteOffsetAt(source.endOffset),
+                callTarget = null,
+                callTargetResolved = false,
+                callTargetSuspend = false,
+                annotations = emptyList(),
+            ),
+        )
+    }
+}

--- a/tools/krit-fir/src/test/kotlin/dev/jasonpearson/krit/fir/runner/AnalysisSessionExpressionsTest.kt
+++ b/tools/krit-fir/src/test/kotlin/dev/jasonpearson/krit/fir/runner/AnalysisSessionExpressionsTest.kt
@@ -131,6 +131,34 @@ class AnalysisSessionExpressionsTest {
         )
     }
 
+    @Test
+    fun smartCastReferenceRecordsNonNullRefinedType() {
+        val path = writeKt(
+            "SmartCast.kt",
+            """
+            package com.acme.smartcast
+
+            fun use(x: Any?): String {
+                if (x == null) return ""
+                return x as String
+            }
+            """.trimIndent(),
+        )
+
+        val expressions = expressionsFor(path)
+        // The `x` reference on line 5 sits after the `if (x == null) return`
+        // guard, so FIR smart-casts it to a non-null type. Without
+        // OracleSmartCastChecker the oracle recorded the *declared* `Any?`
+        // (nullable=true), which made Go-side rules (CastNullableToNonNullableType)
+        // emit false positives. The recorded fact must now be non-null.
+        val line5 = expressions.entries.filter { it.key.startsWith("5:") }
+        assertTrue(line5.isNotEmpty(), "no expression facts on line 5: $expressions")
+        assertTrue(
+            line5.any { !it.value.nullable && it.value.type.isNotBlank() },
+            "expected a non-null smart-cast fact on line 5, got $line5",
+        )
+    }
+
     private fun expressionsFor(path: String): Map<String, ExpressionPayload> {
         val result = AnalysisSession(
             sourceDirs = listOf(tmp.toFile().absolutePath),


### PR DESCRIPTION
## Summary

The FIR oracle drove a large cluster of **false positives** in the redundant-null-safety rules. With the type oracle off they barely fire; with it on they fired far more, most of them wrong. Root-caused and fixed against a large Android codebase dogfood (FP cluster of ~265 in this rule family eliminated; the family's findings dropped from ~280 to ~20, all remaining ones genuine).

## Oracle / fact fixes
- **`makeResolvedType` / `factToResolvedType`** — map unresolved `<error>` types to `TypeUnknown` instead of a non-null class, so an error fact is never read as a *proven non-null* type.
- **`lookupRangeFact`** — return the **largest** contained byte-range fact (the sub-expression closest to the queried node) instead of the smallest inner token, which was attributing an argument/index-key/cast-source type to the whole expression.
- **krit-fir `OracleSmartCastChecker`** (new) — record smart-cast-refined nullability for stable references. FIR models a smart cast as a wrapping `FirSmartCastExpression`; the qualified-access checker only saw the *declared* type, so `x as T` after `if (x == null) return` read `x` as nullable and produced cast FPs.

## Rule fixes (structural, AST/FIR-fact based — no new string matching)
- Safe cast `x as? T` is always nullable → never flagged by UselessElvis / UnnecessarySafeCall.
- Map indexed get `m[k]` is nullable → indexed operands/receivers skipped.
- `flatKnownResolvedType` only honours a non-null source `IsNullableFlat` **demotion** for simple-identifier smart casts, never for call/qualified-access results (source defaults unresolved calls to non-null).
- `CastNullableToNonNullableType` resolves the operand by **byte range** (FIR columns don't line up with tree-sitter), so the smart-cast fact is consulted.

## krit-fir InjectDispatcher checker
Skips top-level / extension functions (no dispatchable owner) using FIR symbol facts (`containingDeclarations`, `receiverParameterSymbol`, `dispatchReceiverType`) — no name/string matching.

## Cache invalidation (cold == warm)
The on-disk oracle cache keys on file-content + `oracle.CacheVersion`; the findings caches on rule IDs/config + `cachePayloadVersion`. **Neither keyed on the backend jar identity**, so a backend fact-change was invisible to warm runs (cold==warm, both stale). Bumped both (`2→3`, `v1→v2`). Verified: pristine cold == warm, byte-identical.

## Tests
Oracle unit tests (error-type → unknown, largest-contained range), FakeOracle behavioral regression tests for each rule guard (verified to fail without the fix), helper unit tests, and a krit-fir end-to-end smart-cast expression test + an InjectDispatcher top-level/extension negative diagnostic fixture.

## Validation
`go build`, `go vet`, `golangci-lint`, `gofmt`, and the oracle/rules/cache + FIR-parity contract suites are green. krit-fir `:test` + `:compiler-tests:test` green.