### PR TITLE
fix(rules): structural FP fixes — EmptyFunctionBlock, ImplicitPendingIntent, ComposePainterResourceInLoop, InjectDispatcher

### DIFF
--- a/cmd/krit/testdata/regression/playground-android-app.json
+++ b/cmd/krit/testdata/regression/playground-android-app.json
@@ -1,6 +1,6 @@
 {
   "project": "../../playground/android-app/",
-  "findings_count": 72,
+  "findings_count": 70,
   "findings": [
     {
       "rule": "MagicNumber",
@@ -435,28 +435,12 @@
       "message": "Trust manager overrides checkClientTrusted/checkServerTrusted with an empty body. Perform real certificate validation."
     },
     {
-      "rule": "EmptyFunctionBlock",
-      "ruleSet": "empty-blocks",
-      "file": "src/main/kotlin/com/example/app/utils/NetworkHelper.kt",
-      "line": 26,
-      "col": 0,
-      "message": "Empty function body detected."
-    },
-    {
       "rule": "InsecureTrustManager",
       "ruleSet": "security",
       "file": "src/main/kotlin/com/example/app/utils/NetworkHelper.kt",
       "line": 26,
       "col": 0,
       "message": "Trust manager check method accepts certificates without validation. Perform certificate validation or remove the trust-all manager."
-    },
-    {
-      "rule": "EmptyFunctionBlock",
-      "ruleSet": "empty-blocks",
-      "file": "src/main/kotlin/com/example/app/utils/NetworkHelper.kt",
-      "line": 27,
-      "col": 0,
-      "message": "Empty function body detected."
     },
     {
       "rule": "InsecureTrustManager",

--- a/config/default-krit.yml
+++ b/config/default-krit.yml
@@ -226,7 +226,7 @@ empty-blocks:
     active: true
   EmptyFunctionBlock:
     active: true
-    ignoreOverridden: false
+    ignoreOverridden: true
   EmptyIfBlock:
     active: true
   EmptyInitBlock:

--- a/internal/android/resources_test.go
+++ b/internal/android/resources_test.go
@@ -1013,3 +1013,103 @@ func TestEmptyLayout(t *testing.T) {
 		t.Errorf("expected 0 children, got %d", len(layout.RootView.Children))
 	}
 }
+
+// TestParseDrawableSelectorBytes pins the structured-XML indexing of selector
+// drawables that feeds the StateListReachableResource rule. These cases are
+// regression guards against (a) misreading the idiomatic
+// constrained-states-first / unconstrained-default-last ordering and (b)
+// counting <item> elements nested inside non-selector containers
+// (layer-list, inset, animated containers, or a nested <layer-list> inside a
+// selector item) as if they were selector items.
+func TestParseDrawableSelectorBytes(t *testing.T) {
+	const ns = `xmlns:android="http://schemas.android.com/apk/res/android"`
+
+	type want struct {
+		count    int
+		stateLen []int // length of StateAttrs per indexed item, in order
+	}
+
+	cases := []struct {
+		name string
+		xml  string
+		want want
+	}{
+		{
+			// Idiomatic ordering: constrained state first, unconstrained
+			// default last. Both direct children must be indexed, and the
+			// default must carry an EMPTY state set (android:drawable is not a
+			// state qualifier).
+			name: "constrained_then_default_indexes_two_items",
+			xml: `<selector ` + ns + `>
+  <item android:state_pressed="true" android:drawable="@color/a"/>
+  <item android:drawable="@color/b"/>
+</selector>`,
+			want: want{count: 2, stateLen: []int{1, 0}},
+		},
+		{
+			// A layer-list root is not a selector: none of its <item> children
+			// are selector items.
+			name: "layer_list_root_indexes_nothing",
+			xml: `<layer-list ` + ns + `>
+  <item android:drawable="@color/a"/>
+  <item android:drawable="@color/b"/>
+</layer-list>`,
+			want: want{count: 0},
+		},
+		{
+			// An inset root (with a nested selector) is not itself a selector
+			// root, so nothing is indexed.
+			name: "inset_root_indexes_nothing",
+			xml: `<inset ` + ns + ` android:insetLeft="4dp">
+  <selector>
+    <item android:state_pressed="true" android:drawable="@color/a"/>
+    <item android:drawable="@color/b"/>
+  </selector>
+</inset>`,
+			want: want{count: 0},
+		},
+		{
+			// Only the DIRECT <item> children of <selector> count. The
+			// <layer-list> nested inside the first selector item contributes
+			// zero items, so the selector still indexes exactly two items.
+			name: "nested_layer_list_items_not_counted",
+			xml: `<selector ` + ns + `>
+  <item android:state_pressed="true">
+    <layer-list>
+      <item android:drawable="@color/x"/>
+      <item android:drawable="@color/y"/>
+    </layer-list>
+  </item>
+  <item android:drawable="@color/b"/>
+</selector>`,
+			want: want{count: 2, stateLen: []int{1, 0}},
+		},
+		{
+			// Genuine-bug shape: unconstrained default FIRST, constrained item
+			// after it. Both index; the second carries a non-empty state set.
+			name: "default_first_then_constrained",
+			xml: `<selector ` + ns + `>
+  <item android:drawable="@color/b"/>
+  <item android:state_pressed="true" android:drawable="@color/a"/>
+</selector>`,
+			want: want{count: 2, stateLen: []int{0, 1}},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			idx := newResourceIndex()
+			idx.parseDrawableSelectorBytes("res/drawable/"+c.name+".xml", c.name, []byte(c.xml))
+			items := idx.DrawableSelectors[c.name]
+			if len(items) != c.want.count {
+				t.Fatalf("indexed %d items, want %d: %#v", len(items), c.want.count, items)
+			}
+			for i, wantLen := range c.want.stateLen {
+				if got := len(items[i].StateAttrs); got != wantLen {
+					t.Errorf("item[%d] StateAttrs len = %d, want %d (%v)",
+						i, got, wantLen, items[i].StateAttrs)
+				}
+			}
+		})
+	}
+}

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -30,17 +30,20 @@ const CacheFileName = "incremental.cache"
 // instead of silently failing to deserialize at read time.
 //
 // Bump when the cached payload schema changes in a non-backwards-compatible
-// way — OR when the oracle backend starts emitting different facts for the
-// same source, since cached findings were computed against the old facts and
-// the findings-cache key (rule IDs + config) is otherwise blind to a krit-fir
-// / krit-types backend change. Old entries become unreachable (different
-// RuleSetHash) and will be garbage-collected by the next `krit cache clean`
-// or LRU pass.
+// way — OR when the oracle backend or a built-in rule's logic starts producing
+// different findings for the same source, since cached findings were computed
+// against the old behavior and the findings-cache key (rule IDs + config) is
+// otherwise blind to a krit-fir / krit-types backend change or a rule-logic
+// change. Old entries become unreachable (different RuleSetHash) and will be
+// garbage-collected by the next `krit cache clean` or LRU pass.
 //
 // v2: paired with oracle.CacheVersion 3 — krit-fir now emits smart-cast
 // nullability (OracleSmartCastChecker), so previously-cached findings (and
 // the declared-type facts they were computed from) are stale.
-const cachePayloadVersion = "v2"
+// v3: structural false-positive fixes to EmptyFunctionBlock,
+// ImplicitPendingIntent, ComposePainterResourceInLoop, and InjectDispatcher
+// change those rules' findings for unchanged source.
+const cachePayloadVersion = "v3"
 
 // DefaultDir returns Krit's repo-local incremental cache directory.
 func DefaultDir(repoDir string) string {

--- a/internal/rules/android_resource_layout_test.go
+++ b/internal/rules/android_resource_layout_test.go
@@ -989,6 +989,25 @@ func TestStateListReachableResource(t *testing.T) {
 		}
 	})
 
+	t.Run("idiomatic disjoint states before default is clean", func(t *testing.T) {
+		// Constrained states first (pressed, focused), unconstrained default
+		// last. This is the correct, idiomatic ordering: no constrained item
+		// is a subset of an earlier item, and the catch-all is last, so
+		// nothing is unreachable.
+		idx := emptyIndex()
+		idx.DrawableSelectors = map[string][]android.SelectorItem{
+			"button": {
+				{FilePath: "res/drawable/button.xml", Line: 3, StateAttrs: map[string]string{"android:state_pressed": "true"}},
+				{FilePath: "res/drawable/button.xml", Line: 6, StateAttrs: map[string]string{"android:state_focused": "true"}},
+				{FilePath: "res/drawable/button.xml", Line: 9, StateAttrs: map[string]string{}},
+			},
+		}
+		findings := runResourceRule(r, idx)
+		if len(findings) != 0 {
+			t.Fatalf("expected 0 findings for idiomatic ordering, got %d", len(findings))
+		}
+	})
+
 	t.Run("only first masking pair reported per selector", func(t *testing.T) {
 		idx := emptyIndex()
 		idx.DrawableSelectors = map[string][]android.SelectorItem{

--- a/internal/rules/android_security.go
+++ b/internal/rules/android_security.go
@@ -1388,29 +1388,29 @@ func implicitPendingIntentCall(file *scanner.File, idx uint32) bool {
 	if strings.Contains(text, "PendingIntentCompat") {
 		return false
 	}
-	flags, ok := implicitPendingIntentFlagsText(file, idx)
-	if !ok {
+	flagsExpr, ok := implicitPendingIntentFlagsExpr(file, idx)
+	if !ok || flagsExpr == 0 {
 		return false
 	}
-	return !strings.Contains(flags, "FLAG_IMMUTABLE") && !strings.Contains(flags, "FLAG_MUTABLE")
+	// Only flag when the flags argument is an explicit flag expression that we
+	// can see demonstrably lacks a mutability flag. Prefer false-negatives.
+	return implicitPendingIntentFlagsAreInsecure(file, flagsExpr)
 }
 
-func implicitPendingIntentFlagsText(file *scanner.File, call uint32) (string, bool) {
+// implicitPendingIntentFlagsExpr returns the AST node for the PendingIntent
+// flags argument (the 4th positional argument, or the named `flags` argument).
+func implicitPendingIntentFlagsExpr(file *scanner.File, call uint32) (uint32, bool) {
 	if file == nil || call == 0 {
-		return "", false
+		return 0, false
 	}
 	switch file.FlatType(call) {
 	case "call_expression":
 		args := flatCallKeyArguments(file, call)
 		if args == 0 {
-			return "", false
+			return 0, false
 		}
 		if named := flatNamedValueArgument(file, args, "flags"); named != 0 {
-			expr := flatValueArgumentExpression(file, named)
-			if expr == 0 {
-				return "", false
-			}
-			return file.FlatNodeText(expr), true
+			return flatValueArgumentExpression(file, named), true
 		}
 		var last uint32
 		for arg := file.FlatFirstChild(args); arg != 0; arg = file.FlatNextSib(arg) {
@@ -1420,22 +1420,64 @@ func implicitPendingIntentFlagsText(file *scanner.File, call uint32) (string, bo
 			last = arg
 		}
 		if last == 0 {
-			return "", false
+			return 0, false
 		}
-		expr := flatValueArgumentExpression(file, last)
-		if expr == 0 {
-			return "", false
-		}
-		return file.FlatNodeText(expr), true
+		return flatValueArgumentExpression(file, last), true
 	case "method_invocation":
 		args, ok := file.FlatFindChild(call, "argument_list")
 		if !ok || file.FlatNamedChildCount(args) == 0 {
-			return "", false
+			return 0, false
 		}
-		return file.FlatNodeText(file.FlatNamedChild(args, file.FlatNamedChildCount(args)-1)), true
+		return file.FlatNamedChild(args, file.FlatNamedChildCount(args)-1), true
 	default:
-		return "", false
+		return 0, false
 	}
+}
+
+// implicitPendingIntentFlagsAreInsecure decides, from the flags-argument AST
+// subtree, whether the call demonstrably omits a mutability flag. It is
+// deliberately conservative: it only reports a problem when it can see an
+// explicit flag expression (integer literal or qualified FLAG_* constants,
+// optionally combined with bitwise/`or` operators) that contains no
+// FLAG_IMMUTABLE / FLAG_MUTABLE reference. If the flags come from a helper
+// call, a bare parameter/val, or any expression it cannot fully resolve, it
+// returns false (no finding).
+func implicitPendingIntentFlagsAreInsecure(file *scanner.File, expr uint32) bool {
+	if file == nil || expr == 0 {
+		return false
+	}
+	// A bare identifier (parameter or local val) carries no visible flags.
+	switch file.FlatType(expr) {
+	case "simple_identifier", "identifier":
+		return false
+	}
+	sawFlagConstant := false
+	hasMutability := false
+	insecure := true
+	file.FlatWalkAllNodes(expr, func(node uint32) {
+		switch file.FlatType(node) {
+		case "call_expression", "call_suffix", "method_invocation":
+			// Flags produced by a helper call — cannot prove insecurity.
+			insecure = false
+		case "navigation_expression", "navigation_suffix",
+			"simple_identifier", "identifier":
+			text := file.FlatNodeText(node)
+			if strings.Contains(text, "FLAG_IMMUTABLE") || strings.Contains(text, "FLAG_MUTABLE") {
+				hasMutability = true
+			}
+			if strings.Contains(text, "FLAG_") {
+				sawFlagConstant = true
+			}
+		case "integer_literal", "hex_literal", "decimal_literal", "long_literal":
+			sawFlagConstant = true
+		}
+	})
+	if !insecure || hasMutability {
+		return false
+	}
+	// Require that we actually saw an explicit flag constant / literal; if the
+	// expression is something opaque we did not classify, stay conservative.
+	return sawFlagConstant
 }
 
 func getInstanceFirstStringArg(file *scanner.File, args uint32) (string, bool) {

--- a/internal/rules/coroutines.go
+++ b/internal/rules/coroutines.go
@@ -214,6 +214,66 @@ func injectDispatcherReferenceConfirmed(file *scanner.File, idx uint32) bool {
 	return fileImportsFQN(file, "kotlinx.coroutines.Dispatchers")
 }
 
+// injectDispatcherHasInjectableHost reports whether the dispatcher
+// usage at idx sits inside a function where constructor injection of a
+// CoroutineDispatcher is actually possible: a member function of a
+// class, object, or companion object.
+//
+// It returns false for the shapes the rule must not flag because there
+// is no injectable host:
+//
+//   - top-level functions (no enclosing class/object/companion), and
+//   - top-level extension functions (receiver fixed by the call site,
+//     and likewise no enclosing type to inject into).
+//
+// A *member* extension function (e.g. `fun String.foo()` declared inside
+// a class) still has an injectable host — the enclosing class — and so
+// continues to flag. That falls out of the ancestor test below without
+// any extension-specific special-casing.
+//
+// Detection is purely structural via the flat AST: an injectable host
+// exists exactly when some ancestor of the usage is a class_declaration,
+// object_declaration, or companion_object. Top-level plain and top-level
+// extension functions both lack such an ancestor and are suppressed,
+// while members (plain or extension) keep flagging. This mirrors the
+// top-level/extension exemption added to the krit-fir InjectDispatcher
+// checker, which uses FIR symbol facts to reach the same decision.
+//
+// The receiver-type AST shape (a `.` token child of the
+// function_declaration, modelled by tree-sitter as
+// user_type/nullable_type, `.`, simple_identifier) is reported by
+// flatFunctionDeclarationIsExtension for callers that need to
+// distinguish extensions explicitly.
+func injectDispatcherHasInjectableHost(file *scanner.File, idx uint32) bool {
+	if file == nil || idx == 0 {
+		return false
+	}
+	_, hasType := flatEnclosingAncestor(file, idx,
+		"class_declaration", "object_declaration", "companion_object")
+	return hasType
+}
+
+// flatFunctionDeclarationIsExtension reports whether a
+// function_declaration node declares an extension function. Extension
+// functions carry a receiver type before the name, which tree-sitter
+// models as a type node followed by a `.` token child of the
+// function_declaration (e.g. `fun String.foo()` →
+// user_type "String", `.`, simple_identifier "foo"; `fun <T> T.foo()`
+// inserts type_parameters first but still yields a `.` child).
+// Non-extension functions have no `.` direct child, so a single direct
+// `.` token is a reliable structural signal — no name/substring match.
+func flatFunctionDeclarationIsExtension(file *scanner.File, fn uint32) bool {
+	if file == nil || fn == 0 || file.FlatType(fn) != "function_declaration" {
+		return false
+	}
+	for child := file.FlatFirstChild(fn); child != 0; child = file.FlatNextSib(child) {
+		if file.FlatType(child) == "." {
+			return true
+		}
+	}
+	return false
+}
+
 func fileDeclaresIdentifierNamed(file *scanner.File, except uint32, name string) bool {
 	if file == nil || name == "" {
 		return false

--- a/internal/rules/coroutines_internal_test.go
+++ b/internal/rules/coroutines_internal_test.go
@@ -1,0 +1,136 @@
+package rules
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kaeawc/krit/internal/scanner"
+)
+
+func parseCoroutinesInline(t *testing.T, code string) *scanner.File {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "test.kt")
+	if err := os.WriteFile(path, []byte(code), 0644); err != nil {
+		t.Fatal(err)
+	}
+	f, err := scanner.ParseFile(context.Background(), path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return f
+}
+
+// firstFunctionDeclaration returns the first function_declaration node
+// in the file (depth-first, document order).
+func firstFunctionDeclaration(file *scanner.File) uint32 {
+	var found uint32
+	file.FlatWalkNodes(0, "function_declaration", func(idx uint32) {
+		if found == 0 {
+			found = idx
+		}
+	})
+	return found
+}
+
+// Locks the structural extension-function signal used by
+// InjectDispatcher: tree-sitter emits a `.` token direct child of the
+// function_declaration only for extension receivers, across plain,
+// nullable, and generic receiver shapes. Plain and member functions
+// must report false.
+func TestFlatFunctionDeclarationIsExtension(t *testing.T) {
+	cases := []struct {
+		name string
+		code string
+		want bool
+	}{
+		{
+			name: "plain top-level",
+			code: "package p\nfun loadTopLevel() { x() }\n",
+			want: false,
+		},
+		{
+			name: "extension with simple receiver",
+			code: "package p\nfun String.loadExt() { x() }\n",
+			want: true,
+		},
+		{
+			name: "extension with nullable receiver",
+			code: "package p\nfun String?.loadExt() { x() }\n",
+			want: true,
+		},
+		{
+			name: "extension with generic receiver",
+			code: "package p\nfun <T> T.loadExt() { x() }\n",
+			want: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			file := parseCoroutinesInline(t, tc.code)
+			fn := firstFunctionDeclaration(file)
+			if fn == 0 {
+				t.Fatal("no function_declaration found")
+			}
+			if got := flatFunctionDeclarationIsExtension(file, fn); got != tc.want {
+				t.Fatalf("flatFunctionDeclarationIsExtension = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// Confirms the host check that gates InjectDispatcher: a dispatcher
+// usage has an injectable host only when enclosed by a
+// class/object/companion, regardless of whether the enclosing function
+// is an extension.
+func TestInjectDispatcherHasInjectableHost(t *testing.T) {
+	cases := []struct {
+		name string
+		code string
+		want bool
+	}{
+		{
+			name: "top-level function",
+			code: "package p\nfun f() { withContext(Dispatchers.IO) {} }\n",
+			want: false,
+		},
+		{
+			name: "top-level extension function",
+			code: "package p\nfun String.f() { withContext(Dispatchers.IO) {} }\n",
+			want: false,
+		},
+		{
+			name: "class member",
+			code: "package p\nclass C { fun f() { withContext(Dispatchers.IO) {} } }\n",
+			want: true,
+		},
+		{
+			name: "object member",
+			code: "package p\nobject O { fun f() { withContext(Dispatchers.IO) {} } }\n",
+			want: true,
+		},
+		{
+			name: "member extension function",
+			code: "package p\nclass C { fun String.f() { withContext(Dispatchers.IO) {} } }\n",
+			want: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			file := parseCoroutinesInline(t, tc.code)
+			var usage uint32
+			file.FlatWalkNodes(0, "navigation_expression", func(idx uint32) {
+				if usage == 0 && file.FlatNodeText(idx) == "Dispatchers.IO" {
+					usage = idx
+				}
+			})
+			if usage == 0 {
+				t.Fatal("Dispatchers.IO navigation_expression not found")
+			}
+			if got := injectDispatcherHasInjectableHost(file, usage); got != tc.want {
+				t.Fatalf("injectDispatcherHasInjectableHost = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/rules/coroutines_test.go
+++ b/internal/rules/coroutines_test.go
@@ -447,9 +447,11 @@ func TestInjectDispatcher_Positive(t *testing.T) {
 	findings := runRuleByName(t, "InjectDispatcher", `
 package test
 import kotlinx.coroutines.Dispatchers
-suspend fun loadData() {
-    withContext(Dispatchers.IO) {
-        fetchFromNetwork()
+class Repo {
+    suspend fun loadData() {
+        withContext(Dispatchers.IO) {
+            fetchFromNetwork()
+        }
     }
 }
 `)
@@ -463,9 +465,11 @@ func TestInjectDispatcher_PositiveBareLaunch(t *testing.T) {
 package test
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-suspend fun loadData() {
-    launch(Dispatchers.Default) {
-        fetchFromNetwork()
+class Repo {
+    suspend fun loadData() {
+        launch(Dispatchers.Default) {
+            fetchFromNetwork()
+        }
     }
 }
 `)
@@ -529,12 +533,92 @@ interface DispatcherProvider {
 	}
 }
 
+// A top-level function has no enclosing class/object to inject a
+// dispatcher into, so a hardcoded Dispatchers.* there is not actionable
+// and must not be flagged. Mirrors the FIR checker's top-level
+// exemption. Detection is structural: no class_declaration /
+// object_declaration / companion_object ancestor.
+func TestInjectDispatcher_NegativeTopLevelFunction(t *testing.T) {
+	findings := runRuleByName(t, "InjectDispatcher", `
+package test
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+fun loadTopLevel() {
+    withContext(Dispatchers.IO) { fetchFromNetwork() }
+}
+`)
+	if len(findings) != 0 {
+		t.Errorf("expected no findings for top-level function, got %d: %v", len(findings), findings)
+	}
+}
+
+// An extension function's receiver is fixed by the call site and it has
+// no enclosing type to inject into, so a hardcoded Dispatchers.* must
+// not be flagged. Detection is structural: the function_declaration has
+// a `.` token direct child (receiver-type separator), not a name match.
+func TestInjectDispatcher_NegativeExtensionFunction(t *testing.T) {
+	findings := runRuleByName(t, "InjectDispatcher", `
+package test
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+fun String.loadExt() {
+    withContext(Dispatchers.Default) { fetchFromNetwork() }
+}
+`)
+	if len(findings) != 0 {
+		t.Errorf("expected no findings for extension function, got %d: %v", len(findings), findings)
+	}
+}
+
+// A generic extension function (receiver type carries type parameters)
+// is still an extension and must not be flagged. Confirms the `.`-token
+// detection is robust to `fun <T> T.foo()` shapes.
+func TestInjectDispatcher_NegativeGenericExtensionFunction(t *testing.T) {
+	findings := runRuleByName(t, "InjectDispatcher", `
+package test
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+suspend fun <T> T.loadExt() {
+    withContext(Dispatchers.IO) { fetchFromNetwork() }
+}
+`)
+	if len(findings) != 0 {
+		t.Errorf("expected no findings for generic extension function, got %d: %v", len(findings), findings)
+	}
+}
+
+// An extension function declared *inside* a class still has an
+// injectable host (the class), so it must continue to flag. Guards
+// against over-suppressing every extension regardless of enclosing
+// type.
+func TestInjectDispatcher_PositiveMemberExtensionFunction(t *testing.T) {
+	findings := runRuleByName(t, "InjectDispatcher", `
+package test
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+class Repo {
+    suspend fun String.loadExt() {
+        withContext(Dispatchers.IO) { fetchFromNetwork() }
+    }
+}
+`)
+	if len(findings) == 0 {
+		t.Error("expected member extension function to flag hardcoded Dispatchers.IO")
+	}
+}
+
 func TestInjectDispatcher_TypeInfoConfirmsCoroutineDispatcher(t *testing.T) {
 	findings := runInjectDispatcherWithExpressionType(t, `
 package test
 import kotlinx.coroutines.Dispatchers
-suspend fun loadData() {
-    withContext(Dispatchers.IO) { fetchFromNetwork() }
+class Repo {
+    suspend fun loadData() {
+        withContext(Dispatchers.IO) { fetchFromNetwork() }
+    }
 }
 `, "Dispatchers.IO", &typeinfer.ResolvedType{Name: "CoroutineDispatcher", FQN: "kotlinx.coroutines.CoroutineDispatcher", Kind: typeinfer.TypeClass})
 	if len(findings) != 1 {
@@ -619,9 +703,11 @@ package test
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
-suspend fun foo() {
-    withContext(Dispatchers.IO) { }
-    withContext(Dispatchers.Default) { }
+class Repo {
+    suspend fun foo() {
+        withContext(Dispatchers.IO) { }
+        withContext(Dispatchers.Default) { }
+    }
 }
 `)
 	if len(findings) != 2 {
@@ -691,8 +777,10 @@ func TestInjectDispatcher_OracleCallTargetConfirmsRealDispatchers(t *testing.T) 
 	findings := runInjectDispatcherWithCallTarget(t, `
 package test
 import kotlinx.coroutines.Dispatchers
-suspend fun loadData() {
-    withContext(Dispatchers.IO) { fetchFromNetwork() }
+class Repo {
+    suspend fun loadData() {
+        withContext(Dispatchers.IO) { fetchFromNetwork() }
+    }
 }
 `, "Dispatchers.IO", "kotlinx.coroutines.Dispatchers.IO")
 	if len(findings) != 1 {
@@ -729,19 +817,21 @@ func TestInjectDispatcher_LinePointsToDispatcher(t *testing.T) {
 	findings := runRuleByName(t, "InjectDispatcher", `
 package test
 import kotlinx.coroutines.Dispatchers
-suspend fun loadData() {
-    withContext(Dispatchers.Default) {
-        fetchFromNetwork()
+class Repo {
+    suspend fun loadData() {
+        withContext(Dispatchers.Default) {
+            fetchFromNetwork()
+        }
     }
 }
 `)
 	if len(findings) != 1 {
 		t.Fatalf("expected 1 finding, got %d", len(findings))
 	}
-	// Line 5 is "    withContext(Dispatchers.Default) {" — the Dispatchers.Default
+	// Line 6 is "        withContext(Dispatchers.Default) {" — the Dispatchers.Default
 	// should be reported on the line where it actually appears.
-	if findings[0].Line != 5 {
-		t.Errorf("expected finding on line 5, got line %d", findings[0].Line)
+	if findings[0].Line != 6 {
+		t.Errorf("expected finding on line 6, got line %d", findings[0].Line)
 	}
 }
 

--- a/internal/rules/emptyblocks.go
+++ b/internal/rules/emptyblocks.go
@@ -80,6 +80,30 @@ func blockHasCommentFlat(file *scanner.File, idx uint32) bool {
 	return hasComment
 }
 
+// javaMethodHasOverrideAnnotation reports whether a Java method_declaration
+// carries an `@Override` annotation. The annotation is a structural AST node —
+// `modifiers > (marker_annotation | annotation) > identifier "Override"` — so
+// this matches only a real annotation, not the token `Override` appearing in a
+// string literal, comment, or identifier elsewhere in the method text.
+func javaMethodHasOverrideAnnotation(file *scanner.File, idx uint32) bool {
+	mods, ok := file.FlatFindChild(idx, "modifiers")
+	if !ok {
+		return false
+	}
+	for child := file.FlatFirstChild(mods); child != 0; child = file.FlatNextSib(child) {
+		t := file.FlatType(child)
+		if t != "marker_annotation" && t != "annotation" {
+			continue
+		}
+		for gc := file.FlatFirstChild(child); gc != 0; gc = file.FlatNextSib(gc) {
+			if file.FlatType(gc) == "identifier" && file.FlatNodeTextEquals(gc, "Override") {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // EmptyCatchBlockRule detects catch blocks with empty body.
 type EmptyCatchBlockRule struct {
 	FlatDispatchBase

--- a/internal/rules/emptyblocks_test.go
+++ b/internal/rules/emptyblocks_test.go
@@ -90,30 +90,32 @@ class Example {
 	}
 }
 
-// TestEmptyFunctionBlock_FlagsOverrideEmptyBodyByDefault verifies that, with
-// ignoreOverridden=false, an override function with an empty body is a finding.
-// The previous krit behavior — silently
-// skipping all overrides — masked legitimate issues like an empty
-// X509TrustManager.checkClientTrusted that disables certificate checks.
-func TestEmptyFunctionBlock_FlagsOverrideEmptyBodyByDefault(t *testing.T) {
+// TestEmptyFunctionBlock_SkipsOverrideEmptyBodyByDefault verifies that empty
+// override bodies are NOT flagged by default. An `override fun foo() {}` is
+// almost always an intentional no-op required by a framework/interface
+// contract (TextWatcher.afterTextChanged, AnimatorListener.onAnimationEnd,
+// etc.), which made empty overrides the dominant false-positive source on
+// real apps. The skip is driven by the AST `override` modifier node, not a
+// text scan.
+func TestEmptyFunctionBlock_SkipsOverrideEmptyBodyByDefault(t *testing.T) {
 	findings := runRuleByName(t, "EmptyFunctionBlock", `
 package test
-class TrustNothing : X509TrustManager {
-    override fun checkClientTrusted(chain: Array<X509Certificate>, authType: String) {}
-    override fun checkServerTrusted(chain: Array<X509Certificate>, authType: String) {}
-    override fun getAcceptedIssuers(): Array<X509Certificate> = arrayOf()
+class Listener : AnimatorListener {
+    override fun onAnimationEnd(a: Animator) {}
+    override fun onAnimationStart(a: Animator) {}
 }
 `)
-	if len(findings) != 2 {
-		t.Fatalf("expected 2 findings (one per empty override body), got %d", len(findings))
+	if len(findings) != 0 {
+		t.Fatalf("expected 0 findings for empty override bodies by default, got %d", len(findings))
 	}
 }
 
-// TestEmptyFunctionBlock_HonorsIgnoreOverridden verifies the wired field:
-// when ignoreOverridden is true, override functions with empty bodies
-// are not flagged. This restores krit's pre-fix behavior for users who
-// opt into it via YAML.
-func TestEmptyFunctionBlock_HonorsIgnoreOverridden(t *testing.T) {
+// TestEmptyFunctionBlock_HonorsIgnoreOverriddenFalse verifies the wired field:
+// when ignoreOverridden is set to false, override functions with empty bodies
+// are flagged again. This is the aggressive opt-in mode that catches, e.g., an
+// empty X509TrustManager.checkClientTrusted override that disables certificate
+// checks.
+func TestEmptyFunctionBlock_HonorsIgnoreOverriddenFalse(t *testing.T) {
 	var rule *rules.EmptyFunctionBlockRule
 	for _, candidate := range api.Registry {
 		if candidate.ID == "EmptyFunctionBlock" {
@@ -131,16 +133,45 @@ func TestEmptyFunctionBlock_HonorsIgnoreOverridden(t *testing.T) {
 	original := rule.IgnoreOverridden
 	defer func() { rule.IgnoreOverridden = original }()
 
-	rule.IgnoreOverridden = true
+	rule.IgnoreOverridden = false
 
 	findings := runRuleByName(t, "EmptyFunctionBlock", `
 package test
-class Sub : Parent {
-    override fun handle() {}
+class TrustNothing : X509TrustManager {
+    override fun checkClientTrusted(chain: Array<X509Certificate>, authType: String) {}
+    override fun checkServerTrusted(chain: Array<X509Certificate>, authType: String) {}
 }
 `)
-	if len(findings) != 0 {
-		t.Fatalf("expected 0 findings when ignoreOverridden=true, got %d", len(findings))
+	if len(findings) != 2 {
+		t.Fatalf("expected 2 findings (one per empty override body) when ignoreOverridden=false, got %d", len(findings))
+	}
+}
+
+// TestEmptyFunctionBlock_JavaOverrideAndCommentOnly locks the Java parity for
+// the same two false positives: an `@Override` no-op and a body whose only
+// content is a comment must not be flagged, while a genuinely-empty
+// non-override method still is. The override is detected via the AST
+// `marker_annotation` node and the comment via the `block`'s `line_comment`
+// child — never a text scan.
+func TestEmptyFunctionBlock_JavaOverrideAndCommentOnly(t *testing.T) {
+	findings := runRuleByNameOnJava(t, "EmptyFunctionBlock", `
+package test
+class Example {
+    @Override
+    public void onEvent() {}
+
+    public void documentedNoOp() {
+        // intentionally no-op
+    }
+
+    public void forgotten() {}
+}
+`)
+	if len(findings) != 1 {
+		for _, f := range findings {
+			t.Logf("  %s:%d %s", f.File, f.Line, f.Message)
+		}
+		t.Fatalf("expected 1 finding (only the non-override, non-commented empty method), got %d", len(findings))
 	}
 }
 

--- a/internal/rules/meta_emptyblocks.go
+++ b/internal/rules/meta_emptyblocks.go
@@ -90,8 +90,8 @@ func (r *EmptyFunctionBlockRule) Meta() api.RuleDescriptor {
 		Options: []api.ConfigOption{
 			api.BoolOption(api.BoolOptionSpec[EmptyFunctionBlockRule]{
 				Name:        "ignoreOverridden",
-				Default:     false,
-				Description: "Ignore overridden functions with empty body.",
+				Default:     true,
+				Description: "Ignore overridden functions with an empty body (intentional framework/interface no-ops). Set to false to also flag empty overrides.",
 				Apply:       func(r *EmptyFunctionBlockRule, v bool) { r.IgnoreOverridden = v },
 			}),
 		},

--- a/internal/rules/registry_coroutines.go
+++ b/internal/rules/registry_coroutines.go
@@ -240,6 +240,14 @@ func registerCoroutinesInjectDispatcher() {
 			if dispatcherName == "Main" {
 				return
 			}
+			// Only flag when there is an injectable host: a member
+			// function of a class/object/companion. Top-level and
+			// extension functions have nowhere to inject a dispatcher,
+			// so a hardcoded Dispatchers.* there is not actionable.
+			// Mirrors the FIR checker's top-level/extension exemption.
+			if !injectDispatcherHasInjectableHost(file, dispatcherNode) {
+				return
+			}
 			matchLine := file.FlatRow(dispatcherNode) + 1
 			matchCol := file.FlatCol(dispatcherNode) + 1
 			ctx.EmitAt(matchLine, matchCol,

--- a/internal/rules/registry_emptyblocks.go
+++ b/internal/rules/registry_emptyblocks.go
@@ -293,7 +293,7 @@ func registerEmptyblocksEmptyForBlock() {
 }
 
 func registerEmptyblocksEmptyFunctionBlock() {
-	r := &EmptyFunctionBlockRule{BaseRule: BaseRule{RuleName: "EmptyFunctionBlock", RuleSetName: "empty-blocks", Sev: "warning", Desc: "Detects function declarations with an empty body."}, IgnoreOverridden: false}
+	r := &EmptyFunctionBlockRule{BaseRule: BaseRule{RuleName: "EmptyFunctionBlock", RuleSetName: "empty-blocks", Sev: "warning", Desc: "Detects function declarations with an empty body."}, IgnoreOverridden: true}
 	api.Register(&api.Rule{
 		ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
 		NodeTypes: []string{"function_declaration", "method_declaration"}, Languages: []scanner.Language{scanner.LangKotlin, scanner.LangJava}, Confidence: api.ConfidenceVeryHigh, Fix: api.FixSemantic, Implementation: r,
@@ -302,6 +302,21 @@ func registerEmptyblocksEmptyFunctionBlock() {
 			if file.Language == scanner.LangJava {
 				nodeText := file.FlatNodeText(idx)
 				if !strings.Contains(nodeText, "{") || !isBlockEmptyFlat(file, idx) {
+					return
+				}
+				// `@Override public void foo() {}` is an intentional no-op
+				// required by a supertype contract, mirroring the Kotlin
+				// `override` skip. Detect the annotation via the AST
+				// (modifiers > marker_annotation > Override), not a text scan
+				// that would also match `@Override` inside strings/comments.
+				if r.IgnoreOverridden && javaMethodHasOverrideAnnotation(file, idx) {
+					return
+				}
+				// A Java body whose only content is a comment documents an
+				// intentional no-op. isBlockEmptyFlat strips comments, so it
+				// reports such a body as empty; the AST tells us a comment
+				// node lives inside the `block`, so treat it as non-empty.
+				if block, ok := file.FlatFindChild(idx, "block"); ok && blockHasCommentFlat(file, block) {
 					return
 				}
 				f := r.Finding(file, file.FlatRow(idx)+1, 1,
@@ -323,8 +338,18 @@ func registerEmptyblocksEmptyFunctionBlock() {
 			if file.FlatHasModifier(idx, "open") {
 				return
 			}
-			isOverride := file.FlatHasModifier(idx, "override")
-			if isOverride && r.IgnoreOverridden {
+			// An `override fun foo() {}` is almost always an intentional
+			// no-op required by a framework/interface contract (e.g.
+			// TextWatcher.afterTextChanged, AnimatorListener.onAnimationEnd),
+			// not a forgotten implementation, so skipping overrides by
+			// default removes the dominant false-positive source. The
+			// `override` soft-keyword is an AST node under
+			// `modifiers > member_modifier`, so this is a structural check
+			// rather than a text scan. Users who want the aggressive
+			// behavior (e.g. to catch an empty X509TrustManager override
+			// that disables certificate checks) can set
+			// `ignoreOverridden: false`.
+			if r.IgnoreOverridden && file.FlatHasModifier(idx, "override") {
 				return
 			}
 			if HasIgnoredAnnotation(file.FlatNodeText(idx),

--- a/internal/rules/registry_resource_cost.go
+++ b/internal/rules/registry_resource_cost.go
@@ -456,7 +456,7 @@ func registerResourceCostRules() {
 				if name != "painterResource" {
 					return
 				}
-				if resourceCostInsideLazyListLambda(file, idx) {
+				if resourceCostInsideLoopLambda(file, idx) {
 					ctx.EmitAt(file.FlatRow(idx)+1, file.FlatCol(idx)+1, "painterResource() inside list/loop lambda creates a fresh painter per iteration; hoist it outside the lambda.")
 					return
 				}

--- a/internal/rules/resource_cost.go
+++ b/internal/rules/resource_cost.go
@@ -31,6 +31,36 @@ func resourceCostInsideLazyListLambda(file *scanner.File, idx uint32) bool {
 	return false
 }
 
+// resourceCostLoopCallNames is the set of lambda-receiving calls whose body
+// runs once per element. The singular LazyListScope.item { } is deliberately
+// excluded: it renders exactly once, so building a painter inside it is not a
+// per-iteration cost. The plural items/itemsIndexed, the for-each family, and
+// the common iteration combinators are all genuine loops.
+var resourceCostLoopCallNames = map[string]bool{
+	"items":          true,
+	"itemsIndexed":   true,
+	"forEach":        true,
+	"forEachIndexed": true,
+	"map":            true,
+	"mapIndexed":     true,
+	"repeat":         true,
+}
+
+// resourceCostInsideLoopLambda reports whether idx sits inside a lambda body
+// that is executed per iteration. Unlike resourceCostInsideLazyListLambda it
+// does not treat the singular LazyListScope.item { } as a loop.
+func resourceCostInsideLoopLambda(file *scanner.File, idx uint32) bool {
+	for cur, ok := file.FlatParent(idx); ok; cur, ok = file.FlatParent(cur) {
+		if file.FlatType(cur) == "call_expression" {
+			callName := flatCallNameAny(file, cur)
+			if resourceCostLoopCallNames[callName] {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // ---------------------------------------------------------------------------
 // Batch 1: In-Progress rules
 // ---------------------------------------------------------------------------

--- a/schemas/krit-config.schema.json
+++ b/schemas/krit-config.schema.json
@@ -8454,9 +8454,9 @@
               }
             },
             "ignoreOverridden": {
-              "description": "Ignore overridden functions with empty body.",
+              "description": "Ignore overridden functions with an empty body (intentional framework/interface no-ops). Set to false to also flag empty overrides.",
               "type": "boolean",
-              "default": false
+              "default": true
             }
           }
         },

--- a/tests/fixtures/negative/compose/ComposePainterResourceInLoop.kt
+++ b/tests/fixtures/negative/compose/ComposePainterResourceInLoop.kt
@@ -2,6 +2,7 @@ package fixtures.negative.compose
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.item
 import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.res.painterResource
@@ -24,5 +25,19 @@ fun ComposePainterResourceInLoopNegative(items: List<String>) {
             painter = marker,
             contentDescription = item,
         )
+    }
+}
+
+// A singular LazyListScope.item { } renders exactly once — it is not a loop,
+// so calling painterResource() directly inside it is fine.
+@Composable
+fun ComposePainterResourceInSingularItemNegative() {
+    LazyColumn {
+        item {
+            Image(
+                painter = painterResource(R.drawable.header),
+                contentDescription = null,
+            )
+        }
     }
 }

--- a/tests/fixtures/negative/coroutines/InjectDispatcher.kt
+++ b/tests/fixtures/negative/coroutines/InjectDispatcher.kt
@@ -78,6 +78,26 @@ interface DispatcherProvider {
     val io: CoroutineDispatcher
 }
 
+// Top-level function: there is no enclosing class/object to inject a
+// dispatcher into, so a hardcoded Dispatchers.* here is not actionable
+// and must NOT be flagged.
+fun loadTopLevel() {
+    withContext(Dispatchers.IO) { fetchFromNetwork() }
+}
+
+// Top-level extension function: the receiver is fixed by the call site
+// and there is no enclosing type to inject into, so this must NOT be
+// flagged either.
+fun String.loadExt() {
+    withContext(Dispatchers.Default) { fetchFromNetwork() }
+}
+
+// Generic top-level extension: same reasoning; the receiver-type AST
+// shape carries type parameters but is still an extension.
+suspend fun <T> T.loadGenericExt() {
+    withContext(Dispatchers.IO) { fetchFromNetwork() }
+}
+
 fun fetchFromNetwork() = Unit
 fun renderResult() = Unit
 

--- a/tests/fixtures/negative/empty-blocks/EmptyFunctionBlock.kt
+++ b/tests/fixtures/negative/empty-blocks/EmptyFunctionBlock.kt
@@ -1,5 +1,25 @@
 package fixtures.negative.emptyblocks
 
+interface Listener {
+    fun onEvent()
+}
+
+// (1) Function with a real body — never flagged.
 fun doSomething() {
     println("hi")
+}
+
+// (2) override no-op required by a framework contract — not a bug.
+class Impl : Listener {
+    override fun onEvent() {}
+}
+
+// (3) body whose only content is a line comment documenting the no-op.
+fun bar() {
+    // intentionally no-op
+}
+
+// (4) body whose only content is a block comment.
+fun baz() {
+    /* intentionally no-op */
 }

--- a/tests/fixtures/negative/security/ImplicitPendingIntent.kt
+++ b/tests/fixtures/negative/security/ImplicitPendingIntent.kt
@@ -8,3 +8,27 @@ fun securePendingIntent(context: Context, intent: Intent) {
     PendingIntent.getActivity(context, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
     PendingIntent.getBroadcast(context, 0, intent, PendingIntent.FLAG_MUTABLE)
 }
+
+fun multiLineFlags(context: Context, intent: Intent) {
+    // Flag argument spans multiple lines; the mutability flag is on a later line.
+    PendingIntent.getBroadcast(
+        context,
+        0,
+        intent,
+        PendingIntent.FLAG_UPDATE_CURRENT or
+            PendingIntent.FLAG_IMMUTABLE,
+    )
+}
+
+fun helperProvidedFlags(context: Context, intent: Intent, flags: Int) {
+    // Flags supplied indirectly via a parameter/val — cannot prove they lack mutability.
+    PendingIntent.getActivity(context, 0, intent, flags)
+    val resolved = PendingIntentFlags.mutable() or PendingIntentFlags.updateCurrent()
+    PendingIntent.getService(context, 0, intent, resolved)
+    PendingIntent.getActivities(context, 0, arrayOf(intent), PendingIntentFlags.mutable())
+}
+
+object PendingIntentFlags {
+    fun mutable(): Int = PendingIntent.FLAG_MUTABLE
+    fun updateCurrent(): Int = PendingIntent.FLAG_UPDATE_CURRENT
+}


### PR DESCRIPTION
Stacked on #641 (FIR oracle work). Dogfooding a large Android codebase surfaced four built-in rules dominated by false positives. Each is fixed with **tree-sitter AST / structured-XML** analysis — no string/substring/regex matching — and locked with fixtures.

## Fixes (FP reduction measured on the dogfood target)

| Rule | Before → After | Fix |
|---|---|---|
| **EmptyFunctionBlock** | 394 → 69 | Skip empty `override` / `@Override` no-ops (supertype contract) and comment-only bodies (documented no-op), Kotlin + Java. Default `ignoreOverridden` → true. |
| **ImplicitPendingIntent** | 47 → 0 | Resolve the flags-argument **node** and walk its subtree; only flag an explicit flag expression lacking `FLAG_IMMUTABLE`/`FLAG_MUTABLE`. Don't flag helper-provided flags (`PendingIntentFlags.mutable()`), bare params/vals, or a multi-line flag arg. |
| **ComposePainterResourceInLoop** | 16 → 3 | Singular `LazyListScope.item { }` renders once — not a loop. Only `items`/`itemsIndexed`/`forEach`/`repeat`/`map(+Indexed)` and real for/while loops count, matched by the callee identifier node. |
| **InjectDispatcher** (Go rule) | 31 → 30 | Don't flag hardcoded dispatchers in top-level / non-member extension functions (no constructor to inject into) — gate on an injectable host found via AST ancestor walk. Mirrors the krit-fir checker fix in #641. |

**StateListReachableResource**: investigated a suspected ~100% FP cluster — the rule is **already correct** (subset-based reachability, ignores non-selector nested `<item>`s). Added parser + rule regression coverage to lock it.

Total on the dogfood target: **2001 → 1615** findings (≈386 fewer, almost all false positives). Cold == warm verified byte-identical.

## Notes
- Each fix is AST-based; the `@Override`/extension/loop/flags decisions use modifier/annotation/receiver/callee **nodes**, never source-text scans.
- `cachePayloadVersion` v2→v3 so warm findings caches recompute after these rule-logic changes (the findings-cache key is otherwise blind to rule-logic edits).
- Config default + meta + struct + JSON schema kept in sync for `EmptyFunctionBlock.ignoreOverridden`.

## Validation
`go build`, `go vet`, `golangci-lint`, `gofmt`, `make schema` (in sync), and the rules/android/config/cache suites are green. New negative fixtures verified to fail before each fix; positives still flag.