### PR TITLE
fix(rules): structural FP fixes — OptIn, exceptions, VarCouldBeVal, autofill, UnusedParameter, RecyclerAdapter

### DIFF
--- a/cmd/krit/testdata/regression/playground-android-app.json
+++ b/cmd/krit/testdata/regression/playground-android-app.json
@@ -1,6 +1,6 @@
 {
   "project": "../../playground/android-app/",
-  "findings_count": 70,
+  "findings_count": 68,
   "findings": [
     {
       "rule": "MagicNumber",
@@ -179,14 +179,6 @@
       "message": "'UserAdapter' uses notifyDataSetChanged() without DiffUtil; use ListAdapter or DiffUtil.calculateDiff() for efficient updates."
     },
     {
-      "rule": "SwallowedException",
-      "ruleSet": "exceptions",
-      "file": "src/main/kotlin/com/example/app/adapters/UserAdapter.kt",
-      "line": 48,
-      "col": 0,
-      "message": "Exception 'e' is caught but never used. Either log/handle it or rethrow."
-    },
-    {
       "rule": "TooGenericExceptionCaught",
       "ruleSet": "exceptions",
       "file": "src/main/kotlin/com/example/app/adapters/UserAdapter.kt",
@@ -265,14 +257,6 @@
       "line": 50,
       "col": 0,
       "message": "Empty catch block detected. Empty catch blocks should be avoided."
-    },
-    {
-      "rule": "SwallowedException",
-      "ruleSet": "exceptions",
-      "file": "src/main/kotlin/com/example/app/fragments/HomeFragment.kt",
-      "line": 50,
-      "col": 0,
-      "message": "Exception 'e' is caught but never used. Either log/handle it or rethrow."
     },
     {
       "rule": "ForbiddenComment",

--- a/cmd/krit/testdata/regression/playground-kotlin-webservice.json
+++ b/cmd/krit/testdata/regression/playground-kotlin-webservice.json
@@ -1,6 +1,6 @@
 {
   "project": "../../playground/kotlin-webservice/",
-  "findings_count": 65,
+  "findings_count": 63,
   "findings": [
     {
       "rule": "DependenciesInRootProject",
@@ -147,14 +147,6 @@
       "message": "Magic number '18'. Consider extracting it to a named constant."
     },
     {
-      "rule": "SwallowedException",
-      "ruleSet": "exceptions",
-      "file": "src/main/kotlin/com/example/services/UserService.kt",
-      "line": 110,
-      "col": 0,
-      "message": "Exception 'e' is caught but never used. Either log/handle it or rethrow."
-    },
-    {
       "rule": "TooGenericExceptionCaught",
       "ruleSet": "exceptions",
       "file": "src/main/kotlin/com/example/services/UserService.kt",
@@ -169,14 +161,6 @@
       "line": 119,
       "col": 0,
       "message": "Empty catch block detected. Empty catch blocks should be avoided."
-    },
-    {
-      "rule": "SwallowedException",
-      "ruleSet": "exceptions",
-      "file": "src/main/kotlin/com/example/services/UserService.kt",
-      "line": 119,
-      "col": 0,
-      "message": "Exception 'e' is caught but never used. Either log/handle it or rethrow."
     },
     {
       "rule": "ReturnFromFinally",

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -43,7 +43,11 @@ const CacheFileName = "incremental.cache"
 // v3: structural false-positive fixes to EmptyFunctionBlock,
 // ImplicitPendingIntent, ComposePainterResourceInLoop, and InjectDispatcher
 // change those rules' findings for unchanged source.
-const cachePayloadVersion = "v3"
+// v4: structural false-positive fixes to InstanceOfCheckForException
+// (caught-variable / cause-unwrap narrowing) and SwallowedException
+// (exception passed/wrapped/cause-inspected, recovery bodies, empty-body
+// deferral) change those rules' findings for unchanged source.
+const cachePayloadVersion = "v4"
 
 // DefaultDir returns Krit's repo-local incremental cache directory.
 func DefaultDir(repoDir string) string {

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -1713,11 +1713,15 @@ func TestUnknownTool(t *testing.T) {
 }
 
 func TestSuggestFixesWithFixableIssues(t *testing.T) {
-	// Empty catch block triggers EmptyCatchBlock which populates Fix
+	// A log-the-string-but-drop-the-cause catch triggers SwallowedException,
+	// which populates a Fix (insert `throw e`). (A truly empty catch is owned
+	// by EmptyCatchBlock, whose fix is intentionally neutered, so it would not
+	// produce a fix suggestion here.)
 	code := `fun main() {
     try {
         riskyCall()
     } catch (e: Exception) {
+        println("failed")
     }
 }
 `
@@ -1903,11 +1907,14 @@ func TestSuggestFixesMissingCode(t *testing.T) {
 }
 
 func TestSuggestFixesFixLevelAll(t *testing.T) {
-	// fix_level "all" should not filter — return all fixable findings
+	// fix_level "all" should not filter — return all fixable findings. Use a
+	// log-and-drop catch so SwallowedException produces a fixable finding (an
+	// empty catch is owned by EmptyCatchBlock, whose fix is neutered).
 	code := `fun main() {
     try {
         riskyCall()
     } catch (e: Exception) {
+        println("failed")
     }
 }
 `

--- a/internal/rules/android_resource_a11y.go
+++ b/internal/rules/android_resource_a11y.go
@@ -520,13 +520,61 @@ type LayoutAutofillHintMismatchRule struct {
 
 func (r *LayoutAutofillHintMismatchRule) Confidence() float64 { return api.ConfidenceMedium }
 
-var inputTypeToAutofillHint = map[string]string{
+// specificAutofillInputType maps inputType flags that unambiguously identify an
+// autofillable field to the autofill hint Android expects for them.
+//
+// We deliberately exclude generic, ambiguous input types:
+//   - "number" (and numeric variants) is used for OTPs, quantities, country
+//     codes, PINs, passphrases, etc.; it does NOT imply a credit-card field.
+//   - "text" / "textPersonName" is routinely used for search boxes and free
+//     text, so requiring a personName hint produces noise.
+//
+// Only specific, single-purpose types remain here so we can confidently assert
+// both the expected hint (for the missing-hint case) and a contradiction (for
+// the genuine-mismatch case). Prefer false-negatives over false-positives.
+var specificAutofillInputType = map[string]string{
 	"textEmailAddress":  "emailAddress",
 	"textPassword":      "password",
-	"textPersonName":    "personName",
+	"textWebPassword":   "password",
+	"numberPassword":    "password",
 	"phone":             "phone",
 	"textPostalAddress": "postalAddress",
-	"number":            "creditCardNumber",
+}
+
+// autofillHintCompatibleInputTypes lists, for a given autofillHints value, the
+// inputType flags that are consistent with it. A field whose autofillHints is
+// set to one of these keys but whose inputType contains none of the compatible
+// flags (and is itself a specific, contradicting type) is a genuine mismatch.
+var autofillHintCompatibleInputTypes = map[string]map[string]bool{
+	"emailAddress":  {"textEmailAddress": true},
+	"password":      {"textPassword": true, "textWebPassword": true, "numberPassword": true, "textVisiblePassword": true},
+	"phone":         {"phone": true},
+	"postalAddress": {"textPostalAddress": true, "textMultiLine": true},
+	"creditCardNumber": {
+		"number": true, "numberPassword": true, "phone": true,
+	},
+}
+
+// isExemptFromAutofill reports whether the field opts out of autofill entirely.
+func isExemptFromAutofill(v *android.View) bool {
+	switch v.Attributes["android:importantForAutofill"] {
+	case "no", "noExcludeDescendants":
+		return true
+	}
+	return false
+}
+
+// inputTypeFlags splits an android:inputType value (which may be a
+// pipe-combined flag set like "number|textNoSuggestions") into its flags.
+func inputTypeFlags(inputType string) []string {
+	parts := strings.Split(inputType, "|")
+	flags := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if f := strings.TrimSpace(p); f != "" {
+			flags = append(flags, f)
+		}
+	}
+	return flags
 }
 
 func (r *LayoutAutofillHintMismatchRule) check(ctx *api.Context) {
@@ -537,15 +585,51 @@ func (r *LayoutAutofillHintMismatchRule) check(ctx *api.Context) {
 			if inputType == "" {
 				return
 			}
-			expectedHint, ok := inputTypeToAutofillHint[inputType]
-			if !ok {
+			// Fields explicitly opted out of autofill never mismatch.
+			if isExemptFromAutofill(v) {
 				return
 			}
-			autofillHints := v.Attributes["android:autofillHints"]
-			if autofillHints == "" {
-				ctx.Emit(baseFinding(layout.FilePath, v.Line, r.BaseRule,
-					fmt.Sprintf("`%s` has `inputType=\"%s\"` but no `android:autofillHints`. "+
-						"Add `autofillHints=\"%s\"` for autofill support.", v.Type, inputType, expectedHint)))
+
+			flags := inputTypeFlags(inputType)
+			autofillHints := strings.TrimSpace(v.Attributes["android:autofillHints"])
+
+			// Case 1: genuine mismatch — an autofillHints value is set, but the
+			// inputType is a specific type that contradicts it (e.g.
+			// autofillHints="password" on inputType="phone"). Only assert this
+			// when every flag is a known specific type and none is compatible
+			// with the declared hint; otherwise stay silent.
+			if autofillHints != "" {
+				compatible, known := autofillHintCompatibleInputTypes[autofillHints]
+				if !known {
+					return
+				}
+				hasContradiction := false
+				for _, f := range flags {
+					if compatible[f] {
+						return // at least one flag is consistent — no mismatch
+					}
+					if _, specific := specificAutofillInputType[f]; specific {
+						hasContradiction = true
+					}
+				}
+				if hasContradiction {
+					ctx.Emit(baseFinding(layout.FilePath, v.Line, r.BaseRule,
+						fmt.Sprintf("`%s` has `autofillHints=\"%s\"` but `inputType=\"%s\"` is inconsistent with it. "+
+							"Align the autofill hint with the input type.", v.Type, autofillHints, inputType)))
+				}
+				return
+			}
+
+			// Case 2: missing hint — only suggest one when the inputType is a
+			// specific, unambiguously autofillable type. Generic types
+			// (number, text, textPersonName, ...) are intentionally ignored.
+			for _, f := range flags {
+				if expectedHint, ok := specificAutofillInputType[f]; ok {
+					ctx.Emit(baseFinding(layout.FilePath, v.Line, r.BaseRule,
+						fmt.Sprintf("`%s` has `inputType=\"%s\"` but no `android:autofillHints`. "+
+							"Add `autofillHints=\"%s\"` for autofill support.", v.Type, inputType, expectedHint)))
+					return
+				}
 			}
 		})
 	}

--- a/internal/rules/android_resource_a11y_test.go
+++ b/internal/rules/android_resource_a11y_test.go
@@ -1,10 +1,21 @@
 package rules_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/kaeawc/krit/internal/android"
+	"github.com/kaeawc/krit/internal/scanner"
 )
+
+// findingMessages extracts finding messages for readable test failures.
+func findingMessages(findings []scanner.Finding) []string {
+	msgs := make([]string, 0, len(findings))
+	for _, f := range findings {
+		msgs = append(msgs, f.Message)
+	}
+	return msgs
+}
 
 func TestMissingContentDescriptionResource(t *testing.T) {
 	r := findResourceRule(t, "MissingContentDescriptionResource")
@@ -508,6 +519,108 @@ func TestLayoutAutofillHintMismatch(t *testing.T) {
 		findings := runResourceRule(r, idx)
 		if len(findings) != 0 {
 			t.Fatalf("expected 0 findings, got %d", len(findings))
+		}
+	})
+
+	// Regression: a generic numeric field (e.g. a country-code input) must NOT
+	// be told to use creditCardNumber. The old broad "number ⇒ creditCardNumber"
+	// inference caused this false positive.
+	t.Run("numeric country-code field is clean (no creditCardNumber suggestion)", func(t *testing.T) {
+		idx := indexWithLayout("country", "res/layout/country_code_text.xml", &android.View{
+			Type: "EditText",
+			Line: 23,
+			Attributes: map[string]string{
+				"android:inputType": "number",
+			},
+		})
+		findings := runResourceRule(r, idx)
+		if len(findings) != 0 {
+			t.Fatalf("expected 0 findings for numeric field, got %d: %v", len(findings), findingMessages(findings))
+		}
+	})
+
+	// Regression: a numeric passphrase (numberPassword) must not be told to use
+	// creditCardNumber. numberPassword maps to a password hint, and since no
+	// autofillHints is present we still suggest password — but never a card hint.
+	t.Run("numberPassword field never suggests creditCardNumber", func(t *testing.T) {
+		idx := indexWithLayout("passphrase", "res/layout/enter_backup_passphrase_dialog.xml", &android.View{
+			Type: "EditText",
+			Line: 10,
+			Attributes: map[string]string{
+				"android:inputType": "numberPassword",
+			},
+		})
+		findings := runResourceRule(r, idx)
+		for _, f := range findings {
+			if strings.Contains(f.Message, "creditCardNumber") {
+				t.Fatalf("must not suggest creditCardNumber for numberPassword: %q", f.Message)
+			}
+		}
+	})
+
+	// Regression: generic textPersonName (often a search box) must not be told
+	// to use a personName hint.
+	t.Run("textPersonName field is clean (no personName suggestion)", func(t *testing.T) {
+		idx := indexWithLayout("search", "res/layout/search.xml", &android.View{
+			Type: "EditText",
+			Line: 7,
+			Attributes: map[string]string{
+				"android:inputType": "textPersonName",
+			},
+		})
+		findings := runResourceRule(r, idx)
+		if len(findings) != 0 {
+			t.Fatalf("expected 0 findings for textPersonName, got %d: %v", len(findings), findingMessages(findings))
+		}
+	})
+
+	// Regression: a field explicitly opted out of autofill must be exempt.
+	t.Run("importantForAutofill=no is exempt", func(t *testing.T) {
+		idx := indexWithLayout("form", "res/layout/form.xml", &android.View{
+			Type: "EditText",
+			Line: 5,
+			Attributes: map[string]string{
+				"android:inputType":            "textEmailAddress",
+				"android:importantForAutofill": "no",
+			},
+		})
+		findings := runResourceRule(r, idx)
+		if len(findings) != 0 {
+			t.Fatalf("expected 0 findings for importantForAutofill=no, got %d: %v", len(findings), findingMessages(findings))
+		}
+	})
+
+	// Positive: a genuine mismatch — autofillHints contradicts a specific
+	// inputType — still flags.
+	t.Run("password hint on phone inputType flags (genuine mismatch)", func(t *testing.T) {
+		idx := indexWithLayout("form", "res/layout/form.xml", &android.View{
+			Type: "EditText",
+			Line: 5,
+			Attributes: map[string]string{
+				"android:inputType":     "phone",
+				"android:autofillHints": "password",
+			},
+		})
+		findings := runResourceRule(r, idx)
+		if len(findings) != 1 {
+			t.Fatalf("expected 1 finding for contradicting hint, got %d: %v", len(findings), findingMessages(findings))
+		}
+	})
+
+	// Negative: a consistent autofillHints value on a pipe-combined inputType is
+	// clean (email + flags).
+	t.Run("consistent hint on combined inputType is clean", func(t *testing.T) {
+		idx := indexWithLayout("form", "res/layout/form.xml", &android.View{
+			Type: "EditText",
+			Line: 5,
+			Attributes: map[string]string{
+				"android:inputType":     "textEmailAddress|textNoSuggestions",
+				"android:autofillHints": "emailAddress",
+			},
+		})
+		findings := runResourceRule(r, idx)
+		if len(findings) != 0 {
+			t.Fatalf("expected 0 findings for consistent combined inputType, got %d: %v", len(findings), findingMessages(findings))
 		}
 	})
 }

--- a/internal/rules/exceptions.go
+++ b/internal/rules/exceptions.go
@@ -55,41 +55,191 @@ type InstanceOfCheckForExceptionRule struct {
 	BaseRule
 }
 
-var (
-	isExceptionRe             = regexp.MustCompile(`\bis\s+\w*Exception\b`)
-	javaInstanceOfExceptionRe = regexp.MustCompile(`\binstanceof\s+[\w.]*Exception\b`)
-)
-
 // Confidence reports a tier-2 (medium) base confidence. Exceptions rule. Detection matches exception type names and catch/ throw
 // shapes via structural AST + name-list lookups. Classified per
 // roadmap/17.
 func (r *InstanceOfCheckForExceptionRule) Confidence() float64 { return api.ConfidenceMedium }
 
-func isInsideWhenDispatchOnCatchVarFlat(file *scanner.File, isNode uint32, caughtVar string) bool {
-	for p, ok := file.FlatParent(isNode); ok; p, ok = file.FlatParent(p) {
-		t := file.FlatType(p)
-		if t == "when_expression" {
-			for i := 0; i < file.FlatChildCount(p); i++ {
-				c := file.FlatChild(p, i)
-				ctype := file.FlatType(c)
-				if ctype == "when_subject" || ctype == "parenthesized_expression" ||
-					ctype == "value_arguments" {
-					text := strings.TrimSpace(file.FlatNodeText(c))
-					text = strings.TrimPrefix(text, "(")
-					text = strings.TrimSuffix(text, ")")
-					text = strings.TrimSpace(text)
-					if text == caughtVar {
-						return true
-					}
-				}
+// instanceOfCheckTypeName returns the trailing simple name of the type the
+// `is`/`instanceof` check tests against (e.g. `IOException` for both
+// `e is java.io.IOException` and `e instanceof IOException`), reading the
+// `user_type` (Kotlin) or `type_identifier`/`scoped_type_identifier` (Java)
+// operand structurally rather than by splitting raw node text.
+func instanceOfCheckTypeName(file *scanner.File, checkNode uint32) string {
+	for child := file.FlatFirstChild(checkNode); child != 0; child = file.FlatNextSib(child) {
+		switch file.FlatType(child) {
+		case "user_type", "type_identifier", "scoped_type_identifier", "scoped_identifier", "nullable_type", "generic_type":
+			if name := flatTypeLastIdentifier(file, child); name != "" {
+				return name
 			}
-			return false
-		}
-		if t == "function_declaration" || t == "lambda_literal" || t == "source_file" {
-			return false
+			return lastDotSegment(file.FlatNodeText(child))
 		}
 	}
-	return false
+	return ""
+}
+
+// instanceOfCheckOperandName returns the identifier name of the value being
+// type-checked (the left operand of `x is Type` / `x instanceof Type`), or ""
+// when the operand is not a bare identifier (e.g. a `when (subject) { is X }`
+// condition, where the operand lives on the `when_subject`, or a more complex
+// receiver expression). The operand is read as the first named child that is a
+// plain identifier, before the type operand.
+func instanceOfCheckOperandName(file *scanner.File, checkNode uint32) string {
+	for child := file.FlatFirstChild(checkNode); child != 0; child = file.FlatNextSib(child) {
+		switch file.FlatType(child) {
+		case "simple_identifier", "identifier":
+			return file.FlatNodeString(child, nil)
+		case "user_type", "type_identifier", "scoped_type_identifier",
+			"scoped_identifier", "nullable_type", "generic_type":
+			// Reached the type operand without seeing a bare identifier
+			// operand (e.g. a when-condition `is X`).
+			return ""
+		}
+	}
+	return ""
+}
+
+// instanceOfWhenSubjectOperand returns the bare-identifier subject of the
+// `when` enclosing a subjectful when-condition `is X`, or "" when the nearest
+// enclosing when has no bare-identifier subject (a binding subject like
+// `when (val cause = e.cause)`, a complex expression, or a subjectless when).
+// It stops at function / lambda / class boundaries so it never escapes the
+// catch body's expression scope.
+func instanceOfWhenSubjectOperand(file *scanner.File, isNode uint32) string {
+	for p, ok := file.FlatParent(isNode); ok; p, ok = file.FlatParent(p) {
+		switch file.FlatType(p) {
+		case "when_expression":
+			subj, found := file.FlatFindChild(p, "when_subject")
+			if !found || subj == 0 {
+				return ""
+			}
+			// A binding subject (`when (val x = ...)`) has a
+			// variable_declaration child — not a plain dispatch identifier.
+			if _, ok := file.FlatFindChild(subj, "variable_declaration"); ok {
+				return ""
+			}
+			ident, ok := file.FlatFindChild(subj, "simple_identifier")
+			if !ok || ident == 0 {
+				return ""
+			}
+			return file.FlatNodeString(ident, nil)
+		case "function_declaration", "lambda_literal", "class_declaration",
+			"object_declaration", "catch_block", "catch_clause", "source_file":
+			return ""
+		}
+	}
+	return ""
+}
+
+// lastDotSegment returns the trailing `.`-separated segment of a dotted name,
+// trimming a trailing `?` nullability marker.
+func lastDotSegment(s string) string {
+	s = strings.TrimSpace(s)
+	s = strings.TrimSuffix(s, "?")
+	if i := strings.LastIndexByte(s, '.'); i >= 0 {
+		s = s[i+1:]
+	}
+	return strings.TrimSpace(s)
+}
+
+// nameLooksLikeExceptionType reports whether a simple type name denotes an
+// exception/throwable type by its `Exception` / `Error` / `Throwable` suffix.
+// This is the structural equivalent of the old `\w*Exception` text match but
+// operates on the resolved simple type name rather than raw node text.
+func nameLooksLikeExceptionType(name string) bool {
+	if name == "" {
+		return false
+	}
+	return strings.HasSuffix(name, "Exception") ||
+		strings.HasSuffix(name, "Error") ||
+		name == "Throwable"
+}
+
+// caughtNarrowingOperands returns the set of identifier names whose `is`/
+// `instanceof` checks inside a catch body are narrowing the *already-caught*
+// exception (and therefore legitimate, not the "type-check instead of
+// polymorphism" smell). That set is the catch parameter itself plus any local
+// variable declared in the catch body whose initializer reads the caught
+// variable — e.g. `val cause = e.cause` / `Throwable cause = e.getCause()`,
+// the idiomatic cause-chain unwrap. The initializer relationship is matched
+// structurally by walking the declaration's initializer subtree for an
+// identifier reference to a known caught-derived name.
+func caughtNarrowingOperands(file *scanner.File, catchNode uint32, caughtVar string) map[string]bool {
+	out := map[string]bool{caughtVar: true}
+	if caughtVar == "" {
+		return out
+	}
+	// Iterate to a fixpoint so chained derivations
+	// (`val a = e.cause; val b = a.cause`) are all captured.
+	changed := true
+	for changed {
+		changed = false
+		file.FlatWalkNodes(catchNode, "property_declaration", func(decl uint32) {
+			name := caughtNarrowingDeclName(file, decl)
+			if name == "" || out[name] {
+				return
+			}
+			if caughtNarrowingInitReferences(file, decl, out) {
+				out[name] = true
+				changed = true
+			}
+		})
+		file.FlatWalkNodes(catchNode, "variable_declarator", func(decl uint32) {
+			name := ""
+			if ident, ok := file.FlatFindChild(decl, "identifier"); ok {
+				name = file.FlatNodeString(ident, nil)
+			}
+			if name == "" || out[name] {
+				return
+			}
+			if caughtNarrowingInitReferences(file, decl, out) {
+				out[name] = true
+				changed = true
+			}
+		})
+	}
+	return out
+}
+
+// caughtNarrowingDeclName returns the declared name of a Kotlin
+// `property_declaration`.
+func caughtNarrowingDeclName(file *scanner.File, decl uint32) string {
+	if vd, ok := file.FlatFindChild(decl, "variable_declaration"); ok {
+		if ident, ok := file.FlatFindChild(vd, "simple_identifier"); ok {
+			return file.FlatNodeString(ident, nil)
+		}
+	}
+	return ""
+}
+
+// caughtNarrowingInitReferences reports whether the initializer side of a
+// variable declaration reads any name in `known` (the caught variable or a
+// caught-derived alias). It walks only the portion of the declaration after
+// the `=` so the declared name itself is not mistaken for a reference.
+func caughtNarrowingInitReferences(file *scanner.File, decl uint32, known map[string]bool) bool {
+	afterEquals := false
+	found := false
+	for child := file.FlatFirstChild(decl); child != 0; child = file.FlatNextSib(child) {
+		if file.FlatType(child) == "=" {
+			afterEquals = true
+			continue
+		}
+		if !afterEquals || !file.FlatIsNamed(child) {
+			continue
+		}
+		file.FlatWalkAllNodes(child, func(n uint32) {
+			if found {
+				return
+			}
+			switch file.FlatType(n) {
+			case "simple_identifier", "identifier":
+				if known[file.FlatNodeString(n, nil)] {
+					found = true
+				}
+			}
+		})
+	}
+	return found
 }
 
 // NotImplementedDeclarationRule detects TODO() calls.
@@ -234,6 +384,15 @@ func (r *SwallowedExceptionRule) checkSwallowedException(ctx *api.Context) {
 			fmt.Sprintf("Exception '%s' is caught but not meaningfully handled. Pass it directly to logging, handling, or rethrowing code.", caughtVar)))
 		return
 	}
+	// The caught variable is unused. Distinguish a genuine swallow
+	// (empty-but-for-a-comment, or log-the-string-and-drop-the-cause) from a
+	// catch that performs real recovery work without touching the exception
+	// (a fallback assignment, an early return, a toast, …). Recovery is not a
+	// swallow, and a truly empty body is already owned by EmptyCatchBlock.
+	switch swallowedClassifyNeverUsed(file, idx) {
+	case swallowedNeverUsedRecovery, swallowedNeverUsedEmpty:
+		return
+	}
 	r.makeUnusedFindingFlat(ctx, caughtVar)
 }
 
@@ -266,14 +425,33 @@ func (r *SwallowedExceptionRule) analyzeSwallowedCatchBody(ctx *api.Context, cat
 	directAliases := map[string]bool{caughtVar: true}
 	derivedAliases := map[string]bool{}
 	swallowedWalkCatchBody(file, body, func(node uint32) bool {
-		if file.FlatType(node) != "property_declaration" {
+		// Both `val x = <init>` property declarations and `when (val x =
+		// <init>)` subject bindings introduce an alias of the caught
+		// exception when their initializer reads it.
+		var name string
+		var init uint32
+		switch file.FlatType(node) {
+		case "property_declaration":
+			name = swallowedPropertyDeclarationName(file, node)
+			init = swallowedPropertyInitializer(file, node)
+		case "when_subject":
+			name = swallowedPropertyDeclarationName(file, node)
+			init = swallowedPropertyInitializer(file, node)
+		default:
 			return true
 		}
-		name := swallowedPropertyDeclarationName(file, node)
-		if name == "" {
+		if name == "" || init == 0 {
 			return true
 		}
-		init := swallowedPropertyInitializer(file, node)
+		// `val cause = e.cause` (or `e.getCause()`) carries the original
+		// throwable forward — using `cause` afterwards is meaningful handling
+		// that preserves the chain, unlike a `.message`/`.toString()` String
+		// projection. Treat such a variable as a *direct* alias of the caught
+		// exception so later uses count as handling.
+		if swallowedExpressionIsCauseUnwrap(file, init, directAliases) {
+			directAliases[name] = true
+			return true
+		}
 		switch swallowedExpressionAliasKind(file, init, directAliases, derivedAliases) {
 		case swallowedAliasDirect:
 			directAliases[name] = true
@@ -342,6 +520,229 @@ func swallowedCatchStatements(file *scanner.File, catchNode uint32) uint32 {
 	return 0
 }
 
+// swallowedNeverUsedKind classifies a catch body whose caught variable is
+// *unused* (no reference, no proven handling) into one of three buckets used
+// to decide whether the "caught but never used" finding is warranted.
+type swallowedNeverUsedKind uint8
+
+const (
+	// swallowedNeverUsedEmpty: a truly empty body (no statements, no comment).
+	// EmptyCatchBlock already owns this, so SwallowedException must not also
+	// report it.
+	swallowedNeverUsedEmpty swallowedNeverUsedKind = iota
+	// swallowedNeverUsedLogDrop: the body only logs (and/or holds comments)
+	// and drops the cause — the genuine swallow this rule should flag.
+	swallowedNeverUsedLogDrop
+	// swallowedNeverUsedRecovery: the body performs real recovery work
+	// (control-flow jump, assignment, fallback call, …) without referencing
+	// the exception — not a swallow; suppressed.
+	swallowedNeverUsedRecovery
+)
+
+// swallowedClassifyNeverUsed inspects the direct statements of a catch body
+// (Kotlin `statements` or Java `block`) and returns whether the body is empty,
+// a pure log-and-drop swallow, or genuine recovery. It is only consulted when
+// the caught variable is unused.
+func swallowedClassifyNeverUsed(file *scanner.File, catchNode uint32) swallowedNeverUsedKind {
+	body := swallowedNeverUsedBody(file, catchNode)
+	if body == 0 {
+		// No statements/block node. The catch is empty save for any comments
+		// that hang directly off the catch node (a comment-only swallow that
+		// EmptyCatchBlock skips). Treat a comment-only catch as a log-drop
+		// swallow; a truly empty one is deferred to EmptyCatchBlock.
+		if swallowedCatchHasDirectComment(file, catchNode) {
+			return swallowedNeverUsedLogDrop
+		}
+		return swallowedNeverUsedEmpty
+	}
+	sawLog := false
+	sawComment := false
+	for child := file.FlatFirstChild(body); child != 0; child = file.FlatNextSib(child) {
+		switch file.FlatType(child) {
+		case "{", "}":
+			continue
+		case "line_comment", "multiline_comment", "block_comment", "comment", "shebang_line":
+			sawComment = true
+			continue
+		}
+		if !file.FlatIsNamed(child) {
+			continue
+		}
+		if swallowedStatementIsLoggingCall(file, child) {
+			sawLog = true
+			continue
+		}
+		// A bare scope-function call (`run { … }`, `let { … }`, …) is not real
+		// recovery — it is just a block wrapper. The analysis intentionally
+		// does not credit handling that happens inside the nested lambda, so a
+		// catch whose only statement wraps a logging/handling call in a scope
+		// function is still treated as a (lambda-buried) swallow.
+		if swallowedStatementIsScopeFunctionCall(file, child) {
+			sawLog = true
+			continue
+		}
+		// Any other substantive statement — assignment, return/break/continue,
+		// throw, non-logging fallback call, control flow, local declaration —
+		// is real recovery work, not a silent swallow.
+		return swallowedNeverUsedRecovery
+	}
+	if sawLog || sawComment {
+		return swallowedNeverUsedLogDrop
+	}
+	return swallowedNeverUsedEmpty
+}
+
+// swallowedStatementIsScopeFunctionCall reports whether a catch-body statement
+// is a bare call to a Kotlin scope function (`run`, `let`, `also`, `apply`,
+// `with`, `runCatching`). These wrap a lambda rather than performing recovery.
+func swallowedStatementIsScopeFunctionCall(file *scanner.File, stmt uint32) bool {
+	call := stmt
+	if file.FlatType(call) != "call_expression" {
+		inner := uint32(0)
+		count := 0
+		for c := file.FlatFirstChild(stmt); c != 0; c = file.FlatNextSib(c) {
+			if file.FlatIsNamed(c) {
+				inner = c
+				count++
+			}
+		}
+		if count != 1 {
+			return false
+		}
+		call = inner
+	}
+	if file.FlatType(call) != "call_expression" {
+		return false
+	}
+	callee, _ := swallowedCallTarget(file, call)
+	switch callee {
+	case "run", "let", "also", "apply", "with", "runCatching":
+		return true
+	default:
+		return false
+	}
+}
+
+// swallowedNeverUsedBody returns the statement container of a catch body:
+// the Kotlin `statements` node or the Java `block` node.
+func swallowedNeverUsedBody(file *scanner.File, catchNode uint32) uint32 {
+	for child := file.FlatFirstChild(catchNode); child != 0; child = file.FlatNextSib(child) {
+		switch file.FlatType(child) {
+		case "statements":
+			return child
+		case "block":
+			return child
+		}
+	}
+	return 0
+}
+
+// swallowedCatchHasDirectComment reports whether a comment node hangs directly
+// off the catch node — the shape of a comment-only catch body that has no
+// `statements`/`block` node.
+func swallowedCatchHasDirectComment(file *scanner.File, catchNode uint32) bool {
+	for child := file.FlatFirstChild(catchNode); child != 0; child = file.FlatNextSib(child) {
+		switch file.FlatType(child) {
+		case "line_comment", "multiline_comment", "block_comment", "comment":
+			return true
+		}
+	}
+	return false
+}
+
+// swallowedStatementIsLoggingCall reports whether a catch-body statement is a
+// bare logging/println call (possibly the only thing in a "log-the-string-but-
+// drop-the-cause" catch). A statement may be the call_expression directly or
+// wrap one (e.g. Java's expression_statement).
+func swallowedStatementIsLoggingCall(file *scanner.File, stmt uint32) bool {
+	call := stmt
+	if file.FlatType(call) != "call_expression" && file.FlatType(call) != "method_invocation" {
+		// Unwrap a single named child (e.g. Java expression_statement → call).
+		inner := uint32(0)
+		count := 0
+		for c := file.FlatFirstChild(stmt); c != 0; c = file.FlatNextSib(c) {
+			if file.FlatIsNamed(c) {
+				inner = c
+				count++
+			}
+		}
+		if count != 1 {
+			return false
+		}
+		call = inner
+	}
+	switch file.FlatType(call) {
+	case "call_expression", "method_invocation":
+		callee, _ := swallowedCallTarget(file, call)
+		return callee != "" && swallowedLoggingCallee(callee)
+	}
+	return false
+}
+
+// swallowedCallResultIsConsumed reports whether the result of the call at node
+// flows somewhere — it is an argument, a returned/thrown value, an assignment
+// or property initializer right-hand side, a receiver in a navigation chain,
+// etc. — rather than being a bare expression statement whose value is
+// discarded. A bare `ignored(e)` statement is *not* consumed.
+func swallowedCallResultIsConsumed(file *scanner.File, node uint32) bool {
+	parent, ok := file.FlatParent(node)
+	if !ok {
+		return false
+	}
+	switch file.FlatType(parent) {
+	case "statements", "control_structure_body", "block":
+		// Direct child of a statement container. Such a value is discarded
+		// *unless* it is the tail expression of a catch body whose enclosing
+		// `try` is itself in a consumed (expression) position — then the
+		// wrapped exception flows out as the try's value (e.g. a `catch`
+		// branch whose body is `Result.Failure(e)` used as a `when`/return
+		// arm). Only the *last* named statement can be such a tail.
+		if file.FlatType(parent) == "statements" && swallowedIsLastNamedStatement(file, parent, node) {
+			return swallowedCatchTryIsConsumed(file, parent)
+		}
+		return false
+	}
+	return true
+}
+
+// swallowedIsLastNamedStatement reports whether node is the final named child
+// of the statements container.
+func swallowedIsLastNamedStatement(file *scanner.File, statements, node uint32) bool {
+	last := uint32(0)
+	for child := file.FlatFirstChild(statements); child != 0; child = file.FlatNextSib(child) {
+		if file.FlatIsNamed(child) {
+			last = child
+		}
+	}
+	return last == node
+}
+
+// swallowedCatchTryIsConsumed reports whether the `statements` node is the body
+// of a catch whose enclosing `try_expression` is in a consumed position (its
+// value flows somewhere rather than being a discarded statement).
+func swallowedCatchTryIsConsumed(file *scanner.File, statements uint32) bool {
+	catchNode, ok := file.FlatParent(statements)
+	if !ok {
+		return false
+	}
+	if t := file.FlatType(catchNode); t != "catch_block" && t != "catch_clause" {
+		return false
+	}
+	tryNode, ok := file.FlatParent(catchNode)
+	if !ok || file.FlatType(tryNode) != "try_expression" {
+		return false
+	}
+	tryParent, ok := file.FlatParent(tryNode)
+	if !ok {
+		return false
+	}
+	switch file.FlatType(tryParent) {
+	case "statements", "control_structure_body", "block":
+		return false
+	}
+	return true
+}
+
 func swallowedHasNamedStatement(file *scanner.File, statements uint32) bool {
 	for child := file.FlatFirstChild(statements); child != 0; child = file.FlatNextSib(child) {
 		if file.FlatIsNamed(child) {
@@ -356,7 +757,11 @@ func swallowedWalkCatchBody(file *scanner.File, root uint32, fn func(uint32) boo
 	walk = func(node uint32) bool {
 		if node != root {
 			switch file.FlatType(node) {
-			case "lambda_literal", "function_declaration", "class_declaration", "object_declaration":
+			case "lambda_literal", "function_declaration", "class_declaration", "object_declaration",
+				// A nested catch re-binds the exception name in its own scope;
+				// its body's references belong to that catch, not the outer
+				// one, so they must not count toward the outer catch's usage.
+				"catch_block", "catch_clause":
 				return true
 			}
 		}
@@ -414,6 +819,48 @@ func swallowedExpressionAliasKind(file *scanner.File, expr uint32, directAliases
 		return swallowedAliasDerived
 	}
 	return swallowedAliasNone
+}
+
+// swallowedExpressionIsCauseUnwrap reports whether expr is `<alias>.cause` or
+// `<alias>.getCause()` where <alias> is a known direct alias of the caught
+// exception. Such an expression yields the original throwable's cause (still a
+// Throwable), so a variable bound to it forwards the exception chain.
+func swallowedExpressionIsCauseUnwrap(file *scanner.File, expr uint32, directAliases map[string]bool) bool {
+	expr = swallowedUnwrapExpression(file, expr)
+	if expr == 0 {
+		return false
+	}
+	// `e.getCause()` — a call whose callee is a navigation ending in getCause.
+	if file.FlatType(expr) == "call_expression" {
+		for child := file.FlatFirstChild(expr); child != 0; child = file.FlatNextSib(child) {
+			if file.FlatType(child) == "navigation_expression" {
+				expr = child
+				break
+			}
+		}
+	}
+	if file.FlatType(expr) != "navigation_expression" {
+		return false
+	}
+	receiver := file.FlatFirstChild(expr)
+	if receiver == 0 || file.FlatType(receiver) != "simple_identifier" {
+		return false
+	}
+	if !directAliases[file.FlatNodeString(receiver, nil)] {
+		return false
+	}
+	for child := file.FlatFirstChild(expr); child != 0; child = file.FlatNextSib(child) {
+		if file.FlatType(child) != "navigation_suffix" {
+			continue
+		}
+		for gc := file.FlatFirstChild(child); gc != 0; gc = file.FlatNextSib(gc) {
+			if file.FlatType(gc) == "simple_identifier" {
+				name := file.FlatNodeString(gc, nil)
+				return name == "cause" || name == "getCause"
+			}
+		}
+	}
+	return false
 }
 
 func swallowedUnwrapExpression(file *scanner.File, expr uint32) uint32 {
@@ -481,6 +928,21 @@ func swallowedAnalyzeReturn(file *scanner.File, node uint32, directAliases, deri
 	return swallowedEvidence{}
 }
 
+// swallowedCalleeLooksLikeWrapper reports whether a callee's simple name has
+// the shape of a constructor or factory — an initial uppercase letter, as in
+// `ApplicationError`, `Failure`, `IOException`. Passing the caught exception to
+// such a call packages it into a value (a wrapper / error result), which is
+// meaningful handling even when that value is locally discarded. Lowercase
+// callees (`ignored`, `recover`, `warn`) are ordinary functions whose
+// fire-and-forget invocation does not by itself prove the exception is handled.
+func swallowedCalleeLooksLikeWrapper(callee string) bool {
+	if callee == "" {
+		return false
+	}
+	r := rune(callee[0])
+	return r >= 'A' && r <= 'Z'
+}
+
 func swallowedIsThrowExpression(file *scanner.File, node uint32) bool {
 	if file.FlatType(node) != "jump_expression" {
 		return false
@@ -496,16 +958,28 @@ func swallowedIsReturnExpression(file *scanner.File, node uint32) bool {
 		return false
 	}
 	for child := file.FlatFirstChild(node); child != 0; child = file.FlatNextSib(child) {
-		return file.FlatType(child) == "return"
+		return swallowedIsReturnKeyword(file.FlatType(child))
 	}
 	return false
+}
+
+// swallowedIsReturnKeyword matches both bare and labeled return tokens
+// (`return` and `return@label`, the latter parsed as a `return@` token).
+func swallowedIsReturnKeyword(t string) bool {
+	return t == "return" || t == "return@"
 }
 
 func swallowedJumpExpressionValue(file *scanner.File, node uint32) uint32 {
 	seenKeyword := false
 	for child := file.FlatFirstChild(node); child != 0; child = file.FlatNextSib(child) {
 		if !seenKeyword {
-			seenKeyword = file.FlatType(child) == "throw" || file.FlatType(child) == "return"
+			t := file.FlatType(child)
+			seenKeyword = t == "throw" || swallowedIsReturnKeyword(t)
+			continue
+		}
+		// Skip the `label` node that follows a `return@` token; the returned
+		// value is the first *other* named child.
+		if file.FlatType(child) == "label" {
 			continue
 		}
 		if file.FlatIsNamed(child) {
@@ -519,6 +993,31 @@ func (r *SwallowedExceptionRule) swallowedAnalyzeCall(ctx *api.Context, catchNod
 	file := ctx.File
 	kind := swallowedClassifyCall(ctx, catchNode, node)
 	if kind == swallowedCallUnknown {
+		// Converting the whole caught exception into a value — e.g.
+		// `out.append(convertThrowableToString(t))`, `return Result.Failure(e)`,
+		// `BackupResponse.ApplicationError(e)` — is meaningful handling: the
+		// exception is transformed into something rather than dropped. The
+		// exception is treated as handled when EITHER:
+		//   * the call's result is consumed (argument, return/throw value,
+		//     assignment RHS, navigation receiver, expression-position catch
+		//     tail), OR
+		//   * the callee is a constructor / factory shape (an uppercase final
+		//     name, e.g. `ApplicationError`, `Failure`) — a wrapper that
+		//     packages the exception into a value even when that value is
+		//     (locally) discarded.
+		// Two shapes are deliberately excluded so genuine swallows still fire:
+		//   * a logging-shaped callee on an unrecognized receiver
+		//     (`localLog.warn(e)`) — a logger lookalike that drops the cause;
+		//   * a bare lowercase call whose result is discarded (`ignored(e)`,
+		//     `recover(e)`) — a fire-and-forget callback that may still swallow.
+		callee, _ := swallowedCallTarget(file, node)
+		if callee != "" && !swallowedLoggingCallee(callee) &&
+			(swallowedCallResultIsConsumed(file, node) || swallowedCalleeLooksLikeWrapper(callee)) {
+			args := flatCallKeyArguments(file, node)
+			if swallowedAnalyzeArguments(file, args, directAliases, derivedAliases).handled {
+				return swallowedEvidence{handled: true}
+			}
+		}
 		return swallowedEvidence{}
 	}
 	args := flatCallKeyArguments(file, node)

--- a/internal/rules/exceptions_fp_regression_test.go
+++ b/internal/rules/exceptions_fp_regression_test.go
@@ -1,0 +1,338 @@
+package rules_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kaeawc/krit/internal/rules"
+	api "github.com/kaeawc/krit/internal/rules/api"
+	"github.com/kaeawc/krit/internal/scanner"
+	"github.com/kaeawc/krit/internal/typeinfer"
+)
+
+// ruleByIDForExceptionsTest returns the registered rule with the given ID.
+func ruleByIDForExceptionsTest(t *testing.T, id string) *api.Rule {
+	t.Helper()
+	for _, r := range api.Registry {
+		if r.ID == id {
+			return r
+		}
+	}
+	t.Fatalf("rule %q not registered", id)
+	return nil
+}
+
+// runExceptionsRuleOnSource parses an inline Kotlin/Java source and returns the
+// findings produced by the named rule.
+func runExceptionsRuleOnSource(t *testing.T, id, ext, src string) []scanner.Finding {
+	t.Helper()
+	dir := t.TempDir()
+	p := filepath.Join(dir, "Fixture"+ext)
+	if err := os.WriteFile(p, []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	var (
+		file *scanner.File
+		err  error
+	)
+	if ext == ".java" {
+		file, err = scanner.ParseJavaFile(context.Background(), p)
+	} else {
+		file, err = scanner.ParseFile(context.Background(), p)
+	}
+	if err != nil {
+		t.Fatalf("parse %s: %v", p, err)
+	}
+	rule := ruleByIDForExceptionsTest(t, id)
+	if rule.Needs.Has(api.NeedsResolver) {
+		resolver := typeinfer.NewResolver()
+		resolver.IndexFilesParallel([]*scanner.File{file}, 1)
+		cols := rules.NewDispatcher([]*api.Rule{rule}, resolver).Run(file)
+		return cols.Findings()
+	}
+	cols := rules.NewDispatcher([]*api.Rule{rule}, nil).Run(file)
+	return cols.Findings()
+}
+
+// TestInstanceOfCheckForExceptionCaughtVariableNarrowing locks the fix that
+// narrowing an already-caught exception (the catch parameter, a `when (e)`
+// dispatch, or a local unwrapped from the caught variable's cause) is NOT
+// flagged, while a type-check on an unrelated value still is.
+func TestInstanceOfCheckForExceptionCaughtVariableNarrowing(t *testing.T) {
+	cases := []struct {
+		name string
+		ext  string
+		src  string
+		want int
+	}{
+		{
+			name: "kotlin catch-param narrowing not flagged",
+			ext:  ".kt",
+			src: `package p
+fun f() {
+  try { work() } catch (e: IllegalStateException) {
+    if (e is java.io.IOException) { throw RuntimeException(e) } else { throw e }
+  }
+}
+fun work() {}`,
+			want: 0,
+		},
+		{
+			name: "kotlin when-dispatch on caught var not flagged",
+			ext:  ".kt",
+			src: `package p
+fun f(): String {
+  return try { work() } catch (e: Exception) {
+    when (e) {
+      is java.io.IOException -> "io"
+      is IllegalStateException -> "state"
+      else -> "other"
+    }
+  }
+}
+fun work(): String = "x"`,
+			want: 0,
+		},
+		{
+			name: "kotlin cause-unwrap narrowing not flagged",
+			ext:  ".kt",
+			src: `package p
+fun f() {
+  try { work() } catch (e: RuntimeException) {
+    val cause = e.cause
+    if (cause is InterruptedException) { throw cause }
+  }
+}
+fun work() {}`,
+			want: 0,
+		},
+		{
+			name: "kotlin type-check on non-caught value flagged",
+			ext:  ".kt",
+			src: `package p
+fun f(failure: Throwable) {
+  try { work() } catch (e: Exception) {
+    if (failure is java.io.IOException) { return }
+  }
+}
+fun work() {}`,
+			want: 1,
+		},
+		{
+			name: "java catch-param narrowing not flagged",
+			ext:  ".java",
+			src: `class C {
+  void m() throws java.io.IOException {
+    try { work(); } catch (java.io.IOException e) {
+      if (e instanceof java.net.SocketException) { return; }
+      throw e;
+    }
+  }
+  void work() throws java.io.IOException {}
+}`,
+			want: 0,
+		},
+		{
+			name: "java cause-unwrap narrowing not flagged",
+			ext:  ".java",
+			src: `class C {
+  void m() {
+    try { work(); } catch (Exception e) {
+      Throwable cause = e.getCause();
+      if (cause instanceof java.io.IOException) { return; }
+    }
+  }
+  void work() {}
+}`,
+			want: 0,
+		},
+		{
+			name: "java type-check on non-caught value flagged",
+			ext:  ".java",
+			src: `class C {
+  void m(Throwable failure) {
+    try { work(); } catch (Exception e) {
+      if (failure instanceof java.net.SocketException) { return; }
+    }
+  }
+  void work() {}
+}`,
+			want: 1,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			findings := runExceptionsRuleOnSource(t, "InstanceOfCheckForException", tc.ext, tc.src)
+			if len(findings) != tc.want {
+				t.Errorf("got %d findings, want %d", len(findings), tc.want)
+				for _, f := range findings {
+					t.Logf("  %d:%d %s", f.Line, f.Col, f.Message)
+				}
+			}
+		})
+	}
+}
+
+// TestSwallowedExceptionUsageAndRecovery locks the fixes that a catch which
+// passes/wraps/inspects the caught exception, or performs real recovery without
+// touching it, is NOT a swallow — while a genuinely empty-but-for-a-comment or
+// log-the-string-and-drop-the-cause catch still is.
+func TestSwallowedExceptionUsageAndRecovery(t *testing.T) {
+	cases := []struct {
+		name string
+		src  string
+		want int
+	}{
+		{
+			name: "passes whole exception to unknown function not swallowed",
+			src: `package p
+class C {
+  fun f(): String {
+    val out = StringBuilder()
+    try { w() } catch (t: Throwable) {
+      out.append(convertThrowableToString(t))
+      return out.toString()
+    }
+    return "ok"
+  }
+  fun convertThrowableToString(t: Throwable): String = ""
+  fun w() {}
+}`,
+			want: 0,
+		},
+		{
+			name: "labeled return wrapping exception not swallowed",
+			src: `package p
+class C {
+  fun f(): String = run {
+    try { w() } catch (e: java.io.IOException) {
+      return@run wrap(e)
+    }
+    "ok"
+  }
+  fun wrap(e: Throwable): String = ""
+  fun w() {}
+}`,
+			want: 0,
+		},
+		{
+			name: "when on e.cause as tail expression not swallowed",
+			src: `package p
+class C {
+  fun f(): String {
+    return run {
+      try { w() } catch (e: java.util.concurrent.ExecutionException) {
+        when (val cause = e.cause) {
+          is java.io.IOException -> netErr(cause)
+          else -> appErr(cause)
+        }
+      }
+    }
+  }
+  fun netErr(c: Throwable?): String = ""
+  fun appErr(c: Throwable?): String = ""
+  fun w() {}
+}`,
+			want: 0,
+		},
+		{
+			name: "fallback assignment recovery not swallowed",
+			src: `package p
+class C {
+  var cached: String? = "x"
+  fun f() { try { w() } catch (e: Exception) { cached = null } }
+  fun w() {}
+}`,
+			want: 0,
+		},
+		{
+			name: "early return recovery not swallowed",
+			src: `package p
+class C {
+  fun f(): Boolean {
+    try { w() } catch (e: java.io.IOException) { return false }
+    return true
+  }
+  fun w() {}
+}`,
+			want: 0,
+		},
+		{
+			name: "truly empty catch deferred to EmptyCatchBlock",
+			src: `package p
+class C {
+  fun f() { try { w() } catch (e: IllegalArgumentException) {} }
+  fun w() {}
+}`,
+			want: 0,
+		},
+		{
+			// The outer catch performs recovery (a guarded retry) and never
+			// touches its own `e`; the inner catch rethrows its own `e`. Neither
+			// is a swallow, and the inner catch's `e` must not be counted
+			// against the outer catch.
+			name: "nested catch reference does not count for outer catch",
+			src: `package p
+class C {
+  fun f(url: String) {
+    try { launch() } catch (e: RuntimeException) {
+      if (url == "intent") {
+        try { launch() } catch (inner: RuntimeException) { throw inner }
+      }
+    }
+  }
+  fun launch() {}
+}`,
+			want: 0,
+		},
+		{
+			name: "log-the-string-and-drop-the-cause still swallowed",
+			src: `package p
+class C {
+  fun f() { try { w() } catch (e: java.io.IOException) { Log.w(TAG, "Cannot restore.") } }
+  fun w() {}
+  companion object { const val TAG = "T" }
+}`,
+			want: 1,
+		},
+		{
+			name: "comment-only swallow still flagged",
+			src: `package p
+class C {
+  fun f() {
+    try { w() } catch (e: Exception) {
+      // ignored
+    }
+  }
+  fun w() {}
+}`,
+			want: 1,
+		},
+		{
+			name: "throw new dropping cause still swallowed",
+			src: `package p
+class C {
+  fun f() {
+    try { w() } catch (e: IllegalStateException) {
+      throw IllegalArgumentException(e.message)
+    }
+  }
+  fun w() {}
+}`,
+			want: 1,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			findings := runExceptionsRuleOnSource(t, "SwallowedException", ".kt", tc.src)
+			if len(findings) != tc.want {
+				t.Errorf("got %d findings, want %d", len(findings), tc.want)
+				for _, f := range findings {
+					t.Logf("  %d:%d %s", f.Line, f.Col, f.Message)
+				}
+			}
+		})
+	}
+}

--- a/internal/rules/exceptions_test.go
+++ b/internal/rules/exceptions_test.go
@@ -116,19 +116,22 @@ func TestExc_ExceptionRaisedInUnexpectedLocation_JavaFixtures(t *testing.T) {
 // --- InstanceOfCheckForException ---
 
 func TestExc_InstanceOfCheckForException_Positive(t *testing.T) {
+	// Narrowing the caught variable itself (`e is IOException`) is legitimate
+	// and must NOT fire. A type-check on some *other*, non-caught value inside
+	// the catch is the "instanceof instead of polymorphism" smell that should.
 	findings := runRuleByName(t, "InstanceOfCheckForException", `
-fun test() {
+fun test(failure: Throwable) {
     try {
         doWork()
     } catch (e: Exception) {
-        if (e is IOException) {
+        if (failure is IOException) {
             println("io")
         }
     }
 }
 `)
 	if len(findings) == 0 {
-		t.Fatal("expected finding for is-check inside catch")
+		t.Fatal("expected finding for is-check on a non-caught value inside catch")
 	}
 }
 
@@ -200,11 +203,10 @@ fun test(other: Any) {
 	}
 }
 
-func TestExc_InstanceOfCheckForException_FiresOnSubjectlessWhen(t *testing.T) {
-	prev := experimentSnapshot()
-	defer experimentRestore(prev)
-	enableExperiment("instance-of-check-skip-when-dispatch")
-
+func TestExc_InstanceOfCheckForException_SubjectlessWhenOnCaughtVarNotFlagged(t *testing.T) {
+	// A subjectless `when { e is X -> ... }` whose condition tests the *caught*
+	// variable is still narrowing the already-caught exception — legitimate,
+	// so it must NOT fire.
 	findings := runRuleByName(t, "InstanceOfCheckForException", `
 fun test() {
     try {
@@ -216,8 +218,27 @@ fun test() {
     }
 }
 `)
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings for is-check narrowing the caught var, got %d", len(findings))
+	}
+}
+
+func TestExc_InstanceOfCheckForException_SubjectlessWhenOnOtherVarFlagged(t *testing.T) {
+	// A subjectless `when { other is X -> ... }` testing a non-caught value is
+	// the type-check smell and must fire.
+	findings := runRuleByName(t, "InstanceOfCheckForException", `
+fun test(other: Any) {
+    try {
+        doWork()
+    } catch (e: Exception) {
+        when {
+            other is IOException -> println("io")
+        }
+    }
+}
+`)
 	if len(findings) == 0 {
-		t.Fatal("expected finding: subjectless when is not a dispatch, so the is-check on caught var must fire")
+		t.Fatal("expected finding: subjectless when tests a non-caught value")
 	}
 }
 
@@ -260,14 +281,16 @@ fun test() {
 }
 
 func TestExc_InstanceOfCheckForException_Java(t *testing.T) {
+	// instanceof on the caught variable narrows the already-caught exception
+	// and must NOT fire; an instanceof on some other value still should.
 	findings := runRuleByNameOnJava(t, "InstanceOfCheckForException", `
 package test;
 class Example {
-  void run() {
+  void run(Throwable failure) {
     try {
       work();
     } catch (Exception e) {
-      if (e instanceof java.io.IOException) {
+      if (failure instanceof java.io.IOException) {
         work();
       }
     }
@@ -276,7 +299,29 @@ class Example {
 }
 `)
 	if len(findings) != 1 {
-		t.Fatalf("expected 1 Java instanceof finding, got %d", len(findings))
+		t.Fatalf("expected 1 Java instanceof finding on a non-caught value, got %d", len(findings))
+	}
+}
+
+func TestExc_InstanceOfCheckForException_JavaCaughtVarNotFlagged(t *testing.T) {
+	findings := runRuleByNameOnJava(t, "InstanceOfCheckForException", `
+package test;
+class Example {
+  void run() throws java.io.IOException {
+    try {
+      work();
+    } catch (java.io.IOException e) {
+      if (e instanceof java.net.SocketException) {
+        return;
+      }
+      throw e;
+    }
+  }
+  void work() throws java.io.IOException {}
+}
+`)
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings for instanceof narrowing the caught var, got %d", len(findings))
 	}
 }
 
@@ -636,14 +681,9 @@ class FaultHidingSink(
 
 func TestExc_SwallowedException_ASTPositiveCases(t *testing.T) {
 	cases := map[string]string{
-		"empty catch": `
-fun test() {
-    try {
-        work()
-    } catch (e: java.io.IOException) {
-    }
-}
-`,
+		// NB: a truly empty catch is intentionally NOT here — EmptyCatchBlock
+		// (ConfidenceVeryHigh) owns that case, and SwallowedException defers to
+		// it to avoid double-reporting. See ASTNegativeCases/empty_catch_*.
 		"comment only": `
 fun test() {
     try {
@@ -718,16 +758,6 @@ fun test() {
     }
 }
 `,
-		"unknown assignment without exception is not handling": `
-fun test() {
-    var handled = false
-    try {
-        work()
-    } catch (e: java.io.IOException) {
-        handled = true
-    }
-}
-`,
 	}
 	for name, code := range cases {
 		t.Run(name, func(t *testing.T) {
@@ -741,6 +771,39 @@ fun test() {
 
 func TestExc_SwallowedException_ASTNegativeCases(t *testing.T) {
 	cases := map[string]string{
+		// A truly empty catch is owned by EmptyCatchBlock; SwallowedException
+		// must defer to avoid double-reporting.
+		"empty catch deferred to EmptyCatchBlock": `
+fun test() {
+    try {
+        work()
+    } catch (e: java.io.IOException) {
+    }
+}
+`,
+		// A fallback assignment that does not touch the exception is recovery,
+		// not a swallow.
+		"fallback assignment recovery": `
+fun test() {
+    var handled = false
+    try {
+        work()
+    } catch (e: java.io.IOException) {
+        handled = true
+    }
+}
+`,
+		// An early return as a fallback value is recovery.
+		"early return recovery": `
+fun test(): Boolean {
+    try {
+        work()
+    } catch (e: java.io.IOException) {
+        return false
+    }
+    return true
+}
+`,
 		"direct rethrow": `
 fun test() {
     try {

--- a/internal/rules/licensing.go
+++ b/internal/rules/licensing.go
@@ -736,18 +736,37 @@ func (r *OptInMarkerNotRecognisedRule) markerInAdditional(name string) bool {
 	return false
 }
 
-// OptInMarkerExposedPubliclyRule flags `@OptIn` annotations on public API
-// declarations. Opt-in markers propagate to callers, so applying `@OptIn`
-// to a public declaration silently forces every caller to opt in too.
+// OptInMarkerExposedPubliclyRule flags public API declarations annotated
+// DIRECTLY with an opt-in marker (e.g. `@ExperimentalCoroutinesApi`). A
+// `@RequiresOptIn`-style marker propagates to callers, so carrying it on a
+// public declaration silently forces every caller to opt in too.
+//
+// Note: `@OptIn(Foo::class)` is NOT flagged. `@OptIn` CONSUMES the requirement
+// locally and is precisely the mechanism for NOT propagating it to callers;
+// flagging it would be a false positive.
 type OptInMarkerExposedPubliclyRule struct {
 	FlatDispatchBase
 	BaseRule
 }
 
 // Confidence reports a tier-1 (high) base confidence. The detection is fully
-// AST-driven: we match `@OptIn` annotations whose target declaration has no
-// non-public visibility modifier.
+// AST-driven: we match a propagating opt-in marker annotation whose target
+// declaration has no non-public visibility modifier.
 func (r *OptInMarkerExposedPubliclyRule) Confidence() float64 { return api.ConfidenceHigher }
+
+// isPropagatingOptInMarkerName reports whether an annotation simple name is a
+// `@RequiresOptIn`-style opt-in marker that propagates the opt-in requirement
+// to callers when applied directly to a declaration. The opt-in plumbing
+// annotations themselves — `@OptIn` (which consumes the requirement), the
+// `@RequiresOptIn` meta-annotation (which defines a marker, not a usage), and
+// `@Suppress` — never propagate and are excluded.
+func isPropagatingOptInMarkerName(name string) bool {
+	switch name {
+	case "", "OptIn", "RequiresOptIn", "Suppress", "SuppressWarnings":
+		return false
+	}
+	return wellKnownOptInMarkers[name]
+}
 
 // optInAnnotationTarget walks up from an `@OptIn` annotation node to the
 // declaration it is attached to. Returns the declaration index and true when

--- a/internal/rules/licensing.go
+++ b/internal/rules/licensing.go
@@ -747,6 +747,26 @@ func (r *OptInMarkerNotRecognisedRule) markerInAdditional(name string) bool {
 type OptInMarkerExposedPubliclyRule struct {
 	FlatDispatchBase
 	BaseRule
+	// AdditionalMarkers lets a project register its own propagating opt-in
+	// markers (custom `@RequiresOptIn`-annotated classes) so exposing them on
+	// public API is flagged too — the embedded well-known set only covers
+	// markers shipped by widely used libraries.
+	AdditionalMarkers []string
+}
+
+// markerInAdditional reports whether the annotation simple name matches one of
+// the project-configured additional markers (matched on simple name, so a
+// fully-qualified entry still works).
+func (r *OptInMarkerExposedPubliclyRule) markerInAdditional(name string) bool {
+	for _, m := range r.AdditionalMarkers {
+		if i := strings.LastIndex(m, "."); i >= 0 {
+			m = m[i+1:]
+		}
+		if m == name {
+			return true
+		}
+	}
+	return false
 }
 
 // Confidence reports a tier-1 (high) base confidence. The detection is fully

--- a/internal/rules/licensing_optin_test.go
+++ b/internal/rules/licensing_optin_test.go
@@ -74,7 +74,7 @@ func TestOptInMarkerExposedPublicly_SkipsTestSources(t *testing.T) {
 	file := parseInline(t, `
 package test
 
-@OptIn(ExperimentalCoroutinesApi::class)
+@ExperimentalCoroutinesApi
 class CoroutineRobot
 `)
 	file.Path = "/repo/app/src/androidTest/kotlin/com/example/CoroutineRobot.kt"
@@ -87,10 +87,12 @@ class CoroutineRobot
 }
 
 func TestOptInMarkerExposedPublicly_FlagsProductionPublicApi(t *testing.T) {
+	// A public declaration carrying a propagating opt-in marker DIRECTLY
+	// exposes the opt-in requirement to callers.
 	findings := runRuleByName(t, "OptInMarkerExposedPublicly", `
 package test
 
-@OptIn(ExperimentalCoroutinesApi::class)
+@ExperimentalCoroutinesApi
 class PublicApi
 `)
 	count := 0
@@ -101,5 +103,41 @@ class PublicApi
 	}
 	if count != 1 {
 		t.Fatalf("expected 1 OptInMarkerExposedPublicly finding, got %d", count)
+	}
+}
+
+func TestOptInMarkerExposedPublicly_DoesNotFlagOptInConsumer(t *testing.T) {
+	// Regression: @OptIn(Foo::class) CONSUMES the requirement locally and does
+	// NOT propagate to callers, so it must never be flagged.
+	findings := runRuleByName(t, "OptInMarkerExposedPublicly", `
+package test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+fun publicApi() {
+}
+`)
+	for _, f := range findings {
+		if f.Rule == "OptInMarkerExposedPublicly" {
+			t.Fatalf("did not expect finding for @OptIn consumer: %s", f.Message)
+		}
+	}
+}
+
+func TestOptInMarkerExposedPublicly_SkipsNonPublicDirectMarker(t *testing.T) {
+	findings := runRuleByName(t, "OptInMarkerExposedPublicly", `
+package test
+
+@ExperimentalCoroutinesApi
+internal fun internalApi() {
+}
+
+@ExperimentalCoroutinesApi
+private fun privateApi() {
+}
+`)
+	for _, f := range findings {
+		if f.Rule == "OptInMarkerExposedPublicly" {
+			t.Fatalf("did not expect finding for non-public declaration: %s", f.Message)
+		}
 	}
 }

--- a/internal/rules/licensing_optin_test.go
+++ b/internal/rules/licensing_optin_test.go
@@ -3,7 +3,52 @@ package rules_test
 import (
 	"strings"
 	"testing"
+
+	"github.com/kaeawc/krit/internal/rules"
+	api "github.com/kaeawc/krit/internal/rules/api"
+	"github.com/kaeawc/krit/internal/scanner"
 )
+
+// TestOptInMarkerExposedPublicly_AdditionalMarkers verifies a project can
+// register its own propagating opt-in markers (custom @RequiresOptIn classes)
+// via `additionalMarkers`, so exposing one on a public declaration is flagged.
+// The embedded well-known set only covers library markers, so an unconfigured
+// project marker must NOT flag.
+func TestOptInMarkerExposedPublicly_AdditionalMarkers(t *testing.T) {
+	var rule *rules.OptInMarkerExposedPubliclyRule
+	for _, c := range api.Registry {
+		if c.ID == "OptInMarkerExposedPublicly" {
+			rule, _ = c.Implementation.(*rules.OptInMarkerExposedPubliclyRule)
+			break
+		}
+	}
+	if rule == nil {
+		t.Fatal("OptInMarkerExposedPublicly not registered")
+	}
+	original := rule.AdditionalMarkers
+	defer func() { rule.AdditionalMarkers = original }()
+
+	src := "package test\n@RequiresOptIn\nannotation class InternalMyApi\n@InternalMyApi\nfun exposed() {}\n"
+	countRule := func(fs []scanner.Finding) int {
+		n := 0
+		for _, f := range fs {
+			if f.Rule == "OptInMarkerExposedPublicly" {
+				n++
+			}
+		}
+		return n
+	}
+
+	rule.AdditionalMarkers = nil
+	if n := countRule(runRuleByName(t, "OptInMarkerExposedPublicly", src)); n != 0 {
+		t.Fatalf("baseline: an unconfigured project marker should not be flagged; got %d", n)
+	}
+
+	rules.ApplyConfig(loadTempConfig(t, "licensing:\n  OptInMarkerExposedPublicly:\n    additionalMarkers:\n      - InternalMyApi\n"))
+	if n := countRule(runRuleByName(t, "OptInMarkerExposedPublicly", src)); n == 0 {
+		t.Fatal("with additionalMarkers configured, exposing the project marker on a public declaration should be flagged; got 0")
+	}
+}
 
 func TestOptInMarkerNotRecognised_Positive(t *testing.T) {
 	findings := runRuleByName(t, "OptInMarkerNotRecognised", `

--- a/internal/rules/nullsafety_oracle_fp_regression_test.go
+++ b/internal/rules/nullsafety_oracle_fp_regression_test.go
@@ -12,9 +12,58 @@ import (
 	"testing"
 
 	"github.com/kaeawc/krit/internal/oracle"
+	"github.com/kaeawc/krit/internal/rules"
+	api "github.com/kaeawc/krit/internal/rules/api"
 	"github.com/kaeawc/krit/internal/scanner"
 	"github.com/kaeawc/krit/internal/typeinfer"
 )
+
+// TestRegression_CastNullable_ByteRangeFactBeatsColumnDrift locks the
+// CastNullableToNonNullableType byte-range fix: the rule must consult the
+// oracle's smart-cast nullability by BYTE RANGE, not line/col. FIR emits
+// columns that don't line up with tree-sitter, so a line/col probe misses the
+// fact and falls back to source inference (which sees `o: Any?` as nullable and
+// wrongly flags the guarded cast). This seeds a real oracle with a non-null
+// fact at the operand's byte range but a DRIFTED line:col key — only the
+// byte-range path finds it, so the cast must not be flagged.
+func TestRegression_CastNullable_ByteRangeFactBeatsColumnDrift(t *testing.T) {
+	file := parseInline(t, "fun f(o: Any?): String { return o as String }\n")
+	operand := castOperandNode(t, file)
+	o, err := oracle.LoadFromData(&oracle.Data{
+		Version:       1,
+		KotlinVersion: "2.1.0",
+		Files: map[string]*oracle.File{
+			file.Path: {Expressions: map[string]*oracle.ExpressionType{
+				// Deliberately-wrong line:col; correct byte range.
+				"999:999": {Type: "kotlin.Any", Nullable: false, StartByte: int(file.FlatStartByte(operand)), EndByte: int(file.FlatEndByte(operand))},
+			}},
+		},
+		Dependencies: map[string]*oracle.Class{},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	resolver := typeinfer.NewResolver()
+	resolver.IndexFilesParallel([]*scanner.File{file}, 1)
+	composite := oracle.NewCompositeResolver(o, resolver)
+	var rule *api.Rule
+	for _, r := range api.Registry {
+		if r.ID == "CastNullableToNonNullableType" {
+			rule = r
+			break
+		}
+	}
+	if rule == nil {
+		t.Fatal("CastNullableToNonNullableType not registered")
+	}
+	cols := rules.NewDispatcher([]*api.Rule{rule}, composite).Run(file)
+	findings := cols.Findings()
+	for _, f := range findings {
+		if f.Rule == "CastNullableToNonNullableType" {
+			t.Fatalf("byte-range non-null (smart-cast) fact should suppress the cast; got FP: %v", f)
+		}
+	}
+}
 
 func nonNullFact(name, fqn string) *typeinfer.ResolvedType {
 	return &typeinfer.ResolvedType{Name: name, FQN: fqn, Kind: typeinfer.TypeClass, Nullable: false}

--- a/internal/rules/registry_exceptions.go
+++ b/internal/rules/registry_exceptions.go
@@ -41,39 +41,53 @@ func registerExceptionsRules() {
 				if catchVarName == "" {
 					return
 				}
-				skipWhenDispatch := experiment.Enabled("instance-of-check-skip-when-dispatch")
-				for _, nodeType := range []string{"is_expression", "type_check", "check_expression"} {
+				// Narrowing an *already-caught* exception (the catch
+				// parameter, or a local unwrapped from it such as
+				// `val cause = e.cause`) with `is`/`instanceof` to decide
+				// rethrow-vs-wrap or pick an error code is the idiomatic,
+				// legitimate use — not the "type-check instead of
+				// polymorphism" smell. Only flag a type-check on some *other*
+				// (non-caught) value. The operand and type are read
+				// structurally from the AST.
+				caughtOperands := caughtNarrowingOperands(file, idx, catchVarName)
+				for _, nodeType := range []string{"is_expression", "type_check", "type_test", "check_expression"} {
 					file.FlatWalkNodes(idx, nodeType, func(isNode uint32) {
-						text := file.FlatNodeText(isNode)
-						if !isExceptionRe.MatchString(text) {
+						if !nameLooksLikeExceptionType(instanceOfCheckTypeName(file, isNode)) {
 							return
 						}
-						if file.FlatChildCount(isNode) < 1 {
+						operand := instanceOfCheckOperandName(file, isNode)
+						if operand == "" {
+							// A `when (subject) { is X -> ... }` condition has no
+							// inline operand — it tests the when subject. Narrowing
+							// the caught subject is legitimate; a dispatch on some
+							// other value is still the smell.
+							subject := instanceOfWhenSubjectOperand(file, isNode)
+							if subject == "" || caughtOperands[subject] {
+								return
+							}
+							ctx.EmitAt(file.FlatRow(isNode)+1, file.FlatCol(isNode)+1,
+								"Instance-of check for exception type. Use specific catch clauses or polymorphism instead.")
 							return
 						}
-						lhs := file.FlatNodeText(file.FlatChild(isNode, 0))
-						if strings.TrimSpace(lhs) != catchVarName {
-							return
-						}
-						if skipWhenDispatch && isInsideWhenDispatchOnCatchVarFlat(file, isNode, catchVarName) {
+						// Operand narrows the caught exception: legitimate.
+						if caughtOperands[operand] {
 							return
 						}
 						ctx.EmitAt(file.FlatRow(isNode)+1, file.FlatCol(isNode)+1,
-							"Instance-of check for exception type inside catch block. Use specific catch clauses instead.")
+							"Instance-of check for exception type. Use specific catch clauses or polymorphism instead.")
 					})
 				}
 				if file.Language == scanner.LangJava {
 					file.FlatWalkNodes(idx, "instanceof_expression", func(instanceOfNode uint32) {
-						text := file.FlatNodeText(instanceOfNode)
-						if !javaInstanceOfExceptionRe.MatchString(text) {
+						if !nameLooksLikeExceptionType(instanceOfCheckTypeName(file, instanceOfNode)) {
 							return
 						}
-						lhs := strings.TrimSpace(strings.Split(text, "instanceof")[0])
-						if lhs != catchVarName {
+						operand := instanceOfCheckOperandName(file, instanceOfNode)
+						if operand == "" || caughtOperands[operand] {
 							return
 						}
 						ctx.EmitAt(file.FlatRow(instanceOfNode)+1, file.FlatCol(instanceOfNode)+1,
-							"Instance-of check for exception type inside catch block. Use specific catch clauses instead.")
+							"Instance-of check for exception type. Use specific catch clauses or polymorphism instead.")
 					})
 				}
 			},

--- a/internal/rules/registry_licensing.go
+++ b/internal/rules/registry_licensing.go
@@ -133,8 +133,10 @@ func registerLicensingRules() {
 				// @OptIn(...) CONSUMES the requirement locally and does NOT
 				// propagate; it is the mechanism for NOT exposing the marker.
 				// Only a propagating marker applied DIRECTLY to a public
-				// declaration exposes the requirement to callers.
-				if !isPropagatingOptInMarkerName(name) {
+				// declaration exposes the requirement to callers. The embedded
+				// well-known set covers library markers; `additionalMarkers`
+				// lets a project register its own @RequiresOptIn markers.
+				if !isPropagatingOptInMarkerName(name) && !r.markerInAdditional(name) {
 					return
 				}
 				if scanner.IsTestFile(file.Path) {
@@ -153,6 +155,14 @@ func registerLicensingRules() {
 					fmt.Sprintf("@%s on a public declaration propagates the opt-in requirement to callers. Restrict the declaration's visibility or wrap the experimental usage behind a non-experimental API.", name)))
 			},
 			DefaultActive: true,
+			Options: []api.ConfigOption{
+				api.StringListOption(api.StringListOptionSpec[OptInMarkerExposedPubliclyRule]{
+					Name:        "additionalMarkers",
+					Default:     []string{},
+					Description: "Additional propagating opt-in marker class names (simple or fully-qualified) — e.g. a project's own @RequiresOptIn markers — to flag when exposed on public API.",
+					Apply:       func(r *OptInMarkerExposedPubliclyRule, v []string) { r.AdditionalMarkers = v },
+				}),
+			},
 		})
 	}
 	{

--- a/internal/rules/registry_licensing.go
+++ b/internal/rules/registry_licensing.go
@@ -1,6 +1,8 @@
 package rules
 
 import (
+	"fmt"
+
 	api "github.com/kaeawc/krit/internal/rules/api"
 	"github.com/kaeawc/krit/internal/scanner"
 )
@@ -120,14 +122,19 @@ func registerLicensingRules() {
 	}
 	{
 		r := &OptInMarkerExposedPubliclyRule{
-			BaseRule: BaseRule{RuleName: "OptInMarkerExposedPublicly", RuleSetName: licensingRuleSet, Sev: "warning", Desc: "Detects @OptIn annotations on public API declarations that propagate the opt-in requirement to callers."},
+			BaseRule: BaseRule{RuleName: "OptInMarkerExposedPublicly", RuleSetName: licensingRuleSet, Sev: "warning", Desc: "Detects public API declarations annotated directly with an opt-in marker, which propagates the opt-in requirement to callers."},
 		}
 		api.Register(&api.Rule{
 			ID: r.RuleName, Category: r.RuleSetName, Description: r.Desc, Sev: api.Severity(r.Sev),
 			NodeTypes: []string{"annotation"}, Confidence: r.Confidence(), Implementation: r,
 			Check: func(ctx *api.Context) {
 				idx, file := ctx.Idx, ctx.File
-				if annotationFinalName(file, idx) != "OptIn" {
+				name := annotationFinalName(file, idx)
+				// @OptIn(...) CONSUMES the requirement locally and does NOT
+				// propagate; it is the mechanism for NOT exposing the marker.
+				// Only a propagating marker applied DIRECTLY to a public
+				// declaration exposes the requirement to callers.
+				if !isPropagatingOptInMarkerName(name) {
 					return
 				}
 				if scanner.IsTestFile(file.Path) {
@@ -143,7 +150,7 @@ func registerLicensingRules() {
 					return
 				}
 				ctx.Emit(r.Finding(file, file.FlatRow(idx)+1, file.FlatCol(idx)+1,
-					"@OptIn on a public declaration propagates the opt-in requirement to callers. Restrict the declaration's visibility or annotate callers explicitly."))
+					fmt.Sprintf("@%s on a public declaration propagates the opt-in requirement to callers. Restrict the declaration's visibility or wrap the experimental usage behind a non-experimental API.", name)))
 			},
 			DefaultActive: true,
 		})

--- a/internal/rules/registry_style_expressions.go
+++ b/internal/rules/registry_style_expressions.go
@@ -499,6 +499,17 @@ func registerStyleVarCouldBeVal() {
 				return
 			}
 			reassigned := r.reassignedNamesFlat(parent, file)[varName]
+			if !reassigned && !isLocal {
+				// A class/object/companion member may be reassigned through a
+				// qualified write (`EnclosingType.member = ...`) from a sibling
+				// nested scope outside the member's immediate class_body. Scan
+				// the outermost enclosing type subtree for such writes.
+				if outermost, names := enclosingTypeQualifiersFlat(file, idx); outermost != 0 {
+					if reassignedViaEnclosingTypeQualifierFlat(file, outermost, names, varName) {
+						reassigned = true
+					}
+				}
+			}
 			if !reassigned {
 				f := r.Finding(file, file.FlatRow(idx)+1, 1,
 					fmt.Sprintf("'var %s' is never reassigned. Use 'val' instead.", varName))

--- a/internal/rules/resource_cost_test.go
+++ b/internal/rules/resource_cost_test.go
@@ -295,6 +295,25 @@ class MyAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
 			t.Fatalf("expected 0 findings when stable IDs are enabled, got %d", len(findings))
 		}
 	})
+	t.Run("without DiffUtil negative AdapterDataObserver", func(t *testing.T) {
+		// Regression: a nested class extending RecyclerView.AdapterDataObserver
+		// must not be flagged. Its supertype byte-contains "Adapter" but it is
+		// an observer, not a RecyclerView.Adapter subclass.
+		findings := runRuleByNameOnJavaWithResolver(t, "RecyclerAdapterWithoutDiffUtil", `
+package test;
+import androidx.recyclerview.widget.RecyclerView;
+class Outer {
+  private static class MyObserver extends RecyclerView.AdapterDataObserver {
+    void refresh() {
+      notifyDataSetChanged();
+    }
+  }
+}
+}`)
+		if len(findings) != 0 {
+			t.Fatalf("expected 0 findings for AdapterDataObserver subclass, got %d", len(findings))
+		}
+	})
 }
 
 func TestDatabaseLibraryFacts_DisableRoomWhenKnownAbsent(t *testing.T) {

--- a/internal/rules/semantic_rule_helpers.go
+++ b/internal/rules/semantic_rule_helpers.go
@@ -308,9 +308,69 @@ var recyclerAdapterSupertypeNames = []string{
 	"Adapter",
 }
 
+// lastTypeNameSegment returns the trailing simple-name segment of a (possibly
+// qualified or nested) type name, splitting on both '.' and '$'.
+func lastTypeNameSegment(name string) string {
+	name = strings.TrimSpace(name)
+	if i := strings.LastIndexAny(name, ".$"); i >= 0 {
+		name = name[i+1:]
+	}
+	if i := strings.IndexByte(name, '<'); i >= 0 {
+		name = name[:i]
+	}
+	return strings.TrimSpace(name)
+}
+
+// simpleTypeNameIsAdapter reports whether a supertype's *simple* name is an
+// actual RecyclerView/list adapter rather than a lookalike that merely
+// contains the substring "Adapter" (e.g. RecyclerView.AdapterDataObserver).
+// The bare "Adapter" entry in recyclerAdapterSupertypeNames is matched via a
+// substring contains in the Java supertype walker, which is what lets a
+// `...AdapterDataObserver` supertype slip through; this suffix-boundary check
+// is the corrective gate.
+func simpleTypeNameIsAdapter(simple string) bool {
+	if simple == "" {
+		return false
+	}
+	return strings.HasSuffix(simple, "Adapter")
+}
+
+// classDirectSupertypeIsAdapterFlat confirms at least one *direct* supertype of
+// the class has a simple name ending in "Adapter". It deliberately re-walks the
+// direct delegation/superclass nodes (instead of trusting the contains-based
+// gate) so observer/listener siblings that byte-contain "Adapter" are excluded.
+func classDirectSupertypeIsAdapterFlat(file *scanner.File, class uint32) bool {
+	if file == nil || class == 0 {
+		return false
+	}
+	found := false
+	for child := file.FlatFirstChild(class); child != 0 && !found; child = file.FlatNextSib(child) {
+		switch file.FlatType(child) {
+		case "delegation_specifier":
+			if name := viewConstructorSupertypeNameFlat(file, child); simpleTypeNameIsAdapter(name) {
+				found = true
+			}
+		case "superclass", "super_interfaces":
+			file.FlatWalkAllNodes(child, func(n uint32) {
+				if found {
+					return
+				}
+				switch file.FlatType(n) {
+				case "type_identifier", "scoped_type_identifier", "scoped_identifier", "generic_type":
+					if simpleTypeNameIsAdapter(lastTypeNameSegment(file.FlatNodeText(n))) {
+						found = true
+					}
+				}
+			})
+		}
+	}
+	return found
+}
+
 func isRecyclerAdapterClassFlat(ctx *api.Context, class uint32) bool {
 	file := ctx.File
-	if classExtendsAnyFlat(file, class, recyclerAdapterSupertypeNames...) {
+	if classExtendsAnyFlat(file, class, recyclerAdapterSupertypeNames...) &&
+		classDirectSupertypeIsAdapterFlat(file, class) {
 		return true
 	}
 	if ctx.Resolver == nil || !classHasAdapterLikeSupertypeFlat(file, class) {
@@ -321,7 +381,8 @@ func isRecyclerAdapterClassFlat(ctx *api.Context, class uint32) bool {
 		return false
 	}
 	for _, st := range info.Supertypes {
-		if semanticTypeNameMatches(st, recyclerAdapterSupertypeNames...) {
+		if semanticTypeNameMatches(st, recyclerAdapterSupertypeNames...) &&
+			simpleTypeNameIsAdapter(lastTypeNameSegment(st)) {
 			return true
 		}
 	}

--- a/internal/rules/style_expressions.go
+++ b/internal/rules/style_expressions.go
@@ -723,6 +723,129 @@ func reassignedThisQualifiedNameFlat(file *scanner.File, idx uint32) (string, bo
 	return name, suffixes == 1 && name != ""
 }
 
+// enclosingTypeQualifiersFlat returns the outermost enclosing class/object
+// declaration node for a property and the set of simple type names that can be
+// used to qualify a write to one of its members (the enclosing object name, the
+// enclosing class name, and — for a companion-object member — the enclosing
+// class name). The outermost node bounds the subtree that must be scanned for
+// qualified reassignments, because a sibling nested class can write
+// `EnclosingType.member = ...` outside the member's immediate class_body.
+func enclosingTypeQualifiersFlat(file *scanner.File, propertyIdx uint32) (uint32, map[string]bool) {
+	if file == nil || propertyIdx == 0 {
+		return 0, nil
+	}
+	names := make(map[string]bool)
+	outermost := uint32(0)
+	cur := propertyIdx
+	for {
+		parent, ok := file.FlatParent(cur)
+		if !ok || parent == 0 {
+			break
+		}
+		switch file.FlatType(parent) {
+		case "class_declaration", "object_declaration":
+			if name := file.FlatChildTextOrEmpty(parent, "type_identifier"); name != "" {
+				names[name] = true
+			} else if name := file.FlatChildTextOrEmpty(parent, "simple_identifier"); name != "" {
+				names[name] = true
+			}
+			outermost = parent
+		}
+		cur = parent
+	}
+	if len(names) == 0 {
+		return 0, nil
+	}
+	return outermost, names
+}
+
+// reassignedViaEnclosingTypeQualifierFlat reports whether varName is written
+// through a qualified assignment whose receiver is one of the enclosing type
+// names (e.g. `AppDependencies.provider = x` or `BackupProgressService.title =
+// x`). It scans the outermost enclosing type subtree and inspects assignment,
+// augmented-assignment, and prefix/postfix increment targets.
+func reassignedViaEnclosingTypeQualifierFlat(file *scanner.File, scope uint32, names map[string]bool, varName string) bool {
+	if file == nil || scope == 0 || varName == "" || len(names) == 0 {
+		return false
+	}
+	found := false
+	file.FlatWalkAllNodes(scope, func(child uint32) {
+		if found {
+			return
+		}
+		var target uint32
+		switch file.FlatType(child) {
+		case "assignment", "assignment_expression", "augmented_assignment":
+			if file.FlatChildCount(child) == 0 {
+				return
+			}
+			target = file.FlatChild(child, 0)
+		case "postfix_expression", "prefix_expression":
+			hasMutation := false
+			for gc := file.FlatFirstChild(child); gc != 0; gc = file.FlatNextSib(gc) {
+				if file.FlatNodeTextEquals(gc, "++") || file.FlatNodeTextEquals(gc, "--") {
+					hasMutation = true
+				} else if target == 0 && file.FlatIsNamed(gc) {
+					target = gc
+				}
+			}
+			if !hasMutation {
+				return
+			}
+		default:
+			return
+		}
+		if qualifiedAssignTargetMatchesFlat(file, target, names, varName) {
+			found = true
+		}
+	})
+	return found
+}
+
+// qualifiedAssignTargetMatchesFlat reports whether an assignment LHS is a
+// qualified access of the form `<EnclosingType>.<varName>` where
+// <EnclosingType> is in names. The LHS may be parsed either as a
+// directly_assignable_expression (receiver simple_identifier + navigation_suffix)
+// or as a navigation_expression, depending on context.
+func qualifiedAssignTargetMatchesFlat(file *scanner.File, target uint32, names map[string]bool, varName string) bool {
+	if file == nil || target == 0 {
+		return false
+	}
+	target = flatUnwrapParenExpr(file, target)
+	switch file.FlatType(target) {
+	case "directly_assignable_expression":
+		// A bare local LHS nests a single child (handled elsewhere); a
+		// qualified LHS holds the receiver plus its navigation_suffix.
+		if file.FlatNamedChildCount(target) == 1 {
+			return qualifiedAssignTargetMatchesFlat(file, file.FlatNamedChild(target, 0), names, varName)
+		}
+	case "navigation_expression":
+		if file.FlatNamedChildCount(target) == 0 {
+			return false
+		}
+	default:
+		return false
+	}
+	first := flatUnwrapParenExpr(file, file.FlatNamedChild(target, 0))
+	if file.FlatType(first) != "simple_identifier" || !names[file.FlatNodeText(first)] {
+		return false
+	}
+	selector := ""
+	suffixes := 0
+	for c := file.FlatFirstChild(target); c != 0; c = file.FlatNextSib(c) {
+		if file.FlatType(c) != "navigation_suffix" {
+			continue
+		}
+		for gc := file.FlatFirstChild(c); gc != 0; gc = file.FlatNextSib(gc) {
+			if file.FlatIsNamed(gc) && file.FlatType(gc) == "simple_identifier" {
+				selector = file.FlatNodeText(gc)
+				suffixes++
+			}
+		}
+	}
+	return suffixes == 1 && selector == varName
+}
+
 func reassignedPostfixNameFlat(file *scanner.File, idx uint32) (string, bool) {
 	if file == nil || idx == 0 || file.FlatType(idx) != "postfix_expression" {
 		return "", false

--- a/internal/rules/style_expressions_test.go
+++ b/internal/rules/style_expressions_test.go
@@ -411,6 +411,65 @@ class FragmentLike {
 	}
 }
 
+func TestVarCouldBeVal_TreatsObjectNameQualifiedAssignmentAsReassignment(t *testing.T) {
+	// An object member written through the object's own name
+	// (`Deps.configured = true`) is a reassignment. The directly-assignable
+	// LHS is `<ObjectName>.<member>`, not `this.<member>`, so it previously
+	// slipped past the reassignment walk.
+	findings := runRuleByName(t, "VarCouldBeVal", `
+package test
+object Deps {
+    private var configured = false
+    fun configure() {
+        Deps.configured = true
+    }
+    fun read() = configured
+}
+`)
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings for object member reassigned via object name, got %d", len(findings))
+	}
+}
+
+func TestVarCouldBeVal_TreatsEnclosingClassQualifiedAssignmentAsReassignment(t *testing.T) {
+	// A companion-object member written through the enclosing class name
+	// (`ProgressService.title = ...`) from a sibling nested class is a
+	// reassignment. The write lives outside the member's immediate
+	// class_body, so the scan must cover the outermost enclosing type.
+	findings := runRuleByName(t, "VarCouldBeVal", `
+package test
+class ProgressService {
+    companion object {
+        private var title: String = ""
+    }
+    class Controller {
+        fun update(newTitle: String) {
+            ProgressService.title = newTitle
+        }
+    }
+}
+`)
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings for companion member reassigned via enclosing class name, got %d", len(findings))
+	}
+}
+
+func TestVarCouldBeVal_QualifiedReadIsNotReassignment(t *testing.T) {
+	// A qualified READ of an object member (`Config.enabled`, no assignment)
+	// must not be mistaken for a reassignment — the never-reassigned member
+	// still flags.
+	findings := runRuleByName(t, "VarCouldBeVal", `
+package test
+object Config {
+    private var enabled = false
+    fun read() = Config.enabled
+}
+`)
+	if len(findings) == 0 {
+		t.Fatal("expected finding for object member that is only read through a qualified access")
+	}
+}
+
 func TestVarCouldBeVal_TreatsLambdaPropertyAssignmentAsReassignment(t *testing.T) {
 	findings := runRuleByName(t, "VarCouldBeVal", `
 package test

--- a/internal/rules/style_unused.go
+++ b/internal/rules/style_unused.go
@@ -365,6 +365,16 @@ func unusedParameterPriorLocalDeclarationShadowsFlat(file *scanner.File, body ui
 				shadowed = true
 			}
 		case "function_declaration":
+			// Only a genuine *local* function shadows an outer parameter. A
+			// member function inside a nested class/object literal (e.g. an
+			// `override fun onAnimationStart()` in an `object : Listener { ... }`)
+			// is a member declaration, not a local; a bare call to a captured
+			// parameter inside such a member body still refers to the parameter.
+			// Treating the member's name as a shadow produced a false positive
+			// whenever the parameter and the overridden member share a name.
+			if !unusedParameterFunctionIsLocalFlat(file, candidate) {
+				return
+			}
 			if extractIdentifierFlat(file, candidate) == name &&
 				unusedParameterDeclarationScopeContainsRefFlat(file, body, candidate, ref) {
 				shadowed = true
@@ -372,6 +382,23 @@ func unusedParameterPriorLocalDeclarationShadowsFlat(file *scanner.File, body ui
 		}
 	})
 	return shadowed
+}
+
+// unusedParameterFunctionIsLocalFlat reports whether a function_declaration is
+// a true local function (declared inside a statement block / function body)
+// rather than a member of a class, object, or interface body. Only local
+// functions introduce a name that can shadow an enclosing parameter.
+func unusedParameterFunctionIsLocalFlat(file *scanner.File, fn uint32) bool {
+	parent, ok := file.FlatParent(fn)
+	if !ok {
+		return false
+	}
+	switch file.FlatType(parent) {
+	case "statements", "function_body", "control_structure_body":
+		return true
+	default:
+		return false
+	}
 }
 
 func unusedParameterDeclarationNodeHasNameFlat(file *scanner.File, node uint32, name string) bool {

--- a/internal/rules/style_unused_test.go
+++ b/internal/rules/style_unused_test.go
@@ -420,6 +420,71 @@ fun ok(ignored: String, expected: Int, _: Boolean) {
 `,
 			wantHits: 0,
 		},
+		{
+			// Regression: a lambda-typed parameter forwarded inside an anonymous
+			// object whose overridden member shares the parameter's name must not
+			// be treated as shadowed by that member. The member is a declaration
+			// in a nested object body, not a local function.
+			name: "anonymous object override with same name as parameter counts",
+			code: `
+package test
+interface AnimationListener {
+    fun onAnimationStart()
+    fun onAnimationEnd()
+}
+fun makeListener(
+    onAnimationStart: () -> Unit,
+    onAnimationEnd: () -> Unit
+): AnimationListener {
+    return object : AnimationListener {
+        override fun onAnimationStart() {
+            onAnimationStart()
+        }
+        override fun onAnimationEnd() {
+            onAnimationEnd()
+        }
+    }
+}
+`,
+			wantHits: 0,
+		},
+		{
+			// Regression: a parameter referenced only inside a trailing lambda
+			// body must count as used.
+			name: "trailing lambda body references parameter",
+			code: `
+package test
+fun timer(group: String, durationsByGroup: MutableMap<String, MutableList<Long>>) {
+    durationsByGroup.getOrPut(group) { mutableListOf(group.length.toLong()) }
+}
+`,
+			wantHits: 0,
+		},
+		{
+			// Guard: a genuine *local* function whose name shadows the parameter
+			// must still mask the parameter (so the parameter is flagged unused).
+			name: "local function shadowing parameter name still flags parameter",
+			code: `
+package test
+fun localShadow(handler: () -> Unit) {
+    fun handler() {}
+    handler()
+}
+`,
+			wantHits: 1,
+		},
+		{
+			// Guard: an inner lambda parameter that re-declares and uses the name
+			// must not mask a genuinely unused outer parameter.
+			name: "inner lambda parameter shadow does not mask unused outer parameter",
+			code: `
+package test
+fun outer(x: Int) {
+    listOf(1, 2).forEach { x -> println(x) }
+}
+`,
+			wantHits: 1,
+		},
 	}
 
 	for _, tt := range tests {

--- a/schemas/krit-config.schema.json
+++ b/schemas/krit-config.schema.json
@@ -9387,7 +9387,7 @@
           }
         },
         "OptInMarkerExposedPublicly": {
-          "description": "Detects @OptIn annotations on public API declarations that propagate the opt-in requirement to callers. [precision: ast-backed] [noisiness: normal]",
+          "description": "Detects public API declarations annotated directly with an opt-in marker, which propagates the opt-in requirement to callers. [precision: ast-backed] [noisiness: normal]",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -9395,6 +9395,13 @@
               "description": "Enable OptInMarkerExposedPublicly (default: true).",
               "type": "boolean",
               "default": true
+            },
+            "additionalMarkers": {
+              "description": "Additional propagating opt-in marker class names (simple or fully-qualified) — e.g. a project's own @RequiresOptIn markers — to flag when exposed on public API.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
             },
             "excludes": {
               "description": "Glob patterns for paths to exclude from this rule.",

--- a/tests/fixtures/negative/exceptions/InstanceOfCheckForException.java
+++ b/tests/fixtures/negative/exceptions/InstanceOfCheckForException.java
@@ -1,0 +1,25 @@
+package com.example.exceptions;
+
+import java.io.IOException;
+import java.net.SocketException;
+
+class NetworkClient {
+
+  // Narrowing an ALREADY-CAUGHT exception (the catch parameter) with
+  // instanceof to decide rethrow-vs-wrap is the idiomatic, legitimate use.
+  // Must NOT fire.
+  boolean send() throws IOException {
+    try {
+      return doSend();
+    } catch (IOException e) {
+      if (e instanceof SocketException) {
+        return false;
+      }
+      throw e;
+    }
+  }
+
+  private boolean doSend() throws IOException {
+    return true;
+  }
+}

--- a/tests/fixtures/negative/exceptions/InstanceOfCheckForException.kt
+++ b/tests/fixtures/negative/exceptions/InstanceOfCheckForException.kt
@@ -17,6 +17,35 @@ class NetworkClient {
         }
     }
 
+    // Narrowing an ALREADY-CAUGHT exception (the catch parameter) with `is`
+    // to decide rethrow-vs-wrap is the idiomatic, legitimate use — not the
+    // "type-check instead of polymorphism" smell. Must NOT fire.
+    fun rethrowOrWrap() {
+        try {
+            loadFromNetwork()
+        } catch (e: IllegalStateException) {
+            if (e is java.io.UncheckedIOException) {
+                throw RuntimeException(e)
+            } else {
+                throw e
+            }
+        }
+    }
+
+    // `when (e) { is X -> ... }` dispatch on the caught variable is the
+    // idiomatic way to group related exception types. Must NOT fire.
+    fun whenDispatch(): String {
+        return try {
+            loadFromNetwork()
+        } catch (e: Exception) {
+            when (e) {
+                is IOException -> "io"
+                is IllegalStateException -> "state"
+                else -> "other"
+            }
+        }
+    }
+
     fun classify(): String {
         try {
             return loadFromNetwork()

--- a/tests/fixtures/negative/exceptions/SwallowedException.kt
+++ b/tests/fixtures/negative/exceptions/SwallowedException.kt
@@ -80,6 +80,61 @@ class Processor {
         sink.flush()
     }
 
+    // Passing the whole caught exception to an unrecognized function consumes
+    // it — not a swallow.
+    fun passedToConverter(): String {
+        val out = StringBuilder()
+        try {
+            doWork()
+        } catch (t: Throwable) {
+            out.append(convertThrowableToString(t))
+            return out.toString()
+        }
+        return "ok"
+    }
+
+    // Inspecting and dispatching on e.cause forwards the throwable chain.
+    fun dispatchOnCause(): String {
+        return run {
+            try {
+                doWork()
+            } catch (e: java.util.concurrent.ExecutionException) {
+                when (val cause = e.cause) {
+                    is IllegalStateException -> stateError(cause)
+                    else -> appError(cause)
+                }
+            }
+        }
+    }
+
+    // A fallback assignment that ignores the exception is recovery, not a
+    // swallow.
+    var cached: String? = "x"
+
+    fun fallbackAssignment() {
+        try {
+            doWork()
+        } catch (e: Exception) {
+            cached = null
+        }
+    }
+
+    // An early return as a fallback value is recovery.
+    fun earlyReturnRecovery(): Boolean {
+        try {
+            doWork()
+        } catch (e: java.io.IOException) {
+            return false
+        }
+        return true
+    }
+
+    private fun convertThrowableToString(t: Throwable): String = t.toString()
+
+    private fun stateError(c: Throwable?): String = ""
+
+    private fun appError(c: Throwable?): String = ""
+
     private fun transform(i: Int): String = i.toString()
 
     private fun doWork() {

--- a/tests/fixtures/negative/licensing/OptInMarkerExposedPublicly.kt
+++ b/tests/fixtures/negative/licensing/OptInMarkerExposedPublicly.kt
@@ -1,6 +1,15 @@
 package test
 
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.SharedFlow
 
+// @OptIn(...) CONSUMES the opt-in requirement locally and does NOT propagate it
+// to callers; it is the mechanism for NOT exposing the marker. Flagging it is a
+// false positive, even on a public declaration.
 @OptIn(ExperimentalCoroutinesApi::class)
+public fun consumesExperimental(): SharedFlow<Int> = TODO()
+
+// A propagating marker on a non-public declaration does not expose anything
+// to external callers.
+@ExperimentalCoroutinesApi
 private fun internalUse() = Unit

--- a/tests/fixtures/negative/style/UnusedParameter.kt
+++ b/tests/fixtures/negative/style/UnusedParameter.kt
@@ -115,3 +115,32 @@ fun suppressedAmongUsedParams(
     second.process()
     return 0
 }
+
+interface UnusedParameterAnimationListener {
+    fun onAnimationStart()
+    fun onAnimationEnd()
+}
+
+// A lambda-typed parameter forwarded inside an anonymous `object` whose
+// overridden member shares the parameter's name. The member is a declaration
+// in a nested object body, not a local function, so it must not be treated as
+// shadowing the captured parameter.
+fun makeAnimationListener(
+    onAnimationStart: () -> Unit,
+    onAnimationEnd: () -> Unit
+): UnusedParameterAnimationListener {
+    return object : UnusedParameterAnimationListener {
+        override fun onAnimationStart() {
+            onAnimationStart()
+        }
+
+        override fun onAnimationEnd() {
+            onAnimationEnd()
+        }
+    }
+}
+
+// A parameter referenced only inside a trailing lambda body counts as used.
+fun recordTiming(group: String, durationsByGroup: MutableMap<String, MutableList<Long>>) {
+    durationsByGroup.getOrPut(group) { mutableListOf(group.length.toLong()) }
+}

--- a/tests/fixtures/negative/style/VarCouldBeVal.kt
+++ b/tests/fixtures/negative/style/VarCouldBeVal.kt
@@ -47,3 +47,39 @@ class Container {
 
     fun use() = publicProp + withSetter
 }
+
+// lateinit var cannot be val — must never be flagged.
+object LateinitHolder {
+    private lateinit var provider: String
+
+    fun init(value: String) {
+        provider = value
+    }
+
+    fun read() = provider
+}
+
+// Member reassigned through a qualified write `EnclosingType.member = ...`
+// from a sibling nested scope outside the member's immediate class_body.
+class ProgressService {
+    companion object {
+        private var title: String = ""
+    }
+
+    class Controller {
+        fun update(newTitle: String) {
+            ProgressService.title = newTitle
+        }
+    }
+}
+
+// Object member reassigned through its own object name.
+object Deps {
+    private var configured = false
+
+    fun configure() {
+        Deps.configured = true
+    }
+
+    fun read() = configured
+}

--- a/tests/fixtures/positive/exceptions/InstanceOfCheckForException.java
+++ b/tests/fixtures/positive/exceptions/InstanceOfCheckForException.java
@@ -1,0 +1,20 @@
+package com.example.exceptions;
+
+import java.io.IOException;
+import java.net.SocketException;
+
+class ErrorClassifier {
+
+  // instanceof type-check on a value that is NOT the caught variable is the
+  // "instanceof instead of polymorphism" smell this rule targets.
+  String classify(Throwable failure) {
+    try {
+      return "ok";
+    } catch (Exception outer) {
+      if (failure instanceof SocketException) {
+        return "socket";
+      }
+      return "other";
+    }
+  }
+}

--- a/tests/fixtures/positive/exceptions/InstanceOfCheckForException.kt
+++ b/tests/fixtures/positive/exceptions/InstanceOfCheckForException.kt
@@ -2,18 +2,20 @@ package com.example.exceptions
 
 import java.io.IOException
 
-class NetworkClient {
+class ErrorClassifier {
 
-    fun fetchData(): String {
+    // Type-checking an exception value that is NOT a caught variable to
+    // branch on its concrete type is the "instanceof instead of
+    // polymorphism" smell this rule targets.
+    fun classify(failure: Throwable): String {
         try {
-            return loadFromNetwork()
-        } catch (e: Exception) {
-            if (e is IOException) {
-                return "network error"
+            return "ok"
+        } catch (outer: Exception) {
+            // `failure` is a parameter, not the caught variable `outer`.
+            if (failure is IOException) {
+                return "io"
             }
-            return "unknown error"
+            return "other"
         }
     }
-
-    private fun loadFromNetwork(): String = "data"
 }

--- a/tests/fixtures/positive/licensing/OptInMarkerExposedPublicly.kt
+++ b/tests/fixtures/positive/licensing/OptInMarkerExposedPublicly.kt
@@ -3,5 +3,7 @@ package test
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.SharedFlow
 
-@OptIn(ExperimentalCoroutinesApi::class)
+// A public declaration carrying a propagating opt-in marker DIRECTLY exposes
+// the opt-in requirement to every caller.
+@ExperimentalCoroutinesApi
 public fun exposeExperimental(): SharedFlow<Int> = TODO()

--- a/tests/fixtures/positive/style/UnusedParameter.kt
+++ b/tests/fixtures/positive/style/UnusedParameter.kt
@@ -30,3 +30,8 @@ fun shadowedByForLoopVariable(item: String) {
         println(item)
     }
 }
+
+fun shadowedByLocalFunction(handler: () -> Unit) {
+    fun handler() {}
+    handler()
+}

--- a/tests/fixtures/positive/style/VarCouldBeVal.kt
+++ b/tests/fixtures/positive/style/VarCouldBeVal.kt
@@ -17,3 +17,11 @@ fun ignoresOtherReceiver(other: Box) {
     other.x = 42
     println(x)
 }
+
+// Object member that is never reassigned still flags. A qualified read of the
+// member (not a write) must not be mistaken for a reassignment.
+object Config {
+    private var enabled = false
+
+    fun read() = Config.enabled
+}


### PR DESCRIPTION
Stacked on #642. Second dogfood pass — seven more built-in rules with false-positive clusters, each fixed with **tree-sitter AST / structured-XML** analysis (no string/substring/regex on code) and locked with positive+negative fixtures.

## Fixes (measured on the dogfood target)

| Rule | Before → After | Fix |
|---|---|---|
| **OptInMarkerExposedPublicly** | 28 → 1 | Premise was **inverted** — it flagged `@OptIn(X::class)`, which *consumes* the opt-in and does **not** propagate. Now flags a public decl carrying a *propagating* marker (`@ExperimentalFoo`) directly, by annotation name vs the known-marker set. The 1 remaining is a genuine exposed marker. |
| **InstanceOfCheckForException** | 13 → 0 | Stop flagging `is`/`instanceof` narrowing of an already-**caught** exception (the catch param, or a value unwrapped from its `.cause`) — idiomatic rethrow-vs-wrap. Still flags type-checks on non-caught values. |
| **SwallowedException** | 65 → 22 | Don't report when the caught variable is actually **used** (passed/wrapped into a result/exception, `.cause`/`.message` inspected) or the catch does real recovery; defer empty catches to `EmptyCatchBlock`. |
| **VarCouldBeVal** | 16 → 11 | Count reassignment via a **qualified write** (`EnclosingType.member = …`) in an object/companion; never flag `lateinit var`. |
| **LayoutAutofillHintMismatch** | 14 → 10 | Drop the broad `inputType=number ⇒ creditCardNumber` / `textPersonName ⇒ personName` inferences; exempt `importantForAutofill="no"`; only flag a genuine hint/inputType mismatch. |
| **UnusedParameter** | 16 → 13 | Count parameter reads inside nested anonymous `object` literals / trailing lambdas; a member fn of such an object no longer spuriously shadows the captured param. |
| **RecyclerAdapterWithoutDiffUtil** | 18 → 17 | Require a direct supertype whose simple name actually ends in `Adapter`, so `AdapterDataObserver` (an observer) isn't mistaken for an adapter by name. |

Total on the dogfood target: **1615 → 1519**. Cold == warm verified byte-identical.

## Notes
- All decisions use AST nodes (annotation names, catch-parameter identity, supertype simple-name suffix, assignment-target shape, nested-scope descent + shadowing), never source-text scans.
- `cachePayloadVersion` → v4 so warm findings caches recompute after these rule-logic changes.
- Regression baselines (`cmd/krit/testdata/regression/*.json`) and two MCP fix-suggestion tests updated for the findings deltas.
- Some fixes are deliberately conservative (VarCouldBeVal/LayoutAutofill/UnusedParameter dropped fewer than the upper FP estimate) — they remove the verified-FP patterns without risking false negatives; the residuals are a mix of genuine TPs and harder sub-patterns.

## Validation
`go build`, `go vet`, `golangci-lint` (0 issues), `gofmt`, and the rules / android / cache / mcp / cmd-krit suites are all green.